### PR TITLE
fix(wcs): expire manual subscriptions after on-hold duration

### DIFF
--- a/includes/plugins/woocommerce-subscriptions/class-on-hold-duration.php
+++ b/includes/plugins/woocommerce-subscriptions/class-on-hold-duration.php
@@ -126,9 +126,9 @@ class On_Hold_Duration {
 	 */
 	public static function maybe_schedule_expiration( $order_id, $subscription ) {
 		if ( 'on-hold' === $subscription->get_status() ) {
-			$on_hold_duration    = self::get_on_hold_duration();
-			$on_hold_duration_ts = 0 < $on_hold_duration ? $on_hold_duration * DAY_IN_SECONDS : HOUR_IN_SECONDS;
-			$timestamp           = $subscription->get_time( 'next_payment' ) + $on_hold_duration_ts;
+			$default_grace_period = 7 * DAY_IN_SECONDS; // 7 days, the number of days the retry system normally waits before marking a subscription as expired.
+			$on_hold_duration     = self::get_on_hold_duration() * DAY_IN_SECONDS;
+			$timestamp            = $subscription->get_time( 'next_payment' ) + $default_grace_period + $on_hold_duration;
 			as_schedule_single_action( $timestamp, self::AS_HOOK, [ $subscription->get_id() ], self::AS_GROUP );
 		}
 	}

--- a/includes/plugins/woocommerce-subscriptions/class-on-hold-duration.php
+++ b/includes/plugins/woocommerce-subscriptions/class-on-hold-duration.php
@@ -35,7 +35,7 @@ class On_Hold_Duration {
 		add_filter( 'wcs_default_retry_rules', [ __CLASS__, 'maybe_apply_on_hold_duration_rule' ], 99, 1 );
 		add_action( 'woocommerce_generated_manual_renewal_order', [ __CLASS__, 'maybe_schedule_expiration' ], 10, 2 );
 		add_action( 'woocommerce_subscription_renewal_payment_complete', [ __CLASS__, 'maybe_unschedule_expiration_on_manual_renewal' ], 10, 2 );
-		add_action( self::AS_HOOK, [ __CLASS__, 'handle_cron_event' ] );
+		add_action( self::AS_HOOK, [ __CLASS__, 'handle_scheduled_action' ] );
 	}
 
 	/**
@@ -126,11 +126,10 @@ class On_Hold_Duration {
 	 */
 	public static function maybe_schedule_expiration( $order_id, $subscription ) {
 		if ( 'on-hold' === $subscription->get_status() ) {
-			$on_hold_duration = self::get_on_hold_duration();
-			if ( 0 < $on_hold_duration ) {
-				$timestamp = $subscription->get_time( 'next_payment' ) + $on_hold_duration * DAY_IN_SECONDS;
-				as_schedule_single_action( $timestamp, self::AS_HOOK, [ $subscription->get_id() ], self::AS_GROUP );
-			}
+			$on_hold_duration    = self::get_on_hold_duration();
+			$on_hold_duration_ts = 0 < $on_hold_duration ? $on_hold_duration * DAY_IN_SECONDS : HOUR_IN_SECONDS;
+			$timestamp           = $subscription->get_time( 'next_payment' ) + $on_hold_duration_ts;
+			as_schedule_single_action( $timestamp, self::AS_HOOK, [ $subscription->get_id() ], self::AS_GROUP );
 		}
 	}
 
@@ -147,11 +146,11 @@ class On_Hold_Duration {
 	}
 
 	/**
-	 * Handle newspack_expire_manual_subscription cron event.
+	 * Handle expiration scheduled action.
 	 *
 	 * @param int $subscription_id Subscription ID.
 	 */
-	public static function handle_cron_event( $subscription_id ) {
+	public static function handle_scheduled_action( $subscription_id ) {
 		$subscription = wcs_get_subscription( $subscription_id );
 		if ( $subscription && 'on-hold' === $subscription->get_status() ) {
 			$subscription->update_status( 'expired' );

--- a/includes/plugins/woocommerce-subscriptions/class-on-hold-duration.php
+++ b/includes/plugins/woocommerce-subscriptions/class-on-hold-duration.php
@@ -14,6 +14,16 @@ defined( 'ABSPATH' ) || exit;
  */
 class On_Hold_Duration {
 	/**
+	 * The hook name for the manual subscription expiration scheduled action.
+	 */
+	const AS_HOOK = 'newspack_expire_manual_subscription';
+
+	/**
+	 * The group name for the manual subscription expiration scheduled action.
+	 */
+	const AS_GROUP = 'newspack_expire_manual_subscription';
+
+	/**
 	 * Initialize hooks and filters.
 	 */
 	public static function init() {
@@ -23,6 +33,9 @@ class On_Hold_Duration {
 
 		add_filter( 'woocommerce_subscription_settings', [ __CLASS__, 'add_on_hold_duration_setting' ], 11, 1 );
 		add_filter( 'wcs_default_retry_rules', [ __CLASS__, 'maybe_apply_on_hold_duration_rule' ], 99, 1 );
+		add_action( 'woocommerce_generated_manual_renewal_order', [ __CLASS__, 'maybe_schedule_expiration' ], 10, 2 );
+		add_action( 'woocommerce_subscription_renewal_payment_complete', [ __CLASS__, 'maybe_unschedule_expiration_on_manual_renewal' ], 10, 2 );
+		add_action( self::AS_HOOK, [ __CLASS__, 'handle_cron_event' ] );
 	}
 
 	/**
@@ -103,5 +116,45 @@ class On_Hold_Duration {
 			];
 		}
 		return $retry_rules;
+	}
+
+	/**
+	 * Conditionally schedule expiration action.
+	 *
+	 * @param int    $order_id     Order ID.
+	 * @param object $subscription Subscription object.
+	 */
+	public static function maybe_schedule_expiration( $order_id, $subscription ) {
+		if ( 'on-hold' === $subscription->get_status() ) {
+			$on_hold_duration = self::get_on_hold_duration();
+			if ( 0 < $on_hold_duration ) {
+				$timestamp = $subscription->get_time( 'next_payment' ) + $on_hold_duration * DAY_IN_SECONDS;
+				as_schedule_single_action( $timestamp, self::AS_HOOK, [ $subscription->get_id() ], self::AS_GROUP );
+			}
+		}
+	}
+
+	/**
+	 * Unschedule expiration if scheduled when manual subscription is renewed.
+	 *
+	 * @param \WC_Subscription $subscription The Subscription.
+	 * @param \WC_Order        $order        The order.
+	 */
+	public static function maybe_unschedule_expiration_on_manual_renewal( $subscription, $order ) {
+		if ( false !== as_has_scheduled_action( self::AS_HOOK, [ $subscription->get_id() ], self::AS_GROUP ) ) {
+			as_unschedule_action( self::AS_HOOK, [ $subscription->get_id() ], self::AS_GROUP );
+		}
+	}
+
+	/**
+	 * Handle newspack_expire_manual_subscription cron event.
+	 *
+	 * @param int $subscription_id Subscription ID.
+	 */
+	public static function handle_cron_event( $subscription_id ) {
+		$subscription = wcs_get_subscription( $subscription_id );
+		if ( $subscription && 'on-hold' === $subscription->get_status() ) {
+			$subscription->update_status( 'expired' );
+		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Part of https://app.asana.com/0/1200550061930446/1209066781737999/f

This PR adds a new scheduled action to expire manual subscriptions after the specified on-hold duration:

![Screenshot 2025-01-16 at 17 19 11](https://github.com/user-attachments/assets/6eec052b-2367-4a99-8d5a-d4e9cea6dc48)


### How to test the changes in this Pull Request:

1. Set at least two active subscriptions to manual, either as the reader via my-account or as admin via the edit subscriptions page in the edit billing menu.
2. Manually process renewals for both subscriptions via the edit subscriptions page.
3. In WPAdmin, WooCommerce > Status > Scheduled Actions, look for two pending `newspack_expire_manual_subscription` events that are scheduled to run X days after the next payment date, where X is what you have set as your site's on-hold duration (WooCommerce > Settings > Subscriptions > On-hold Duration) plus 7 days
4. As a reader, renew one of the on-hold subscriptions via my-account
5. Verify the subscription is now active as admin, and the matching scheduled action is no longer pending.
6. As admin, manually trigger the other `newspack_expire_manual_subscription` action
7. Verify the matching subscription is now expired

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209066782957092