### PR TITLE
Revert "refactor(corrections): remove corrections feature flag (#3797)"

### DIFF
--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -19,7 +19,7 @@ final class Blocks {
 	public static function init() {
 		require_once NEWSPACK_ABSPATH . 'src/blocks/reader-registration/index.php';
 
-		if ( wp_is_block_theme() && class_exists( 'Newspack\Corrections' ) ) {
+		if ( wp_is_block_theme() && class_exists( 'Newspack\Corrections' ) && defined( 'NEWSPACK_CORRECTIONS_ENABLED' ) && NEWSPACK_CORRECTIONS_ENABLED ) {
 			require_once NEWSPACK_ABSPATH . 'src/blocks/correction-box/class-correction-box-block.php';
 			require_once NEWSPACK_ABSPATH . 'src/blocks/correction-item/class-correction-item-block.php';
 		}
@@ -53,7 +53,7 @@ final class Blocks {
 				'reader_activation_url'   => Reader_Activation::get_setting( 'terms_url' ),
 				'has_recaptcha'           => Recaptcha::can_use_captcha(),
 				'recaptcha_url'           => admin_url( 'admin.php?page=newspack-connections-wizard' ),
-				'corrections_enabled'     => wp_is_block_theme() && class_exists( 'Newspack\Corrections' ),
+				'corrections_enabled'     => wp_is_block_theme() && class_exists( 'Newspack\Corrections' ) && defined( 'NEWSPACK_CORRECTIONS_ENABLED' ) && NEWSPACK_CORRECTIONS_ENABLED,
 			]
 		);
 		\wp_enqueue_style(

--- a/includes/corrections/README.md
+++ b/includes/corrections/README.md
@@ -8,11 +8,11 @@ When you enable this feature, a new meta box will be added to the post editor sc
 
 ## Usage
 
-This feature is enabled by default. Start adding corrections to your posts by following these steps:
-1. Click on Manage Corrections in Corrections & Clarifications Menu.
-2. Click on Add New Correction.
-3. Fill in the correction details.
-4. Click on Save & Close.
+This feature can be enabled by adding the following constant to your `wp-config.php`:
+
+```php
+define( 'NEWSPACK_CORRECTIONS_ENABLED', true );
+```
 
 ## Data
 

--- a/includes/corrections/class-corrections.php
+++ b/includes/corrections/class-corrections.php
@@ -60,6 +60,9 @@ class Corrections {
 	 * Initializes the class.
 	 */
 	public static function init() {
+		if ( ! self::is_enabled() ) {
+			return;
+		}
 		add_action( 'init', [ __CLASS__, 'register_post_type' ] );
 		add_action( 'init', [ __CLASS__, 'add_corrections_shortcode' ] );
 		add_filter( 'the_content', [ __CLASS__, 'output_corrections_on_post' ] );
@@ -70,6 +73,19 @@ class Corrections {
 		add_action( 'admin_init', [ __CLASS__, 'register_corrections_block_patterns' ] );
 		add_action( 'init', [ __CLASS__, 'register_corrections_template' ] );
 	}
+
+	/**
+	 * Checks if the feature is enabled.
+	 *
+	 * True when:
+	 * - NEWSPACK_CORRECTIONS_ENABLED is defined and true.
+	 *
+	 * @return bool True if the feature is enabled, false otherwise.
+	 */
+	public static function is_enabled() {
+		return defined( 'NEWSPACK_CORRECTIONS_ENABLED' ) && NEWSPACK_CORRECTIONS_ENABLED;
+	}
+
 
 	/**
 	 * Enqueue scripts and styles.

--- a/tests/unit-tests/corrections.php
+++ b/tests/unit-tests/corrections.php
@@ -27,10 +27,23 @@ class Test_Corrections extends WP_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 
+		if ( ! defined( 'NEWSPACK_CORRECTIONS_ENABLED' ) ) {
+			define( 'NEWSPACK_CORRECTIONS_ENABLED', true );
+		}
+
 		Corrections::init();
 
 		self::$post_id = $this->factory()->post->create( [ 'post_type' => 'post' ] );
 		update_post_meta( self::$post_id, Corrections::CORRECTIONS_ACTIVE_META, true );
+	}
+
+	/**
+	 * Test that the corrections feature is enabled.
+	 *
+	 * @covers Corrections::is_enabled
+	 */
+	public function test_is_enabled() {
+		$this->assertTrue( Corrections::is_enabled() );
 	}
 
 	/**


### PR DESCRIPTION
This reverts commit 777695726a57ee4c29e42dfb27814e2b7a4eedc9.

We'll need to change something on this feature and therefore we are keeping the feature flag.

This will need to be cherry picked to alphas once it's merged to trunk

== Testing ==

Confirm that the corrections feature is only available if the `NEWSPACK_CORRECTIONS_ENABLED` constant is set to true