### PR TITLE
fix(my-account): send email change emails to old and new emails

### DIFF
--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -819,29 +819,45 @@ class WooCommerce_My_Account {
 			if ( ! $update ) {
 				\wc_add_notice( __( 'Something went wrong. Please try again.', 'newspack-plugin' ), 'error' );
 			} else {
-				$sent = Emails::send_email(
-					Reader_Activation_Emails::EMAIL_TYPES['CHANGE_EMAIL'],
-					$new_email,
-					[
-						[
-							'template' => '*EMAIL_VERIFICATION_URL*',
-							'value'    => \add_query_arg(
+				$sent = [];
+				foreach ( [ $old_email, $new_email ] as $email ) {
+					if (
+						Emails::send_email(
+							Reader_Activation_Emails::EMAIL_TYPES['CHANGE_EMAIL'],
+							$email,
+							[
 								[
-									self::VERIFY_EMAIL_CHANGE_PARAM => \wp_create_nonce( self::VERIFY_EMAIL_CHANGE_PARAM ),
+									'template' => '*EMAIL_VERIFICATION_URL*',
+									'value'    => \add_query_arg(
+										[
+											self::VERIFY_EMAIL_CHANGE_PARAM => \wp_create_nonce( self::VERIFY_EMAIL_CHANGE_PARAM ),
+										],
+										\home_url()
+									),
 								],
-								\home_url()
-							),
-						],
-					]
-				);
-				if ( ! $sent ) {
+							]
+						)
+					) {
+						$sent[] = $email;
+					}
+				}
+				if ( empty( $sent ) ) {
 					\wc_add_notice( __( 'Something went wrong. Please contact the site administrator.', 'newspack-plugin' ), 'error' );
+				} elseif ( count( $sent ) === 1 ) {
+					\wc_add_notice(
+						sprintf(
+							// Translators: %s is the email address the verification email was sent to..
+							__( 'A verification email has been sent to %s. Please verify to complete the change.', 'newspack-plugin' ),
+							$sent[0]
+						)
+					);
 				} else {
 					\wc_add_notice(
 						sprintf(
-							// Translators: %s is the new email address.
-							__( 'A verification email has been sent to %s. Please verify to complete the change.', 'newspack-plugin' ),
-							$new_email
+							// Translators: 1 and 2 are the email addresses the verification email was sent to.
+							__( 'A verification email has been sent to %1$s and %2$s. Please verify to complete the change.', 'newspack-plugin' ),
+							$sent[0],
+							$sent[1]
 						)
 					);
 				}


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1208993180326452/1209498219917239/f

This PR sends the email change email to both the old and new email addresses to ensure the reader is able to find this email regardless of which inbox they check.

![Screenshot 2025-02-27 at 13 08 52](https://github.com/user-attachments/assets/14058c9d-0c84-477a-9552-5dddcec4d9fa)


### How to test the changes in this Pull Request:

1. Ensure the `NEWSPACK_EMAIL_CHANGE_ENABLED` FF is added in wp-config.
2. As a logged in reader go to my account and update the email address, then save changes
3. Verify a notice appears asking you to verify and indicating the verification email has been sent to both the old and new email address
4. Confirm the email has actually been sent to both and you are able to verify via either email

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->