### PR TITLE
fix(wcs): account for pagination and failed scheduled retries in on-hold migration script

### DIFF
--- a/includes/cli/class-woocommerce-subscriptions.php
+++ b/includes/cli/class-woocommerce-subscriptions.php
@@ -163,7 +163,6 @@ class WooCommerce_Subscriptions {
 									$subscription->save();
 								}
 							}
-							++$scheduled;
 						} else {
 							// If there have been no retries, schedule expiration.
 							if ( self::$verbose ) {
@@ -174,8 +173,8 @@ class WooCommerce_Subscriptions {
 								$subscription->update_meta_data( '_newspack_cli_expiration_scheduled', true );
 								$subscription->save();
 							}
-							++$scheduled;
 						}
+						++$scheduled;
 					}
 				}
 				// Expire any subscriptinos that have passed the on-hold duration.

--- a/includes/cli/class-woocommerce-subscriptions.php
+++ b/includes/cli/class-woocommerce-subscriptions.php
@@ -151,17 +151,10 @@ class WooCommerce_Subscriptions {
 								remove_filter( 'wcs_is_scheduled_payment_attempt', '__return_true' );
 								if ( 0 === $subscription->get_date( 'payment_retry' ) ) {
 									if ( self::$verbose ) {
-										WP_CLI::line( 'Failed to schedule payment retry.' );
-									}
-									// There are cases on live sites where a renewed subscription status fails to transition back to active,
-									// so check to make sure the last order is not completed before flagging for expiration.
-									if ( ! $last_order || 'completed' !== $last_order->get_status() ) {
-										$should_expire = true;
-									} else {
-										WP_CLI::line( 'Subscription last order is completed. Moving to next subscription...' );
+										WP_CLI::line( 'Failed to schedule payment retry. Moving to next subscription...' );
 										WP_CLI::line( '' );
-										continue;
 									}
+									continue;
 								} else {
 									$subscription->add_order_note(
 										__( 'Final payment retry scheduled by Newspack CLI command.', 'newspack-plugin' )
@@ -207,20 +200,20 @@ class WooCommerce_Subscriptions {
 			$subscriptions = self::get_subscriptions( ++$page );
 		}
 		// Update flagged subscriptions.
-		if ( self::$live ) {
-			$flagged_subscriptions = self::get_flagged_subscriptions();
-			while ( ! empty( $flagged_subscriptions ) ) {
-				$end_date  = $subscription->get_meta( '_newspack_cli_end_date' );
-				$to_status = $subscription->get_meta( '_newspack_cli_to_status' );
+		$flagged_subscriptions = self::get_flagged_subscriptions();
+		while ( ! empty( $flagged_subscriptions ) ) {
+			$to_status = $subscription->get_meta( '_newspack_cli_to_status' );
+			if ( self::$live ) {
+				$end_date = $subscription->get_meta( '_newspack_cli_end_date' );
 				$subscription->set_end_date( $end_date );
 				$subscription->update_status( $to_status, __( 'Subscription status updated by Newspack CLI command.', 'newspack-plugin' ) );
-				if ( 'trash' === $to_status ) {
-					$trashed++;
-				} else {
-					$updated++;
-				}
-				$flagged_subscriptions = self::get_flagged_subscriptions();
 			}
+			if ( 'trash' === $to_status ) {
+				$trashed++;
+			} else {
+				$updated++;
+			}
+			$flagged_subscriptions = self::get_flagged_subscriptions();
 		}
 		WP_CLI::success( 'Finished processing subscriptions. ' . $updated . ' subscriptions updated. ' . $scheduled . ' retries scheduled. ' . $trashed . ' subscriptions trashed.' );
 		if ( ! self::$live ) {
@@ -253,7 +246,7 @@ class WooCommerce_Subscriptions {
 			$subscriptions = wcs_get_subscriptions(
 				[
 					'paged'                  => $page,
-					'subscriptions_per_page' => 50,
+					'subscriptions_per_page' => 1,
 					'subscription_status'    => 'on-hold',
 				]
 			);

--- a/includes/cli/class-woocommerce-subscriptions.php
+++ b/includes/cli/class-woocommerce-subscriptions.php
@@ -200,6 +200,11 @@ class WooCommerce_Subscriptions {
 		}
 		// Update flagged subscriptions.
 		$flagged_subscriptions = self::get_flagged_subscriptions();
+
+		if ( self::$verbose ) {
+			WP_CLI::line( '' );
+			WP_CLI::line( 'Processing flagged subscriptions:' );
+		}
 		while ( ! empty( $flagged_subscriptions ) ) {
 			foreach ( $flagged_subscriptions as $flagged_subscription ) {
 				if ( self::$live ) {
@@ -211,6 +216,9 @@ class WooCommerce_Subscriptions {
 					$flagged_subscription->update_meta_data( '_newspack_cli_status_updated', true );
 					$flagged_subscription->set_end_date( $end_date );
 					$flagged_subscription->save();
+					if ( self::$verbose ) {
+						WP_CLI::line( 'Updated subscription ' . $flagged_subscription->get_id() . ' to ' . $to_status );
+					}
 				}
 			}
 			$flagged_subscriptions = self::get_flagged_subscriptions();

--- a/includes/cli/class-woocommerce-subscriptions.php
+++ b/includes/cli/class-woocommerce-subscriptions.php
@@ -151,9 +151,10 @@ class WooCommerce_Subscriptions {
 								remove_filter( 'wcs_is_scheduled_payment_attempt', '__return_true' );
 								if ( 0 === $subscription->get_date( 'payment_retry' ) ) {
 									if ( self::$verbose ) {
-										WP_CLI::line( 'Failed to schedule payment retry. Moving to next subscription...' );
+										WP_CLI::line( 'Failed to schedule payment retry. Expiring...' );
 										WP_CLI::line( '' );
 									}
+									$should_expire = true;
 									continue;
 								} else {
 									$subscription->add_order_note(
@@ -163,7 +164,9 @@ class WooCommerce_Subscriptions {
 									$subscription->save();
 								}
 							}
-							++$scheduled;
+							if ( ! $should_expire ) {
+								++$scheduled;
+							}
 						} else {
 							// If there have been no retries, schedule expiration.
 							if ( self::$verbose ) {

--- a/includes/cli/class-woocommerce-subscriptions.php
+++ b/includes/cli/class-woocommerce-subscriptions.php
@@ -153,7 +153,15 @@ class WooCommerce_Subscriptions {
 									if ( self::$verbose ) {
 										WP_CLI::line( 'Failed to schedule payment retry.' );
 									}
-									$should_expire = true;
+									// There are cases on live sites where a renewed subscription status fails to transition back to active,
+									// so check to make sure the last order is not completed before flagging for expiration.
+									if ( ! $last_order || 'completed' !== $last_order->get_status() ) {
+										$should_expire = true;
+									} else {
+										WP_CLI::line( 'Subscription last order is completed. Moving to next subscription...' );
+										WP_CLI::line( '' );
+										continue;
+									}
 								} else {
 									$subscription->add_order_note(
 										__( 'Final payment retry scheduled by Newspack CLI command.', 'newspack-plugin' )

--- a/includes/cli/class-woocommerce-subscriptions.php
+++ b/includes/cli/class-woocommerce-subscriptions.php
@@ -113,7 +113,6 @@ class WooCommerce_Subscriptions {
 						if ( self::$live ) {
 							// Flag the update so we don't break wcs_get_subscriptions pagination.
 							$subscription->update_meta_data( '_newspack_cli_end_date', $subscription->get_date( 'next_payment' ) );
-							$subscription->update_meta_data( '_newspack_cli_status_updated', true );
 							$subscription->update_meta_data( '_newspack_cli_to_status', 'trash' );
 							$subscription->save();
 						}
@@ -162,9 +161,7 @@ class WooCommerce_Subscriptions {
 									$subscription->save();
 								}
 							}
-							if ( ! $should_expire ) {
-								++$scheduled;
-							}
+							++$scheduled;
 						} else {
 							// If there have been no retries, schedule expiration.
 							if ( self::$verbose ) {
@@ -186,7 +183,6 @@ class WooCommerce_Subscriptions {
 					if ( self::$live ) {
 						// Flag the update so we don't break wcs_get_subscriptions pagination.
 						$subscription->update_meta_data( '_newspack_cli_end_date', $end_date );
-						$subscription->update_meta_data( '_newspack_cli_status_updated', true );
 						$subscription->update_meta_data( '_newspack_cli_to_status', 'expired' );
 						$subscription->save();
 					}
@@ -204,8 +200,12 @@ class WooCommerce_Subscriptions {
 			$to_status = $subscription->get_meta( '_newspack_cli_to_status' );
 			if ( self::$live ) {
 				$end_date = $subscription->get_meta( '_newspack_cli_end_date' );
-				$subscription->set_end_date( $end_date );
 				$subscription->update_status( $to_status, __( 'Subscription status updated by Newspack CLI command.', 'newspack-plugin' ) );
+				$subscription->delete_meta_data( '_newspack_cli_end_date' );
+				$subscription->delete_meta_data( '_newspack_cli_to_status' );
+				$subscription->update_meta_data( '_newspack_cli_status_updated', true );
+				$subscription->set_end_date( $end_date );
+				$subscription->save();
 			}
 			if ( 'trash' === $to_status ) {
 				$trashed++;
@@ -265,7 +265,7 @@ class WooCommerce_Subscriptions {
 				'subscription_status'    => 'on-hold',
 				'meta_query'             => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 					[
-						'key'     => '_newspack_cli_status_updated',
+						'key'     => '_newspack_cli_to_status',
 						'compare' => 'EXISTS',
 					],
 				],

--- a/includes/cli/class-woocommerce-subscriptions.php
+++ b/includes/cli/class-woocommerce-subscriptions.php
@@ -71,7 +71,6 @@ class WooCommerce_Subscriptions {
 		$updated       = 0;
 		$trashed       = 0;
 		$page          = 1;
-		$per_page      = 25;
 		$subscriptions = self::get_subscriptions( $page );
 		if ( empty( $subscriptions ) ) {
 			WP_CLI::success( 'No on-hold subscriptions to process.' );
@@ -246,7 +245,7 @@ class WooCommerce_Subscriptions {
 			$subscriptions = wcs_get_subscriptions(
 				[
 					'paged'                  => $page,
-					'subscriptions_per_page' => 1,
+					'subscriptions_per_page' => 50,
 					'subscription_status'    => 'on-hold',
 				]
 			);

--- a/includes/cli/class-woocommerce-subscriptions.php
+++ b/includes/cli/class-woocommerce-subscriptions.php
@@ -133,9 +133,10 @@ class WooCommerce_Subscriptions {
 						++$scheduled;
 					}
 				} else {
-					$last_retry    = \WCS_Retry_Manager::store()->get_last_retry_for_order( wcs_get_objects_property( $last_order, 'id' ) );
-					$end_date      = $last_retry ? $last_retry->get_date() : $subscription->get_date( 'next_payment' );
-					$should_expire = wcs_date_to_time( $end_date ) + ( On_Hold_Duration::get_on_hold_duration() * DAY_IN_SECONDS ) < time();
+					$last_retry       = \WCS_Retry_Manager::store()->get_last_retry_for_order( wcs_get_objects_property( $last_order, 'id' ) );
+					$end_date         = $last_retry ? $last_retry->get_date() : $subscription->get_date( 'next_payment' );
+					$on_hold_duration = On_Hold_Duration::get_on_hold_duration() * DAY_IN_SECONDS;
+					$should_expire    = wcs_date_to_time( $end_date ) + $on_hold_duration < time();
 					if ( ! $should_expire ) {
 						// If there have been retries, schedule the final retry.
 						if ( $last_retry ) {
@@ -149,10 +150,11 @@ class WooCommerce_Subscriptions {
 								remove_filter( 'wcs_is_scheduled_payment_attempt', '__return_true' );
 								if ( 0 === $subscription->get_date( 'payment_retry' ) ) {
 									if ( self::$verbose ) {
-										WP_CLI::line( 'Failed to schedule payment retry. Moving to next subscription...' );
-										WP_CLI::line( '' );
+										WP_CLI::line( 'Failed to schedule payment retry. Scheduling subscription expiration...' );
 									}
-									continue;
+									On_Hold_Duration::schedule_expiration( $subscription->get_id(), wcs_date_to_time( $end_date ) + $on_hold_duration );
+									$subscription->update_meta_data( '_newspack_cli_expiration_scheduled', true );
+									$subscription->save();
 								} else {
 									$subscription->add_order_note(
 										__( 'Final payment retry scheduled by Newspack CLI command.', 'newspack-plugin' )
@@ -168,8 +170,9 @@ class WooCommerce_Subscriptions {
 								WP_CLI::line( 'No retries found. Scheduling subscription expiration...' );
 							}
 							if ( self::$live ) {
-								$on_hold_duration = On_Hold_Duration::get_on_hold_duration() * DAY_IN_SECONDS;
 								On_Hold_Duration::schedule_expiration( $subscription->get_id(), $subscription->get_time( 'next_payment' ) + $on_hold_duration );
+								$subscription->update_meta_data( '_newspack_cli_expiration_scheduled', true );
+								$subscription->save();
 							}
 							++$scheduled;
 						}

--- a/includes/cli/class-woocommerce-subscriptions.php
+++ b/includes/cli/class-woocommerce-subscriptions.php
@@ -108,16 +108,16 @@ class WooCommerce_Subscriptions {
 					// If the last order is the parent order and has a failed status, trash the subscription.
 					if ( $last_order && 'failed' === $last_order->get_status() ) {
 						if ( self::$verbose ) {
-							WP_CLI::line( 'Subscription parent order failed. Moving to trash...' );
+							WP_CLI::line( 'Subscription parent order failed. Flagging for trash...' );
 							WP_CLI::line( '' );
 						}
 						if ( self::$live ) {
-							$subscription->update_status( 'trash', __( 'Subscription status updated by Newspack CLI command.', 'newspack-plugin' ) );
-							$subscription->set_end_date( $subscription->get_date( 'next_payment' ) );
+							// Flag the update so we don't break wcs_get_subscriptions pagination.
+							$subscription->update_meta_data( '_newspack_cli_end_date', $subscription->get_date( 'next_payment' ) );
 							$subscription->update_meta_data( '_newspack_cli_status_updated', true );
+							$subscription->update_meta_data( '_newspack_cli_to_status', 'trash' );
 							$subscription->save();
 						}
-						++$trashed;
 						continue;
 					}
 				}
@@ -151,11 +151,9 @@ class WooCommerce_Subscriptions {
 								remove_filter( 'wcs_is_scheduled_payment_attempt', '__return_true' );
 								if ( 0 === $subscription->get_date( 'payment_retry' ) ) {
 									if ( self::$verbose ) {
-										WP_CLI::line( 'Failed to schedule payment retry. Expiring...' );
-										WP_CLI::line( '' );
+										WP_CLI::line( 'Failed to schedule payment retry.' );
 									}
 									$should_expire = true;
-									continue;
 								} else {
 									$subscription->add_order_note(
 										__( 'Final payment retry scheduled by Newspack CLI command.', 'newspack-plugin' )
@@ -183,15 +181,15 @@ class WooCommerce_Subscriptions {
 				// Expire any subscriptinos that have passed the on-hold duration.
 				if ( $should_expire ) {
 					if ( self::$verbose ) {
-						WP_CLI::line( 'Updating subscription status to expired...' );
+						WP_CLI::line( 'Flagging subscription for expiration...' );
 					}
 					if ( self::$live ) {
-						$subscription->update_status( 'expired', __( 'Subscription status updated by Newspack CLI command.', 'newspack-plugin' ) );
-						$subscription->set_end_date( $end_date );
+						// Flag the update so we don't break wcs_get_subscriptions pagination.
+						$subscription->update_meta_data( '_newspack_cli_end_date', $end_date );
 						$subscription->update_meta_data( '_newspack_cli_status_updated', true );
+						$subscription->update_meta_data( '_newspack_cli_to_status', 'expired' );
 						$subscription->save();
 					}
-					++$updated;
 				}
 				if ( self::$verbose ) {
 					WP_CLI::line( 'Finished processing subscription ' . $id );
@@ -199,6 +197,22 @@ class WooCommerce_Subscriptions {
 				}
 			}
 			$subscriptions = self::get_subscriptions( ++$page );
+		}
+		// Update flagged subscriptions.
+		if ( self::$live ) {
+			$flagged_subscriptions = self::get_flagged_subscriptions();
+			while ( ! empty( $flagged_subscriptions ) ) {
+				$end_date  = $subscription->get_meta( '_newspack_cli_end_date' );
+				$to_status = $subscription->get_meta( '_newspack_cli_to_status' );
+				$subscription->set_end_date( $end_date );
+				$subscription->update_status( $to_status, __( 'Subscription status updated by Newspack CLI command.', 'newspack-plugin' ) );
+				if ( 'trash' === $to_status ) {
+					$trashed++;
+				} else {
+					$updated++;
+				}
+				$flagged_subscriptions = self::get_flagged_subscriptions();
+			}
 		}
 		WP_CLI::success( 'Finished processing subscriptions. ' . $updated . ' subscriptions updated. ' . $scheduled . ' retries scheduled. ' . $trashed . ' subscriptions trashed.' );
 		if ( ! self::$live ) {
@@ -231,11 +245,32 @@ class WooCommerce_Subscriptions {
 			$subscriptions = wcs_get_subscriptions(
 				[
 					'paged'                  => $page,
-					'subscriptions_per_page' => 25,
+					'subscriptions_per_page' => 50,
 					'subscription_status'    => 'on-hold',
 				]
 			);
 		}
+		return $subscriptions;
+	}
+
+	/**
+	 * Get flagged subscriptions to update.
+	 *
+	 * @return array
+	 */
+	private static function get_flagged_subscriptions() {
+		$subscriptions = wcs_get_subscriptions(
+			[
+				'subscriptions_per_page' => 50,
+				'subscription_status'    => 'on-hold',
+				'meta_query'             => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+					[
+						'key'     => '_newspack_cli_status_updated',
+						'compare' => 'EXISTS',
+					],
+				],
+			]
+		);
 		return $subscriptions;
 	}
 }

--- a/includes/cli/class-woocommerce-subscriptions.php
+++ b/includes/cli/class-woocommerce-subscriptions.php
@@ -116,6 +116,7 @@ class WooCommerce_Subscriptions {
 							$subscription->update_meta_data( '_newspack_cli_to_status', 'trash' );
 							$subscription->save();
 						}
+						++$trashed;
 						continue;
 					}
 				}
@@ -188,6 +189,7 @@ class WooCommerce_Subscriptions {
 						$subscription->update_meta_data( '_newspack_cli_to_status', 'expired' );
 						$subscription->save();
 					}
+					++$updated;
 				}
 				if ( self::$verbose ) {
 					WP_CLI::line( 'Finished processing subscription ' . $id );
@@ -199,20 +201,17 @@ class WooCommerce_Subscriptions {
 		// Update flagged subscriptions.
 		$flagged_subscriptions = self::get_flagged_subscriptions();
 		while ( ! empty( $flagged_subscriptions ) ) {
-			$to_status = $subscription->get_meta( '_newspack_cli_to_status' );
-			if ( self::$live ) {
-				$end_date = $subscription->get_meta( '_newspack_cli_end_date' );
-				$subscription->update_status( $to_status, __( 'Subscription status updated by Newspack CLI command.', 'newspack-plugin' ) );
-				$subscription->delete_meta_data( '_newspack_cli_end_date' );
-				$subscription->delete_meta_data( '_newspack_cli_to_status' );
-				$subscription->update_meta_data( '_newspack_cli_status_updated', true );
-				$subscription->set_end_date( $end_date );
-				$subscription->save();
-			}
-			if ( 'trash' === $to_status ) {
-				$trashed++;
-			} else {
-				$updated++;
+			foreach ( $flagged_subscriptions as $flagged_subscription ) {
+				if ( self::$live ) {
+					$end_date  = $flagged_subscription->get_meta( '_newspack_cli_end_date' );
+					$to_status = $flagged_subscription->get_meta( '_newspack_cli_to_status' );
+					$flagged_subscription->update_status( $to_status, __( 'Subscription status updated by Newspack CLI command.', 'newspack-plugin' ) );
+					$flagged_subscription->delete_meta_data( '_newspack_cli_end_date' );
+					$flagged_subscription->delete_meta_data( '_newspack_cli_to_status' );
+					$flagged_subscription->update_meta_data( '_newspack_cli_status_updated', true );
+					$flagged_subscription->set_end_date( $end_date );
+					$flagged_subscription->save();
+				}
 			}
 			$flagged_subscriptions = self::get_flagged_subscriptions();
 		}


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

See https://a8c.slack.com/archives/C015W6BES8J/p1739466463068249?thread_ts=1738343578.900239&cid=C015W6BES8J

This PR fixes an issue where updating a subscription status throws off the results of `wcs_get_subscriptions` when using pagination.

This also adjusts the logic to expire a subscription that has failed to schedule a payment retry.

### How to test the changes in this Pull Request:

**Setup tips**:
    - **To setup a subscription with a failed parent order**, add the following filter `add_filter( 'newspack_subscriptions_expiration_enabled', '__return_false' );` then attempt to purchase a sub as reader using this stripe test card: `4000000000000002`
    - **To setup subscriptions that end up in the on-hold status after retries**, add the following filter `add_filter( 'newspack_subscriptions_expiration_enabled', '__return_false' );` then follow [these steps](https://woocommerce.com/document/subscriptions/develop/failed-payment-retry/#section-7).
    - **To setup a subscription with a next payment in the past**, use the following via wp shell on a currently on-hold subscription to manually set the start and/or next_payment dates:
```
$s = wcs_get_subscription(SUBSCRIPTION_ID);
$s->update_dates([ 'start' => 'YYYY-MM-DD HH:MM:SS', 'next_payment' => 'YYYY-MM-DD HH:MM:SS' ]);
```

**Testing steps**:
Note: Be sure to remove the above filter before running the script.

1. Change this value to something like `1`: https://github.com/Automattic/newspack-plugin/blob/535d8274dae721e2e1ce38689b344ee585e63da1/includes/cli/class-woocommerce-subscriptions.php#L248
2. On a test site ensure you have one of each of these kinds of on-hold subscriptions (see setup tips above):
  - with a failed parent order
  - with a next payment date set two months ago
  - that has completed all standard retries
3. I'm not sure how to force a failed scheduled retry, but you can change this line to something like `if ( true ) {` to simulate this case: https://github.com/Automattic/newspack-plugin/blob/4bd37d7dd4bf887cc376bae18479a8d441318a7b/includes/cli/class-woocommerce-subscriptions.php#L151
3. Run the script with the `--verbose --live` flag and confirm all on-hold subscriptions appear in the output
4. Check scheduled actions for a new `newspack_expire_manual_subscription` event for the subscription that has completed all standard retries (WooCommerce > Status > Scheduled Actions)

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->