### PR TITLE
feat(correction-blocks): update corrections template

### DIFF
--- a/includes/templates/block-patterns/corrections/corrections-loop.php
+++ b/includes/templates/block-patterns/corrections/corrections-loop.php
@@ -14,12 +14,12 @@
 
 	<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30","margin":{"bottom":"var:preset|spacing|80"}}},"layout":{"type":"flex","orientation":"vertical"}} -->
 	<div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--80)">
-		<!-- wp:heading {"level":3} -->
-			<h3 class="wp-block-heading"><?php _e( 'Corrections & Clarifications', 'newspack-plugin' ); ?></h3>
+		<!-- wp:heading {"level":1} -->
+		<h1 class="wp-block-heading"><?php esc_html_e( 'Corrections & Clarifications', 'newspack-plugin' ); ?></h1>
 		<!-- /wp:heading -->
 
 		<!-- wp:paragraph -->
-			<p><?php _e( 'We are committed to truthful, transparent, and accurate reporting. When we make a mistake, we correct it promptly and note the change clearly. Clarifications, when needed, provide additional context.', 'newspack-plugin' ); ?></p>
+		<p><?php esc_html_e( 'We are committed to truthful, transparent, and accurate reporting. When we make a mistake, we correct it promptly and note the change clearly. Clarifications, when needed, provide additional context.', 'newspack-plugin' ); ?></p>
 		<!-- /wp:paragraph -->
 	</div>
 	<!-- /wp:group -->

--- a/includes/templates/corrections/corrections-archive.php
+++ b/includes/templates/corrections/corrections-archive.php
@@ -7,21 +7,17 @@
 
 ?>
 
-<!-- wp:paragraph -->
-<p><?php _e( 'Replace this with your Header', 'newspack-plugin' ); ?></p>
-<!-- /wp:paragraph -->
-
 <!-- wp:query {"queryId":0,"query":{"perPage":20,"pages":0,"offset":0,"postType":"newspack_correction","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":null,"parents":[]},"tagName":"main","layout":{"type":"constrained"}} -->
 <main class="wp-block-query">
 
 	<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30","margin":{"bottom":"var:preset|spacing|80"}}},"layout":{"type":"flex","orientation":"vertical"}} -->
 	<div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--80)">
 		<!-- wp:heading {"level":1} -->
-			<h1 class="wp-block-heading"><?php _e( 'Corrections & Clarifications', 'newspack-plugin' ); ?></h1>
+		<h1 class="wp-block-heading"><?php esc_html_e( 'Corrections & Clarifications', 'newspack-plugin' ); ?></h1>
 		<!-- /wp:heading -->
 
 		<!-- wp:paragraph -->
-			<p><?php _e( 'We are committed to truthful, transparent, and accurate reporting. When we make a mistake, we correct it promptly and note the change clearly. Clarifications, when needed, provide additional context.', 'newspack-plugin' ); ?></p>
+		<p><?php esc_html_e( 'We are committed to truthful, transparent, and accurate reporting. When we make a mistake, we correct it promptly and note the change clearly. Clarifications, when needed, provide additional context.', 'newspack-plugin' ); ?></p>
 		<!-- /wp:paragraph -->
 	</div>
 	<!-- /wp:group -->
@@ -64,7 +60,3 @@
 
 </main>
 <!-- /wp:query -->
-
-<!-- wp:paragraph -->
-<p><?php _e( 'Replace this with your Footer', 'newspack-plugin' ); ?></p>
-<!-- /wp:paragraph -->


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Simplify archive and escape strings.

### How to test the changes in this Pull Request:

1. Make sure you use the Block Theme
2. Enable corrections in wp-config `define( 'NEWSPACK_CORRECTIONS_ENABLED', true );`
3. Add some corrections to some posts
4. Check the archive page `/corrections`
5. Check the pattern
6. Make sure both are still outputting the correct content

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->