### PR TITLE
fix(esp-sync): broken CLI sync command

### DIFF
--- a/includes/cli/class-ras-esp-sync.php
+++ b/includes/cli/class-ras-esp-sync.php
@@ -178,6 +178,8 @@ class RAS_ESP_Sync extends Reader_Activation\ESP_Sync {
 							$result->get_error_message()
 						)
 					);
+				} elseif ( ! empty( static::$results ) ) {
+					static::$results['processed']++;
 				}
 			}
 		}

--- a/includes/reader-activation/sync/class-esp-sync.php
+++ b/includes/reader-activation/sync/class-esp-sync.php
@@ -238,12 +238,9 @@ class ESP_Sync extends Sync {
 					// Translators: %1$s is the status and %2$s is the contact's email address.
 					__( '%1$s contact data for %2$s.', 'newspack-plugin' ),
 					$is_dry_run ? __( 'Would sync', 'newspack-plugin' ) : __( 'Synced', 'newspack-plugin' ),
-					$customer->get_email()
+					$contact['email']
 				)
 			);
-			if ( ! empty( static::$results ) ) {
-				static::$results['processed']++;
-			}
 		}
 
 		return $result;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

There must have been a bad merge recently which broke the `wp newspack esp sync` CLI command.

### How to test the changes in this Pull Request:

1. On `release`, run `wp newspack esp sync` via CLI and observe an error:

```bash
Warning: Undefined variable $customer in /wordpress/plugins/newspack-plugin/5.14.0/includes/reader-activation/sync/class-esp-sync.php on line 241
Fatal error: Uncaught Error: Call to a member function get_email() on null in /wordpress/plugins/newspack-plugin/5.14.0/includes/reader-activation/sync/class-esp-sync.php:241
Stack trace:
#0 /wordpress/plugins/newspack-plugin/5.14.0/includes/cli/class-ras-esp-sync.php(223): Newspack\Reader_Activation\ESP_Sync::sync_contact('10612', true)
#1 /wordpress/plugins/newspack-plugin/5.14.0/includes/cli/class-ras-esp-sync.php(394): Newspack\CLI\RAS_ESP_Sync::sync_contacts(Array)
#2 [internal function]: Newspack\CLI\RAS_ESP_Sync::cli_sync_contacts(Array, Array)
#3 phar:///usr/local/bin/wp-cli/vendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/CommandFactory.php(100): call_user_func(Array, Array, Array)
#4 [internal function]: WP_CLI\Dispatcher\CommandFactory::WP_CLI\Dispatcher\{closure}(Array, Array)
#5 phar:///usr/local/bin/wp-cli/vendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/Subcommand.php(497): call_user_func(Object(Closure), Array, Array)
#6 phar:///usr/local/bin/wp-cli/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(441): WP_CLI\Dispatcher\Subcommand->invoke(Array, Array, Array)
#7 phar:///usr/local/bin/wp-cli/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(464): WP_CLI\Runner->run_command(Array, Array)
#8 phar:///usr/local/bin/wp-cli/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(1295): WP_CLI\Runner->run_command_and_exit()
#9 phar:///usr/local/bin/wp-cli/vendor/wp-cli/wp-cli/php/WP_CLI/Bootstrap/LaunchRunner.php(28): WP_CLI\Runner->start()
#10 phar:///usr/local/bin/wp-cli/vendor/wp-cli/wp-cli/php/bootstrap.php(83): WP_CLI\Bootstrap\LaunchRunner->process(Object(WP_CLI\Bootstrap\BootstrapState))
#11 phar:///usr/local/bin/wp-cli/vendor/wp-cli/wp-cli/php/wp-cli.php(32): WP_CLI\bootstrap()
#12 phar:///usr/local/bin/wp-cli/php/boot-phar.php(20): include('phar:///usr/loc...')
#13 /usr/local/bin/wp-cli(4): include('phar:///usr/loc...')
#14 {main}
  thrown in /wordpress/plugins/newspack-plugin/5.14.0/includes/reader-activation/sync/class-esp-sync.php on line 241
Error: There has been a critical error on this website.Learn more about troubleshooting WordPress. There has been a critical error on this website.
```

2. Check out this branch, re-run, and confirm that it succeeds.
 
### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->