### PR TITLE
Remove support for legacy form checkout

### DIFF
--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -38,6 +38,7 @@ class WooCommerce_Connection {
 		include_once __DIR__ . '/class-woocommerce-duplicate-orders.php';
 
 		\add_action( 'admin_init', [ __CLASS__, 'disable_woocommerce_setup' ] );
+		\add_action( 'wp_loaded', [ __CLASS__, 'disable_legacy_form_checkout' ], 1 );
 		\add_filter( 'option_woocommerce_subscriptions_allow_switching', [ __CLASS__, 'force_allow_subscription_switching' ], 10, 2 );
 		\add_filter( 'option_woocommerce_subscriptions_allow_switching_nyp_price', [ __CLASS__, 'force_allow_subscription_switching' ], 10, 2 );
 		\add_filter( 'option_woocommerce_subscriptions_enable_retry', [ __CLASS__, 'force_allow_failed_payment_retry' ] );
@@ -94,6 +95,20 @@ class WooCommerce_Connection {
 			if ( $task_list ) {
 				$task_list->hide();
 			}
+		}
+	}
+
+	/**
+	 * Remove support for the legacy form-based checkout.
+	 * It's not necessary because all sites use modal or ajax checkout.
+	 */
+	public static function disable_legacy_form_checkout() {
+		if ( defined( 'NEWSPACK_ALLOW_LEGACY_FORM_CHECKOUT' ) && NEWSPACK_ALLOW_LEGACY_FORM_CHECKOUT ) {
+			return;
+		}
+
+		if ( class_exists( 'WC_Form_Handler' ) ) {
+			\remove_action( 'wp_loaded', [ 'WC_Form_Handler', 'checkout_action' ], 20 );
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Removes support for the legacy form-based WooCommerce checkout. Other than for backwards compatibility, I believe the main purpose it's still around is to support browsers that have JS disabled, but that's not something we support (especially since it wouldn't work with reCaptcha).

### How to test the changes in this Pull Request:

Simplest way to verify that it's been removed:

1. Add a `die( 'ATTEMPTING FORM CHECKOUT' );` [here in your Woo plugin](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/includes/class-wc-form-handler.php#L382) in the `checkout_action` method.
2. Put this script somewhere:
```
<?php

$site = 'http://newspackdev.local';

$body = [
	'woocommerce_checkout_place_order'    => 1,
];

var_dump( wp_remote_post( $site, [ 'body' => $body, 'timeout' => 50 ] ) );
```
4. Run it with `wp eval-file scriptfile.php` before applying this patch. Observe that the response contains that `ATTEMPTING FORM CHECKOUT` string within it.
5. Apply the patch. Run the script again. Observe that the response doesn't contain the string.
6. Verify regular Checkout screen and modal checkout work.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->