### PR TITLE
feat: add corrections customize settings

### DIFF
--- a/includes/corrections/class-corrections.php
+++ b/includes/corrections/class-corrections.php
@@ -448,7 +448,7 @@ class Corrections {
 	 * @return string the post content with corrections.
 	 */
 	public static function output_corrections_on_post( $content ) {
-		if ( is_admin() || ! is_single() ) {
+		if ( is_admin() || ! is_single() || wp_is_block_theme() ) {
 			return $content;
 		}
 

--- a/includes/corrections/class-corrections.php
+++ b/includes/corrections/class-corrections.php
@@ -52,6 +52,11 @@ class Corrections {
 	const REST_ROUTE = '/corrections';
 
 	/**
+	 * Customize settings for corrections.
+	 */
+	const CORRECTIONS_LOCATION_CUSTOMIZE_SETTING = 'corrections_location';
+
+	/**
 	 * Initializes the class.
 	 */
 	public static function init() {
@@ -61,6 +66,7 @@ class Corrections {
 		add_action( 'init', [ __CLASS__, 'register_post_type' ] );
 		add_action( 'init', [ __CLASS__, 'add_corrections_shortcode' ] );
 		add_filter( 'the_content', [ __CLASS__, 'output_corrections_on_post' ] );
+		add_action( 'customize_register', [ __CLASS__, 'corrections_customize_register' ] );
 		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'wp_enqueue_scripts' ] );
 		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'wp_enqueue_scripts' ] );
 		add_action( 'rest_api_init', [ __CLASS__, 'register_rest_routes' ] );
@@ -83,6 +89,13 @@ class Corrections {
 	 * Enqueue scripts and styles.
 	 */
 	public static function wp_enqueue_scripts() {
+		\wp_enqueue_style(
+			'newspack-corrections-single',
+			Newspack::plugin_url() . '/dist/other-scripts/corrections.css',
+			[],
+			NEWSPACK_PLUGIN_VERSION
+		);
+
 		if ( ! is_admin() || ! filter_input( INPUT_GET, 'post', FILTER_VALIDATE_INT ) ) {
 			return;
 		}
@@ -448,37 +461,89 @@ class Corrections {
 			return $content;
 		}
 
+		$corrections_archive_url = get_post_type_archive_link( self::POST_TYPE );
+
 		ob_start();
 		?>
 		<!-- wp:group {"className":"correction-module","backgroundColor":"light-gray"} -->
-		<div class="wp-block-group correction-module has-light-gray-background-color has-background">
-			<div class="wp-block-group__inner-container">
-			<?php
-			foreach ( $corrections as $correction ) :
+		<div class="wp-block-group newspack-corrections-module">
+			<?php foreach ( $corrections as $correction ) : ?>
+				<?php
 				$correction_content = $correction->post_content;
 				$correction_date    = \get_the_date( get_option( 'date_format' ), $correction->ID );
 				$correction_time    = \get_the_time( get_option( 'time_format' ), $correction->ID );
+				$timezone           = \wp_timezone()->getName();
 				$correction_heading = sprintf(
-					'%s, %s %s',
-					self::get_correction_type_label( get_post_meta( $correction->ID, self::CORRECTIONS_TYPE_META, true ) ),
+					'%s, %s %s %s:',
+					self::get_correction_type( $correction->ID ),
 					$correction_date,
-					$correction_time
+					$correction_time,
+					$timezone
 				);
 				?>
-				<!-- wp:paragraph {"fontSize":"small"} -->
-				<p class="has-small-font-size correction-heading"><?php echo esc_html( $correction_heading ); ?></p>
-				<!-- /wp:paragraph -->
+				<p class="correction">
+					<a class="correction-title" href="<?php echo esc_url( $corrections_archive_url ); ?>"><?php echo esc_html( $correction_heading ); ?></a>
 
-				<!-- wp:paragraph {"fontSize":"normal"} -->
-				<p class="has-normal-font-size correction-body"><?php echo esc_html( $correction_content ); ?></p>
-				<!-- /wp:paragraph -->
+					<span class="correction-content"><?php echo esc_html( $correction_content ); ?></span>
+				</p>
 			<?php endforeach; ?>
-			</div>
 		</div>
 		<!-- /wp:group -->
 		<?php
 		$markup = do_blocks( ob_get_clean() );
-		return 'top' === get_post_meta( get_the_ID(), self::CORRECTIONS_LOCATION_META, true ) ? $markup . $content : $content . $markup;
+		return 'top' === get_theme_mod( 'corrections_location', 'bottom' ) ? $markup . $content : $content . $markup;
+	}
+
+	/**
+	 * Register the customizer setting for the corrections location.
+	 *
+	 * @param WP_Customize_Manager $wp_customize The customizer manager.
+	 */
+	public static function corrections_customize_register( $wp_customize ) {
+		/**
+		 * Corrections Panel.
+		 */
+		$wp_customize->add_panel(
+			self::POST_TYPE . '_panel',
+			array(
+				'title' => esc_html__( 'Corrections Settings', 'newspack-plugin' ),
+			)
+		);
+
+		/**
+		 * Corection settings section.
+		 */
+		$wp_customize->add_section(
+			self::POST_TYPE . '_settings',
+			array(
+				'title' => esc_html__( 'Corrections & Clarifications', 'newspack' ),
+				'panel' => self::POST_TYPE . '_panel',
+			)
+		);
+
+		// Add a setting & control to choose the location of corrections.
+		$wp_customize->add_setting(
+			self::CORRECTIONS_LOCATION_CUSTOMIZE_SETTING,
+			array(
+				'type'              => 'theme_mod',
+				'capability'        => 'edit_theme_options',
+				'default'           => 'bottom',
+				'sanitize_callback' => 'sanitize_text_field',
+			)
+		);
+		$wp_customize->add_control(
+			self::CORRECTIONS_LOCATION_CUSTOMIZE_SETTING,
+			array(
+				'label'       => esc_html__( 'Corrections Location', 'newspack-plugin' ),
+				'description' => esc_html__( 'Choose where to display corrections on the post.', 'newspack-plugin' ),
+				'section'     => self::POST_TYPE . '_settings',
+				'type'        => 'radio',
+				'choices'     => array(
+					'top'    => esc_html__( 'Top of content', 'newspack-plugin' ),
+					'bottom' => esc_html__( 'Bottom of content', 'newspack-plugin' ),
+				),
+			)
+		);
 	}
 }
 Corrections::init();

--- a/includes/corrections/class-corrections.php
+++ b/includes/corrections/class-corrections.php
@@ -491,7 +491,7 @@ class Corrections {
 		<!-- /wp:group -->
 		<?php
 		$markup = do_blocks( ob_get_clean() );
-		return 'top' === get_theme_mod( 'corrections_location', 'bottom' ) ? $markup . $content : $content . $markup;
+		return 'top' === get_theme_mod( self::CORRECTIONS_LOCATION_CUSTOMIZE_SETTING, 'bottom' ) ? $markup . $content : $content . $markup;
 	}
 
 	/**

--- a/src/other-scripts/corrections-modal/index.js
+++ b/src/other-scripts/corrections-modal/index.js
@@ -87,6 +87,13 @@ const CorrectionsModal = () => {
 		}
 	}, [] );
 
+	// Send Corrections.
+	useEffect( () => {
+		if ( isSaving ) {
+			saveCorrections();
+		}
+	}, [ isSaving ]);
+
 	// Add a new correction to the list.
 	const saveCorrection = () => {
 		// Check if the correction is empty.
@@ -136,8 +143,7 @@ const CorrectionsModal = () => {
 
 	// Save all corrections.
 	const saveCorrections = async () => {
-		setIsSaving(true);
-		setSaveError(null);
+		setSaveError( null );
 
 		const payload = {
 			post_id: postId,
@@ -285,7 +291,7 @@ const CorrectionsModal = () => {
 							variant="primary"
 							onClick={ () => {
 								saveCorrection();
-								saveCorrections();
+								setIsSaving( true );
 							} }
 							isBusy={ isSaving }
 						>

--- a/src/other-scripts/corrections/index.js
+++ b/src/other-scripts/corrections/index.js
@@ -1,0 +1,1 @@
+import './style.scss';

--- a/src/other-scripts/corrections/style.scss
+++ b/src/other-scripts/corrections/style.scss
@@ -1,0 +1,7 @@
+/* Corrections Single */
+.newspack-corrections-module {
+	.correction {
+		color: var(--newspack-theme-color-text-light, var(--wp--preset--color--contrast-3));
+		font-size: var(--newspack-theme-font-size-sm, var(--wp--preset--font-size--small));
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

- Add a new Panel and global customizer setting “Corrections Location” (with options “Top” and “Bottom”).
- Fix a edge case in Correction Modal.

Closes # .

### How to test the changes in this Pull Request:

1. Open the WordPress Customizer and Load a single post in the theme.
2. Open Template Settings > Correction Settings > Corrections & Clarifications, and check the Radio buttons Top & Bottom to see the impact.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->