### PR TITLE
feat(my-account): sync email change with esp

### DIFF
--- a/includes/reader-activation/sync/class-esp-sync.php
+++ b/includes/reader-activation/sync/class-esp-sync.php
@@ -186,7 +186,7 @@ class ESP_Sync extends Sync {
 	 *
 	 * @param int $user_id The user ID.
 	 */
-	protected static function get_contact_data( $user_id ) {
+	public static function get_contact_data( $user_id ) {
 		$user = \get_userdata( $user_id );
 
 		$customer = new \WC_Customer( $user_id );

--- a/includes/reader-activation/sync/class-esp-sync.php
+++ b/includes/reader-activation/sync/class-esp-sync.php
@@ -93,13 +93,12 @@ class ESP_Sync extends Sync {
 	/**
 	 * Sync contact to the ESP.
 	 *
-	 * @param array      $contact The contact data to sync.
-	 * @param string     $context The context of the sync. Defaults to static::$context.
-	 * @param array|null $existing_contact Optional. The existing contact data to compare against.
+	 * @param array  $contact The contact data to sync.
+	 * @param string $context The context of the sync. Defaults to static::$context.
 	 *
 	 * @return true|\WP_Error True if succeeded or WP_Error.
 	 */
-	public static function sync( $contact, $context = '', $existing_contact = null ) {
+	public static function sync( $contact, $context = '' ) {
 		$can_sync = static::can_esp_sync( true );
 		if ( $can_sync->has_errors() ) {
 			return $can_sync;
@@ -130,7 +129,7 @@ class ESP_Sync extends Sync {
 
 		$contact = Sync\Metadata::normalize_contact_data( $contact );
 
-		$result = \Newspack_Newsletters_Contacts::upsert( $contact, $master_list_id, $context, $existing_contact );
+		$result = \Newspack_Newsletters_Contacts::upsert( $contact, $master_list_id, $context );
 
 		return \is_wp_error( $result ) ? $result : true;
 	}

--- a/includes/reader-activation/sync/class-esp-sync.php
+++ b/includes/reader-activation/sync/class-esp-sync.php
@@ -93,12 +93,13 @@ class ESP_Sync extends Sync {
 	/**
 	 * Sync contact to the ESP.
 	 *
-	 * @param array  $contact The contact data to sync.
-	 * @param string $context The context of the sync. Defaults to static::$context.
+	 * @param array      $contact The contact data to sync.
+	 * @param string     $context The context of the sync. Defaults to static::$context.
+	 * @param array|null $existing_contact Optional. The existing contact data to compare against.
 	 *
 	 * @return true|\WP_Error True if succeeded or WP_Error.
 	 */
-	public static function sync( $contact, $context = '' ) {
+	public static function sync( $contact, $context = '', $existing_contact = null ) {
 		$can_sync = static::can_esp_sync( true );
 		if ( $can_sync->has_errors() ) {
 			return $can_sync;
@@ -129,7 +130,7 @@ class ESP_Sync extends Sync {
 
 		$contact = Sync\Metadata::normalize_contact_data( $contact );
 
-		$result = \Newspack_Newsletters_Contacts::upsert( $contact, $master_list_id, $context );
+		$result = \Newspack_Newsletters_Contacts::upsert( $contact, $master_list_id, $context, $existing_contact );
 
 		return \is_wp_error( $result ) ? $result : true;
 	}

--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -8,6 +8,7 @@
 namespace Newspack;
 
 use Newspack\Reader_Activation;
+use Newspack\Reader_Activation\Sync\Metadata;
 use Newspack\Reader_Activation\ESP_Sync;
 use Newspack\Stripe_Connection;
 use Newspack\WooCommerce_Connection;
@@ -982,16 +983,19 @@ class WooCommerce_My_Account {
 	 * @param int    $user_id User ID.
 	 * @param string $new_email New email address.
 	 * @param string $old_email Old email address.
-	 *
-	 * @return bool
 	 */
 	public static function sync_email_change( $user_id, $new_email, $old_email ) {
+		if ( ! class_exists( 'Newspack_Newsletters_Contacts' ) ) {
+			return;
+		}
 		$contact = ESP_Sync::get_contact_data( $user_id );
 		if ( ! $contact ) {
-			return false;
+			return;
 		}
+		$list_id          = Reader_Activation::get_esp_master_list_id();
 		$existing_contact = array_merge( $contact, [ 'email' => $old_email ] );
-		$update = ESP_Sync::sync( $contact, 'Email Change', $existing_contact );
+		$contact          = Metadata::normalize_contact_data( $contact );
+		$update           = \Newspack_Newsletters_Contacts::upsert( $contact, $list_id, 'Email_Change', $existing_contact );
 		if ( is_wp_error( $update ) ) {
 			// TODO: reschedule the sync if failure is not due to existing email.
 			Logger::error( 'Error syncing email change: ' . $update->get_error_message() );

--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -979,17 +979,19 @@ class WooCommerce_My_Account {
 	/**
 	 * Sync email change with site ESPs.
 	 *
-	 * @param int $user_id User ID.
+	 * @param int    $user_id User ID.
+	 * @param string $new_email New email address.
+	 * @param string $old_email Old email address.
 	 *
 	 * @return bool
 	 */
-	public static function sync_email_change( $user_id ) {
+	public static function sync_email_change( $user_id, $new_email, $old_email ) {
 		$contact = ESP_Sync::get_contact_data( $user_id );
 		if ( ! $contact ) {
 			return false;
 		}
-		// TODO: replace sync with update when ESP_Sync::update is implemented.
-		$update = ESP_Sync::sync( $contact );
+		$existing_contact = array_merge( $contact, [ 'email' => $old_email ] );
+		$update = ESP_Sync::sync( $contact, 'Email Change', $existing_contact );
 		if ( is_wp_error( $update ) ) {
 			// TODO: reschedule the sync if failure is not due to existing email.
 			Logger::error( 'Error syncing email change: ' . $update->get_error_message() );

--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -924,7 +924,7 @@ class WooCommerce_My_Account {
 				$customer->set_billing_email( $new_email );
 				$customer->save();
 				self::maybe_sync_email_change_with_stripe( $user_id, $new_email );
-				self::sync_email_change( $user_id );
+				self::sync_email_change( $user_id, $new_email, $old_email );
 				\delete_user_meta( $user_id, self::PENDING_EMAIL_CHANGE_META );
 				\wc_add_notice( __( 'Your email address has been successfully updated.', 'newspack-plugin' ) );
 			} else {

--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -8,6 +8,7 @@
 namespace Newspack;
 
 use Newspack\Reader_Activation;
+use Newspack\Reader_Activation\ESP_Sync;
 use Newspack\Stripe_Connection;
 use Newspack\WooCommerce_Connection;
 
@@ -922,6 +923,7 @@ class WooCommerce_My_Account {
 				$customer->set_billing_email( $new_email );
 				$customer->save();
 				self::maybe_sync_email_change_with_stripe( $user_id, $new_email );
+				self::sync_email_change( $user_id );
 				\delete_user_meta( $user_id, self::PENDING_EMAIL_CHANGE_META );
 				\wc_add_notice( __( 'Your email address has been successfully updated.', 'newspack-plugin' ) );
 			} else {
@@ -972,6 +974,28 @@ class WooCommerce_My_Account {
 		if ( \is_wp_error( $request ) ) {
 			Logger::error( 'Error updating Stripe customer email: ' . $result->get_error_message() );
 		}
+	}
+
+	/**
+	 * Sync email change with site ESPs.
+	 *
+	 * @param int $user_id User ID.
+	 *
+	 * @return bool
+	 */
+	public static function sync_email_change( $user_id ) {
+		$contact = ESP_Sync::get_contact_data( $user_id );
+		if ( ! $contact ) {
+			return false;
+		}
+		// TODO: replace sync with update when ESP_Sync::update is implemented.
+		$update = ESP_Sync::sync( $contact );
+		if ( is_wp_error( $update ) ) {
+			// TODO: reschedule the sync if failure is not due to existing email.
+			Logger::error( 'Error syncing email change: ' . $update->get_error_message() );
+			return false;
+		}
+		return $update;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Part of https://app.asana.com/0/1208993180326452/1209215513701719

This and the accompanying newsletters PR (https://github.com/Automattic/newspack-newsletters/pull/1764) trigger email change updates in the connected ESP after an email change is verified.

### How to test the changes in this Pull Request:

You will need to do three rounds of testing, one for MailChimp, one for Active Campaign, and one for Constant Contact

1. Make sure the `NEWSPACK_EMAIL_CHANGE_ENABLED` is added and `true` in wp-config.
2. With this and the newsletters PR checked out, ensure your test site is connected to the ESP
3. Log into a reader account that exists in the ESP
4. Go to my account, update the email address, and save changes
5. Check the verification email and click the button to verify
6. Ensure you are redirected to my account with a success message and the new email address showing
7. Log into the ESP dashboard, and search for the new contact by email
8. Also verify the old contact email is no longer present
9. **For mailchimp**, check for a contact note indicating the contact was migrated, and the old contact email is now archived

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->