### PR TITLE
fix: update paths to share button, social CSS in Perfmatters

### DIFF
--- a/includes/plugins/class-perfmatters.php
+++ b/includes/plugins/class-perfmatters.php
@@ -85,8 +85,8 @@ class Perfmatters {
 			'plugins/newspack-newsletters', // Newspack Newsletters.
 			'plugins/newspack-plugin', // Newspack main plugin.
 			'plugins/newspack-popups', // Newspack Campaigns.
-			'plugins/jetpack/modules/sharedaddy', // Jetpack's share buttons.
-			'plugins/jetpack/_inc/social-logos', // Jetpack's social logos CSS.
+			'modules/sharedaddy', // Jetpack's share buttons.
+			'_inc/social-logos', // Jetpack's social logos CSS.
 			'plugins/jetpack/css/jetpack.css', // Jetpack's main CSS.
 			'plugins/the-events-calendar', // The Events Calendar.
 			'plugins/events-calendar-pro', // The Events Calendar Pro.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

I noticed while digging into an image size issue on one of our sites that their share buttons were super slow to load, and just sat in the bulleted list form for a while. 

After digging around a bit, it looks like the file structure used for Jetpack when loading static files from the CDN is pretty different from when it's loading them the plugin. The sharing CSS loads from https://c0.wp.com/p/jetpack/14.4/modules/sharedaddy/sharing.css and the social logos load from https://c0.wp.com/p/jetpack/14.4/_inc/social-logos/social-logos.min.css. 

This PR updates the paths in the Perfmatters settings so they should work when the files are served from the CDN and when they are not. Hopefully they're not too generic now!

(I left the jetpack.css as is because it doesn't seem to be loading on my test site so I'm not sure what the path should change to! It may be defunct now, though). 

See: 1200550061930446-as-1209168099234266

### How to test the changes in this Pull Request:

1. Apply this PR.
2. Turn on the Site Accelerator, and turn it on for static files. 
3. Enable Jetpack's share buttons and Perfmatters default settings.
4. Confirm that the share buttons are loading okay.
5. Turn off Site Accelerator for static files.
6. Confirm that the share buttons are still loading okay.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->