### PR TITLE
fix: avoid fatal when sitekit is not configured

### DIFF
--- a/includes/plugins/google-site-kit/class-googlesitekit.php
+++ b/includes/plugins/google-site-kit/class-googlesitekit.php
@@ -34,6 +34,9 @@ class GoogleSiteKit {
 	 * @param array $googlesitekit_analytics_settings GA settings.
 	 */
 	public static function filter_ga_settings( $googlesitekit_analytics_settings ) {
+		if ( ! is_array( $googlesitekit_analytics_settings ) || ! isset( $googlesitekit_analytics_settings['trackingDisabled'] ) || ! is_array( $googlesitekit_analytics_settings['trackingDisabled'] ) ) {
+			return $googlesitekit_analytics_settings;
+		}
 		if ( in_array( 'loggedinUsers', $googlesitekit_analytics_settings['trackingDisabled'] ) ) {
 			$googlesitekit_analytics_settings['trackingDisabled'] = [ 'contentCreators' ];
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

https://github.com/Automattic/newspack-plugin/pull/3802 may throw a Fatal if Site kit is not properly configured on the site. 

```
PHP Fatal error:  Uncaught TypeError: in_array(): Argument #2 ($haystack) must be of type array, null given in /newspack-repos/newspack-plugin/includes/plugins/google-site-kit/class-googlesitekit.php:41
```

This PR avoids it

### How to test the changes in this Pull Request:

1. reset Site kit / disconnect it
2. Confirm you see no fatals
3. See instructions on https://github.com/Automattic/newspack-plugin/pull/3802

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->