### PR TITLE
Fix: Guest Contributors Role Init for CLI and PHPUnit

### DIFF
--- a/includes/plugins/co-authors-plus/class-guest-contributor-role.php
+++ b/includes/plugins/co-authors-plus/class-guest-contributor-role.php
@@ -50,16 +50,11 @@ class Guest_Contributor_Role {
 	 */
 	public static function initialize() {
 		add_filter( 'coauthors_edit_author_cap', [ __CLASS__, 'coauthors_edit_author_cap' ] );
-
-		// Setup the custom role directly after global $wp_roles is initialized in wp-settings.php.
-		// Do not use 'admin_init' as this will not account for CLI commands where the admin is not initialized.
-		// @link https://github.com/WordPress/WordPress/blob/414951bc877589f671b0367918069166304662c2/wp-settings.php#L646-L653 .
-		add_action( 'setup_theme', [ __CLASS__, 'setup_custom_role_and_capability' ] );
-
 		add_action( 'template_redirect', [ __CLASS__, 'prevent_myaccount_update' ] );
 		add_action( 'newspack_before_delete_account', [ __CLASS__, 'before_delete_account' ] );
 
 		add_action( 'init', [ __CLASS__, 'early_init' ], 5 );
+		add_action( 'init', [ __CLASS__, 'setup_custom_role_and_capability' ] );
 
 		// Do not allow guest authors to login.
 		\add_filter( 'wp_authenticate_user', [ __CLASS__, 'wp_authenticate_user' ], 10, 2 );

--- a/includes/plugins/co-authors-plus/class-guest-contributor-role.php
+++ b/includes/plugins/co-authors-plus/class-guest-contributor-role.php
@@ -50,7 +50,12 @@ class Guest_Contributor_Role {
 	 */
 	public static function initialize() {
 		add_filter( 'coauthors_edit_author_cap', [ __CLASS__, 'coauthors_edit_author_cap' ] );
-		add_action( 'admin_init', [ __CLASS__, 'setup_custom_role_and_capability' ] );
+
+		// Setup the custom role directly after global $wp_roles is initialized in wp-settings.php.
+		// Do not use 'admin_init' as this will not account for CLI commands where the admin is not initialized.
+		// @link https://github.com/WordPress/WordPress/blob/414951bc877589f671b0367918069166304662c2/wp-settings.php#L646-L653 .
+		add_action( 'setup_theme', [ __CLASS__, 'setup_custom_role_and_capability' ] );
+
 		add_action( 'template_redirect', [ __CLASS__, 'prevent_myaccount_update' ] );
 		add_action( 'newspack_before_delete_account', [ __CLASS__, 'before_delete_account' ] );
 

--- a/tests/unit-tests/guest-contributor-role.php
+++ b/tests/unit-tests/guest-contributor-role.php
@@ -11,9 +11,6 @@ use Newspack\Guest_Contributor_Role;
  * Tests the Guest_Contributor_Role.
  */
 class Newspack_Test_Guest_Contributor_Role extends WP_UnitTestCase {
-	public static function set_up_before_class() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
-		Guest_Contributor_Role::setup_custom_role_and_capability();
-	}
 
 	public function set_up() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
 		wp_reset_postdata();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

If a new WordPress website is created using only the CLI or PHPUnit without any browser navigation to `/wp-admin/`, then `admin_init` isn't run and the custom Guest Contributors role will not get created.  To avoid this, the role creation should happen on `init`.  This will make sure the role exists for `/wp-admin/`, CLI, and PHPUnit (also if newpack plugin is included as a dependency in a secondary repo's PHPUnit).

### How to test the changes in this Pull Request:

Without this change, do a `n sites-add` with Newspack Docker so that a new site will be created via CLI.  Do not open the site in the browser.  Verify the role does not exist by running `wp role list`

Now, pull the change and do the same steps on a new `n sites-add` and you'll see `wp role list` will show the Guest Contributor role.

Also, the PHPUnit test has been updated to remove `set_up_before_class` since it is no longer needed because `init` will run for PHPUnit.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->