### PR TITLE
fix: spacer block handling with registration block

### DIFF
--- a/src/blocks/reader-registration/style.scss
+++ b/src/blocks/reader-registration/style.scss
@@ -258,7 +258,7 @@
 	}
 
 	&--hidden,
-	+ div:empty {
+	+ div:empty:not(.wp-block-spacer) {
 		display: none;
 	}
 
@@ -283,15 +283,6 @@
 		@media screen and ( min-width: 600px ) {
 			padding-right: 0;
 		}
-	}
-}
-
-@keyframes spin {
-	from {
-		transform: rotate(0deg);
-	}
-	to {
-		transform: rotate(360deg);
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adjusts an overly aggressive CSS rule, which caused a spacer block to be hidden if adjacent to a registration block.

Also removes a duplicated keyframes declaration.

### How to test the changes in this Pull Request:

1. On `trunk`, insert a registration block, followed by a spacer block
2. Observe that on the frontend, the spacer block is hidden
3. Switch to this branch, refresh page, observe the spacer block is visible

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->