### PR TITLE
feat(rss-feed): Add Feed enhancements for Republications.

### DIFF
--- a/includes/optional-modules/class-rss.php
+++ b/includes/optional-modules/class-rss.php
@@ -465,7 +465,9 @@ class RSS {
 						<input type="checkbox" name="only_republishable" value="1" <?php checked( $settings['only_republishable'] ); ?> />
 					</td>
 				</tr>
-				<tr>
+
+			<?php endif; ?>
+			<tr>
 					<th><?php esc_html_e( 'Feed format', 'newspack-plugin' ); ?></th>
 					<td>
 						<select name="feed_format">
@@ -474,7 +476,6 @@ class RSS {
 						</select>
 					</td>
 				</tr>
-			<?php endif; ?>
 		</table>
 		<?php
 	}
@@ -573,9 +574,10 @@ class RSS {
 			$only_republishable             = filter_input( INPUT_POST, 'only_republishable', FILTER_SANITIZE_NUMBER_INT );
 			$settings['only_republishable'] = (bool) $only_republishable;
 
-			$feed_format             = filter_input( INPUT_POST, 'feed_format', FILTER_SANITIZE_SPECIAL_CHARS );
-			$settings['feed_format'] = in_array( $feed_format, [ 'rss', 'atom' ] ) ? $feed_format : 'rss';
 		}
+
+		$feed_format             = filter_input( INPUT_POST, 'feed_format', FILTER_SANITIZE_SPECIAL_CHARS );
+		$settings['feed_format'] = in_array( $feed_format, [ 'rss', 'atom' ] ) ? $feed_format : 'rss';
 
 		update_post_meta( $feed_post_id, self::FEED_SETTINGS_META, $settings );
 		// @todo flush feed cache here.

--- a/includes/optional-modules/class-rss.php
+++ b/includes/optional-modules/class-rss.php
@@ -376,7 +376,7 @@ class RSS {
 
 			<?php
 			// Only show this new option if the Republication Tracker Tool plugin is active.
-			if ( class_exists( 'Republication_Tracker_Tool' ) ) :
+			if ( self::is_republication_tracker_plugin_active() ) :
 				?>
 				<tr>
 					<th>
@@ -479,7 +479,7 @@ class RSS {
 			<?php endif; ?>
 			<?php
 			// Only show this new option if the Republication Tracker Tool plugin is active.
-			if ( class_exists( 'Republication_Tracker_Tool' ) ) :
+			if ( self::is_republication_tracker_plugin_active() ) :
 				?>
 				<tr>
 					<th><?php esc_html_e( 'Add republication tracker snippet to posts', 'newspack-plugin' ); ?></th>
@@ -581,7 +581,7 @@ class RSS {
 		}
 
 		// Process Republication Tracker options only if the plugin is active.
-		if ( class_exists( 'Republication_Tracker_Tool' ) ) {
+		if ( self::is_republication_tracker_plugin_active() ) {
 			$republication_tracker             = filter_input( INPUT_POST, 'republication_tracker', FILTER_SANITIZE_NUMBER_INT );
 			$settings['republication_tracker'] = (bool) $republication_tracker;
 
@@ -653,7 +653,7 @@ class RSS {
 			);
 		}
 
-		if ( class_exists( 'Republication_Tracker_Tool' ) && ! empty( $settings['only_republishable'] ) ) {
+		if ( self::is_republication_tracker_plugin_active() && ! empty( $settings['only_republishable'] ) ) {
 			$meta_query = $query->get( 'meta_query' );
 			if ( ! is_array( $meta_query ) ) {
 				$meta_query = [];
@@ -819,6 +819,16 @@ xmlns:media="http://search.yahoo.com/mrss/"
 		}
 
 		return $title;
+	}
+
+	/**
+	 * Check if the Republication Tracker Tool plugin is active.
+	 * This is used to determine whether to show additional options in the RSS feed settings.
+	 *
+	 * @return bool Whether the Republication Tracker Tool plugin is active.
+	 */
+	private static function is_republication_tracker_plugin_active() {
+		return class_exists( 'Republication_Tracker_Tool' );
 	}
 }
 RSS::init();

--- a/includes/optional-modules/class-rss.php
+++ b/includes/optional-modules/class-rss.php
@@ -36,6 +36,7 @@ class RSS {
 		add_filter( 'option_rss_use_excerpt', [ __CLASS__, 'filter_use_rss_excerpt' ] );
 		add_action( 'pre_get_posts', [ __CLASS__, 'modify_feed_query' ] );
 		add_action( 'rss2_item', [ __CLASS__, 'add_extra_tags' ] );
+		add_action( 'atom_entry', [ __CLASS__, 'add_extra_tags' ] );
 		add_filter( 'the_excerpt_rss', [ __CLASS__, 'maybe_remove_content_featured_image' ], 1 );
 		add_filter( 'the_content_feed', [ __CLASS__, 'maybe_remove_content_featured_image' ], 1 );
 		add_filter( 'wpseo_include_rss_footer', [ __CLASS__, 'maybe_suppress_yoast' ] );
@@ -49,8 +50,11 @@ class RSS {
 	 * @param WP_Post $feed_post RSS feed post object.
 	 */
 	public static function get_feed_url( $feed_post ) {
-		$base_feed_url = get_bloginfo( 'rss2_url' );
+		$settings      = self::get_feed_settings( $feed_post );
 		$feed_slug     = is_numeric( $feed_post ) ? get_post_field( 'post_name', $feed_post ) : $feed_post->post_name;
+		$base_feed_url = ( isset( $settings['feed_format'] ) && 'atom' === $settings['feed_format'] )
+			? get_bloginfo( 'atom_url' )
+			: get_bloginfo( 'rss2_url' );
 		return add_query_arg( self::FEED_QUERY_ARG, $feed_slug, $base_feed_url );
 	}
 
@@ -78,6 +82,9 @@ class RSS {
 			'update_frequency'       => false,
 			'use_post_id_as_guid'    => false,
 			'cdata_titles'           => false,
+			'republication_tracker'  => false,
+			'only_republishable'     => false,
+			'feed_format'            => 'rss',
 		];
 
 		if ( ! $feed_post ) {
@@ -427,6 +434,34 @@ class RSS {
 					</td>
 				</tr>
 			<?php endif; ?>
+			<?php
+			// Only show these new options if the Republication Tracker Tool plugin is active.
+			if ( class_exists( 'Republication_Tracker_Tool' ) ) :
+				?>
+				<tr>
+					<th><?php esc_html_e( 'Add republication tracker snippet to posts', 'newspack-plugin' ); ?></th>
+					<td>
+						<input type="hidden" name="republication_tracker" value="0" />
+						<input type="checkbox" name="republication_tracker" value="1" <?php checked( $settings['republication_tracker'] ); ?> />
+					</td>
+				</tr>
+				<tr>
+					<th><?php esc_html_e( 'Only include republishable posts', 'newspack-plugin' ); ?></th>
+					<td>
+						<input type="hidden" name="only_republishable" value="0" />
+						<input type="checkbox" name="only_republishable" value="1" <?php checked( $settings['only_republishable'] ); ?> />
+					</td>
+				</tr>
+				<tr>
+					<th><?php esc_html_e( 'Feed format', 'newspack-plugin' ); ?></th>
+					<td>
+						<select name="feed_format">
+							<option value="rss" <?php selected( $settings['feed_format'], 'rss' ); ?>><?php esc_html_e( 'RSS', 'newspack-plugin' ); ?></option>
+							<option value="atom" <?php selected( $settings['feed_format'], 'atom' ); ?>><?php esc_html_e( 'Atom', 'newspack-plugin' ); ?></option>
+						</select>
+					</td>
+				</tr>
+			<?php endif; ?>
 		</table>
 		<?php
 	}
@@ -517,6 +552,18 @@ class RSS {
 			}
 		}
 
+		// Process Republication Tracker options only if the plugin is active.
+		if ( class_exists( 'Republication_Tracker_Tool' ) ) {
+			$republication_tracker             = filter_input( INPUT_POST, 'republication_tracker', FILTER_SANITIZE_NUMBER_INT );
+			$settings['republication_tracker'] = (bool) $republication_tracker;
+
+			$only_republishable             = filter_input( INPUT_POST, 'only_republishable', FILTER_SANITIZE_NUMBER_INT );
+			$settings['only_republishable'] = (bool) $only_republishable;
+
+			$feed_format             = filter_input( INPUT_POST, 'feed_format', FILTER_SANITIZE_SPECIAL_CHARS );
+			$settings['feed_format'] = in_array( $feed_format, [ 'rss', 'atom' ] ) ? $feed_format : 'rss';
+		}
+
 		update_post_meta( $feed_post_id, self::FEED_SETTINGS_META, $settings );
 		// @todo flush feed cache here.
 	}
@@ -578,6 +625,19 @@ class RSS {
 				10,
 				2
 			);
+		}
+
+		if ( ! empty( $settings['only_republishable'] ) ) {
+			$meta_query = $query->get( 'meta_query' );
+			if ( ! is_array( $meta_query ) ) {
+				$meta_query = [];
+			}
+			$meta_query[] = [
+				'key'     => 'republication-tracker-tool-hide-widget',
+				'value'   => '1',
+				'compare' => '!=',
+			];
+			$query->set( 'meta_query', $meta_query );
 		}
 	}
 
@@ -654,6 +714,13 @@ class RSS {
 					<?php
 				}
 			}
+		}
+
+		// If the Republication Tracker Tool is enabled and the option is checked, output the tracker snippet.
+		if ( ! empty( $settings['republication_tracker'] ) && method_exists( 'Republication_Tracker_Tool', 'create_tracking_pixel_markup' ) ) {
+			?>
+			<republication_tracker><?php echo \Republication_Tracker_Tool::create_tracking_pixel_markup( $post->ID ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></republication_tracker>
+			<?php
 		}
 	}
 

--- a/includes/optional-modules/class-rss.php
+++ b/includes/optional-modules/class-rss.php
@@ -266,7 +266,7 @@ class RSS {
 		?>
 		<table>
 			<tr>
-				<td><h3><?php esc_html_e( 'RSS :-', 'newspack-plugin' ); ?></h3></td>
+				<td><h3><?php esc_html_e( 'RSS -', 'newspack-plugin' ); ?></h3></td>
 				<td>
 					<h3>
 						<a href="<?php echo esc_url( $rss_feed_url ); ?>" target="_blank">
@@ -276,7 +276,7 @@ class RSS {
 				</td>
 			</tr>
 			<tr>
-				<td><h3><?php esc_html_e( 'Atom :-', 'newspack-plugin' ); ?></h3></td>
+				<td><h3><?php esc_html_e( 'Atom -', 'newspack-plugin' ); ?></h3></td>
 				<td>
 					<h3>
 						<a href="<?php echo esc_url( $atom_feed_url ); ?>" target="_blank">
@@ -381,7 +381,7 @@ class RSS {
 				<tr>
 					<th>
 						<?php esc_html_e( 'Only include republishable posts', 'newspack-plugin' ); ?>
-						<p class="description"><?php echo esc_html_x( '(When toggled on, posts which have republication disabled will be excluded from the feed.)', 'help text for only republishable setting', 'newspack-plugin' ); ?></p>
+						<p class="description"><?php echo esc_html_x( 'When toggled on, posts which have republication disabled will be excluded from the feed.', 'help text for only republishable setting', 'newspack-plugin' ); ?></p>
 					</th>
 					<td>
 						<input type="hidden" name="only_republishable" value="0" />

--- a/includes/optional-modules/class-rss.php
+++ b/includes/optional-modules/class-rss.php
@@ -48,13 +48,13 @@ class RSS {
 	 * Get URL for a feed.
 	 *
 	 * @param WP_Post $feed_post RSS feed post object.
+	 * @param string  $feed_type Feed type (rss or atom).
+	 *
+	 * @return string Feed URL.
 	 */
-	public static function get_feed_url( $feed_post ) {
-		$settings      = self::get_feed_settings( $feed_post );
+	public static function get_feed_url( $feed_post, $feed_type = 'rss' ) {
 		$feed_slug     = is_numeric( $feed_post ) ? get_post_field( 'post_name', $feed_post ) : $feed_post->post_name;
-		$base_feed_url = ( isset( $settings['feed_format'] ) && 'atom' === $settings['feed_format'] )
-			? get_bloginfo( 'atom_url' )
-			: get_bloginfo( 'rss2_url' );
+		$base_feed_url = 'atom' === $feed_type ? get_bloginfo( 'atom_url' ) : get_bloginfo( 'rss2_url' );
 		return add_query_arg( self::FEED_QUERY_ARG, $feed_slug, $base_feed_url );
 	}
 
@@ -84,7 +84,6 @@ class RSS {
 			'cdata_titles'           => false,
 			'republication_tracker'  => false,
 			'only_republishable'     => false,
-			'feed_format'            => 'rss',
 		];
 
 		if ( ! $feed_post ) {
@@ -161,7 +160,7 @@ class RSS {
 	 * @return array Modified $columns.
 	 */
 	public static function columns_head( $columns ) {
-		$columns['feed_url'] = __( 'Feed URL', 'newspack-plugin' );
+		$columns['feed_url'] = __( 'Feed URLs', 'newspack-plugin' );
 		return $columns;
 	}
 
@@ -173,11 +172,22 @@ class RSS {
 	 */
 	public static function column_content( $column_name, $post_id ) {
 		if ( 'feed_url' === $column_name ) {
-			$feed_url = self::get_feed_url( $post_id );
+			$rss_feed_url  = self::get_feed_url( $post_id );
+			$atom_feed_url = self::get_feed_url( $post_id, 'atom' );
 			?>
-			<a href='<?php echo esc_url( $feed_url ); ?>' target='_blank'>
-				<?php echo esc_url( $feed_url ); ?>
-			</a>
+			<span>
+				<strong><?php esc_html_e( 'RSS:', 'newspack-plugin' ); ?></strong>
+				<a href='<?php echo esc_url( $rss_feed_url ); ?>' target='_blank'>
+					<?php echo esc_url( $rss_feed_url ); ?>
+				</a>
+			</span>
+			<br />
+			<span>
+				<strong><?php esc_html_e( 'Atom:', 'newspack-plugin' ); ?></strong>
+				<a href='<?php echo esc_url( $atom_feed_url ); ?>' target='_blank'>
+					<?php echo esc_url( $atom_feed_url ); ?>
+				</a>
+			</span>
 			<?php
 		}
 	}
@@ -190,7 +200,7 @@ class RSS {
 	public static function add_metaboxes( $feed_post ) {
 		add_meta_box(
 			'partner_rss_feed_url',
-			__( 'Feed URL', 'newspack-plugin' ),
+			__( 'Feed URLs', 'newspack-plugin' ),
 			[ __CLASS__, 'render_url_metabox' ],
 			self::FEED_CPT
 		);
@@ -251,14 +261,31 @@ class RSS {
 			return;
 		}
 
-		$feed_url = self::get_feed_url( $feed_post );
-
+		$rss_feed_url  = self::get_feed_url( $feed_post );
+		$atom_feed_url = self::get_feed_url( $feed_post, 'atom' );
 		?>
-		<h3>
-			<a href='<?php echo esc_url( $feed_url ); ?>' target='_blank'>
-				<?php echo esc_url( $feed_url ); ?>
-			</a>
-		</h3>
+		<table>
+			<tr>
+				<td><h3><?php esc_html_e( 'RSS :-', 'newspack-plugin' ); ?></h3></td>
+				<td>
+					<h3>
+						<a href="<?php echo esc_url( $rss_feed_url ); ?>" target="_blank">
+							<?php echo esc_url( $rss_feed_url ); ?>
+						</a>
+					</h3>
+				</td>
+			</tr>
+			<tr>
+				<td><h3><?php esc_html_e( 'Atom :-', 'newspack-plugin' ); ?></h3></td>
+				<td>
+					<h3>
+						<a href="<?php echo esc_url( $atom_feed_url ); ?>" target="_blank">
+							<?php echo esc_url( $atom_feed_url ); ?>
+						</a>
+					</h3>
+				</td>
+			</tr>
+		</table>
 		<?php
 	}
 
@@ -346,25 +373,28 @@ class RSS {
 					<input type="checkbox" name="use_post_id_as_guid" value="1" <?php checked( $settings['use_post_id_as_guid'] ); ?> />
 				</td>
 			</tr>
+
+			<?php
+			// Only show this new option if the Republication Tracker Tool plugin is active.
+			if ( class_exists( 'Republication_Tracker_Tool' ) ) :
+				?>
+				<tr>
+					<th>
+						<?php esc_html_e( 'Only include republishable posts', 'newspack-plugin' ); ?>
+						<p class="description"><?php echo esc_html_x( '(When toggled on, posts which have republication disabled will be excluded from the feed.)', 'help text for only republishable setting', 'newspack-plugin' ); ?></p>
+					</th>
+					<td>
+						<input type="hidden" name="only_republishable" value="0" />
+						<input type="checkbox" name="only_republishable" value="1" <?php checked( $settings['only_republishable'] ); ?> />
+					</td>
+				</tr>
+			<?php endif; ?>
 		</table>
 
 		<script>
-			const handleCDATA = function() {
-				if ( 'atom' === jQuery( '[name="feed_format"]' ).val() ) {
-					jQuery( '[name="cdata_titles"]' ).prop( 'checked', false );
-					jQuery( '[name="cdata_titles"]' ).prop( 'disabled', true );
-				} else {
-					jQuery( '[name="cdata_titles"]' ).prop( 'disabled', false );
-				}
-			};
-
 			jQuery( document ).ready( function() {
 				jQuery( '#category_include' ).select2();
 				jQuery( '#category_exclude' ).select2();
-
-				// WordPress wraps Atom feed titles in CDATA tags by default.
-				handleCDATA();
-				jQuery( '[name="feed_format"]' ).on( 'change', handleCDATA );
 			} );
 		</script>
 		<?php
@@ -448,7 +478,7 @@ class RSS {
 				</tr>
 			<?php endif; ?>
 			<?php
-			// Only show these new options if the Republication Tracker Tool plugin is active.
+			// Only show this new option if the Republication Tracker Tool plugin is active.
 			if ( class_exists( 'Republication_Tracker_Tool' ) ) :
 				?>
 				<tr>
@@ -458,24 +488,8 @@ class RSS {
 						<input type="checkbox" name="republication_tracker" value="1" <?php checked( $settings['republication_tracker'] ); ?> />
 					</td>
 				</tr>
-				<tr>
-					<th><?php esc_html_e( 'Only include republishable posts', 'newspack-plugin' ); ?></th>
-					<td>
-						<input type="hidden" name="only_republishable" value="0" />
-						<input type="checkbox" name="only_republishable" value="1" <?php checked( $settings['only_republishable'] ); ?> />
-					</td>
-				</tr>
 
 			<?php endif; ?>
-			<tr>
-					<th><?php esc_html_e( 'Feed format', 'newspack-plugin' ); ?></th>
-					<td>
-						<select name="feed_format">
-							<option value="rss" <?php selected( $settings['feed_format'], 'rss' ); ?>><?php esc_html_e( 'RSS', 'newspack-plugin' ); ?></option>
-							<option value="atom" <?php selected( $settings['feed_format'], 'atom' ); ?>><?php esc_html_e( 'Atom', 'newspack-plugin' ); ?></option>
-						</select>
-					</td>
-				</tr>
 		</table>
 		<?php
 	}
@@ -575,9 +589,6 @@ class RSS {
 			$settings['only_republishable'] = (bool) $only_republishable;
 
 		}
-
-		$feed_format             = filter_input( INPUT_POST, 'feed_format', FILTER_SANITIZE_SPECIAL_CHARS );
-		$settings['feed_format'] = in_array( $feed_format, [ 'rss', 'atom' ] ) ? $feed_format : 'rss';
 
 		update_post_meta( $feed_post_id, self::FEED_SETTINGS_META, $settings );
 		// @todo flush feed cache here.
@@ -803,7 +814,7 @@ xmlns:media="http://search.yahoo.com/mrss/"
 			return $title;
 		}
 
-		if ( $settings['cdata_titles'] && 'atom' !== $settings['feed_format'] ) {
+		if ( $settings['cdata_titles'] && 'atom' !== get_query_var( 'feed' ) ) {
 			$title = '<![CDATA[' . $title . ']]>';
 		}
 

--- a/includes/optional-modules/class-rss.php
+++ b/includes/optional-modules/class-rss.php
@@ -39,6 +39,7 @@ class RSS {
 		add_action( 'atom_entry', [ __CLASS__, 'add_extra_tags' ] );
 		add_filter( 'the_excerpt_rss', [ __CLASS__, 'maybe_remove_content_featured_image' ], 1 );
 		add_filter( 'the_content_feed', [ __CLASS__, 'maybe_remove_content_featured_image' ], 1 );
+		add_filter( 'the_content_feed', [ __CLASS__, 'maybe_add_tracking_snippet' ], 1 );
 		add_filter( 'wpseo_include_rss_footer', [ __CLASS__, 'maybe_suppress_yoast' ] );
 		add_action( 'rss2_ns', [ __CLASS__, 'maybe_inject_yahoo_namespace' ] );
 		add_filter( 'the_title_rss', [ __CLASS__, 'maybe_wrap_titles_in_cdata' ] );
@@ -741,13 +742,53 @@ class RSS {
 				}
 			}
 		}
+	}
 
-		// If the Republication Tracker Tool is enabled and the option is checked, output the tracker snippet.
-		if ( ! empty( $settings['republication_tracker'] ) && method_exists( 'Republication_Tracker_Tool', 'create_tracking_pixel_markup' ) ) {
-			?>
-			<republication_tracker><?php echo \Republication_Tracker_Tool::create_tracking_pixel_markup( $post->ID ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></republication_tracker>
-			<?php
+	/**
+	 * Add tracking pixel to feed content if setting is checked.
+	 *
+	 * @param string $content Feed content.
+	 * @return string Modified $content.
+	 */
+	public static function maybe_add_tracking_snippet( $content ) {
+		$settings = self::get_feed_settings();
+
+		if ( ! $settings || empty( $settings['republication_tracker'] ) || ! method_exists( 'Republication_Tracker_Tool', 'create_tracking_pixel_markup' ) ) {
+			return $content;
 		}
+
+		$post_id          = get_the_ID();
+		$pixel            = \Republication_Tracker_Tool::create_tracking_pixel_markup( $post_id );
+		$parsely_tracking = \Republication_Tracker_Tool::create_parsely_tracking( $post_id );
+
+		// Check if the attribution should be displayed.
+		$display_attribution = get_option( 'republication_tracker_tool_display_attribution', 'on' );
+
+		if ( 'on' !== $display_attribution ) {
+			return $content . $pixel . $parsely_tracking;
+		}
+
+		$site_icon_markup = '';
+		$site_icon_url    = get_site_icon_url( 150 );
+		if ( ! empty( $site_icon_url ) ) {
+			$site_icon_markup = sprintf(
+				'<img src="%1$s" style="width:1em;height:1em;margin-left:10px;">',
+				esc_attr( $site_icon_url )
+			);
+		}
+
+		$attribution = sprintf(
+			'This <a target="_blank" href="%1$s">article</a> first appeared on <a target="_blank" href="%2$s">%3$s</a> and is republished here under a Creative Commons license. %4$s %5$s',
+			esc_url( get_permalink( $post_id ) ),
+			esc_url( home_url() ),
+			esc_html( get_bloginfo() ) . $site_icon_markup,
+			$pixel,
+			$parsely_tracking
+		);
+
+		$content .= $attribution;
+
+		return $content;
 	}
 
 	/**

--- a/includes/optional-modules/class-rss.php
+++ b/includes/optional-modules/class-rss.php
@@ -349,9 +349,22 @@ class RSS {
 		</table>
 
 		<script>
+			const handleCDATA = function() {
+				if ( 'atom' === jQuery( '[name="feed_format"]' ).val() ) {
+					jQuery( '[name="cdata_titles"]' ).prop( 'checked', false );
+					jQuery( '[name="cdata_titles"]' ).prop( 'disabled', true );
+				} else {
+					jQuery( '[name="cdata_titles"]' ).prop( 'disabled', false );
+				}
+			};
+
 			jQuery( document ).ready( function() {
 				jQuery( '#category_include' ).select2();
 				jQuery( '#category_exclude' ).select2();
+
+				// WordPress wraps Atom feed titles in CDATA tags by default.
+				handleCDATA();
+				jQuery( '[name="feed_format"]' ).on( 'change', handleCDATA );
 			} );
 		</script>
 		<?php
@@ -788,7 +801,7 @@ xmlns:media="http://search.yahoo.com/mrss/"
 			return $title;
 		}
 
-		if ( $settings['cdata_titles'] ) {
+		if ( $settings['cdata_titles'] && 'atom' !== $settings['feed_format'] ) {
 			$title = '<![CDATA[' . $title . ']]>';
 		}
 

--- a/includes/optional-modules/class-rss.php
+++ b/includes/optional-modules/class-rss.php
@@ -640,7 +640,7 @@ class RSS {
 			);
 		}
 
-		if ( ! empty( $settings['only_republishable'] ) ) {
+		if ( class_exists( 'Republication_Tracker_Tool' ) && ! empty( $settings['only_republishable'] ) ) {
 			$meta_query = $query->get( 'meta_query' );
 			if ( ! is_array( $meta_query ) ) {
 				$meta_query = [];


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Addresses https://app.asana.com/0/0/1209344511155915/f .

1. Add relevant options to the RSS Feed settings, if the Republication tracker plugin is activated:
    - A checkbox to add a republication tracker snippet to posts.
    - A checkbox to filter the feed to only include republishable posts.
    - A select field to choose between RSS and Atom feed formats.
2. When the user selects the Atom feed format, the "Wrap the content of <title> elements in CDATA tags" option is disabled and forced to false (since WordPress Atom feeds encoded title by default).
3. Adjusts the feed URL generation and query modifications to reflect the selected feed format.
4. Outputs the <republication_tracker> tag in the feed when the tracker option is enabled.
5. Modifies the meta query so that only posts not marked to hide the republishing button are included when filtering is active.

### How to test the changes in this Pull Request:

1. Install & Configure Republication Tracker Tool.
2. Create Feeds from Admin > RSS Feeds.
3. Check for new options.
   - Checkbox for adding republication tracker pixel.
   - Checkbox for only including republishable posts.
   - Select for RSS or Atom feeds.
4. Try the above settings and check the feed link generated.
6. If republication tracker pixel checkbox is clicked a `<republication_tracker>` tag is included adding the tracking pixel.
7. If only Include Republishable posts checkbox is added, only posts which have `"Hide Republishing Button"` metabox checkbox unchecked will be included.
8. RSS & Atom feeds will be displayed based on the selected feed type.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->