### PR TITLE
fix(reader-revenue): collect transaction fee settings

### DIFF
--- a/includes/wizards/class-reader-revenue-wizard.php
+++ b/includes/wizards/class-reader-revenue-wizard.php
@@ -399,7 +399,7 @@ class Reader_Revenue_Wizard extends Wizard {
 		}
 
 		if ( isset( $settings['allow_covering_fees_label'] ) ) {
-			update_option( 'newspack_donations_allow_covering_fees_label', intval( $settings['allow_covering_fees_label'] ) );
+			update_option( 'newspack_donations_allow_covering_fees_label', sanitize_text_field( $settings['allow_covering_fees_label'] ) );
 		}
 		if ( isset( $settings['fee_multiplier'] ) ) {
 			update_option( 'newspack_blocks_donate_fee_multiplier', $settings['fee_multiplier'] );
@@ -520,7 +520,7 @@ class Reader_Revenue_Wizard extends Wizard {
 				'woopayments' => $wc_configuration_manager->woopayments_data(),
 			],
 			'additional_settings'      => [
-				'allow_covering_fees'         => boolval( get_option( 'newspack_donations_allow_covering_fees', false ) ),
+				'allow_covering_fees'         => boolval( get_option( 'newspack_donations_allow_covering_fees', true ) ),
 				'allow_covering_fees_default' => boolval( get_option( 'newspack_donations_allow_covering_fees_default', false ) ),
 				'allow_covering_fees_label'   => get_option( 'newspack_donations_allow_covering_fees_label', '' ),
 				'fee_multiplier'              => get_option( 'newspack_blocks_donate_fee_multiplier', '2.9' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes issues with the "Collect transaction fee" settings in Reader Revenue.

### How to test the changes in this Pull Request:

1. Install the [latest release build](https://github.com/Automattic/newspack-plugin/releases/tag/v5.12.3) on a fresh testing site and complete initial setup + install required Woo extensions
2.  Visit **Newspack > Reader Revenue > Payment Methods** and connect a payment gateway. Observe that the "Collect transaction fees" section appears but disabled.

<img width="1056" alt="Screenshot 2025-01-23 at 5 08 22 PM" src="https://github.com/user-attachments/assets/561753fd-98da-489b-9154-9d8838033f0a" />

3. As a reader, start a transaction via the Donate block. Proceed to the second screen and observe that the checkbox to cover transaction fees appears in the payment details box, even though it appears disabled in the settings section.
4. Install the build from this PR and refresh the settings page. Confirm that the settings section now appears enabled, matching the reader-facing state. Also confirm that you can disable and reenable it, and that the reader-facing state always matches the admin state.
5. Add a custom message in the "custom message" field and save. Confirm that the custom string persists after saving and refreshing the admin page, and that the reader-facing checkbox shows the custom message here, too.
6. Delete the custom message and save. Confirm that the empty field persists and that the reader-facing checkbox now shows the default message again.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209144885590735