### PR TITLE
fix(my-account): handle email change esp sync errors

### DIFF
--- a/includes/reader-activation/sync/class-esp-sync.php
+++ b/includes/reader-activation/sync/class-esp-sync.php
@@ -93,13 +93,12 @@ class ESP_Sync extends Sync {
 	/**
 	 * Sync contact to the ESP.
 	 *
-	 * @param array      $contact The contact data to sync.
-	 * @param string     $context The context of the sync. Defaults to static::$context.
-	 * @param array|null $existing_contact Optional. The existing contact data to compare against.
+	 * @param array  $contact The contact data to sync.
+	 * @param string $context The context of the sync. Defaults to static::$context.
 	 *
 	 * @return true|\WP_Error True if succeeded or WP_Error.
 	 */
-	public static function sync( $contact, $context = '', $existing_contact = null ) {
+	public static function sync( $contact, $context = '' ) {
 		$can_sync = static::can_esp_sync( true );
 		if ( $can_sync->has_errors() ) {
 			return $can_sync;
@@ -130,7 +129,7 @@ class ESP_Sync extends Sync {
 
 		$contact = Sync\Metadata::normalize_contact_data( $contact );
 
-		$result = \Newspack_Newsletters_Contacts::upsert( $contact, $master_list_id, $context, $existing_contact );
+		$result = \Newspack_Newsletters_Contacts::upsert( $contact, $master_list_id, $context );
 
 		return \is_wp_error( $result ) ? $result : true;
 	}

--- a/includes/reader-activation/sync/class-esp-sync.php
+++ b/includes/reader-activation/sync/class-esp-sync.php
@@ -16,6 +16,10 @@ defined( 'ABSPATH' ) || exit;
  * ESP Sync Class.
  */
 class ESP_Sync extends Sync {
+	/**
+	 * Cron hook for syncing email change with ESP.
+	 */
+	const SYNC_ESP_EMAIL_CHANGE_CRON_HOOK = 'newspack_esp_sync_email_change';
 
 	/**
 	 * Context of the sync.
@@ -37,6 +41,7 @@ class ESP_Sync extends Sync {
 	public static function init_hooks() {
 		add_action( 'newspack_scheduled_esp_sync', [ __CLASS__, 'scheduled_sync' ], 10, 2 );
 		add_action( 'shutdown', [ __CLASS__, 'run_queued_syncs' ] );
+		add_action( self::SYNC_ESP_EMAIL_CHANGE_CRON_HOOK, [ __CLASS__, 'sync_email_change' ], 10, 3 );
 	}
 
 	/**
@@ -271,6 +276,33 @@ class ESP_Sync extends Sync {
 		}
 
 		self::$queued_syncs = [];
+	}
+
+
+	/**
+	 * Sync email change with site ESPs.
+	 *
+	 * @param int    $user_id User ID.
+	 * @param string $new_email New email address.
+	 * @param string $old_email Old email address.
+	 */
+	public static function sync_email_change( $user_id, $new_email, $old_email ) {
+		if ( ! class_exists( 'Newspack_Newsletters_Contacts' ) ) {
+			return;
+		}
+		$contact = self::get_contact_data( $user_id );
+		if ( ! $contact ) {
+			return;
+		}
+		$list_id          = Reader_Activation::get_esp_master_list_id();
+		$existing_contact = array_merge( $contact, [ 'email' => $old_email ] );
+		$contact          = Sync\Metadata::normalize_contact_data( $contact );
+		$update           = \Newspack_Newsletters_Contacts::upsert( $contact, $list_id, 'Email_Change', $existing_contact );
+		if ( is_wp_error( $update ) ) {
+			// If the update failed, retry in 24 hours.
+			\wp_schedule_single_event( time() + DAY_IN_SECONDS, self::SYNC_ESP_EMAIL_CHANGE_CRON_HOOK, [ $user_id, $new_email, $old_email ] );
+			Logger::error( 'Error syncing email change with ESP: ' . $update->get_error_message() . '. Retrying in 24 hours.' );
+		}
 	}
 }
 ESP_Sync::init_hooks();

--- a/includes/reader-activation/sync/class-esp-sync.php
+++ b/includes/reader-activation/sync/class-esp-sync.php
@@ -93,12 +93,13 @@ class ESP_Sync extends Sync {
 	/**
 	 * Sync contact to the ESP.
 	 *
-	 * @param array  $contact The contact data to sync.
-	 * @param string $context The context of the sync. Defaults to static::$context.
+	 * @param array      $contact The contact data to sync.
+	 * @param string     $context The context of the sync. Defaults to static::$context.
+	 * @param array|null $existing_contact Optional. The existing contact data to compare against.
 	 *
 	 * @return true|\WP_Error True if succeeded or WP_Error.
 	 */
-	public static function sync( $contact, $context = '' ) {
+	public static function sync( $contact, $context = '', $existing_contact = null ) {
 		$can_sync = static::can_esp_sync( true );
 		if ( $can_sync->has_errors() ) {
 			return $can_sync;
@@ -129,7 +130,7 @@ class ESP_Sync extends Sync {
 
 		$contact = Sync\Metadata::normalize_contact_data( $contact );
 
-		$result = \Newspack_Newsletters_Contacts::upsert( $contact, $master_list_id, $context );
+		$result = \Newspack_Newsletters_Contacts::upsert( $contact, $master_list_id, $context, $existing_contact );
 
 		return \is_wp_error( $result ) ? $result : true;
 	}

--- a/includes/reader-activation/sync/class-esp-sync.php
+++ b/includes/reader-activation/sync/class-esp-sync.php
@@ -9,6 +9,7 @@ namespace Newspack\Reader_Activation;
 
 use Newspack\Reader_Activation;
 use Newspack\Data_Events;
+use Newspack\Logger;
 
 defined( 'ABSPATH' ) || exit;
 

--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -1013,8 +1013,8 @@ class WooCommerce_My_Account {
 			return;
 		}
 		$list_id          = Reader_Activation::get_esp_master_list_id();
-		$contact          = Metadata::normalize_contact_data( $contact );
 		$existing_contact = array_merge( $contact, [ 'email' => $old_email ] );
+		$contact          = Metadata::normalize_contact_data( $contact );
 		$update           = \Newspack_Newsletters_Contacts::upsert( $contact, $list_id, 'Email_Change', $existing_contact );
 		if ( is_wp_error( $update ) ) {
 			// TODO: reschedule the sync if failure is not due to existing email.

--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -1023,9 +1023,9 @@ class WooCommerce_My_Account {
 		$contact          = Metadata::normalize_contact_data( $contact );
 		$update           = \Newspack_Newsletters_Contacts::upsert( $contact, $list_id, 'Email_Change', $existing_contact );
 		if ( is_wp_error( $update ) ) {
-			// If the update failed, retry in 1 hour.
-			\wp_schedule_single_event( time() + HOUR_IN_SECONDS, self::SYNC_ESP_EMAIL_CHANGE_CRON_HOOK, [ $user_id, $new_email, $old_email ] );
-			Logger::error( 'Error syncing email change with ESP: ' . $update->get_error_message() . '. Retrying in 1 hour.' );
+			// If the update failed, retry in 24 hours.
+			\wp_schedule_single_event( time() + DAY_IN_SECONDS, self::SYNC_ESP_EMAIL_CHANGE_CRON_HOOK, [ $user_id, $new_email, $old_email ] );
+			Logger::error( 'Error syncing email change with ESP: ' . $update->get_error_message() . '. Retrying in 24 hours.' );
 		}
 	}
 

--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -1013,8 +1013,8 @@ class WooCommerce_My_Account {
 			return;
 		}
 		$list_id          = Reader_Activation::get_esp_master_list_id();
-		$existing_contact = array_merge( $contact, [ 'email' => $old_email ] );
 		$contact          = Metadata::normalize_contact_data( $contact );
+		$existing_contact = array_merge( $contact, [ 'email' => $old_email ] );
 		$update           = \Newspack_Newsletters_Contacts::upsert( $contact, $list_id, 'Email_Change', $existing_contact );
 		if ( is_wp_error( $update ) ) {
 			// TODO: reschedule the sync if failure is not due to existing email.

--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -37,11 +37,6 @@ class WooCommerce_My_Account {
 	];
 
 	/**
-	 * Cron hook for syncing email change with ESP.
-	 */
-	const SYNC_ESP_EMAIL_CHANGE_CRON_HOOK = 'newspack_esp_sync_email_change';
-
-	/**
 	 * Initialize.
 	 *
 	 * @codeCoverageIgnore
@@ -78,7 +73,6 @@ class WooCommerce_My_Account {
 			\add_filter( 'wc_memberships_members_area_my-memberships_actions', [ __CLASS__, 'hide_cancel_button_from_memberships_table' ] );
 			\add_filter( 'wc_memberships_my_memberships_column_names', [ __CLASS__, 'remove_next_bill_on' ], 21 );
 			\add_action( 'profile_update', [ __CLASS__, 'handle_admin_email_change_request' ], 10, 3 );
-			\add_action( self::SYNC_ESP_EMAIL_CHANGE_CRON_HOOK, [ __CLASS__, 'sync_email_change' ], 10, 3 );
 		}
 	}
 
@@ -918,7 +912,7 @@ class WooCommerce_My_Account {
 		$old_email = $user->user_email;
 		if ( $new_email !== $old_email && \is_email( $new_email ) && \is_email( $old_email ) ) {
 			self::maybe_sync_email_change_with_stripe( $user_id, $new_email );
-			self::sync_email_change( $user_id, $new_email, $old_email );
+			ESP_Sync::sync_email_change( $user_id, $new_email, $old_email );
 		}
 	}
 
@@ -950,7 +944,7 @@ class WooCommerce_My_Account {
 				$customer->set_billing_email( $new_email );
 				$customer->save();
 				self::maybe_sync_email_change_with_stripe( $user_id, $new_email );
-				self::sync_email_change( $user_id, $new_email, $old_email );
+				ESP_Sync::sync_email_change( $user_id, $new_email, $old_email );
 				\delete_user_meta( $user_id, self::PENDING_EMAIL_CHANGE_META );
 				\wc_add_notice( __( 'Your email address has been successfully updated.', 'newspack-plugin' ) );
 			} else {
@@ -1000,32 +994,6 @@ class WooCommerce_My_Account {
 		);
 		if ( \is_wp_error( $request ) ) {
 			Logger::error( 'Error updating Stripe customer email: ' . $result->get_error_message() );
-		}
-	}
-
-	/**
-	 * Sync email change with site ESPs.
-	 *
-	 * @param int    $user_id User ID.
-	 * @param string $new_email New email address.
-	 * @param string $old_email Old email address.
-	 */
-	public static function sync_email_change( $user_id, $new_email, $old_email ) {
-		if ( ! class_exists( 'Newspack_Newsletters_Contacts' ) ) {
-			return;
-		}
-		$contact = ESP_Sync::get_contact_data( $user_id );
-		if ( ! $contact ) {
-			return;
-		}
-		$list_id          = Reader_Activation::get_esp_master_list_id();
-		$existing_contact = array_merge( $contact, [ 'email' => $old_email ] );
-		$contact          = Metadata::normalize_contact_data( $contact );
-		$update           = \Newspack_Newsletters_Contacts::upsert( $contact, $list_id, 'Email_Change', $existing_contact );
-		if ( is_wp_error( $update ) ) {
-			// If the update failed, retry in 24 hours.
-			\wp_schedule_single_event( time() + DAY_IN_SECONDS, self::SYNC_ESP_EMAIL_CHANGE_CRON_HOOK, [ $user_id, $new_email, $old_email ] );
-			Logger::error( 'Error syncing email change with ESP: ' . $update->get_error_message() . '. Retrying in 24 hours.' );
 		}
 	}
 

--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -37,6 +37,11 @@ class WooCommerce_My_Account {
 	];
 
 	/**
+	 * Cron hook for syncing email change with ESP.
+	 */
+	const SYNC_ESP_EMAIL_CHANGE_CRON_HOOK = 'newspack_esp_sync_email_change';
+
+	/**
 	 * Initialize.
 	 *
 	 * @codeCoverageIgnore
@@ -73,6 +78,7 @@ class WooCommerce_My_Account {
 			\add_filter( 'wc_memberships_members_area_my-memberships_actions', [ __CLASS__, 'hide_cancel_button_from_memberships_table' ] );
 			\add_filter( 'wc_memberships_my_memberships_column_names', [ __CLASS__, 'remove_next_bill_on' ], 21 );
 			\add_action( 'profile_update', [ __CLASS__, 'handle_admin_email_change_request' ], 10, 3 );
+			\add_action( self::SYNC_ESP_EMAIL_CHANGE_CRON_HOOK, [ __CLASS__, 'sync_email_change' ], 10, 3 );
 		}
 	}
 
@@ -1017,11 +1023,10 @@ class WooCommerce_My_Account {
 		$contact          = Metadata::normalize_contact_data( $contact );
 		$update           = \Newspack_Newsletters_Contacts::upsert( $contact, $list_id, 'Email_Change', $existing_contact );
 		if ( is_wp_error( $update ) ) {
-			// TODO: reschedule the sync if failure is not due to existing email.
-			Logger::error( 'Error syncing email change: ' . $update->get_error_message() );
-			return false;
+			// If the update failed, retry in 1 hour.
+			\wp_schedule_single_event( time() + HOUR_IN_SECONDS, self::SYNC_ESP_EMAIL_CHANGE_CRON_HOOK, [ $user_id, $new_email, $old_email ] );
+			Logger::error( 'Error syncing email change with ESP: ' . $update->get_error_message() . '. Retrying in 1 hour.' );
 		}
-		return $update;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1208993180326452/1209215513701719

This and [the partner newsletters PR](https://github.com/Automattic/newspack-newsletters/pull/1769) account for errors when attempting to sync an email change with ESPs.

We account for two types of issues:

1. The email address we are updating to already exists in the ESP. In these cases, we delete the old contact and trigger an update request to the new contact.
2. Any other generic error is handled by rescheduling the sync for 24 hours.


### How to test the changes in this Pull Request:

Be sure to also checkout https://github.com/Automattic/newspack-newsletters/pull/1769 before testing.

1. Ensure the `NEWSPACK_EMAIL_CHANGE_ENABLED` constant is defined and true in wp-config.
2. Ensure your test site ESP is mailchimp and connected
3. Log into a reader account that exists in mailchimp and update the email address to a new one altogether
4. Complete verification then check mailchimp to ensure the email address updated correctly for the contact
5. Now repeat step 3, but this time update to an email address that exists in the ESP but does not exist in the test site (you may need to manually add the contact in MC).
6. Complete verification then check mailchimp to ensure the old contact has been removed and the one that you updated to still exists
7. Now go Engagement > Newsletters and replace the ESP key with something invalid
8. Repeat step 3 one more time
9. Complete verification then confirm a new `newspack_esp_sync_email_change` cron job has been scheduled (`wp cron event list`)
10. Fix the ESP key, then manually trigger the cron job (`wp cron event run newspack_esp_sync_email_change`)
11. Check mailchimp and verify the email update occurred as expected
12. Repeat the above steps for both Active Campaign and Constant Contact

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->