### PR TITLE
fix(ia): newsletters component for the setup wizard

### DIFF
--- a/src/wizards/setup/views/services/index.js
+++ b/src/wizards/setup/views/services/index.js
@@ -18,7 +18,7 @@ import apiFetch from '@wordpress/api-fetch';
  */
 import { withWizardScreen, Wizard, ActionCard, hooks } from '../../../../components/src';
 import ReaderRevenue from './ReaderRevenue';
-import { Settings as NewslettersSettings } from '../../../newsletters/views';
+import { Settings as NewslettersSettings } from '../../../newsletters/views/settings';
 import GAMOnboarding from '../../../advertising/components/onboarding';
 import { AUDIENCE_DONATIONS_WIZARD_SLUG } from '../../../audience/constants';
 import './style.scss';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

1205919985867982-as-1209354311969241

Fixes the Newsletters settings component import for the setup wizard.

### How to test the changes in this Pull Request:

1. While on the `epic/ia` branch, navigate to the `/wp-admin/admin.php?page=newspack-setup-wizard#/services` page
2. Toggle "Newsletters" on and confirm the fatal js error
3. Checkout this branch and refresh the page
4. Toggle "Newsletters" on and confirm you are able to configure and continue

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->