### PR TITLE
fix(memberships): reset end date on subscription

### DIFF
--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -58,7 +58,7 @@ class Memberships {
 		add_filter( 'user_has_cap', [ __CLASS__, 'user_has_cap' ], 10, 3 );
 		add_action( 'wp', [ __CLASS__, 'remove_unnecessary_content_restriction' ], 11 );
 		add_filter( 'body_class', [ __CLASS__, 'add_body_class' ] );
-		add_filter( 'wc_memberships_expire_user_membership', [ __CLASS__, 'handle_wc_memberships_expire_user_membership' ], 10, 2 );
+		add_action( 'woocommerce_subscription_status_updated', [ __CLASS__, 'fix_membership_end_date' ], 11, 2 );
 
 		/** Add gate content filters to mimic 'the_content'. See 'wp-includes/default-filters.php' for reference. */
 		add_filter( 'newspack_gate_content', 'capital_P_dangit', 11 );
@@ -1067,24 +1067,34 @@ class Memberships {
 	}
 
 	/**
-	 * Prevent User Membership expiring, if the linked subscription is active.
+	 * Ensure that the end date of a membership is reset when a subscription
+	 * reactivates it.
 	 *
-	 * @param bool                            $expire true will expire this membership, false will retain it - default: true, expire it.
-	 * @param \WC_Memberships_User_Membership $user_membership the User Membership object being expired.
+	 * @param \WC_Subscription $subscription Subscription object.
+	 * @param string           $status_to    New status.
 	 */
-	public static function handle_wc_memberships_expire_user_membership( $expire, $user_membership ) {
-		$integration = wc_memberships()->get_integrations_instance()->get_subscriptions_instance();
-		if ( ! $integration ) {
-			return $expire;
+	public static function fix_membership_end_date( $subscription, $status_to ) {
+		if ( 'active' !== $status_to ) {
+			return;
 		}
-		$subscription = $integration->get_subscription_from_membership( $user_membership->get_id() );
-		if ( $subscription ) {
-			$subscription_status = $integration->get_subscription_status( $subscription );
-			if ( 'active' === $subscription_status ) {
-				return false;
+		if ( ! function_exists( 'wc_memberships_get_memberships_from_subscription' ) ) {
+			return;
+		}
+		$memberships = wc_memberships_get_memberships_from_subscription( $subscription );
+		if ( empty( $memberships ) ) {
+			return;
+		}
+		foreach ( $memberships as $membership ) {
+			$plan = $membership->get_plan();
+			// Only reset end date for plans with access set to subscription length.
+			if ( ! $plan->is_access_length_type( 'subscription' ) ) {
+				continue;
+			}
+			$end_date = $membership->get_end_date();
+			if ( ! empty( $end_date ) ) {
+				$membership->set_end_date( '' );
 			}
 		}
-		return $expire;
 	}
 }
 Memberships::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

An alternative approach for #3768 and #3393.

There's a known bug that Woo Memberships doesn't reset a membership's "end date" if a subscription reactivates it. On a cron routine, the end date value will get picked up and expire the membership.

This approach hooks into a subscription status update to manually reset the end date of a membership attached to it.

### How to test the changes in this Pull Request:

Same steps from #3768

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->