### PR TITLE
fix(memberships): ensure user membership is linked to the correct subscription

### DIFF
--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -10,6 +10,7 @@ namespace Newspack;
 use Newspack\Data_Events;
 use Newspack\Logger;
 use Newspack\Memberships\Metering;
+use Newspack\Reader_Activation;
 use Newspack\WooCommerce_Connection;
 
 defined( 'ABSPATH' ) || exit;
@@ -41,7 +42,6 @@ class Memberships {
 	 * Initialize hooks and filters.
 	 */
 	public static function init() {
-		add_action( 'init', [ __CLASS__, 'register_data_event_handlers' ] );
 		add_action( 'init', [ __CLASS__, 'register_post_type' ] );
 		add_action( 'init', [ __CLASS__, 'register_meta' ] );
 		add_action( 'admin_init', [ __CLASS__, 'redirect_cpt' ] );
@@ -75,6 +75,10 @@ class Memberships {
 		add_filter( 'newspack_gate_content', 'wp_replace_insecure_home_url' );
 		add_filter( 'newspack_gate_content', 'do_shortcode', 11 ); // AFTER wpautop().
 
+		/** Fixes to ensure that memberships are linked to the correct active subscription. */
+		add_action( 'woocommerce_subscription_status_updated', [ __CLASS__, 'check_user_memberships_on_subscription_update' ] );
+		add_action( 'wp_login', [ __CLASS__, 'check_user_memberships_on_login' ], 10, 2 );
+
 		include __DIR__ . '/class-block-patterns.php';
 		include __DIR__ . '/class-metering.php';
 		include __DIR__ . '/class-import-export.php';
@@ -85,102 +89,6 @@ class Memberships {
 	 */
 	public static function is_active() {
 		return class_exists( 'WC_Memberships' ) && function_exists( 'wc_memberships' );
-	}
-
-	/**
-	 * Register data event handlers.
-	 */
-	public static function register_data_event_handlers() {
-		Data_Events::register_handler( [ __CLASS__, 'check_user_membership_linked_subscription' ], 'product_subscription_changed' );
-		Data_Events::register_handler( [ __CLASS__, 'check_user_membership_linked_subscription' ], 'reader_logged_in' );
-	}
-
-	/**
-	 * Ensure that the user's membership is linked to the correct subscription.
-	 *
-	 * @param int   $timestamp Timestamp of the event.
-	 * @param array $data      Data associated with the event.
-	 */
-	public static function check_user_membership_linked_subscription( $timestamp, $data ) {
-		if ( empty( $data['user_id'] ) ) {
-			return;
-		}
-		$user_id = $data['user_id'];
-		self::maybe_relink_user_membership_subscription( $user_id );
-	}
-
-	/**
-	 * Ensure that the user membership is linked to the user's most recent active subscription, if any.
-	 *
-	 * @param int $user_id User ID.
-	 *
-	 * @return bool True if user membership was relinked to a different subscription, false otherwise.
-	 */
-	public static function maybe_relink_user_membership_subscription( $user_id ) {
-		$updated = false;
-		if ( ! self::is_active() ) {
-			return $updated;
-		}
-		$user_memberships = wc_memberships_get_user_memberships( $user_id );
-		foreach ( $user_memberships as $user_membership ) {
-			$membership_plan_id      = $user_membership->get_plan_id();
-			$user_membership_id      = $user_membership->get_id();
-			$subscription_membership = new \WC_Memberships_Integration_Subscriptions_User_Membership( $user_membership_id );
-			$active_subscription_id     = self::get_user_subscription_for_membership_plan( $user_id, $subscription_membership->get_plan_id() );
-			if ( $subscription_membership && ! empty( $active_subscription_id ) ) {
-				$linked_subscription_id = (int) $subscription_membership->get_subscription_id();
-
-				// If the user membership is linked to the wrong subscription, relink it.
-				if ( $linked_subscription_id !== $active_subscription_id ) {
-					$updated         = $subscription_membership->set_subscription_id( $active_subscription_id );
-					$membership_plan = $subscription_membership->get_plan();
-
-					// Reset end date for plans with access set to subscription length.
-					if ( $membership_plan->is_access_length_type( 'subscription' ) && ! empty( $subscription_membership->get_end_date() ) ) {
-						$subscription_membership->set_end_date( '' );
-					}
-					Logger::newspack_log(
-						'newspack_user_membership_subscription_relinked',
-						__( 'User membership linked subscription updated.', 'newspack-plugin' ),
-						[
-							'user_id'             => $user_id,
-							'membership_id'       => $user_membership_id,
-							'old_subscription_id' => $linked_subscription_id,
-							'new_subscription_id' => $active_subscription_id,
-							'success'             => $updated,
-						],
-						'debug'
-					);
-				}
-			}
-		}
-
-		return $updated;
-	}
-
-	/**
-	 * Does the given user have an active subscription with the product required by the given membership plan?
-	 *
-	 * @param int $user_id User ID.
-	 * @param int $membership_plan_id Membership plan ID.
-	 *
-	 * @return int Subscription ID if the user has an active subscription with the required product. False if the user does not have the required subscription. Null if the membership plan doesn't require a subscription.
-	 */
-	public static function get_user_subscription_for_membership_plan( $user_id, $membership_plan_id ) {
-		$integrations = wc_memberships()->get_integrations_instance();
-		$integration  = $integrations ? $integrations->get_subscriptions_instance() : null;
-		if ( ! $integration || ! $integration->has_membership_plan_subscription( $membership_plan_id ) ) {
-			return null;
-		}
-
-		$subscription_plan  = new \WC_Memberships_Integration_Subscriptions_Membership_Plan( $membership_plan_id );
-		$required_products  = $subscription_plan->get_subscription_product_ids();
-		$user_subscriptions = WooCommerce_Connection::get_active_subscriptions_for_user( $user_id, $required_products );
-		if ( empty( $user_subscriptions ) ) {
-			return false;
-		}
-
-		return (int) reset( $user_subscriptions );
 	}
 
 	/**
@@ -1178,6 +1086,102 @@ class Memberships {
 			}
 		}
 		return $expire;
+	}
+
+	/**
+	 * When a subscription's status changes, ensure that any related user memberships are linked to the correct subscription.
+	 *
+	 * @param WC_Subscription $subscription An instance of a WC_Subscription object that just had its status changed.
+	 */
+	public static function check_user_memberships_on_subscription_update( $subscription ) {
+		self::maybe_relink_user_membership_subscription( $subscription->get_user_id() );
+	}
+
+	/**
+	 * When a reader logs in, ensure that their user memberships are linked to the correct subscription.
+	 *
+	 * @param string  $user_login User's login.
+	 * @param WP_User $user WP_User object for the logged-in user.
+	 */
+	public static function check_user_memberships_on_login( $user_login, $user ) {
+		if ( ! Reader_Activation::is_user_reader( $user ) ) {
+			return;
+		}
+		self::maybe_relink_user_membership_subscription( $user->ID );
+	}
+
+	/**
+	 * Ensure that the user membership is linked to the user's most recent active subscription, if any.
+	 *
+	 * @param int $user_id User ID.
+	 *
+	 * @return bool True if user membership was relinked to a different subscription, false otherwise.
+	 */
+	public static function maybe_relink_user_membership_subscription( $user_id ) {
+		$updated = false;
+		if ( ! self::is_active() ) {
+			return $updated;
+		}
+		$user_memberships = wc_memberships_get_user_memberships( $user_id );
+		foreach ( $user_memberships as $user_membership ) {
+			$membership_plan_id      = $user_membership->get_plan_id();
+			$user_membership_id      = $user_membership->get_id();
+			$subscription_membership = new \WC_Memberships_Integration_Subscriptions_User_Membership( $user_membership_id );
+			$active_subscription_id     = self::get_user_subscription_for_membership_plan( $user_id, $subscription_membership->get_plan_id() );
+			if ( $subscription_membership && ! empty( $active_subscription_id ) ) {
+				$linked_subscription_id = (int) $subscription_membership->get_subscription_id();
+
+				// If the user membership is linked to the wrong subscription, relink it.
+				if ( $linked_subscription_id !== $active_subscription_id ) {
+					$updated         = $subscription_membership->set_subscription_id( $active_subscription_id );
+					$membership_plan = $subscription_membership->get_plan();
+
+					// Reset end date for plans with access set to subscription length.
+					if ( $membership_plan->is_access_length_type( 'subscription' ) && ! empty( $subscription_membership->get_end_date() ) ) {
+						$subscription_membership->set_end_date( '' );
+					}
+					Logger::newspack_log(
+						'newspack_user_membership_subscription_relinked',
+						__( 'User membership linked subscription updated.', 'newspack-plugin' ),
+						[
+							'user_id'             => $user_id,
+							'membership_id'       => $user_membership_id,
+							'old_subscription_id' => $linked_subscription_id,
+							'new_subscription_id' => $active_subscription_id,
+							'success'             => $updated,
+						],
+						'debug'
+					);
+				}
+			}
+		}
+
+		return $updated;
+	}
+
+	/**
+	 * Does the given user have an active subscription with the product required by the given membership plan?
+	 *
+	 * @param int $user_id User ID.
+	 * @param int $membership_plan_id Membership plan ID.
+	 *
+	 * @return int Subscription ID if the user has an active subscription with the required product. False if the user does not have the required subscription. Null if the membership plan doesn't require a subscription.
+	 */
+	public static function get_user_subscription_for_membership_plan( $user_id, $membership_plan_id ) {
+		$integrations = wc_memberships()->get_integrations_instance();
+		$integration  = $integrations ? $integrations->get_subscriptions_instance() : null;
+		if ( ! $integration || ! $integration->has_membership_plan_subscription( $membership_plan_id ) ) {
+			return null;
+		}
+
+		$subscription_plan  = new \WC_Memberships_Integration_Subscriptions_Membership_Plan( $membership_plan_id );
+		$required_products  = $subscription_plan->get_subscription_product_ids();
+		$user_subscriptions = WooCommerce_Connection::get_active_subscriptions_for_user( $user_id, $required_products );
+		if ( empty( $user_subscriptions ) ) {
+			return false;
+		}
+
+		return (int) reset( $user_subscriptions );
 	}
 }
 Memberships::init();

--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -76,7 +76,7 @@ class Memberships {
 		add_filter( 'newspack_gate_content', 'do_shortcode', 11 ); // AFTER wpautop().
 
 		/** Fixes to ensure that memberships are linked to the correct active subscription. */
-		add_action( 'woocommerce_subscription_status_updated', [ __CLASS__, 'check_user_memberships_on_subscription_update' ], 11 );
+		add_action( 'woocommerce_subscription_status_updated', [ __CLASS__, 'check_user_memberships_on_subscription_update' ], 999 );
 		add_action( 'wp_login', [ __CLASS__, 'check_user_memberships_on_login' ], 10, 2 );
 
 		include __DIR__ . '/class-block-patterns.php';
@@ -1074,17 +1074,12 @@ class Memberships {
 	 * @param \WC_Memberships_User_Membership $user_membership the User Membership object being expired.
 	 */
 	public static function handle_wc_memberships_expire_user_membership( $expire, $user_membership ) {
-		$integration = wc_memberships()->get_integrations_instance()->get_subscriptions_instance();
-		if ( ! $integration ) {
-			return $expire;
+		$user_id = $user_membership->get_user_id();
+		$relinked = self::maybe_relink_user_membership_subscription( $user_id );
+		if ( $relinked ) {
+			return false;
 		}
-		$subscription = $integration->get_subscription_from_membership( $user_membership->get_id() );
-		if ( $subscription ) {
-			$subscription_status = $integration->get_subscription_status( $subscription );
-			if ( 'active' === $subscription_status ) {
-				return false;
-			}
-		}
+
 		return $expire;
 	}
 
@@ -1124,7 +1119,6 @@ class Memberships {
 		}
 		$user_memberships = wc_memberships_get_user_memberships( $user_id );
 		foreach ( $user_memberships as $user_membership ) {
-			$membership_plan_id      = $user_membership->get_plan_id();
 			$user_membership_id      = $user_membership->get_id();
 			$subscription_membership = new \WC_Memberships_Integration_Subscriptions_User_Membership( $user_membership_id );
 			$active_subscription_id  = self::get_user_subscription_for_membership_plan( $user_id, $subscription_membership->get_plan_id() );
@@ -1135,6 +1129,10 @@ class Memberships {
 				if ( $linked_subscription_id !== $active_subscription_id ) {
 					$updated         = $subscription_membership->set_subscription_id( $active_subscription_id );
 					$membership_plan = $subscription_membership->get_plan();
+					$message         = __( 'User membership linked subscription updated.', 'newspack-plugin' );
+
+					// Reset membership to active status.
+					$subscription_membership->update_status( 'active', $message );
 
 					// Reset end date for plans with access set to subscription length.
 					if ( $membership_plan->is_access_length_type( 'subscription' ) && ! empty( $subscription_membership->get_end_date() ) ) {
@@ -1142,7 +1140,7 @@ class Memberships {
 					}
 					Logger::newspack_log(
 						'newspack_user_membership_subscription_relinked',
-						__( 'User membership linked subscription updated.', 'newspack-plugin' ),
+						$message,
 						[
 							'user_id'             => $user_id,
 							'membership_id'       => $user_membership_id,

--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -61,7 +61,6 @@ class Memberships {
 		add_filter( 'user_has_cap', [ __CLASS__, 'user_has_cap' ], 10, 3 );
 		add_action( 'wp', [ __CLASS__, 'remove_unnecessary_content_restriction' ], 11 );
 		add_filter( 'body_class', [ __CLASS__, 'add_body_class' ] );
-		add_filter( 'wc_memberships_expire_user_membership', [ __CLASS__, 'handle_wc_memberships_expire_user_membership' ], 10, 2 );
 
 		/** Add gate content filters to mimic 'the_content'. See 'wp-includes/default-filters.php' for reference. */
 		add_filter( 'newspack_gate_content', 'capital_P_dangit', 11 );
@@ -76,6 +75,7 @@ class Memberships {
 		add_filter( 'newspack_gate_content', 'do_shortcode', 11 ); // AFTER wpautop().
 
 		/** Fixes to ensure that memberships are linked to the correct active subscription. */
+		add_filter( 'wc_memberships_expire_user_membership', [ __CLASS__, 'check_user_memberships_on_expire' ], 10, 2 );
 		add_action( 'woocommerce_subscription_status_updated', [ __CLASS__, 'check_user_memberships_on_subscription_update' ], 999 );
 		add_action( 'wp_login', [ __CLASS__, 'check_user_memberships_on_login' ], 10, 2 );
 
@@ -1068,15 +1068,16 @@ class Memberships {
 	}
 
 	/**
-	 * Prevent User Membership expiring, if the linked subscription is active.
+	 * When a user membership is about to expire, ensure that it's linked to the correct subscription.
 	 *
 	 * @param bool                            $expire true will expire this membership, false will retain it - default: true, expire it.
 	 * @param \WC_Memberships_User_Membership $user_membership the User Membership object being expired.
 	 */
-	public static function handle_wc_memberships_expire_user_membership( $expire, $user_membership ) {
-		$user_id = $user_membership->get_user_id();
-		$relinked = self::maybe_relink_user_membership_subscription( $user_id );
-		if ( $relinked ) {
+	public static function check_user_memberships_on_expire( $expire, $user_membership ) {
+		$user_id                 = $user_membership->get_user_id();
+		$active_subscription_id  = self::get_user_subscription_for_membership_plan( $user_id, $user_membership->get_plan_id() );
+		if ( $active_subscription_id ) {
+			self::maybe_relink_user_membership_subscription( $user_id );
 			return false;
 		}
 

--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -91,7 +91,7 @@ class Memberships {
 	 * Register data event handlers.
 	 */
 	public static function register_data_event_handlers() {
-		Data_Events::register_handler( [ __CLASS__, 'check_user_membership_linked_subscription' ], 'subscription_updated' );
+		Data_Events::register_handler( [ __CLASS__, 'check_user_membership_linked_subscription' ], 'product_subscription_changed' );
 		Data_Events::register_handler( [ __CLASS__, 'check_user_membership_linked_subscription' ], 'reader_logged_in' );
 	}
 

--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -76,7 +76,7 @@ class Memberships {
 		add_filter( 'newspack_gate_content', 'do_shortcode', 11 ); // AFTER wpautop().
 
 		/** Fixes to ensure that memberships are linked to the correct active subscription. */
-		add_action( 'woocommerce_subscription_status_updated', [ __CLASS__, 'check_user_memberships_on_subscription_update' ] );
+		add_action( 'woocommerce_subscription_status_updated', [ __CLASS__, 'check_user_memberships_on_subscription_update' ], 11 );
 		add_action( 'wp_login', [ __CLASS__, 'check_user_memberships_on_login' ], 10, 2 );
 
 		include __DIR__ . '/class-block-patterns.php';

--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -7,7 +7,6 @@
 
 namespace Newspack;
 
-use Newspack\Data_Events;
 use Newspack\Logger;
 use Newspack\Memberships\Metering;
 use Newspack\Reader_Activation;

--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -1127,7 +1127,7 @@ class Memberships {
 			$membership_plan_id      = $user_membership->get_plan_id();
 			$user_membership_id      = $user_membership->get_id();
 			$subscription_membership = new \WC_Memberships_Integration_Subscriptions_User_Membership( $user_membership_id );
-			$active_subscription_id     = self::get_user_subscription_for_membership_plan( $user_id, $subscription_membership->get_plan_id() );
+			$active_subscription_id  = self::get_user_subscription_for_membership_plan( $user_id, $subscription_membership->get_plan_id() );
 			if ( $subscription_membership && ! empty( $active_subscription_id ) ) {
 				$linked_subscription_id = (int) $subscription_membership->get_subscription_id();
 

--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -144,7 +144,7 @@ class Memberships {
 						__( 'User membership linked subscription updated.', 'newspack-plugin' ),
 						[
 							'user_id'             => $user_id,
-							'membership_id'       => $membership_plan_id,
+							'membership_id'       => $user_membership_id,
 							'old_subscription_id' => $linked_subscription_id,
 							'new_subscription_id' => $active_subscription_id,
 							'success'             => $updated,

--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -7,6 +7,8 @@
 
 namespace Newspack;
 
+use Newspack\Data_Events;
+use Newspack\Logger;
 use Newspack\Memberships\Metering;
 use Newspack\WooCommerce_Connection;
 
@@ -39,6 +41,7 @@ class Memberships {
 	 * Initialize hooks and filters.
 	 */
 	public static function init() {
+		add_action( 'init', [ __CLASS__, 'register_data_event_handlers' ] );
 		add_action( 'init', [ __CLASS__, 'register_post_type' ] );
 		add_action( 'init', [ __CLASS__, 'register_meta' ] );
 		add_action( 'admin_init', [ __CLASS__, 'redirect_cpt' ] );
@@ -82,6 +85,102 @@ class Memberships {
 	 */
 	public static function is_active() {
 		return class_exists( 'WC_Memberships' ) && function_exists( 'wc_memberships' );
+	}
+
+	/**
+	 * Register data event handlers.
+	 */
+	public static function register_data_event_handlers() {
+		Data_Events::register_handler( [ __CLASS__, 'check_user_membership_linked_subscription' ], 'subscription_updated' );
+		Data_Events::register_handler( [ __CLASS__, 'check_user_membership_linked_subscription' ], 'reader_logged_in' );
+	}
+
+	/**
+	 * Ensure that the user's membership is linked to the correct subscription.
+	 *
+	 * @param int   $timestamp Timestamp of the event.
+	 * @param array $data      Data associated with the event.
+	 */
+	public static function check_user_membership_linked_subscription( $timestamp, $data ) {
+		if ( empty( $data['user_id'] ) ) {
+			return;
+		}
+		$user_id = $data['user_id'];
+		self::maybe_relink_user_membership_subscription( $user_id );
+	}
+
+	/**
+	 * Ensure that the user membership is linked to the user's most recent active subscription, if any.
+	 *
+	 * @param int $user_id User ID.
+	 *
+	 * @return bool True if user membership was relinked to a different subscription, false otherwise.
+	 */
+	public static function maybe_relink_user_membership_subscription( $user_id ) {
+		$updated = false;
+		if ( ! self::is_active() ) {
+			return $updated;
+		}
+		$user_memberships = wc_memberships_get_user_memberships( $user_id );
+		foreach ( $user_memberships as $user_membership ) {
+			$membership_plan_id      = $user_membership->get_plan_id();
+			$user_membership_id      = $user_membership->get_id();
+			$subscription_membership = new \WC_Memberships_Integration_Subscriptions_User_Membership( $user_membership_id );
+			$active_subscription_id     = self::get_user_subscription_for_membership_plan( $user_id, $subscription_membership->get_plan_id() );
+			if ( $subscription_membership && ! empty( $active_subscription_id ) ) {
+				$linked_subscription_id = (int) $subscription_membership->get_subscription_id();
+
+				// If the user membership is linked to the wrong subscription, relink it.
+				if ( $linked_subscription_id !== $active_subscription_id ) {
+					$updated         = $subscription_membership->set_subscription_id( $active_subscription_id );
+					$membership_plan = $subscription_membership->get_plan();
+
+					// Reset end date for plans with access set to subscription length.
+					if ( $membership_plan->is_access_length_type( 'subscription' ) && ! empty( $subscription_membership->get_end_date() ) ) {
+						$subscription_membership->set_end_date( '' );
+					}
+					Logger::newspack_log(
+						'newspack_user_membership_subscription_relinked',
+						__( 'User membership linked subscription updated.', 'newspack-plugin' ),
+						[
+							'user_id'             => $user_id,
+							'membership_id'       => $membership_plan_id,
+							'old_subscription_id' => $linked_subscription_id,
+							'new_subscription_id' => $active_subscription_id,
+							'success'             => $updated,
+						],
+						'debug'
+					);
+				}
+			}
+		}
+
+		return $updated;
+	}
+
+	/**
+	 * Does the given user have an active subscription with the product required by the given membership plan?
+	 *
+	 * @param int $user_id User ID.
+	 * @param int $membership_plan_id Membership plan ID.
+	 *
+	 * @return int Subscription ID if the user has an active subscription with the required product. False if the user does not have the required subscription. Null if the membership plan doesn't require a subscription.
+	 */
+	public static function get_user_subscription_for_membership_plan( $user_id, $membership_plan_id ) {
+		$integrations = wc_memberships()->get_integrations_instance();
+		$integration  = $integrations ? $integrations->get_subscriptions_instance() : null;
+		if ( ! $integration || ! $integration->has_membership_plan_subscription( $membership_plan_id ) ) {
+			return null;
+		}
+
+		$subscription_plan  = new \WC_Memberships_Integration_Subscriptions_Membership_Plan( $membership_plan_id );
+		$required_products  = $subscription_plan->get_subscription_product_ids();
+		$user_subscriptions = WooCommerce_Connection::get_active_subscriptions_for_user( $user_id, $required_products );
+		if ( empty( $user_subscriptions ) ) {
+			return false;
+		}
+
+		return (int) reset( $user_subscriptions );
 	}
 
 	/**
@@ -934,19 +1033,13 @@ class Memberships {
 			return true;
 		}
 
-		$integrations      = wc_memberships()->get_integrations_instance();
-		$integration       = $integrations ? $integrations->get_subscriptions_instance() : null;
 		$require_all_plans = self::get_require_all_plans_setting();
 		$has_access        = false;
 		$has_subscription  = false;
 
 		foreach ( $rules as $rule ) {
 			$membership_plan_id = $rule->get_membership_plan_id();
-			if ( $integration && $integration->has_membership_plan_subscription( $membership_plan_id ) ) {
-				$subscription_plan  = new \WC_Memberships_Integration_Subscriptions_Membership_Plan( $membership_plan_id );
-				$required_products  = $subscription_plan->get_subscription_product_ids();
-				$has_subscription   = ! empty( WooCommerce_Connection::get_active_subscriptions_for_user( $user_id, $required_products ) );
-			}
+			$has_subscription   = ! empty( self::get_user_subscription_for_membership_plan( $user_id, $membership_plan_id ) );
 
 			// If no object ID is provided, then we are looking at rules that apply to whole post types or taxonomies.
 			// In this case, rules that apply to specific objects should be skipped.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Yet another attempt to fix the WooCommerce Memberships bug addressed in #3050, #3060, #3268, #3338, #3380, and #3393. This bug exists in the [WooCommerce Memberships plugin](https://github.com/woocommerce/woocommerce-memberships/pull/115) itself, but there's no indication that the issue will be addressed upstream, so we're applying a patch here as it continues to affect live sites.

The crux of the issue: if a user purchases more than one subscription for a product required by a user membership plan, and the first subscription has an **Expired** status, their user membership will remain linked to the expired subscription. Even if they subsequently purchase a new subscription for the same product, the membership will remain linked to the expired subscription, and will remain in expired status—so the user won't be able to access restricted content despite having purchased the required subscription.

This PR addresses the issue by checking the user's memberships upon login and subscription status change. If a user membership requires a subscription to specific products and the user has active subscriptions for those products, the membership will be relinked to the most recent active subscription, and the expiration date will be cleared. This should trigger the membership to automatically reactivate, granting the user access to any restricted content defined in the membership plan.

### How to test the changes in this Pull Request:

1. Publish a membership plan that requires a subscription product and is tied the subscription length. Optionally add content restrictions to test user access to the restricted content.

<img width="1229" alt="Screenshot 2025-02-20 at 4 45 57 PM" src="https://github.com/user-attachments/assets/f579a49d-405a-4536-a313-ef80b1afb979" />

2. On `release`, as a reader, purchase a subscription with the required product.
3. As an admin, change the subscription's status to `expired`.
4. As the reader, purchase a second subscription with the required product.
5. As an admin, find the user's membership (in **WooCommerce > Memberships**). 
6. Observe that the user membership remains linked to the initial expired subscription, and remains in "Expired" status, meaning that the reader won't be able to access any content restricted by the membership plan.
7. Check out this branch.
8. As the reader, log out and then log back into the site again to trigger the `reader_logged_in` data event.
9. Confirm that the user membership has been relinked to the active subscription, that the membership now has an "Active" status with no expiration date, and that the reader can now access restricted content.

<img width="926" alt="Screenshot 2025-02-20 at 4 56 01 PM" src="https://github.com/user-attachments/assets/8ab204f1-05d9-430b-87da-f34a384aefdf" />

10. As an admin, set the active subscription to `expired` status and confirm that the membership also changes to expired status again.
11. As the reader, purchase a subscription for the required product again. Confirm that the user membership has been once again relinked to the new active subscription, that the membership now has an "Active" status with no expiration date, and that the reader can now access restricted content.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210190746201040
  - https://app.asana.com/0/0/1209414048559497