### PR TITLE
feat: rate limit checkout attempts

### DIFF
--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -174,14 +174,15 @@ class WooCommerce_Connection {
 	 * Check the rate limit for the current user or IP.
 	 * Currently locked behind a NEWSPACK_CHECKOUT_RATE_LIMIT environment constant, for controlled rollout.
 	 *
+	 * @param string $action_name   The action the user is trying to perform.
 	 * @param string $error_message Error message to display or return if the user should be rate-limited.
 	 * @param bool   $return_error  If true and the user should be rate-limited, return a WP_Error with the given message instead of a boolean value.
 	 *
 	 * @return bool|WP_Error True or WP_Error if the rate limit is exceeded, false otherwise.
 	 */
-	public static function rate_limit_by_user( $error_message = '', $return_error = false ) {
+	public static function rate_limit_by_user( $action_name, $error_message = '', $return_error = false ) {
 		$rate_limited = false;
-		if ( ! defined( 'NEWSPACK_CHECKOUT_RATE_LIMIT' ) ) {
+		if ( ! defined( 'NEWSPACK_CHECKOUT_RATE_LIMIT' ) || ! class_exists( 'WC_Rate_Limiter' ) ) {
 			return $rate_limited;
 		}
 		if ( ! $error_message ) {
@@ -191,7 +192,7 @@ class WooCommerce_Connection {
 		$now        = time();
 		$rate_limit = defined( 'NEWSPACK_CHECKOUT_RATE_LIMIT' ) ? (int) NEWSPACK_CHECKOUT_RATE_LIMIT : 90; // Number of seconds to wait before allowing the same user to attempt another checkout action. Default: 90.
 		if ( 0 === $rate_limit ) {
-			return $rate_limited; // If $rate_limit is 0 seconds, bail early to avoid creating a non-expiring transient.
+			return $rate_limited; // If $rate_limit is 0 seconds, no need to proceed.
 		}
 
 		// If not logged in, use IP.
@@ -201,13 +202,9 @@ class WooCommerce_Connection {
 		if ( ! $user_id ) {
 			return $rate_limited;
 		}
-		$transient_name = 'last_checkout_attempt_' . \wp_hash( $user_id, 'nonce' );
-		$last_attempt = (int) \get_transient( $transient_name );
-		if ( $last_attempt && $now - $last_attempt < $rate_limit ) {
-			$rate_limited = true;
-		}
-		\set_transient( $transient_name, $now, $rate_limit );
-
+		$hashed_user_id = \wp_hash( $user_id, 'nonce' );
+		$user_action    = "{$action_name}_{$hashed_user_id}";
+		$rate_limited   = \WC_Rate_Limiter::retried_too_soon( $user_action );
 		if ( $rate_limited ) {
 			if ( $return_error ) {
 				return new \WP_Error( 'newspack_rate_limit', $error_message );
@@ -215,6 +212,8 @@ class WooCommerce_Connection {
 				self::add_wc_notice( $error_message, 'error' );
 			}
 		}
+
+		\WC_Rate_Limiter::set_rate_limit( $user_action, $rate_limit );
 		return $rate_limited;
 	}
 
@@ -231,7 +230,7 @@ class WooCommerce_Connection {
 		if ( $is_validation_only || $errors->has_errors() ) {
 			return;
 		}
-		self::rate_limit_by_user( __( 'Please wait a moment before trying to complete this transaction again.', 'newspack-plugin' ) );
+		self::rate_limit_by_user( 'checkout', __( 'Please wait a moment before trying to complete this transaction again.', 'newspack-plugin' ) );
 	}
 
 	/**
@@ -242,7 +241,7 @@ class WooCommerce_Connection {
 	 * @return bool
 	 */
 	public static function rate_limit_payment_methods( $is_valid ) {
-		if ( self::rate_limit_by_user( __( 'Please wait a moment before trying to add a new payment method.', 'newspack-plugin' ) ) ) {
+		if ( self::rate_limit_by_user( 'add_payment_method', __( 'Please wait a moment before trying to add a new payment method.', 'newspack-plugin' ) ) ) {
 			return false;
 		}
 

--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -58,6 +58,8 @@ class WooCommerce_Connection {
 		\add_filter( 'wc_memberships_for_teams_product_team_user_input_fields', [ __CLASS__, 'wc_memberships_for_teams_product_team_user_input_fields' ] );
 
 		\add_action( 'woocommerce_payment_complete', [ __CLASS__, 'order_paid' ], 101 );
+		\add_action( 'woocommerce_after_checkout_validation', [ __CLASS__, 'rate_limit_checkout' ], 10, 2 );
+		\add_filter( 'woocommerce_add_payment_method_form_is_valid', [ __CLASS__, 'rate_limit_payment_methods' ] );
 		\add_action( 'wc_stripe_save_to_subs_checked', '__return_true' );
 
 		\add_filter( 'page_template', [ __CLASS__, 'page_template' ] );
@@ -131,6 +133,82 @@ class WooCommerce_Connection {
 		 * @param int $product_id Donation product post ID.
 		 */
 		\do_action( 'newspack_donation_order_processed', $order_id, $product_id );
+	}
+
+	/**
+	 * Get client IP.
+	 *
+	 * @return string|null Client IP.
+	 */
+	private static function get_client_ip() {
+		foreach ( array( 'HTTP_CLIENT_IP', 'HTTP_X_FORWARDED_FOR', 'HTTP_X_FORWARDED', 'HTTP_X_CLUSTER_CLIENT_IP', 'HTTP_FORWARDED_FOR', 'HTTP_FORWARDED', 'REMOTE_ADDR' ) as $key ) {
+			if ( array_key_exists( $key, $_SERVER ) === true ) {
+				foreach ( explode( ',', $_SERVER[ $key ] ) as $ip ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- sanitized below
+					$ip = trim( $ip );
+
+					if ( filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE ) !== false ) {
+						return $ip;
+					}
+				}
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Check the rate limit for the current user or IP.
+	 *
+	 * @param string $error_message Error message to display or return if the user should be rate-limited.
+	 * @param bool   $return_error  If true and the user should be rate-limited, return a WP_Error with the given message instead of a boolean value.
+	 *
+	 * @return bool|WP_Error True or WP_Error if the rate limit is exceeded, false otherwise.
+	 */
+	public static function rate_limit_by_user( $error_message = '', $return_error = false ) {
+		if ( ! $error_message ) {
+			$error_message = __( 'Please wait a moment before trying again.', 'newspack-plugin' );
+		}
+		$rate_limited = false;
+		$user_id      = get_current_user_id();
+		$now          = time();
+
+		// If not logged in, use IP.
+		if ( ! $user_id ) {
+			$user_id = self::get_client_ip();
+		}
+		if ( ! $user_id ) {
+			return $rate_limited;
+		}
+		$transient_name = 'last_checkout_attempt_' . \wp_hash( $user_id, 'nonce' );
+		$last_attempt = (int) \get_transient( $transient_name );
+		if ( $last_attempt && $now - $last_attempt < 90 ) {
+			$rate_limited = true;
+		}
+		\set_transient( $transient_name, $now, 90 );
+
+		if ( $rate_limited ) {
+			if ( $return_error ) {
+				return new \WP_Error( 'newspack_rate_limit', $error_message );
+			} else {
+				self::add_wc_notice( $error_message, 'error' );
+			}
+		}
+		return $rate_limited;
+	}
+
+	/**
+	 * Rate limit checkout attempts per user.
+	 *
+	 * @param  array    $posted_data An array of posted data.
+	 * @param  WP_Error $errors Validation error.
+	 */
+	public static function rate_limit_checkout( $posted_data, $errors ) {
+		$is_validation_only = boolval( filter_input( INPUT_POST, 'is_validation_only', FILTER_SANITIZE_NUMBER_INT ) );
+
+		// Don't rate limit if we're just validating checkout, or if there are other checkout errors.
+		if ( $is_validation_only || $errors->has_errors() ) {
+			return;
+		}
+		self::rate_limit_by_user( __( 'Please wait a moment before trying to complete this transaction again.', 'newspack-plugin' ) );
 	}
 
 	/**

--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -157,6 +157,7 @@ class WooCommerce_Connection {
 
 	/**
 	 * Check the rate limit for the current user or IP.
+	 * Currently locked behind a NEWSPACK_CHECKOUT_RATE_LIMIT environment constant, for controlled rollout.
 	 *
 	 * @param string $error_message Error message to display or return if the user should be rate-limited.
 	 * @param bool   $return_error  If true and the user should be rate-limited, return a WP_Error with the given message instead of a boolean value.
@@ -164,12 +165,16 @@ class WooCommerce_Connection {
 	 * @return bool|WP_Error True or WP_Error if the rate limit is exceeded, false otherwise.
 	 */
 	public static function rate_limit_by_user( $error_message = '', $return_error = false ) {
+		if ( ! defined( 'NEWSPACK_CHECKOUT_RATE_LIMIT' ) ) {
+			return false;
+		}
 		if ( ! $error_message ) {
 			$error_message = __( 'Please wait a moment before trying again.', 'newspack-plugin' );
 		}
 		$rate_limited = false;
 		$user_id      = get_current_user_id();
 		$now          = time();
+		$rate_limit   = defined( 'NEWSPACK_CHECKOUT_RATE_LIMIT' ) ? (int) NEWSPACK_CHECKOUT_RATE_LIMIT : 90; // Number of seconds to wait before allowing the same user to attempt another checkout action. Default: 90.
 
 		// If not logged in, use IP.
 		if ( ! $user_id ) {
@@ -180,10 +185,10 @@ class WooCommerce_Connection {
 		}
 		$transient_name = 'last_checkout_attempt_' . \wp_hash( $user_id, 'nonce' );
 		$last_attempt = (int) \get_transient( $transient_name );
-		if ( $last_attempt && $now - $last_attempt < 90 ) {
+		if ( $last_attempt && $now - $last_attempt < $rate_limit ) {
 			$rate_limited = true;
 		}
-		\set_transient( $transient_name, $now, 90 );
+		\set_transient( $transient_name, $now, $rate_limit );
 
 		if ( $rate_limited ) {
 			if ( $return_error ) {

--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -165,16 +165,19 @@ class WooCommerce_Connection {
 	 * @return bool|WP_Error True or WP_Error if the rate limit is exceeded, false otherwise.
 	 */
 	public static function rate_limit_by_user( $error_message = '', $return_error = false ) {
+		$rate_limited = false;
 		if ( ! defined( 'NEWSPACK_CHECKOUT_RATE_LIMIT' ) ) {
-			return false;
+			return $rate_limited;
 		}
 		if ( ! $error_message ) {
 			$error_message = __( 'Please wait a moment before trying again.', 'newspack-plugin' );
 		}
-		$rate_limited = false;
-		$user_id      = get_current_user_id();
-		$now          = time();
-		$rate_limit   = defined( 'NEWSPACK_CHECKOUT_RATE_LIMIT' ) ? (int) NEWSPACK_CHECKOUT_RATE_LIMIT : 90; // Number of seconds to wait before allowing the same user to attempt another checkout action. Default: 90.
+		$user_id    = get_current_user_id();
+		$now        = time();
+		$rate_limit = defined( 'NEWSPACK_CHECKOUT_RATE_LIMIT' ) ? (int) NEWSPACK_CHECKOUT_RATE_LIMIT : 90; // Number of seconds to wait before allowing the same user to attempt another checkout action. Default: 90.
+		if ( 0 === $rate_limit ) {
+			return $rate_limited; // If $rate_limit is 0 seconds, bail early to avoid creating a non-expiring transient.
+		}
 
 		// If not logged in, use IP.
 		if ( ! $user_id ) {
@@ -214,6 +217,21 @@ class WooCommerce_Connection {
 			return;
 		}
 		self::rate_limit_by_user( __( 'Please wait a moment before trying to complete this transaction again.', 'newspack-plugin' ) );
+	}
+
+	/**
+	 * Rate limit new payment methods per user.
+	 *
+	 * @param bool $is_valid Whether the form is valid.
+	 *
+	 * @return bool
+	 */
+	public static function rate_limit_payment_methods( $is_valid ) {
+		if ( self::rate_limit_by_user( __( 'Please wait a moment before trying to add a new payment method.', 'newspack-plugin' ) ) ) {
+			return false;
+		}
+
+		return $is_valid;
 	}
 
 	/**

--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -224,10 +224,8 @@ class WooCommerce_Connection {
 	 * @param  WP_Error $errors Validation error.
 	 */
 	public static function rate_limit_checkout( $posted_data, $errors ) {
-		$is_validation_only = boolval( filter_input( INPUT_POST, 'is_validation_only', FILTER_SANITIZE_NUMBER_INT ) );
-
-		// Don't rate limit if we're just validating checkout, or if there are other checkout errors.
-		if ( $is_validation_only || $errors->has_errors() ) {
+		// Don't rate limit if there are other checkout errors.
+		if ( $errors->has_errors() ) {
 			return;
 		}
 		self::rate_limit_by_user( 'checkout', __( 'Please wait a moment before trying to complete this transaction again.', 'newspack-plugin' ) );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds support for rate limiting checkout attempts by user. If a `NEWSPACK_CHECKOUT_RATE_LIMIT` environment constant is defined as an integer, checkout attempts that occur within that number of seconds of a prior checkout attempt by the same user (if logged in) or IP (if not logged in) will be rejected before WooCommerce sends payment info to any payment gateways. 

If WooCommerce detects any other checkout validation errors that would prevent the checkout from occurring (such as missing required fields), we won't count this as a checkout attempt, so that readers can attempt successive checkouts in order to correct errors without being rate limited. So in practice, only successful transactions and checkout requests which would result in declined payments should be rate-limited.

The mechanism used is WooCommerce's built-in [`WC_Rate_Limiter` utility](https://woocommerce.github.io/code-reference/classes/WC-Rate-Limiter.html). This offers a lightweight API to check and limit the rate of particular actions by arbitrary ID string.

Also adds rate-limiting for adding new payment methods in My Account, but because of how this feature is split between the main WooCommerce plugin and many payment gateway extension plugins, it doesn't necessarily rate limit declined payment methods (thus still allowing for card testing with some payment gateways). This will need to be handled in a separate PR, possibly via JS since each payment method behaves differently when deciding when/whether to contact the payment processor.

### How to test the changes in this Pull Request:

1. Check out this branch. Optionally disable reCAPTCHA in Newspack > Connections to make testing easier.
2. In `wp-config.php`, define `NEWSPACK_CHECKOUT_RATE_LIMIT` as something long enough for manual testing like `60` or `90`.
3. As an anonymous reader in a new browser session, start a Woo checkout modal checkout. After completing the first screen (payment details), click "Back" from the second screen and confirm that you can proceed to the second screen again without being rate-limited (validation-only checkout requests are not rate-limited).
4. Attempt to complete the checkout but with invalid input: for example, by using dev tools to edit the value of the email address field to an invalid email address, then submitting. Confirm that the response includes the error(s) about the invalid input, but not anything about rate limiting. You can also use WP CLI or error logging to confirm that a new transient is not created from this invalid checkout request.
5. Complete the checkout with valid inputs, but use a [test Stripe payment which will be declined](https://docs.stripe.com/testing#declined-payments).
6. After getting the "payment declined" error message and within the number of seconds defined in step 2, complete checkout again with a valid/non-declined payment method and confirm that you get an error message to `Please wait a moment before trying to complete this transaction again`.
7. Wait until the number of seconds elapses and then submit once more, and confirm that the transaction completes successfully.
8. Repeat with a new checkout session while logged into a reader account with saved payment details.
9. Repeat again with a regular (non-modal) Woo checkout.

#### Testing rate-limiting of adding new payment methods

1. Log into My Account as a reader and visit the Payment Methods menu link to add a new payment method (alternatively, just plug in `/my-account/add-payment-method` since this URL isn't blocked even if the menu item is hidden).
2. Add a new valid payment method, then try to immediately add another new payment method and confirm that the request is rejected with a `Please wait a moment before trying to add a new payment method` error message. (Note that the error message may flash and disappear after a moment, but this seems to be a Woo/My Account bug and isn't related to the changes in this PR.)
3. Wait until the number of seconds elapses and then try again, and confirm that the payment method is successfully added.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->