### PR TITLE
fix(donations): handle trashed products and avoid creating dupes

### DIFF
--- a/src/wizards/readerRevenue/views/donation/index.tsx
+++ b/src/wizards/readerRevenue/views/donation/index.tsx
@@ -66,7 +66,7 @@ type WizardData = {
 				tiered: boolean;
 				minimumDonation: string;
 				billingFields: string[];
-				trashed: [ string ];
+				trashed: string[];
 		};
 	platform_data: {
 		platform: string;

--- a/src/wizards/readerRevenue/views/donation/index.tsx
+++ b/src/wizards/readerRevenue/views/donation/index.tsx
@@ -1,8 +1,8 @@
 /**
  * WordPress dependencies.
  */
+import { __, sprintf } from '@wordpress/i18n';
 import { useDispatch } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
 import { ToggleControl, CheckboxControl } from '@wordpress/components';
 
 /**
@@ -66,6 +66,7 @@ type WizardData = {
 				tiered: boolean;
 				minimumDonation: string;
 				billingFields: string[];
+				trashed: [ string ];
 		};
 	platform_data: {
 		platform: string;
@@ -88,7 +89,7 @@ export const DonationAmounts = () => {
 		return null;
 	}
 
-	const { amounts, currencySymbol, tiered, disabledFrequencies, minimumDonation } =
+	const { amounts, currencySymbol, tiered, disabledFrequencies, minimumDonation, trashed } =
 		wizardData.donation_data;
 
 	const changeHandler = ( path: ( string | number )[] ) => ( value: any ) =>
@@ -111,6 +112,27 @@ export const DonationAmounts = () => {
 
 	return (
 		<>
+			{
+				Array.isArray( trashed ) && 0 < trashed.length && (
+					<Notice isError>
+						{ <p
+							dangerouslySetInnerHTML={
+								{ __html: sprintf(
+										// Translators: %1$s is a link to the trashed products. %2$s is a comma-separated list of trashed product names.
+										__(
+											'One or more donation products is in trash. Please <a href="%1$s">restore the product(s)</a> to continue using donation features: %2$s',
+											'newspack-plugin'
+										),
+										'/wp-admin/edit.php?post_status=trash&post_type=product',
+										trashed.join( ', ' )
+									)
+								}
+							}
+						/>
+					}
+				</Notice>
+				)
+			}
 			<Card headerActions noBorder>
 				<SectionHeader
 					title={ __( 'Suggested Donations', 'newspack-plugin' ) }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Avoids creating duplicate Donation products if any existing products are in trash. Instead, shows a warning in the admin if any Donation products are found in trash.

Closes `1200550061930446/1209402201928806`.

### How to test the changes in this Pull Request:

1. On `trunk`, set your Reader Revenue platform to "Newspack" and then trash one or more of the Newspack Donate products.
2. Go to **Newspack > Reader Revenue > Donations** and save donation settings. Observe that new duplicate versions of the trashed products have been created in **Products**.
3. Check out this branch and repeat. This time, confirm that no duplicate products are created. Also confirm that when visiting **Newspack > Reader Revenue > Donations**, a warning is shown with a link to trashed products:

<img width="986" alt="Screenshot 2025-02-17 at 3 53 09 PM" src="https://github.com/user-attachments/assets/6a9d5a6c-b50a-43f0-878d-15a6dad54493" />

4. Restore the trashed products and confirm that when visiting **Newspack > Reader Revenue > Donations**, the warning no longer appears.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209402201928806