### PR TITLE
fix(ras): rename Reader Activation to Audience Management throughout admin

### DIFF
--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -793,7 +793,7 @@ final class Reader_Activation {
 					'newspack-popups' => class_exists( '\Newspack_Popups_Model' ),
 				],
 				'label'          => __( 'Audience Management Campaign', 'newspack-plugin' ),
-				'description'    => __( 'Building a set of prompts with default segments and settings allows for an improved experience optimized for Reader Activation.', 'newspack-plugin' ),
+				'description'    => __( 'Building a set of prompts with default segments and settings allows for an improved experience optimized for audience management.', 'newspack-plugin' ),
 				'help_url'       => 'https://help.newspack.com/engagement/audience-management-system/',
 				'href'           => self::is_ras_campaign_configured() ? admin_url( '/admin.php?page=newspack-audience-campaigns' ) : admin_url( '/admin.php?page=newspack-audience#/campaign' ),
 				'action_enabled' => self::is_ras_ready_to_configure(),

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -792,12 +792,12 @@ final class Reader_Activation {
 				'plugins'        => [
 					'newspack-popups' => class_exists( '\Newspack_Popups_Model' ),
 				],
-				'label'          => __( 'Reader Activation Campaign', 'newspack-plugin' ),
+				'label'          => __( 'Audience Management Campaign', 'newspack-plugin' ),
 				'description'    => __( 'Building a set of prompts with default segments and settings allows for an improved experience optimized for Reader Activation.', 'newspack-plugin' ),
 				'help_url'       => 'https://help.newspack.com/engagement/audience-management-system/',
 				'href'           => self::is_ras_campaign_configured() ? admin_url( '/admin.php?page=newspack-audience-campaigns' ) : admin_url( '/admin.php?page=newspack-audience#/campaign' ),
 				'action_enabled' => self::is_ras_ready_to_configure(),
-				'action_text'    => __( 'Reader Activation campaign', 'newspack-plugin' ),
+				'action_text'    => __( 'Audience Management campaign', 'newspack-plugin' ),
 				'disabled_text'  => __( 'Waiting for all settings to be ready', 'newspack-plugin' ),
 			],
 		];

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Reader Activation.
+ * Reader Activation (publicly rebranded as "Audience Management").
  *
  * @package Newspack
  */
@@ -373,7 +373,7 @@ final class Reader_Activation {
 	}
 
 	/**
-	 * Get a reader activation settings.
+	 * Get a setting value.
 	 *
 	 * @param string $name Setting name.
 	 *
@@ -394,7 +394,7 @@ final class Reader_Activation {
 	}
 
 	/**
-	 * Update a reader activation setting.
+	 * Update a setting value.
 	 *
 	 * @param string $key   Option name.
 	 * @param mixed  $value Option value.
@@ -411,7 +411,7 @@ final class Reader_Activation {
 		}
 
 		/**
-		 * Fires just before a Reader Activation setting is updated
+		 * Fires just before a setting is updated
 		 *
 		 * @param string $key   Option name.
 		 * @param mixed  $value Option value.
@@ -722,7 +722,7 @@ final class Reader_Activation {
 				'active'      => self::is_terms_configured(),
 				'label'       => __( 'Legal Pages', 'newspack-plugin' ),
 				'description' => __( 'Displaying legal pages like Privacy Policy and Terms of Service on your site is recommended for allowing readers to register and access their account.', 'newspack-plugin' ),
-				'help_url'    => 'https://help.newspack.com/engagement/reader-activation-system',
+				'help_url'    => 'https://help.newspack.com/engagement/audience-management-system/',
 				'warning'     => __( 'Privacy policies that tell users how you collect and use their data are essential for running a  trustworthy website. While rules and regulations can differ by country, certain legal pages might be required by law.', 'newspack-plugin' ),
 				'fields'      => [
 					'terms_text' => [
@@ -743,7 +743,7 @@ final class Reader_Activation {
 				'label'        => __( 'Email Service Provider (ESP)', 'newspack-plugin' ),
 				'description'  => __( 'Connect to your ESP to register readers with their email addresses and send newsletters.', 'newspack-plugin' ),
 				'instructions' => __( 'Connect to your email service provider (ESP) and enable at least one subscription list.', 'newspack-plugin' ),
-				'help_url'     => 'https://help.newspack.com/engagement/reader-activation-system',
+				'help_url'     => 'https://help.newspack.com/engagement/audience-management-system/',
 				'href'         => \admin_url( 'edit.php?post_type=newspack_nl_cpt&page=newspack-newsletters' ),
 				'action_text'  => __( 'ESP settings' ),
 			],
@@ -751,7 +751,7 @@ final class Reader_Activation {
 				'active'      => self::is_transactional_email_configured(),
 				'label'       => __( 'Transactional Emails', 'newspack-plugin' ),
 				'description' => __( 'Your sender name and email address determines how readers find emails related to their account in their inbox. To customize the content of these emails, visit Advanced Settings below.', 'newspack-plugin' ),
-				'help_url'    => 'https://help.newspack.com/engagement/reader-activation-system',
+				'help_url'    => 'https://help.newspack.com/engagement/audience-management-system/',
 				'fields'      => [
 					'sender_name'           => [
 						'label'       => __( 'Sender Name', 'newspack-plugin' ),
@@ -772,7 +772,7 @@ final class Reader_Activation {
 				'label'        => __( 'reCAPTCHA', 'newspack-plugin' ),
 				'description'  => __( 'Connecting to a Google reCAPTCHA account enables enhanced anti-spam for all Newspack sign-up blocks.', 'newspack-plugin' ),
 				'instructions' => __( 'Enable reCAPTCHA and enter your account credentials.', 'newspack-plugin' ),
-				'help_url'     => 'https://help.newspack.com/engagement/reader-activation-system',
+				'help_url'     => 'https://help.newspack.com/engagement/audience-management-system/',
 				'href'         => \admin_url( '/admin.php?page=newspack-settings&scrollTo=newspack-settings-recaptcha' ),
 				'action_text'  => __( 'reCAPTCHA settings' ),
 			],
@@ -782,7 +782,7 @@ final class Reader_Activation {
 				'label'        => __( 'Reader Revenue', 'newspack-plugin' ),
 				'description'  => __( 'Setting suggested donation amounts is required for enabling a streamlined donation experience.', 'newspack-plugin' ),
 				'instructions' => __( 'Set platform to "Newspack" or "News Revenue Hub" and configure your default donation settings. If using News Revenue Hub, set an Organization ID and a Donor Landing Page in News Revenue Hub Settings.', 'newspack-plugin' ),
-				'help_url'     => 'https://help.newspack.com/engagement/reader-activation-system',
+				'help_url'     => 'https://help.newspack.com/engagement/audience-management-system/',
 				'href'         => \admin_url( '/admin.php?page=newspack-audience#/payment' ),
 				'action_text'  => __( 'Reader Revenue settings' ),
 			],
@@ -794,7 +794,7 @@ final class Reader_Activation {
 				],
 				'label'          => __( 'Reader Activation Campaign', 'newspack-plugin' ),
 				'description'    => __( 'Building a set of prompts with default segments and settings allows for an improved experience optimized for Reader Activation.', 'newspack-plugin' ),
-				'help_url'       => 'https://help.newspack.com/engagement/reader-activation-system',
+				'help_url'       => 'https://help.newspack.com/engagement/audience-management-system/',
 				'href'           => self::is_ras_campaign_configured() ? admin_url( '/admin.php?page=newspack-audience-campaigns' ) : admin_url( '/admin.php?page=newspack-audience#/campaign' ),
 				'action_enabled' => self::is_ras_ready_to_configure(),
 				'action_text'    => __( 'Reader Activation campaign', 'newspack-plugin' ),

--- a/includes/reader-activation/sync/class-sync.php
+++ b/includes/reader-activation/sync/class-sync.php
@@ -48,14 +48,14 @@ class Sync {
 		if ( ! Reader_Activation::is_enabled() ) {
 			$errors->add(
 				'ras_not_enabled',
-				__( 'Reader Activation is not enabled.', 'newspack-plugin' )
+				__( 'Audience Management is not enabled.', 'newspack-plugin' )
 			);
 		}
 
 		if ( class_exists( 'WCS_Staging' ) && \WCS_Staging::is_duplicate_site() ) {
 			$errors->add(
 				'wcs_duplicate_site',
-				__( 'Reader Activation sync is disabled for cloned sites.', 'newspack-plugin' )
+				__( 'Audience Management contact data syncing is disabled for cloned sites.', 'newspack-plugin' )
 			);
 		}
 
@@ -71,7 +71,7 @@ class Sync {
 		) {
 			$errors->add(
 				'esp_sync_not_allowed',
-				__( 'Sync is disabled for staging sites. To bypass this check, set the NEWSPACK_ALLOW_READER_SYNC constant in your wp-config.php.', 'newspack-plugin' )
+				__( 'Contact data syncing is disabled for staging sites. To bypass this check, set the NEWSPACK_ALLOW_READER_SYNC constant in your wp-config.php.', 'newspack-plugin' )
 			);
 		}
 

--- a/includes/wizards/audience/class-audience-campaigns.php
+++ b/includes/wizards/audience/class-audience-campaigns.php
@@ -47,7 +47,7 @@ class Audience_Campaigns extends Wizard {
 	 * @return string The wizard name.
 	 */
 	public function get_name() {
-		return esc_html__( 'Audience Development / Campaigns', 'newspack-plugin' );
+		return esc_html__( 'Audience Management / Campaigns', 'newspack-plugin' );
 	}
 
 	/**

--- a/includes/wizards/audience/class-audience-donations.php
+++ b/includes/wizards/audience/class-audience-donations.php
@@ -43,7 +43,7 @@ class Audience_Donations extends Wizard {
 	 * @return string The wizard name.
 	 */
 	public function get_name() {
-		return esc_html__( 'Audience Development / Donations', 'newspack-plugin' );
+		return esc_html__( 'Audience Management / Donations', 'newspack-plugin' );
 	}
 
 	/**

--- a/includes/wizards/audience/class-audience-subscriptions.php
+++ b/includes/wizards/audience/class-audience-subscriptions.php
@@ -34,7 +34,7 @@ class Audience_Subscriptions extends Wizard {
 	 * @return string The wizard name.
 	 */
 	public function get_name() {
-		return esc_html__( 'Audience Development / Subscriptions', 'newspack-plugin' );
+		return esc_html__( 'Audience Management / Subscriptions', 'newspack-plugin' );
 	}
 
 	/**

--- a/includes/wizards/audience/class-audience-wizard.php
+++ b/includes/wizards/audience/class-audience-wizard.php
@@ -67,7 +67,7 @@ class Audience_Wizard extends Wizard {
 	 * @return string The wizard name.
 	 */
 	public function get_name() {
-		return esc_html__( 'Audience Development / Setup', 'newspack-plugin' );
+		return esc_html__( 'Audience Management / Setup', 'newspack-plugin' );
 	}
 
 	/**
@@ -149,7 +149,7 @@ class Audience_Wizard extends Wizard {
 	public function register_api_endpoints() {
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
-			'/wizard/' . $this->slug . '/reader-activation',
+			'/wizard/' . $this->slug . '/audience-management',
 			[
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'api_get_reader_activation_settings' ],
@@ -158,7 +158,7 @@ class Audience_Wizard extends Wizard {
 		);
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
-			'/wizard/' . $this->slug . '/reader-activation',
+			'/wizard/' . $this->slug . '/audience-management',
 			[
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => [ $this, 'api_update_reader_activation_settings' ],
@@ -167,7 +167,7 @@ class Audience_Wizard extends Wizard {
 		);
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
-			'/wizard/' . $this->slug . '/reader-activation/activate',
+			'/wizard/' . $this->slug . '/audience-management/activate',
 			[
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => [ $this, 'api_activate_reader_activation' ],
@@ -176,7 +176,7 @@ class Audience_Wizard extends Wizard {
 		);
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
-			'/wizard/' . $this->slug . '/reader-activation/emails/(?P<id>\d+)',
+			'/wizard/' . $this->slug . '/audience-management/emails/(?P<id>\d+)',
 			[
 				'methods'             => \WP_REST_Server::DELETABLE,
 				'callback'            => [ $this, 'api_reset_reader_activation_email' ],
@@ -185,7 +185,7 @@ class Audience_Wizard extends Wizard {
 		);
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
-			'/wizard/' . $this->slug . '/reader-activation/skip-campaign',
+			'/wizard/' . $this->slug . '/audience-management/skip-campaign',
 			[
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => function( $request ) {

--- a/includes/wizards/class-wizard.php
+++ b/includes/wizards/class-wizard.php
@@ -209,7 +209,7 @@ abstract class Wizard {
 			'newspack-wizards',
 			Newspack::plugin_url() . '/dist/wizards.js',
 			$this->get_script_dependencies(),
-			$asset_file['version'] ?? NEWSPACK_PLUGIN_VERSION,
+			NEWSPACK_PLUGIN_VERSION,
 			true
 		);
 	}

--- a/includes/wizards/newspack/class-newspack-dashboard.php
+++ b/includes/wizards/newspack/class-newspack-dashboard.php
@@ -31,7 +31,7 @@ class Newspack_Dashboard extends Wizard {
 	/**
 	 * Use a high priorty so that the Newspack parent menu will be created
 	 * prior to submenu items being added.
-	 * 
+	 *
 	 * @var int.
 	 */
 	protected $admin_menu_priority = 1;
@@ -44,13 +44,13 @@ class Newspack_Dashboard extends Wizard {
 	public function get_dashboard() {
 		$dashboard = [
 			'audience_development' => [
-				'title' => __( 'Audience development', 'newspack-plugin' ),
+				'title' => __( 'Audience Management', 'newspack-plugin' ),
 				'desc'  => __( 'Engage your readers more deeply with tools to build customer relationships that drive towards sustainable revenue.', 'newspack-plugin' ),
 				'cards' => [
 					[
 						'icon'  => 'settings',
 						'title' => __( 'Configuration', 'newspack-plugin' ),
-						'desc'  => __( 'Manage your audience development setup.', 'newspack-plugin' ),
+						'desc'  => __( 'Manage your Audience Management setup.', 'newspack-plugin' ),
 						'href'  => admin_url( 'admin.php?page=newspack-audience' ),
 					],
 					[
@@ -258,12 +258,12 @@ class Newspack_Dashboard extends Wizard {
 			'plugins'      => get_plugins(),
 			'siteStatuses' => [
 				'readerActivation' => [
-					'label'        => __( 'Reader Activation', 'newspack-plugin' ),
+					'label'        => __( 'Audience Management', 'newspack-plugin' ),
 					'statuses'     => [
 						'success' => __( 'Enabled', 'newspack-plugin' ),
 						'error'   => __( 'Disabled', 'newspack-plugin' ),
 					],
-					'endpoint'     => '/newspack/v1/wizard/newspack-audience/reader-activation',
+					'endpoint'     => '/newspack/v1/wizard/newspack-audience/audience-management',
 					'configLink'   => admin_url( 'admin.php?page=newspack-audience#/' ),
 					'dependencies' => [
 						'woocommerce' => [

--- a/src/wizards/audience/components/prompt.tsx
+++ b/src/wizards/audience/components/prompt.tsx
@@ -159,7 +159,7 @@ export default function Prompt( {
 			setSuccess( false );
 			setInFlight( true );
 			apiFetch< [ PromptType ] >( {
-				path: '/newspack-popups/v1/reader-activation/campaign',
+				path: '/newspack-popups/v1/audience-management/campaign',
 				method: 'post',
 				data: {
 					slug,

--- a/src/wizards/audience/views/campaigns/index.js
+++ b/src/wizards/audience/views/campaigns/index.js
@@ -27,7 +27,7 @@ import { CampaignsContext } from '../../contexts';
 
 const { HashRouter, Redirect, Route, Switch } = Router;
 
-const headerText = __( 'Audience Development / Campaigns', 'newspack-plugin' );
+const headerText = __( 'Audience Management / Campaigns', 'newspack-plugin' );
 
 const tabbedNavigation = [
 	{

--- a/src/wizards/audience/views/donations/index.js
+++ b/src/wizards/audience/views/donations/index.js
@@ -37,7 +37,7 @@ const AudienceDonations = () => {
 	];
 	return (
 		<Wizard
-			headerText={ __( 'Audience Development / Donations', 'newspack-plugin' ) }
+			headerText={ __( 'Audience Management / Donations', 'newspack-plugin' ) }
 			sections={ sections }
 			apiSlug={ AUDIENCE_DONATIONS_WIZARD_SLUG }
 			renderAboveSections={ () =>

--- a/src/wizards/audience/views/setup/campaign.js
+++ b/src/wizards/audience/views/setup/campaign.js
@@ -42,7 +42,7 @@ export default withWizardScreen( () => {
 		setError( false );
 		setInFlight( true );
 		apiFetch( {
-			path: '/newspack-popups/v1/reader-activation/campaign',
+			path: '/newspack-popups/v1/audience-management/campaign',
 		} )
 			.then( fetchedPrompts => {
 				setPrompts( fetchedPrompts );
@@ -61,7 +61,7 @@ export default withWizardScreen( () => {
 		if (
 			! utils.confirmAction(
 				__(
-					'Are you sure you want to skip setting up a reader activation campaign?',
+					'Are you sure you want to skip setting up an Audience Management campaign?',
 					'newspack-plugin'
 				)
 			)
@@ -72,7 +72,7 @@ export default withWizardScreen( () => {
 		setSkipped( { ...skipped, status: 'pending' } );
 		try {
 			const request = await apiFetch( {
-				path: '/newspack/v1/wizard/newspack-audience/reader-activation/skip-campaign',
+				path: '/newspack/v1/wizard/newspack-audience/audience-management/skip-campaign',
 				method: 'POST',
 				data: { skip: ! skipped.isSkipped },
 			} );
@@ -107,7 +107,7 @@ export default withWizardScreen( () => {
 	return (
 		<WizardsTab
 			title={ __(
-				'Set Up Reader Activation Campaign',
+				'Set Up Audience Management Campaign',
 				'newspack-plugin'
 			) }
 			description={ __(

--- a/src/wizards/audience/views/setup/complete.js
+++ b/src/wizards/audience/views/setup/complete.js
@@ -127,7 +127,7 @@ export default withWizardScreen( ( { fetchConfig } ) => {
 		try {
 			setCompleted(
 				await apiFetch( {
-					path: '/newspack/v1/wizard/newspack-audience/reader-activation/activate',
+					path: '/newspack/v1/wizard/newspack-audience/audience-management/activate',
 					method: 'post',
 					data: {
 						skip_activation: isSkippedCampaignSetup,

--- a/src/wizards/audience/views/setup/complete.js
+++ b/src/wizards/audience/views/setup/complete.js
@@ -37,7 +37,7 @@ const listItems = [
 	},
 	{
 		text: __(
-			'The <strong>Reader Activation campaign</strong> will be activated with default segments and settings.',
+			'The <strong>Audience Management campaign</strong> will be activated with default segments and settings.',
 			'newspack-plugin'
 		),
 		isSkipped: '<span class="is-skipped">[skipped]</span>',
@@ -47,7 +47,7 @@ const listItems = [
 const DEFAULT_ACTIVATION_STEPS = {
 	campaignsSegments: __( 'Setting up new segments…', 'newspack-plugin' ),
 	readerRegistration: __( 'Activating reader registration…', 'newspack-plugin' ),
-	campaignsPrompts: __( 'Activating Reader Activation Campaign…', 'newspack-plugin' ),
+	campaignsPrompts: __( 'Activating Audience Management Campaign…', 'newspack-plugin' ),
 };
 
 /**
@@ -142,7 +142,7 @@ export default withWizardScreen( ( { fetchConfig } ) => {
 	return (
 		<div className="newspack-ras-campaign__completed">
 			<WizardsTab
-				title={ __( 'Enable Reader Activation', 'newspack-plugin' ) }
+				title={ __( 'Enable Audience Management', 'newspack-plugin' ) }
 				description={
 					<>
 						{ __(
@@ -170,7 +170,7 @@ export default withWizardScreen( ( { fetchConfig } ) => {
 				) }
 				{ ! inFlight && (
 					<Card className="newspack-ras-campaign__completed-card">
-						<h2>{ __( "You're all set to enable Reader Activation!", 'newspack-plugin' ) }</h2>
+						<h2>{ __( "You're all set to enable Audience Management!", 'newspack-plugin' ) }</h2>
 						<p>{ __( 'This is what will happen next:', 'newspack-plugin' ) }</p>
 
 						<Card noBorder className="justify-center">
@@ -186,7 +186,7 @@ export default withWizardScreen( ( { fetchConfig } ) => {
 
 						<Card buttonsCard noBorder className="justify-center">
 							<Button isPrimary onClick={ () => activate() }>
-								{ __( 'Enable Reader Activation', 'newspack-plugin' ) }
+								{ __( 'Enable Audience Management', 'newspack-plugin' ) }
 							</Button>
 						</Card>
 					</Card>

--- a/src/wizards/audience/views/setup/content-gating.js
+++ b/src/wizards/audience/views/setup/content-gating.js
@@ -73,7 +73,7 @@ export default withWizardScreen( () => {
 					) }
 					<ExternalLink
 						href={
-							'https://help.newspack.com/engagement/reader-activation-system/content-gating/'
+							'https://help.newspack.com/engagement/audience-management-system/content-gating/'
 						}
 					>
 						{ __( 'Learn more', 'newspack-plugin' ) }

--- a/src/wizards/audience/views/setup/index.js
+++ b/src/wizards/audience/views/setup/index.js
@@ -34,7 +34,7 @@ function AudienceWizard( { pluginRequirements, wizardApiFetch } ) {
 		setError( false );
 		setInFlight( true );
 		return wizardApiFetch( {
-			path: '/newspack/v1/wizard/newspack-audience/reader-activation',
+			path: '/newspack/v1/wizard/newspack-audience/audience-management',
 		} )
 			.then( ( { config: fetchedConfig, prerequisites_status, can_esp_sync } ) => {
 				setPrerequisites( prerequisites_status );
@@ -51,7 +51,7 @@ function AudienceWizard( { pluginRequirements, wizardApiFetch } ) {
 		setError( false );
 		setInFlight( true );
 		wizardApiFetch( {
-			path: '/newspack/v1/wizard/newspack-audience/reader-activation',
+			path: '/newspack/v1/wizard/newspack-audience/audience-management',
 			method: 'post',
 			quiet: true,
 			data,
@@ -117,7 +117,7 @@ function AudienceWizard( { pluginRequirements, wizardApiFetch } ) {
 
 	const props = {
 		headerText: __(
-			'Audience Development',
+			'Audience Management',
 			'newspack-plugin'
 		),
 		tabbedNavigation: tabs,

--- a/src/wizards/audience/views/setup/setup.js
+++ b/src/wizards/audience/views/setup/setup.js
@@ -84,16 +84,16 @@ export default withWizardScreen( ( { config, fetchConfig, updateConfig, getShare
 
 	return (
 		<WizardsTab
-			title={ __( 'Audience Development', 'newspack-plugin' ) }
+			title={ __( 'Audience Management', 'newspack-plugin' ) }
 			description={
 				<>
 					{ __(
-						"Newspack's Reader Activation system is a set of features that aim to increase reader loyalty, promote engagement, and drive revenue. ",
+						"Newspack's Audience Management system is a set of features that aim to increase reader loyalty, promote engagement, and drive revenue. ",
 						'newspack-plugin'
 					) }
 					<ExternalLink
 						href={
-							'https://help.newspack.com/engagement/reader-activation-system'
+							'https://help.newspack.com/engagement/audience-management-system'
 						}
 					>
 						{ __( 'Learn more', 'newspack-plugin' ) }
@@ -122,7 +122,7 @@ export default withWizardScreen( ( { config, fetchConfig, updateConfig, getShare
 			{ 0 === missingPlugins.length && prerequisites && ! allReady && (
 				<Notice
 					noticeText={ __(
-						'Complete these settings to enable Reader Activation.',
+						'Complete these settings to enable Audience Management.',
 						'newspack-plugin'
 					) }
 					isWarning
@@ -131,7 +131,7 @@ export default withWizardScreen( ( { config, fetchConfig, updateConfig, getShare
 			{ prerequisites && allReady && config.enabled && (
 				<Notice
 					noticeText={ __(
-						'Reader Activation is enabled.',
+						'Audience Management is enabled.',
 						'newspack-plugin'
 					) }
 					isSuccess
@@ -140,7 +140,7 @@ export default withWizardScreen( ( { config, fetchConfig, updateConfig, getShare
 			{ ! prerequisites && (
 				<>
 					<Waiting isLeft />
-					{ __( 'Retrieving status…', 'newspack-plugin' ) }
+					{ __( 'Fetching status…', 'newspack-plugin' ) }
 				</>
 			) }
 			{ 0 < missingPlugins.length && prerequisites && (

--- a/src/wizards/audience/views/setup/transactional-emails.js
+++ b/src/wizards/audience/views/setup/transactional-emails.js
@@ -15,7 +15,7 @@ export default withWizardScreen(
 			setError( false );
 			setInFlight( true );
 			wizardApiFetch( {
-				path: `/newspack/v1/wizard/newspack-audience/reader-activation/emails/${ postId }`,
+				path: `/newspack/v1/wizard/newspack-audience/audience-management/emails/${ postId }`,
 				method: 'DELETE',
 				quiet: true,
 			} )

--- a/src/wizards/audience/views/subscriptions/index.tsx
+++ b/src/wizards/audience/views/subscriptions/index.tsx
@@ -37,7 +37,7 @@ function AudienceSubscriptions() {
 	return (
 		<Wizard
 			headerText={ __(
-				'Audience Development / Subscriptions',
+				'Audience Management / Subscriptions',
 				'newspack-plugin'
 			) }
 			sections={ tabs }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Renames "Reader Activation" and "Audience Development" to "Audience Management" throughout admin pages, for consistency.

Also renames REST API routes from `reader-activation` to `audience-management`.

Also updates Help site URLs containing `reader-activation-system` to `audience-management-system` (these aren't ready yet, but are set to temporarily redirect to `reader-activation-system` for now).

Does not rename files, functions, classes, methods, etc. in code, as this would require much more careful QA! We can consider doing this in the future.

Goes along with https://github.com/Automattic/newspack-popups/pull/1393.

Closes `1205919985867982/1209354311969236`.

### How to test the changes in this Pull Request:

1. Check out this branch and https://github.com/Automattic/newspack-popups/pull/1393 and rebuild assets. Confirm there are no build errors.
2. In WP admin, navigate to **Audience > Setup** .
3. Confirm that all admin-facing text describes "Audience Management" features instead of "Reader Activation" and "Audience Development" (these shouldn't be mentioned anywhere anymore). Also confirm that any outgoing links to URLs containing `audience-management-system`  lead to the correct pages on the Help site. Make sure to expand every card in the onboarding wizard and inspect every settings element below and in the other Audience sub-tabs.
4. Smoke test updating some settings throughout the Audience wizard pages and confirm that all continue to function as usual.
5. Install both this and the Campaigns plugin on a fresh testing site and complete site setup and the onboarding wizard in **Audience > Setup**. Confirm that the campaign created after the last step is called "Audience Management Campaign" instead of "Reader Activation Campaign".

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->