### PR TITLE
feat(esp-sync): queue data events sync to run once (#3661)

### DIFF
--- a/includes/data-events/class-data-events.php
+++ b/includes/data-events/class-data-events.php
@@ -45,6 +45,13 @@ final class Data_Events {
 	private static $queued_dispatches = [];
 
 	/**
+	 * Current action event.
+	 *
+	 * @var string|null
+	 */
+	private static $current_event = null;
+
+	/**
 	 * Initialize hooks.
 	 */
 	public static function init() {
@@ -95,6 +102,9 @@ final class Data_Events {
 	 * @param string $client_id   Client ID.
 	 */
 	public static function handle( $action_name, $timestamp, $data, $client_id ) {
+		// Set current event.
+		self::set_current_event( $action_name );
+
 		// Execute global handlers.
 		Logger::log(
 			sprintf( 'Executing global action handlers for "%s".', $action_name ),
@@ -145,6 +155,27 @@ final class Data_Events {
 		 * @param string $client_id   Client ID.
 		 */
 		\do_action( 'newspack_data_event', $action_name, $timestamp, $data, $client_id );
+
+		// Unset current event.
+		self::set_current_event( null );
+	}
+
+	/**
+	 * Get the current event being handled.
+	 *
+	 * @return string|null Current event.
+	 */
+	public static function current_event() {
+		return self::$current_event;
+	}
+
+	/**
+	 * Set the current event being handled.
+	 *
+	 * @param string|null $name Event name.
+	 */
+	private static function set_current_event( $name ) {
+		self::$current_event = $name;
 	}
 
 	/**

--- a/includes/reader-activation/sync/class-esp-sync.php
+++ b/includes/reader-activation/sync/class-esp-sync.php
@@ -8,6 +8,7 @@
 namespace Newspack\Reader_Activation;
 
 use Newspack\Reader_Activation;
+use Newspack\Data_Events;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -22,11 +23,20 @@ class ESP_Sync extends Sync {
 	 * @var string
 	 */
 	protected static $context = 'ESP Sync';
+
+	/**
+	 * Queued syncs containing their contexts keyed by email address.
+	 *
+	 * @var array[]
+	 */
+	protected static $queued_syncs = [];
+
 	/**
 	 * Initialize hooks.
 	 */
 	public static function init_hooks() {
 		add_action( 'newspack_scheduled_esp_sync', [ __CLASS__, 'scheduled_sync' ], 10, 2 );
+		add_action( 'shutdown', [ __CLASS__, 'run_queued_syncs' ] );
 	}
 
 	/**
@@ -98,6 +108,15 @@ class ESP_Sync extends Sync {
 			$context = static::$context;
 		}
 
+		// If we're running in a data event, queue the sync to run on shutdown.
+		if ( Data_Events::current_event() && ! did_action( 'shutdown' ) ) {
+			if ( ! isset( self::$queued_syncs[ $contact['email'] ] ) ) {
+				self::$queued_syncs[ $contact['email'] ] = [];
+			}
+			self::$queued_syncs[ $contact['email'] ][] = $context;
+			return;
+		}
+
 		$master_list_id = Reader_Activation::get_esp_master_list_id();
 
 		/**
@@ -163,24 +182,12 @@ class ESP_Sync extends Sync {
 	}
 
 	/**
-	 * Given a user ID or WooCommerce Order, sync that reader's contact data to
-	 * the connected ESP.
+	 * Get contact data for syncing.
 	 *
-	 * @param int|\WC_order $user_id_or_order User ID or WC_Order object.
-	 * @param bool          $is_dry_run       True if a dry run.
-	 *
-	 * @return true|\WP_Error True if the contact was synced successfully, WP_Error otherwise.
+	 * @param int $user_id The user ID.
 	 */
-	public static function sync_contact( $user_id_or_order, $is_dry_run = false ) {
-		$can_sync = static::can_esp_sync( true );
-		if ( ! $is_dry_run && $can_sync->has_errors() ) {
-			return $can_sync;
-		}
-
-		$is_order = $user_id_or_order instanceof \WC_Order;
-		$order    = $is_order ? $user_id_or_order : false;
-		$user_id  = $is_order ? $order->get_customer_id() : $user_id_or_order;
-		$user     = \get_userdata( $user_id );
+	protected static function get_contact_data( $user_id ) {
+		$user = \get_userdata( $user_id );
 
 		$customer = new \WC_Customer( $user_id );
 		if ( ! $customer || ! $customer->get_id() ) {
@@ -200,7 +207,29 @@ class ESP_Sync extends Sync {
 			$customer->save();
 		}
 
-		$contact = $is_order ? Sync\WooCommerce::get_contact_from_order( $order ) : Sync\WooCommerce::get_contact_from_customer( $customer );
+		return Sync\WooCommerce::get_contact_from_customer( $customer );
+	}
+
+	/**
+	 * Given a user ID or WooCommerce Order, sync that reader's contact data to
+	 * the connected ESP.
+	 *
+	 * @param int|\WC_order $user_id_or_order User ID or WC_Order object.
+	 * @param bool          $is_dry_run       True if a dry run.
+	 *
+	 * @return true|\WP_Error True if the contact was synced successfully, WP_Error otherwise.
+	 */
+	public static function sync_contact( $user_id_or_order, $is_dry_run = false ) {
+		$can_sync = static::can_esp_sync( true );
+		if ( ! $is_dry_run && $can_sync->has_errors() ) {
+			return $can_sync;
+		}
+
+		$is_order = $user_id_or_order instanceof \WC_Order;
+		$order    = $is_order ? $user_id_or_order : false;
+		$user_id  = $is_order ? $order->get_customer_id() : $user_id_or_order;
+
+		$contact = $is_order ? Sync\WooCommerce::get_contact_from_order( $order ) : self::get_contact_data( $user_id );
 		$result  = $is_dry_run ? true : self::sync( $contact );
 
 		if ( $result && ! \is_wp_error( $result ) ) {
@@ -218,6 +247,33 @@ class ESP_Sync extends Sync {
 		}
 
 		return $result;
+	}
+
+	/**
+	 * Run queued syncs.
+	 *
+	 * @return void
+	 */
+	public static function run_queued_syncs() {
+		if ( empty( self::$queued_syncs ) ) {
+			return;
+		}
+
+		foreach ( self::$queued_syncs as $email => $contexts ) {
+			$user = get_user_by( 'email', $email );
+			if ( ! $user ) {
+				continue;
+			}
+
+			$contact = self::get_contact_data( $user->ID );
+			if ( ! $contact ) {
+				continue;
+			}
+
+			self::sync( $contact, implode( '; ', $contexts ) );
+		}
+
+		self::$queued_syncs = [];
 	}
 }
 ESP_Sync::init_hooks();

--- a/tests/unit-tests/data-events.php
+++ b/tests/unit-tests/data-events.php
@@ -269,4 +269,47 @@ class Newspack_Test_Data_Events extends WP_UnitTestCase {
 			$parsed_data
 		);
 	}
+
+	/**
+	 * Test the current event is set and available during handler execution.
+	 */
+	public function test_current_event() {
+		Data_Events::register_action( 'test_action' );
+		Data_Events::register_action( 'test_action2' );
+
+		$handler = function() {
+			$this->assertEquals( 'test_action', Data_Events::current_event(), 'Current event should be set and equal to the action name' );
+		};
+		Data_Events::register_handler( $handler, 'test_action' );
+		Data_Events::handle( 'test_action', time(), [], 'test-client-id' );
+
+		$this->assertNull( Data_Events::current_event(), 'Current event should be null after handling' );
+
+		$handler2 = function() {
+			$this->assertEquals( 'test_action2', Data_Events::current_event(), 'Current event should be set and equal to the action name' );
+		};
+		Data_Events::register_handler( $handler2, 'test_action2' );
+		Data_Events::handle( 'test_action2', time(), [], 'test-client-id' );
+
+		$this->assertNull( Data_Events::current_event(), 'Current event should be null after handling' );
+	}
+
+	/**
+	 * Test that the current event is set to null even if a handler throws an exception.
+	 */
+	public function test_current_event_exception() {
+		Data_Events::register_action( 'test_action' );
+
+		$handler = function() {
+			$this->assertEquals( 'test_action', Data_Events::current_event(), 'Current event should be set and equal to the action name' );
+			throw new Exception( 'Test exception' );
+		};
+		Data_Events::register_handler( $handler, 'test_action' );
+
+		try {
+			Data_Events::handle( 'test_action', time(), [], 'test-client-id' );
+		} catch ( Exception $e ) {
+			$this->assertNull( Data_Events::current_event(), 'Current event should be null after handling' );
+		}
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Hotfixes a feature from #3661, which fixes a bug reported by a publisher where not all contact data is getting synced upon a new subscription that's tied to premium newsletters. It seems that without this fix, a race condition can occur where the multiple sync requests that occur after a new subscription can result in some data ultimately not being synced.

### How to test the changes in this Pull Request:

1. Set up a membership plan tied to a subscription product that restricts one or more subscription lists (premium newsletters). Connect the site to Mailchimp.
2. On `release`, as a reader purchase a premium newsletter subscription and observe that the contact in Mailchimp does not receive data on the current subscription product.
3. Check out this branch, repeat with another new reader/new subscription, and confirm that the contact in Mailchimp does receive all data on the current subscription product.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->