### PR TITLE
feat(reader-revenue): add PayPal Payments gateway to wizard

### DIFF
--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -253,6 +253,15 @@ class Plugin_Manager {
 				'Download'    => 'wporg',
 				'EditPath'    => 'admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments',
 			],
+			'woocommerce-paypal-payments' => [
+				'Name'        => \esc_html__( 'PayPal Payments', 'newspack-plugin' ),
+				'Description' => \esc_html__( 'PayPal\'s latest complete payments processing solution. Accept PayPal, Pay Later, credit/debit cards, alternative digital wallets local payment types and bank accounts. Turn on only PayPal options or process a full suite of payment methods. Enable global transaction with extensive currency and country coverage.', 'newspack-plugin' ),
+				'Author'      => \esc_html__( 'WooCommerce', 'newspack-plugin' ),
+				'PluginURI'   => \esc_url( 'https://woocommerce.com/' ),
+				'AuthorURI'   => \esc_url( 'https://woocommerce.com/' ),
+				'Download'    => 'wporg',
+				'EditPath'    => 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway',
+			],
 			'woocommerce-name-your-price' => [
 				'Name'        => \esc_html__( 'WooCommerce Name Your Price', 'newspack-plugin' ),
 				'Description' => \esc_html__( 'WooCommerce Name Your Price allows customers to set their own price for products or donations.', 'newspack-plugin' ),

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -254,7 +254,7 @@ class Plugin_Manager {
 				'EditPath'    => 'admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments',
 			],
 			'woocommerce-paypal-payments' => [
-				'Name'        => \esc_html__( 'PayPal Payments', 'newspack-plugin' ),
+				'Name'        => \esc_html__( 'WooCommerce PayPal Payments', 'newspack-plugin' ),
 				'Description' => \esc_html__( 'PayPal\'s latest complete payments processing solution. Accept PayPal, Pay Later, credit/debit cards, alternative digital wallets local payment types and bank accounts. Turn on only PayPal options or process a full suite of payment methods. Enable global transaction with extensive currency and country coverage.', 'newspack-plugin' ),
 				'Author'      => \esc_html__( 'WooCommerce', 'newspack-plugin' ),
 				'PluginURI'   => \esc_url( 'https://woocommerce.com/' ),

--- a/includes/configuration_managers/class-woocommerce-configuration-manager.php
+++ b/includes/configuration_managers/class-woocommerce-configuration-manager.php
@@ -191,6 +191,15 @@ class WooCommerce_Configuration_Manager extends Configuration_Manager {
 	}
 
 	/**
+	 * Get slugs for supported payment gateways.
+	 *
+	 * @return array
+	 */
+	public function get_supported_payment_gateways() {
+		return array_keys( $this->supported_gateways );
+	}
+
+	/**
 	 * Get payment gateway by slug, if available.
 	 *
 	 * @param string $gateway The slug for the payment gateway to get.

--- a/includes/configuration_managers/class-woocommerce-configuration-manager.php
+++ b/includes/configuration_managers/class-woocommerce-configuration-manager.php
@@ -26,6 +26,35 @@ class WooCommerce_Configuration_Manager extends Configuration_Manager {
 	public $slug = 'woocommerce';
 
 	/**
+	 * Fully-supported payment gateways.
+	 *
+	 * @var array
+	 */
+	public $supported_gateways = [
+		'ppcp-gateway'         => [
+			'name'     => 'PayPal Payments',
+			'plugin'   => 'woocommerce-paypal-payments',
+			'url'      => 'https://woocommerce.com/products/woocommerce-paypal-payments/',
+			'connect'  => 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway&ppcp-tab=ppcp-connection',
+			'settings' => 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway',
+		],
+		'stripe'               => [
+			'name'     => 'Stripe',
+			'plugin'   => 'woocommerce-gateway-stripe',
+			'url'      => 'https://woocommerce.com/document/stripe/',
+			'connect'  => 'admin.php?page=wc-settings&tab=checkout&section=stripe',
+			'settings' => 'admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings',
+		],
+		'woocommerce_payments' => [
+			'name'     => 'WooCommerce Payments',
+			'plugin'   => 'woocommerce-payments',
+			'url'      => 'https://woocommerce.com/payments/',
+			'connect'  => 'admin.php?page=wc-admin&path=%2Fpayments%2Foverview',
+			'settings' => 'admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments',
+		],
+	];
+
+	/**
 	 * Get whether the WooCommerce plugin is active and set up.
 	 *
 	 * @todo Actually implement this.
@@ -162,15 +191,16 @@ class WooCommerce_Configuration_Manager extends Configuration_Manager {
 	}
 
 	/**
-	 * Get WooPayments payment gateway, if available.
+	 * Get payment gateway by slug, if available.
 	 *
-	 * @param bool $only_enabled If true, only return the gateway if enabled.
+	 * @param string $gateway The slug for the payment gateway to get.
+	 * @param bool   $only_enabled If true, only return the gateway if enabled.
 	 *
 	 * @return WC_Gateway_Stripe|bool WC_Gateway_Stripe instance if Stripe payment gateway is available, false if not.
 	 */
-	public static function get_woopayments_gateway( $only_enabled = false ) {
+	public static function get_payment_gateway( $gateway, $only_enabled = false ) {
 		$gateways = self::get_payment_gateways( $only_enabled );
-		return isset( $gateways['woocommerce_payments'] ) ? $gateways['woocommerce_payments'] : false;
+		return isset( $gateways[ $gateway ] ) ? $gateways[ $gateway ] : false;
 	}
 
 	/**
@@ -197,20 +227,44 @@ class WooCommerce_Configuration_Manager extends Configuration_Manager {
 	}
 
 	/**
-	 * Retrieve WooPayments data
+	 * Retrieve data for the given payment gateway.
 	 *
-	 * @return Array|bool Array of WooPayments data, or false if WooPayments gateway isn't available.
+	 * @param string $gateway_slug The slug for the payment gateway to get.
+	 *
+	 * @return Array|bool Array of gateway data, or false if gateway isn't available.
 	 */
-	public function woopayments_data() {
-		$woopayments_gateway = self::get_woopayments_gateway();
-		if ( ! $woopayments_gateway ) {
+	public function gateway_data( $gateway_slug ) {
+		if ( ! isset( $this->supported_gateways[ $gateway_slug ] ) ) {
 			return false;
+		}
+		$gateway      = self::get_payment_gateway( $gateway_slug );
+		$is_connected = $gateway && method_exists( $gateway, 'is_connected' ) ? $gateway->is_connected() : false;
+		$test_mode    = $gateway && 'yes' === $gateway->get_option( 'test_mode', false ) ? true : false;
+
+		// PayPal gateway doesn't provide helper functions, so we need to use its internal API.
+		if ( 'ppcp-gateway' === $gateway_slug && method_exists( 'WooCommerce\PayPalCommerce\PPCP', 'container' ) ) {
+			$paypal = \WooCommerce\PayPalCommerce\PPCP::container();
+			if ( $paypal ) {
+				$env = $paypal->get( 'onboarding.environment' );
+				if ( $env && $env->current_environment_is( $env::SANDBOX ) ) {
+					$test_mode = true;
+				}
+				$state = $paypal->get( 'onboarding.state' );
+				if ( $state && $state::STATE_ONBOARDED <= $state->current_state() ) {
+					$is_connected = true;
+				}
+			}
 		}
 
 		return [
-			'enabled'      => 'yes' === $woopayments_gateway->get_option( 'enabled', false ) ? true : false,
-			'test_mode'    => 'yes' === $woopayments_gateway->get_option( 'test_mode', false ) ? true : false,
-			'is_connected' => $woopayments_gateway->is_connected(),
+			'enabled'      => $gateway && 'yes' === $gateway->get_option( 'enabled', false ) ? true : false,
+			'name'         => esc_html( $this->supported_gateways[ $gateway_slug ]['name'] ),
+			'test_mode'    => $test_mode,
+			'is_connected' => $is_connected,
+			'slug'         => $gateway_slug,
+			'url'          => $this->supported_gateways[ $gateway_slug ]['url'],
+			'connect'      => \admin_url( $this->supported_gateways[ $gateway_slug ]['connect'] ),
+			'settings'     => \admin_url( $this->supported_gateways[ $gateway_slug ]['settings'] ),
 		];
 	}
 
@@ -271,37 +325,49 @@ class WooCommerce_Configuration_Manager extends Configuration_Manager {
 	}
 
 	/**
-	 * Update WooPayments settings
+	 * Update settings for the given payment gateway.
 	 *
-	 * @param Array $args Settings.
+	 * @param string $gateway_slug The slug for the payment gateway to update.
+	 * @param Array  $args Settings.
 	 * @return Array|WP_Error The data that was updated or an error.
 	 */
-	public function update_wc_woopayments_settings( $args ) {
+	public function update_gateway_settings( $gateway_slug, $args ) {
 		if ( ! class_exists( 'WC_Payment_Gateways' ) ) {
 			return false;
 		}
 
-		// Get the WooPayments payment gateway instance.
-		$woopayments = self::get_woopayments_gateway();
-		if ( ! $woopayments ) {
+		if ( ! isset( $this->supported_gateways[ $gateway_slug ] ) ) {
+			return false;
+		}
+
+		// Get the payment gateway instance.
+		$gateway = self::get_payment_gateway( $gateway_slug );
+		if ( ! $gateway ) {
 			if ( isset( $args['enabled'] ) && $args['enabled'] ) {
-				// WooPayments gateway is not installed and we want to use it. Install/Activate/Initialize it.
-				Plugin_Manager::activate( 'woocommerce-payments' );
+				// Gateway is not installed and we want to use it. Install/Activate/Initialize it.
+				Plugin_Manager::activate( $this->supported_gateways[ $gateway_slug ]['plugin'] );
 				do_action( 'plugins_loaded' );
 				\WC_Payment_Gateways::instance()->init();
-				$woopayments = self::get_woopayments_gateway();
-				if ( ! $woopayments ) {
-					return new WP_Error( 'newspack_woopayments_gateway_error', __( 'Error activating WooPayments.', 'newspack-plugin' ) );
+				$gateway = self::get_payment_gateway( $gateway_slug );
+				if ( ! $gateway ) {
+					return new WP_Error(
+						'newspack_payment_gateway_error',
+						sprintf(
+							// Translators: %s is the slug of the payment gateway.
+							__( 'Error activating %s gateway.', 'newspack-plugin' ),
+							$gateway_slug
+						)
+					);
 				}
 			} else {
-				// WooPayments is not installed and we don't want to use it. No settings needed.
+				// Gateway is not installed and we don't want to use it. No settings needed.
 				return true;
 			}
 		}
 
-		// Update WooPayments settings.
+		// Update gateway settings.
 		if ( isset( $args['enabled'] ) ) {
-			$woopayments->update_option( 'enabled', $args['enabled'] ? 'yes' : 'no' );
+			$gateway->update_option( 'enabled', $args['enabled'] ? 'yes' : 'no' );
 		}
 
 		return true;

--- a/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php
@@ -13,8 +13,7 @@ defined( 'ABSPATH' ) || exit;
  * WooCommerce Order UTM class.
  */
 class WooCommerce_Cover_Fees {
-	const CUSTOM_FIELD_NAME  = 'newspack-wc-pay-fees';
-	const SUPPORTED_GATEWAYS = [ 'stripe', 'woocommerce_payments' ];
+	const CUSTOM_FIELD_NAME = 'newspack-wc-pay-fees';
 
 	/**
 	 * Initialize hooks.
@@ -135,7 +134,8 @@ class WooCommerce_Cover_Fees {
 		if ( ! self::should_allow_covering_fees() ) {
 			return false;
 		}
-		if ( ! isset( $data['payment_method'] ) || ! in_array( $data['payment_method'], self::SUPPORTED_GATEWAYS, true ) ) {
+		$wc_configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'woocommerce' );
+		if ( ! isset( $data['payment_method'] ) || ! in_array( $data['payment_method'], $wc_configuration_manager->get_supported_payment_gateways(), true ) ) {
 			return false;
 		}
 		if ( ! isset( $data[ self::CUSTOM_FIELD_NAME ] ) || '1' !== $data[ self::CUSTOM_FIELD_NAME ] ) {
@@ -150,7 +150,8 @@ class WooCommerce_Cover_Fees {
 	 * @param string $payment_gateway The slug for the payment gateway rendering these payment fields.
 	 */
 	public static function render_transaction_fee_input( $payment_gateway ) {
-		if ( ! self::should_allow_covering_fees() || ! in_array( $payment_gateway, self::SUPPORTED_GATEWAYS, true ) ) {
+		$wc_configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'woocommerce' );
+		if ( ! self::should_allow_covering_fees() || ! in_array( $payment_gateway, $wc_configuration_manager->get_supported_payment_gateways(), true ) ) {
 			return;
 		}
 		?>

--- a/includes/wizards/class-reader-revenue-wizard.php
+++ b/includes/wizards/class-reader-revenue-wizard.php
@@ -168,13 +168,13 @@ class Reader_Revenue_Wizard extends Wizard {
 			]
 		);
 
-		// Save WooPayments info.
+		// Save payment gateway info.
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
-			'/wizard/' . $this->slug . '/woopayments/',
+			'/wizard/' . $this->slug . '/gateway/',
 			[
 				'methods'             => \WP_REST_Server::EDITABLE,
-				'callback'            => [ $this, 'api_update_woopayments_settings' ],
+				'callback'            => [ $this, 'api_update_gateway_settings' ],
 				'permission_callback' => [ $this, 'api_permissions_check' ],
 				'args'                => [
 					'activate' => [
@@ -182,6 +182,9 @@ class Reader_Revenue_Wizard extends Wizard {
 					],
 					'enabled'  => [
 						'sanitize_callback' => 'Newspack\newspack_string_to_bool',
+					],
+					'slug'     => [
+						'sanitize_callback' => 'Newspack\newspack_clean',
 					],
 				],
 			]
@@ -423,16 +426,23 @@ class Reader_Revenue_Wizard extends Wizard {
 	}
 
 	/**
-	 * Save WooPayments settings.
+	 * Save payment gateway settings.
 	 *
 	 * @param WP_REST_Request $request Request object.
 	 * @return WP_REST_Response Response.
 	 */
-	public function api_update_woopayments_settings( $request ) {
+	public function api_update_gateway_settings( $request ) {
 		$wc_configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'woocommerce' );
 
 		$params = $request->get_params();
-		$result = $wc_configuration_manager->update_wc_woopayments_settings( $params );
+		if ( ! isset( $params['slug'] ) ) {
+			return \rest_ensure_response(
+				new WP_Error( 'newspack_invalid_param', __( 'Gateway slug is required.', 'newspack' ) )
+			);
+		}
+		$slug = $params['slug'];
+		unset( $params['slug'] );
+		$result = $wc_configuration_manager->update_gateway_settings( $slug, $params );
 		return \rest_ensure_response( $result );
 	}
 
@@ -495,7 +505,6 @@ class Reader_Revenue_Wizard extends Wizard {
 		$platform                 = Donations::get_platform_slug();
 		$wc_configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'woocommerce' );
 		$wc_installed             = 'active' === Plugin_Manager::get_managed_plugin_status( 'woocommerce' );
-		$stripe_data              = Stripe_Connection::get_stripe_data();
 
 		$billing_fields    = null;
 		$order_notes_field = [];
@@ -516,8 +525,9 @@ class Reader_Revenue_Wizard extends Wizard {
 			'currency_fields'          => newspack_get_currencies_options(),
 			'location_data'            => [],
 			'payment_gateways'         => [
-				'stripe'      => $stripe_data,
-				'woopayments' => $wc_configuration_manager->woopayments_data(),
+				'stripe'               => Stripe_Connection::get_stripe_data(),
+				'woocommerce_payments' => $wc_configuration_manager->gateway_data( 'woocommerce_payments' ),
+				'ppcp-gateway'         => $wc_configuration_manager->gateway_data( 'ppcp-gateway' ),
 			],
 			'additional_settings'      => [
 				'allow_covering_fees'         => boolval( get_option( 'newspack_donations_allow_covering_fees', false ) ),

--- a/src/wizards/readerRevenue/views/payment-methods/index.js
+++ b/src/wizards/readerRevenue/views/payment-methods/index.js
@@ -9,7 +9,7 @@ import { ExternalLink } from '@wordpress/components';
  */
 import { AdditionalSettings } from './additional-settings';
 import { Stripe } from './stripe';
-import { WooPayments } from './woopayments';
+import { PaymentGateway } from './payment-gateway';
 import { Notice, SectionHeader, Wizard } from '../../../../components/src';
 import './style.scss';
 
@@ -26,7 +26,6 @@ const PaymentGateways = () => {
 		return null;
 	}
 
-	const { stripe = false, woopayments = false } = paymentGateways;
 	const hasPaymentGateway = Object.keys( paymentGateways ).some( gateway => paymentGateways[ gateway ]?.enabled );
 	return (
 		<>
@@ -64,8 +63,15 @@ const PaymentGateways = () => {
 					}
 				/>
 			) }
-			<Stripe stripe={ stripe } />
-			<WooPayments woopayments={ woopayments } />
+			{
+				Object.keys( paymentGateways ).map( gateway => {
+					// Stripe has unique connection status and badge level logic.
+					if ( 'stripe' === gateway ) {
+						return <Stripe key={ paymentGateways[ gateway ] } stripe={ paymentGateways[ gateway ] } />;
+					}
+					return <PaymentGateway key={ gateway } gateway={ paymentGateways[ gateway ] } />;
+				} )
+			}
 			{ hasPaymentGateway && (
 				<AdditionalSettings
 					settings={ settings }

--- a/src/wizards/readerRevenue/views/payment-methods/payment-gateway.js
+++ b/src/wizards/readerRevenue/views/payment-methods/payment-gateway.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { ExternalLink } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 
@@ -15,14 +15,14 @@ import {
 } from '../../../../components/src';
 import { READER_REVENUE_WIZARD_SLUG } from '../../constants';
 
-export const WooPayments = ( { woopayments } ) => {
+export const PaymentGateway = ( { gateway } ) => {
 	const isLoading = useSelect( select => select( Wizard.STORE_NAMESPACE ).isLoading() );
 	const isQuietLoading = useSelect( select => select( Wizard.STORE_NAMESPACE ).isQuietLoading() );
 	const { updateWizardSettings } = useDispatch( Wizard.STORE_NAMESPACE );
 	const changeHandler = ( key, value ) =>
 		updateWizardSettings( {
 			slug: READER_REVENUE_WIZARD_SLUG,
-			path: [ 'payment_gateways', 'woopayments', key ],
+			path: [ 'payment_gateways', gateway.slug, key ],
 			value,
 		} );
 
@@ -30,13 +30,13 @@ export const WooPayments = ( { woopayments } ) => {
 	const onSave = () =>
 		saveWizardSettings( {
 			slug: READER_REVENUE_WIZARD_SLUG,
-			section: 'woopayments',
-			payloadPath: [ 'payment_gateways', 'woopayments' ],
+			section: 'gateway',
+			payloadPath: [ 'payment_gateways', gateway.slug ],
 		} );
-	const testMode = woopayments?.test_mode;
-	const isConnected = woopayments?.is_connected;
+	const testMode = gateway?.test_mode;
+	const isConnected = gateway?.is_connected;
 	const getConnectionStatus = () => {
-		if ( ! woopayments?.enabled ) {
+		if ( ! gateway?.enabled ) {
 			return null;
 		}
 		if ( isLoading || isQuietLoading ) {
@@ -51,7 +51,7 @@ export const WooPayments = ( { woopayments } ) => {
 		return __( 'Connected', 'newspack-plugin' );
 	}
 	const getBadgeLevel = () => {
-		if ( ! woopayments?.enabled || isLoading || isQuietLoading ) {
+		if ( ! gateway?.enabled || isLoading || isQuietLoading ) {
 			return 'info';
 		}
 		if ( ! isConnected ) {
@@ -63,31 +63,34 @@ export const WooPayments = ( { woopayments } ) => {
 	return (
 		<ActionCard
 			isMedium
-			title={ __( 'WooPayments', 'newspack-plugin' ) }
+			title={ gateway.name }
 			description={ () => (
 				<>
-					{ __(
-						'Enable WooPayments. ',
-						'newspack-plugin'
+					{ sprintf(
+						// Translators: %s is the payment gateway name.
+						__( 'Enable %s. ', 'newspack-plugin' ),
+						gateway.name
 					) }
-					<ExternalLink href="https://woocommerce.com/payments/">
-						{ __( 'Learn more', 'newspack-plugin' ) }
-					</ExternalLink>
+					{ gateway.url && (
+						<ExternalLink href={ gateway.url }>
+							{ __( 'Learn more', 'newspack-plugin' ) }
+						</ExternalLink>
+					) }
 				</>
 			) }
 			hasWhiteHeader
-			toggleChecked={ !! woopayments.enabled }
+			toggleChecked={ !! gateway.enabled }
 			toggleOnChange={ () => {
-				changeHandler( 'enabled', ! woopayments.enabled );
+				changeHandler( 'enabled', ! gateway.enabled );
 				onSave();
 			} }
 			badge={ getConnectionStatus() }
 			badgeLevel={ getBadgeLevel() }
 			// eslint-disable-next-line no-nested-ternary
-			actionContent={ ( ! woopayments?.enabled || isLoading || isQuietLoading ) ? null : isConnected ? (
+			actionContent={ ( ! gateway?.enabled || isLoading || isQuietLoading ) ? null : isConnected ? (
 				<Button
 					variant="secondary"
-					href="/wp-admin/admin.php?page=wc-settings&tab=checkout&section=woocommerce_payments"
+					href={ gateway.settings }
 					target="_blank"
 					rel="noreferrer"
 				>
@@ -96,7 +99,7 @@ export const WooPayments = ( { woopayments } ) => {
 			) : (
 				<Button
 					variant="primary"
-					href="/wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Foverview"
+					href={ gateway.connect }
 					target="_blank"
 					rel="noreferrer"
 				>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds PayPal Payments to the list of fully-supported payment gateways in the Reader Revenue wizard.

### How to test the changes in this Pull Request:

1. Start with a new testing site and install all required WooCommerce plugins (main Woo + Subscriptions).
2. After completing setup, visit Reader Revenue and choose the "Newspack" platform if not already selected.
3. Visit the Payment Methods tab and confirm you see PayPal Payments as an option here, and confirm that the "Learn more" link leads to the correct plugin info page:

<img width="1198" alt="Screenshot 2025-01-10 at 2 55 10 PM" src="https://github.com/user-attachments/assets/4897352e-f6ca-4064-9eae-93600dbc5c6a" />

4. Enable PayPal Payments and confirm it installs and activates the plugin, then click "Connect" and confirm it leads you to the PayPal Payments plugin's onboarding page.
5. Complete onboarding by connecting to a sandbox PayPal account ([instructions](https://woocommerce.com/document/woocommerce-paypal-payments/#testing-in-sandbox))
6. Go back to Reader Revenue > Payment Methods and confirm that the PayPal Payments card now shows it as connected in test mode. Confirm that the "Configure" button leads to the PayPal Payments plugin settings page.

<img width="1054" alt="Screenshot 2025-01-10 at 3 01 35 PM" src="https://github.com/user-attachments/assets/89c2858f-0c4f-44f5-b1cd-d04638fa9666" />

7. Confirm that you can complete a test transaction as a reader via modal checkout using PayPal. Test both with and without covering donation fees.
8. Smoke test enabling and connecting Stripe and WooPayments, all links and buttons within those cards, and completing test transactions using those payment gateways both with and without covering fees, too.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209009673306532