### PR TITLE
fix: update GAM preflight error text

### DIFF
--- a/includes/wizards/newspack/class-newspack-dashboard.php
+++ b/includes/wizards/newspack/class-newspack-dashboard.php
@@ -275,7 +275,7 @@ class Newspack_Dashboard extends Wizard {
 				'googleAdManager'  => [
 					'label'            => __( 'Google Ad Manager', 'newspack-plugin' ),
 					'statuses'         => [
-						'error-preflight' => __( 'Proxy Not Configured', 'newspack-plugin' ),
+						'error-preflight' => __( 'Disconnected', 'newspack-plugin' ),
 					],
 					'endpoint'         => '/newspack/v1/wizard/billboard',
 					'isPreflightValid' => ( new Newspack_Ads_Configuration_Manager() )->is_gam_connected(),


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/inbox/1206274567818680/1209021112743395/1209324783532172/f

Updates the GAM proxy connection error to "Disconnected"

![Screenshot 2025-02-11 at 12 05 01](https://github.com/user-attachments/assets/998820d2-385b-4ffa-80bd-32a6363c6ffd)


### How to test the changes in this Pull Request:

1. On a test site make sure GAM is not connected and the newspack manager connection is broken
2. Go to Newspack > Dashboard
3. On `epic/ia` the GAM status will display a "Proxy Not Configured" error. On this branch, it will display "Disconnected"

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->