### PR TITLE
fix: auth modal issues with content gating

### DIFF
--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -759,9 +759,8 @@ class Memberships {
 	/**
 	 * Render footer JS.
 	 *
-	 * If the gate was rendered, reload the page after 2 seconds in case RAS
-	 * detects a new reader. This allows the membership purchase to unlock the
-	 * content.
+	 * If the gate was rendered, reload the page after a new reader is detected.
+	 * This allows the membership purchase to unlock the content.
 	 */
 	public static function render_js() {
 		if ( ! self::$gate_rendered ) {
@@ -774,15 +773,18 @@ class Memberships {
 				ras.on( 'reader', function( ev ) {
 					if ( ev.detail.authenticated && ! window?.newspackReaderActivation?.getPendingCheckout() ) {
 						if ( ras.overlays.get().length ) {
+							// When an overlay is added or removed,
+							// check if there are none – this means an overlay was removed and there are none left.
+							// In this case, reload the window.
 							ras.on( 'overlay', function( ev ) {
-								if ( ! ev.detail.overlays.length && ! window?.newspackReaderActivation?.openNewslettersSignupModal ) {
+								if ( ! ev.detail.overlays.length ) {
 									window.location.reload();
 								}
 							} );
 						} else {
 							setTimeout( function() {
 								window.location.reload();
-							}, 2000 );
+							}, 2000 ); // HACK: 2s delay to allow the purchase to be processed.
 						}
 					}
 				} );

--- a/src/reader-activation-auth/index.js
+++ b/src/reader-activation-auth/index.js
@@ -32,7 +32,7 @@ window.newspackRAS.push( readerActivation => {
 				}
 
 				container.setFormAction( currentHash === 'register_modal' ? 'register' : 'signin' );
-				openAuthModal();
+				openAuthModal( { closeOnSuccess: true } );
 			}
 		}
 		window.addEventListener( 'hashchange', handleHashChange );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an issue with the "Continue" button being unresponsive when the hash-triggered auth modal was used.

### How to test the changes in this Pull Request:

1. On `trunk`,
1. Ensure RAS is configured
2. Create a membership plan that is restricted by registration, and set it to restrict all posts
3. Edit the content gate and insert a registration button there – a button and set the link to `#register_modal`
1. On a different page (which won't be content gated), also insert the registration button
4. On the frontend, visit that page and click the button. Insert and email and click "Continue"
5. After the registration completes, the modal will progress to the success state
6. Observe that the "Continue" button there does not work
7. Now visit a content-gate post – use the button to register and observe the same issue
8. Switch to this branch
9. Observe that on the success state, the modal "Continue" button:
    1. Closes the modal on the regular page
    2. Closes the modal and reloads the page – so the gate is lifted – on the restricted post

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209599296873194