### PR TITLE
feat(my-account): add pending email change state

### DIFF
--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -600,7 +600,6 @@ class WooCommerce_My_Account {
 			empty( $_POST['account_email'] ) // phpcs:ignore WordPress.Security.NonceVerification.Missing
 			|| ! \is_user_logged_in()
 			|| ! Reader_Activation::is_enabled()
-			|| self::is_email_change_enabled()
 		) {
 			return;
 		}
@@ -768,32 +767,42 @@ class WooCommerce_My_Account {
 		) {
 			return;
 		}
-		\update_user_meta( $user_id, self::PENDING_EMAIL_CHANGE_META, $new_email );
-		// TODO: Update email with custom template.
-		\wp_mail( // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_mail_wp_mail
-			$new_email,
-			__( 'Please verify your new email address', 'newspack-plugin' ),
-			\wp_kses_post(
-				sprintf(
-					// Translators: %s is the verification link.
-					__( 'Please verify your new email address by clicking the following link: %s', 'newspack-plugin' ),
-					\add_query_arg(
-						[
-							'newspack_verify_email' => $new_email,
-							'nonce'                 => \wp_create_nonce( 'newspack_verify_email' ),
-						],
-						\home_url()
+		$old_email = \wp_get_current_user()->user_email;
+		if ( $new_email === $old_email ) {
+			return;
+		}
+		if ( ! \is_email( $new_email ) ) {
+			\wc_add_notice( __( 'Please enter a valid email address.', 'newspack-plugin' ), 'error' );
+		} elseif ( \email_exists( $new_email ) ) {
+			\wc_add_notice( __( 'This email address is already in use.', 'newspack-plugin' ), 'error' );
+		} else {
+			\update_user_meta( $user_id, self::PENDING_EMAIL_CHANGE_META, $new_email );
+			// TODO: Update email with custom template.
+			\wp_mail( // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_mail_wp_mail
+				$new_email,
+				__( 'Please verify your new email address', 'newspack-plugin' ),
+				\wp_kses_post(
+					sprintf(
+						// Translators: %s is the verification link.
+						__( 'Please verify your new email address by clicking the following link: %s', 'newspack-plugin' ),
+						\add_query_arg(
+							[
+								'newspack_verify_email' => $new_email,
+								'nonce'                 => \wp_create_nonce( 'newspack_verify_email' ),
+							],
+							\home_url()
+						)
 					)
 				)
-			)
-		);
-		\wc_add_notice(
-			sprintf(
-				// Translators: %s is the new email address.
-				__( 'A verification email has been sent to %s. Please verify to complete the change.', 'newspack-plugin' ),
-				$new_email
-			)
-		);
+			);
+			\wc_add_notice(
+				sprintf(
+					// Translators: %s is the new email address.
+					__( 'A verification email has been sent to %s. Please verify to complete the change.', 'newspack-plugin' ),
+					$new_email
+				)
+			);
+		}
 		// Redirect and exit ahead of Woo so only our notice is displayed.
 		\wp_safe_redirect( \wc_get_endpoint_url( 'edit-account', '', \wc_get_page_permalink( 'myaccount' ) ) );
 		exit;

--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -21,6 +21,7 @@ class WooCommerce_My_Account {
 	const DELETE_ACCOUNT_FORM          = 'delete-account-form';
 	const SEND_MAGIC_LINK_PARAM        = 'magic-link';
 	const AFTER_ACCOUNT_DELETION_PARAM = 'account-deleted';
+	const PENDING_EMAIL_CHANGE_META    = 'newspack_pending_email_change';
 
 	/**
 	 * Initialize.
@@ -45,6 +46,7 @@ class WooCommerce_My_Account {
 			\add_action( 'template_redirect', [ __CLASS__, 'handle_magic_link_request' ] );
 			\add_action( 'template_redirect', [ __CLASS__, 'redirect_to_account_details' ] );
 			\add_action( 'template_redirect', [ __CLASS__, 'edit_account_prevent_email_update' ] );
+			\add_action( 'woocommerce_save_account_details', [ __CLASS__, 'handle_email_change_request' ] );
 			\add_action( 'init', [ __CLASS__, 'restrict_account_content' ], 100 );
 			\add_filter( 'woocommerce_save_account_details_required_fields', [ __CLASS__, 'remove_required_fields' ] );
 			\add_action( 'template_redirect', [ __CLASS__, 'verify_saved_account_details' ] );
@@ -749,6 +751,25 @@ class WooCommerce_My_Account {
 		 * @param bool $enabled Whether or not to allow email changes.
 		 */
 		return \apply_filters( 'newspack_email_change_enabled', $is_enabled );
+	}
+
+	/**
+	 * Handle email change request.
+	 *
+	 * @param int $user_id User ID.
+	 */
+	public static function handle_email_change_request( $user_id ) {
+		$new_email = filter_input( INPUT_POST, 'newspack_account_email', FILTER_SANITIZE_EMAIL );
+		if (
+			empty( $new_email )
+			|| ! \is_user_logged_in()
+			|| ! Reader_Activation::is_enabled()
+			|| ! self::is_email_change_enabled()
+		) {
+			return;
+		}
+		\update_user_meta( $user_id, self::PENDING_EMAIL_CHANGE_META, $new_email );
+		// TODO: Send email to new email address with verification link.
 	}
 }
 

--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -769,7 +769,34 @@ class WooCommerce_My_Account {
 			return;
 		}
 		\update_user_meta( $user_id, self::PENDING_EMAIL_CHANGE_META, $new_email );
-		// TODO: Send email to new email address with verification link.
+		// TODO: Update email with custom template.
+		\wp_mail( // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_mail_wp_mail
+			$new_email,
+			__( 'Please verify your new email address', 'newspack-plugin' ),
+			\wp_kses_post(
+				sprintf(
+					// Translators: %s is the verification link.
+					__( 'Please verify your new email address by clicking the following link: %s', 'newspack-plugin' ),
+					\add_query_arg(
+						[
+							'newspack_verify_email' => $new_email,
+							'nonce'                 => \wp_create_nonce( 'newspack_verify_email' ),
+						],
+						\home_url()
+					)
+				)
+			)
+		);
+		\wc_add_notice(
+			sprintf(
+				// Translators: %s is the new email address.
+				__( 'A verification email has been sent to %s. Please verify to complete the change.', 'newspack-plugin' ),
+				$new_email
+			)
+		);
+		// Redirect and exit ahead of Woo so only our notice is displayed.
+		\wp_safe_redirect( \wc_get_endpoint_url( 'edit-account', '', \wc_get_page_permalink( 'myaccount' ) ) );
+		exit;
 	}
 }
 

--- a/includes/reader-revenue/templates/myaccount-edit-account.php
+++ b/includes/reader-revenue/templates/myaccount-edit-account.php
@@ -32,6 +32,8 @@ if ( isset( $_GET['is_error'] ) ) { // phpcs:ignore WordPress.Security.NonceVeri
 $without_password        = true === Reader_Activation::is_reader_without_password( $user );
 $is_reader               = true === Reader_Activation::is_user_reader( $user );
 $is_email_change_enabled = true === WooCommerce_My_Account::is_email_change_enabled();
+$is_pending_email_change = $user->get( WooCommerce_My_Account::PENDING_EMAIL_CHANGE_META ) ? true : false;
+$display_email           = $user->get( WooCommerce_My_Account::PENDING_EMAIL_CHANGE_META ) ?? $user->user_email;
 ?>
 
 <?php
@@ -65,7 +67,8 @@ endif;
 	<p class="woocommerce-form-row woocommerce-form-row--wide form-row form-row-wide mt0">
 		<label for="account_email_display"><?php \esc_html_e( 'Email address', 'newspack-plugin' ); ?>
 		<?php if ( $is_email_change_enabled ) : ?>
-		<input type="email" class="woocommerce-Input woocommerce-Input--email input-text" name="account_email" id="account_email" autocomplete="email" value="<?php echo \esc_attr( $user->user_email ); ?>" />
+		<input type="email" class="woocommerce-Input woocommerce-Input--email input-text" name="newspack_account_email" id="newspack_account_email" autocomplete="email" <?php echo \esc_attr( $is_pending_email_change ? 'disabled' : '' ); ?> value="<?php echo \esc_attr( $display_email ); ?>" />
+		<input type="hidden" class="woocommerce-Input woocommerce-Input--email input-text" name="account_email" id="account_email" autocomplete="email" value="<?php echo \esc_attr( $user->user_email ); ?>" />
 		<?php else : ?>
 		<input type="email" class="woocommerce-Input woocommerce-Input--email input-text" name="account_email_display" id="account_email_display" autocomplete="email" disabled value="<?php echo \esc_attr( $user->user_email ); ?>" />
 		<input type="hidden" class="woocommerce-Input woocommerce-Input--email input-text" name="account_email" id="account_email" autocomplete="email" value="<?php echo \esc_attr( $user->user_email ); ?>" />

--- a/includes/reader-revenue/templates/myaccount-edit-account.php
+++ b/includes/reader-revenue/templates/myaccount-edit-account.php
@@ -33,7 +33,7 @@ $without_password        = true === Reader_Activation::is_reader_without_passwor
 $is_reader               = true === Reader_Activation::is_user_reader( $user );
 $is_email_change_enabled = true === WooCommerce_My_Account::is_email_change_enabled();
 $is_pending_email_change = $user->get( WooCommerce_My_Account::PENDING_EMAIL_CHANGE_META ) ? true : false;
-$display_email           = $user->get( WooCommerce_My_Account::PENDING_EMAIL_CHANGE_META ) ?? $user->user_email;
+$display_email           = $is_pending_email_change ? $user->get( WooCommerce_My_Account::PENDING_EMAIL_CHANGE_META ) : $user->user_email;
 ?>
 
 <?php


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1208993180326452/1209215513701713/f

This PR adds a pending change state to email updates in my account:

![Screenshot 2025-02-19 at 14 46 11](https://github.com/user-attachments/assets/ce7a4c93-2ffa-4a5e-898d-3c594d5bb8f6)

### How to test the changes in this Pull Request:

1. Ensure the `NEWSPACK_EMAIL_CHANGE_ENABLED` FF is set in wp-config
2. As a logged in reader, go to your my account dashboard
3. Confirm the form displays your current email address
4. Update the email address to something new and save changes
5. Verify the page reloads, the email field now shows the new email address, is disabled, and a `wc_notice` appears asking you to check your new email to verify the change
6. Confirm a basic email has been sent to the new email address (Note: we are not handling the verification link in this PR)
7. Now remove the `NEWSPACK_EMAIL_CHANGE_ENABLED` FF in wp-config
8. Go back to my account and verify the field is disabled and the old email address appears

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->