### PR TITLE
Hotfix/reader data sync requests

### DIFF
--- a/src/reader-activation/checkout.js
+++ b/src/reader-activation/checkout.js
@@ -1,12 +1,6 @@
 import { EVENTS, emit } from './events.js';
 
-import { getReader } from './index.js';
-import Store from './store.js';
-
-/**
- * Reader Activation Library.
- */
-export const store = Store();
+import { store, getReader } from './index.js';
 
 /**
  * Set the pending checkout URL.

--- a/src/reader-activation/store.js
+++ b/src/reader-activation/store.js
@@ -109,6 +109,11 @@ function syncItem( key ) {
 		payload.value = JSON.stringify( value );
 	}
 
+	// Bail if value matches server value.
+	if ( newspack_reader_data?.items && newspack_reader_data.items[ key ] === payload.value ) {
+		return Promise.reject( 'Value is equal to the one stored.' );
+	}
+
 	const req = new XMLHttpRequest();
 	req.open( payload.value ? 'POST' : 'DELETE', newspack_reader_data.api_url, true );
 	req.setRequestHeader( 'Content-Type', 'application/json' );
@@ -125,6 +130,8 @@ function syncItem( key ) {
 			if ( 200 !== req.status ) {
 				return reject( req );
 			}
+			// Update the known server value.
+			newspack_reader_data.items[ key ] = payload.value;
 			return resolve( req );
 		};
 	} );

--- a/src/reader-activation/store.js
+++ b/src/reader-activation/store.js
@@ -23,22 +23,24 @@ const config = {
 };
 
 /**
- * Queue of keys to sync with the server every second.
- * No need to sync data for temporary sessions.
+ * Initialize sync interval.
  *
- * @type {string[]} Array of keys.
+ * @param {string[]} queue Store items keys to sync.
+ *
+ * @return {void}
  */
-const syncQueue = [];
-
-setInterval( () => {
-	if ( ! syncQueue.length || newspack_reader_data?.is_temporary ) {
-		return;
-	}
-	const key = syncQueue.shift();
-	syncItem( key )
-		.then( () => clearPendingSync( key ) )
-		.catch( () => setPendingSync( key ) );
-}, 1000 );
+function initializeSyncInterval( queue ) {
+	setInterval( () => {
+		// Bail if there are no items to sync or if it's a temporary session.
+		if ( ! queue.length || newspack_reader_data?.is_temporary ) {
+			return;
+		}
+		const key = queue.shift();
+		syncItem( key )
+			.then( () => clearPendingSync( key ) )
+			.catch( () => setPendingSync( key ) );
+	}, 1000 );
+}
 
 /**
  * Get store item key
@@ -111,7 +113,7 @@ function syncItem( key ) {
 
 	// Bail if value matches server value.
 	if ( newspack_reader_data?.items && newspack_reader_data.items[ key ] === payload.value ) {
-		return Promise.reject( 'Value is equal to the one stored.' );
+		return Promise.resolve();
 	}
 
 	const req = new XMLHttpRequest();
@@ -206,10 +208,27 @@ function _set( key, value, internal = false ) {
  * @return {Object} The store object.
  */
 export default function Store() {
+	/**
+	 * There should only be one store instance.
+	 */
+	if ( window.newspackRASInitialized && window.newspackReaderActivation?.store ) {
+		return window.newspackReaderActivation.store;
+	}
+
+	/**
+	 * Queue of keys to sync with the server every second.
+	 *
+	 * @type {string[]} Array of keys.
+	 */
+	const syncQueue = [];
+	initializeSyncInterval( syncQueue );
+
 	// Push unsynced items to the sync queue.
 	const unsynced = _get( 'unsynced', true ) || [];
 	for ( const key of unsynced ) {
-		syncQueue.push( key );
+		if ( ! syncQueue.includes( key ) ) {
+			syncQueue.push( key );
+		}
 	}
 
 	// Rehydrate items from server. No need to rehydrate for temporary sessions.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

p1737659676664879-slack-C015W6BES8J

This hotfix reduces the amount of unnecessary requests to sync reader data:

1. Fix the duplicate initialization of the store from the checkout js by importing the one already initialized
2. Prevent syncing data that matches the value already stored
3. Refactor the store a bit to ensure only one instance is initialized and the sync interval is attached to the store instantiation

### How to test the changes in this Pull Request:

1. While on the release branch, sign in as a reader, visit an article, and confirm you always get 2 consecutive requests with the same payload
2. Also confirm that it also posts requests containing `article_view_per_month`,  `article_view_per_week` with values that already match the ones pulled from the server (see `window.newspack_reader_data.items`)
4. Checkout this branch, refresh the article page and confirm only one request goes out containing the pageview payload to update
5. Navigate to other articles and confirm the `article_view_per_month` and `article_view_per_week` (one for each) sync requests go out with new payload

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->