### PR TITLE
fix(corrections): remove newspack_corrections_ids meta

### DIFF
--- a/includes/corrections/README.md
+++ b/includes/corrections/README.md
@@ -31,4 +31,3 @@ In addition, some correction data is stored in the associated post as post meta:
 | ------------------------------- | ----------------------- | ----------- | ------------------------------------------------------------- |
 | `newspack_corrections_active`   | `bool`                  | `post_meta` | Whether the feature is enabled for the post.                  |
 | `newspack_corrections_location` | `string`                | `post_meta` | Where the correction should be displayed. (`top` or `bottom`) |
-| `newspack_corrections_ids`      | `array`                 | `post_meta` | An array of IDs of the corrections associated with the post.  |

--- a/includes/corrections/class-corrections.php
+++ b/includes/corrections/class-corrections.php
@@ -32,11 +32,6 @@ class Corrections {
 	const CORRECTIONS_LOCATION_META = 'newspack_corrections_location';
 
 	/**
-	 * Meta key for post corrections ids meta.
-	 */
-	const CORRECTIONS_IDS_META = 'newspack_corrections_ids';
-
-	/**
 	 * Initializes the class.
 	 */
 	public static function init() {
@@ -156,10 +151,6 @@ class Corrections {
 	 * @param array $corrections The corrections.
 	 */
 	public static function add_corrections( $post_id, $corrections ) {
-		$correction_ids = get_post_meta( $post_id, self::CORRECTIONS_IDS_META, true );
-		if ( ! is_array( $correction_ids ) ) {
-			$correction_ids = [];
-		}
 		foreach ( $corrections as $correction ) {
 			$id = wp_insert_post(
 				[
@@ -177,7 +168,6 @@ class Corrections {
 				$correction_ids[] = $id;
 			}
 		}
-		update_post_meta( $post_id, self::CORRECTIONS_IDS_META, $correction_ids );
 	}
 
 	/**
@@ -188,15 +178,14 @@ class Corrections {
 	 * @return array The corrections.
 	 */
 	public static function get_corrections( $post_id ) {
-		$correction_ids = get_post_meta( $post_id, self::CORRECTIONS_IDS_META, true );
-		if ( ! is_array( $correction_ids ) ) {
-			return [];
-		}
 		return get_posts(
 			[
 				'posts_per_page' => -1,
 				'post_type'      => self::POST_TYPE,
-				'include'        => $correction_ids,
+				'meta_key'       => self::CORRECTION_POST_ID_META, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_value'     => $post_id, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+				'orderby'        => 'date',
+				'order'          => 'DESC',
 			]
 		);
 	}
@@ -224,17 +213,9 @@ class Corrections {
 	 * @param array $correction_ids correction ids.
 	 */
 	public static function delete_corrections( $post_id, $correction_ids ) {
-		$stored_correction_ids = get_post_meta( $post_id, self::CORRECTIONS_IDS_META, true );
-		if ( ! is_array( $stored_correction_ids ) ) {
-			$stored_correction_ids = [];
-		}
 		foreach ( $correction_ids as $id ) {
 			wp_delete_post( $id, true );
-			if ( isset( $stored_correction_ids[ $id ] ) ) {
-				unset( $stored_correction_ids[ $id ] );
-			}
 		}
-		update_post_meta( $post_id, self::CORRECTIONS_IDS_META, $stored_correction_ids );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This removes a redundant post meta related to corrections (`newspack_corrections_ids`) to avoid an issue with two sources of truth for correction id.

### How to test the changes in this Pull Request:

1. Ensure the `NEWSPACK_CORRECTIONS_ENABLED` FF is enabled in wp-config and smoke test corrections

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->