### PR TITLE
feat(my-account): sync email change with stripe

### DIFF
--- a/includes/reader-revenue/stripe/class-stripe-connection.php
+++ b/includes/reader-revenue/stripe/class-stripe-connection.php
@@ -80,4 +80,24 @@ class Stripe_Connection {
 			update_option( 'woocommerce_default_country', $updated_stripe_data['location_code'] );
 		}
 	}
+
+	/**
+	 * Update stripe customer data.
+	 *
+	 * @param int   $user_id User ID.
+	 * @param array $data    Stripe customer data.
+	 *
+	 * @return bool|WP_Error
+	 */
+	public static function update_customer_data( $user_id, $data ) {
+		if ( ! class_exists( 'WC_Stripe_API' ) ) {
+			return false;
+		}
+		$stripe_customer_id = \get_user_option( '_stripe_customer_id', $user_id );
+		if ( ! $stripe_customer_id ) {
+			return false;
+		}
+		$result = \WC_Stripe_API::request( $data, 'customers/' . $stripe_customer_id );
+		return \is_wp_error( $result ) ? $result : true;
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1208993180326452/1209215513701723

This PR ensures a customers email address is updated in Stripe when changed via my account:

![Screenshot 2025-02-28 at 15 54 15](https://github.com/user-attachments/assets/19349a5f-0c1e-4cd3-a1ed-9d29bd3a354d)


### How to test the changes in this Pull Request:

1. Find any reader in your stripe dashboard
2. Log in as the reader and go to my account
3. Update your email address and save details
4. Verify via the sent email
5. Once redirected to my account, check the stripe dashboard and confirm the email address has updated there as well
6. Repeat steps 1-4 with a reader account that is not associated with stripe
7. Verify you don't run into any errors or issues

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->