### PR TITLE
feat(my-account): reCAPTCHA check on add payment method

### DIFF
--- a/includes/class-recaptcha.php
+++ b/includes/class-recaptcha.php
@@ -28,9 +28,13 @@ final class Recaptcha {
 		// Add reCAPTCHA to the Woo checkout form.
 		\add_action( 'woocommerce_review_order_before_submit', [ __CLASS__, 'add_recaptcha_v2_to_checkout' ] );
 		\add_action( 'woocommerce_checkout_after_customer_details', [ __CLASS__, 'add_recaptcha_v3_to_checkout' ] );
+		\add_action( 'woocommerce_add_payment_method_form_bottom', [ __CLASS__, 'add_recaptcha_v3_to_checkout' ] );
 
 		// Verify reCAPTCHA on checkout submission.
 		\add_action( 'woocommerce_checkout_process', [ __CLASS__, 'verify_recaptcha_on_checkout' ] );
+
+		// Verify reCAPTCHA when adding new payment method.
+		\add_filter( 'woocommerce_add_payment_method_form_is_valid', [ __CLASS__, 'verify_recaptcha_on_add_payment_method' ] );
 	}
 
 	/**
@@ -519,6 +523,27 @@ final class Recaptcha {
 		if ( \is_wp_error( $check ) ) {
 			WooCommerce_Connection::add_wc_notice( $check->get_error_message(), 'error' );
 		}
+	}
+
+	/**
+	 * Verify reCAPTCHA when adding new payment method in My Account.
+	 *
+	 * @param bool $is_valid Whether the form is valid.
+	 *
+	 * @rturn bool
+	 */
+	public static function verify_recaptcha_on_add_payment_method( $is_valid ) {
+		$url                   = \home_url( \add_query_arg( null, null ) );
+		$should_verify_captcha = apply_filters( 'newspack_recaptcha_verify_captcha', self::can_use_captcha(), $url );
+		if ( ! $should_verify_captcha ) {
+			return $is_valid;
+		}
+		$check = self::verify_captcha();
+		if ( \is_wp_error( $check ) ) {
+			WooCommerce_Connection::add_wc_notice( $check->get_error_message(), 'error' );
+			return false;
+		}
+		return $is_valid;
 	}
 }
 

--- a/src/other-scripts/recaptcha/index.js
+++ b/src/other-scripts/recaptcha/index.js
@@ -136,7 +136,9 @@ function render( forms = [], onSuccess = null, onError = null ) {
 
 	const formsToHandle = forms.length
 		? forms
-		: [ ...document.querySelectorAll( 'form[data-newspack-recaptcha]' ) ];
+		: [ ...document.querySelectorAll(
+			'form[data-newspack-recaptcha],form#add_payment_method',
+		) ];
 
 	formsToHandle.forEach( form => {
 		const renderForm = () => {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a reCAPTCHA check to the form to add payment methods in My Account.

### How to test the changes in this Pull Request:

We'll want to test with both reCAPTCHA v2 and v3.

1. Enable reCAPTCHA v2 in Newspack > Connections and check out this branch.
2. At [this line](https://github.com/Automattic/newspack-plugin/blob/hotfix/protect-add-payment-method/includes/class-recaptcha.php#L406-L407), add `error_log( print_r( $captcha_verify, true ) );` so we can confirm that we're verifying with the reCAPTCHA service after form submit.
3. Register a new reader account, log in, and verify as needed to view My Account.
4. Visit `<site URL>/my-account/add-payment-method/` and add a payment method.
5. (when testing v2 only) Confirm that you get a v2 widget challenge when you click the "Add payment method" submit button.
6. After submitting the form, confirm that the verification result is logged to debug.log (after adding the `error_log` in step 2).
7. To test a rejection, add `return new \WP_Error( 'newspack_test_error', 'Test error message' );` at [this line](https://github.com/Automattic/newspack-plugin/blob/hotfix/protect-add-payment-method/includes/class-recaptcha.php#L379-L380).
8. Repeat the "Add payment method" form submission and confirm that the submission is rejected with your test error message (note that the message might disappear after a second, but this seems to be a WooCommerce behavior and not related to this PR). Visit `<site URL>/my-account/payment-methods` and confirm that a new payment method was NOT saved.
9. Repeat all testing steps with reCAPTCHA v3.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209016655921587