### PR TITLE
feat(corrections): Unit tests for Corrections functionality

### DIFF
--- a/tests/unit-tests/corrections.php
+++ b/tests/unit-tests/corrections.php
@@ -34,6 +34,7 @@ class Test_Corrections extends WP_UnitTestCase {
 		Corrections::init();
 
 		self::$post_id = $this->factory->post->create( [ 'post_type' => 'post' ] );
+		update_post_meta( self::$post_id, Corrections::CORRECTIONS_ACTIVE_META, true );
 	}
 
 	/**
@@ -486,5 +487,49 @@ class Test_Corrections extends WP_UnitTestCase {
 
 		$clarification_type = Corrections::get_correction_type( $clarification_id );
 		$this->assertEquals( 'Clarification', $clarification_type, 'The correction type should be "Clarification".' );
+	}
+
+	/**
+	 * Test that the corrections shortcode is handled.
+	 *
+	 * @covers Corrections::handle_corrections_shortcode
+	 */
+	public function test_handle_corrections_shortcode() {
+		$correction_1 = array(
+			'content' => 'Test correction content',
+			'type'    => 'correction',
+			'date'    => current_time( 'mysql' ),
+		);
+
+		$correction_1_id = Corrections::add_correction( self::$post_id, $correction_1 );
+		$this->assertNotWPError( $correction_1_id );
+		$this->assertNotEquals( 0, $correction_1_id );
+
+		$correction_2 = array(
+			'content' => 'Test correction content 2',
+			'type'    => 'clarification',
+			'date'    => current_time( 'mysql' ),
+		);
+
+		$correction_2_id = Corrections::add_correction( self::$post_id, $correction_2 );
+		$this->assertNotWPError( $correction_2_id );
+		$this->assertNotEquals( 0, $correction_2_id );
+
+		$page = $this->factory->post->create_and_get(
+			[
+				'post_type'    => 'page',
+				'post_content' => 'Test Page:- [corrections]',
+			]
+		);
+
+		$corrections_shortcode_output = do_shortcode( $page->post_content );
+		$this->assertStringNotContainsString( '[corrections]', $corrections_shortcode_output, 'The corrections shortcode should be removed from the output.' );
+
+		$this->assertStringContainsString( 'Test correction content', $corrections_shortcode_output, 'The correction content should be included in the output.' );
+		$this->assertStringContainsString( 'Test correction content 2', $corrections_shortcode_output, 'The correction content should be included in the output.' );
+		$correction_1_heading = sprintf( 'Correction on %s', get_the_date( 'M j, Y', $correction_1_id ) );
+		$this->assertStringContainsString( $correction_1_heading, $corrections_shortcode_output, 'The correction date should be included in the output.' );
+		$correction_2_heading = sprintf( 'Correction on %s', get_the_date( 'M j, Y', $correction_2_id ) );
+		$this->assertStringContainsString( $correction_2_heading, $corrections_shortcode_output, 'The correction date should be included in the output.' );
 	}
 }

--- a/tests/unit-tests/corrections.php
+++ b/tests/unit-tests/corrections.php
@@ -33,15 +33,8 @@ class Test_Corrections extends WP_UnitTestCase {
 
 		Corrections::init();
 
-		self::$post_id = $this->factory->post->create( [ 'post_type' => 'post' ] );
+		self::$post_id = $this->factory()->post->create( [ 'post_type' => 'post' ] );
 		update_post_meta( self::$post_id, Corrections::CORRECTIONS_ACTIVE_META, true );
-	}
-
-	/**
-	 * Tear down test fixtures.
-	 */
-	public function tear_down() {
-		wp_delete_post( self::$post_id, true );
 	}
 
 	/**
@@ -515,7 +508,7 @@ class Test_Corrections extends WP_UnitTestCase {
 		$this->assertNotWPError( $correction_2_id );
 		$this->assertNotEquals( 0, $correction_2_id );
 
-		$page = $this->factory->post->create_and_get(
+		$page = $this->factory()->post->create_and_get(
 			[
 				'post_type'    => 'page',
 				'post_content' => 'Test Page:- [corrections]',

--- a/tests/unit-tests/corrections.php
+++ b/tests/unit-tests/corrections.php
@@ -532,4 +532,56 @@ class Test_Corrections extends WP_UnitTestCase {
 		$correction_2_heading = sprintf( 'Correction on %s', get_the_date( 'M j, Y', $correction_2_id ) );
 		$this->assertStringContainsString( $correction_2_heading, $corrections_shortcode_output, 'The correction date should be included in the output.' );
 	}
+
+	/**
+	 * Test that the corrections are output on the post.
+	 *
+	 * @covers Corrections::output_corrections_on_post
+	 */
+	public function test_output_corrections_on_post_appends_markup() {
+		$correction_1 = array(
+			'content' => 'Test correction content',
+			'type'    => 'correction',
+			'date'    => current_time( 'mysql' ),
+		);
+
+		$correction_1_id = Corrections::add_correction( self::$post_id, $correction_1 );
+		$this->assertNotWPError( $correction_1_id );
+		$this->assertNotEquals( 0, $correction_1_id );
+
+		$correction_2 = array(
+			'content' => 'Test correction content 2',
+			'type'    => 'clarification',
+			'date'    => current_time( 'mysql' ),
+		);
+
+		$correction_2_id = Corrections::add_correction( self::$post_id, $correction_2 );
+		$this->assertNotWPError( $correction_2_id );
+		$this->assertNotEquals( 0, $correction_2_id );
+
+		// Visit the post.
+		$this->go_to( get_permalink( self::$post_id ) );
+		$this->assertQueryTrue( 'is_single', 'is_singular' );
+		$post_content = get_the_content();
+
+		$corrections_markup = Corrections::output_corrections_on_post( $post_content );
+
+		$correction_1_heading = sprintf(
+			'%s, %s %s',
+			Corrections::get_correction_type( $correction_1_id ),
+			get_the_date( get_option( 'date_format' ), $correction_1_id ),
+			get_the_time( get_option( 'time_format' ), $correction_1_id )
+		);
+		$this->assertStringContainsString( $correction_1_heading, $corrections_markup, 'The correction date should be included in the output.' );
+		$this->assertStringContainsString( 'Test correction content', $corrections_markup, 'The correction content should be included in the output.' );
+
+		$correction_2_heading = sprintf(
+			'%s, %s %s',
+			Corrections::get_correction_type( $correction_2_id ),
+			get_the_date( get_option( 'date_format' ), $correction_2_id ),
+			get_the_time( get_option( 'time_format' ), $correction_2_id )
+		);
+		$this->assertStringContainsString( $correction_2_heading, $corrections_markup, 'The correction date should be included in the output.' );
+		$this->assertStringContainsString( 'Test correction content 2', $corrections_markup, 'The correction content should be included in the output.' );
+	}
 }

--- a/tests/unit-tests/corrections.php
+++ b/tests/unit-tests/corrections.php
@@ -1,0 +1,490 @@
+<?php
+/**
+ * Test_Corrections class.
+ *
+ * @package Newspack
+ */
+
+use Newspack\Corrections;
+
+/**
+ * Class Test_Corrections
+ *
+ * @group corrections
+ */
+class Test_Corrections extends WP_UnitTestCase {
+
+	/**
+	 * Holds a post ID to work with.
+	 *
+	 * @var int
+	 */
+	protected static $post_id;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		if ( ! defined( 'NEWSPACK_CORRECTIONS_ENABLED' ) ) {
+			define( 'NEWSPACK_CORRECTIONS_ENABLED', true );
+		}
+
+		Corrections::init();
+
+		self::$post_id = $this->factory->post->create( [ 'post_type' => 'post' ] );
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tear_down() {
+		wp_delete_post( self::$post_id, true );
+	}
+
+	/**
+	 * Test that the corrections feature is enabled.
+	 *
+	 * @covers Corrections::is_enabled
+	 */
+	public function test_is_enabled() {
+		$this->assertTrue( Corrections::is_enabled() );
+	}
+
+	/**
+	 * Test that the corrections feature is disabled.
+	 *
+	 * @covers Corrections::register_rest_routes
+	 */
+	public function test_register_rest_routes() {
+		do_action( 'rest_api_init' );
+
+		$routes = rest_get_server()->get_routes( NEWSPACK_API_NAMESPACE );
+
+		$expected_route = '/' . NEWSPACK_API_NAMESPACE . '/corrections/(?P<id>\\d+)';
+		$this->assertArrayHasKey( $expected_route, $routes, 'The corrections REST route should be registered.' );
+
+		$endpoint = $routes[ $expected_route ][0];
+
+		$this->assertArrayHasKey(
+			WP_REST_Server::CREATABLE,
+			$endpoint['methods'],
+			'The corrections REST route should be registered with the POST method (CREATABLE).'
+		);
+		$this->assertTrue( $endpoint['methods'][ WP_REST_Server::CREATABLE ] );
+
+		$this->assertTrue(
+			is_callable( $endpoint['callback'] ),
+			'The corrections REST route callback should be callable.'
+		);
+
+		$this->assertTrue(
+			is_callable( $endpoint['permission_callback'] ),
+			'The corrections REST route permission callback should be callable.'
+		);
+	}
+
+	/**
+	 * Test that an invalid post ID returns a WP_Error.
+	 *
+	 * @covers Corrections::rest_save_corrections
+	 */
+	public function test_invalid_post_id_returns_error() {
+		$request = new WP_REST_Request( WP_REST_Server::CREATABLE, '/' . NEWSPACK_API_NAMESPACE . '/corrections/9999999' );
+		$request->set_param( 'corrections', array() );
+
+		$response = Corrections::rest_save_corrections( $request );
+
+		$this->assertInstanceOf( 'WP_Error', $response, 'Expected a WP_Error for an invalid post ID.' );
+		$this->assertEquals( 'invalid_post_id', $response->get_error_code() );
+	}
+
+	/**
+	 * Test that a new correction is created.
+	 *
+	 * @covers Corrections::rest_save_corrections
+	 */
+	public function test_new_correction_is_created() {
+		$corrections = array(
+			array(
+				'id'      => null, // New correction.
+				'content' => 'Test correction content',
+				'type'    => 'correction',
+				'date'    => current_time( 'mysql' ),
+			),
+		);
+
+		$request = new WP_REST_Request( WP_REST_Server::CREATABLE, '/' . NEWSPACK_API_NAMESPACE . '/corrections/' );
+		$request->set_param( 'post_id', self::$post_id );
+		$request->set_param( 'corrections', $corrections );
+
+		$response = Corrections::rest_save_corrections( $request );
+		$this->assertInstanceOf( 'WP_REST_Response', $response, 'Expected a WP_REST_Response for a new correction.' );
+
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'success', $data );
+		$this->assertTrue( $data['success'] );
+		$this->assertArrayHasKey( 'corrections_saved', $data );
+		$this->assertCount( 1, $data['corrections_saved'] );
+
+		$response_message = $data['message'];
+		$this->assertEquals( 'Corrections saved successfully.', $response_message );
+	}
+
+	/**
+	 * Test that an existing correction is updated.
+	 *
+	 * @covers Corrections::rest_save_corrections
+	 */
+	public function test_existing_correction_is_updated() {
+		$initial_data = array(
+			'content' => 'Original correction content',
+			'type'    => 'correction',
+			'date'    => current_time( 'mysql' ),
+		);
+		$correction_id = Corrections::add_correction( self::$post_id, $initial_data );
+		$this->assertNotWPError( $correction_id );
+		$this->assertNotEquals( 0, $correction_id );
+
+		$updated_data = array(
+			array(
+				'id'      => $correction_id,
+				'content' => 'Updated correction content',
+				'type'    => 'clarification',
+				'date'    => current_time( 'mysql' ),
+			),
+		);
+
+		$request = new WP_REST_Request( WP_REST_Server::CREATABLE, '/' . NEWSPACK_API_NAMESPACE . '/corrections/' );
+		$request->set_param( 'post_id', self::$post_id );
+		$request->set_param( 'corrections', $updated_data );
+		$response = Corrections::rest_save_corrections( $request );
+		$data = $response->get_data();
+
+		$this->assertTrue( $data['success'], 'Expected success response on update.' );
+
+		$updated_correction = get_post( $correction_id );
+		$this->assertEquals( 'Updated correction content', $updated_correction->post_content, 'The correction content should be updated.' );
+
+		$updated_correction_type = get_post_meta( $correction_id, Corrections::CORRECTIONS_TYPE_META, true );
+		$this->assertEquals( 'clarification', $updated_correction_type, 'The correction type should be updated.' );
+	}
+
+	/**
+	 * Test that multiple corrections are saved.
+	 *
+	 * @covers Corrections::rest_save_corrections
+	 */
+	public function test_multiple_corrections_are_saved() {
+		$corrections = array(
+			array(
+				'id'      => null, // New correction.
+				'content' => 'Test correction content 1',
+				'type'    => 'correction',
+				'date'    => current_time( 'mysql' ),
+			),
+			array(
+				'id'      => null, // New correction.
+				'content' => 'Test correction content 2',
+				'type'    => 'clarification',
+				'date'    => current_time( 'mysql' ),
+			),
+		);
+
+		$request = new WP_REST_Request( WP_REST_Server::CREATABLE, '/' . NEWSPACK_API_NAMESPACE . '/corrections/' );
+		$request->set_param( 'post_id', self::$post_id );
+		$request->set_param( 'corrections', $corrections );
+
+		$response = Corrections::rest_save_corrections( $request );
+		$this->assertInstanceOf( 'WP_REST_Response', $response, 'Expected a WP_REST_Response for multiple corrections.' );
+
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'success', $data );
+		$this->assertTrue( $data['success'] );
+		$this->assertArrayHasKey( 'corrections_saved', $data );
+		$this->assertCount( 2, $data['corrections_saved'] );
+
+		$response_message = $data['message'];
+		$this->assertEquals( 'Corrections saved successfully.', $response_message );
+	}
+
+	/**
+	 * Test that a correction is deleted.
+	 *
+	 * @covers Corrections::rest_save_corrections
+	 */
+	public function test_correction_is_deleted() {
+		$correction_1 = array(
+			'id'      => null, // New correction.
+			'content' => 'Test correction content',
+			'type'    => 'correction',
+			'date'    => current_time( 'mysql' ),
+		);
+
+		$correction_id_1 = Corrections::add_correction( self::$post_id, $correction_1 );
+		$this->assertNotWPError( $correction_id_1 );
+		$this->assertNotEquals( 0, $correction_id_1 );
+
+		$correction_2 = array(
+			'id'      => null, // New correction.
+			'content' => 'Test correction content 2',
+			'type'    => 'clarification',
+			'date'    => current_time( 'mysql' ),
+		);
+
+		$correction_id_2 = Corrections::add_correction( self::$post_id, $correction_2 );
+		$this->assertNotWPError( $correction_id_2 );
+		$this->assertNotEquals( 0, $correction_id_2 );
+
+		$updated_corrections_array = array(
+			array(
+				'id'      => $correction_id_1,
+				'content' => 'Updated correction content',
+				'type'    => 'clarification',
+				'date'    => current_time( 'mysql' ),
+			),
+		);
+
+		$request = new WP_REST_Request( WP_REST_Server::CREATABLE, '/' . NEWSPACK_API_NAMESPACE . '/corrections/' );
+		$request->set_param( 'post_id', self::$post_id );
+		$request->set_param( 'corrections', $updated_corrections_array );
+
+		$response = Corrections::rest_save_corrections( $request );
+		$data = $response->get_data();
+
+		$this->assertTrue( $data['success'], 'Expected success response on update.' );
+		$this->assertCount( 1, $data['corrections_saved'] );
+		$this->assertContains( $correction_id_1, $data['corrections_saved'] );
+		$this->assertNotContains( $correction_id_2, $data['corrections_saved'] );
+
+		$deleted_correction = get_post( $correction_id_2 );
+		$this->assertNull( $deleted_correction, 'The deleted correction should not be found.' );
+
+		$updated_correction = get_post( $correction_id_1 );
+		$this->assertEquals( 'Updated correction content', $updated_correction->post_content, 'The correction content should be updated.' );
+
+		$updated_correction_type = get_post_meta( $correction_id_1, Corrections::CORRECTIONS_TYPE_META, true );
+		$this->assertEquals( 'clarification', $updated_correction_type, 'The correction type should be updated.' );
+	}
+
+	/**
+	 * Test that a correction created and added to a post and is returned.
+	 *
+	 * @covers Corrections::add_correction
+	 */
+	public function test_add_correction() {
+		$correction = array(
+			'content' => 'Test correction content',
+			'type'    => 'correction',
+			'date'    => current_time( 'mysql' ),
+		);
+
+		$correction_id = Corrections::add_correction( self::$post_id, $correction );
+		$this->assertNotWPError( $correction_id );
+		$this->assertNotEquals( 0, $correction_id );
+
+		$correction_post = get_post( $correction_id );
+		$this->assertInstanceOf( 'WP_Post', $correction_post, 'Expected a WP_Post object for the correction.' );
+		$this->assertEquals( Corrections::POST_TYPE, $correction_post->post_type, 'The correction post type should be "correction".' );
+		$this->assertEquals( 'Test correction content', $correction_post->post_content, 'The correction content should be set.' );
+
+		$correction_type = get_post_meta( $correction_id, Corrections::CORRECTIONS_TYPE_META, true );
+		$this->assertEquals( 'correction', $correction_type, 'The correction type should be set.' );
+
+		$correction_relate_post_id = get_post_meta( $correction_id, Corrections::CORRECTION_POST_ID_META, true );
+		$this->assertEquals( self::$post_id, $correction_relate_post_id, 'The correction post ID should be set.' );
+
+		$correction_title = sprintf( 'Correction for %s', get_the_title( self::$post_id ) );
+		$this->assertEquals( $correction_title, $correction_post->post_title, 'The correction title should be set.' );
+	}
+
+	/**
+	 * Test that a correction created and added to a post and is returned.
+	 *
+	 * @covers Corrections::get_corrections
+	 */
+	public function test_get_corrections() {
+		$time = time() - 60 * 60;
+		$correction_1 = array(
+			'content' => 'Test correction content 1',
+			'type'    => 'correction',
+			'date'    => gmdate( 'Y-m-d H:i:s', $time ), // 1 hour ago.
+		);
+
+		$correction_id_1 = Corrections::add_correction( self::$post_id, $correction_1 );
+		$this->assertNotWPError( $correction_id_1 );
+		$this->assertNotEquals( 0, $correction_id_1 );
+
+		$correction_2 = array(
+			'content' => 'Test correction content 2',
+			'type'    => 'clarification',
+			'date'    => gmdate( 'Y-m-d H:i:s', $time + 20 * 60 ), // 40 minutes ago.
+		);
+
+		$correction_id_2 = Corrections::add_correction( self::$post_id, $correction_2 );
+		$this->assertNotWPError( $correction_id_2 );
+		$this->assertNotEquals( 0, $correction_id_2 );
+
+		$corrections = Corrections::get_corrections( self::$post_id );
+		$this->assertCount( 2, $corrections );
+
+		// Reverse the order of corrections as they are returned in descending order.
+		$correction_1 = $corrections[1];
+		$correction_2 = $corrections[0];
+
+		$this->assertInstanceof( 'WP_Post', $correction_1, 'Expected a WP_Post object for the first correction.' );
+		$this->assertInstanceof( 'WP_Post', $correction_2, 'Expected a WP_Post object for the second correction.' );
+
+		$this->assertEquals( Corrections::POST_TYPE, $correction_1->post_type, 'The correction post type should be "correction".' );
+		$this->assertEquals( Corrections::POST_TYPE, $correction_2->post_type, 'The correction post type should be "correction".' );
+
+		$this->assertEquals( $correction_id_1, $correction_1->ID );
+		$this->assertEquals( $correction_id_2, $correction_2->ID );
+
+		$this->assertEquals( 'Test correction content 1', $correction_1->post_content, 'The correction content is correct.' );
+		$this->assertEquals( 'Test correction content 2', $correction_2->post_content, 'The correction content is correct.' );
+
+		$this->assertEquals( 'correction', $correction_1->correction_type, 'The correction type is correct.' );
+		$this->assertEquals( 'clarification', $correction_2->correction_type, 'The correction type is correct.' );
+
+		$this->assertEquals( gmdate( 'Y-m-d H:i:s', $time ), $correction_1->correction_date, 'The correction date is correct.' );
+		$this->assertEquals( gmdate( 'Y-m-d H:i:s', $time + 20 * 60 ), $correction_2->correction_date, 'The correction date is correct.' );
+	}
+
+	/**
+	 * Test that a correction created and added to a post and is returned.
+	 *
+	 * @covers Corrections::get_corrections
+	 */
+	public function test_get_corrections_with_no_corrections() {
+		$corrections = Corrections::get_corrections( self::$post_id );
+		$this->assertCount( 0, $corrections );
+	}
+
+	/**
+	 * Test that a created correction is updated.
+	 *
+	 * @covers Corrections::update_correction
+	 */
+	public function test_update_correction() {
+		$correction = array(
+			'content' => 'Test correction content',
+			'type'    => 'correction',
+			'date'    => current_time( 'mysql' ),
+		);
+
+		$correction_id = Corrections::add_correction( self::$post_id, $correction );
+		$this->assertNotWPError( $correction_id );
+		$this->assertNotEquals( 0, $correction_id );
+
+		$updated_data = array(
+			'content' => 'Updated correction content',
+			'type'    => 'clarification',
+			'date'    => current_time( 'mysql' ),
+		);
+
+		Corrections::update_correction( $correction_id, $updated_data );
+
+		$updated_correction = get_post( $correction_id );
+		$this->assertInstanceOf( 'WP_Post', $updated_correction, 'Expected a WP_Post object for the updated correction.' );
+		$this->assertEquals( 'Updated correction content', $updated_correction->post_content, 'The correction content should be updated.' );
+
+		$updated_correction_type = get_post_meta( $correction_id, Corrections::CORRECTIONS_TYPE_META, true );
+		$this->assertEquals( 'clarification', $updated_correction_type, 'The correction type should be updated.' );
+	}
+
+	/**
+	 * Test that created corrections are deleted.
+	 *
+	 * @covers Corrections::delete_corrections
+	 */
+	public function test_delete_corrections() {
+		$correction_1 = array(
+			'content' => 'Test correction content',
+			'type'    => 'correction',
+			'date'    => current_time( 'mysql' ),
+		);
+
+		$correction_1_id = Corrections::add_correction( self::$post_id, $correction_1 );
+		$this->assertNotWPError( $correction_1_id );
+		$this->assertNotEquals( 0, $correction_1_id );
+
+		$correction_2 = array(
+			'content' => 'Test correction content 2',
+			'type'    => 'clarification',
+			'date'    => current_time( 'mysql' ),
+		);
+
+		$correction_2_id = Corrections::add_correction( self::$post_id, $correction_2 );
+		$this->assertNotWPError( $correction_2_id );
+		$this->assertNotEquals( 0, $correction_2_id );
+
+		Corrections::delete_corrections( self::$post_id, [ $correction_1_id, $correction_2_id ] );
+
+		$deleted_correction = get_post( $correction_1_id );
+		$this->assertNull( $deleted_correction, 'The deleted correction should not be found.' );
+
+		$deleted_correction = get_post( $correction_2_id );
+		$this->assertNull( $deleted_correction, 'The deleted correction should not be found.' );
+	}
+
+	/**
+	 * Test that the corrections shortcode is added.
+	 *
+	 * @covers Corrections::add_corrections_shortcode
+	 */
+	public function test_add_corrections_shortcode() {
+		global $shortcode_tags;
+
+		Corrections::add_corrections_shortcode();
+
+		$this->assertArrayHasKey( 'corrections', $shortcode_tags, 'The corrections shortcode should be registered.' );
+
+		$callback = $shortcode_tags['corrections'];
+		$this->assertTrue( is_callable( $callback ), 'The corrections shortcode callback should be callable.' );
+
+		$expected_callback = array( 'Newspack\\Corrections', 'handle_corrections_shortcode' );
+		$this->assertEquals( $expected_callback, $callback, 'The corrections shortcode callback does not match the expected value.' );
+	}
+
+	/**
+	 * Test that correction type is returned as "Correction".
+	 *
+	 * @covers Corrections::get_correction_type
+	 */
+	public function test_get_correction_type_is_correction() {
+		$correction = array(
+			'content' => 'Test correction content',
+			'type'    => 'correction',
+			'date'    => current_time( 'mysql' ),
+		);
+
+		$correction_id = Corrections::add_correction( self::$post_id, $correction );
+		$this->assertNotWPError( $correction_id );
+		$this->assertNotEquals( 0, $correction_id );
+
+		$correction_type = Corrections::get_correction_type( $correction_id );
+		$this->assertEquals( 'Correction', $correction_type, 'The correction type should be "Correction".' );
+	}
+
+	/**
+	 * Test that correction type is returned as "Clarification".
+	 *
+	 * @covers Corrections::get_correction_type
+	 */
+	public function test_get_correction_type_is_clarification() {
+		$clarification = array(
+			'content' => 'Test clarification content',
+			'type'    => 'clarification',
+			'date'    => current_time( 'mysql' ),
+		);
+
+		$clarification_id = Corrections::add_correction( self::$post_id, $clarification );
+		$this->assertNotWPError( $clarification_id );
+		$this->assertNotEquals( 0, $clarification_id );
+
+		$clarification_type = Corrections::get_correction_type( $clarification_id );
+		$this->assertEquals( 'Clarification', $clarification_type, 'The correction type should be "Clarification".' );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
This PR adds unit tests for the Corrections class methods. The tests cover functionality such as:

Enabling the corrections feature.
- Adding, updating and deleting corrections.
- REST route registration and its callback/permission checks.
- Updating corrections for a post with the REST API.
- Shortcode handling and output of corrections on post content.

These tests will help ensure that any future changes to the Corrections class maintain expected behavior and improve overall code stability.

### How to test the changes in this Pull Request:

1. Run unit tests specific to corrections class with `vendor/bin/phpunit --filter Test_Corrections`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->