### PR TITLE
fix: is-without-password condition

### DIFF
--- a/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions-gifting.php
+++ b/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions-gifting.php
@@ -73,7 +73,12 @@ class WooCommerce_Subscriptions_Gifting {
 	 * @return bool
 	 */
 	public static function is_reader_without_password( $is_reader_without_password, $user_id ) {
-		return 'true' === get_user_meta( $user_id, 'wcsg_update_account', true );
+		// wcsg_update_account meta will force the user to update/set account information on login.
+		$user_needs_account_update = get_user_meta( $user_id, 'wcsg_update_account', true );
+		if ( ! empty( $user_needs_account_update ) ) {
+			return 'true' === $user_needs_account_update;
+		}
+		return $is_reader_without_password;
 	}
 }
 WooCommerce_Subscriptions_Gifting::init();

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1102,7 +1102,7 @@ final class Reader_Activation {
 	}
 
 	/**
-	 * Whether the reader hasn't set its own password.
+	 * Whether the reader hasn't set their password.
 	 *
 	 * @param \WP_User|int $user_or_user_id User object or user ID.
 	 *

--- a/tests/unit-tests/reader-activation.php
+++ b/tests/unit-tests/reader-activation.php
@@ -68,7 +68,7 @@ class Newspack_Test_Reader_Activation extends WP_UnitTestCase {
 		$user_id = self::register_sample_reader();
 		wp_logout();
 		$result = self::register_sample_reader(); // Reregister the same email.
-		$this->assertTrue( is_wp_error( $result ) );
+		$this->assertFalse( $result );
 		$this->assertFalse( is_user_logged_in() );
 		wp_delete_user( $user_id ); // Clean up.
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

https://github.com/Automattic/newspack-plugin/pull/3747 introduced a regression, this PR fixes it. 

Also fixes an assertion in the `test_register_existing_reader` test - if a user exists, the value returned is false, not a WP Error.

### How to test the changes in this Pull Request:

1. On `trunk`, register as a new reader, log out, then attempt to sign in again using the auth modal
2. Observe that after clicking "Continue" after the email input, the state of the modal progresses to password prompt - even though a password has never been set
3. Switch to this branch, observe that the second state of the modal is an OTP input

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->