### PR TITLE
fix(ia): audience wizard without activation

### DIFF
--- a/includes/wizards/audience/class-audience-wizard.php
+++ b/includes/wizards/audience/class-audience-wizard.php
@@ -67,7 +67,9 @@ class Audience_Wizard extends Wizard {
 	 * @return string The wizard name.
 	 */
 	public function get_name() {
-		return esc_html__( 'Audience Management / Setup', 'newspack-plugin' );
+		return Reader_Activation::is_enabled() ?
+			esc_html__( 'Audience Management / Configuration', 'newspack-plugin' ) :
+			esc_html__( 'Audience Management / Setup', 'newspack-plugin' );
 	}
 
 	/**
@@ -136,7 +138,9 @@ class Audience_Wizard extends Wizard {
 		add_submenu_page(
 			$this->slug,
 			$this->get_name(),
-			__( 'Setup', 'newspack-plugin' ),
+			Reader_Activation::is_enabled() ?
+				__( 'Configuration', 'newspack-plugin' ) :
+				__( 'Setup', 'newspack-plugin' ),
 			$this->capability,
 			$this->slug,
 			[ $this, 'render_wizard' ]

--- a/src/wizards/audience/views/setup/index.js
+++ b/src/wizards/audience/views/setup/index.js
@@ -103,29 +103,25 @@ function AudienceWizard( { confirmAction, pluginRequirements, wizardApiFetch } )
 
 	const emails = Object.values( config.emails || {} );
 
-	let tabs = null;
-
-	if ( config.enabled ) {
-		tabs = [
-			{
-				label: __( 'Setup', 'newspack-plugin' ),
-				path: '/',
-			},
-			newspackAudience.has_memberships && {
-				label: __( 'Content Gating', 'newspack-plugin' ),
-				path: '/content-gating',
-			},
-			emails.length > 0 && {
-				label: __( 'Transactional Emails', 'newspack-plugin' ),
-				path: '/transactional-emails',
-			},
-			{
-				label: __( 'Checkout & Payment', 'newspack-plugin' ),
-				path: '/payment',
-			},
-		];
-		tabs = tabs.filter( tab => tab );
-	}
+	let tabs = [
+		{
+			label: config.enabled ? __( 'Configuration', 'newspack-plugin' ) : __( 'Setup', 'newspack-plugin' ),
+			path: '/',
+		},
+		( config.enabled && newspackAudience.has_memberships ) && {
+			label: __( 'Content Gating', 'newspack-plugin' ),
+			path: '/content-gating',
+		},
+		( config.enabled && emails.length > 0 ) && {
+			label: __( 'Transactional Emails', 'newspack-plugin' ),
+			path: '/transactional-emails',
+		},
+		{
+			label: __( 'Checkout & Payment', 'newspack-plugin' ),
+			path: '/payment',
+		},
+	];
+	tabs = tabs.filter( tab => tab );
 
 	const getSharedProps = ( configKey, type = 'checkbox' ) => {
 		const props = {

--- a/src/wizards/audience/views/setup/setup.js
+++ b/src/wizards/audience/views/setup/setup.js
@@ -179,212 +179,214 @@ export default withWizardScreen(
 						skipPrerequisite={ skipPrerequisite }
 					/>
 				) ) }
-			{ config.enabled && (
-				<Card noBorder>
-					<hr />
-					<SectionHeader
-						title={ __(
-							'Newsletter Subscription Lists',
-							'newspack-plugin'
-						) }
-					/>
-					<ActionCard
-						title={ __(
-							'Present newsletter signup after checkout and registration',
-							'newspack-plugin'
-						) }
-						description={ __(
-							'Ask readers to sign up for newsletters after creating an account or completing a purchase.',
-							'newspack-plugin'
-						) }
-						toggleChecked={ config.use_custom_lists }
-						toggleOnChange={ value =>
-							updateConfig( 'use_custom_lists', value )
-						}
-					/>
-					{ config.use_custom_lists && (
-						<SortableNewsletterListControl
-							lists={
-								newspackAudience.available_newsletter_lists
-							}
-							selected={ config.newsletter_lists }
-							onChange={ selected =>
-								updateConfig( 'newsletter_lists', selected )
-							}
-						/>
-					) }
-
-					<hr />
-
-					<SectionHeader
-						title={ __(
-							'Email Service Provider (ESP) Advanced Settings',
-							'newspack-plugin'
-						) }
-						description={ __(
-							'Settings for Newspack Newsletters integration.',
-							'newspack-plugin'
-						) }
-					/>
-					<TextControl
-						label={ __(
-							'Newsletter subscription text on registration',
-							'newspack-plugin'
-						) }
-						help={ __(
-							'The text to display while subscribing to newsletters from the sign-in modal.',
-							'newspack-plugin'
-						) }
-						{ ...getSharedProps( 'newsletters_label', 'text' ) }
-					/>
-					<ActionCard
-						description={ __(
-							'Configure options for syncing reader data to the connected ESP.',
-							'newspack-plugin'
-						) }
-						hasGreyHeader={ true }
-						isMedium
-						title={ __(
-							'Sync contacts to ESP',
-							'newspack-plugin'
-						) }
-						toggleChecked={ config.sync_esp }
-						toggleOnChange={ value =>
-							updateConfig( 'sync_esp', value )
-						}
-					>
-						{ config.sync_esp && (
-							<>
-								{ 0 < Object.keys( espSyncErrors ).length && (
-									<Notice
-										noticeText={ Object.values(
-											espSyncErrors
-										).join( ' ' ) }
-										isError
-									/>
-								) }
-								{ isMailchimp && (
-									<Mailchimp
-										value={ {
-											audienceId:
-												config.mailchimp_audience_id,
-											readerDefaultStatus:
-												config.mailchimp_reader_default_status,
-										} }
-										onChange={ ( key, value ) => {
-											if ( key === 'audienceId' ) {
-												updateConfig(
-													'mailchimp_audience_id',
-													value
-												);
-											}
-											if (
-												key === 'readerDefaultStatus'
-											) {
-												updateConfig(
-													'mailchimp_reader_default_status',
-													value
-												);
-											}
-										} }
-									/>
-								) }
-								{ isActiveCampaign && (
-									<ActiveCampaign
-										value={ {
-											masterList:
-												config.active_campaign_master_list,
-										} }
-										onChange={ ( key, value ) => {
-											if ( key === 'masterList' ) {
-												updateConfig(
-													'active_campaign_master_list',
-													value
-												);
-											}
-										} }
-									/>
-								) }
-								<MetadataFields
-									availableFields={
-										newspackAudience.esp_metadata_fields ||
-										[]
-									}
-									selectedFields={ config.metadata_fields }
-									updateConfig={ updateConfig }
-									getSharedProps={ getSharedProps }
-								/>
-							</>
-						) }
-					</ActionCard>
-					<div className="newspack-buttons-card">
-						<Button
-							isPrimary
-							onClick={ () => {
-								if ( config.sync_esp ) {
-									if (
-										isMailchimp &&
-										config.mailchimp_audience_id === ''
-									) {
-										// eslint-disable-next-line no-alert
-										alert(
-											__(
-												'Please select a Mailchimp Audience ID.',
-												'newspack-plugin'
-											)
-										);
-										return;
-									}
-									if (
-										isActiveCampaign &&
-										config.active_campaign_master_list ===
-											''
-									) {
-										// eslint-disable-next-line no-alert
-										alert(
-											__(
-												'Please select an ActiveCampaign Master List.',
-												'newspack-plugin'
-											)
-										);
-										return;
-									}
-								}
-								saveConfig( {
-									newsletters_label: config.newsletters_label, // TODO: Deprecate this in favor of user input via the prompt copy wizard.
-									mailchimp_audience_id:
-										config.mailchimp_audience_id,
-									mailchimp_reader_default_status:
-										config.mailchimp_reader_default_status,
-									active_campaign_master_list:
-										config.active_campaign_master_list,
-									use_custom_lists: config.use_custom_lists,
-									newsletter_lists: config.newsletter_lists,
-									sync_esp: config.sync_esp,
-									metadata_fields: config.metadata_fields,
-									metadata_prefix: config.metadata_prefix,
-									woocommerce_registration_required: config.woocommerce_registration_required,
-									woocommerce_checkout_privacy_policy_text: config.woocommerce_checkout_privacy_policy_text,
-									woocommerce_post_checkout_success_text: config.woocommerce_post_checkout_success_text,
-									woocommerce_post_checkout_registration_success_text: config.woocommerce_post_checkout_registration_success_text,
-								} );
-							} }
-							disabled={ inFlight }
-						>
-							{ __(
-								'Save Settings',
+			<Card noBorder>
+				{ config.enabled && (
+					<>
+						<hr />
+						<SectionHeader
+							title={ __(
+								'Newsletter Subscription Lists',
 								'newspack-plugin'
 							) }
-						</Button>
-					</div>
-					{ newspackAudience.can_use_salesforce && (
-						<>
-							<hr />
-							<Salesforce />
-						</>
-					) }
-				</Card>
-			) }
+						/>
+						<ActionCard
+							title={ __(
+								'Present newsletter signup after checkout and registration',
+								'newspack-plugin'
+							) }
+							description={ __(
+								'Ask readers to sign up for newsletters after creating an account or completing a purchase.',
+								'newspack-plugin'
+							) }
+							toggleChecked={ config.use_custom_lists }
+							toggleOnChange={ value =>
+								updateConfig( 'use_custom_lists', value )
+							}
+						/>
+						{ config.use_custom_lists && (
+							<SortableNewsletterListControl
+								lists={
+									newspackAudience.available_newsletter_lists
+								}
+								selected={ config.newsletter_lists }
+								onChange={ selected =>
+									updateConfig( 'newsletter_lists', selected )
+								}
+							/>
+						) }
+
+						<hr />
+
+						<SectionHeader
+							title={ __(
+								'Email Service Provider (ESP) Advanced Settings',
+								'newspack-plugin'
+							) }
+							description={ __(
+								'Settings for Newspack Newsletters integration.',
+								'newspack-plugin'
+							) }
+						/>
+						<TextControl
+							label={ __(
+								'Newsletter subscription text on registration',
+								'newspack-plugin'
+							) }
+							help={ __(
+								'The text to display while subscribing to newsletters from the sign-in modal.',
+								'newspack-plugin'
+							) }
+							{ ...getSharedProps( 'newsletters_label', 'text' ) }
+						/>
+						<ActionCard
+							description={ __(
+								'Configure options for syncing reader data to the connected ESP.',
+								'newspack-plugin'
+							) }
+							hasGreyHeader={ true }
+							isMedium
+							title={ __(
+								'Sync contacts to ESP',
+								'newspack-plugin'
+							) }
+							toggleChecked={ config.sync_esp }
+							toggleOnChange={ value =>
+								updateConfig( 'sync_esp', value )
+							}
+						>
+							{ config.sync_esp && (
+								<>
+									{ 0 < Object.keys( espSyncErrors ).length && (
+										<Notice
+											noticeText={ Object.values(
+												espSyncErrors
+											).join( ' ' ) }
+											isError
+										/>
+									) }
+									{ isMailchimp && (
+										<Mailchimp
+											value={ {
+												audienceId:
+													config.mailchimp_audience_id,
+												readerDefaultStatus:
+													config.mailchimp_reader_default_status,
+											} }
+											onChange={ ( key, value ) => {
+												if ( key === 'audienceId' ) {
+													updateConfig(
+														'mailchimp_audience_id',
+														value
+													);
+												}
+												if (
+													key === 'readerDefaultStatus'
+												) {
+													updateConfig(
+														'mailchimp_reader_default_status',
+														value
+													);
+												}
+											} }
+										/>
+									) }
+									{ isActiveCampaign && (
+										<ActiveCampaign
+											value={ {
+												masterList:
+													config.active_campaign_master_list,
+											} }
+											onChange={ ( key, value ) => {
+												if ( key === 'masterList' ) {
+													updateConfig(
+														'active_campaign_master_list',
+														value
+													);
+												}
+											} }
+										/>
+									) }
+									<MetadataFields
+										availableFields={
+											newspackAudience.esp_metadata_fields ||
+											[]
+										}
+										selectedFields={ config.metadata_fields }
+										updateConfig={ updateConfig }
+										getSharedProps={ getSharedProps }
+									/>
+								</>
+							) }
+						</ActionCard>
+						<div className="newspack-buttons-card">
+							<Button
+								isPrimary
+								onClick={ () => {
+									if ( config.sync_esp ) {
+										if (
+											isMailchimp &&
+											config.mailchimp_audience_id === ''
+										) {
+											// eslint-disable-next-line no-alert
+											alert(
+												__(
+													'Please select a Mailchimp Audience ID.',
+													'newspack-plugin'
+												)
+											);
+											return;
+										}
+										if (
+											isActiveCampaign &&
+											config.active_campaign_master_list ===
+												''
+										) {
+											// eslint-disable-next-line no-alert
+											alert(
+												__(
+													'Please select an ActiveCampaign Master List.',
+													'newspack-plugin'
+												)
+											);
+											return;
+										}
+									}
+									saveConfig( {
+										newsletters_label: config.newsletters_label, // TODO: Deprecate this in favor of user input via the prompt copy wizard.
+										mailchimp_audience_id:
+											config.mailchimp_audience_id,
+										mailchimp_reader_default_status:
+											config.mailchimp_reader_default_status,
+										active_campaign_master_list:
+											config.active_campaign_master_list,
+										use_custom_lists: config.use_custom_lists,
+										newsletter_lists: config.newsletter_lists,
+										sync_esp: config.sync_esp,
+										metadata_fields: config.metadata_fields,
+										metadata_prefix: config.metadata_prefix,
+										woocommerce_registration_required: config.woocommerce_registration_required,
+										woocommerce_checkout_privacy_policy_text: config.woocommerce_checkout_privacy_policy_text,
+										woocommerce_post_checkout_success_text: config.woocommerce_post_checkout_success_text,
+										woocommerce_post_checkout_registration_success_text: config.woocommerce_post_checkout_registration_success_text,
+									} );
+								} }
+								disabled={ inFlight }
+							>
+								{ __(
+									'Save Settings',
+									'newspack-plugin'
+								) }
+							</Button>
+						</div>
+					</>
+				) }
+				{ newspackAudience.can_use_salesforce && (
+					<>
+						<hr />
+						<Salesforce />
+					</>
+				) }
+			</Card>
 		</WizardsTab>
 	);
 } );

--- a/src/wizards/audience/views/setup/setup.js
+++ b/src/wizards/audience/views/setup/setup.js
@@ -179,214 +179,212 @@ export default withWizardScreen(
 						skipPrerequisite={ skipPrerequisite }
 					/>
 				) ) }
-			<Card noBorder>
-				{ config.enabled && (
-					<>
-						<hr />
-						<SectionHeader
-							title={ __(
-								'Newsletter Subscription Lists',
-								'newspack-plugin'
-							) }
-						/>
-						<ActionCard
-							title={ __(
-								'Present newsletter signup after checkout and registration',
-								'newspack-plugin'
-							) }
-							description={ __(
-								'Ask readers to sign up for newsletters after creating an account or completing a purchase.',
-								'newspack-plugin'
-							) }
-							toggleChecked={ config.use_custom_lists }
-							toggleOnChange={ value =>
-								updateConfig( 'use_custom_lists', value )
-							}
-						/>
-						{ config.use_custom_lists && (
-							<SortableNewsletterListControl
-								lists={
-									newspackAudience.available_newsletter_lists
-								}
-								selected={ config.newsletter_lists }
-								onChange={ selected =>
-									updateConfig( 'newsletter_lists', selected )
-								}
-							/>
+			{ config.enabled && (
+				<Card noBorder>
+					<hr />
+					<SectionHeader
+						title={ __(
+							'Newsletter Subscription Lists',
+							'newspack-plugin'
 						) }
-
-						<hr />
-
-						<SectionHeader
-							title={ __(
-								'Email Service Provider (ESP) Advanced Settings',
-								'newspack-plugin'
-							) }
-							description={ __(
-								'Settings for Newspack Newsletters integration.',
-								'newspack-plugin'
-							) }
-						/>
-						<TextControl
-							label={ __(
-								'Newsletter subscription text on registration',
-								'newspack-plugin'
-							) }
-							help={ __(
-								'The text to display while subscribing to newsletters from the sign-in modal.',
-								'newspack-plugin'
-							) }
-							{ ...getSharedProps( 'newsletters_label', 'text' ) }
-						/>
-						<ActionCard
-							description={ __(
-								'Configure options for syncing reader data to the connected ESP.',
-								'newspack-plugin'
-							) }
-							hasGreyHeader={ true }
-							isMedium
-							title={ __(
-								'Sync contacts to ESP',
-								'newspack-plugin'
-							) }
-							toggleChecked={ config.sync_esp }
-							toggleOnChange={ value =>
-								updateConfig( 'sync_esp', value )
+					/>
+					<ActionCard
+						title={ __(
+							'Present newsletter signup after checkout and registration',
+							'newspack-plugin'
+						) }
+						description={ __(
+							'Ask readers to sign up for newsletters after creating an account or completing a purchase.',
+							'newspack-plugin'
+						) }
+						toggleChecked={ config.use_custom_lists }
+						toggleOnChange={ value =>
+							updateConfig( 'use_custom_lists', value )
+						}
+					/>
+					{ config.use_custom_lists && (
+						<SortableNewsletterListControl
+							lists={
+								newspackAudience.available_newsletter_lists
 							}
-						>
-							{ config.sync_esp && (
-								<>
-									{ 0 < Object.keys( espSyncErrors ).length && (
-										<Notice
-											noticeText={ Object.values(
-												espSyncErrors
-											).join( ' ' ) }
-											isError
-										/>
-									) }
-									{ isMailchimp && (
-										<Mailchimp
-											value={ {
-												audienceId:
-													config.mailchimp_audience_id,
-												readerDefaultStatus:
-													config.mailchimp_reader_default_status,
-											} }
-											onChange={ ( key, value ) => {
-												if ( key === 'audienceId' ) {
-													updateConfig(
-														'mailchimp_audience_id',
-														value
-													);
-												}
-												if (
-													key === 'readerDefaultStatus'
-												) {
-													updateConfig(
-														'mailchimp_reader_default_status',
-														value
-													);
-												}
-											} }
-										/>
-									) }
-									{ isActiveCampaign && (
-										<ActiveCampaign
-											value={ {
-												masterList:
-													config.active_campaign_master_list,
-											} }
-											onChange={ ( key, value ) => {
-												if ( key === 'masterList' ) {
-													updateConfig(
-														'active_campaign_master_list',
-														value
-													);
-												}
-											} }
-										/>
-									) }
-									<MetadataFields
-										availableFields={
-											newspackAudience.esp_metadata_fields ||
-											[]
-										}
-										selectedFields={ config.metadata_fields }
-										updateConfig={ updateConfig }
-										getSharedProps={ getSharedProps }
+							selected={ config.newsletter_lists }
+							onChange={ selected =>
+								updateConfig( 'newsletter_lists', selected )
+							}
+						/>
+					) }
+
+					<hr />
+
+					<SectionHeader
+						title={ __(
+							'Email Service Provider (ESP) Advanced Settings',
+							'newspack-plugin'
+						) }
+						description={ __(
+							'Settings for Newspack Newsletters integration.',
+							'newspack-plugin'
+						) }
+					/>
+					<TextControl
+						label={ __(
+							'Newsletter subscription text on registration',
+							'newspack-plugin'
+						) }
+						help={ __(
+							'The text to display while subscribing to newsletters from the sign-in modal.',
+							'newspack-plugin'
+						) }
+						{ ...getSharedProps( 'newsletters_label', 'text' ) }
+					/>
+					<ActionCard
+						description={ __(
+							'Configure options for syncing reader data to the connected ESP.',
+							'newspack-plugin'
+						) }
+						hasGreyHeader={ true }
+						isMedium
+						title={ __(
+							'Sync contacts to ESP',
+							'newspack-plugin'
+						) }
+						toggleChecked={ config.sync_esp }
+						toggleOnChange={ value =>
+							updateConfig( 'sync_esp', value )
+						}
+					>
+						{ config.sync_esp && (
+							<>
+								{ 0 < Object.keys( espSyncErrors ).length && (
+									<Notice
+										noticeText={ Object.values(
+											espSyncErrors
+										).join( ' ' ) }
+										isError
 									/>
-								</>
-							) }
-						</ActionCard>
-						<div className="newspack-buttons-card">
-							<Button
-								isPrimary
-								onClick={ () => {
-									if ( config.sync_esp ) {
-										if (
-											isMailchimp &&
-											config.mailchimp_audience_id === ''
-										) {
-											// eslint-disable-next-line no-alert
-											alert(
-												__(
-													'Please select a Mailchimp Audience ID.',
-													'newspack-plugin'
-												)
-											);
-											return;
-										}
-										if (
-											isActiveCampaign &&
-											config.active_campaign_master_list ===
-												''
-										) {
-											// eslint-disable-next-line no-alert
-											alert(
-												__(
-													'Please select an ActiveCampaign Master List.',
-													'newspack-plugin'
-												)
-											);
-											return;
-										}
-									}
-									saveConfig( {
-										newsletters_label: config.newsletters_label, // TODO: Deprecate this in favor of user input via the prompt copy wizard.
-										mailchimp_audience_id:
-											config.mailchimp_audience_id,
-										mailchimp_reader_default_status:
-											config.mailchimp_reader_default_status,
-										active_campaign_master_list:
-											config.active_campaign_master_list,
-										use_custom_lists: config.use_custom_lists,
-										newsletter_lists: config.newsletter_lists,
-										sync_esp: config.sync_esp,
-										metadata_fields: config.metadata_fields,
-										metadata_prefix: config.metadata_prefix,
-										woocommerce_registration_required: config.woocommerce_registration_required,
-										woocommerce_checkout_privacy_policy_text: config.woocommerce_checkout_privacy_policy_text,
-										woocommerce_post_checkout_success_text: config.woocommerce_post_checkout_success_text,
-										woocommerce_post_checkout_registration_success_text: config.woocommerce_post_checkout_registration_success_text,
-									} );
-								} }
-								disabled={ inFlight }
-							>
-								{ __(
-									'Save Settings',
-									'newspack-plugin'
 								) }
-							</Button>
-						</div>
-					</>
-				) }
-				{ newspackAudience.can_use_salesforce && (
-					<>
-						<hr />
-						<Salesforce />
-					</>
-				) }
-			</Card>
+								{ isMailchimp && (
+									<Mailchimp
+										value={ {
+											audienceId:
+												config.mailchimp_audience_id,
+											readerDefaultStatus:
+												config.mailchimp_reader_default_status,
+										} }
+										onChange={ ( key, value ) => {
+											if ( key === 'audienceId' ) {
+												updateConfig(
+													'mailchimp_audience_id',
+													value
+												);
+											}
+											if (
+												key === 'readerDefaultStatus'
+											) {
+												updateConfig(
+													'mailchimp_reader_default_status',
+													value
+												);
+											}
+										} }
+									/>
+								) }
+								{ isActiveCampaign && (
+									<ActiveCampaign
+										value={ {
+											masterList:
+												config.active_campaign_master_list,
+										} }
+										onChange={ ( key, value ) => {
+											if ( key === 'masterList' ) {
+												updateConfig(
+													'active_campaign_master_list',
+													value
+												);
+											}
+										} }
+									/>
+								) }
+								<MetadataFields
+									availableFields={
+										newspackAudience.esp_metadata_fields ||
+										[]
+									}
+									selectedFields={ config.metadata_fields }
+									updateConfig={ updateConfig }
+									getSharedProps={ getSharedProps }
+								/>
+							</>
+						) }
+					</ActionCard>
+					<div className="newspack-buttons-card">
+						<Button
+							isPrimary
+							onClick={ () => {
+								if ( config.sync_esp ) {
+									if (
+										isMailchimp &&
+										config.mailchimp_audience_id === ''
+									) {
+										// eslint-disable-next-line no-alert
+										alert(
+											__(
+												'Please select a Mailchimp Audience ID.',
+												'newspack-plugin'
+											)
+										);
+										return;
+									}
+									if (
+										isActiveCampaign &&
+										config.active_campaign_master_list ===
+											''
+									) {
+										// eslint-disable-next-line no-alert
+										alert(
+											__(
+												'Please select an ActiveCampaign Master List.',
+												'newspack-plugin'
+											)
+										);
+										return;
+									}
+								}
+								saveConfig( {
+									newsletters_label: config.newsletters_label, // TODO: Deprecate this in favor of user input via the prompt copy wizard.
+									mailchimp_audience_id:
+										config.mailchimp_audience_id,
+									mailchimp_reader_default_status:
+										config.mailchimp_reader_default_status,
+									active_campaign_master_list:
+										config.active_campaign_master_list,
+									use_custom_lists: config.use_custom_lists,
+									newsletter_lists: config.newsletter_lists,
+									sync_esp: config.sync_esp,
+									metadata_fields: config.metadata_fields,
+									metadata_prefix: config.metadata_prefix,
+									woocommerce_registration_required: config.woocommerce_registration_required,
+									woocommerce_checkout_privacy_policy_text: config.woocommerce_checkout_privacy_policy_text,
+									woocommerce_post_checkout_success_text: config.woocommerce_post_checkout_success_text,
+									woocommerce_post_checkout_registration_success_text: config.woocommerce_post_checkout_registration_success_text,
+								} );
+							} }
+							disabled={ inFlight }
+						>
+							{ __(
+								'Save Settings',
+								'newspack-plugin'
+							) }
+						</Button>
+					</div>
+				</Card>
+			) }
+			{ newspackAudience.can_use_salesforce && (
+				<Card noBorder>
+					<hr />
+					<Salesforce />
+				</Card>
+			) }
 		</WizardsTab>
 	);
 } );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The audience wizard does not render anything other than the Audience Management setup when its not activated. Not all publishers will set it up but should still use the Salesforce integration and the "Checkout & Payment" tab.

This PR fixes that behavior and also tweaks the labels to render "Setup" in the menu item and tab only when deactivated. It should render "Configuration" once activated.

### How to test the changes in this Pull Request:

1. Deactivate audience management: `wp option delete newspack_reader_activation_enabled`
2. Visit the "Audience -> Setup" wizard and confirm the "Salesforce" section renders as well as the Checkout & Payment tab
3. Activate audience management and confirm the menu item and tab changed from "Setup" to "Configuration" and all the other components render

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->