### PR TITLE
fix(ia): rerender subscription lists on esp provider update

### DIFF
--- a/src/wizards/newsletters/views/settings/index.js
+++ b/src/wizards/newsletters/views/settings/index.js
@@ -52,8 +52,13 @@ export const Settings = ( {
 		const newProvider = newslettersConfig?.newspack_newsletters_service_provider || '';
 		if ( provider !== newProvider ) {
 			setError( false );
-			setLockedLists( !! provider );
 			setProvider( newProvider );
+			if ( config?.settings?.newspack_newsletters_service_provider?.onboarding ) {
+				// We are onboarding, so we should always lock the lists until saved.
+				setLockedLists( true );
+			} else {
+				setLockedLists( !! provider );
+			}
 		}
 	}, [ newslettersConfig?.newspack_newsletters_service_provider ] );
 	// Verify token for OAuth providers.

--- a/src/wizards/newsletters/views/settings/index.js
+++ b/src/wizards/newsletters/views/settings/index.js
@@ -36,45 +36,42 @@ import './style.scss';
 
 export const Settings = ( {
 	onUpdate,
-	initialProvider,
 	newslettersConfig,
 	isOnboarding = true,
 	authUrl = false,
-	setInitialProvider = () => {},
+	provider,
+	setProvider = () => {},
 	setAuthUrl = () => {},
 	setLockedLists = () => {},
 } ) => {
 	const [ inFlight, setInFlight ] = useState( false );
 	const [ error, setError ] = useState( false );
 	const [ config, updateConfig ] = hooks.useObjectState( {} );
-
+	// Handle provider updates.
 	useEffect( () => {
-		const provider = newslettersConfig?.newspack_newsletters_service_provider;
-		if ( initialProvider && provider !== initialProvider ) {
-			setLockedLists( true );
-		} else {
-			setLockedLists( false );
-		}
-		if ( ! initialProvider && provider ) {
-			setInitialProvider( provider );
+		const newProvider = newslettersConfig?.newspack_newsletters_service_provider || '';
+		if ( provider !== newProvider ) {
+			setError( false );
+			setLockedLists( !! provider );
+			setProvider( newProvider );
 		}
 	}, [ newslettersConfig?.newspack_newsletters_service_provider ] );
-
+	// Verify token for OAuth providers.
 	useEffect( () => {
 		verifyToken( newslettersConfig?.newspack_newsletters_service_provider );
 	}, [ newslettersConfig?.newspack_newsletters_service_provider ] );
 
-	const verifyToken = provider => {
+	const verifyToken = serviceProvider => {
 		setAuthUrl( false );
-		if ( ! provider ) {
+		if ( ! serviceProvider ) {
 			return;
 		}
 		// Constant Contact is the only provider using an OAuth strategy.
-		if ( 'constant_contact' !== provider ) {
+		if ( 'constant_contact' !== serviceProvider ) {
 			return;
 		}
 		setInFlight( true );
-		apiFetch( { path: `/newspack-newsletters/v1/${ provider }/verify_token` } )
+		apiFetch( { path: `/newspack-newsletters/v1/${ serviceProvider }/verify_token` } )
 			.then( response => {
 				if ( ! response.valid && response.auth_url ) {
 					setAuthUrl( response.auth_url );
@@ -127,7 +124,7 @@ export const Settings = ( {
 			method: 'POST',
 			data: newslettersConfig,
 		} ).finally( () => {
-			setInitialProvider( newslettersConfig?.newspack_newsletters_service_provider );
+			setProvider( newslettersConfig?.newspack_newsletters_service_provider );
 			verifyToken( newslettersConfig?.newspack_newsletters_service_provider );
 			setLockedLists( false );
 			setInFlight( false );
@@ -254,7 +251,7 @@ export const Settings = ( {
 	);
 };
 
-export const SubscriptionLists = ( { lockedLists, onUpdate, initialProvider } ) => {
+export const SubscriptionLists = ( { lockedLists, onUpdate, provider } ) => {
 	const [ error, setError ] = useState( false );
 	const [ inFlight, setInFlight ] = useState( false );
 	const [ lists, setLists ] = useState( [] );
@@ -291,7 +288,18 @@ export const SubscriptionLists = ( { lockedLists, onUpdate, initialProvider } ) 
 		newLists[ index ][ name ] = value;
 		updateConfig( newLists );
 	};
-	useEffect( fetchLists, [ initialProvider ] );
+	// Handle provider updates.
+	useEffect(
+		() => {
+			setError( false );
+			if ( provider && ! lockedLists ) {
+				// Empty lists before fetching to prevent previous list from appearing while fetching.
+				setLists( [] );
+				fetchLists();
+			}
+		},
+		[ provider, lockedLists ]
+	);
 
 	if ( ! inFlight && ! lists?.length && ! error ) {
 		return null;
@@ -305,6 +313,16 @@ export const SubscriptionLists = ( { lockedLists, onUpdate, initialProvider } ) 
 		);
 	}
 
+	/* eslint-disable no-nested-ternary */
+	const notification = lockedLists ?
+		__(
+			'Please save your ESP settings before changing your subscription lists.',
+			'newspack-plugin'
+		) :
+		error ?
+			error?.message || __( 'Something went wrong.', 'newspack-plugin' ) :
+			null;
+
 	return (
 		<ActionCard
 			isMedium
@@ -313,16 +331,7 @@ export const SubscriptionLists = ( { lockedLists, onUpdate, initialProvider } ) 
 				'Manage the lists available to readers for subscription.',
 				'newspack-plugin'
 			) }
-			notification={
-				/* eslint-disable no-nested-ternary */
-				error
-					? error?.message || __( 'Something went wrong.', 'newspack-plugin' )
-					: lockedLists
-						? __(
-							'Please save your ESP settings before changing your subscription lists.',
-							'newspack-plugin'
-						) : null
-			}
+			notification={ notification }
 			notificationLevel={ error ? 'error' : 'warning' }
 			hasGreyHeader
 			actionContent={
@@ -343,7 +352,7 @@ export const SubscriptionLists = ( { lockedLists, onUpdate, initialProvider } ) 
 			}
 			disabled={ inFlight || lockedLists }
 		>
-			{ ! lockedLists &&
+			{ ! lockedLists && ! error &&
 				lists.map( ( list, index ) => (
 					<ActionCard
 						key={ index }
@@ -392,7 +401,7 @@ export const SubscriptionLists = ( { lockedLists, onUpdate, initialProvider } ) 
 
 const NewslettersSettings = () => {
 	const [ { newslettersConfig }, updateConfiguration ] = hooks.useObjectState( {} );
-	const [ initialProvider, setInitialProvider ] = useState( '' );
+	const [ provider, setProvider ] = useState( '' );
 	const [ lockedLists, setLockedLists ] = useState( false );
 	const [ authUrl, setAuthUrl ] = useState( false );
 
@@ -403,13 +412,13 @@ const NewslettersSettings = () => {
 				isOnboarding={ false }
 				onUpdate={ config => updateConfiguration( { newslettersConfig: config } ) }
 				authUrl={ authUrl }
-				setAuthUrl={ setAuthUrl }
 				newslettersConfig={ newslettersConfig }
+				provider={ provider }
+				setProvider={ setProvider }
+				setAuthUrl={ setAuthUrl }
 				setLockedLists={ setLockedLists }
-				initialProvider={ initialProvider }
-				setInitialProvider={ setInitialProvider }
 			/>
-			<SubscriptionLists lockedLists={ lockedLists } initialProvider={ initialProvider } />
+			<SubscriptionLists lockedLists={ lockedLists } provider={ provider } />
 		</>
 	);
 };

--- a/src/wizards/newsletters/views/settings/index.js
+++ b/src/wizards/newsletters/views/settings/index.js
@@ -53,7 +53,12 @@ export const Settings = ( {
 		if ( provider !== newProvider ) {
 			setError( false );
 			setProvider( newProvider );
-			setLockedLists( !! provider );
+			// Don't lock lists if we are setting the initial provider and a key is already set.
+			if ( ! provider && hasSelectedProviderKey() ) {
+				setLockedLists( false );
+			} else {
+				setLockedLists( true );
+			}
 		}
 	}, [ newslettersConfig?.newspack_newsletters_service_provider ] );
 	// Verify token for OAuth providers.
@@ -106,6 +111,15 @@ export const Settings = ( {
 		const value = configItem?.value;
 		return configItem?.options?.find( option => option.value === value )?.name;
 	};
+	const hasSelectedProviderKey = () => {
+		const selectedProvider = newslettersConfig?.newspack_newsletters_service_provider;
+		if ( ! selectedProvider ) {
+			return false
+		}
+		const regex = new RegExp( `${selectedProvider}.*key` );
+		const configKeys = Object.keys( newslettersConfig ).filter( key => regex.test( key ) );
+		return configKeys.some( key => !! newslettersConfig[ key ] );
+	}
 	const handleAuth = () => {
 		if ( authUrl ) {
 			const authWindow = window.open( authUrl, 'esp_oauth', 'width=500,height=600' );

--- a/src/wizards/newsletters/views/settings/index.js
+++ b/src/wizards/newsletters/views/settings/index.js
@@ -53,12 +53,7 @@ export const Settings = ( {
 		if ( provider !== newProvider ) {
 			setError( false );
 			setProvider( newProvider );
-			if ( config?.settings?.newspack_newsletters_service_provider?.onboarding ) {
-				// We are onboarding, so we should always lock the lists until saved.
-				setLockedLists( true );
-			} else {
-				setLockedLists( !! provider );
-			}
+			setLockedLists( !! provider );
 		}
 	}, [ newslettersConfig?.newspack_newsletters_service_provider ] );
 	// Verify token for OAuth providers.


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/1/26890605006346/project/1205919985867982/task/1209464932054166?focus=true

This PR fixes an issue where updating a provider does not always refresh the subscriptions lists associated with that provider until a page reload. This happened because subscriptions lists would rerender when the provider was updated, but before api credentials were stored and settings were saved. As a result updating the provider would cause the subscriptions lists to fetch using the outdated provider details.

We fix this by:
- Only rerendering subscriptions lists when provider updates AND lists are not locked
- Correctly locking lists depending on provider update conditions

![Screenshot 2025-03-12 at 11 47 40](https://github.com/user-attachments/assets/89b97044-7bcc-42ac-a72a-9ac7d8c60cc2)


### How to test the changes in this Pull Request:

**Onboarding**
1. Reset newspack via the `reset newspack` link at the bottom of any wizard
![Screenshot 2025-03-12 at 11 48 42](https://github.com/user-attachments/assets/4c77b964-6508-4d9e-9817-c9c4a55d821e)
2. Navigate to Audience > Setup > Email Service Provider, and click the button to do the ESP step
3. Confirm the subscriptions lists section is not visible
4. Select an ESP provider and enter valid credentials
5. Confirm the subscriptions lists section appears and renders the expected lists

**Switching Providers**
1. Select a different provider
2. Confirm the subscriptions lists section renders a warning to save before editing subscriptions lists
3. Enter valid credentials for the new ESP
4. Confirm the subscriptions lists section renders the expected lists after loading

Bonus: Smoke test the ESP and Subscriptions Lists settings with invalid credentials, etc.


### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->