### PR TITLE
fix(recaptcha): improvements for reCAPTCHA v2 + modal checkout

### DIFF
--- a/includes/reader-revenue/woocommerce/class-woocommerce-products.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-products.php
@@ -52,7 +52,7 @@ class WooCommerce_Products {
 		return [
 			'newspack_autocomplete_orders' => [
 				'id'            => '_newspack_autocomplete_orders',
-				'wrapper_class' => 'show_if_virtual',
+				'wrapper_class' => '',
 				'label'         => __( 'Auto-complete orders', 'newspack-plugin' ),
 				'description'   => __( 'Allow orders containing this product to automatically complete upon successful payment.', 'newspack-plugin' ),
 				'default'       => 'yes',
@@ -197,11 +197,7 @@ class WooCommerce_Products {
 	 * @param WC_Product $product The product associated with this order item.
 	 */
 	public static function require_order_processing( $needs_proccessing, $product ) {
-		if ( $product->is_virtual() ) {
-			return self::get_custom_option_value( $product, 'newspack_autocomplete_orders' ) ? false : $needs_proccessing;
-		}
-
-		return $needs_proccessing;
+		return self::get_custom_option_value( $product, 'newspack_autocomplete_orders' ) ? false : $needs_proccessing;
 	}
 }
 

--- a/newspack.php
+++ b/newspack.php
@@ -14,7 +14,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'NEWSPACK_PLUGIN_VERSION', '5.12.0' );
+define( 'NEWSPACK_PLUGIN_VERSION', '5.12.0--recaptcha-test.8' );
 
 // Define NEWSPACK_PLUGIN_FILE.
 if ( ! defined( 'NEWSPACK_PLUGIN_FILE' ) ) {

--- a/newspack.php
+++ b/newspack.php
@@ -14,7 +14,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'NEWSPACK_PLUGIN_VERSION', '5.12.0--recaptcha-test.8' );
+define( 'NEWSPACK_PLUGIN_VERSION', '5.12.0' );
 
 // Define NEWSPACK_PLUGIN_FILE.
 if ( ! defined( 'NEWSPACK_PLUGIN_FILE' ) ) {

--- a/src/other-scripts/recaptcha/index.js
+++ b/src/other-scripts/recaptcha/index.js
@@ -50,11 +50,16 @@ function renderV2Widget( form, onSuccess = null, onError = null ) {
 			form.appendChild( hiddenField );
 		}
 		hiddenField.value = token;
-		const buttons = [
-			...form.querySelectorAll( 'input[type="submit"], button[type="submit"]' )
-		];
 		form.setAttribute( 'data-recaptcha-validated', '1' );
-		form.requestSubmit( buttons[ buttons.length - 1 ] );
+
+		// If the form has a #place_order button, click it.
+		const placeOrder = form.querySelector( '#place_order' );
+		if ( placeOrder ) {
+			placeOrder.click();
+		} else {
+			form.requestSubmit( form.querySelector( 'input[type="submit"], button[type="submit"]' ) );
+		}
+
 		refreshV2Widget( form );
 	};
 	// Callback when reCAPTCHA rendering fails or expires.
@@ -77,8 +82,10 @@ function renderV2Widget( form, onSuccess = null, onError = null ) {
 
 	// Attach widget to form events.
 	const attachListeners = () => {
+		form.removeAttribute( 'data-submit-button-click' );
 		getIntersectionObserver( () => renderV2Widget( form, onSuccess, onError ) ).observe( form, { attributes: true } );
-		form.addEventListener( 'submit', e => {
+
+		const handleSubmit = e => {
 			if ( ! form.hasAttribute( 'data-recaptcha-validated' ) && ! form.hasAttribute( 'data-skip-recaptcha' ) ) {
 				e.preventDefault();
 				e.stopImmediatePropagation();
@@ -94,7 +101,17 @@ function renderV2Widget( form, onSuccess = null, onError = null ) {
 			} else {
 				form.removeAttribute( 'data-recaptcha-validated' );
 			}
-		}, true );
+		};
+		form.addEventListener( 'submit', handleSubmit, true );
+
+		const placeOrderClone = form.querySelector( '#place_order_clone' );
+		if ( placeOrderClone ) {
+			placeOrderClone.addEventListener( 'click', e => {
+				e.preventDefault();
+				e.stopImmediatePropagation();
+				handleSubmit( e )
+			}, true );
+		}
 	}
 	// Refresh reCAPTCHA widgets on Woo checkout update and error.
 	if ( jQuery ) {

--- a/src/other-scripts/recaptcha/style.scss
+++ b/src/other-scripts/recaptcha/style.scss
@@ -23,3 +23,14 @@
 		margin-top: 0 !important;
 	}
 }
+
+// Hide the "real" #place_order button but only in modal checkout and if we've rendered a v2 widget.
+/* stylelint-disable-next-line selector-id-pattern */
+#newspack_modal_checkout_container form[name="checkout"] {
+	&[data-recaptcha-widget-id] {
+		/* stylelint-disable-next-line selector-id-pattern */
+		#place_order {
+			display: none !important;
+		}
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Along with https://github.com/Automattic/newspack-blocks/pull/2028, implements improvements to the reCAPTCHA v2 integration in a modal checkout context. Also introduces a new option (via environment constant, for now) to allow third-party WooCommerce extensions to load their assets in modal checkout, to allow for greater flexibility. Not all Woo extensions are guaranteed to work with the modal checkout, but many will.

These changes came about due to issues some publishers saw when using the [ELEX Address Verification plugin](https://wordpress.org/plugins/address-validation-address-auto-complete/)—this plugin triggers actions on the `click` event of the `#place_order` button in checkout, which is also bound to our reCAPTCHA v2 widget execution. This causes a conflict where only one of these bound events will fire on click—but because both ELEX and reCAPTCHA can block a checkout request upon failure, enabling both will make it impossible to complete checkout.

This PR avoids such conflicts by creating a clone of the `#place_order` button in our modal checkout template, hiding the original button element, and binding our reCAPTCHA v2 widget execution to the clone instead of the original. When the reCAPTCHA widget fires its success callback (either upon initial pass or challenge pass), it will trigger a `click` event on the "real" `#place_order` button, which will allow other extensions with events bound to that button to do their own thing.

To be clear, this PR doesn't indicate full Newspack support for the ELEX plugin—but it will allow for publishers to test and use plugins like ELEX alongside Newspack, if the resulting experience is acceptable.

### How to test the changes in this Pull Request:

#### Pre-testing setup

1. Add `define( 'NEWSPACK_ALLOW_ALL_CHECKOUT_SCRIPTS', true );` to wp-config.php to allow unsupported Woo extensions to load their assets in modal checkout.
2. Connect and enble reCAPTCHA v2 in Newspack > Connections.
3. Install, activate and configure an unsupported Woo extension plugin which would normally conflict with reCAPTCHA v2. To test with [ELEX](https://wordpress.org/plugins/address-validation-address-auto-complete/), install the plugin, then sign up for a free EasyPost account to obtain a test API key (or DM me for a key you can use) and enter the key in the API credentials screen (`https://siteurl/wp-admin/admin.php?page=wc-settings&tab=elex_address_autocomplete_validation&section=elex-api-credentials`). Also make sure to enable address validation via EasyPost in the Address Validation settings page:

<img width="820" alt="Screenshot 2025-01-21 at 12 25 31 PM" src="https://github.com/user-attachments/assets/c69ed045-ef77-4405-a90b-04e1b46535a8" />

4. If using ELEX, make sure to enable address fields in **Newspack > Reader Revenue > Donations** or ELEX will block all checkout requests due to missing address inputs. Alternatively, test using a shippable product, which will always show both billing and shipping address fields in modal checkouts.

#### Testing steps

1. Check out this branch and https://github.com/Automattic/newspack-blocks/pull/2028.
2. As a reader, start a modal checkout via Donate or Checkout Button blocks.
3. Fill in all required address fields but using a fake (non-existent) address on modal screen 1.
4. On modal screen 2, complete payment details and click "Complete transaction" to start the checkout request.
5. Confirm that you see a reCAPTCHA v2 widget challenge (make sure your reCAPTCHA settings in Google are set to highest security to ensure that you'll always be challenged).
6. After completing the reCAPTCHA challenge, confirm that you get an error response: `Address verification failed`
7. Go back to modal screen 1 and update the address fields using a real address (I tested with a US-based address—non-US addresses are currently untested).
8. Go back to modal screen 2 and submit payment details again. Confirm that you get another reCAPTCHA v2 challenge.
9. After completing the reCAPTCHA challenge, this time confirm that the address verification succeeds with a popup:

<img width="675" alt="Screenshot 2025-01-21 at 12 35 02 PM" src="https://github.com/user-attachments/assets/aef892f1-15f2-4397-a994-19ef3b6cdf9a" />

10. After accepting the suggested address, confirm that the transaction completes successfully.
11. Smoke test transactions with reCAPTCHA v3 enabled, and reCAPTCHA disabled entirely. In both cases the address verification should occur as soon as you first click "Complete transaction" with all required fields filled out.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209184701915831