### PR TITLE
fix: make sure segments scroll to top on load

### DIFF
--- a/src/wizards/audience/views/campaigns/segments/segments-list.js
+++ b/src/wizards/audience/views/campaigns/segments/segments-list.js
@@ -2,7 +2,7 @@
 /**
  * WordPress dependencies.
  */
-import { useRef, useState, Fragment } from '@wordpress/element';
+import { useRef, useState, Fragment, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Draggable, MenuItem } from '@wordpress/components';
 import { ESCAPE } from '@wordpress/keycodes';
@@ -249,6 +249,9 @@ const SegmentsList = ( { wizardApiFetch, segments, setSegments, isLoading } ) =>
 	const [ inFlight, setInFlight ] = useState( false );
 	const [ error, setError ] = useState( null );
 	const ref = useRef();
+	useEffect( () => {
+		window.scrollTo( 0, 0 );
+	}, [] );
 	const toggleSegmentStatus = segment => {
 		setInFlight( true );
 		setError( null );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR makes sure the Segments screen scrolls back to the top after you add a new segment, instead of leaving you at the bottom of the screen.

See: 1200550061930446-as-1209601625704671

### How to test the changes in this Pull Request:

1. On epic/ia (or trunk -- it happens on both!), navigate to the Campaigns Segment screen, and click 'Add New Segment'.
2. Fill out the segment name and at least one criteria, then scroll to the bottom and click 'Save'.
3. Confirm you get brought back to the main Segments screen, but you're scrolled to the very bottom.
4. Apply this PR and run `npm run build`.
5. Repeat the steps to create a new segment.
6. After saving, confirm you're brought to the top of the main Segments screen.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->