### PR TITLE
feat(media): enable setting a default image for 404 images

### DIFF
--- a/includes/class-default-image.php
+++ b/includes/class-default-image.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Newspack News Revenue Hub feature management.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Handles Default Image functionality.
+ */
+class Default_Image {
+	/**
+	 * Form field name.
+	 */
+	const FIELD_NAME = 'is_default_image';
+
+	/**
+	 * Option name.
+	 */
+	const OPTION_NAME = 'newspack_default_image_url';
+
+	/**
+	 * Add hooks.
+	 */
+	public static function init() {
+		add_filter( 'attachment_fields_to_save', [ __CLASS__, 'save_attachement_settings' ], 10, 2 );
+		add_filter( 'attachment_fields_to_edit', [ __CLASS__, 'add_attachment_field' ], 10, 2 );
+		add_action( 'template_redirect', [ __CLASS__, 'handle_not_found_image' ] );
+	}
+
+	/**
+	 * Handle not found image.
+	 */
+	public static function handle_not_found_image() {
+		if ( is_404() ) {
+			if ( empty( $_SERVER['REQUEST_URI'] ) ) {
+				return;
+			}
+			$requested_url = $_SERVER['REQUEST_URI']; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			if ( preg_match( '/\.(jpg|jpeg|png|gif|webp)$/i', $requested_url ) ) {
+				$default_image_url = get_option( self::OPTION_NAME );
+				if ( ! empty( $default_image_url ) ) {
+					wp_safe_redirect( $default_image_url, 301 );
+					exit;
+				}
+			}
+		}
+	}
+
+	/**
+	 * Add the relevant setting in the media editing screen.
+	 *
+	 * @param array   $fields Array of media editor field info.
+	 * @param WP_Post $post Post object for current attachment.
+	 * @return array Modified $fields.
+	 */
+	public static function add_attachment_field( $fields, $post ) {
+		$field_name = 'attachments[' . $post->ID . '][' . self::FIELD_NAME . ']';
+		$value = ( wp_get_attachment_url( $post->ID ) === get_option( self::OPTION_NAME ) );
+		$fields[ self::FIELD_NAME ] = [
+			'label' => __( 'Is default image?', 'newspack-image-credits' ),
+			'input' => 'html',
+			'html'  => '<input id="' . $field_name . '" name="' . $field_name . '" type="hidden" value="0" /><input id="' . $field_name . '" name="' . $field_name . '" type="checkbox" value="1" ' . checked( $value, true, false ) . ' />',
+			'helps' => __( 'Use this image as a default image, if the requested one is not found (404 status).', 'newspack-plugin' ),
+		];
+		return $fields;
+	}
+
+	/**
+	 * Save the relevant setting.
+	 *
+	 * @param array $post Array of post info.
+	 * @param array $attachment Array of media field input info.
+	 * @return array $post Unmodified post info.
+	 */
+	public static function save_attachement_settings( $post, $attachment ) {
+		if ( isset( $attachment[ self::FIELD_NAME ] ) ) {
+			if ( '1' === $attachment[ self::FIELD_NAME ] ) {
+				update_option( self::OPTION_NAME, wp_get_attachment_url( $post['ID'] ) );
+			} else {
+				delete_option( self::OPTION_NAME );
+			}
+		}
+
+		return $post;
+	}
+}
+Default_Image::init();

--- a/includes/class-default-image.php
+++ b/includes/class-default-image.php
@@ -36,17 +36,15 @@ class Default_Image {
 	 * Handle not found image.
 	 */
 	public static function handle_not_found_image() {
-		if ( is_404() ) {
-			if ( empty( $_SERVER['REQUEST_URI'] ) ) {
-				return;
-			}
-			$requested_url = $_SERVER['REQUEST_URI']; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-			if ( preg_match( '/\.(jpg|jpeg|png|gif|webp)$/i', $requested_url ) ) {
-				$default_image_url = get_option( self::OPTION_NAME );
-				if ( ! empty( $default_image_url ) ) {
-					wp_safe_redirect( $default_image_url, 301 );
-					exit;
-				}
+		if ( ! is_404() || empty( $_SERVER['REQUEST_URI'] ) ) {
+			return;
+		}
+		$requested_url = $_SERVER['REQUEST_URI']; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		if ( preg_match( '/\.(jpg|jpeg|png|gif|webp)$/i', $requested_url ) ) {
+			$default_image_url = get_option( self::OPTION_NAME );
+			if ( ! empty( $default_image_url ) ) {
+				wp_safe_redirect( $default_image_url, 301 );
+				exit;
 			}
 		}
 	}

--- a/includes/class-default-image.php
+++ b/includes/class-default-image.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Newspack News Revenue Hub feature management.
+ * Handles Default Image functionality.
  *
  * @package Newspack
  */

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -184,6 +184,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/class-patches.php';
 		include_once NEWSPACK_ABSPATH . 'includes/polyfills/class-amp-polyfills.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-performance.php';
+		include_once NEWSPACK_ABSPATH . 'includes/class-default-image.php';
 
 		include_once NEWSPACK_ABSPATH . 'includes/optional-modules/class-rss.php';
 		include_once NEWSPACK_ABSPATH . 'includes/optional-modules/class-media-partners.php';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a feature to designate an image in the media library as a "404 Not Found" image. This image will be served when the asset is not found.

<img width="409" alt="image" src="https://github.com/user-attachments/assets/1ea6c474-99e5-4cea-ac92-6c9408966107" />


### How to test the changes in this Pull Request:

1. Insert an image in a post, then remove the image in the media library
2. Visit the front-end, observe the image element is broken
3. Visit the media library, edit an image and mark it as the default image using the "Is default image?" option
4. Reload the front-end, observe the default image is now loaded
5. Load the post editor, observe that the default image is used there, too

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209600985817377