### PR TITLE
fix(ia): dashboard header icon background

### DIFF
--- a/src/wizards/newspack/views/dashboard/style.scss
+++ b/src/wizards/newspack/views/dashboard/style.scss
@@ -5,10 +5,6 @@
 @use "~@wordpress/base-styles/colors" as wp-colors;
 @use "../../../../shared/scss/colors";
 
-.newspack-icon {
-	background-color: var(--newspack-ui-color-primary);
-}
-
 .newspack-wizard__content {
 	margin: 0;
 	max-width: 100%;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The variable being used to render the Newspack icon for the dashboard wizard (`--newspack-ui-color-primary`) is not available, causing it to appear as a blank square:

<img width="516" alt="image" src="https://github.com/user-attachments/assets/70bc7bf4-d8b6-46c8-9d6c-86fce6a8b691" />

Removing it allows for the Newspack icon to render the same way for all wizards, which is the new darker blue.

### How to test the changes in this Pull Request:

1. While on `epic/ia`, confirm that the wizard on "Newspack -> Dashboard" doesn't render the Newspack icon correctly
2. Checkout this branch, refresh the page and confirm the header renders as expected
3. Navigate to "Audience -> Setup" and confirm it renders the same

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->