### PR TITLE
fix(ia): re-add suppression advertising settings

### DIFF
--- a/src/wizards/advertising/index.js
+++ b/src/wizards/advertising/index.js
@@ -194,8 +194,14 @@ class AdvertisingWizard extends Component {
 							path="/suppression"
 							render={ () => (
 								<Suppression
-									headerText={ __( 'Advertising / Ad Suppression', 'newspack-plugin' ) }
+									headerText={ __( 'Advertising / Suppression', 'newspack-plugin' ) }
+									subHeaderText={ __(
+										'Allows you to manage site-wide ad suppression',
+										'newspack-plugin'
+									) }
 									tabbedNavigation={ tabs }
+									config={ advertisingData.suppression }
+									onChange={ config => this.updateAdSuppression( config ) }
 								/>
 							) }
 						/>

--- a/src/wizards/advertising/index.js
+++ b/src/wizards/advertising/index.js
@@ -15,7 +15,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { withWizard, utils } from '../../components/src';
 import Router from '../../components/src/proxied-imports/router';
-import { AdUnit, AdUnits, Providers, Settings, Placements } from './views';
+import { AdUnit, AdUnits, Providers, Settings, Placements, Suppression } from './views';
 import { getSizes } from './components/ad-unit-size-control';
 import './style.scss';
 
@@ -155,6 +155,10 @@ class AdvertisingWizard extends Component {
 				path: '/placements',
 			},
 			{
+				label: __( 'Suppression', 'newspack-plugin' ),
+				path: '/suppression',
+			},
+			{
 				label: __( 'Settings', 'newspack-plugin' ),
 				path: '/settings',
 			},
@@ -182,6 +186,15 @@ class AdvertisingWizard extends Component {
 							render={ () => (
 								<Placements
 									headerText={ __( 'Advertising / Display Ads', 'newspack-plugin' ) }
+									tabbedNavigation={ tabs }
+								/>
+							) }
+						/>
+						<Route
+							path="/suppression"
+							render={ () => (
+								<Suppression
+									headerText={ __( 'Advertising / Ad Suppression', 'newspack-plugin' ) }
 									tabbedNavigation={ tabs }
 								/>
 							) }

--- a/src/wizards/advertising/views/index.js
+++ b/src/wizards/advertising/views/index.js
@@ -3,3 +3,4 @@ export { default as Placements } from './placements';
 export { default as Settings } from './settings';
 export { default as AdUnits } from './ad-units';
 export { default as AdUnit } from './ad-unit';
+export { default as Suppression } from './suppression';

--- a/src/wizards/advertising/views/suppression/index.js
+++ b/src/wizards/advertising/views/suppression/index.js
@@ -18,6 +18,7 @@ import {
 	CategoryAutocomplete,
 	SectionHeader,
 	Waiting,
+	withWizardScreen,
 } from '../../../../components/src';
 
 const Suppression = () => {
@@ -66,6 +67,7 @@ const Suppression = () => {
 	}
 	return (
 		<>
+			<h1>{ __( 'Suppression', 'newspack-plugin' ) }</h1>
 			{ error && <Notice isError noticeText={ error.message } /> }
 			<SectionHeader
 				title={ __( 'Post Types', 'newspack-plugin' ) }
@@ -168,4 +170,4 @@ const Suppression = () => {
 	);
 };
 
-export default Suppression;
+export default withWizardScreen( Suppression );


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/1/26890605006346/project/1205919985867982/task/1209609051530450?focus=true

This PR adds the suppression tab back into the Advertising wizard

![Screenshot 2025-03-07 at 15 19 29](https://github.com/user-attachments/assets/d801ae4d-87af-4d0a-83de-52de502dc652)

### How to test the changes in this Pull Request:

1. Navigate to Advertising > Suppression
2. Make changes to the suppression settings and save
3. Reload and confirm changes persist
4. Verify changes actually impact ad suppression on site

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->