### PR TITLE
style(tabbed-nav): avoid 1px jank on link hover

### DIFF
--- a/src/components/src/tabbed-navigation/style.scss
+++ b/src/components/src/tabbed-navigation/style.scss
@@ -39,6 +39,7 @@
 			display: flex;
 			font-weight: bold;
 			height: 48px;
+			outline: none;
 			padding: 12px 15px;
 			text-decoration: none;
 
@@ -51,15 +52,10 @@
 			&:focus,
 			&:hover {
 				color: var(--wp-admin-theme-color);
-				outline: none;
-			}
-
-			&:focus {
-				box-shadow: none;
 			}
 
 			&:focus-visible {
-				outline: 2px solid;
+				outline: 2px solid var(--wp-admin-theme-color);
 				outline-offset: -2px;
 			}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Attempts to avoid issues with some browsers/OS combinations that result in a tiny 1px movement when hovering over tabbed navigation links.

### How to test the changes in this Pull Request:

Confirm that link styles change as expected in `:hover`, `:focus`, and `:focus-visible` states, and that the words within don't shift position at all when transitioning between states.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->