### PR TITLE
fix(ia): hide audience subscriptions when memberships inactive

### DIFF
--- a/includes/class-wizards.php
+++ b/includes/class-wizards.php
@@ -8,6 +8,7 @@
 namespace Newspack;
 
 use Newspack\Wizards\Newspack\Newspack_Settings;
+use Newspack\Memberships;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -25,9 +26,20 @@ class Wizards {
 	protected static $wizards = [];
 
 	/**
-	 * Initialize and register all of the wizards.
+	 * Initialize.
 	 */
 	public static function init() {
+		add_action( 'init', [ __CLASS__, 'init_wizards' ] );
+		// Allow custom menu order.
+		add_filter( 'custom_menu_order', '__return_true' );
+		// Fix menu order for wizards with parent menu items.
+		add_filter( 'menu_order', [ __CLASS__, 'menu_order' ], 11 );
+	}
+
+	/**
+	 * Initialize wizards.
+	 */
+	public static function init_wizards() {
 		self::$wizards = [
 			'components-demo'         => new Components_Demo(),
 			// v2 Information Architecture.
@@ -49,16 +61,13 @@ class Wizards {
 			'audience'                => new Audience_Wizard(),
 			'audience-campaigns'      => new Audience_Campaigns(),
 			'audience-donations'      => new Audience_Donations(),
-			'audience-subscriptions'  => new Audience_Subscriptions(),
 			'listings'                => new Listings_Wizard(),
 			'network'                 => new Network_Wizard(),
 			'newsletters'             => new Newsletters_Wizard(),
 		];
-
-		// Allow custom menu order.
-		add_filter( 'custom_menu_order', '__return_true' );
-		// Fix menu order for wizards with parent menu items.
-		add_filter( 'menu_order', [ __CLASS__, 'menu_order' ], 11 );
+		if ( Memberships::is_active() ) {
+			self::$wizards['audience-subscriptions'] = new Audience_Subscriptions();
+		}
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/1/26890605006346/project/1205919985867982/task/1209598724590410

This PR hides the Audience > Subscriptions menu when memberships is not available. This menu only contains a link to the membership plans menu, so it is not needed when memberships isn't active.

![Screenshot 2025-03-12 at 16 29 54](https://github.com/user-attachments/assets/c5c7bbcf-6e73-443e-9dc5-354ae13851d2)

### How to test the changes in this Pull Request:

1. On a test site with memberships active, login as admin
2. Navigate to Audience > Subscriptions
3. Verify the Manage Subscriptions button is present and takes you to the membership plans page
4. Now deactivate memberships
5. Verify the Audience > Subscriptions menu is no longer present

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->