### PR TITLE
fix(recaptcha): remove v3 from heading; preserve settings on toggle

### DIFF
--- a/src/wizards/newspack/views/settings/connections/index.tsx
+++ b/src/wizards/newspack/views/settings/connections/index.tsx
@@ -51,7 +51,7 @@ function Connections() {
 			{ /* reCAPTCHA */ }
 			<WizardSection
 				scrollToAnchor="newspack-settings-recaptcha"
-				title={ __( 'reCAPTCHA v3', 'newspack-plugin' ) }
+				title={ __( 'reCAPTCHA', 'newspack-plugin' ) }
 			>
 				<Recaptcha />
 			</WizardSection>

--- a/src/wizards/newspack/views/settings/connections/recaptcha.tsx
+++ b/src/wizards/newspack/views/settings/connections/recaptcha.tsx
@@ -195,7 +195,7 @@ function Recaptcha() {
 			toggleOnChange={ () =>
 				updateSettings(
 					{
-						...settingsDefault,
+						...settings,
 						use_captcha: ! settings.use_captcha,
 					},
 					true


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes the heading for reCAPTCHA in Newspack > Settings, and fixes a small bug when toggling on or off.

### How to test the changes in this Pull Request:

1. On `epic/ia`, visit **Newspack > Settings**.
2. Observe that the reCAPTCHA settings heading says `reCAPTCHA v3`.
3. Toggle on reCAPTCHA, select v2, enter some credentials, and save.
4. Toggle off reCAPTCHA, then toggle on again, and observe that the settings you saved in step 3 have been lost.
5. Check out this branch and refresh.
6. Confirm that the heading now says just `reCAPTCHA`.
7. Repeat steps 3-4 and confirm that after toggling reCAPTCHA on again, your previously saved settings are restored.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->