### PR TITLE
fix: undo forcing WC order attribution to off

### DIFF
--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -48,7 +48,6 @@ class WooCommerce_Connection {
 		\add_filter( 'woocommerce_email_enabled_customer_completed_order', [ __CLASS__, 'send_customizable_receipt_email' ], 10, 3 );
 		\add_filter( 'woocommerce_email_enabled_cancelled_subscription', [ __CLASS__, 'send_customizable_cancellation_email' ], 10, 3 );
 		\add_action( 'woocommerce_order_status_completed', [ __CLASS__, 'maybe_update_reader_display_name' ], 10, 2 );
-		\add_action( 'option_woocommerce_feature_order_attribution_enabled', [ __CLASS__, 'force_disable_order_attribution' ] );
 		\add_filter( 'woocommerce_related_products', [ __CLASS__, 'disable_related_products' ] );
 		\add_action( 'cli_init', [ __CLASS__, 'register_cli_commands' ] );
 
@@ -367,24 +366,6 @@ class WooCommerce_Connection {
 		}
 
 		return 'yes';
-	}
-
-	/**
-	 * Force option for enabling order attribution to OFF unless the
-	 * NEWSPACK_PREVENT_WC_ALLOW_ORDER_ATTRIBUTION_OVERRIDE constant is set.
-	 * Right now, it causes JavaScript errors in the modal checkout.
-	 *
-	 * See:https://woo.com/document/order-attribution-tracking/
-	 *
-	 * @param bool $should_allow Whether WooCommerce should allow enabling Order Attribution.
-	 *
-	 * @return string Option value.
-	 */
-	public static function force_disable_order_attribution( $should_allow ) {
-		if ( defined( 'NEWSPACK_PREVENT_WC_ALLOW_ORDER_ATTRIBUTION_OVERRIDE' ) && NEWSPACK_PREVENT_WC_ALLOW_ORDER_ATTRIBUTION_OVERRIDE ) {
-			return $should_allow;
-		}
-		return false;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR undoes https://github.com/Automattic/newspack-plugin/pull/2911, which forced WooCommerce's Order Attribution feature to "off". At the time, it was throwing JS errors in the modal checkout, but this doesn't appear to be the case since we rebuilt it, and publishers are interested in using the feature. 

See: p1740166420426339-slack-newspack-support

### How to test the changes in this Pull Request:

1. Apply this PR.
2. Navigate to WP Admin > WooCommerce > Advanced > Features, and confirm that you can check and save the option "Enable this feature to track and credit channels and campaigns that contribute to orders on your site" (or confirm that it's already checked; IIRC it's the default).
3. Run through a modal checkout and confirm you don't see any errors.
4. View the source of the modal checkout iframe, and confirm the order attribution JS is loading (you can search for `order-attribution.min.js` in the source). 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->