### PR TITLE
feat(my-account): disable WC password nag

### DIFF
--- a/includes/plugins/class-woocommerce.php
+++ b/includes/plugins/class-woocommerce.php
@@ -21,6 +21,7 @@ class WooCommerce {
 		add_action( 'wp_loaded', [ __CLASS__, 'disable_wc_author_archive_override' ] );
 		add_filter( 'woocommerce_rest_prepare_shop_order_object', [ __CLASS__, 'modify_shop_order_wc_rest_api_payload' ] );
 		add_filter( 'woocommerce_create_pages', [ __CLASS__, 'use_shortcodes_for_cart_checkout' ] );
+		add_filter( 'get_user_option_default_password_nag', [ __CLASS__, 'disable_default_password_nag' ] );
 	}
 
 	/**
@@ -65,6 +66,16 @@ class WooCommerce {
 		$woocommerce_pages['checkout']['content'] = '<!-- wp:shortcode -->[woocommerce_checkout]<!-- /wp:shortcode -->';
 
 		return $woocommerce_pages;
+	}
+
+	/**
+	 * Disable WC's password nag ("Your account with <site-title> is using a temporary password.
+	 * We emailed you a link to change your password.").
+	 *
+	 * @param mixed $value User meta value.
+	 */
+	public static function disable_default_password_nag( $value ) {
+		return false;
 	}
 }
 WooCommerce::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

WooCommerce has recently added a password nag notice. In the context of Newspack, it makes little sense to display this notice, since the My Account page display a password reset button.

### How to test the changes in this Pull Request:

1. On `trunk`
1. Make a donation and visit /my-account, observe a notice ("Your account with <site-title> is using a temporary password. We emailed you a link to change your password.")
2. Switch to this branch, reload, observe there's no notice 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209571170057174