### PR TITLE
feat(my-account): add email change feature flag

### DIFF
--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -55,7 +55,6 @@ class WooCommerce_My_Account {
 			\add_filter( 'wcs_my_account_redirect_to_single_subscription', [ __CLASS__, 'redirect_to_single_subscription' ] );
 			\add_filter( 'wc_memberships_members_area_my-memberships_actions', [ __CLASS__, 'hide_cancel_button_from_memberships_table' ] );
 			\add_filter( 'wc_memberships_my_memberships_column_names', [ __CLASS__, 'remove_next_bill_on' ], 21 );
-
 		}
 	}
 
@@ -761,6 +760,19 @@ class WooCommerce_My_Account {
 			'on-hold',
 			'pending-cancel',
 		];
+	}
+
+	/**
+	 * Whether the email changes are enabled.
+	 */
+	public static function is_email_change_enabled() {
+		$is_enabled = defined( 'NEWSPACK_EMAIL_CHANGE_ENABLED' ) && NEWSPACK_EMAIL_CHANGE_ENABLED;
+		/**
+		 * Filters whether or not to allow email changes in My Account.
+		 *
+		 * @param bool $enabled Whether or not to allow email changes.
+		 */
+		return \apply_filters( 'newspack_email_change_enabled', $is_enabled );
 	}
 }
 

--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -623,6 +623,7 @@ class WooCommerce_My_Account {
 			empty( $_POST['account_email'] ) // phpcs:ignore WordPress.Security.NonceVerification.Missing
 			|| ! \is_user_logged_in()
 			|| ! Reader_Activation::is_enabled()
+			|| self::is_email_change_enabled()
 		) {
 			return;
 		}
@@ -763,7 +764,7 @@ class WooCommerce_My_Account {
 	}
 
 	/**
-	 * Whether the email changes are enabled.
+	 * Whether email changes are enabled.
 	 */
 	public static function is_email_change_enabled() {
 		$is_enabled = defined( 'NEWSPACK_EMAIL_CHANGE_ENABLED' ) && NEWSPACK_EMAIL_CHANGE_ENABLED;

--- a/includes/reader-revenue/templates/myaccount-edit-account.php
+++ b/includes/reader-revenue/templates/myaccount-edit-account.php
@@ -29,9 +29,9 @@ if ( isset( $_GET['is_error'] ) ) { // phpcs:ignore WordPress.Security.NonceVeri
 	$is_error = $_GET['is_error']; // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 }
 
-$without_password     = true === Reader_Activation::is_reader_without_password( $user );
-$is_reader            = true === Reader_Activation::is_user_reader( $user );
-$email_change_enabled = true === WooCommerce_My_Account::is_email_change_enabled();
+$without_password        = true === Reader_Activation::is_reader_without_password( $user );
+$is_reader               = true === Reader_Activation::is_user_reader( $user );
+$is_email_change_enabled = true === WooCommerce_My_Account::is_email_change_enabled();
 ?>
 
 <?php
@@ -64,8 +64,12 @@ endif;
 
 	<p class="woocommerce-form-row woocommerce-form-row--wide form-row form-row-wide mt0">
 		<label for="account_email_display"><?php \esc_html_e( 'Email address', 'newspack-plugin' ); ?>
-		<input type="email" class="woocommerce-Input woocommerce-Input--email input-text" name="account_email_display" id="account_email_display" autocomplete="email" value="<?php echo \esc_attr( $user->user_email ); ?>" <?php echo esc_attr( $email_change_enabled ? '' : 'disabled' ); ?>  />
+		<?php if ( $is_email_change_enabled ) : ?>
+		<input type="email" class="woocommerce-Input woocommerce-Input--email input-text" name="account_email" id="account_email" autocomplete="email" value="<?php echo \esc_attr( $user->user_email ); ?>" />
+		<?php else : ?>
+		<input type="email" class="woocommerce-Input woocommerce-Input--email input-text" name="account_email_display" id="account_email_display" autocomplete="email" disabled value="<?php echo \esc_attr( $user->user_email ); ?>" />
 		<input type="hidden" class="woocommerce-Input woocommerce-Input--email input-text" name="account_email" id="account_email" autocomplete="email" value="<?php echo \esc_attr( $user->user_email ); ?>" />
+		<?php endif; ?>
 	</p>
 
 	<?php

--- a/includes/reader-revenue/templates/myaccount-edit-account.php
+++ b/includes/reader-revenue/templates/myaccount-edit-account.php
@@ -29,8 +29,9 @@ if ( isset( $_GET['is_error'] ) ) { // phpcs:ignore WordPress.Security.NonceVeri
 	$is_error = $_GET['is_error']; // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 }
 
-$without_password = true === Reader_Activation::is_reader_without_password( $user );
-$is_reader        = true === Reader_Activation::is_user_reader( $user );
+$without_password     = true === Reader_Activation::is_reader_without_password( $user );
+$is_reader            = true === Reader_Activation::is_user_reader( $user );
+$email_change_enabled = true === WooCommerce_My_Account::is_email_change_enabled();
 ?>
 
 <?php
@@ -63,7 +64,7 @@ endif;
 
 	<p class="woocommerce-form-row woocommerce-form-row--wide form-row form-row-wide mt0">
 		<label for="account_email_display"><?php \esc_html_e( 'Email address', 'newspack-plugin' ); ?>
-		<input type="email" disabled class="woocommerce-Input woocommerce-Input--email input-text" name="account_email_display" id="account_email_display" autocomplete="email" value="<?php echo \esc_attr( $user->user_email ); ?>" />
+		<input type="email" class="woocommerce-Input woocommerce-Input--email input-text" name="account_email_display" id="account_email_display" autocomplete="email" value="<?php echo \esc_attr( $user->user_email ); ?>" <?php echo esc_attr( $email_change_enabled ? '' : 'disabled' ); ?>  />
 		<input type="hidden" class="woocommerce-Input woocommerce-Input--email input-text" name="account_email" id="account_email" autocomplete="email" value="<?php echo \esc_attr( $user->user_email ); ?>" />
 	</p>
 


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1208993180326452/1209215513701725

This PR adds a feature flag to re-enable Woo's standard email change behavior

![Screenshot 2025-02-17 at 15 59 48](https://github.com/user-attachments/assets/480e6f9e-bcb3-4ea2-95b7-3da69ef91b1c)

### How to test the changes in this Pull Request:

1. Ensure the `NEWSPACK_EMAIL_CHANGE_ENABLED` feature flag is not set and Audience Management is active on the site
2. As a logged in reader, visit the my account dashboard. The email field should be disabled
3. Now enable the `NEWSPACK_EMAIL_CHANGE_ENABLED` flag in wp-config ( `define( 'NEWSPACK_EMAIL_CHANGE_ENABLED', true );`)
4. As the logged in reader again, visit the my account dashboard. The email field should not be disabled. 
5. Enter a new email address and save. Confirm this updates the email address for the reader.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->