### PR TITLE
refactor(corrections): Remove corrections feature flag

### DIFF
--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -19,7 +19,7 @@ final class Blocks {
 	public static function init() {
 		require_once NEWSPACK_ABSPATH . 'src/blocks/reader-registration/index.php';
 
-		if ( wp_is_block_theme() && class_exists( 'Newspack\Corrections' ) && defined( 'NEWSPACK_CORRECTIONS_ENABLED' ) && NEWSPACK_CORRECTIONS_ENABLED ) {
+		if ( wp_is_block_theme() && class_exists( 'Newspack\Corrections' ) ) {
 			require_once NEWSPACK_ABSPATH . 'src/blocks/correction-box/class-correction-box-block.php';
 			require_once NEWSPACK_ABSPATH . 'src/blocks/correction-item/class-correction-item-block.php';
 		}
@@ -53,7 +53,7 @@ final class Blocks {
 				'reader_activation_url'   => Reader_Activation::get_setting( 'terms_url' ),
 				'has_recaptcha'           => Recaptcha::can_use_captcha(),
 				'recaptcha_url'           => admin_url( 'admin.php?page=newspack-connections-wizard' ),
-				'corrections_enabled'     => wp_is_block_theme() && class_exists( 'Newspack\Corrections' ) && defined( 'NEWSPACK_CORRECTIONS_ENABLED' ) && NEWSPACK_CORRECTIONS_ENABLED,
+				'corrections_enabled'     => wp_is_block_theme() && class_exists( 'Newspack\Corrections' ),
 			]
 		);
 		\wp_enqueue_style(

--- a/includes/corrections/README.md
+++ b/includes/corrections/README.md
@@ -8,11 +8,11 @@ When you enable this feature, a new meta box will be added to the post editor sc
 
 ## Usage
 
-This feature can be enabled by adding the following constant to your `wp-config.php`:
-
-```php
-define( 'NEWSPACK_CORRECTIONS_ENABLED', true );
-```
+This feature is enabled by default. Start adding corrections to your posts by following these steps:
+1. Click on Manage Corrections in Corrections & Clarifications Menu.
+2. Click on Add New Correction.
+3. Fill in the correction details.
+4. Click on Save & Close.
 
 ## Data
 

--- a/includes/corrections/class-corrections.php
+++ b/includes/corrections/class-corrections.php
@@ -60,9 +60,6 @@ class Corrections {
 	 * Initializes the class.
 	 */
 	public static function init() {
-		if ( ! self::is_enabled() ) {
-			return;
-		}
 		add_action( 'init', [ __CLASS__, 'register_post_type' ] );
 		add_action( 'init', [ __CLASS__, 'add_corrections_shortcode' ] );
 		add_filter( 'the_content', [ __CLASS__, 'output_corrections_on_post' ] );
@@ -73,19 +70,6 @@ class Corrections {
 		add_action( 'admin_init', [ __CLASS__, 'register_corrections_block_patterns' ] );
 		add_action( 'init', [ __CLASS__, 'register_corrections_template' ] );
 	}
-
-	/**
-	 * Checks if the feature is enabled.
-	 *
-	 * True when:
-	 * - NEWSPACK_CORRECTIONS_ENABLED is defined and true.
-	 *
-	 * @return bool True if the feature is enabled, false otherwise.
-	 */
-	public static function is_enabled() {
-		return defined( 'NEWSPACK_CORRECTIONS_ENABLED' ) && NEWSPACK_CORRECTIONS_ENABLED;
-	}
-
 
 	/**
 	 * Enqueue scripts and styles.

--- a/tests/unit-tests/corrections.php
+++ b/tests/unit-tests/corrections.php
@@ -27,23 +27,10 @@ class Test_Corrections extends WP_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 
-		if ( ! defined( 'NEWSPACK_CORRECTIONS_ENABLED' ) ) {
-			define( 'NEWSPACK_CORRECTIONS_ENABLED', true );
-		}
-
 		Corrections::init();
 
 		self::$post_id = $this->factory()->post->create( [ 'post_type' => 'post' ] );
 		update_post_meta( self::$post_id, Corrections::CORRECTIONS_ACTIVE_META, true );
-	}
-
-	/**
-	 * Test that the corrections feature is enabled.
-	 *
-	 * @covers Corrections::is_enabled
-	 */
-	public function test_is_enabled() {
-		$this->assertTrue( Corrections::is_enabled() );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
Remove the feature flag `NEWSPACK_CORRECTIONS_ENABLED`. The Corrections/Clarification features should now be enabled by default.

Closes https://app.asana.com/0/1209292256643614/1209535906175871 .

### How to test the changes in this Pull Request:

1. Remove the constant `NEWSPACK_CORRECTIONS_ENABLED` and the functionality should work as expected.
2. Check by adding /modify existing corrections.
3. Check the correctison are enabled in the front-end.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->