### PR TITLE
feat: enable email change for newspack users

### DIFF
--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -795,8 +795,8 @@ class WooCommerce_My_Account {
 	 * Whether email changes are enabled.
 	 */
 	public static function is_email_change_enabled() {
-		if ( class_exists( '\Newspack_Manager\Features' ) ) {
-			return \Newspack_Manager\Features::is_newspack_user();
+		if ( class_exists( '\Newspack_Manager\Features' ) && \Newspack_Manager\Features::is_automattician() ) {
+			return true;
 		}
 		$is_enabled = defined( 'NEWSPACK_EMAIL_CHANGE_ENABLED' ) && NEWSPACK_EMAIL_CHANGE_ENABLED;
 		/**

--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -795,6 +795,9 @@ class WooCommerce_My_Account {
 	 * Whether email changes are enabled.
 	 */
 	public static function is_email_change_enabled() {
+		if ( class_exists( '\Newspack_Manager\Features' ) ) {
+			return \Newspack_Manager\Features::is_newspack_user();
+		}
 		$is_enabled = defined( 'NEWSPACK_EMAIL_CHANGE_ENABLED' ) && NEWSPACK_EMAIL_CHANGE_ENABLED;
 		/**
 		 * Filters whether or not to allow email changes in My Account.


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Goes with https://github.com/Automattic/newspack-manager/pull/331

This PR enables the email change feature for all newspack users.

![Screenshot 2025-03-12 at 15 44 25](https://github.com/user-attachments/assets/d9ed0d0b-313e-4357-9fe4-b4ee63492abd)

### How to test the changes in this Pull Request:

Be sure to also checkout https://github.com/Automattic/newspack-manager/pull/331 before testing.

1. Log in as a reader with a non-a8c email address (i.e. email@test.com)
2. Go to My Account > Account details and verify the email input is disabled (You may need to verify the account first)
3. Repeat steps 1 and 2, this time with an a8c email address, and confirming the email input is not disabled

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->