### PR TITLE
feat(corrections-location): integrate Correction location logic

### DIFF
--- a/includes/corrections/README.md
+++ b/includes/corrections/README.md
@@ -18,17 +18,18 @@ define( 'NEWSPACK_CORRECTIONS_ENABLED', true );
 
 Corrections are stored as `newspack_correction` custom post type. A correction consists of the following fields:
 
-| Name                          | Type     | Stored As      | Description                                                                    |
-| ----------------------------- | -------- | -------------- | ------------------------------------------------------------------------------ |
-| `title`                       | `string` | `post_title`   | The correction title. Defaults to 'Correction for [post title]'                |
-| `content`                     | `string` | `post_content` | The correction text.                                                           |
-| `date`                        | `string` | `post_date`    | The date assigned to the correction.                                           |
-| `newspack_correction-post-id` | `int`    | `post_meta`    | The ID of the post to which the correction is associated.                      |
-| `newspack_corrections_type`   | `string` | `post_meta`    | Whether it's a correction or a clarification (`correction` or `clarification`) |
+| Name                            | Type     | Stored As      | Description                                                                    |
+| ------------------------------- | -------- | -------------- | ------------------------------------------------------------------------------ |
+| `title`                         | `string` | `post_title`   | The correction title. Defaults to 'Correction for [post title]'                |
+| `content`                       | `string` | `post_content` | The correction text.                                                           |
+| `date`                          | `string` | `post_date`    | The date assigned to the correction.                                           |
+| `newspack_correction-post-id`   | `int`    | `post_meta`    | The ID of the post to which the correction is associated.                      |
+| `newspack_corrections_type`     | `string` | `post_meta`    | Whether it's a correction or a clarification (`correction` or `clarification`) |
+| `newspack_corrections_location` | `string` | `post_meta`    | Where the correction should be displayed. (`top` or `bottom`)                  |
 
 In addition, some correction data is stored in the associated post as post meta:
 
 | Name                            | Type                    | Stored As   | Description                                                   |
 | ------------------------------- | ----------------------- | ----------- | ------------------------------------------------------------- |
 | `newspack_corrections_active`   | `bool`                  | `post_meta` | Whether the feature is enabled for the post.                  |
-| `newspack_corrections_location` | `string`                | `post_meta` | Where the correction should be displayed. (`top` or `bottom`) |
+

--- a/includes/corrections/class-corrections.php
+++ b/includes/corrections/class-corrections.php
@@ -444,12 +444,45 @@ class Corrections {
 			return $content;
 		}
 
+		// Separate corrections by location.
+		$top_corrections    = [];
+		$bottom_corrections = [];
+
+		foreach ( $corrections as $correction ) {
+			$location = get_post_meta( $correction->ID, self::CORRECTIONS_LOCATION_META, true );
+			if ( 'top' === $location ) {
+				$top_corrections[] = $correction;
+			} else {
+				$bottom_corrections[] = $correction;
+			}
+		}
+
+		$top_corrections_markup    = ! empty( $top_corrections ) ? self::get_corrections_markup( $top_corrections, 'top' ) : '';
+		$bottom_corrections_markup = ! empty( $bottom_corrections ) ? self::get_corrections_markup( $bottom_corrections, 'bottom' ) : '';
+
+		return $top_corrections_markup . $content . $bottom_corrections_markup;
+	}
+
+	/**
+	 * Generates the corrections markup from an array of correction posts.
+	 *
+	 * @param array  $corrections Array of correction post objects.
+	 * @param string $corrections_location The location of the corrections.
+	 *
+	 * @return string Generated markup (or an empty string if no corrections).
+	 */
+	private static function get_corrections_markup( $corrections, $corrections_location = 'bottom' ) {
+		// If no corrections, return an empty string.
+		if ( empty( $corrections ) ) {
+			return '';
+		}
+
 		$corrections_archive_url = get_post_type_archive_link( self::POST_TYPE );
 
 		ob_start();
 		?>
 		<!-- wp:group {"className":"correction-module","backgroundColor":"light-gray"} -->
-		<div class="wp-block-group newspack-corrections-module">
+		<div class="wp-block-group newspack-corrections-module corrections-<?php echo esc_attr( $corrections_location ); ?>-module">
 			<?php foreach ( $corrections as $correction ) : ?>
 				<?php
 				$correction_content = $correction->post_content;
@@ -471,8 +504,7 @@ class Corrections {
 		</div>
 		<!-- /wp:group -->
 		<?php
-		$markup = do_blocks( ob_get_clean() );
-		return $content . $markup;
+		return do_blocks( ob_get_clean() );
 	}
 
 	/**

--- a/includes/corrections/class-corrections.php
+++ b/includes/corrections/class-corrections.php
@@ -449,8 +449,7 @@ class Corrections {
 		$bottom_corrections = [];
 
 		foreach ( $corrections as $correction ) {
-			$location = get_post_meta( $correction->ID, self::CORRECTIONS_LOCATION_META, true );
-			if ( 'top' === $location ) {
+			if ( 'top' === $correction->correction_location ) {
 				$top_corrections[] = $correction;
 			} else {
 				$bottom_corrections[] = $correction;

--- a/includes/corrections/class-corrections.php
+++ b/includes/corrections/class-corrections.php
@@ -27,11 +27,6 @@ class Corrections {
 	const CORRECTION_POST_ID_META = 'newspack_correction-post-id';
 
 	/**
-	 * Meta key for post corrections active meta.
-	 */
-	const CORRECTIONS_ACTIVE_META = 'newspack_corrections_active';
-
-	/**
 	 * Meta key for post corrections location meta.
 	 */
 	const CORRECTIONS_LOCATION_META = 'newspack_corrections_location';
@@ -390,15 +385,11 @@ class Corrections {
 	public static function handle_corrections_shortcode() {
 		global $wpdb;
 
-		$post_ids = get_posts(
-			[
-				'posts_per_page' => -1,
-				'meta_key'       => self::CORRECTIONS_ACTIVE_META,
-				'meta_value'     => 1, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
-				'fields'         => 'ids',
-				'orderby'        => 'date',
-				'order'          => 'DESC',
-			]
+		$post_ids = $wpdb->get_col( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->prepare(
+				"SELECT DISTINCT meta_value FROM $wpdb->postmeta WHERE meta_key = %s",
+				self::CORRECTION_POST_ID_META
+			)
 		);
 
 		ob_start();
@@ -448,10 +439,6 @@ class Corrections {
 	 */
 	public static function output_corrections_on_post( $content ) {
 		if ( is_admin() || ! is_single() || wp_is_block_theme() ) {
-			return $content;
-		}
-
-		if ( 0 == get_post_meta( get_the_ID(), self::CORRECTIONS_ACTIVE_META, true ) ) {
 			return $content;
 		}
 

--- a/includes/corrections/class-corrections.php
+++ b/includes/corrections/class-corrections.php
@@ -54,7 +54,6 @@ class Corrections {
 			return;
 		}
 		add_action( 'init', [ __CLASS__, 'register_post_type' ] );
-		add_action( 'init', [ __CLASS__, 'add_corrections_shortcode' ] );
 		add_filter( 'the_content', [ __CLASS__, 'output_corrections_on_post' ] );
 		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'wp_enqueue_scripts' ] );
 		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'wp_enqueue_scripts' ] );
@@ -345,13 +344,6 @@ class Corrections {
 	}
 
 	/**
-	 * Adds the corrections shortcode.
-	 */
-	public static function add_corrections_shortcode() {
-		add_shortcode( 'corrections', [ __CLASS__, 'handle_corrections_shortcode' ] );
-	}
-
-	/**
 	 * Gets the Correction type label for a given post. Defaults to the current global post if none is provided.
 	 *
 	 * @param int $post_id The correction id.
@@ -375,59 +367,6 @@ class Corrections {
 			return __( 'Clarification', 'newspack-plugin' );
 		}
 		return __( 'Correction', 'newspack-plugin' );
-	}
-
-	/**
-	 * Handles the corrections shortcode.
-	 *
-	 * @return string the shortcode output.
-	 */
-	public static function handle_corrections_shortcode() {
-		global $wpdb;
-
-		$post_ids = $wpdb->get_col( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-			$wpdb->prepare(
-				"SELECT DISTINCT meta_value FROM $wpdb->postmeta WHERE meta_key = %s",
-				self::CORRECTION_POST_ID_META
-			)
-		);
-
-		ob_start();
-		foreach ( $post_ids as $post_id ) :
-			$corrections = self::get_corrections( $post_id );
-			if ( empty( $corrections ) ) {
-				continue;
-			}
-
-			?>
-			<!-- wp:group {"className":"is-style-default correction-shortcode-item"} -->
-			<div class="wp-block-group is-style-default correction-shortcode-item">
-				<div class="wp-block-group__inner-container">
-					<!-- wp:newspack-blocks/homepage-articles {"showExcerpt":false,"showDate":false,"showAuthor":false,"mediaPosition":"left","specificPosts":["<?php echo intval( $post_id ); ?>"],"imageScale":2,"specificMode":true} /-->
-
-					<div class="correction-list">
-						<?php
-						foreach ( $corrections as $correction ) :
-							$correction_content = $correction->post_content;
-							$correction_date    = \get_the_date( 'M j, Y', $correction->ID );
-							$correction_heading = sprintf(
-								// translators: %s: correction date.
-								__( 'Correction on %s', 'newspack-plugin' ),
-								$correction_date
-							);
-							?>
-							<p>
-								<span class="correction-date"><?php echo esc_html( $correction_heading ); ?><span>:</span></span>
-								<?php echo esc_html( $correction_content ); ?>
-							</p>
-						<?php endforeach; ?>
-					</div>
-				</div>
-			</div>
-			<!-- /wp:group -->
-			<?php
-		endforeach;
-		return do_blocks( ob_get_clean() );
 	}
 
 	/**

--- a/includes/corrections/class-corrections.php
+++ b/includes/corrections/class-corrections.php
@@ -226,7 +226,7 @@ class Corrections {
 
 		// Track processed corrections to handle deletions.
 		$processed_ids = [];
-	
+
 		foreach ( $corrections as $correction ) {
 			$correction_id = $correction['id'];
 

--- a/includes/corrections/class-corrections.php
+++ b/includes/corrections/class-corrections.php
@@ -262,8 +262,9 @@ class Corrections {
 				'post_type'    => self::POST_TYPE,
 				'post_status'  => 'publish',
 				'meta_input'   => [
-					self::CORRECTION_POST_ID_META => $post_id,
-					self::CORRECTIONS_TYPE_META   => $correction['type'],
+					self::CORRECTION_POST_ID_META   => $post_id,
+					self::CORRECTIONS_TYPE_META     => $correction['type'],
+					self::CORRECTIONS_LOCATION_META => $correction['location'],
 				],
 			]
 		);
@@ -292,8 +293,9 @@ class Corrections {
 
 		// Attach correction type & date to each post.
 		foreach ( $corrections as $correction ) {
-			$correction->correction_type = get_post_meta( $correction->ID, self::CORRECTIONS_TYPE_META, true );
-			$correction->correction_date = get_post_datetime( $correction->ID )->format( 'Y-m-d H:i:s' );
+			$correction->correction_type     = get_post_meta( $correction->ID, self::CORRECTIONS_TYPE_META, true );
+			$correction->correction_date     = get_post_datetime( $correction->ID )->format( 'Y-m-d H:i:s' );
+			$correction->correction_location = get_post_meta( $correction->ID, self::CORRECTIONS_LOCATION_META, true );
 		}
 
 		return $corrections;
@@ -312,7 +314,8 @@ class Corrections {
 				'post_content' => sanitize_textarea_field( $correction['content'] ),
 				'post_date'    => sanitize_text_field( $correction['date'] ),
 				'meta_input'   => [
-					self::CORRECTIONS_TYPE_META => $correction['type'],
+					self::CORRECTIONS_TYPE_META     => $correction['type'],
+					self::CORRECTIONS_LOCATION_META => $correction['location'],
 				],
 			]
 		);
@@ -452,13 +455,11 @@ class Corrections {
 				$correction_content = $correction->post_content;
 				$correction_date    = \get_the_date( get_option( 'date_format' ), $correction->ID );
 				$correction_time    = \get_the_time( get_option( 'time_format' ), $correction->ID );
-				$timezone           = \wp_timezone()->getName();
 				$correction_heading = sprintf(
-					'%s, %s %s %s:',
+					'%s, %s %s:',
 					self::get_correction_type( $correction->ID ),
 					$correction_date,
-					$correction_time,
-					$timezone
+					$correction_time
 				);
 				?>
 				<p class="correction">

--- a/includes/corrections/class-corrections.php
+++ b/includes/corrections/class-corrections.php
@@ -52,18 +52,12 @@ class Corrections {
 	const REST_ROUTE = '/corrections';
 
 	/**
-	 * Customize settings for corrections.
-	 */
-	const CORRECTIONS_LOCATION_CUSTOMIZE_SETTING = 'corrections_location';
-
-	/**
 	 * Initializes the class.
 	 */
 	public static function init() {
 		add_action( 'init', [ __CLASS__, 'register_post_type' ] );
 		add_action( 'init', [ __CLASS__, 'add_corrections_shortcode' ] );
 		add_filter( 'the_content', [ __CLASS__, 'output_corrections_on_post' ] );
-		add_action( 'customize_register', [ __CLASS__, 'corrections_customize_register' ] );
 		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'wp_enqueue_scripts' ] );
 		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'wp_enqueue_scripts' ] );
 		add_action( 'rest_api_init', [ __CLASS__, 'register_rest_routes' ] );
@@ -477,59 +471,7 @@ class Corrections {
 		<!-- /wp:group -->
 		<?php
 		$markup = do_blocks( ob_get_clean() );
-		return 'top' === get_theme_mod( self::CORRECTIONS_LOCATION_CUSTOMIZE_SETTING, 'bottom' ) ? $markup . $content : $content . $markup;
-	}
-
-	/**
-	 * Register the customizer setting for the corrections location.
-	 *
-	 * @param WP_Customize_Manager $wp_customize The customizer manager.
-	 */
-	public static function corrections_customize_register( $wp_customize ) {
-		/**
-		 * Corrections Panel.
-		 */
-		$wp_customize->add_panel(
-			self::POST_TYPE . '_panel',
-			array(
-				'title' => esc_html__( 'Corrections Settings', 'newspack-plugin' ),
-			)
-		);
-
-		/**
-		 * Corection settings section.
-		 */
-		$wp_customize->add_section(
-			self::POST_TYPE . '_settings',
-			array(
-				'title' => esc_html__( 'Corrections & Clarifications', 'newspack' ),
-				'panel' => self::POST_TYPE . '_panel',
-			)
-		);
-
-		// Add a setting & control to choose the location of corrections.
-		$wp_customize->add_setting(
-			self::CORRECTIONS_LOCATION_CUSTOMIZE_SETTING,
-			array(
-				'type'              => 'theme_mod',
-				'capability'        => 'edit_theme_options',
-				'default'           => 'bottom',
-				'sanitize_callback' => 'sanitize_text_field',
-			)
-		);
-		$wp_customize->add_control(
-			self::CORRECTIONS_LOCATION_CUSTOMIZE_SETTING,
-			array(
-				'label'       => esc_html__( 'Corrections Location', 'newspack-plugin' ),
-				'description' => esc_html__( 'Choose where to display corrections on the post.', 'newspack-plugin' ),
-				'section'     => self::POST_TYPE . '_settings',
-				'type'        => 'radio',
-				'choices'     => array(
-					'top'    => esc_html__( 'Top of content', 'newspack-plugin' ),
-					'bottom' => esc_html__( 'Bottom of content', 'newspack-plugin' ),
-				),
-			)
-		);
+		return $content . $markup;
 	}
 
 	/**

--- a/src/other-scripts/corrections-modal/index.js
+++ b/src/other-scripts/corrections-modal/index.js
@@ -323,7 +323,9 @@ const CorrectionsModal = () => {
 							} }
 							isBusy={ isSaving }
 						>
-							{ isSaving ? __( 'Saving…', 'newspack-plugin' ) : __( 'Close & save', 'newspack-plugin' ) }
+							{ isSaving
+								? __( 'Saving…', 'newspack-plugin' )
+								: __( 'Save & close', 'newspack-plugin' ) }
 						</Button>
 						<Button
 							variant="tertiary"

--- a/src/other-scripts/corrections-modal/index.js
+++ b/src/other-scripts/corrections-modal/index.js
@@ -36,6 +36,16 @@ const types = [
 ];
 
 /**
+ * Correction locations.
+ *
+ * @type {Object[]} The correction locations.
+ */
+const locations = [
+	{ label: __( 'Top', 'newspack-plugin' ), value: 'top' },
+	{ label: __( 'Bottom', 'newspack-plugin' ), value: 'bottom' },
+];
+
+/**
  * Save the corrections data.
  *
  * @param {number} postId  The post ID.
@@ -72,6 +82,7 @@ const CorrectionsModal = () => {
 	const [ corrections, setCorrections ] = useState( [] );
 	const [ newCorrection, setNewCorrection ] = useState( '' );
 	const [ newCorrectionType, setNewCorrectionType ] = useState( 'correction' );
+	const [ newCorrectionLocation, setNewCorrectionLocation ] = useState( 'bottom' );
 	const [ isDatePopoverOpen, setIsDatePopoverOpen ] = useState( null );
 
 	// Fetch corrections when modal opens
@@ -82,6 +93,7 @@ const CorrectionsModal = () => {
 					...correction,
 					type: correction.correction_type || 'correction',
 					date: correction.correction_date,
+					location: correction.correction_location || 'bottom',
 				} ) )
 			);
 		}
@@ -117,6 +129,7 @@ const CorrectionsModal = () => {
 					post_content: newCorrection,
 					type: newCorrectionType,
 					date: adjustedDate,
+					location: newCorrectionLocation,
 					isNew: true
 				},
 				...corrections
@@ -127,10 +140,10 @@ const CorrectionsModal = () => {
 	};
 
 	// Update an existing correction.
-	const updateCorrection = ( correctionId, postContent, type, date ) => {
+	const updateCorrection = ( correctionId, postContent, type, date, location ) => {
 		setCorrections( corrections.map( ( correction ) => {
 			if ( correction.ID === correctionId ) {
-				return { ...correction, post_content: postContent, type, date };
+				return { ...correction, post_content: postContent, type, date, location };
 			}
 			return correction;
 		} ) );
@@ -147,10 +160,11 @@ const CorrectionsModal = () => {
 
 		const payload = {
 			post_id: postId,
-			corrections: corrections.map( ( { ID, post_content, type, date, isNew } ) => ({
+			corrections: corrections.map( ( { ID, post_content, type, date, location, isNew } ) => ({
 				id: isNew ? null : ID, // Null means create a new correction
 				content: post_content,
 				type,
+				location,
 				date: moment( new Date( date ) ).format( 'YYYY-MM-DD HH:mm:ss' ),
 			} ) ),
 		};
@@ -202,7 +216,14 @@ const CorrectionsModal = () => {
 												label={ __( 'Type', 'newspack-plugin' ) }
 												value={ correction.type }
 												options={ types }
-												onChange={ ( value ) => updateCorrection( correction.ID, correction.post_content, value, correction.date ) }
+												onChange={ ( value ) => updateCorrection( correction.ID, correction.post_content, value, correction.date, correction.location ) }
+												__next40pxDefaultSize
+											/>
+											<SelectControl
+												label={ __( 'Location', 'newspack-plugin' ) }
+												value={ correction.location }
+												options={ locations }
+												onChange={ ( value ) => updateCorrection( correction.ID, correction.post_content, correction.type, correction.date, value ) }
 												__next40pxDefaultSize
 											/>
 											<BaseControl
@@ -231,7 +252,7 @@ const CorrectionsModal = () => {
 														className='correction-date'
 														is12Hour={ true }
 														currentDate={ new Date( correction.date ) }
-														onChange={ ( value ) => updateCorrection( correction.ID, correction.post_content, correction.type, value ) }
+														onChange={ ( value ) => updateCorrection( correction.ID, correction.post_content, correction.type, value, correction.location ) }
 													/>
 												</Popover>
 											) }
@@ -240,7 +261,7 @@ const CorrectionsModal = () => {
 											label={ __( 'Description', 'newspack-plugin' ) }
 											rows={ 3 }
 											value={ correction.post_content }
-											onChange={ ( value ) => updateCorrection( correction.ID, value, correction.type, correction.date ) }
+											onChange={ ( value ) => updateCorrection( correction.ID, value, correction.type, correction.date, correction.location ) }
 										/>
 										<Button
 											text={ __( 'Delete', 'newspack-plugin' ) }
@@ -266,6 +287,13 @@ const CorrectionsModal = () => {
 									value={ newCorrectionType }
 									options={ types }
 									onChange={ ( value ) => setNewCorrectionType( value ) }
+									__next40pxDefaultSize
+								/>
+								<SelectControl
+									label={ __( 'Location', 'newspack-plugin' ) }
+									value={ newCorrectionLocation }
+									options={ locations }
+									onChange={ ( value ) => setNewCorrectionLocation( value ) }
 									__next40pxDefaultSize
 								/>
 								<TextareaControl

--- a/tests/unit-tests/corrections.php
+++ b/tests/unit-tests/corrections.php
@@ -89,10 +89,11 @@ class Test_Corrections extends WP_UnitTestCase {
 	public function test_new_correction_is_created() {
 		$corrections = array(
 			array(
-				'id'      => null, // New correction.
-				'content' => 'Test correction content',
-				'type'    => 'correction',
-				'date'    => current_time( 'mysql' ),
+				'id'       => null, // New correction.
+				'content'  => 'Test correction content',
+				'type'     => 'correction',
+				'date'     => current_time( 'mysql' ),
+				'location' => 'bottom',
 			),
 		);
 
@@ -120,9 +121,10 @@ class Test_Corrections extends WP_UnitTestCase {
 	 */
 	public function test_existing_correction_is_updated() {
 		$initial_data = array(
-			'content' => 'Original correction content',
-			'type'    => 'correction',
-			'date'    => current_time( 'mysql' ),
+			'content'  => 'Original correction content',
+			'type'     => 'correction',
+			'date'     => current_time( 'mysql' ),
+			'location' => 'bottom',
 		);
 		$correction_id = Corrections::add_correction( self::$post_id, $initial_data );
 		$this->assertNotWPError( $correction_id );
@@ -130,10 +132,11 @@ class Test_Corrections extends WP_UnitTestCase {
 
 		$updated_data = array(
 			array(
-				'id'      => $correction_id,
-				'content' => 'Updated correction content',
-				'type'    => 'clarification',
-				'date'    => current_time( 'mysql' ),
+				'id'       => $correction_id,
+				'content'  => 'Updated correction content',
+				'type'     => 'clarification',
+				'date'     => current_time( 'mysql' ),
+				'location' => 'top',
 			),
 		);
 
@@ -160,16 +163,18 @@ class Test_Corrections extends WP_UnitTestCase {
 	public function test_multiple_corrections_are_saved() {
 		$corrections = array(
 			array(
-				'id'      => null, // New correction.
-				'content' => 'Test correction content 1',
-				'type'    => 'correction',
-				'date'    => current_time( 'mysql' ),
+				'id'       => null, // New correction.
+				'content'  => 'Test correction content 1',
+				'type'     => 'correction',
+				'date'     => current_time( 'mysql' ),
+				'location' => 'bottom',
 			),
 			array(
-				'id'      => null, // New correction.
-				'content' => 'Test correction content 2',
-				'type'    => 'clarification',
-				'date'    => current_time( 'mysql' ),
+				'id'       => null, // New correction.
+				'content'  => 'Test correction content 2',
+				'type'     => 'clarification',
+				'date'     => current_time( 'mysql' ),
+				'location' => 'top',
 			),
 		);
 
@@ -197,10 +202,11 @@ class Test_Corrections extends WP_UnitTestCase {
 	 */
 	public function test_correction_is_deleted() {
 		$correction_1 = array(
-			'id'      => null, // New correction.
-			'content' => 'Test correction content',
-			'type'    => 'correction',
-			'date'    => current_time( 'mysql' ),
+			'id'       => null, // New correction.
+			'content'  => 'Test correction content',
+			'type'     => 'correction',
+			'date'     => current_time( 'mysql' ),
+			'location' => 'bottom',
 		);
 
 		$correction_id_1 = Corrections::add_correction( self::$post_id, $correction_1 );
@@ -208,10 +214,11 @@ class Test_Corrections extends WP_UnitTestCase {
 		$this->assertNotEquals( 0, $correction_id_1 );
 
 		$correction_2 = array(
-			'id'      => null, // New correction.
-			'content' => 'Test correction content 2',
-			'type'    => 'clarification',
-			'date'    => current_time( 'mysql' ),
+			'id'       => null, // New correction.
+			'content'  => 'Test correction content 2',
+			'type'     => 'clarification',
+			'date'     => current_time( 'mysql' ),
+			'location' => 'top',
 		);
 
 		$correction_id_2 = Corrections::add_correction( self::$post_id, $correction_2 );
@@ -220,10 +227,11 @@ class Test_Corrections extends WP_UnitTestCase {
 
 		$updated_corrections_array = array(
 			array(
-				'id'      => $correction_id_1,
-				'content' => 'Updated correction content',
-				'type'    => 'clarification',
-				'date'    => current_time( 'mysql' ),
+				'id'       => $correction_id_1,
+				'content'  => 'Updated correction content',
+				'type'     => 'clarification',
+				'date'     => current_time( 'mysql' ),
+				'location' => 'top',
 			),
 		);
 
@@ -256,9 +264,10 @@ class Test_Corrections extends WP_UnitTestCase {
 	 */
 	public function test_add_correction() {
 		$correction = array(
-			'content' => 'Test correction content',
-			'type'    => 'correction',
-			'date'    => current_time( 'mysql' ),
+			'content'  => 'Test correction content',
+			'type'     => 'correction',
+			'date'     => current_time( 'mysql' ),
+			'location' => 'top',
 		);
 
 		$correction_id = Corrections::add_correction( self::$post_id, $correction );
@@ -278,6 +287,9 @@ class Test_Corrections extends WP_UnitTestCase {
 
 		$correction_title = sprintf( 'Correction for %s', get_the_title( self::$post_id ) );
 		$this->assertEquals( $correction_title, $correction_post->post_title, 'The correction title should be set.' );
+
+		$correction_location = get_post_meta( $correction_id, Corrections::CORRECTIONS_LOCATION_META, true );
+		$this->assertEquals( 'top', $correction_location, 'The correction location should be set.' );
 	}
 
 	/**
@@ -288,9 +300,10 @@ class Test_Corrections extends WP_UnitTestCase {
 	public function test_get_corrections() {
 		$time = time() - 60 * 60;
 		$correction_1 = array(
-			'content' => 'Test correction content 1',
-			'type'    => 'correction',
-			'date'    => gmdate( 'Y-m-d H:i:s', $time ), // 1 hour ago.
+			'content'  => 'Test correction content 1',
+			'type'     => 'correction',
+			'date'     => gmdate( 'Y-m-d H:i:s', $time ), // 1 hour ago.
+			'location' => 'bottom',
 		);
 
 		$correction_id_1 = Corrections::add_correction( self::$post_id, $correction_1 );
@@ -298,9 +311,10 @@ class Test_Corrections extends WP_UnitTestCase {
 		$this->assertNotEquals( 0, $correction_id_1 );
 
 		$correction_2 = array(
-			'content' => 'Test correction content 2',
-			'type'    => 'clarification',
-			'date'    => gmdate( 'Y-m-d H:i:s', $time + 20 * 60 ), // 40 minutes ago.
+			'content'  => 'Test correction content 2',
+			'type'     => 'clarification',
+			'date'     => gmdate( 'Y-m-d H:i:s', $time + 20 * 60 ), // 40 minutes ago.
+			'location' => 'top',
 		);
 
 		$correction_id_2 = Corrections::add_correction( self::$post_id, $correction_2 );
@@ -331,6 +345,9 @@ class Test_Corrections extends WP_UnitTestCase {
 
 		$this->assertEquals( gmdate( 'Y-m-d H:i:s', $time ), $correction_1->correction_date, 'The correction date is correct.' );
 		$this->assertEquals( gmdate( 'Y-m-d H:i:s', $time + 20 * 60 ), $correction_2->correction_date, 'The correction date is correct.' );
+
+		$this->assertEquals( 'bottom', $correction_1->correction_location, 'The correction location is correct.' );
+		$this->assertEquals( 'top', $correction_2->correction_location, 'The correction location is correct.' );
 	}
 
 	/**
@@ -350,9 +367,10 @@ class Test_Corrections extends WP_UnitTestCase {
 	 */
 	public function test_update_correction() {
 		$correction = array(
-			'content' => 'Test correction content',
-			'type'    => 'correction',
-			'date'    => current_time( 'mysql' ),
+			'content'  => 'Test correction content',
+			'type'     => 'correction',
+			'date'     => current_time( 'mysql' ),
+			'location' => 'bottom',
 		);
 
 		$correction_id = Corrections::add_correction( self::$post_id, $correction );
@@ -360,9 +378,10 @@ class Test_Corrections extends WP_UnitTestCase {
 		$this->assertNotEquals( 0, $correction_id );
 
 		$updated_data = array(
-			'content' => 'Updated correction content',
-			'type'    => 'clarification',
-			'date'    => current_time( 'mysql' ),
+			'content'  => 'Updated correction content',
+			'type'     => 'clarification',
+			'date'     => current_time( 'mysql' ),
+			'location' => 'top',
 		);
 
 		Corrections::update_correction( $correction_id, $updated_data );
@@ -373,6 +392,9 @@ class Test_Corrections extends WP_UnitTestCase {
 
 		$updated_correction_type = get_post_meta( $correction_id, Corrections::CORRECTIONS_TYPE_META, true );
 		$this->assertEquals( 'clarification', $updated_correction_type, 'The correction type should be updated.' );
+
+		$updated_correction_location = get_post_meta( $correction_id, Corrections::CORRECTIONS_LOCATION_META, true );
+		$this->assertEquals( 'top', $updated_correction_location, 'The correction location should be updated.' );
 	}
 
 	/**
@@ -382,9 +404,10 @@ class Test_Corrections extends WP_UnitTestCase {
 	 */
 	public function test_delete_corrections() {
 		$correction_1 = array(
-			'content' => 'Test correction content',
-			'type'    => 'correction',
-			'date'    => current_time( 'mysql' ),
+			'content'  => 'Test correction content',
+			'type'     => 'correction',
+			'date'     => current_time( 'mysql' ),
+			'location' => 'bottom',
 		);
 
 		$correction_1_id = Corrections::add_correction( self::$post_id, $correction_1 );
@@ -392,9 +415,10 @@ class Test_Corrections extends WP_UnitTestCase {
 		$this->assertNotEquals( 0, $correction_1_id );
 
 		$correction_2 = array(
-			'content' => 'Test correction content 2',
-			'type'    => 'clarification',
-			'date'    => current_time( 'mysql' ),
+			'content'  => 'Test correction content 2',
+			'type'     => 'clarification',
+			'date'     => current_time( 'mysql' ),
+			'location' => 'top',
 		);
 
 		$correction_2_id = Corrections::add_correction( self::$post_id, $correction_2 );
@@ -436,9 +460,10 @@ class Test_Corrections extends WP_UnitTestCase {
 	 */
 	public function test_get_correction_type_is_correction() {
 		$correction = array(
-			'content' => 'Test correction content',
-			'type'    => 'correction',
-			'date'    => current_time( 'mysql' ),
+			'content'  => 'Test correction content',
+			'type'     => 'correction',
+			'date'     => current_time( 'mysql' ),
+			'location' => 'bottom',
 		);
 
 		$correction_id = Corrections::add_correction( self::$post_id, $correction );
@@ -456,9 +481,10 @@ class Test_Corrections extends WP_UnitTestCase {
 	 */
 	public function test_get_correction_type_is_clarification() {
 		$clarification = array(
-			'content' => 'Test clarification content',
-			'type'    => 'clarification',
-			'date'    => current_time( 'mysql' ),
+			'content'  => 'Test clarification content',
+			'type'     => 'clarification',
+			'date'     => current_time( 'mysql' ),
+			'location' => 'bottom',
 		);
 
 		$clarification_id = Corrections::add_correction( self::$post_id, $clarification );
@@ -476,9 +502,10 @@ class Test_Corrections extends WP_UnitTestCase {
 	 */
 	public function test_handle_corrections_shortcode() {
 		$correction_1 = array(
-			'content' => 'Test correction content',
-			'type'    => 'correction',
-			'date'    => current_time( 'mysql' ),
+			'content'  => 'Test correction content',
+			'type'     => 'correction',
+			'date'     => current_time( 'mysql' ),
+			'location' => 'bottom',
 		);
 
 		$correction_1_id = Corrections::add_correction( self::$post_id, $correction_1 );
@@ -486,9 +513,10 @@ class Test_Corrections extends WP_UnitTestCase {
 		$this->assertNotEquals( 0, $correction_1_id );
 
 		$correction_2 = array(
-			'content' => 'Test correction content 2',
-			'type'    => 'clarification',
-			'date'    => current_time( 'mysql' ),
+			'content'  => 'Test correction content 2',
+			'type'     => 'clarification',
+			'date'     => current_time( 'mysql' ),
+			'location' => 'top',
 		);
 
 		$correction_2_id = Corrections::add_correction( self::$post_id, $correction_2 );
@@ -520,9 +548,10 @@ class Test_Corrections extends WP_UnitTestCase {
 	 */
 	public function test_output_corrections_on_post_appends_markup() {
 		$correction_1 = array(
-			'content' => 'Test correction content',
-			'type'    => 'correction',
-			'date'    => current_time( 'mysql' ),
+			'content'  => 'Test correction content',
+			'type'     => 'correction',
+			'date'     => current_time( 'mysql' ),
+			'location' => 'bottom',
 		);
 
 		$correction_1_id = Corrections::add_correction( self::$post_id, $correction_1 );
@@ -530,9 +559,10 @@ class Test_Corrections extends WP_UnitTestCase {
 		$this->assertNotEquals( 0, $correction_1_id );
 
 		$correction_2 = array(
-			'content' => 'Test correction content 2',
-			'type'    => 'clarification',
-			'date'    => current_time( 'mysql' ),
+			'content'  => 'Test correction content 2',
+			'type'     => 'clarification',
+			'date'     => current_time( 'mysql' ),
+			'location' => 'top',
 		);
 
 		$correction_2_id = Corrections::add_correction( self::$post_id, $correction_2 );
@@ -554,6 +584,7 @@ class Test_Corrections extends WP_UnitTestCase {
 		);
 		$this->assertStringContainsString( $correction_1_heading, $corrections_markup, 'The correction date should be included in the output.' );
 		$this->assertStringContainsString( 'Test correction content', $corrections_markup, 'The correction content should be included in the output.' );
+		$this->assertStringContainsString( 'corrections-bottom-module', $corrections_markup, 'The correction location should be included in the output.' );
 
 		$correction_2_heading = sprintf(
 			'%s, %s %s',
@@ -563,5 +594,6 @@ class Test_Corrections extends WP_UnitTestCase {
 		);
 		$this->assertStringContainsString( $correction_2_heading, $corrections_markup, 'The correction date should be included in the output.' );
 		$this->assertStringContainsString( 'Test correction content 2', $corrections_markup, 'The correction content should be included in the output.' );
+		$this->assertStringContainsString( 'corrections-top-module', $corrections_markup, 'The correction location should be included in the output.' );
 	}
 }

--- a/tests/unit-tests/corrections.php
+++ b/tests/unit-tests/corrections.php
@@ -34,7 +34,6 @@ class Test_Corrections extends WP_UnitTestCase {
 		Corrections::init();
 
 		self::$post_id = $this->factory()->post->create( [ 'post_type' => 'post' ] );
-		update_post_meta( self::$post_id, Corrections::CORRECTIONS_ACTIVE_META, true );
 	}
 
 	/**

--- a/tests/unit-tests/corrections.php
+++ b/tests/unit-tests/corrections.php
@@ -447,25 +447,6 @@ class Test_Corrections extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that the corrections shortcode is added.
-	 *
-	 * @covers Corrections::add_corrections_shortcode
-	 */
-	public function test_add_corrections_shortcode() {
-		global $shortcode_tags;
-
-		Corrections::add_corrections_shortcode();
-
-		$this->assertArrayHasKey( 'corrections', $shortcode_tags, 'The corrections shortcode should be registered.' );
-
-		$callback = $shortcode_tags['corrections'];
-		$this->assertTrue( is_callable( $callback ), 'The corrections shortcode callback should be callable.' );
-
-		$expected_callback = array( 'Newspack\\Corrections', 'handle_corrections_shortcode' );
-		$this->assertEquals( $expected_callback, $callback, 'The corrections shortcode callback does not match the expected value.' );
-	}
-
-	/**
 	 * Test that correction type is returned as "Correction".
 	 *
 	 * @covers Corrections::get_correction_type
@@ -505,52 +486,6 @@ class Test_Corrections extends WP_UnitTestCase {
 
 		$clarification_type = Corrections::get_correction_type( $clarification_id );
 		$this->assertEquals( 'Clarification', $clarification_type, 'The correction type should be "Clarification".' );
-	}
-
-	/**
-	 * Test that the corrections shortcode is handled.
-	 *
-	 * @covers Corrections::handle_corrections_shortcode
-	 */
-	public function test_handle_corrections_shortcode() {
-		$correction_1 = array(
-			'content'  => 'Test correction content',
-			'type'     => 'correction',
-			'date'     => current_time( 'mysql' ),
-			'location' => 'bottom',
-		);
-
-		$correction_1_id = Corrections::add_correction( self::$post_id, $correction_1 );
-		$this->assertNotWPError( $correction_1_id );
-		$this->assertNotEquals( 0, $correction_1_id );
-
-		$correction_2 = array(
-			'content'  => 'Test correction content 2',
-			'type'     => 'clarification',
-			'date'     => current_time( 'mysql' ),
-			'location' => 'top',
-		);
-
-		$correction_2_id = Corrections::add_correction( self::$post_id, $correction_2 );
-		$this->assertNotWPError( $correction_2_id );
-		$this->assertNotEquals( 0, $correction_2_id );
-
-		$page = $this->factory()->post->create_and_get(
-			[
-				'post_type'    => 'page',
-				'post_content' => 'Test Page:- [corrections]',
-			]
-		);
-
-		$corrections_shortcode_output = do_shortcode( $page->post_content );
-		$this->assertStringNotContainsString( '[corrections]', $corrections_shortcode_output, 'The corrections shortcode should be removed from the output.' );
-
-		$this->assertStringContainsString( 'Test correction content', $corrections_shortcode_output, 'The correction content should be included in the output.' );
-		$this->assertStringContainsString( 'Test correction content 2', $corrections_shortcode_output, 'The correction content should be included in the output.' );
-		$correction_1_heading = sprintf( 'Correction on %s', get_the_date( 'M j, Y', $correction_1_id ) );
-		$this->assertStringContainsString( $correction_1_heading, $corrections_shortcode_output, 'The correction date should be included in the output.' );
-		$correction_2_heading = sprintf( 'Correction on %s', get_the_date( 'M j, Y', $correction_2_id ) );
-		$this->assertStringContainsString( $correction_2_heading, $corrections_shortcode_output, 'The correction date should be included in the output.' );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/1/26890605006346/project/1209292256643614/task/1209635079338293.

### How to test the changes in this Pull Request:

1. Create a Test Post > Manage Corrections.
2. Check Manage Corrections modal should have a new `LOCATION` setting. Default: `Bottom`.
3. Add at some corrections with the location set to "top" and others with the location set to "bottom".
4. Verify that each correction’s meta field for location is correctly saved. After reloading few times.
5. View the post on the front-end and confirm that corrections with the "top" location are displayed above the post content and corrections with the "bottom" location are displayed below the post content.
6. Ensure that if no corrections exist for a given location, no corrections in that location is rendered.

### Next Steps:-
- Refactor Corrections blocks to work with the location setting.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->