### PR TITLE
feat: add Lite sites feature

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -127,6 +127,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/authors/class-authors-custom-fields.php';
 		include_once NEWSPACK_ABSPATH . 'includes/corrections/class-corrections.php';
 		include_once NEWSPACK_ABSPATH . 'includes/bylines/class-bylines.php';
+		include_once NEWSPACK_ABSPATH . 'includes/lite-site/class-lite-site.php';
 
 		include_once NEWSPACK_ABSPATH . 'includes/starter_content/class-starter-content-provider.php';
 		include_once NEWSPACK_ABSPATH . 'includes/starter_content/class-starter-content-generated.php';

--- a/includes/lite-site/class-lite-site.php
+++ b/includes/lite-site/class-lite-site.php
@@ -85,14 +85,14 @@ class Lite_Site {
 
 		add_settings_section(
 			'newspack_lite_site_main',
-			__( 'Lite Site Settings', 'newspack' ),
+			__( 'Lite Site Settings', 'newspack-plugin' ),
 			'__return_null',
 			'newspack_lite_site'
 		);
 
 		add_settings_field(
 			'enabled',
-			__( 'Enable Lite Site', 'newspack' ),
+			__( 'Enable Lite Site', 'newspack-plugin' ),
 			[ __CLASS__, 'render_enabled_field' ],
 			'newspack_lite_site',
 			'newspack_lite_site_main'
@@ -100,7 +100,7 @@ class Lite_Site {
 
 		add_settings_field(
 			'url_base',
-			__( 'URL Base', 'newspack' ),
+			__( 'URL Base', 'newspack-plugin' ),
 			[ __CLASS__, 'render_url_base_field' ],
 			'newspack_lite_site',
 			'newspack_lite_site_main'
@@ -108,7 +108,7 @@ class Lite_Site {
 
 		add_settings_field(
 			'number_of_posts',
-			__( 'Posts per Page', 'newspack' ),
+			__( 'Posts per Page', 'newspack-plugin' ),
 			[ __CLASS__, 'render_number_of_posts_field' ],
 			'newspack_lite_site',
 			'newspack_lite_site_main'
@@ -116,7 +116,7 @@ class Lite_Site {
 
 		add_settings_field(
 			'categories',
-			__( 'Categories', 'newspack' ),
+			__( 'Categories', 'newspack-plugin' ),
 			[ __CLASS__, 'render_categories_field' ],
 			'newspack_lite_site',
 			'newspack_lite_site_main'
@@ -124,7 +124,7 @@ class Lite_Site {
 
 		add_settings_field(
 			'footer_html',
-			__( 'Footer HTML', 'newspack' ),
+			__( 'Footer HTML', 'newspack-plugin' ),
 			[ __CLASS__, 'render_footer_html_field' ],
 			'newspack_lite_site',
 			'newspack_lite_site_main'
@@ -136,8 +136,8 @@ class Lite_Site {
 	 */
 	public static function add_menu_page() {
 		add_options_page(
-			__( 'Lite Site', 'newspack' ),
-			__( 'Lite Site', 'newspack' ),
+			__( 'Lite Site', 'newspack-plugin' ),
+			__( 'Lite Site', 'newspack-plugin' ),
 			'manage_options',
 			'newspack-lite-site',
 			[ __CLASS__, 'render_settings_page' ]
@@ -150,7 +150,7 @@ class Lite_Site {
 	public static function render_settings_page() {
 		?>
 		<div class="wrap">
-			<h1><?php esc_html_e( 'Lite Site Settings', 'newspack' ); ?></h1>
+			<h1><?php esc_html_e( 'Lite Site Settings', 'newspack-plugin' ); ?></h1>
 			<form action="options.php" method="post">
 				<?php
 				settings_fields( 'newspack_lite_site' );
@@ -175,7 +175,7 @@ class Lite_Site {
 				value="1"
 				<?php checked( ! empty( $settings['enabled'] ) ); ?>
 			>
-			<?php esc_html_e( 'Enable lite site feature', 'newspack' ); ?>
+			<?php esc_html_e( 'Enable lite site feature', 'newspack-plugin' ); ?>
 		</label>
 		<?php
 	}
@@ -194,7 +194,7 @@ class Lite_Site {
 			class="regular-text"
 		>
 		<p class="description">
-			<?php esc_html_e( 'The URL base for the lite site (e.g. "text" for /text/)', 'newspack' ); ?>
+			<?php esc_html_e( 'The URL base for the lite site (e.g. "text" for /text/)', 'newspack-plugin' ); ?>
 		</p>
 		<?php
 	}
@@ -244,7 +244,7 @@ class Lite_Site {
 			<?php endforeach; ?>
 		</select>
 		<p class="description">
-			<?php esc_html_e( 'Select categories to include. Leave empty to include all categories.', 'newspack' ); ?>
+			<?php esc_html_e( 'Select categories to include.', 'newspack-plugin' ); ?>
 		</p>
 		<?php
 	}
@@ -262,7 +262,7 @@ class Lite_Site {
 			class="large-text"
 		><?php echo esc_textarea( $footer_html ); ?></textarea>
 		<p class="description">
-			<?php esc_html_e( 'HTML to be displayed in the footer of lite site pages.', 'newspack' ); ?>
+			<?php esc_html_e( 'HTML to be displayed in the footer of lite site pages.', 'newspack-plugin' ); ?>
 		</p>
 		<?php
 	}
@@ -389,15 +389,18 @@ class Lite_Site {
 
 			if ( count( $author_links ) > 1 ) {
 				$last_author = array_pop( $author_links );
-				$author_string = implode(
-					/* translators: separator for all but last author in a list */
-					__( ', ', 'newspack' ),
+				$first_authors = implode(
+					', ',
 					$author_links
 				);
-				$author_string .= ' ' .
-					/* translators: separator for last author in a list */
-					__( 'and', 'newspack' ) .
-					' ' . $last_author;
+
+				$author_string = sprintf(
+					/* translators: %1$s: a comma separated list of authors names with links and, after the "and" %2$s: one last author link */
+					__( '%1$s and %2$s', 'newspack-plugin' ),
+					$first_authors,
+					$last_author
+				);
+
 			} else {
 				$author_string = $author_links[0];
 			}
@@ -411,7 +414,7 @@ class Lite_Site {
 
 		return sprintf(
 			/* translators: %s: author name(s) */
-			__( 'By %s', 'newspack' ),
+			__( 'By %s', 'newspack-plugin' ),
 			$author_string
 		);
 	}

--- a/includes/lite-site/class-lite-site.php
+++ b/includes/lite-site/class-lite-site.php
@@ -151,8 +151,8 @@ class Lite_Site {
 		?>
 		<div class="wrap">
 			<h1><?php esc_html_e( 'Lite Site', 'newspack-plugin' ); ?></h1>
-			<p>Lite Site is a text-only version of this website that loads faster and uses less data.</p>
-			<p>It’s designed to allow your readers to still be able to access your content despite connectivity issues, poor network coverage, or in the event of natural disasters and emergencies.</p>
+			<p><?php esc_html_e( 'Lite Site is a text-only version of this website that loads faster and uses less data.', 'newspack-plugin' ); ?></p>
+			<p><?php esc_html_e( 'It’s designed to allow your readers to still be able to access your content despite connectivity issues, poor network coverage, or in the event of natural disasters and emergencies.', 'newspack-plugin' ); ?></p>
 			<form action="options.php" method="post">
 				<?php
 				settings_fields( 'newspack_lite_site' );

--- a/includes/lite-site/class-lite-site.php
+++ b/includes/lite-site/class-lite-site.php
@@ -10,40 +10,305 @@
  */
 class Lite_Site {
 	/**
+	 * The option name for storing settings
+	 */
+	const OPTION_NAME = 'newspack_lite_site_settings';
+
+	/**
 	 * Initialize the lite site functionality
 	 */
 	public static function init() {
-		add_action( 'init', [ __CLASS__, 'register_rewrite_rules' ] );
-		add_action( 'init', [ __CLASS__, 'maybe_flush_rewrite_rules' ], 11 );
-		add_filter( 'query_vars', [ __CLASS__, 'register_query_vars' ] );
-		add_action( 'template_redirect', [ __CLASS__, 'handle_lite_site_templates' ] );
+		// Only register rewrite rules if the feature is enabled.
+		if ( self::is_enabled() ) {
+			add_action( 'init', [ __CLASS__, 'register_rewrite_rules' ] );
+			add_filter( 'query_vars', [ __CLASS__, 'register_query_vars' ] );
+			add_action( 'template_redirect', [ __CLASS__, 'handle_lite_site_templates' ] );
+		}
+
+		// Always register settings.
+		add_action( 'admin_init', [ __CLASS__, 'register_settings' ] );
+		add_action( 'admin_menu', [ __CLASS__, 'add_menu_page' ] );
+	}
+
+	/**
+	 * Check if the lite site feature is enabled
+	 */
+	public static function is_enabled() {
+		$settings = get_option( self::OPTION_NAME, [] );
+		return ! empty( $settings['enabled'] );
+	}
+
+	/**
+	 * Get the lite site URL base
+	 */
+	public static function get_url_base() {
+		$settings = get_option( self::OPTION_NAME, [] );
+		return ! empty( $settings['url_base'] ) ? $settings['url_base'] : 'text';
+	}
+
+	/**
+	 * Get the number of posts to display
+	 */
+	public static function get_posts_per_page() {
+		$settings = get_option( self::OPTION_NAME, [] );
+		return ! empty( $settings['posts_per_page'] ) ? intval( $settings['posts_per_page'] ) : 20;
+	}
+
+	/**
+	 * Get the selected categories
+	 */
+	public static function get_categories() {
+		$settings = get_option( self::OPTION_NAME, [] );
+		return ! empty( $settings['categories'] ) ? (array) $settings['categories'] : [];
+	}
+
+	/**
+	 * Get the footer HTML
+	 */
+	public static function get_footer_html() {
+		$settings = get_option( self::OPTION_NAME, [] );
+		return ! empty( $settings['footer_html'] ) ? $settings['footer_html'] : '';
+	}
+
+	/**
+	 * Register settings
+	 */
+	public static function register_settings() {
+		register_setting(
+			'newspack_lite_site',
+			self::OPTION_NAME,
+			[
+				'type'              => 'object',
+				'sanitize_callback' => [ __CLASS__, 'sanitize_settings' ],
+			]
+		);
+
+		add_settings_section(
+			'newspack_lite_site_main',
+			__( 'Lite Site Settings', 'newspack' ),
+			'__return_null',
+			'newspack_lite_site'
+		);
+
+		add_settings_field(
+			'enabled',
+			__( 'Enable Lite Site', 'newspack' ),
+			[ __CLASS__, 'render_enabled_field' ],
+			'newspack_lite_site',
+			'newspack_lite_site_main'
+		);
+
+		add_settings_field(
+			'url_base',
+			__( 'URL Base', 'newspack' ),
+			[ __CLASS__, 'render_url_base_field' ],
+			'newspack_lite_site',
+			'newspack_lite_site_main'
+		);
+
+		add_settings_field(
+			'posts_per_page',
+			__( 'Posts per Page', 'newspack' ),
+			[ __CLASS__, 'render_posts_per_page_field' ],
+			'newspack_lite_site',
+			'newspack_lite_site_main'
+		);
+
+		add_settings_field(
+			'categories',
+			__( 'Categories', 'newspack' ),
+			[ __CLASS__, 'render_categories_field' ],
+			'newspack_lite_site',
+			'newspack_lite_site_main'
+		);
+
+		add_settings_field(
+			'footer_html',
+			__( 'Footer HTML', 'newspack' ),
+			[ __CLASS__, 'render_footer_html_field' ],
+			'newspack_lite_site',
+			'newspack_lite_site_main'
+		);
+	}
+
+	/**
+	 * Add menu page
+	 */
+	public static function add_menu_page() {
+		add_options_page(
+			__( 'Lite Site', 'newspack' ),
+			__( 'Lite Site', 'newspack' ),
+			'manage_options',
+			'newspack-lite-site',
+			[ __CLASS__, 'render_settings_page' ]
+		);
+	}
+
+	/**
+	 * Render settings page
+	 */
+	public static function render_settings_page() {
+		?>
+		<div class="wrap">
+			<h1><?php esc_html_e( 'Lite Site Settings', 'newspack' ); ?></h1>
+			<form action="options.php" method="post">
+				<?php
+				settings_fields( 'newspack_lite_site' );
+				do_settings_sections( 'newspack_lite_site' );
+				submit_button();
+				?>
+			</form>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Render enabled field
+	 */
+	public static function render_enabled_field() {
+		$settings = get_option( self::OPTION_NAME, [] );
+		?>
+		<label>
+			<input
+				type="checkbox"
+				name="<?php echo esc_attr( self::OPTION_NAME ); ?>[enabled]"
+				value="1"
+				<?php checked( ! empty( $settings['enabled'] ) ); ?>
+			>
+			<?php esc_html_e( 'Enable lite site feature', 'newspack' ); ?>
+		</label>
+		<?php
+	}
+
+	/**
+	 * Render URL base field
+	 */
+	public static function render_url_base_field() {
+		$settings = get_option( self::OPTION_NAME, [] );
+		$url_base = ! empty( $settings['url_base'] ) ? $settings['url_base'] : 'text';
+		?>
+		<input
+			type="text"
+			name="<?php echo esc_attr( self::OPTION_NAME ); ?>[url_base]"
+			value="<?php echo esc_attr( $url_base ); ?>"
+			class="regular-text"
+		>
+		<p class="description">
+			<?php esc_html_e( 'The URL base for the lite site (e.g. "text" for /text/)', 'newspack' ); ?>
+		</p>
+		<?php
+	}
+
+	/**
+	 * Render posts per page field
+	 */
+	public static function render_posts_per_page_field() {
+		$settings = get_option( self::OPTION_NAME, [] );
+		$posts_per_page = ! empty( $settings['posts_per_page'] ) ? intval( $settings['posts_per_page'] ) : 20;
+		?>
+		<input
+			type="number"
+			name="<?php echo esc_attr( self::OPTION_NAME ); ?>[posts_per_page]"
+			value="<?php echo esc_attr( $posts_per_page ); ?>"
+			min="1"
+			max="100"
+			step="1"
+		>
+		<?php
+	}
+
+	/**
+	 * Render categories field
+	 */
+	public static function render_categories_field() {
+		$settings = get_option( self::OPTION_NAME, [] );
+		$selected_categories = ! empty( $settings['categories'] ) ? (array) $settings['categories'] : [];
+		$categories = get_categories( [ 'hide_empty' => false ] );
+		?>
+		<select
+			name="<?php echo esc_attr( self::OPTION_NAME ); ?>[categories][]"
+			multiple
+			class="regular-text"
+			style="min-height: 100px;"
+		>
+			<option value="" <?php selected( empty( $selected_categories ) ); ?>>
+				All categories
+			</option>
+			<?php foreach ( $categories as $category ) : ?>
+				<option
+					value="<?php echo esc_attr( $category->term_id ); ?>"
+					<?php selected( in_array( $category->term_id, $selected_categories ) ); ?>
+				>
+					<?php echo esc_html( $category->name ); ?>
+				</option>
+			<?php endforeach; ?>
+		</select>
+		<p class="description">
+			<?php esc_html_e( 'Select categories to include. Leave empty to include all categories.', 'newspack' ); ?>
+		</p>
+		<?php
+	}
+
+	/**
+	 * Render footer HTML field
+	 */
+	public static function render_footer_html_field() {
+		$settings = get_option( self::OPTION_NAME, [] );
+		$footer_html = ! empty( $settings['footer_html'] ) ? $settings['footer_html'] : '';
+		?>
+		<textarea
+			name="<?php echo esc_attr( self::OPTION_NAME ); ?>[footer_html]"
+			rows="5"
+			class="large-text"
+		><?php echo esc_textarea( $footer_html ); ?></textarea>
+		<p class="description">
+			<?php esc_html_e( 'HTML to be displayed in the footer of lite site pages.', 'newspack' ); ?>
+		</p>
+		<?php
+	}
+
+	/**
+	 * Sanitize settings
+	 *
+	 * @param array $settings The settings to sanitize.
+	 * @return array The sanitized settings.
+	 */
+	public static function sanitize_settings( $settings ) {
+		$old_settings = get_option( self::OPTION_NAME, [] );
+
+		flush_rewrite_rules(); // phpcs:ignore
+
+		// handle All categories.
+		if ( in_array( '', $settings['categories'] ) ) {
+			$settings['categories'] = [];
+		}
+
+		return [
+			'enabled'        => ! empty( $settings['enabled'] ),
+			'url_base'       => sanitize_title( $settings['url_base'] ),
+			'posts_per_page' => min( 100, max( 1, intval( $settings['posts_per_page'] ) ) ),
+			'categories'     => ! empty( $settings['categories'] ) ? array_map( 'intval', $settings['categories'] ) : [],
+			'footer_html'    => wp_kses_post( $settings['footer_html'] ),
+		];
 	}
 
 	/**
 	 * Register the rewrite rules for the lite site
 	 */
 	public static function register_rewrite_rules() {
+		$url_base = self::get_url_base();
+
 		add_rewrite_rule(
-			'^text/?$',
+			'^' . $url_base . '/?$',
 			'index.php?lite_site=archive',
 			'top'
 		);
 
 		add_rewrite_rule(
-			'^text/([0-9]+)/?$',
+			'^' . $url_base . '/([0-9]+)/?$',
 			'index.php?lite_site=single&lite_site_id=$matches[1]',
 			'top'
 		);
-	}
-
-	/**
-	 * Flush rewrite rules if they haven't been flushed yet
-	 */
-	public static function maybe_flush_rewrite_rules() {
-		if ( ! get_option( 'lite_site_rewrite_rules_flushed' ) ) {
-			flush_rewrite_rules(); // phpcs:ignore
-			update_option( 'lite_site_rewrite_rules_flushed', true );
-		}
 	}
 
 	/**

--- a/includes/lite-site/class-lite-site.php
+++ b/includes/lite-site/class-lite-site.php
@@ -49,9 +49,9 @@ class Lite_Site {
 	/**
 	 * Get the number of posts to display
 	 */
-	public static function get_posts_per_page() {
+	public static function get_number_of_posts() {
 		$settings = get_option( self::OPTION_NAME, [] );
-		return ! empty( $settings['posts_per_page'] ) ? intval( $settings['posts_per_page'] ) : 20;
+		return ! empty( $settings['number_of_posts'] ) ? intval( $settings['number_of_posts'] ) : 20;
 	}
 
 	/**
@@ -107,9 +107,9 @@ class Lite_Site {
 		);
 
 		add_settings_field(
-			'posts_per_page',
+			'number_of_posts',
 			__( 'Posts per Page', 'newspack' ),
-			[ __CLASS__, 'render_posts_per_page_field' ],
+			[ __CLASS__, 'render_number_of_posts_field' ],
 			'newspack_lite_site',
 			'newspack_lite_site_main'
 		);
@@ -202,14 +202,14 @@ class Lite_Site {
 	/**
 	 * Render posts per page field
 	 */
-	public static function render_posts_per_page_field() {
+	public static function render_number_of_posts_field() {
 		$settings = get_option( self::OPTION_NAME, [] );
-		$posts_per_page = ! empty( $settings['posts_per_page'] ) ? intval( $settings['posts_per_page'] ) : 20;
+		$number_of_posts = ! empty( $settings['number_of_posts'] ) ? intval( $settings['number_of_posts'] ) : 20;
 		?>
 		<input
 			type="number"
-			name="<?php echo esc_attr( self::OPTION_NAME ); ?>[posts_per_page]"
-			value="<?php echo esc_attr( $posts_per_page ); ?>"
+			name="<?php echo esc_attr( self::OPTION_NAME ); ?>[number_of_posts]"
+			value="<?php echo esc_attr( $number_of_posts ); ?>"
 			min="1"
 			max="100"
 			step="1"
@@ -284,11 +284,11 @@ class Lite_Site {
 		}
 
 		return [
-			'enabled'        => ! empty( $settings['enabled'] ),
-			'url_base'       => sanitize_title( $settings['url_base'] ),
-			'posts_per_page' => min( 100, max( 1, intval( $settings['posts_per_page'] ) ) ),
-			'categories'     => ! empty( $settings['categories'] ) ? array_map( 'intval', $settings['categories'] ) : [],
-			'footer_html'    => wp_kses_post( $settings['footer_html'] ),
+			'enabled'         => ! empty( $settings['enabled'] ),
+			'url_base'        => sanitize_title( $settings['url_base'] ),
+			'number_of_posts' => min( 100, max( 1, intval( $settings['number_of_posts'] ) ) ),
+			'categories'      => ! empty( $settings['categories'] ) ? array_map( 'intval', $settings['categories'] ) : [],
+			'footer_html'     => wp_kses_post( $settings['footer_html'] ),
 		];
 	}
 

--- a/includes/lite-site/class-lite-site.php
+++ b/includes/lite-site/class-lite-site.php
@@ -1,0 +1,201 @@
+<?php
+/**
+ * Lite Site functionality
+ *
+ * @package newspack
+ */
+
+/**
+ * Lite Site class
+ */
+class Lite_Site {
+	/**
+	 * Initialize the lite site functionality
+	 */
+	public static function init() {
+		add_action( 'init', [ __CLASS__, 'register_rewrite_rules' ] );
+		add_action( 'init', [ __CLASS__, 'maybe_flush_rewrite_rules' ], 11 );
+		add_filter( 'query_vars', [ __CLASS__, 'register_query_vars' ] );
+		add_action( 'template_redirect', [ __CLASS__, 'handle_lite_site_templates' ] );
+	}
+
+	/**
+	 * Register the rewrite rules for the lite site
+	 */
+	public static function register_rewrite_rules() {
+		add_rewrite_rule(
+			'^text/?$',
+			'index.php?lite_site=archive',
+			'top'
+		);
+
+		add_rewrite_rule(
+			'^text/([0-9]+)/?$',
+			'index.php?lite_site=single&lite_site_id=$matches[1]',
+			'top'
+		);
+	}
+
+	/**
+	 * Flush rewrite rules if they haven't been flushed yet
+	 */
+	public static function maybe_flush_rewrite_rules() {
+		if ( ! get_option( 'lite_site_rewrite_rules_flushed' ) ) {
+			flush_rewrite_rules(); // phpcs:ignore
+			update_option( 'lite_site_rewrite_rules_flushed', true );
+		}
+	}
+
+	/**
+	 * Register custom query variables
+	 *
+	 * @param array $vars The array of query variables.
+	 * @return array The modified array of query variables.
+	 */
+	public static function register_query_vars( $vars ) {
+		$vars[] = 'lite_site';
+		$vars[] = 'lite_site_id';
+		return $vars;
+	}
+
+	/**
+	 * Handle template routing for lite site pages
+	 */
+	public static function handle_lite_site_templates() {
+		$lite_site = get_query_var( 'lite_site' );
+
+		if ( ! $lite_site ) {
+			return;
+		}
+
+		// Disable all other output.
+		remove_all_actions( 'wp_head' );
+		remove_all_actions( 'wp_footer' );
+
+		if ( $lite_site === 'archive' ) {
+			include_once __DIR__ . '/templates/archive.php';
+			exit;
+		}
+
+		if ( $lite_site === 'single' ) {
+			include_once __DIR__ . '/templates/single.php';
+			exit;
+		}
+	}
+
+	/**
+	 * Get the primary color
+	 *
+	 * @return string The primary color.
+	 */
+	public static function get_primary_color() {
+		if ( ! function_exists( 'newspack_get_primary_color' ) ) {
+			return '#000';
+		}
+
+		$primary_color = newspack_get_primary_color();
+
+		if ( 'default' !== get_theme_mod( 'theme_colors' ) ) {
+			$primary_color = get_theme_mod( 'primary_color_hex', $primary_color );
+		}
+
+		return $primary_color;
+	}
+
+	/**
+	 * Get the author(s) for a post
+	 *
+	 * @param WP_Post $post The post object.
+	 * @return string The formatted author(s) string with links.
+	 */
+	public static function get_authors( $post ) {
+		if ( function_exists( 'coauthors_posts_links' ) ) {
+			$authors = get_coauthors( $post->ID );
+			$author_links = array_map(
+				function( $author ) {
+					return sprintf(
+						'<a href="%s">%s</a>',
+						esc_url( get_author_posts_url( $author->ID, $author->user_nicename ) ),
+						esc_html( $author->display_name )
+					);
+				},
+				$authors
+			);
+
+			if ( count( $author_links ) > 1 ) {
+				$last_author = array_pop( $author_links );
+				$author_string = implode(
+					/* translators: separator for all but last author in a list */
+					__( ', ', 'newspack' ),
+					$author_links
+				);
+				$author_string .= ' ' .
+					/* translators: separator for last author in a list */
+					__( 'and', 'newspack' ) .
+					' ' . $last_author;
+			} else {
+				$author_string = $author_links[0];
+			}
+		} else {
+			$author_string = sprintf(
+				'<a href="%s">%s</a>',
+				esc_url( get_author_posts_url( $post->post_author ) ),
+				esc_html( get_the_author_meta( 'display_name', $post->post_author ) )
+			);
+		}
+
+		return sprintf(
+			/* translators: %s: author name(s) */
+			__( 'By %s', 'newspack' ),
+			$author_string
+		);
+	}
+
+	/**
+	 * Clean the post content for lite display
+	 *
+	 * @param string $content The post content.
+	 * @return string The cleaned content.
+	 */
+	public static function clean_content( $content ) {
+		// Remove HTML comments.
+		$content = preg_replace( '/<!--(.|\s)*?-->/', '', $content );
+
+		// First remove figures and their contents (including images and captions).
+		$content = preg_replace( '/<figure.*?>.*?<\/figure>/s', '', $content );
+
+		// Define allowed HTML elements for text-only content.
+		$allowed_html = [
+			'p'          => [],
+			'h1'         => [],
+			'h2'         => [],
+			'h3'         => [],
+			'h4'         => [],
+			'h5'         => [],
+			'h6'         => [],
+			'ul'         => [],
+			'ol'         => [],
+			'li'         => [],
+			'blockquote' => [],
+			'strong'     => [],
+			'em'         => [],
+			'b'          => [],
+			'i'          => [],
+			'a'          => [
+				'href'  => true,
+				'title' => true,
+			],
+		];
+
+		// Strip all HTML except allowed elements.
+		$content = wp_kses( $content, $allowed_html );
+
+		// Clean up any empty paragraphs.
+		$content = preg_replace( '/<p>\s*<\/p>/', '', $content );
+
+		return $content;
+	}
+}
+
+// Initialize the class.
+Lite_Site::init();

--- a/includes/lite-site/class-lite-site.php
+++ b/includes/lite-site/class-lite-site.php
@@ -108,7 +108,7 @@ class Lite_Site {
 
 		add_settings_field(
 			'number_of_posts',
-			__( 'Posts per Page', 'newspack-plugin' ),
+			__( 'Number of posts to display', 'newspack-plugin' ),
 			[ __CLASS__, 'render_number_of_posts_field' ],
 			'newspack_lite_site',
 			'newspack_lite_site_main'

--- a/includes/lite-site/class-lite-site.php
+++ b/includes/lite-site/class-lite-site.php
@@ -355,7 +355,7 @@ class Lite_Site {
 	 */
 	public static function get_primary_color() {
 		if ( ! function_exists( 'newspack_get_primary_color' ) ) {
-			return '#000';
+			return 'currentcolor';
 		}
 
 		$primary_color = newspack_get_primary_color();

--- a/includes/lite-site/class-lite-site.php
+++ b/includes/lite-site/class-lite-site.php
@@ -85,7 +85,7 @@ class Lite_Site {
 
 		add_settings_section(
 			'newspack_lite_site_main',
-			__( 'Lite Site Settings', 'newspack-plugin' ),
+			__( 'Settings', 'newspack-plugin' ),
 			'__return_null',
 			'newspack_lite_site'
 		);
@@ -150,7 +150,9 @@ class Lite_Site {
 	public static function render_settings_page() {
 		?>
 		<div class="wrap">
-			<h1><?php esc_html_e( 'Lite Site Settings', 'newspack-plugin' ); ?></h1>
+			<h1><?php esc_html_e( 'Lite Site', 'newspack-plugin' ); ?></h1>
+			<p>Lite Site is a text-only version of this website that loads faster and uses less data.</p>
+			<p>It’s designed to allow your readers to still be able to access your content despite connectivity issues, poor network coverage, or in the event of natural disasters and emergencies.</p>
 			<form action="options.php" method="post">
 				<?php
 				settings_fields( 'newspack_lite_site' );
@@ -194,7 +196,13 @@ class Lite_Site {
 			class="regular-text"
 		>
 		<p class="description">
-			<?php esc_html_e( 'The URL base for the lite site (e.g. "text" for /text/)', 'newspack-plugin' ); ?>
+			<?php
+			printf(
+				/* translators: %s: is the site URL without a trailing slash, ex: https://example.com */
+				esc_html__( 'The URL base for the lite site (e.g. "text" for %s/text)', 'newspack-plugin' ),
+				esc_url( untrailingslashit( home_url() ) )
+			);
+			?>
 		</p>
 		<?php
 	}

--- a/includes/lite-site/templates/archive.php
+++ b/includes/lite-site/templates/archive.php
@@ -16,14 +16,14 @@
 </head>
 <body>
 	<header class="back">
-		<a href="<?php echo esc_url( home_url() ); ?>" >View full site</a>
+		<a href="<?php echo esc_url( home_url() ); ?>" ><?php esc_html_e( 'View full site', 'newspack-plugin' ); ?></a>
 	</header>
 	<h1><?php bloginfo( 'name' ); ?></h1>
 	<hr class="separator">
 	<ul>
 	<?php
 	$query_args = [
-		'posts_per_page' => Lite_Site::get_posts_per_page(),
+		'posts_per_page' => Lite_Site::get_number_of_posts(),
 		'post_status'    => 'publish',
 	];
 

--- a/includes/lite-site/templates/archive.php
+++ b/includes/lite-site/templates/archive.php
@@ -22,12 +22,17 @@
 	<hr class="separator">
 	<ul>
 	<?php
-	$recent_posts = get_posts(
-		array(
-			'posts_per_page' => 20,
-			'post_status'    => 'publish',
-		)
-	);
+	$query_args = [
+		'posts_per_page' => Lite_Site::get_posts_per_page(),
+		'post_status'    => 'publish',
+	];
+
+	$categories = Lite_Site::get_categories();
+	if ( ! empty( $categories ) ) {
+		$query_args['category__in'] = $categories;
+	}
+
+	$recent_posts = get_posts( $query_args );
 
 	foreach ( $recent_posts as $current_post ) {
 		printf(
@@ -38,5 +43,14 @@
 	}
 	?>
 	</ul>
+	<?php
+	$footer_html = Lite_Site::get_footer_html();
+	if ( ! empty( $footer_html ) ) :
+		?>
+		<hr class="separator">
+		<footer class="site-footer">
+			<?php echo wp_kses_post( $footer_html ); ?>
+		</footer>
+	<?php endif; ?>
 </body>
 </html>

--- a/includes/lite-site/templates/archive.php
+++ b/includes/lite-site/templates/archive.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Template for the lite site archive page
+ *
+ * @package newspack
+ */
+
+?>
+<!DOCTYPE html>
+<html lang="<?php bloginfo( 'language' ); ?>">
+<head>
+	<meta charset="<?php bloginfo( 'charset' ); ?>">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title><?php bloginfo( 'name' ); ?></title>
+	<?php require __DIR__ . '/lite-site-styles.php'; ?>
+</head>
+<body>
+	<header class="back">
+		<a href="<?php echo esc_url( home_url() ); ?>" >View full site</a>
+	</header>
+	<h1><?php bloginfo( 'name' ); ?></h1>
+	<hr class="separator">
+	<ul>
+	<?php
+	$recent_posts = get_posts(
+		array(
+			'posts_per_page' => 20,
+			'post_status'    => 'publish',
+		)
+	);
+
+	foreach ( $recent_posts as $current_post ) {
+		printf(
+			'<li><a href="/text/%d">%s</a></li>',
+			esc_attr( $current_post->ID ),
+			esc_html( $current_post->post_title )
+		);
+	}
+	?>
+	</ul>
+</body>
+</html>

--- a/includes/lite-site/templates/lite-site-styles.php
+++ b/includes/lite-site/templates/lite-site-styles.php
@@ -29,4 +29,8 @@
 	.meta .date {
 		margin-top: 0.5rem;
 	}
+	.site-footer {
+		margin-top: 2rem;
+		color: #515151;
+	}
 </style>

--- a/includes/lite-site/templates/lite-site-styles.php
+++ b/includes/lite-site/templates/lite-site-styles.php
@@ -9,28 +9,50 @@
 <style>
 	body {
 		font-family: system-ui, -apple-system, sans-serif;
-		line-height: 1.5;
-		max-width: 41.5rem;
-		margin: 2rem auto;
-		padding: 0 1rem;
+		font-size: clamp( 1.125rem, 0.929rem + 0.402vw, 1.25rem );
+		line-height: 1.6;
+		margin: 0 auto;
+		max-width: 39.5rem;
+		padding: 2rem 1rem;
 	}
-	h1 { margin-bottom: 2rem; }
-	ul { padding-left: 0; list-style: none; }
-	li { margin-bottom: 1rem; }
-	a { color: #000; }
-	.back { display: block; margin-bottom: 2rem; }
+	h1 {
+		font-size: clamp( 1.75rem, -0.213rem + 4.016vw, 3rem );
+		line-height: 1.25;
+		margin: 0 0 2rem;
+	}
+	ul {
+		list-style: none;
+		padding-left: 0;
+	}
+	li {
+		margin-bottom: 1rem;
+	}
+	a {
+		color: currentcolor;
+	}
 	hr.separator {
-		border: 2px solid <?php echo esc_attr( Lite_Site::get_primary_color() ); ?>;
+		border: 0.125rem solid <?php echo esc_attr( Lite_Site::get_primary_color() ); ?>;
+		margin: 2rem 0;
+	}
+	.back {
+		display: block;
+		font-size: 1rem;
+		line-height: 1.5;
+		margin: 0 0 0.5rem;
 	}
 	.meta {
-		color: #515151;
+		color: currentcolor;
 		margin-bottom: 2rem;
 	}
 	.meta .date {
 		margin-top: 0.5rem;
 	}
 	.site-footer {
+		font-size: 1rem;
+		line-height: 1.5;
 		margin-top: 2rem;
-		color: #515151;
+	}
+	.site-footer > :last-child {
+		margin-bottom: 0;
 	}
 </style>

--- a/includes/lite-site/templates/lite-site-styles.php
+++ b/includes/lite-site/templates/lite-site-styles.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Shared styles for lite site templates
+ *
+ * @package newspack
+ */
+
+?>
+<style>
+	body {
+		font-family: system-ui, -apple-system, sans-serif;
+		line-height: 1.5;
+		max-width: 41.5rem;
+		margin: 2rem auto;
+		padding: 0 1rem;
+	}
+	h1 { margin-bottom: 2rem; }
+	ul { padding-left: 0; list-style: none; }
+	li { margin-bottom: 1rem; }
+	a { color: #000; }
+	.back { display: block; margin-bottom: 2rem; }
+	hr.separator {
+		border: 2px solid <?php echo esc_attr( Lite_Site::get_primary_color() ); ?>;
+	}
+	.meta {
+		color: #515151;
+		margin-bottom: 2rem;
+	}
+	.meta .date {
+		margin-top: 0.5rem;
+	}
+</style>

--- a/includes/lite-site/templates/lite-site-styles.php
+++ b/includes/lite-site/templates/lite-site-styles.php
@@ -55,4 +55,12 @@
 	.site-footer > :last-child {
 		margin-bottom: 0;
 	}
+
+	<?php
+	/**
+	 * Hook fired at the end of the style tag in the Lite Site templates.
+	 */
+	do_action( 'newspack_lite_site_styles' );
+	?>
+
 </style>

--- a/includes/lite-site/templates/single.php
+++ b/includes/lite-site/templates/single.php
@@ -23,8 +23,8 @@ if ( ! $current_post ) {
 </head>
 <body>
 	<header class="back">
-		<a href="/text">← Back to posts</a> |
-		<a href="<?php echo esc_url( get_permalink( $current_post ) ); ?>">View full site</a>
+		<a href="/text">← <?php esc_html_e( 'Back to posts', 'newspack-plugin' ); ?></a> |
+		<a href="<?php echo esc_url( get_permalink( $current_post ) ); ?>"><?php esc_html_e( 'View full site', 'newspack-plugin' ); ?></a>
 	</header>
 	<h1><?php echo esc_html( $current_post->post_title ); ?></h1>
 	<div class="meta">

--- a/includes/lite-site/templates/single.php
+++ b/includes/lite-site/templates/single.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Template for the lite site single post page
+ *
+ * @package newspack
+ */
+
+$current_post_id = get_query_var( 'lite_site_id' );
+$current_post = get_post( $current_post_id );
+
+if ( ! $current_post ) {
+	status_header( 404 );
+	exit( 'Post not found' );
+}
+?>
+<!DOCTYPE html>
+<html lang="<?php bloginfo( 'language' ); ?>">
+<head>
+	<meta charset="<?php bloginfo( 'charset' ); ?>">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title><?php echo esc_html( $current_post->post_title ); ?> - <?php bloginfo( 'name' ); ?></title>
+	<?php require __DIR__ . '/lite-site-styles.php'; ?>
+</head>
+<body>
+	<header class="back">
+		<a href="/text">← Back to posts</a> |
+		<a href="<?php echo esc_url( get_permalink( $current_post ) ); ?>">View full site</a>
+	</header>
+	<h1><?php echo esc_html( $current_post->post_title ); ?></h1>
+	<div class="meta">
+		<div class="authors">
+			<?php echo wp_kses_post( Lite_Site::get_authors( $current_post ) ); ?>
+		</div>
+		<div class="date">
+			<?php echo get_the_date(); ?>
+		</div>
+	</div>
+	<hr class="separator">
+
+	<div class="content">
+		<?php echo wp_kses_post( Lite_Site::clean_content( $current_post->post_content ) ); ?>
+	</div>
+</body>
+</html>

--- a/includes/lite-site/templates/single.php
+++ b/includes/lite-site/templates/single.php
@@ -40,5 +40,14 @@ if ( ! $current_post ) {
 	<div class="content">
 		<?php echo wp_kses_post( Lite_Site::clean_content( $current_post->post_content ) ); ?>
 	</div>
+	<?php
+	$footer_html = Lite_Site::get_footer_html();
+	if ( ! empty( $footer_html ) ) :
+		?>
+		<hr class="separator">
+		<footer class="site-footer">
+			<?php echo wp_kses_post( $footer_html ); ?>
+		</footer>
+	<?php endif; ?>
 </body>
 </html>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds the Lite site feature

Note: Built a simple Settings page for now - we can build a Newspack settings page after AI is released

### How to test the changes in this Pull Request:

1. Go to Settings > Lite Site
2. Enable the feature and save
3. Visit yoursite.com/text and confirm you see a text only version of the site
4. Visit the posts and confirm they look good
5. Confirm images and any other non-textual elements are removed from the posts
6. Confirm the HR in the header and footer follow Newspack theme's primary color
7. Tweak the settings and confirm they work as expected


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->