### PR TITLE
fix(recaptcha): no need to scroll to top when showing v2 widget

### DIFF
--- a/src/other-scripts/recaptcha/index.js
+++ b/src/other-scripts/recaptcha/index.js
@@ -92,12 +92,7 @@ function renderV2Widget( form, onSuccess = null, onError = null ) {
 				// Empty error messages if present.
 				removeErrorMessages( form );
 
-				grecaptcha.execute( widgetId ).then( () => {
-					// If we are in an iframe scroll to top.
-					if ( window?.location !== window?.parent?.location ) {
-						document.body.scrollIntoView( { behavior: 'smooth' } );
-					}
-				} );
+				grecaptcha.execute( widgetId );
 			} else {
 				form.removeAttribute( 'data-recaptcha-validated' );
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Goes along with https://github.com/Automattic/newspack-blocks/pull/2052. With the changes in that PR, modal elements will exhibit proper scroll/fixed-positioning behavior, so the reCAPTCHA v2 widget will no longer render at the top of the modal content window, and thus we'll no longer need to scroll it into view.

### How to test the changes in this Pull Request:

See testing instructions in https://github.com/Automattic/newspack-blocks/pull/2052.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->