### PR TITLE
fix: make the cart, checkout pages use shortcodes on install

### DIFF
--- a/includes/plugins/class-woocommerce.php
+++ b/includes/plugins/class-woocommerce.php
@@ -20,6 +20,7 @@ class WooCommerce {
 	public static function init() {
 		add_action( 'wp_loaded', [ __CLASS__, 'disable_wc_author_archive_override' ] );
 		add_filter( 'woocommerce_rest_prepare_shop_order_object', [ __CLASS__, 'modify_shop_order_wc_rest_api_payload' ] );
+		add_filter( 'woocommerce_create_pages', [ __CLASS__, 'use_shortcodes_for_cart_checkout' ] );
 	}
 
 	/**
@@ -51,6 +52,19 @@ class WooCommerce {
 		}
 		$response->set_data( $data );
 		return $response;
+	}
+
+	/**
+	 * Override the default page contents when creating the WooCommerce Cart and Checkout pages.
+	 *
+	 * @param array $woocommerce_pages Defaults for WooCommerce pages created on install.
+	 * @return array
+	 */
+	public static function use_shortcodes_for_cart_checkout( $woocommerce_pages ) {
+		$woocommerce_pages['cart']['content'] = '<!-- wp:shortcode -->[woocommerce_cart]<!-- /wp:shortcode -->';
+		$woocommerce_pages['checkout']['content'] = '<!-- wp:shortcode -->[woocommerce_checkout]<!-- /wp:shortcode -->';
+
+		return $woocommerce_pages;
 	}
 }
 WooCommerce::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR makes sure new Newspack installs use the shortcode version of the Woo Cart and Checkout. The latter is required for PayPal Payments to work in the modal checkout; there may be other functionality that doesn't work 100% without these shortcodes, too.

See: 1200550061930446-as-1209066781737984

### How to test the changes in this Pull Request:

1. Apply this PR and run `npm run release:archive` to generate a zip of the updated plugin.
2. Install this plugin on a fresh site, like a new Jurassic Ninja site.
3. Activate Woo and let it run it's mini setup (you can skip the guided setup).
4. Navigate to Pages and edit the Cart and Checkout pages; confirm they use the shortcode for the content, and not blocks.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->