### PR TITLE
fix(ia): prevent enqueue of admin css in the frontend

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -415,12 +415,14 @@ final class Newspack {
 		wp_style_add_data( 'newspack-commons', 'rtl', 'replace' );
 		wp_enqueue_style( 'newspack-commons' );
 
-		\wp_enqueue_style(
-			'newspack-admin',
-			self::plugin_url() . '/dist/admin.css',
-			[],
-			NEWSPACK_PLUGIN_VERSION
-		);
+		if ( is_admin() ) {
+			\wp_enqueue_style(
+				'newspack-admin',
+				self::plugin_url() . '/dist/admin.css',
+				[],
+				NEWSPACK_PLUGIN_VERSION
+			);
+		}
 	}
 }
 Newspack::instance();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Prevents Newspack's `admin.css` asset from being enqueued to the frontend in case the `Newspack::load_common_assets()` is called outside of admin context.

Once this gets merged, we should cherry-pick this change to `trunk` as it should also be happening outside of IA, but without a noticeable visual impact.

### How to test the changes in this Pull Request:

Confirm the `/wp-content/plugins/newspack-plugin/dist/admin.css` is not enqueued to the frontend.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->