### PR TITLE
feat(patches): Allow media library access for authors

### DIFF
--- a/includes/class-patches.php
+++ b/includes/class-patches.php
@@ -419,9 +419,10 @@ class Patches {
 	 * @return array Filtered query args.
 	 */
 	public static function restrict_media_library_access_ajax( $query_args ) {
-		$current_user_id = get_current_user_id();
+		$current_user    = wp_get_current_user();
+		$current_user_id = $current_user->ID;
 
-		if ( $current_user_id && ! current_user_can( 'edit_others_posts' ) && ! current_user_can( 'edit_files' ) ) {
+		if ( $current_user_id && ! current_user_can( 'edit_others_posts' ) && ! current_user_can( 'edit_files' ) && ! in_array( 'author', $current_user->roles, true ) ) {
 			$query_args['author'] = $current_user_id;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
Along with the check for specific permissions to restrict media access to certain capabilities, relax author role.

Addressed Issue #1 of https://app.asana.com/1/26890605006346/task/1208711018003751?focus=true

### How to test the changes in this Pull Request:

1. Upload some images as an admin user.
2. Add an author user. Log in as that user.
3. Check that in both the Media Library (from the dashboard) and the block editor, you can access all media library items.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->