### PR TITLE
fix(woo): page template meta leaking to other types

### DIFF
--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -73,11 +73,6 @@ class Memberships {
 		add_filter( 'newspack_gate_content', 'wp_replace_insecure_home_url' );
 		add_filter( 'newspack_gate_content', 'do_shortcode', 11 ); // AFTER wpautop().
 
-		/** Fixes to ensure that memberships are linked to the correct active subscription. */
-		add_filter( 'wc_memberships_expire_user_membership', [ __CLASS__, 'check_user_memberships_on_expire' ], 10, 2 );
-		add_action( 'woocommerce_subscription_status_updated', [ __CLASS__, 'check_user_memberships_on_subscription_update' ], 999 );
-		add_action( 'wp_login', [ __CLASS__, 'check_user_memberships_on_login' ], 10, 2 );
-
 		include __DIR__ . '/class-block-patterns.php';
 		include __DIR__ . '/class-metering.php';
 		include __DIR__ . '/class-import-export.php';
@@ -1064,97 +1059,6 @@ class Memberships {
 			}
 		}
 		return $classes;
-	}
-
-	/**
-	 * When a user membership is about to expire, ensure that it's linked to the correct subscription.
-	 *
-	 * @param bool                            $expire true will expire this membership, false will retain it - default: true, expire it.
-	 * @param \WC_Memberships_User_Membership $user_membership the User Membership object being expired.
-	 */
-	public static function check_user_memberships_on_expire( $expire, $user_membership ) {
-		$user_id                 = $user_membership->get_user_id();
-		$active_subscription_id  = self::get_user_subscription_for_membership_plan( $user_id, $user_membership->get_plan_id() );
-		if ( $active_subscription_id ) {
-			self::maybe_relink_user_membership_subscription( $user_id );
-			return false;
-		}
-
-		return $expire;
-	}
-
-	/**
-	 * When a subscription's status changes, ensure that any related user memberships are linked to the correct subscription.
-	 *
-	 * @param WC_Subscription $subscription An instance of a WC_Subscription object that just had its status changed.
-	 */
-	public static function check_user_memberships_on_subscription_update( $subscription ) {
-		self::maybe_relink_user_membership_subscription( $subscription->get_user_id() );
-	}
-
-	/**
-	 * When a reader logs in, ensure that their user memberships are linked to the correct subscription.
-	 *
-	 * @param string  $user_login User's login.
-	 * @param WP_User $user WP_User object for the logged-in user.
-	 */
-	public static function check_user_memberships_on_login( $user_login, $user ) {
-		if ( ! Reader_Activation::is_user_reader( $user ) ) {
-			return;
-		}
-		self::maybe_relink_user_membership_subscription( $user->ID );
-	}
-
-	/**
-	 * Ensure that the user membership is linked to the user's most recent active subscription, if any.
-	 *
-	 * @param int $user_id User ID.
-	 *
-	 * @return bool True if user membership was relinked to a different subscription, false otherwise.
-	 */
-	public static function maybe_relink_user_membership_subscription( $user_id ) {
-		$updated = false;
-		if ( ! self::is_active() ) {
-			return $updated;
-		}
-		$user_memberships = wc_memberships_get_user_memberships( $user_id );
-		foreach ( $user_memberships as $user_membership ) {
-			$user_membership_id      = $user_membership->get_id();
-			$subscription_membership = new \WC_Memberships_Integration_Subscriptions_User_Membership( $user_membership_id );
-			$active_subscription_id  = self::get_user_subscription_for_membership_plan( $user_id, $subscription_membership->get_plan_id() );
-			if ( $subscription_membership && ! empty( $active_subscription_id ) ) {
-				$linked_subscription_id = (int) $subscription_membership->get_subscription_id();
-
-				// If the user membership is linked to the wrong subscription, relink it.
-				if ( $linked_subscription_id !== $active_subscription_id ) {
-					$updated         = $subscription_membership->set_subscription_id( $active_subscription_id );
-					$membership_plan = $subscription_membership->get_plan();
-					$message         = __( 'User membership linked subscription updated.', 'newspack-plugin' );
-
-					// Reset membership to active status.
-					$subscription_membership->update_status( 'active', $message );
-
-					// Reset end date for plans with access set to subscription length.
-					if ( $membership_plan->is_access_length_type( 'subscription' ) && ! empty( $subscription_membership->get_end_date() ) ) {
-						$subscription_membership->set_end_date( '' );
-					}
-					Logger::newspack_log(
-						'newspack_user_membership_subscription_relinked',
-						$message,
-						[
-							'user_id'             => $user_id,
-							'membership_id'       => $user_membership_id,
-							'old_subscription_id' => $linked_subscription_id,
-							'new_subscription_id' => $active_subscription_id,
-							'success'             => $updated,
-						],
-						'debug'
-					);
-				}
-			}
-		}
-
-		return $updated;
 	}
 
 	/**

--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -672,7 +672,11 @@ class WooCommerce_Connection {
 	 * @param string $meta_key Meta key.
 	 */
 	public static function get_post_metadata( $value, $id, $meta_key ) {
-		if ( '_wp_page_template' === $meta_key && self::should_override_template() ) {
+		if (
+			'_wp_page_template' === $meta_key &&
+			self::should_override_template() &&
+			'page' === get_post_type( $id )
+		) {
 			return 'single-wide';
 		}
 		return $value;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The `get_post_metadata` hook is currently applying the `_wp_page_template` value for any entity in the context of a checkout, cart, or account page. This will include orders, subscriptions, or other types being processed in the request.

Adding the meta value to those objects can have unpredictable consequences, one of which is a bug in the Woo Memberships integration, which we last worked on a fix in #3768.

Initially, the bug was present in Woo Memberships but fixed since v1.26.9 (see changelog in https://woocommerce.com/products/woocommerce-memberships/).

### How to test the changes in this Pull Request:

Repeat steps from #3768

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->