### PR TITLE
fix(modal-checkout): password setup

### DIFF
--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -2146,13 +2146,19 @@ final class Reader_Activation {
 			$user_data['display_name'] = $user_nicename;
 		}
 
+		if ( empty( $user_data['user_pass'] ) ) {
+			$password = \wp_generate_password();
+		} else {
+			$password = $user_data['user_pass'];
+		}
+
 		$user_data = array_merge(
 			$user_data,
 			[
 				'user_login'    => $user_nicename,
 				'user_nicename' => $user_nicename,
 				'display_name'  => $user_nicename,
-				'user_pass'     => \wp_generate_password(),
+				'user_pass'     => $password,
 			]
 		);
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an issue with overriding the password when using the modal checkout.

### How to test the changes in this Pull Request:

1. On `trunk`,
1. Under Newspack > Engagement > Advanced Settings, disable "Require sign in or create account before checkout".
1. Under WooCommerce > Settings > Accounts & Privacy, make Account Creation "During checkout" is checked, but "Send password setup link (recommended)" is not.
1. In an incognito window, run through a checkout either in the modal or regular checkout for a subscription product. 
1. Set a password and complete the checkout.
1. Log out.
1. Try to log in again with that password; you'll get an error. 
2. Switch to this branch, retest - observe the password can be used to log in

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209528745323094