### PR TITLE
feat: fixes and improvements for WooCommerce Subscriptions Gifting

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -176,6 +176,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/wc-memberships/class-memberships.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-woocommerce.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php';
+		include_once NEWSPACK_ABSPATH . 'includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions-gifting.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-teams-for-memberships.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-newspack-elections.php';
 

--- a/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions-gifting.php
+++ b/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions-gifting.php
@@ -41,13 +41,13 @@ class WooCommerce_Subscriptions_Gifting {
 	 * @return array
 	 */
 	public static function new_recipient_fields( $fields ) {
-		// Escape hatch to force required shipping address for virtual products.
+		// Escape hatch to force required shipping address.
 		if ( apply_filters( 'wcsg_require_shipping_address_for_virtual_products', false ) ) { // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 			return $fields;
 		}
 		$required_fields = Donations::get_billing_fields();
 		foreach ( $fields as $field_name => $field_config ) {
-			if ( ! in_array( 'billing_' . $field_name, $required_fields, true ) ) {
+			if ( 'shipping_' !== substr( $field_name, 0, 9 ) && ! in_array( 'billing_' . $field_name, $required_fields, true ) ) {
 				unset( $fields[ $field_name ] );
 			}
 		}
@@ -60,7 +60,7 @@ class WooCommerce_Subscriptions_Gifting {
 	 * @return string
 	 */
 	public static function default_gifting_checkbox_text() {
-		return __( 'This purchase is a gift.', 'newspack' );
+		return __( 'This purchase is a gift', 'newspack' );
 	}
 }
 WooCommerce_Subscriptions_Gifting::init();

--- a/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions-gifting.php
+++ b/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions-gifting.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * WooCommerce Subscriptions Gifting Integration class.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Main class.
+ */
+class WooCommerce_Subscriptions_Gifting {
+	/**
+	 * Initialize hooks and filters.
+	 */
+	public static function init() {
+		\add_filter( 'wcsg_new_recipient_account_details_fields', [ __CLASS__, 'new_recipient_fields' ] );
+		\add_filter( 'wcsg_require_shipping_address_for_virtual_products', '__return_false' );
+		\add_filter( 'default_option_woocommerce_subscriptions_gifting_gifting_checkbox_text', [ __CLASS__, 'default_gifting_checkbox_text' ] );
+	}
+
+	/**
+	 * Check if WooCommerce Subscriptions Gifting is active.
+	 *
+	 * @return bool
+	 */
+	public static function is_active() {
+		return function_exists( 'WC' ) && class_exists( 'WC_Subscriptions' ) && class_exists( 'WCS_Gifting' );
+	}
+
+	/**
+	 * Ensure that only billing address fields enabled in Reader Revenue settings
+	 * are required for new gift recipient accounts.
+	 *
+	 * See: https://github.com/woocommerce/woocommerce-subscriptions-gifting/blob/trunk/includes/class-wcsg-recipient-details.php#L275
+	 *
+	 * @param array $fields Address fields.
+	 * @return array
+	 */
+	public static function new_recipient_fields( $fields ) {
+		// Escape hatch to force required shipping address for virtual products.
+		if ( apply_filters( 'wcsg_require_shipping_address_for_virtual_products', false ) ) { // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+			return $fields;
+		}
+		$required_fields = Donations::get_billing_fields();
+		foreach ( $fields as $field_name => $field_config ) {
+			if ( ! in_array( 'billing_' . $field_name, $required_fields, true ) ) {
+				unset( $fields[ $field_name ] );
+			}
+		}
+		return $fields;
+	}
+
+	/**
+	 * Filters the default text shown for the gifting checkbox during checkout.
+	 *
+	 * @return string
+	 */
+	public static function default_gifting_checkbox_text() {
+		return __( 'This purchase is a gift.', 'newspack' );
+	}
+}
+WooCommerce_Subscriptions_Gifting::init();

--- a/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions-gifting.php
+++ b/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions-gifting.php
@@ -20,6 +20,7 @@ class WooCommerce_Subscriptions_Gifting {
 		\add_filter( 'wcsg_new_recipient_account_details_fields', [ __CLASS__, 'new_recipient_fields' ] );
 		\add_filter( 'wcsg_require_shipping_address_for_virtual_products', '__return_false' );
 		\add_filter( 'default_option_woocommerce_subscriptions_gifting_gifting_checkbox_text', [ __CLASS__, 'default_gifting_checkbox_text' ] );
+		\add_filter( 'newpack_reader_activation_reader_is_without_password', [ __CLASS__, 'is_reader_without_password' ], 10, 2 );
 	}
 
 	/**
@@ -61,6 +62,18 @@ class WooCommerce_Subscriptions_Gifting {
 	 */
 	public static function default_gifting_checkbox_text() {
 		return __( 'This purchase is a gift', 'newspack' );
+	}
+
+	/**
+	 * New gift recipients don't yet have a password.
+	 *
+	 * @param bool $is_reader_without_password True if the reader has not set a password.
+	 * @param int  $user_id The user ID.
+	 *
+	 * @return bool
+	 */
+	public static function is_reader_without_password( $is_reader_without_password, $user_id ) {
+		return 'true' === get_user_meta( $user_id, 'wcsg_update_account', true );
 	}
 }
 WooCommerce_Subscriptions_Gifting::init();

--- a/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions-gifting.php
+++ b/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions-gifting.php
@@ -41,7 +41,7 @@ class WooCommerce_Subscriptions_Gifting {
 	 * @return array
 	 */
 	public static function new_recipient_fields( $fields ) {
-		// Escape hatch to force required shipping address.
+		// Escape hatch to force required shipping address for virtual products.
 		if ( apply_filters( 'wcsg_require_shipping_address_for_virtual_products', false ) ) { // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 			return $fields;
 		}

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1118,7 +1118,14 @@ final class Reader_Activation {
 			return new \WP_Error( 'newspack_is_reader_without_password', __( 'Invalid user.', 'newspack-plugin' ) );
 		}
 
-		return (bool) \get_user_meta( $user->ID, self::WITHOUT_PASSWORD, false );
+		/**
+		 * Filters whether the user should be considered a reader without a password.
+		 *
+		 * @param bool $is_reader_without_password True if the reader has not set a password.
+		 * @param int  $user_id                    User ID.
+		 * @return bool
+		 */
+		return (bool) apply_filters( 'newpack_reader_activation_reader_is_without_password', \get_user_meta( $user->ID, self::WITHOUT_PASSWORD, false ), $user->ID );
 	}
 
 	/**

--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -126,7 +126,7 @@ class WooCommerce_My_Account {
 					unset( $shipping_address[ $ignored_field ] );
 				}
 
-				if ( empty( array_filter( $billing_address ) ) && empty( array_filter( $billing_address ) ) ) {
+				if ( empty( array_filter( $billing_address ) ) && empty( array_filter( $shipping_address ) ) ) {
 					$default_disabled_items[] = 'edit-address';
 				}
 

--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -29,8 +29,6 @@ class WooCommerce_My_Account {
 	 */
 	public static function init() {
 		\add_filter( 'woocommerce_account_menu_items', [ __CLASS__, 'my_account_menu_items' ], 1000 );
-		\add_filter( 'wcsg_new_recipient_account_details_fields', [ __CLASS__, 'new_recipient_fields' ] );
-		\add_filter( 'wcsg_require_shipping_address_for_virtual_products', '__return_false' );
 		\add_filter( 'woocommerce_default_address_fields', [ __CLASS__, 'required_address_fields' ] );
 		\add_filter( 'woocommerce_billing_fields', [ __CLASS__, 'required_address_fields' ] );
 		\add_filter( 'woocommerce_get_checkout_url', [ __CLASS__, 'get_checkout_url' ] );
@@ -548,29 +546,6 @@ class WooCommerce_My_Account {
 			$fields = self::get_required_fields( $fields );
 		}
 
-		return $fields;
-	}
-
-	/**
-	 * Ensure that only billing address fields enabled in Reader Revenue settings
-	 * are required for new gift recipient accounts.
-	 *
-	 * See: https://github.com/woocommerce/woocommerce-subscriptions-gifting/blob/trunk/includes/class-wcsg-recipient-details.php#L275
-	 *
-	 * @param array $fields Address fields.
-	 * @return array
-	 */
-	public static function new_recipient_fields( $fields ) {
-		// Escape hatch to force required shipping address for virtual products.
-		if ( apply_filters( 'wcsg_require_shipping_address_for_virtual_products', false ) ) { // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
-			return $fields;
-		}
-		$required_fields = Donations::get_billing_fields();
-		foreach ( $fields as $field_name => $field_config ) {
-			if ( ! in_array( 'billing_' . $field_name, $required_fields, true ) ) {
-				unset( $fields[ $field_name ] );
-			}
-		}
 		return $fields;
 	}
 

--- a/tests/unit-tests/reader-activation.php
+++ b/tests/unit-tests/reader-activation.php
@@ -68,7 +68,7 @@ class Newspack_Test_Reader_Activation extends WP_UnitTestCase {
 		$user_id = self::register_sample_reader();
 		wp_logout();
 		$result = self::register_sample_reader(); // Reregister the same email.
-		$this->assertFalse( $result );
+		$this->assertTrue( is_wp_error( $result ) );
 		$this->assertFalse( is_user_logged_in() );
 		wp_delete_user( $user_id ); // Clean up.
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

- Establishes a new class for the WooCommerce Subscriptions Gifting (WCSG) extension and moves some existing functionality to this class.
- Fixes an issue where shipping address fields aren't required even if a recipient is gifted a shippable product.
- FIxes an issue where the "Addresses" menu item isn't shown in My Account if the user has a shipping address but no billing address.
- Along with https://github.com/Automattic/newspack-blocks/pull/2053, allows non-donation modal checkouts to show the "Gifting Checkbox Text" setting instead of a hardcoded label.

### How to test the changes in this Pull Request:

1. Check out this branch and https://github.com/Automattic/newspack-blocks/pull/2053 and activate the WooCommerce Subscriptions Gifting plugin. Delete the "Gifting Checkbox Text" option, in case it's been set before (with CLI: `wp option delete woocommerce_subscriptions_gifting_gifting_checkbox_text`)
2. Publish a subscription product that's NOT virtual or downloadable, and set up a shipping zone/method in WooCommerce settings ([documentation](https://woocommerce.com/document/setting-up-shipping-zones/))
3. Add a Checkout Button block set to this shippable subscription product.
4. As a reader, start a modal checkout with this shippable subscription product and confirm that a gifting checkbox appears on the first modal screen with the default non-donation label "This purchase is a gift":

<img width="657" alt="Screenshot 2025-02-12 at 4 28 15 PM" src="https://github.com/user-attachments/assets/a628cd57-a237-4199-9ebb-d127368fb933" />

5. As an admin, go to WooCommerce > Settings > Subscriptions and update the setting for Gifting Checkbox Text to something custom, then save:

<img width="656" alt="Screenshot 2025-02-12 at 4 29 34 PM" src="https://github.com/user-attachments/assets/6b0bfc38-fe6e-4cc0-819b-1801dc61f618" />

6. As a reader, start a modal checkout with the shippable subscription product and confirm that the label has changed to the custom setting from step 5:

<img width="651" alt="Screenshot 2025-02-12 at 4 27 10 PM" src="https://github.com/user-attachments/assets/950d22be-7e6a-4805-8487-5f624ecaeb41" />

7. As the reader, check the gifting option, enter a gift recipient's email address, and complete the transaction.
8. In a new session, log into the site as a reader using the gift recipient's email address.
9. Confirm that immediately upon logging in, you're required to enter any billing address fields as required in **Newspack > Reader Revenue > Donations** billing fields settings, plus all shipping address fields.

<img width="1235" alt="Screenshot 2025-02-12 at 5 01 06 PM" src="https://github.com/user-attachments/assets/67e262c5-c700-491d-bfd3-1adab33fcdd9" />

10. After submitting the required info, confirm that the "Addresses" menu item appears in the My Account menu:

<img width="392" alt="Screenshot 2025-02-12 at 5 02 03 PM" src="https://github.com/user-attachments/assets/2b9393d3-b9b1-49cd-821e-e33edb18c4e9" />

11. Visit My Subscription and confirm that the shipping address is applied to the gifted subscription:

<img width="778" alt="Screenshot 2025-02-12 at 5 02 52 PM" src="https://github.com/user-attachments/assets/7626b30c-6eef-47ee-a5a9-97dc8edd102f" />

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->