### PR TITLE
fix(wcs): account for more on-hold subscription cases

### DIFF
--- a/includes/cli/class-woocommerce-subscriptions.php
+++ b/includes/cli/class-woocommerce-subscriptions.php
@@ -103,10 +103,14 @@ class WooCommerce_Subscriptions {
 						'refunded',
 					]
 				);
-				// If the last order is the parent order and has a failed status, trash the subscription.
 				if ( ! $last_order ) {
 					$last_order = $subscription->get_parent();
+					// If the last order is the parent order and has a failed status, trash the subscription.
 					if ( $last_order && 'failed' === $last_order->get_status() ) {
+						if ( self::$verbose ) {
+							WP_CLI::line( 'Subscription parent order failed. Moving to trash...' );
+							WP_CLI::line( '' );
+						}
 						if ( self::$live ) {
 							$subscription->update_status( 'trash', __( 'Subscription status updated by Newspack CLI command.', 'newspack-plugin' ) );
 							$subscription->set_end_date( $subscription->get_date( 'next_payment' ) );
@@ -114,17 +118,13 @@ class WooCommerce_Subscriptions {
 							$subscription->save();
 						}
 						++$trashed;
-						if ( self::$verbose ) {
-							WP_CLI::line( 'Subscription parent order failed. Moving to trash...' );
-							WP_CLI::line( '' );
-						}
 						continue;
 					}
 				}
 				if ( $subscription->is_manual() ) {
 					$end_date = $subscription->get_date( 'next_payment' );
 					$should_expire = wcs_date_to_time( $end_date ) + ( On_Hold_Duration::get_on_hold_duration() * DAY_IN_SECONDS ) < time();
-
+					// If the manual subscription is within the on-hold duration, schedule expiration.
 					if ( ! $should_expire ) {
 						if ( self::$verbose ) {
 							WP_CLI::line( 'Manual subscription is within the on-hold duration. Scheduling expiration...' );
@@ -135,14 +135,11 @@ class WooCommerce_Subscriptions {
 						++$scheduled;
 					}
 				} else {
-					$last_retry = \WCS_Retry_Manager::store()->get_last_retry_for_order( wcs_get_objects_property( $last_order, 'id' ) );
-					if ( ! $last_retry ) {
-						$end_date = $subscription->get_date( 'next_payment' );
-					} else {
-						$end_date = $last_retry->get_date();
-					}
+					$last_retry    = \WCS_Retry_Manager::store()->get_last_retry_for_order( wcs_get_objects_property( $last_order, 'id' ) );
+					$end_date      = $last_retry ? $last_retry->get_date() : $subscription->get_date( 'next_payment' );
 					$should_expire = wcs_date_to_time( $end_date ) + ( On_Hold_Duration::get_on_hold_duration() * DAY_IN_SECONDS ) < time();
 					if ( ! $should_expire ) {
+						// If there have been retries, schedule the final retry.
 						if ( $last_retry ) {
 							if ( self::$verbose ) {
 								WP_CLI::line( 'Retry date is within the on-hold duration. Scheduling final retry...' );
@@ -168,6 +165,7 @@ class WooCommerce_Subscriptions {
 							}
 							++$scheduled;
 						} else {
+							// If there have been no retries, schedule expiration.
 							if ( self::$verbose ) {
 								WP_CLI::line( 'No retries found. Scheduling subscription expiration...' );
 							}
@@ -179,6 +177,7 @@ class WooCommerce_Subscriptions {
 						}
 					}
 				}
+				// Expire any subscriptinos that have passed the on-hold duration.
 				if ( $should_expire ) {
 					if ( self::$verbose ) {
 						WP_CLI::line( 'Updating subscription status to expired...' );

--- a/includes/cli/class-woocommerce-subscriptions.php
+++ b/includes/cli/class-woocommerce-subscriptions.php
@@ -93,7 +93,7 @@ class WooCommerce_Subscriptions {
 					}
 					continue;
 				}
-				$renewal_order = $subscription->get_last_order(
+				$last_order = $subscription->get_last_order(
 					'all',
 					[ 'renewal' ],
 					[
@@ -102,27 +102,36 @@ class WooCommerce_Subscriptions {
 						'refunded',
 					]
 				);
-				// No failed or pending renewal orders indicates the subscription was likely manually placed on hold.
-				if ( empty( $renewal_order ) ) {
-					if ( self::$verbose ) {
-						WP_CLI::line( 'Subscription has no pending renewal orders. Moving to next subscription...' );
-						WP_CLI::line( '' );
+				// If the last order is the parent order and has a failed status, trash the subscription.
+				if ( ! $last_order ) {
+					$last_order = $subscription->get_parent();
+					if ( $last_order && 'failed' === $parent_order->get_status() ) {
+						if ( self::$verbose ) {
+							WP_CLI::line( 'Subscription parent order has failed status. Moving to trash...' );
+						}
+						if ( self::$live ) {
+							$subscription->update_status( 'trash', __( 'Subscription status updated by Newspack CLI command.', 'newspack-plugin' ) );
+							$subscription->set_end_date( $subscription->get_date( 'next_payment' ) );
+							$subscription->update_meta_data( '_newspack_cli_status_updated', true );
+							$subscription->save();
+						}
+						++$updated;
+						if ( self::$verbose ) {
+							WP_CLI::line( 'Finished processing subscription ' . $id );
+							WP_CLI::line( '' );
+						}
+						continue;
 					}
-					continue;
 				}
-				if ( ! $subscription->payment_method_supports( 'subscription_date_changes' ) ) {
-					if ( self::$verbose ) {
-						WP_CLI::line( 'Subscription payment method does not support retries. Moving to next subscription...' );
-						WP_CLI::line( '' );
-					}
-					continue;
-				}
-
 				if ( $subscription->is_manual() ) {
 					$end_date = $subscription->get_date( 'next_payment' );
 					$should_expire = wcs_date_to_time( $end_date ) + ( On_Hold_Duration::get_on_hold_duration() * DAY_IN_SECONDS ) < time();
 
 					if ( ! $should_expire ) {
+						if ( false !== as_has_scheduled_action( On_Hold_Duration::AS_HOOK, [ $subscription->get_id() ], On_Hold_Duration::AS_GROUP ) ) {
+							// If expiration action hasn't been scheduled, schedule it.
+							as_unschedule_action( On_Hold_Duration::AS_HOOK, [ $subscription->get_id() ], On_Hold_Duration::AS_GROUP );
+						}
 						if ( self::$verbose ) {
 							WP_CLI::line( 'Subscription is within the on-hold duration. Moving to next subscription...' );
 							WP_CLI::line( '' );
@@ -130,29 +139,13 @@ class WooCommerce_Subscriptions {
 						continue;
 					}
 				} else {
-					$last_retry = \WCS_Retry_Manager::store()->get_last_retry_for_order( wcs_get_objects_property( $renewal_order, 'id' ) );
-
-					// No retries indicates the subscription was likely manually placed on hold.
-					if ( empty( $last_retry ) ) {
-						if ( self::$verbose ) {
-							WP_CLI::line( 'No retries scheduled. Moving to next subscription...' );
-							WP_CLI::line( '' );
-						}
-						continue;
+					$last_retry = \WCS_Retry_Manager::store()->get_last_retry_for_order( wcs_get_objects_property( $last_order, 'id' ) );
+					if ( ! $last_retry ) {
+						$end_date = $subscription->get_date( 'next_payment' );
+					} else {
+						$end_date = $last_retry->get_date();
 					}
-
-					$end_date = $last_retry->get_date();
 					$should_expire = wcs_date_to_time( $end_date ) + ( On_Hold_Duration::get_on_hold_duration() * DAY_IN_SECONDS ) < time();
-
-					// A non failed status indicates the retry was either manually cancelled
-					// or was successful at one point but likely placed on hold for some other reason.
-					if ( 'failed' !== $last_retry->get_status() ) {
-						if ( self::$verbose ) {
-							WP_CLI::line( 'Last retry does not have a failed status. Moving to next subscription...' );
-							WP_CLI::line( '' );
-						}
-						continue;
-					}
 					if ( ! $should_expire ) {
 						if ( self::$verbose ) {
 							WP_CLI::line( 'Retry date is within the on-hold duration. Scheduling final retry...' );
@@ -160,7 +153,7 @@ class WooCommerce_Subscriptions {
 						if ( self::$live ) {
 							// Retry rules can only be applied when payment attempt flag is set.
 							add_filter( 'wcs_is_scheduled_payment_attempt', '__return_true' );
-							\WCS_Retry_Manager::maybe_apply_retry_rule( $subscription, $renewal_order );
+							\WCS_Retry_Manager::maybe_apply_retry_rule( $subscription, $last_order );
 							remove_filter( 'wcs_is_scheduled_payment_attempt', '__return_true' );
 							if ( 0 === $subscription->get_date( 'payment_retry' ) ) {
 								if ( self::$verbose ) {
@@ -180,7 +173,6 @@ class WooCommerce_Subscriptions {
 					}
 				}
 				if ( $should_expire ) {
-					// Otherwise, if the retry date is past the on-hold duration, update the subscription status to expired.
 					if ( self::$verbose ) {
 						WP_CLI::line( 'Updating subscription status to expired...' );
 					}

--- a/includes/cli/class-woocommerce-subscriptions.php
+++ b/includes/cli/class-woocommerce-subscriptions.php
@@ -69,6 +69,7 @@ class WooCommerce_Subscriptions {
 		self::$verbose = isset( $assoc_args['verbose'] ) ? true : false;
 		$scheduled     = 0;
 		$updated       = 0;
+		$trashed       = 0;
 		$page          = 1;
 		$per_page      = 25;
 		$subscriptions = self::get_subscriptions( $page );
@@ -105,19 +106,16 @@ class WooCommerce_Subscriptions {
 				// If the last order is the parent order and has a failed status, trash the subscription.
 				if ( ! $last_order ) {
 					$last_order = $subscription->get_parent();
-					if ( $last_order && 'failed' === $parent_order->get_status() ) {
-						if ( self::$verbose ) {
-							WP_CLI::line( 'Subscription parent order has failed status. Moving to trash...' );
-						}
+					if ( $last_order && 'failed' === $last_order->get_status() ) {
 						if ( self::$live ) {
 							$subscription->update_status( 'trash', __( 'Subscription status updated by Newspack CLI command.', 'newspack-plugin' ) );
 							$subscription->set_end_date( $subscription->get_date( 'next_payment' ) );
 							$subscription->update_meta_data( '_newspack_cli_status_updated', true );
 							$subscription->save();
 						}
-						++$updated;
+						++$trashed;
 						if ( self::$verbose ) {
-							WP_CLI::line( 'Finished processing subscription ' . $id );
+							WP_CLI::line( 'Subscription parent order failed. Moving to trash...' );
 							WP_CLI::line( '' );
 						}
 						continue;
@@ -128,15 +126,13 @@ class WooCommerce_Subscriptions {
 					$should_expire = wcs_date_to_time( $end_date ) + ( On_Hold_Duration::get_on_hold_duration() * DAY_IN_SECONDS ) < time();
 
 					if ( ! $should_expire ) {
-						if ( false !== as_has_scheduled_action( On_Hold_Duration::AS_HOOK, [ $subscription->get_id() ], On_Hold_Duration::AS_GROUP ) ) {
-							// If expiration action hasn't been scheduled, schedule it.
-							as_unschedule_action( On_Hold_Duration::AS_HOOK, [ $subscription->get_id() ], On_Hold_Duration::AS_GROUP );
-						}
 						if ( self::$verbose ) {
-							WP_CLI::line( 'Subscription is within the on-hold duration. Moving to next subscription...' );
-							WP_CLI::line( '' );
+							WP_CLI::line( 'Manual subscription is within the on-hold duration. Scheduling expiration...' );
 						}
-						continue;
+						if ( self::$live ) {
+							On_Hold_Duration::maybe_schedule_expiration( $subscription );
+						}
+						++$scheduled;
 					}
 				} else {
 					$last_retry = \WCS_Retry_Manager::store()->get_last_retry_for_order( wcs_get_objects_property( $last_order, 'id' ) );
@@ -147,29 +143,40 @@ class WooCommerce_Subscriptions {
 					}
 					$should_expire = wcs_date_to_time( $end_date ) + ( On_Hold_Duration::get_on_hold_duration() * DAY_IN_SECONDS ) < time();
 					if ( ! $should_expire ) {
-						if ( self::$verbose ) {
-							WP_CLI::line( 'Retry date is within the on-hold duration. Scheduling final retry...' );
-						}
-						if ( self::$live ) {
-							// Retry rules can only be applied when payment attempt flag is set.
-							add_filter( 'wcs_is_scheduled_payment_attempt', '__return_true' );
-							\WCS_Retry_Manager::maybe_apply_retry_rule( $subscription, $last_order );
-							remove_filter( 'wcs_is_scheduled_payment_attempt', '__return_true' );
-							if ( 0 === $subscription->get_date( 'payment_retry' ) ) {
-								if ( self::$verbose ) {
-									WP_CLI::error( 'Failed to schedule payment retry. Moving to next subscription...' );
-									WP_CLI::line( '' );
-								}
-								continue;
-							} else {
-								$subscription->add_order_note(
-									__( 'Final payment retry scheduled by Newspack CLI command.', 'newspack-plugin' )
-								);
-								$subscription->update_meta_data( '_newspack_cli_retry_scheduled', true );
-								$subscription->save();
+						if ( $last_retry ) {
+							if ( self::$verbose ) {
+								WP_CLI::line( 'Retry date is within the on-hold duration. Scheduling final retry...' );
 							}
+							if ( self::$live ) {
+								// Retry rules can only be applied when payment attempt flag is set.
+								add_filter( 'wcs_is_scheduled_payment_attempt', '__return_true' );
+								\WCS_Retry_Manager::maybe_apply_retry_rule( $subscription, $last_order );
+								remove_filter( 'wcs_is_scheduled_payment_attempt', '__return_true' );
+								if ( 0 === $subscription->get_date( 'payment_retry' ) ) {
+									if ( self::$verbose ) {
+										WP_CLI::error( 'Failed to schedule payment retry. Moving to next subscription...' );
+										WP_CLI::line( '' );
+									}
+									continue;
+								} else {
+									$subscription->add_order_note(
+										__( 'Final payment retry scheduled by Newspack CLI command.', 'newspack-plugin' )
+									);
+									$subscription->update_meta_data( '_newspack_cli_retry_scheduled', true );
+									$subscription->save();
+								}
+							}
+							++$scheduled;
+						} else {
+							if ( self::$verbose ) {
+								WP_CLI::line( 'No retries found. Scheduling subscription expiration...' );
+							}
+							if ( self::$live ) {
+								$on_hold_duration = On_Hold_Duration::get_on_hold_duration() * DAY_IN_SECONDS;
+								On_Hold_Duration::schedule_expiration( $subscription->get_id(), $subscription->get_time( 'next_payment' ) + $on_hold_duration );
+							}
+							++$scheduled;
 						}
-						++$scheduled;
 					}
 				}
 				if ( $should_expire ) {
@@ -191,7 +198,7 @@ class WooCommerce_Subscriptions {
 			}
 			$subscriptions = self::get_subscriptions( ++$page );
 		}
-		WP_CLI::success( 'Finished processing subscriptions. ' . $updated . ' subscriptions updated. ' . $scheduled . ' retries scheduled.' );
+		WP_CLI::success( 'Finished processing subscriptions. ' . $updated . ' subscriptions updated. ' . $scheduled . ' retries scheduled. ' . $trashed . ' subscriptions trashed.' );
 		if ( ! self::$live ) {
 			WP_CLI::warning( 'Dry run. Use --live flag to process live subscriptions.' );
 		}

--- a/includes/plugins/woocommerce-subscriptions/class-on-hold-duration.php
+++ b/includes/plugins/woocommerce-subscriptions/class-on-hold-duration.php
@@ -120,12 +120,12 @@ class On_Hold_Duration {
 	}
 
 	/**
-	 * Conditionally schedule expiration action if subscription is manual and/or retry system is disabled.
+	 * Conditionally schedule expiration action if no retries are scheduled.
 	 *
 	 * @param object $subscription Subscription object.
 	 */
 	public static function maybe_schedule_expiration( $subscription ) {
-		if ( $subscription->is_manual() || ! \WCS_Retry_Manager::is_retry_enabled() ) {
+		if ( $subscription->get_date( 'payment_retry' ) === 0 || ! \WCS_Retry_Manager::is_retry_enabled() ) {
 			$default_grace_period = $subscription->is_manual() ? 7 * DAY_IN_SECONDS : 0; // Default grace period is 7 days if the subscription is manual otherwise 0.
 			$on_hold_duration     = self::get_on_hold_duration() * DAY_IN_SECONDS;
 			$timestamp            = $subscription->get_time( 'next_payment' ) + $default_grace_period + $on_hold_duration;

--- a/includes/plugins/woocommerce-subscriptions/class-on-hold-duration.php
+++ b/includes/plugins/woocommerce-subscriptions/class-on-hold-duration.php
@@ -34,7 +34,8 @@ class On_Hold_Duration {
 		add_filter( 'woocommerce_subscription_settings', [ __CLASS__, 'add_on_hold_duration_setting' ], 11, 1 );
 		add_filter( 'wcs_default_retry_rules', [ __CLASS__, 'maybe_apply_on_hold_duration_rule' ], 99, 1 );
 		add_action( 'woocommerce_subscription_status_on-hold', [ __CLASS__, 'maybe_schedule_expiration' ], 10, 1 );
-		add_action( 'woocommerce_subscription_status_active', [ __CLASS__, 'maybe_unschedule_expiration_on_manual_renewal' ], 10, 1 );
+		add_action( 'woocommerce_subscription_status_active', [ __CLASS__, 'maybe_unschedule_expiration' ], 10, 1 );
+		add_action( 'woocommerce_subscriptions_after_apply_retry_rule', [ __CLASS__, 'maybe_unschedule_expiration_on_retry' ], 10, 3 );
 		add_action( 'woocommerce_subscription_payment_failed', [ __CLASS__, 'trash_subscription_on_failed_payment' ], 10, 2 );
 		add_action( self::AS_HOOK, [ __CLASS__, 'handle_scheduled_action' ] );
 	}
@@ -146,13 +147,26 @@ class On_Hold_Duration {
 	}
 
 	/**
-	 * Unschedule expiration if scheduled when manual subscription is renewed.
+	 * Unschedule expiration if scheduled.
 	 *
 	 * @param \WC_Subscription $subscription The Subscription.
 	 */
-	public static function maybe_unschedule_expiration_on_manual_renewal( $subscription ) {
+	public static function maybe_unschedule_expiration( $subscription ) {
 		if ( false !== as_has_scheduled_action( self::AS_HOOK, [ $subscription->get_id() ], self::AS_GROUP ) ) {
 			as_unschedule_action( self::AS_HOOK, [ $subscription->get_id() ], self::AS_GROUP );
+		}
+	}
+
+	/**
+	 * Unschedule expiration if payment retry is scheduled.
+	 *
+	 * @param array            $retry_rule   Retry rule.
+	 * @param \WC_Order        $last_order   The last order.
+	 * @param \WC_Subscription $subscription The Subscription.
+	 */
+	public static function maybe_unschedule_expiration_on_retry( $retry_rule, $last_order, $subscription ) {
+		if ( $subscription->get_date( 'payment_retry' ) > 0 ) {
+			self::maybe_unschedule_expiration( $subscription );
 		}
 	}
 

--- a/includes/plugins/woocommerce-subscriptions/class-on-hold-duration.php
+++ b/includes/plugins/woocommerce-subscriptions/class-on-hold-duration.php
@@ -33,8 +33,8 @@ class On_Hold_Duration {
 
 		add_filter( 'woocommerce_subscription_settings', [ __CLASS__, 'add_on_hold_duration_setting' ], 11, 1 );
 		add_filter( 'wcs_default_retry_rules', [ __CLASS__, 'maybe_apply_on_hold_duration_rule' ], 99, 1 );
-		add_action( 'woocommerce_generated_manual_renewal_order', [ __CLASS__, 'maybe_schedule_expiration' ], 10, 2 );
-		add_action( 'woocommerce_subscription_renewal_payment_complete', [ __CLASS__, 'maybe_unschedule_expiration_on_manual_renewal' ], 10, 2 );
+		add_action( 'woocommerce_subscription_status_on-hold', [ __CLASS__, 'maybe_schedule_expiration' ], 10, 1 );
+		add_action( 'woocommerce_subscription_status_active', [ __CLASS__, 'maybe_unschedule_expiration_on_manual_renewal' ], 10, 1 );
 		add_action( self::AS_HOOK, [ __CLASS__, 'handle_scheduled_action' ] );
 	}
 
@@ -119,14 +119,13 @@ class On_Hold_Duration {
 	}
 
 	/**
-	 * Conditionally schedule expiration action.
+	 * Conditionally schedule expiration action if subscription is manual and/or retry system is disabled.
 	 *
-	 * @param int    $order_id     Order ID.
 	 * @param object $subscription Subscription object.
 	 */
-	public static function maybe_schedule_expiration( $order_id, $subscription ) {
-		if ( 'on-hold' === $subscription->get_status() ) {
-			$default_grace_period = 7 * DAY_IN_SECONDS; // 7 days, the number of days the retry system normally waits before marking a subscription as expired.
+	public static function maybe_schedule_expiration( $subscription ) {
+		if ( $subscription->is_manual() || ! \WCS_Retry_Manager::is_retry_enabled() ) {
+			$default_grace_period = $subscription->is_manual() ? 7 * DAY_IN_SECONDS : 0; // Default grace period is 7 days if the subscription is manual otherwise 0.
 			$on_hold_duration     = self::get_on_hold_duration() * DAY_IN_SECONDS;
 			$timestamp            = $subscription->get_time( 'next_payment' ) + $default_grace_period + $on_hold_duration;
 			as_schedule_single_action( $timestamp, self::AS_HOOK, [ $subscription->get_id() ], self::AS_GROUP );
@@ -137,9 +136,8 @@ class On_Hold_Duration {
 	 * Unschedule expiration if scheduled when manual subscription is renewed.
 	 *
 	 * @param \WC_Subscription $subscription The Subscription.
-	 * @param \WC_Order        $order        The order.
 	 */
-	public static function maybe_unschedule_expiration_on_manual_renewal( $subscription, $order ) {
+	public static function maybe_unschedule_expiration_on_manual_renewal( $subscription ) {
 		if ( false !== as_has_scheduled_action( self::AS_HOOK, [ $subscription->get_id() ], self::AS_GROUP ) ) {
 			as_unschedule_action( self::AS_HOOK, [ $subscription->get_id() ], self::AS_GROUP );
 		}

--- a/includes/plugins/woocommerce-subscriptions/class-on-hold-duration.php
+++ b/includes/plugins/woocommerce-subscriptions/class-on-hold-duration.php
@@ -129,7 +129,19 @@ class On_Hold_Duration {
 			$default_grace_period = $subscription->is_manual() ? 7 * DAY_IN_SECONDS : 0; // Default grace period is 7 days if the subscription is manual otherwise 0.
 			$on_hold_duration     = self::get_on_hold_duration() * DAY_IN_SECONDS;
 			$timestamp            = $subscription->get_time( 'next_payment' ) + $default_grace_period + $on_hold_duration;
-			as_schedule_single_action( $timestamp, self::AS_HOOK, [ $subscription->get_id() ], self::AS_GROUP );
+			self::schedule_expiration( $subscription->get_id(), $timestamp );
+		}
+	}
+
+	/**
+	 * Schedule expiration action.
+	 *
+	 * @param int $subscription_id Subscription ID.
+	 * @param int $timestamp       Timestamp.
+	 */
+	public static function schedule_expiration( $subscription_id, $timestamp ) {
+		if ( ! as_has_scheduled_action( self::AS_HOOK, [ $subscription_id ], self::AS_GROUP ) ) {
+			as_schedule_single_action( $timestamp, self::AS_HOOK, [ $subscription_id ], self::AS_GROUP );
 		}
 	}
 

--- a/includes/plugins/woocommerce-subscriptions/class-on-hold-duration.php
+++ b/includes/plugins/woocommerce-subscriptions/class-on-hold-duration.php
@@ -35,6 +35,7 @@ class On_Hold_Duration {
 		add_filter( 'wcs_default_retry_rules', [ __CLASS__, 'maybe_apply_on_hold_duration_rule' ], 99, 1 );
 		add_action( 'woocommerce_subscription_status_on-hold', [ __CLASS__, 'maybe_schedule_expiration' ], 10, 1 );
 		add_action( 'woocommerce_subscription_status_active', [ __CLASS__, 'maybe_unschedule_expiration_on_manual_renewal' ], 10, 1 );
+		add_action( 'woocommerce_subscription_payment_failed', [ __CLASS__, 'trash_subscription_on_failed_payment' ], 10, 2 );
 		add_action( self::AS_HOOK, [ __CLASS__, 'handle_scheduled_action' ] );
 	}
 
@@ -152,6 +153,20 @@ class On_Hold_Duration {
 		$subscription = wcs_get_subscription( $subscription_id );
 		if ( $subscription && 'on-hold' === $subscription->get_status() ) {
 			$subscription->update_status( 'expired' );
+		}
+	}
+
+	/**
+	 * Trash subscription on failed payment.
+	 *
+	 * @param \WC_Subscription $subscription The Subscription.
+	 * @param string           $status       The status.
+	 */
+	public static function trash_subscription_on_failed_payment( $subscription, $status ) {
+		$last_order = $subscription->get_last_order( 'all' );
+		if ( ! $last_order || $last_order->get_id() === $subscription->get_parent_id() ) {
+			$subscription->update_status( 'trash', __( 'Subscription status updated by Newspack.', 'newspack-plugin' ) );
+			$subscription->save();
 		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

See https://newspackengineering.wordpress.com/2025/01/10/accounting-for-all-on-hold-subscriptions/#comment-1691

This PR ensures our on-hold duration logic accounts for all of the following cases:

**Transition to expired**
- Manual or no-retry subscriptions
- Manual holds for customer support reasons

**Transition to trash**
- Failed parent orders

(The other cases in the p2 comment should already be accounted for.)

### How to test the changes in this Pull Request:

**Setup**

You'll need to set up some subscriptions on a test site before beginning testing. Here are some useful tips for this part:

- To setup no-retry subscriptions, add the following to wp-config then disable auto retries via WooCommerce > Settings > Subscription menu: `define( 'NEWSPACK_PREVENT_WC_ALLOW_FAILED_PAYMENT_RETRIES_OVERRIDE', true );`
- To setup subscriptions that end up in the on-hold status after retries, add the following filter to the site: `add_filter( 'newspack_subscriptions_expiration_enabled', '__return_false' );`, then follow [these steps](https://woocommerce.com/document/subscriptions/develop/failed-payment-retry/#section-7). Also use this filter to setup on-hold subscriptions with failed parent orders.
- To setup manual subscriptions that have passed the on-hold duration, use the following via `wp shell` to manually fix the start and next_payment dates:
```
$s = wcs_get_subscription(SUBSCRIPTION_ID);
$s->update_dates([ 'start' => 'YYYY-MM-DD HH:MM:SS', 'next_payment' => 'YYYY-MM-DD HH:MM:SS' ]);
```

Set up the following subscriptions (all within the on-hold duration except for the last on this list):
 - A non-manual subscriptions that has been put on hold via the admin menu
 - A non-manual subscription that has been put on hold as the result of a failed renewal (with the retry system disabled)
 - A non-manual subscription that has been put on hold after all retries have failed
 - A non-manual subscription that has been put on hold after a failed parent order (paid with Stripe test card `4000 0000 0000 0002` for example)
 - A manual subscription that has been put on hold via the admin menu
 - A manual subscription that has been put on hold as the result of needing a renewal payment
 - Some manual and non-manual subscriptions with next payment dates that are beyond the sites on-hold duration

Once you finish setting up, be sure to remove both the constant and filter before testing.

**Testing**
1. Run the following cli command: `wp newspack migrate-expired-subscriptions --verbose`
2. Verify the output of the command indicates:
  - non-manual subscriptions that have been put on hold by admin are scheduled to expire after the on-hold duration + next payment date
  - non-manual subscriptions with failed renewals when the retry system was disabled are scheduled to expire after the on-hold duration + next payment date
  - non-manual subscriptions that have went through all retries are scheduled a final retry
  - failed parent order subscriptions are trashed
  - manual subscriptions are scheduled to expire after the on-hold duration + next payment date + 7 day grace period
  - subscriptions that are beyond the on-hold duration are expired immediately
3. As a reader, attempt to purchase a subscription with the following decline card, then abandon the cart: `4000 0000 0000 0002`
4. Via wp-admin ensure there is a trashed subscription as a result of the failed payment
5. Set another active subscription to on-hold, then look for a newly scheduled `newspack_subscriptions_expiration_enabled` event via the action scheduler (WooCommerce > Status > Scheduled Actions > Pending)
6. Finally, run the cli command above in live mode (with the `--live` flag) and verify all subscriptions behave as described above.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->