### PR TITLE
fix: making `get_post()` is not `null` before attempting to read props

### DIFF
--- a/includes/data-events/connectors/ga4/class-ga4.php
+++ b/includes/data-events/connectors/ga4/class-ga4.php
@@ -184,7 +184,7 @@ class GA4 {
 					get_coauthors()
 				)
 			);
-		} else {
+		} elseif ( null !== get_post() && is_numeric( get_post()->post_author ) ) {
 			// For some reason, get_the_author() does not work here.
 			$author_user = get_user_by( 'ID', get_post()->post_author );
 			if ( $author_user ) {

--- a/includes/data-events/connectors/ga4/class-ga4.php
+++ b/includes/data-events/connectors/ga4/class-ga4.php
@@ -184,11 +184,14 @@ class GA4 {
 					get_coauthors()
 				)
 			);
-		} elseif ( null !== get_post() && is_numeric( get_post()->post_author ) ) {
-			// For some reason, get_the_author() does not work here.
-			$author_user = get_user_by( 'ID', get_post()->post_author );
-			if ( $author_user ) {
-				$author_name = $author_user->display_name;
+		} else {
+			$post = get_post();
+			if ( null !== $post && is_numeric( $post->post_author ) ) {
+				// For some reason, get_the_author() does not work here.
+				$author_user = get_user_by( 'ID', $post->post_author );
+				if ( $author_user ) {
+					$author_name = $author_user->display_name;
+				}
 			}
 		}
 		if ( ! empty( $author_name ) ) {


### PR DESCRIPTION
This line was leading to many error log entries. It seems `get_post()` can be null at times. Perhaps this requires a deeper fix to investigate when this is being run? Should `get_post()` ever be returning `null`?

### All Submissions:

* [X] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:
Stops polluting the error logs.

### How to test the changes in this Pull Request:

1. Activate this plugin.
2. Tail the error log `tail -f /tmp/php-errrors`
3. Visit any number of posts/pages.
4. Notice the warnings: `PHP Warning:  Attempt to read property "post_author" on null in /wordpress/plugins/newspack-plugin/6.0.3/includes/data-events/connectors/ga4/class-ga4.php on line 189`
5. Checkout out this branch.
6. Reload the opened posts/pages.
7. Notice that the warnings are not thrown again.

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
