### PR TITLE
feat(woo-member-commenting): optional module for member commenting

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -186,6 +186,7 @@ final class Newspack {
 
 		include_once NEWSPACK_ABSPATH . 'includes/optional-modules/class-rss.php';
 		include_once NEWSPACK_ABSPATH . 'includes/optional-modules/class-media-partners.php';
+		include_once NEWSPACK_ABSPATH . 'includes/optional-modules/class-woo-member-commenting.php';
 
 		if ( Donations::is_platform_nrh() ) {
 			include_once NEWSPACK_ABSPATH . 'includes/class-nrh.php';

--- a/includes/cli/class-initializer.php
+++ b/includes/cli/class-initializer.php
@@ -27,6 +27,7 @@ class Initializer {
 		include_once NEWSPACK_ABSPATH . 'includes/cli/class-ras-esp-sync.php';
 		include_once NEWSPACK_ABSPATH . 'includes/cli/class-co-authors-plus.php';
 		include_once NEWSPACK_ABSPATH . 'includes/cli/class-mailchimp.php';
+		include_once NEWSPACK_ABSPATH . 'includes/cli/class-optional-modules.php';
 		include_once NEWSPACK_ABSPATH . 'includes/cli/class-woocommerce-subscriptions.php';
 	}
 
@@ -77,5 +78,7 @@ class Initializer {
 		WP_CLI::add_command( 'newspack migrate-co-authors-guest-authors', [ 'Newspack\CLI\Co_Authors_Plus', 'migrate_guest_authors' ] );
 		WP_CLI::add_command( 'newspack backfill-non-editing-contributors', [ 'Newspack\CLI\Co_Authors_Plus', 'backfill_non_editing_contributor' ] );
 		WP_CLI::add_command( 'newspack migrate-expired-subscriptions', [ 'Newspack\CLI\WooCommerce_Subscriptions', 'migrate_expired_subscriptions' ] );
+
+		Optional_Modules::register_commands();
 	}
 }

--- a/includes/cli/class-optional-modules.php
+++ b/includes/cli/class-optional-modules.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * CLI commands to manage optional modules.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\CLI;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * CLI commands to manage optional modules.
+ */
+class Optional_Modules {
+
+	/**
+	 * Initialize.
+	 *
+	 * @return void
+	 * @throws \Exception If something goes wrong.
+	 */
+	public static function init(): void {
+		if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
+			return;
+		}
+
+		self::register_commands();
+	}
+
+	/**
+	 * Register WP-CLI commands.
+	 *
+	 * @throws \Exception If something goes wrong.
+	 */
+	public static function register_commands(): void {
+		$module_name = [
+			'type'        => 'positional',
+			'name'        => 'module-name',
+			'description' => 'Name of the module to activate/deactivate',
+			'optional'    => false,
+		];
+
+		\WP_CLI::add_command(
+			'newspack optional-module activate',
+			[ __CLASS__, 'cmd_activate_module' ],
+			[
+				'shortdesc' => 'Activate an optional module.',
+				'synopsis'  => [
+					$module_name,
+				],
+			]
+		);
+		\WP_CLI::add_command(
+			'newspack optional-module deactivate',
+			[ __CLASS__, 'cmd_deactivate_module' ],
+			[
+				'shortdesc' => 'Deactivate an optional module.',
+				'synopsis'  => [
+					$module_name,
+				],
+			]
+		);
+	}
+
+	/**
+	 * Command callback to activate an optional module.
+	 *
+	 * @param array $pos_args   Positional args.
+	 * @param array $assoc_args Associative args.
+	 *
+	 * @throws \Exception If something goes wrong.
+	 */
+	public static function cmd_activate_module( array $pos_args, array $assoc_args ): void {
+		$module_name       = $pos_args[0];
+		$available_modules = \Newspack\Settings::get_available_optional_modules();
+		if ( ! in_array( $module_name, $available_modules ) ) {
+			\WP_CLI::error( sprintf( 'Module is not available. These are the available modules: %s', implode( ', ', $available_modules ) ) );
+		}
+
+		$settings = \Newspack\Settings::activate_optional_module( $module_name );
+
+		if ( empty( $settings[ \Newspack\Settings::MODULE_ENABLED_PREFIX . $module_name ] ) ) {
+			\WP_CLI::success( 'Module activated.' );
+		} else {
+			\WP_CLI::error( "Cannot activate module – it's already active" );
+		}
+	}
+
+	/**
+	 * Command callback to deactivate an optional module.
+	 *
+	 * @param array $pos_args   Positional args.
+	 * @param array $assoc_args Associative args.
+	 *
+	 * @throws \Exception If something goes wrong.
+	 */
+	public static function cmd_deactivate_module( array $pos_args, array $assoc_args ) {
+		$module_name = $pos_args[0];
+
+		$enabled_modules = array_filter( \Newspack\Settings::api_get_settings() );
+
+		if ( empty( $enabled_modules[ \Newspack\Settings::MODULE_ENABLED_PREFIX . $module_name ] ) ) {
+			\WP_CLI::error( 'Module is not active. Cannot deactivate it' );
+		}
+		$settings = \Newspack\Settings::deactivate_optional_module( $module_name );
+
+		if ( empty( $settings[ \Newspack\Settings::MODULE_ENABLED_PREFIX . $module_name ] ) ) {
+			\WP_CLI::success( 'Module deactivated.' );
+		} else {
+			\WP_CLI::error( 'Failed to deactivate module.' );
+		}
+	}
+}

--- a/includes/optional-modules/class-woo-member-commenting.php
+++ b/includes/optional-modules/class-woo-member-commenting.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * Woo member commenting.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Woo member commenting.
+ */
+class Woo_Member_Commenting {
+
+	/**
+	 * Initialize.
+	 *
+	 * @return void
+	 */
+	public static function init(): void {
+		add_action( 'init', [ __CLASS__, 'on_init' ] );
+	}
+
+	/**
+	 * Action callback on init.
+	 *
+	 * @return void
+	 */
+	public static function on_init() {
+		if ( ! self::should_load() ) {
+			return;
+		}
+
+		add_filter( 'comment_form_defaults', [ __CLASS__, 'filter_comment_form_defaults' ] );
+		add_filter( 'comment_form_fields', [ __CLASS__, 'filter_comment_form_fields' ] );
+		add_filter( 'comment_form_submit_field', [ __CLASS__, 'filter_comment_form_submit_field' ] );
+	}
+
+	/**
+	 * Filter callback.
+	 *
+	 * @param array $defaults The defaults array to filter.
+	 *
+	 * @return mixed
+	 */
+	public static function filter_comment_form_defaults( $defaults ) {
+		if ( ! self::require_membership_to_comment_for_user() ) {
+			return $defaults;
+		}
+
+		$defaults['comment_notes_before'] = '';
+		$defaults['must_log_in']          = sprintf( '<p class="must-log-in">%s</p>', self::get_membership_required_message() );
+
+		return $defaults;
+	}
+
+
+	/**
+	 * Filter callback.
+	 *
+	 * @param array $fields The fields array to filter.
+	 *
+	 * @return array The filtered fields array.
+	 */
+	public static function filter_comment_form_fields( $fields ) {
+		return self::require_membership_to_comment_for_user() ? [] : $fields;
+	}
+
+	/**
+	 *  Filter callback.
+	 *
+	 * @param string $field Field to filter.
+	 *
+	 * @return string The filtered field.
+	 */
+	public static function filter_comment_form_submit_field( $field ) {
+		if ( ! self::require_membership_to_comment_for_user() ) {
+			return $field;
+		}
+
+		return sprintf( '<p class="must-log-in">%s</p>', self::get_membership_required_message() );
+	}
+
+	/**
+	 * Get the message to display to users that don't have access to commenting.
+	 *
+	 * @return string The message to display.
+	 */
+	private static function get_membership_required_message(): string {
+		$message = __( 'Only Members may post a comment.', 'newspack-plugin' );
+		if ( ! is_user_logged_in() ) {
+			$message .= ' ' . __( 'If you already have a membership, then <a href="/my-account/">sign in</a>.', 'newspack-plugin' );
+		}
+		if ( defined( 'NP_WC_MEMBER_COMMENT_MEMBERSHIP_PURCHASE_SLUG' ) && ! empty( NP_WC_MEMBER_COMMENT_MEMBERSHIP_PURCHASE_SLUG ) ) {
+			/* translators: %s - is the slug to buy a membership */
+			$message .= ' ' . sprintf( __( '<a href="/%s">Become a member now</a>.', 'newspack-plugin' ), NP_WC_MEMBER_COMMENT_MEMBERSHIP_PURCHASE_SLUG );
+		}
+
+		return $message;
+	}
+
+	/**
+	 * Whether class should suppress commenting for non-members.
+	 *
+	 * @return bool True if should suppress commenting for non-members, false otherwise.
+	 */
+	public static function should_load(): bool {
+		if ( empty( self::get_plan_slugs() ) ) {
+			return false;
+		}
+
+		return Settings::is_optional_module_active( 'woo-member-commenting' ) && function_exists( 'wc_memberships_get_user_memberships' ) && ! current_user_can( 'edit_posts' );
+	}
+
+	/**
+	 * Get slugs for membership plans that should allow commenting.
+	 *
+	 * This is managed by a constant for now – note that the constant can be a single string or an array of strings.
+	 *
+	 * @return array Array of plan slugs that allow commenting.
+	 */
+	private static function get_plan_slugs(): array {
+		if ( ! defined( 'NP_WC_MEMBER_COMMENT_PLAN_SLUG' ) || empty( NP_WC_MEMBER_COMMENT_PLAN_SLUG ) ) {
+			return [];
+		}
+		if ( ! is_array( NP_WC_MEMBER_COMMENT_PLAN_SLUG ) ) {
+			return [ NP_WC_MEMBER_COMMENT_PLAN_SLUG ];
+		}
+
+		return NP_WC_MEMBER_COMMENT_PLAN_SLUG;
+	}
+
+	/**
+	 * Whether membership is required to comment for the current user.
+	 *
+	 * @param bool $skip_cache Whether to skip the cache.
+	 *
+	 * @return bool True if membership is required to comment, false otherwise.
+	 */
+	public static function require_membership_to_comment_for_user( bool $skip_cache = false ): bool {
+		// This gets called a lot – so cache the result.
+		static $require_membership_to_comment;
+		if ( $skip_cache || null !== $require_membership_to_comment ) {
+			return $require_membership_to_comment;
+		}
+
+		if ( ! self::should_load() ) {
+			$require_membership_to_comment = false;
+		} else {
+			$memberships_required_plans    = array_filter(
+				wc_memberships_get_user_memberships(),
+				fn( $membership ) => in_array( $membership->get_plan()->get_slug(), self::get_plan_slugs() )
+			);
+			$require_membership_to_comment = empty( $memberships_required_plans );
+		}
+
+		return $require_membership_to_comment;
+	}
+}
+
+Woo_Member_Commenting::init();

--- a/includes/optional-modules/class-woo-member-commenting.php
+++ b/includes/optional-modules/class-woo-member-commenting.php
@@ -178,7 +178,7 @@ class Woo_Member_Commenting {
 			$message = __( 'Become a member now', 'newspack-plugin' );
 		}
 
-		return sprintf( '<a href="%s">%s</a>.', $post_url, $message );
+		return sprintf( '<a href="%s">%s</a>', $post_url, $message );
 	}
 
 	/**

--- a/includes/optional-modules/class-woo-member-commenting.php
+++ b/includes/optional-modules/class-woo-member-commenting.php
@@ -51,7 +51,7 @@ class Woo_Member_Commenting {
 		}
 
 		$defaults['comment_notes_before'] = '';
-		$defaults['must_log_in']          = sprintf( '<p class="must-log-in">%s</p>', self::get_membership_required_message() );
+		$defaults['must_log_in']          = self::get_membership_required_message();
 
 		return $defaults;
 	}
@@ -80,7 +80,7 @@ class Woo_Member_Commenting {
 			return $field;
 		}
 
-		return sprintf( '<p class="must-log-in">%s</p>', self::get_membership_required_message() );
+		return self::get_membership_required_message();
 	}
 
 	/**
@@ -91,20 +91,19 @@ class Woo_Member_Commenting {
 	private static function get_membership_required_message(): string {
 		$message = __( 'Only Members may post a comment.', 'newspack-plugin' );
 		if ( ! is_user_logged_in() ) {
-			$message .= ' ' . __( 'If you already have a membership, then <a href="/my-account/">sign in</a>.', 'newspack-plugin' );
+			$sign_in_url = function_exists( '\wc_get_page_permalink' ) ? \wc_get_page_permalink( 'myaccount' ) : wp_login_url( get_permalink() );
+			/* translators: %s: sign in URL */
+			$message .= ' ' . sprintf( __( 'If you already have a membership, then <a href="%s">sign in</a>.', 'newspack-plugin' ), $sign_in_url );
 		}
-		if ( defined( 'NP_WC_MEMBER_COMMENT_MEMBERSHIP_PURCHASE_SLUG' ) && ! empty( NP_WC_MEMBER_COMMENT_MEMBERSHIP_PURCHASE_SLUG ) ) {
-			/* translators: %s - is the slug to buy a membership */
-			$message .= ' ' . sprintf( __( '<a href="/%s">Become a member now</a>.', 'newspack-plugin' ), NP_WC_MEMBER_COMMENT_MEMBERSHIP_PURCHASE_SLUG );
-		}
+		$message .= ' ' . self::get_purchase_membership_link();
 
-		return $message;
+		return sprintf( '<p class="np-woo-member-commenting must-log-in">%s</p>', $message );
 	}
 
 	/**
 	 * Whether class should suppress commenting for non-members.
 	 *
-	 * @return bool True if should suppress commenting for non-members, false otherwise.
+	 * @return bool True if we should suppress commenting for non-members, false otherwise.
 	 */
 	public static function should_load(): bool {
 		if ( empty( self::get_plan_slugs() ) ) {
@@ -112,24 +111,6 @@ class Woo_Member_Commenting {
 		}
 
 		return Settings::is_optional_module_active( 'woo-member-commenting' ) && function_exists( 'wc_memberships_get_user_memberships' ) && ! current_user_can( 'edit_posts' );
-	}
-
-	/**
-	 * Get slugs for membership plans that should allow commenting.
-	 *
-	 * This is managed by a constant for now – note that the constant can be a single string or an array of strings.
-	 *
-	 * @return array Array of plan slugs that allow commenting.
-	 */
-	private static function get_plan_slugs(): array {
-		if ( ! defined( 'NP_WC_MEMBER_COMMENT_PLAN_SLUG' ) || empty( NP_WC_MEMBER_COMMENT_PLAN_SLUG ) ) {
-			return [];
-		}
-		if ( ! is_array( NP_WC_MEMBER_COMMENT_PLAN_SLUG ) ) {
-			return [ NP_WC_MEMBER_COMMENT_PLAN_SLUG ];
-		}
-
-		return NP_WC_MEMBER_COMMENT_PLAN_SLUG;
 	}
 
 	/**
@@ -157,6 +138,73 @@ class Woo_Member_Commenting {
 		}
 
 		return $require_membership_to_comment;
+	}
+
+	/**
+	 * Get slugs for membership plans that should allow commenting.
+	 *
+	 * This is managed in the constant for now – note that the membership_plan_slug value in the array can be a single string or an array of strings.
+	 *
+	 * @return array Array of plan slugs that allow commenting.
+	 */
+	private static function get_plan_slugs(): array {
+		$slugs = self::get_module_setting( 'membership_plan_slug' );
+		if ( empty( $slugs ) ) {
+			return [];
+		}
+		if ( ! is_array( $slugs ) ) {
+			return [ $slugs ];
+		}
+
+		return $slugs;
+	}
+
+	/**
+	 * Get the link to purchase a membership.
+	 *
+	 * If the setting is empty, then an empty string is returned.
+	 *
+	 * @return string The link to purchase a membership or empty string.
+	 */
+	private static function get_purchase_membership_link(): string {
+		$post_id = self::get_module_setting( 'membership_purchase_post_id' );
+		if ( empty( $post_id ) || ! get_post( $post_id ) ) {
+			return '';
+		}
+
+		$post_url = get_permalink( (int) $post_id );
+		$message  = self::get_module_setting( 'membership_required_message' );
+		if ( empty( $message ) ) {
+			$message = __( 'Become a member now', 'newspack-plugin' );
+		}
+
+		return sprintf( '<a href="%s">%s</a>.', $post_url, $message );
+	}
+
+	/**
+	 * Get setting for this module.
+	 *
+	 * For now, settings are just a constant with an array.
+	 *
+	 * @param string $setting_name The setting to get from the constant array.
+	 *
+	 * @return false|mixed The value of the setting, or false if not found.
+	 */
+	private static function get_module_setting( string $setting_name ) {
+		if ( ! defined( 'NP_WC_MEMBER_COMMENT_SETTINGS' ) || empty( NP_WC_MEMBER_COMMENT_SETTINGS ) || ! is_array( NP_WC_MEMBER_COMMENT_SETTINGS ) ) {
+			return false;
+		}
+
+		$settings = wp_parse_args(
+			NP_WC_MEMBER_COMMENT_SETTINGS,
+			[
+				'membership_plan_slug'        => [],
+				'membership_purchase_post_id' => 0,
+				'membership_required_message' => '',
+			]
+		);
+
+		return $settings[ $setting_name ] ?? false;
 	}
 }
 

--- a/includes/wizards/class-settings.php
+++ b/includes/wizards/class-settings.php
@@ -49,15 +49,19 @@ class Settings extends Wizard {
 		$default_settings = [
 			self::MODULE_ENABLED_PREFIX . 'rss'            => false,
 			self::MODULE_ENABLED_PREFIX . 'media-partners' => false,
+			self::MODULE_ENABLED_PREFIX . 'woo-member-commenting' => false,
 		];
+
 		return wp_parse_args( get_option( self::SETTINGS_OPTION_NAME ), $default_settings );
 	}
 
 	/**
 	 * Get the list of available optional modules.
+	 *
+	 * @return array List of available optional modules.
 	 */
-	private static function get_available_optional_modules() {
-		return [ 'rss' ];
+	public static function get_available_optional_modules(): array {
+		return [ 'rss', 'woo-member-commenting' ];
 	}
 
 	/**
@@ -88,6 +92,15 @@ class Settings extends Wizard {
 	 */
 	public static function activate_optional_module( $module_name ) {
 		return self::update_setting( self::MODULE_ENABLED_PREFIX . $module_name, true );
+	}
+
+	/**
+	 * Deactivate an optional module.
+	 *
+	 * @param string $module_name Name of the module.
+	 */
+	public static function deactivate_optional_module( string $module_name ) {
+		return self::update_setting( self::MODULE_ENABLED_PREFIX . $module_name, false );
 	}
 
 	/**

--- a/tests/unit-tests/settings.php
+++ b/tests/unit-tests/settings.php
@@ -25,8 +25,9 @@ class Newspack_Test_Settings extends WP_UnitTestCase {
 		self::assertEquals(
 			Settings::api_get_settings(),
 			[
-				'module_enabled_rss'            => false,
-				'module_enabled_media-partners' => false,
+				'module_enabled_rss'                   => false,
+				'module_enabled_media-partners'        => false,
+				'module_enabled_woo-member-commenting' => false,
 			],
 			'Default settings are as expected.'
 		);
@@ -42,8 +43,9 @@ class Newspack_Test_Settings extends WP_UnitTestCase {
 		self::assertEquals(
 			Settings::api_get_settings(),
 			[
-				'module_enabled_rss'            => true,
-				'module_enabled_media-partners' => false,
+				'module_enabled_rss'                   => true,
+				'module_enabled_media-partners'        => false,
+				'module_enabled_woo-member-commenting' => false,
 			],
 			'Settings is updated.'
 		);
@@ -53,8 +55,9 @@ class Newspack_Test_Settings extends WP_UnitTestCase {
 		self::assertEquals(
 			Settings::api_get_settings(),
 			[
-				'module_enabled_rss'            => true,
-				'module_enabled_media-partners' => false,
+				'module_enabled_rss'                   => true,
+				'module_enabled_media-partners'        => false,
+				'module_enabled_woo-member-commenting' => false,
 			],
 			'A non-existent setting is not saved.'
 		);
@@ -76,6 +79,13 @@ class Newspack_Test_Settings extends WP_UnitTestCase {
 			Settings::is_optional_module_active( 'rss' ),
 			true,
 			'RSS module is active after being activated.'
+		);
+
+		Settings::deactivate_optional_module( 'rss' );
+		self::assertEquals(
+			Settings::is_optional_module_active( 'rss' ),
+			false,
+			'RSS module is deactivated.'
 		);
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [[Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [[WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [[VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [[Pull Requests](https://github.com/Automattic/pulls)](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This adds a new optional module to Newspack. It makes it possible to only allow comments for user that have a given membership.  It's very much based on `newspack-woocommerce-member-commenting.php` in our custom code repo.

It's a first stab at this optional module, so there are some things that are a bit basic:

* The module can only be enabled from CLI because we don't have the UI for it yet. I added a small class that can activate/deactivate optional modules.
* The membership required is a constant in wp-config.php. 
* The slug (path?) to tease for buying the membership is a constant for now.

#### Questions

* I'm using the `includes/wizards/class-settings.php` class that is also used from the wizard – is that too risky?
* The text that tells the user to log in and/or buy a plan is hardcoded and I wasn't really sure what to do with it. Suggestions welcome.
* We should probably add some styling to the message in italics. Suggestions welcome.

### How to test the changes in this Pull Request:

#### To test the WP_CLI command

1. Run `wp newspack optional-module activate woo-member-commenting` and verify with `wp option get newspack_settings` that the module is enabled (look for true).
2. Run it again and verify that you get an error because it's already active.
3. Run it again with a module name that does not exist. `horse` is a great option there.
4. Run `wp newspack optional-module deactivate woo-member-commenting` and verify with `wp option get newspack_settings` that the module is disabled (look for false).
5. Run it again and check that you get an error.

#### To test the membership comments

1. Make sure you have `woocommerce` and `woocommerce-memberships` active.
2. Go to Woo -> Memberships -> Membership Plans -> and click "Add New Membership Plan" to add a plan – no need for any settings other than the slug. You'll need that, so take note.
3. Now go to Woo -> Members and add that membership to a user.
4. Put the settings for the module in `wp-config.php`. See below for how the array should look.
5. With the admin user, visit a post and verify that you see the comment form under it.
6. WIth the user you added the membership to, visit that post and verify you can comment.
7. With a non-logged in user, visit the post and verify that you get a link to log in and to buy a membership if you filled in the `membership_purchase_post_id` part of the settings.

```php
const NP_WC_MEMBER_COMMENT_SETTINGS = [
  'membership_plan_slug'        => [''], // Slug(s) of membership plans. 
  'membership_purchase_post_id'     => 6, // Post id to a page/post with membershipt tease
  'membership_required_message' => "Become a member, why don't cha?",
];
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

---

- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209425721676725