### PR TITLE
fix(premium-newsletters): show premium lists in post-checkout signup

### DIFF
--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -561,11 +561,6 @@ final class Reader_Activation {
 		}
 
 		foreach ( $available_lists as $list_id => $list ) {
-			// Skip any premium lists since the reader has already made a purchase at this stage.
-			if ( method_exists( '\Newspack_Newsletters\Plugins\Woocommerce_Memberships', 'is_subscription_list_tied_to_plan' ) && \Newspack_Newsletters\Plugins\Woocommerce_Memberships::is_subscription_list_tied_to_plan( $list['db_id'] ) ) {
-				continue;
-			}
-
 			$registration_lists[ $list_id ] = $list;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Goes with https://github.com/Automattic/newspack-newsletters/pull/1766. Allows premium newsletter lists to be shown in the post-modal checkout, if enabled in Reader Activation settings. This should provide publishers with more control over whether to auto-subscribe readers who purchase premium newsletter subscriptions, or present them with the option to subscribe after purchase.

### How to test the changes in this Pull Request:

See testing instructions in https://github.com/Automattic/newspack-newsletters/pull/1766.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->