### PR TITLE
fix: check for WC as well as WCS

### DIFF
--- a/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
+++ b/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
@@ -40,7 +40,7 @@ class WooCommerce_Subscriptions {
 	 * @return bool
 	 */
 	public static function is_active() {
-		return class_exists( 'WC_Subscriptions' );
+		return function_exists( 'WC' ) && class_exists( 'WC_Subscriptions' );
 	}
 
 	/**

--- a/tests/unit-tests/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
+++ b/tests/unit-tests/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
@@ -19,7 +19,7 @@ class Newspack_Test_WooCommerce_Subscriptions extends WP_UnitTestCase {
 	 */
 	public function test_is_active() {
 		$is_active = WooCommerce_Subscriptions::is_active();
-		$this->assertTrue( $is_active, 'WooCommerce Subscriptions integration should be active when WC_Subscriptions class exists.' );
+		$this->assertFalse( $is_active, 'WooCommerce Subscriptions integration should not be active if the main WooCommerce plugin is not available.' );
 	}
 
 	/**
@@ -27,6 +27,6 @@ class Newspack_Test_WooCommerce_Subscriptions extends WP_UnitTestCase {
 	 */
 	public function test_is_enabled() {
 		$is_enabled = WooCommerce_Subscriptions::is_enabled();
-		$this->assertTrue( $is_enabled, 'WooCommerce Subscriptions integration should be enabled when RAS is enabled.' );
+		$this->assertFalse( $is_enabled, 'WooCommerce Subscriptions integration should not be active if the main WooCommerce plugin is not available.' );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Similar to https://github.com/Automattic/newspack-blocks/pull/2043, adds a check for WooCommerce before attempting to call dependent WooCommerce Subscriptions functions. This is a minor edge case since it's unlikely that WCS will be active while Woo isn't, but can't hurt to add some more checks here.

### How to test the changes in this Pull Request:

1.  On a site with RAS enabled, Activate WooCommerce Subscriptions but deactivate WooCommerce. You can do this via CLI using `wp plugin deactivate woocommerce --skip-plugins`
2. Visit a front-end page which will render the auth modal. Observe a fatal error: `PHP Fatal error:  Uncaught Error: Call to undefined function Newspack\is_wc_endpoint_url() in /newspack-repos/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-renewal.php:76`
3. Check out this branch, refresh, confirm no fatal.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->