### PR TITLE
fix(ras-sync): account for missing creation data and first/last name

### DIFF
--- a/includes/reader-activation/sync/class-woocommerce.php
+++ b/includes/reader-activation/sync/class-woocommerce.php
@@ -333,8 +333,11 @@ class WooCommerce {
 
 		$metadata = [];
 
-		$metadata['account']           = $customer->get_id();
-		$metadata['registration_date'] = $customer->get_date_created()->date( Metadata::DATE_FORMAT );
+		$customer_id                   = $customer->get_id();
+		$user                          = \get_user_by( 'id', $customer_id );
+		$created_date                  = $customer->get_date_created();
+		$metadata['account']           = $customer_id;
+		$metadata['registration_date'] = $created_date ? $created_date->date( Metadata::DATE_FORMAT ) : '';
 		$metadata['total_paid']        = $customer->get_total_spent();
 
 		$order = self::get_current_product_order_for_sync( $customer );
@@ -356,7 +359,16 @@ class WooCommerce {
 		$first_name = $customer->get_billing_first_name();
 		$last_name  = $customer->get_billing_last_name();
 		$full_name  = trim( "$first_name $last_name" );
-		$contact    = [
+
+		// Correct for empty First and Last Name fields.
+		if ( ! empty( trim( $first_name ) ) && empty( \get_user_meta( $customer_id, 'first_name', true ) ) ) {
+			\update_user_meta( $customer_id, 'first_name', $first_name );
+		}
+		if ( ! empty( trim( $last_name ) ) && empty( \get_user_meta( $customer_id, 'last_name', true ) ) ) {
+			\update_user_meta( $customer_id, 'last_name', $last_name );
+		}
+
+		$contact = [
 			'email'    => $customer->get_email(),
 			'metadata' => $metadata,
 		];


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Avoids a fatal and accounts for some missing user meta when building contact data for migrated Woo customers. This seems to be an edge case with migrated/imported users as "naturally created" WP users should always have a `user_registered` value, but we've seen that in rare cases imported users can lack this value.

### How to test the changes in this Pull Request:

Since it's impossible to delete the `user_registered` value from a user once created, we need to use `wp shell` to simulate the conditions for the error.

1. On `release`, use `wp shell` to delete the `date_created` value and the First and Last Name meta fields from the user (replace `56` with your test user's ID):

```bash
> $customer = new WC_Customer( 56 );
= WC_Customer {#16805}

> $customer->set_date_created( null );
= null

> $customer->save();
= 56

> delete_user_meta( 56, 'first_name' );
= true

> delete_user_meta( 56, 'last_name' );
= true
```

2. While in the same `wp shell` session, get the contact data and observe a fatal error:

```bash
> Newspack\Reader_Activation\Sync\WooCommerce::get_contact_from_customer( $customer );

   Error  Call to a member function date() on null.
```

3. Check out this branch, start a new `wp shell` session, and repeat. This time confirm that the contact data gets built, but without a `registration_date` value:

```bash
> $customer = new WC_Customer( 56 );
= WC_Customer {#16805}

> $customer->set_date_created( null );
= null

> $customer->save();
= 56

> delete_user_meta( 56, 'first_name' );
= true

> delete_user_meta( 56, 'last_name' );
= true

> Newspack\Reader_Activation\Sync\WooCommerce::get_contact_from_customer( $customer );
= [
    "email" => "user@test.co",
    "metadata" => [
      "payment_page" => "https://site.url/test"
      "membership_status" => "active",
      "sub_start_date" => "2025-01-14 20:53:22",
      "sub_end_date" => "",
      "billing_cycle" => "month",
      "recurring_payment" => "50.00",
      "last_payment_amount" => "50.00",
      "last_payment_date" => "2025-01-14 20:53:22",
      "next_payment_date" => "2025-02-13 20:53:22",
      "product_name" => "Premium Subscription",
      "payment_page_utm_source" => "",
      "payment_page_utm_medium" => "",
      "payment_page_utm_campaign" => "",
      "payment_page_utm_term" => "",
      "payment_page_utm_content" => "",
      "cancellation_reason" => "",
      "total_paid" => "50.00",
      "account" => 56,
      "registration_date" => "",
    ],
    "name" => "Test User",
  ]
```

4. Confirm that after calling `get_contact_from_customer` the billing first/last names are copied to the `first_name` and `last_name` user meta fields (this happens automatically when a new user is created during the checkout flow). You can check this in the User admin page for this user, or via `wp user meta list <user ID>` in WP CLI.

<img width="791" alt="Screenshot 2025-01-14 at 2 38 09 PM" src="https://github.com/user-attachments/assets/030b0bd6-0b6a-45ee-8ab6-5da03d761b91" />


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209154944954046