### PR TITLE
Fix: Path to Autoloader

### DIFF
--- a/newspack.php
+++ b/newspack.php
@@ -26,7 +26,7 @@ if ( ! defined( 'NEWSPACK_PLUGIN_BASEDIR' ) ) {
 	define( 'NEWSPACK_PLUGIN_BASEDIR', dirname( plugin_basename( NEWSPACK_PLUGIN_FILE ) ) );
 }
 
-require_once 'vendor/autoload.php';
+require_once __DIR__ . '/vendor/autoload.php';
 
 // Include the main Newspack class.
 if ( ! class_exists( 'Newspack' ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Changes the main autoloader require path from relative to `__DIR__`.   PHP can confuse relative paths in some contexts to mean the path of the currently running script and not the included file's path.

### How to test the changes in this Pull Request:

1. Verify the plugin works as a normal wordpress plugin.
2. Verify the plugin's CLI commands still work.
3. Verify phpunit tests still work.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->