### PR TITLE
fix(nav-tabs): do not show native nav tabs in post editor

### DIFF
--- a/includes/wizards/class-newsletters-wizard.php
+++ b/includes/wizards/class-newsletters-wizard.php
@@ -368,7 +368,7 @@ class Newsletters_Wizard extends Wizard {
 		if ( 'admin.php' === $pagenow && isset( $this->admin_screens[ $sanitized_page ] ) ) {
 			// admin page screen: admin.php?page={page} .
 			$screen_slug = $sanitized_page;
-		} elseif ( 'edit.php' === $pagenow || 'post-new.php' === $pagenow || 'post.php' === $pagenow ) {
+		} elseif ( 'edit.php' === $pagenow ) {
 			if ( ! $sanitized_post_type ) {
 				$sanitized_post_type = get_post_type( $sanitized_post_id );
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Ensures that the navigation tabs shown in "native" WP-admin-style Newspack dashboard pages are not shown in the post editor. Currently the Newsletters plugin and its pages are the only ones affected.

### How to test the changes in this Pull Request:

1. On `epic/ia`, add a new Newsletters Ad and edit an existing one. Observe that the "Ads" and "Advertisers" navigation tabs are displayed in both contexts, floating above the block editor content area.
2. Check out this branch and refresh both "new" and "edit" pages. Confirm that the tabs don't appear anymore.
3. Confirm that the tabs ARE still shown in the Newsletters Ads and Advertisers dashboard pages, and while editing an Advertiser term.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->