### PR TITLE
fix(perfmatters): default for lazyload img setting parent selector

### DIFF
--- a/includes/plugins/class-perfmatters.php
+++ b/includes/plugins/class-perfmatters.php
@@ -223,6 +223,19 @@ class Perfmatters {
 		$options['lazyload']['youtube_preview_thumbnails'] = true;
 		$options['lazyload']['image_dimensions']           = true;
 
+
+		if ( empty( $options['lazyload']['lazy_loading_parent_exclusions'] ) ) {
+			$options['lazyload']['lazy_loading_parent_exclusions'] = [];
+		}
+		// Add our customizations to the front of the array to avoid confusion when editing
+		// the setting in the UI.
+		$options['lazyload']['lazy_loading_parent_exclusions'] = array_unshift(
+			$options['lazyload']['lazy_loading_parent_exclusions'],
+			[
+				'wp-block-jetpack-image-compare',
+			]
+		);
+
 		// Fonts.
 		if ( ! isset( $options['fonts'] ) ) {
 			$options['fonts'] = [];

--- a/includes/plugins/class-perfmatters.php
+++ b/includes/plugins/class-perfmatters.php
@@ -223,7 +223,6 @@ class Perfmatters {
 		$options['lazyload']['youtube_preview_thumbnails'] = true;
 		$options['lazyload']['image_dimensions']           = true;
 
-
 		if ( empty( $options['lazyload']['lazy_loading_parent_exclusions'] ) ) {
 			$options['lazyload']['lazy_loading_parent_exclusions'] = [];
 		}

--- a/includes/plugins/class-perfmatters.php
+++ b/includes/plugins/class-perfmatters.php
@@ -223,16 +223,11 @@ class Perfmatters {
 		$options['lazyload']['youtube_preview_thumbnails'] = true;
 		$options['lazyload']['image_dimensions']           = true;
 
-		if ( empty( $options['lazyload']['lazy_loading_parent_exclusions'] ) ) {
-			$options['lazyload']['lazy_loading_parent_exclusions'] = [];
-		}
-		// Add our customizations to the front of the array to avoid confusion when editing
-		// the setting in the UI.
-		$options['lazyload']['lazy_loading_parent_exclusions'] = array_unshift(
-			$options['lazyload']['lazy_loading_parent_exclusions'],
-			[
-				'wp-block-jetpack-image-compare',
-			]
+		$parent_exclusions = empty( $options['lazyload']['lazy_loading_parent_exclusions'] ) ? [] : $options['lazyload']['lazy_loading_parent_exclusions'];
+		// Add our customizations to the front of the array to avoid confusion when editing the setting in the UI.
+		$options['lazyload']['lazy_loading_parent_exclusions'] = array_merge(
+			[ 'wp-block-jetpack-image-compare' ],
+			$parent_exclusions
 		);
 
 		// Fonts.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This adds the class for the [Jetpack Image Compare block](https://jetpack.com/support/jetpack-blocks/image-compare-block/) to the" Exclude by Parent Selector" under Lazy Loading in our Perfmatters default settings. It adds it to the beginning of the array to make it a bit less confusing for someone editing the field and adding classes to the end.

### How to test the changes in this Pull Request:

1. Before applying the patch: 
   1. make sure you have perfmatters active 
   2. create an image compare block in a post
   3. See that the block breaks on the frontend (it looks like only the first image is loaded).

2. Now apply the patch and:
   1. Check that `wp option get perfmatters_options` will give you the class in `lazyload ->lazy_loading_parent_exclusions`
   2. Check that the image compare block in your post renderes without out breaking.
   3. Go to `wp-admin/options-general.php?page=perfmatters#lazyload` and add a couple of classes in "Exclude by Parent Selector" under the `wp-block-jetpack-image-compare` class and save the setting.
   4. Do `wp option get perfmatters_options` again and verify that the class is still there – plus whatever classes you added.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209376790297029