### PR TITLE
fix: add check for newsletter modal and fix typo

### DIFF
--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -774,7 +774,7 @@ class Memberships {
 					if ( ev.detail.authenticated && ! window?.newspackReaderActivation?.getPendingCheckout() ) {
 						if ( ras.overlays.get().length ) {
 							ras.on( 'overlay', function( ev ) {
-								if ( ! ev.detail.overlays.length ) {
+								if ( ! ev.detail.overlays.length && ! window?.newspackReaderActivation?.openNewslettersSignupModal ) {
 									window.location.reload();
 								}
 							} );

--- a/src/reader-activation/index.js
+++ b/src/reader-activation/index.js
@@ -193,7 +193,7 @@ export function openNewslettersSignupModal( config = {} ) {
 	config = {
 		...{
 			onSuccess: null,
-			onDissmiss: null,
+			onDismiss: null,
 			onError: null,
 			initialState: null,
 			skipSuccess: false,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR makes sure that the content gate doesn't refresh the page after purchases before the reader can run through the newsletter sign up step of the checkout.

It also fixes a small typo in the `openNewslettersSignupModal()` config settings (changing `Dissmiss` to `Dismiss`). This doesn't appear to be used anywhere else yet, but I'd appreciate confirmation!

See: 1200550061930446-as-1209271919879010

### How to test the changes in this Pull Request:

A lot of the preliminary testing setup is the same as https://github.com/Automattic/newspack-blocks/pull/2044, so it may make sense to test these together!

1. Set up a Membership plan that restricts content.
2. Create two products to use to purchase access to the Membership plan: one simple subscription, and one variable subscription.
3. Enable the Membership Content Gate under Newspack > Engagement > Advanced Settings, and add two checkout button blocks, one for the simple subscription product that can purchase the membership, and one for the variable subscription product that can purchase the membership.
4. Under Newspack > Engagement > Advanced Settings, enable "Present newsletter signup after checkout and registration".
5. In an incognito window, trigger the Content Gate, and purchase a membership using the Simple Subscription product. When you get to the Newsletter sign up step, give it a moment; the post will refresh before the newsletter form is submitted or closed. 
6. Apply this PR.
7. Repeat step 4; confirm that the Newsletter sign up form remains open.
8. In a new incognito window, sign up for a RAS account, and sign up for all newsletters.
9. Repeat step 4; confirm that the Newsletter sign up form is not triggered, and that the post refreshes after the purchase is completed so the Content Gate is no longer visible.

**Bonus testing:**
10. If you're testing with https://github.com/Automattic/newspack-blocks/pull/2044, repeat step 4, but purchase the membership with the variable subscription. Confirm that the newsletter form doesn't refresh until you've submitted it/closed it. 
11. In a new incognito window, repeat steps 7 and 8; for the latter, use the variable subscription product to purchase the membership. Confirm that the newsletter sign up form is not shown, and that the post refreshes to hide the Content Gate.

**Smoke testing**
12. Run through a few regular checkouts in incognito windows. Subscribe to different newsletters, and confirm they are removed from the list when you repeat the email address, and that the newsletter prompt disappears entirely once you've signed up for all.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->