### PR TITLE
Hotfix/add change nicename

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -172,6 +172,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-pwa.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/co-authors-plus/class-guest-contributor-role.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/co-authors-plus/class-nicename-change.php';
+		include_once NEWSPACK_ABSPATH . 'includes/plugins/co-authors-plus/class-nicename-change-ui.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/co-authors-plus/class-search-authors-limit.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/wc-memberships/class-memberships.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-woocommerce.php';

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -171,6 +171,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-perfmatters.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-pwa.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/co-authors-plus/class-guest-contributor-role.php';
+		include_once NEWSPACK_ABSPATH . 'includes/plugins/co-authors-plus/class-nicename-change.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/co-authors-plus/class-search-authors-limit.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/wc-memberships/class-memberships.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-woocommerce.php';

--- a/includes/plugins/co-authors-plus/class-nicename-change-ui.php
+++ b/includes/plugins/co-authors-plus/class-nicename-change-ui.php
@@ -1,0 +1,208 @@
+<?php
+/**
+ * Nicename change UI class.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+
+/**
+ * This class adds a UI to the user profile page to allow users to change their nicename.
+ */
+class Nicename_Change_UI {
+
+	/**
+	 * Registers the hooks.
+	 */
+	public static function init() {
+
+		if ( ! defined( 'NEWSPACK_CHANGE_NICENAME_UI' ) || ! NEWSPACK_CHANGE_NICENAME_UI ) {
+			return;
+		}
+
+		add_action( 'edit_user_profile', [ __CLASS__, 'edit_user_profile' ] );
+
+		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'enqueue_scripts' ] );
+
+		add_action( 'wp_ajax_newspack_change_nicename', [ __CLASS__, 'change_nicename_ajax' ] );
+		add_action( 'wp_ajax_newspack_change_nicename_check', [ __CLASS__, 'change_nicename_check_ajax' ] );
+	}
+
+	/**
+	 * Enqueue scripts.
+	 */
+	public static function enqueue_scripts() {
+		if ( ! is_admin() || \get_current_screen()->id !== 'user-edit' ) {
+			return;
+		}
+
+		\wp_enqueue_script(
+			'newspack-nicename-change',
+			Newspack::plugin_url() . '/dist/nicename-change.js',
+			[],
+			NEWSPACK_PLUGIN_VERSION,
+			true
+		);
+
+		\wp_enqueue_script(
+			'newspack-nicename-change',
+			Newspack::plugin_url() . '/dist/nicename-change.js',
+			[],
+			NEWSPACK_PLUGIN_VERSION,
+			true
+		);
+
+		wp_localize_script(
+			'newspack-nicename-change',
+			'newspack_change_nicename_params',
+			[
+				'ajax_url'      => admin_url( 'admin-ajax.php' ),
+				'empty_message' => esc_html__( 'Please provide a new slug.', 'newspack-plugin' ),
+			]
+		);
+
+		\wp_enqueue_style(
+			'newspack-nicename-change',
+			Newspack::plugin_url() . '/dist/nicename-change.css',
+			[],
+			NEWSPACK_PLUGIN_VERSION
+		);
+	}
+
+	/**
+	 * AJAX handler for checking the nicename availability.
+	 */
+	public static function change_nicename_check_ajax() {
+
+		check_ajax_referer( 'newspack_change_nicename_nonce', 'nonce' );
+
+		$new_nicename = isset( $_POST['new_nicename'] ) ? sanitize_title( wp_unslash( $_POST['new_nicename'] ) ) : '';
+
+		$existing = Nicename_Change::get_existing_nicenames( $new_nicename );
+
+		$response = [
+			'success' => empty( $existing ),
+			// translators: %s is the new nicename.
+			'message' => sprintf( esc_html__( 'Slug %s is available.', 'newspack-plugin' ), $new_nicename ),
+		];
+
+		if ( ! empty( $existing ) ) {
+			$response['message'] = esc_html__( 'Slug is not available.', 'newspack-plugin' );
+
+			foreach ( $existing as $existing_nicename ) {
+				$response['message'] .= '<br/>' . sprintf( ' - %s: %s (ID: %d, %d posts)', $existing_nicename['type'], $existing_nicename['value'], $existing_nicename['id'], $existing_nicename['num_posts'] );
+			}
+		}
+
+		wp_send_json( $response );
+
+		exit;
+	}
+
+	/**
+	 * AJAX handler for changing the user nicename.
+	 */
+	public static function change_nicename_ajax() {
+
+		check_ajax_referer( 'newspack_change_nicename_nonce', 'nonce' );
+
+		$new_nicename = isset( $_POST['new_nicename'] ) ? sanitize_title( wp_unslash( $_POST['new_nicename'] ) ) : '';
+
+		$existing = Nicename_Change::get_existing_nicenames( $new_nicename );
+
+		if ( ! empty( $existing ) ) {
+			return self::change_nicename_check_ajax();
+		}
+
+		$user_id = isset( $_POST['user_id'] ) ? (int) $_POST['user_id'] : 0;
+
+		if ( ! $user_id ) {
+			wp_send_json(
+				[
+					'success' => false,
+					'message' => esc_html__( 'User not found.', 'newspack-plugin' ),
+				]
+			);
+		}
+
+		// Update the nicename.
+		wp_update_user(
+			[
+				'ID'            => $user_id,
+				'user_nicename' => $new_nicename,
+			]
+		);
+
+		$response = [
+			'success' => empty( $existing ),
+			// translators: %s is the new nicename.
+			'message' => sprintf( esc_html__( 'Slug updated to %s!', 'newspack-plugin' ), $new_nicename ),
+		];
+
+		wp_send_json( $response );
+
+		exit;
+	}
+
+	/**
+	 * Add user profile fields.
+	 *
+	 * @param WP_User $user The current WP_User object.
+	 */
+	public static function edit_user_profile( $user ) {
+
+		$user = get_userdata( $user->ID ); // For some reason $user is not the full user object.
+		if ( ! $user ) {
+			return;
+		}
+		$current_nicename = $user->user_nicename;
+		?>
+		<div class="newspack-plugin-cap-options">
+
+			<h2><?php echo esc_html__( 'Change User archive URL', 'newspack-plugin' ); ?></h2>
+
+			<table class="form-table" role="presentation">
+				<tr class="user-newspack_cap_custom_cap_option-wrap">
+					<th scope="row">
+						<?php esc_html_e( 'Current slug', 'newspack-plugin' ); ?>
+					</th>
+					<td>
+						<?php echo esc_html( $current_nicename ); ?>
+					</td>
+				</tr>
+				<tr class="user-newspack_cap_custom_cap_option-wrap">
+					<th scope="row">
+						<?php esc_html_e( 'Change slug', 'newspack-plugin' ); ?>
+					</th>
+					<td>
+						<input type="text" name="newspack_change_nicename" id="newspack_change_nicename" value="" class="regular-text" />
+						<div id="newspack_change_nicename_message_success" class="newspack-change-nicename-ui-message newspack-change-nicename-ui-success" style="display: none;"></div>
+						<div id="newspack_change_nicename_message_error" class="newspack-change-nicename-ui-message newspack-change-nicename-ui-error" style="display: none;"></div>
+						<p class="description">
+							<?php
+							esc_html_e(
+								'Changing the slug will change the URL of your author archive page. The old URL will redirect to the new one after the change.',
+								'newspack-plugin'
+							);
+							?>
+						</p>
+						<input type="hidden" id="newspack_change_nicename_nonce" value="<?php echo esc_attr( wp_create_nonce( 'newspack_change_nicename_nonce' ) ); ?>" />
+						<button class="button newspack-change-nicename-button" id="newspack_change_nicename_check">
+							<?php esc_html_e( 'Check availability', 'newspack-plugin' ); ?>
+						</button>
+						<button class="button newspack-change-nicename-button" id="newspack_change_nicename_submit" data-user-id="<?php echo esc_attr( $user->ID ); ?>">
+							<?php esc_html_e( 'Change slug', 'newspack-plugin' ); ?>
+						</button>
+					</td>
+				</tr>
+			</table>
+		</div>
+		<?php
+	}
+}
+
+Nicename_Change_UI::init();

--- a/includes/plugins/co-authors-plus/class-nicename-change.php
+++ b/includes/plugins/co-authors-plus/class-nicename-change.php
@@ -1,0 +1,302 @@
+<?php
+/**
+ * Nicename change class.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+
+/**
+ * This class adds some tweak to allow for a safe change of the nicename of a user.
+ *
+ * When a nicename changes it will:
+ * * Create a redirect from the old nicename to the new one.
+ * * Update the author term created by Co-Authors Plus.
+ *
+ * It will also register a new CLI command for convenience.
+ */
+class Nicename_Change {
+
+	const OLD_NICENAME_META_KEY = '_np_old_nicename';
+
+	/**
+	 * Registers the hooks.
+	 */
+	public static function init() {
+		add_action( 'profile_update', [ __CLASS__, 'profile_update' ], 10, 2 );
+		add_action( 'template_redirect', [ __CLASS__, 'old_nicename_redirect' ] );
+
+		// add a cli command to update the nicename.
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			\WP_CLI::add_command( 'newspack nicename-change', [ __CLASS__, 'cli_change_nicename' ] );
+			\WP_CLI::add_command( 'newspack nicename-check', [ __CLASS__, 'cli_check_nicename' ] );
+		}
+	}
+
+	/**
+	 * CLI command to check if a nicename is available.
+	 *
+	 * Usage: wp newspack nicename-check <new_nicename>
+	 *
+	 * @param array $args  The arguments.
+	 */
+	public static function cli_check_nicename( $args ) {
+		if ( empty( $args ) ) {
+			\WP_CLI::error( 'Please provide the nicename you want to check.' );
+		}
+
+		$new_nicename = $args[0];
+
+		if ( ! self::cli_check_and_output_nicename( $new_nicename ) ) {
+			\WP_CLI::error( 'Nicename not available.' );
+		}
+
+		\WP_CLI::success( $new_nicename . ' is available.' );
+	}
+
+	/**
+	 * CLI command to safely change the nicename of a user.
+	 *
+	 * This will check the nicename availability before doing anything. If it does, it will:
+	 * * Create a redirect from the old nicename to the new one.
+	 * * Update the author term created by Co-Authors Plus.
+	 *
+	 * Usage: wp newspack nicename-change <user_id> <new_nicename>
+	 *
+	 * @param array $args  The arguments.
+	 */
+	public static function cli_change_nicename( $args ) {
+		if ( empty( $args ) ) {
+			\WP_CLI::error( 'Please provide the user ID and the new nicename.' );
+		}
+
+		$user_id = (int) $args[0];
+		$user_data = get_user_by( 'ID', $user_id );
+
+		if ( ! $user_data ) {
+			\WP_CLI::error( 'User not found.' );
+		}
+
+		$new_nicename = $args[1];
+
+		if ( ! self::cli_check_and_output_nicename( $new_nicename ) ) {
+			\WP_CLI::error( 'Please choose a different nicename or fix the issues above by either removing the users/terms or merging the terms together.' );
+		}
+
+		// Update the nicename.
+		wp_update_user(
+			[
+				'ID'            => $user_id,
+				'user_nicename' => $new_nicename,
+			]
+		);
+
+		\WP_CLI::success( 'Nicename updated.' );
+	}
+
+	/**
+	 * Checks if the nicename is already in use and outputs it to CLI.
+	 *
+	 * @param string $nicename  The nicename to exclude.
+	 * @return bool True if the nicename is available, false otherwise.
+	 */
+	private static function cli_check_and_output_nicename( $nicename ) {
+		$existing_nicenames = self::get_existing_nicenames( $nicename );
+
+		if ( ! empty( $existing_nicenames ) ) {
+			\WP_CLI::line( 'This nicename is already in use:' );
+
+			foreach ( $existing_nicenames as $existing_nicename ) {
+				\WP_CLI::line( sprintf( ' - %s: %s (ID: %d, %d posts)', $existing_nicename['type'], $existing_nicename['value'], $existing_nicename['id'], $existing_nicename['num_posts'] ) );
+			}
+
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Checks if the nicename is already in use and return the usaged is it is.
+	 *
+	 * This will check both user_nicename and the author taxonomy used by Co-Authors Plus.
+	 *
+	 * @param string $nicename  The nicename to exclude.
+	 * @return array An array with the existing usages of this nicename. Each item of the array will be an array with the following keys:
+	 * * type: The type of usage (user_nicename or author taxonomy).
+	 * * id: The ID of the item using this nicename.
+	 * * value: Either the nicename or the term slug.
+	 * * num_posts: The number of posts associated with this nicename.
+	 */
+	private static function get_existing_nicenames( $nicename ) {
+		$existing_nicenames = [];
+
+		// Check the user_nicename.
+		$user = get_user_by( 'slug', $nicename );
+		if ( $user ) {
+			$existing_nicenames[] = [
+				'type'      => 'WP User',
+				'id'        => $user->ID,
+				'value'     => $user->user_nicename,
+				'num_posts' => self::get_num_of_posts( $nicename ),
+			];
+		}
+
+		// Check the author taxonomy.
+		$term = get_term_by( 'slug', $nicename, 'author' );
+		if ( $term ) {
+			$existing_nicenames[] = [
+				'type'      => 'CAP Author term',
+				'id'        => $term->term_id,
+				'value'     => $term->slug,
+				'num_posts' => self::get_num_of_posts( $nicename ),
+			];
+		}
+		$term = get_term_by( 'slug', 'cap-' . $nicename, 'author' );
+		if ( $term ) {
+			$existing_nicenames[] = [
+				'type'      => 'CAP Author term',
+				'id'        => $term->term_id,
+				'value'     => $term->slug,
+				'num_posts' => self::get_num_of_posts( $nicename ),
+			];
+		}
+
+		return $existing_nicenames;
+	}
+
+	/**
+	 * Gets the number of posts associated with a nicename.
+	 *
+	 * @param string $nicename  The nicename to check.
+	 * @return int The number of posts associated with this nicename.
+	 */
+	private static function get_num_of_posts( $nicename ) {
+		global $coauthors_plus, $wpdb;
+		$cap_enabled = false;
+		if ( is_object( $coauthors_plus ) && method_exists( $coauthors_plus, 'search_authors' ) ) {
+			$cap_enabled = true;
+		}
+
+		if ( $cap_enabled ) {
+			$term = get_term_by( 'slug', $nicename, 'author' );
+			if ( ! $term ) {
+				return 0;
+			}
+			$query = $wpdb->prepare( "SELECT COUNT(object_id) FROM $wpdb->term_relationships WHERE term_taxonomy_id = %d", $term->term_taxonomy_id );
+		} else {
+			$user = get_user_by( 'slug', $nicename );
+			if ( ! $user ) {
+				return 0;
+			}
+			$query = $wpdb->prepare( "SELECT COUNT(ID) FROM $wpdb->posts WHERE post_author = %d", $user->ID );
+		}
+
+		return (int) $wpdb->get_var( $query ); //phpcs:ignore
+	}
+
+	/**
+	 * Nicename update listener.
+	 *
+	 * @param int    $user_id        The user ID.
+	 * @param object $old_user_data  The old user data.
+	 */
+	public static function profile_update( $user_id, $old_user_data ) {
+
+		$user_data = get_user( $user_id );
+
+		if ( ! $user_data || $old_user_data->user_nicename === $user_data->user_nicename ) {
+			return;
+		}
+
+		self::handle_old_nicename_meta( $user_id, $old_user_data->user_nicename, $user_data->user_nicename );
+		self::update_author_term( $user_id, $old_user_data->user_nicename, $user_data->user_nicename );
+	}
+
+	/**
+	 * Handles the old nicename meta.
+	 *
+	 * @param int    $user_id       The user ID.
+	 * @param string $old_nicename  The old nicename.
+	 * @param string $new_nicename  The new nicename.
+	 */
+	public static function handle_old_nicename_meta( $user_id, $old_nicename, $new_nicename ) {
+		$old_nicename_meta = (array) get_user_meta( $user_id, self::OLD_NICENAME_META_KEY );
+
+		// If we haven't added this old nicename before, add it now.
+		if ( ! empty( $old_nicename ) && ! in_array( $old_nicename, $old_nicename_meta, true ) ) {
+			add_user_meta( $user_id, self::OLD_NICENAME_META_KEY, $old_nicename );
+		}
+
+		// If the new nicename was used previously, delete it from the list.
+		if ( in_array( $new_nicename, $old_nicename_meta, true ) ) {
+			delete_user_meta( $user_id, self::OLD_NICENAME_META_KEY, $new_nicename );
+		}
+	}
+
+	/**
+	 * Updates the author term created by Co-Authors Plus.
+	 *
+	 * @param int    $user_id       The user ID.
+	 * @param string $old_nicename  The old nicename.
+	 * @param string $new_nicename  The new nicename.
+	 */
+	public static function update_author_term( $user_id, $old_nicename, $new_nicename ) {
+		$term = get_term_by( 'slug', 'cap-' . $old_nicename, 'author' );
+		if ( ! $term ) {
+			$term = get_term_by( 'slug', $old_nicename, 'author' );
+		}
+
+		if ( ! $term ) {
+			return;
+		}
+
+		wp_update_term(
+			$term->term_id,
+			'author',
+			[
+				'slug' => 'cap-' . $new_nicename,
+			]
+		);
+	}
+
+	/**
+	 * Redirect old nicenames to the correct permalink.
+	 *
+	 * Attempts to find the current nicename from the past nicenames.
+	 */
+	public static function old_nicename_redirect() {
+
+		if ( is_404() && '' !== get_query_var( 'author_name' ) ) {
+
+			global $wpdb;
+
+			$new_user_id = $wpdb->get_var( // phpcs:ignore
+				$wpdb->prepare(
+					"SELECT user_id FROM $wpdb->usermeta WHERE meta_key = %s AND meta_value = %s LIMIT 1",
+					self::OLD_NICENAME_META_KEY,
+					get_query_var( 'author_name' )
+				)
+			);
+
+			if ( empty( $new_user_id ) ) {
+				return;
+			}
+
+			$link = get_author_posts_url( $new_user_id );
+
+			if ( ! $link ) {
+				return;
+			}
+
+			wp_safe_redirect( $link, 301 ); // Permanent redirect.
+			exit;
+		}
+	}
+}
+
+Nicename_Change::init();

--- a/includes/plugins/co-authors-plus/class-nicename-change.php
+++ b/includes/plugins/co-authors-plus/class-nicename-change.php
@@ -9,7 +9,6 @@ namespace Newspack;
 
 defined( 'ABSPATH' ) || exit;
 
-
 /**
  * This class adds some tweak to allow for a safe change of the nicename of a user.
  *
@@ -132,7 +131,7 @@ class Nicename_Change {
 	 * * value: Either the nicename or the term slug.
 	 * * num_posts: The number of posts associated with this nicename.
 	 */
-	private static function get_existing_nicenames( $nicename ) {
+	public static function get_existing_nicenames( $nicename ) {
 		$existing_nicenames = [];
 
 		// Check the user_nicename.

--- a/src/nicename-change/index.js
+++ b/src/nicename-change/index.js
@@ -1,0 +1,86 @@
+/* global jQuery,newspack_change_nicename_params */
+
+// eslint-disable object-shorthand
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+( function ( $ ) {
+	function newspack_change_nicename_set_loading_state() {
+		$( '#newspack_change_nicename_check' ).prop( 'disabled', true );
+		$( '#newspack_change_nicename_submit' ).prop( 'disabled', true );
+		$( '#newspack_change_nicename' ).prop( 'disabled', true );
+		$( '#newspack_change_nicename_message_success' ).html( '' ).hide();
+		$( '#newspack_change_nicename_message_error' ).html( '' ).hide();
+	}
+
+	function newspack_change_nicename_unset_loading_state() {
+		$( '#newspack_change_nicename_check' ).prop( 'disabled', false );
+		$( '#newspack_change_nicename_submit' ).prop( 'disabled', false );
+		$( '#newspack_change_nicename' ).prop( 'disabled', false );
+	}
+
+	function newspack_change_nicename_process_response( response ) {
+		if ( response.success ) {
+			$( '#newspack_change_nicename_message_success' )
+				.html( response.message )
+				.show();
+		} else {
+			$( '#newspack_change_nicename_message_error' )
+				.html( response.message )
+				.show();
+		}
+	}
+
+	$( '#newspack_change_nicename_check' ).on( 'click', function () {
+		event.preventDefault();
+		const new_nicename = $( '#newspack_change_nicename' ).val();
+		if ( ! new_nicename ) {
+			alert( newspack_change_nicename_params.empty_message ); // eslint-disable-line no-alert
+			return;
+		}
+		newspack_change_nicename_set_loading_state();
+		const nonce = $( '#newspack_change_nicename_nonce' ).val();
+		$.ajax( {
+			type: 'POST',
+			url: newspack_change_nicename_params.ajax_url,
+			data: {
+				action: 'newspack_change_nicename_check',
+				new_nicename,
+				nonce,
+			},
+			success( response ) {
+				newspack_change_nicename_unset_loading_state();
+				newspack_change_nicename_process_response( response );
+			},
+		} );
+	} );
+
+	$( '#newspack_change_nicename_submit' ).on( 'click', function () {
+		event.preventDefault();
+		const new_nicename = $( '#newspack_change_nicename' ).val();
+		if ( ! new_nicename ) {
+			alert( newspack_change_nicename_params.empty_message ); // eslint-disable-line no-alert
+			return;
+		}
+		newspack_change_nicename_set_loading_state();
+		const user_id = $( this ).data( 'user-id' );
+		const nonce = $( '#newspack_change_nicename_nonce' ).val();
+		$.ajax( {
+			type: 'POST',
+			url: newspack_change_nicename_params.ajax_url,
+			data: {
+				action: 'newspack_change_nicename',
+				new_nicename,
+				nonce,
+				user_id,
+			},
+			success( response ) {
+				newspack_change_nicename_unset_loading_state();
+				newspack_change_nicename_process_response( response );
+			},
+		} );
+	} );
+} )( jQuery );

--- a/src/nicename-change/style.scss
+++ b/src/nicename-change/style.scss
@@ -1,0 +1,17 @@
+.newspack-change-nicename-ui-message {
+	margin-top: 20px;
+	padding: 10px;
+	background-color: #f9f9f9;
+	color: #333;
+	font-size: 14px;
+	line-height: 1.5;
+	border: 1px solid #e5e5e5;
+}
+
+.newspack-change-nicename-ui-error {
+	border-color: red;
+}
+
+.newspack-change-nicename-ui-success {
+	border-color: green;
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -37,8 +37,18 @@ wizardsScripts.forEach( function( wizard ) {
 } );
 
 const entry = {
-	'reader-activation': path.join( __dirname, 'src', 'reader-activation', 'index.js' ),
-	'reader-auth': path.join( __dirname, 'src', 'reader-activation-auth', 'index.js' ),
+	'reader-activation': path.join(
+		__dirname,
+		'src',
+		'reader-activation',
+		'index.js'
+	),
+	'reader-auth': path.join(
+		__dirname,
+		'src',
+		'reader-activation-auth',
+		'index.js'
+	),
 	'newsletters-signup': path.join(
 		__dirname,
 		'src',
@@ -52,15 +62,36 @@ const entry = {
 		'reader-registration',
 		'view.js'
 	),
-	'my-account': path.join( __dirname, 'includes', 'reader-revenue', 'my-account', 'index.js' ),
+	'my-account': path.join(
+		__dirname,
+		'includes',
+		'reader-revenue',
+		'my-account',
+		'index.js'
+	),
 	admin: path.join( __dirname, 'src', 'admin', 'index.js' ),
-	'memberships-gate': path.join( __dirname, 'src', 'memberships-gate', 'gate.js' ),
-	'memberships-gate-metering': path.join( __dirname, 'src', 'memberships-gate', 'metering.js' ),
+	'memberships-gate': path.join(
+		__dirname,
+		'src',
+		'memberships-gate',
+		'gate.js'
+	),
+	'memberships-gate-metering': path.join(
+		__dirname,
+		'src',
+		'memberships-gate',
+		'metering.js'
+	),
 
 	// Newspack wizard assets.
 	...wizardsScriptFiles,
 	blocks: path.join( __dirname, 'src', 'blocks', 'index.js' ),
-	'memberships-gate-editor': path.join( __dirname, 'src', 'memberships-gate', 'editor.js' ),
+	'memberships-gate-editor': path.join(
+		__dirname,
+		'src',
+		'memberships-gate',
+		'editor.js'
+	),
 	'memberships-gate-block-patterns': path.join(
 		__dirname,
 		'src',
@@ -68,7 +99,13 @@ const entry = {
 		'block-patterns.js'
 	),
 	'newspack-ui': path.join( __dirname, 'src', 'newspack-ui', 'index.js' ),
-	'bylines': path.join( __dirname, 'src', 'bylines', 'index.js' ),
+	bylines: path.join( __dirname, 'src', 'bylines', 'index.js' ),
+	'nicename-change': path.join(
+		__dirname,
+		'src',
+		'nicename-change',
+		'index.js'
+	),
 };
 
 // Get files for other scripts.


### PR DESCRIPTION
Adds the change nicename CLI and experimental UI

applies https://github.com/Automattic/newspack-plugin/pull/3725 and https://github.com/Automattic/newspack-plugin/pull/3740

You can see https://github.com/Automattic/newspack-plugin/pull/3740 for testing instructions

choose an author and open its archive page on a new tab
Edit their profile
Check the new "Change user slug" section
Confirm the "Check availability" works, by typing a few options there, including some you know are taken
Change the slug to something else
Back to the author's archive tab, reload the page and confirm it redirects you to the new slug