### PR TITLE
fix: create guest contributors dummy emails

### DIFF
--- a/includes/plugins/co-authors-plus/class-guest-contributor-role.php
+++ b/includes/plugins/co-authors-plus/class-guest-contributor-role.php
@@ -268,7 +268,7 @@ class Guest_Contributor_Role {
 		if ( is_string( $user_or_name ) ) {
 			return $user_or_name . '@' . $email_domain;
 		}
-		return $user->user_login . '@' . $email_domain;
+		return $user_or_name->user_login . '@' . $email_domain;
 	}
 
 	/**

--- a/tests/unit-tests/guest-contributor-role.php
+++ b/tests/unit-tests/guest-contributor-role.php
@@ -22,6 +22,22 @@ class Newspack_Test_Guest_Contributor_Role extends WP_UnitTestCase {
 	/**
 	 * On a post with author.
 	 */
+	public function test_guest_contributor_role_get_dummy_email() {
+		$email_domain = Guest_Contributor_Role::get_dummy_email_domain();
+		$user = get_userdata( 1 );
+
+		$expected = $user->user_login . '@' . $email_domain;
+
+		$dummy_email = Guest_Contributor_Role::get_dummy_email_address( $user );
+		$this->assertSame( $expected, $dummy_email );
+
+		$dummy_email = Guest_Contributor_Role::get_dummy_email_address( $user->user_login );
+		$this->assertSame( $expected, $dummy_email );
+	}
+
+	/**
+	 * On a post with author.
+	 */
 	public function test_guest_contributor_role_dummy_email_hiding_default() {
 		$email_domain = Guest_Contributor_Role::get_dummy_email_domain();
 		$user_id = \wp_insert_user(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a regression added by https://github.com/Automattic/newspack-plugin/pull/3375 that made email for guest contributors not be created.

### How to test the changes in this Pull Request:

1. Create a new guest author and leave the email field empty
2. Confirm that a dummy email was created for the user


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209254840429583