### PR TITLE
fix(corrections): replace deprecated sanitize method

### DIFF
--- a/includes/corrections/class-corrections.php
+++ b/includes/corrections/class-corrections.php
@@ -363,7 +363,7 @@ class Corrections {
 		}
 
 		$corrections_active   = filter_input( INPUT_POST, self::CORRECTIONS_ACTIVE_META, FILTER_SANITIZE_NUMBER_INT );
-		$corrections_location = isset( $_POST[ self::CORRECTIONS_LOCATION_META ] ) ? sanitize_text_field( $_POST[ self::CORRECTIONS_LOCATION_META ] ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		$corrections_location = filter_input( INPUT_POST, self::CORRECTIONS_LOCATION_META, FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 		$corrections_data     = filter_input_array(
 			INPUT_POST,
 			[

--- a/includes/corrections/class-corrections.php
+++ b/includes/corrections/class-corrections.php
@@ -363,7 +363,7 @@ class Corrections {
 		}
 
 		$corrections_active   = filter_input( INPUT_POST, self::CORRECTIONS_ACTIVE_META, FILTER_SANITIZE_NUMBER_INT );
-		$corrections_location = filter_input( INPUT_POST, self::CORRECTIONS_LOCATION_META, FILTER_SANITIZE_STRING );
+		$corrections_location = isset( $_POST[ self::CORRECTIONS_LOCATION_META ] ) ? sanitize_text_field( $_POST[ self::CORRECTIONS_LOCATION_META ] ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing
 		$corrections_data     = filter_input_array(
 			INPUT_POST,
 			[


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

See https://a8c.slack.com/archives/C07LB7B14GZ/p1737646629319029?thread_ts=1736808604.571439&cid=C07LB7B14GZ

This PR replaces the deprecated `FILTER_SANITIZE_STRING` sanitize flag with `FILTER_SANITIZE_FULL_SPECIAL_CHARS`.

### How to test the changes in this Pull Request:

1. Smoke test corrections location behavior (See https://github.com/Automattic/newspack-plugin/pull/3638 for testing instructions for this)

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->