### PR TITLE
fix(ia): tweak syndication plugin cards behavior

### DIFF
--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -562,7 +562,7 @@ class Plugin_Manager {
 		}
 
 		if ( \is_plugin_active( $installed_plugins[ $plugin_slug ] ) ) {
-			return new WP_Error( 'newspack_plugin_already_active', __( 'The plugin is already active.', 'newspack-plugin' ) );
+			return true;
 		}
 
 		$activated = activate_plugin( $installed_plugins[ $plugin_slug ] );

--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -199,7 +199,7 @@ class Plugin_Manager {
 			],
 			'publish-to-apple-news'       => [
 				'Name'        => \esc_html__( 'Publish to Apple News', 'newspack-plugin' ),
-				'Description' => \esc_html__( 'Export and synchronize posts to Apple format', 'newspack-plugin' ),
+				'Description' => \esc_html__( 'Export and synchronize posts to Apple format.', 'newspack-plugin' ),
 				'Author'      => \esc_html__( 'Alley Interactive', 'newspack-plugin' ),
 				'AuthorURI'   => \esc_url( 'https://www.alleyinteractive.com' ),
 				'PluginURI'   => \esc_url( 'https://github.com/alleyinteractive/apple-news' ),

--- a/src/wizards/newspack/views/settings/syndication/plugins.tsx
+++ b/src/wizards/newspack/views/settings/syndication/plugins.tsx
@@ -19,6 +19,7 @@ const PLUGINS: Record< string, PluginCard > = {
 		title: __( 'Apple News', 'newspack-plugin' ),
 		editLink: 'admin.php?page=apple-news-options',
 		isConfigurable: true,
+		reloadOnStatusChange: false,
 		description: __(
 			'Export and synchronize posts to Apple format',
 			'newspack-plugin'
@@ -27,6 +28,8 @@ const PLUGINS: Record< string, PluginCard > = {
 	distributor: {
 		slug: 'distributor',
 		title: __( 'Distributor', 'newspack-plugin' ),
+		editLink: 'admin.php?page=distributor',
+		reloadOnStatusChange: false,
 		description: __(
 			'Distributor is a WordPress plugin that makes it easy to syndicate and reuse content across your websites — whether in a single multisite or across the web.',
 			'newspack-plugin'

--- a/src/wizards/newspack/views/settings/syndication/plugins.tsx
+++ b/src/wizards/newspack/views/settings/syndication/plugins.tsx
@@ -16,12 +16,12 @@ import WizardsPluginCard from '../../../../wizards-plugin-card';
 const PLUGINS: Record< string, PluginCard > = {
 	'publish-to-apple-news': {
 		slug: 'publish-to-apple-news',
-		title: __( 'Apple News', 'newspack-plugin' ),
+		title: __( 'Publish to Apple News', 'newspack-plugin' ),
 		editLink: 'admin.php?page=apple-news-options',
 		isConfigurable: true,
 		reloadOnStatusChange: false,
 		description: __(
-			'Export and synchronize posts to Apple format',
+			'Export and synchronize posts to Apple format.',
 			'newspack-plugin'
 		),
 	},

--- a/src/wizards/newspack/views/settings/syndication/plugins.tsx
+++ b/src/wizards/newspack/views/settings/syndication/plugins.tsx
@@ -19,7 +19,7 @@ const PLUGINS: Record< string, PluginCard > = {
 		title: __( 'Publish to Apple News', 'newspack-plugin' ),
 		editLink: 'admin.php?page=apple-news-options',
 		isConfigurable: true,
-		reloadOnStatusChange: false,
+		reloadOnActivation: false,
 		description: __(
 			'Export and synchronize posts to Apple format.',
 			'newspack-plugin'
@@ -29,7 +29,7 @@ const PLUGINS: Record< string, PluginCard > = {
 		slug: 'distributor',
 		title: __( 'Distributor', 'newspack-plugin' ),
 		editLink: 'admin.php?page=distributor',
-		reloadOnStatusChange: false,
+		reloadOnActivation: false,
 		description: __(
 			'Distributor is a WordPress plugin that makes it easy to syndicate and reuse content across your websites — whether in a single multisite or across the web.',
 			'newspack-plugin'

--- a/src/wizards/types/wizard-action-card.d.ts
+++ b/src/wizards/types/wizard-action-card.d.ts
@@ -89,6 +89,7 @@ type PluginCard = {
 	isStatusPrepended?: boolean;
 	error?: string | null;
 	onStatusChange?: ( statuses: Record< string, boolean > ) => void;
+	reloadOnStatusChange?: boolean;
 	isConfigurable?: boolean;
 	isTogglable?: boolean;
 	isMedium?: boolean;

--- a/src/wizards/types/wizard-action-card.d.ts
+++ b/src/wizards/types/wizard-action-card.d.ts
@@ -89,7 +89,7 @@ type PluginCard = {
 	isStatusPrepended?: boolean;
 	error?: string | null;
 	onStatusChange?: ( statuses: Record< string, boolean > ) => void;
-	reloadOnStatusChange?: boolean;
+	reloadOnActivation?: boolean;
 	isConfigurable?: boolean;
 	isTogglable?: boolean;
 	isMedium?: boolean;

--- a/src/wizards/wizards-plugin-card.tsx
+++ b/src/wizards/wizards-plugin-card.tsx
@@ -156,18 +156,19 @@ function WizardsPluginCardButton( {
 /**
  * Wizard Plugin Card component.
  *
- * @param props                   Component props.
- * @param props.slug              Plugin slug.
- * @param props.title             Plugin title.
- * @param props.subTitle          Plugin subtitle. String appended to title.
- * @param props.editLink          Plugin edit link.
- * @param props.description       Plugin description.
- * @param props.onStatusChange    Callback invoked when the plugin status changes.
- * @param props.isStatusPrepended Should status be prepended to description.
- * @param props.isConfigurable    Whether the plugin is configurable.
- * @param props.isTogglable       Whether the plugin is togglable.
- * @param props.actionText        Action card action text.
- * @param props.statusDescription Plugin status description.
+ * @param props                      Component props.
+ * @param props.slug                 Plugin slug.
+ * @param props.title                Plugin title.
+ * @param props.subTitle             Plugin subtitle. String appended to title.
+ * @param props.editLink             Plugin edit link.
+ * @param props.description          Plugin description.
+ * @param props.onStatusChange       Callback invoked when the plugin status changes.
+ * @param props.reloadOnStatusChange Should the page reload on activation status change?
+ * @param props.isStatusPrepended    Should status be prepended to description.
+ * @param props.isConfigurable       Whether the plugin is configurable.
+ * @param props.isTogglable          Whether the plugin is togglable.
+ * @param props.actionText           Action card action text.
+ * @param props.statusDescription    Plugin status description.
  */
 function WizardsPluginCard( {
 	slug,

--- a/src/wizards/wizards-plugin-card.tsx
+++ b/src/wizards/wizards-plugin-card.tsx
@@ -142,6 +142,14 @@ function WizardsPluginCardButton( {
 			);
 		}
 	}
+	if ( plugin.editLink ) {
+		return (
+			<a href={ plugin.editLink }>
+				{ actionText.configure ??
+					__( 'Configure', 'newspack-plugin' ) }
+			</a>
+		);
+	}
 	return null;
 }
 
@@ -169,6 +177,7 @@ function WizardsPluginCard( {
 	description,
 	statusDescription,
 	onStatusChange = () => {},
+	reloadOnStatusChange = true,
 	isStatusPrepended = true,
 	isConfigurable,
 	isTogglable,
@@ -239,7 +248,8 @@ function WizardsPluginCard( {
 	 */
 	function setPluginAction( callbacksKey: keyof PluginCallbacks ) {
 		// If action is activating or deactivating.
-		const isPluginStateUpdate = [ 'activate', 'deactivate' ].includes(
+		const actions = reloadOnStatusChange ? [ 'activate', 'deactivate' ] : [ 'deactivate' ];
+		const isPluginStateUpdate = actions.includes(
 			callbacksKey
 		);
 		setPluginState( { status: '' } );
@@ -337,7 +347,7 @@ function WizardsPluginCard( {
 			description={ getDescription }
 			className={ `wizards-plugin-card ${ slug }` }
 			actionText={
-				! statuses.isSetup && ! statuses.isError ? (
+				! statuses.isError ? (
 					<WizardsPluginCardButton
 						{ ...{
 							title,
@@ -345,7 +355,7 @@ function WizardsPluginCard( {
 							onActivate,
 							actionText,
 							isConfigurable,
-							onInstall: () => setPluginAction( 'install' ),
+							onInstall: () => setPluginAction( 'activate' ),
 							onConfigure: () => setPluginAction( 'configure' ),
 							...statuses,
 							...pluginState,

--- a/src/wizards/wizards-plugin-card.tsx
+++ b/src/wizards/wizards-plugin-card.tsx
@@ -156,19 +156,19 @@ function WizardsPluginCardButton( {
 /**
  * Wizard Plugin Card component.
  *
- * @param props                      Component props.
- * @param props.slug                 Plugin slug.
- * @param props.title                Plugin title.
- * @param props.subTitle             Plugin subtitle. String appended to title.
- * @param props.editLink             Plugin edit link.
- * @param props.description          Plugin description.
- * @param props.onStatusChange       Callback invoked when the plugin status changes.
- * @param props.reloadOnStatusChange Should the page reload on activation status change?
- * @param props.isStatusPrepended    Should status be prepended to description.
- * @param props.isConfigurable       Whether the plugin is configurable.
- * @param props.isTogglable          Whether the plugin is togglable.
- * @param props.actionText           Action card action text.
- * @param props.statusDescription    Plugin status description.
+ * @param props                    Component props.
+ * @param props.slug               Plugin slug.
+ * @param props.title              Plugin title.
+ * @param props.subTitle           Plugin subtitle. String appended to title.
+ * @param props.editLink           Plugin edit link.
+ * @param props.description        Plugin description.
+ * @param props.onStatusChange     Callback invoked when the plugin status changes.
+ * @param props.reloadOnActivation Should the page reload on activation status change?
+ * @param props.isStatusPrepended  Should status be prepended to description.
+ * @param props.isConfigurable     Whether the plugin is configurable.
+ * @param props.isTogglable        Whether the plugin is togglable.
+ * @param props.actionText         Action card action text.
+ * @param props.statusDescription  Plugin status description.
  */
 function WizardsPluginCard( {
 	slug,
@@ -178,7 +178,7 @@ function WizardsPluginCard( {
 	description,
 	statusDescription,
 	onStatusChange = () => {},
-	reloadOnStatusChange = true,
+	reloadOnActivation = true,
 	isStatusPrepended = true,
 	isConfigurable,
 	isTogglable,
@@ -249,7 +249,7 @@ function WizardsPluginCard( {
 	 */
 	function setPluginAction( callbacksKey: keyof PluginCallbacks ) {
 		// If action is activating or deactivating.
-		const actions = reloadOnStatusChange ? [ 'activate', 'deactivate' ] : [ 'deactivate' ];
+		const actions = reloadOnActivation ? [ 'activate', 'deactivate' ] : [ 'deactivate' ];
 		const isPluginStateUpdate = actions.includes(
 			callbacksKey
 		);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Tweaks the `WizardsPluginCard` component slightly:

- Allows for a `reloadOnActivation` prop to be passed. If set to `false`, the card will not trigger a page reload after installing or activating its plugin. Deactivating the plugin will still result in a page reload, to clear out dead WP admin menu links. Default: `true` so that component instances not specifically touched by this PR are not affected.
- If passed an `editLink` prop, will continue to show the "Configure" link to the plugin's settings page even after the plugin has been fully setup.
- If the plugin isn't yet installed, calls the `Plugin_Manager::activate()` method instead of the `install()` method, as `activate()` will automatically install the plugin first if not installed. This lets the user skip an extra click and REST API roundtrip to install then activate the plugin.

Then, applies these changes to instances of the `WizardsPluginCard` component in the Syndication wizard page:

- Sets both Apple News and Distributor cards to `reloadOnActivation: false`—these don't really require a refresh immediately upon activation as the "Configure" links that appear will work without a page reload.
- Updates the plugin title and description for Publish to Apple News to exactly match those from the plugin itself.
- Adds an `editLink` prop for the Distributor plugin which leads to the "External Connections" settings page.

### How to test the changes in this Pull Request:

1. Start with the Apple News and Distributor plugins not installed on your testing site.
2. Navigate to **Newspack > Settings > Syndication**.
3. Click the toggle button on the left-hand side of each plugin card. Confirm that upon success, both plugins are in a fully-activated state and show their "Configure" buttons, and that the "Configure" buttons lead to the correct plugin settings page.
5. Delete both plugins and repeat step 3, but this time use the "Install <plugin name>" button on the right-hand side of the card. Confirm that the resulting behavior is the same as using the toggle button.
4. Toggle off both plugins using the toggle button and confirm that the page reloads after toggling off each one. Also confirm that the plugins are actually set to a deactivated status.
5. Smoke test the plugin cards elsewhere throughout the wizard pages and confirm that they still work as intended. Most exist in the following Settings subpages:

  - Connections
  - Social
  - Emails

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->