### PR TITLE
Add exception to Admin view for Multisite installations

### DIFF
--- a/includes/class-admin-plugins-screen.php
+++ b/includes/class-admin-plugins-screen.php
@@ -18,8 +18,10 @@ class Admin_Plugins_Screen {
 	 * Constructor.
 	 */
 	public function __construct() {
-		add_filter( 'all_plugins', [ $this, 'inject_managed_plugins' ] );
-		add_filter( 'plugin_action_links', [ $this, 'modify_action_links' ], 10, 3 );
+		if ( ! is_multisite() || is_network_admin() ) {
+			add_filter( 'all_plugins', [ $this, 'inject_managed_plugins' ] );
+			add_filter( 'plugin_action_links', [ $this, 'modify_action_links' ], 10, 3 );
+		}
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts_and_styles' ] );
 		add_action( 'admin_action_newspack_install_plugin', [ $this, 'handle_plugin_install' ] );
 		add_action( 'all_admin_notices', [ $this, 'plugin_install_notices' ] );


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

On a Multisite Network installation, local Admins (as opposed to "Network" AKA "Super" Admins) [have reduced capabilities compared to the Admin role on standard installations](https://developer.wordpress.org/advanced-administration/multisite/administration/#user-access-capabilities). Specifically they can't install new plugins.

For Multisite users viewing the Admin page but who do not have Network Admin privileges, this commit skips over some `add_filter` calls that were causing errors on the plugin listing page (since the Admin did not actually have those capabilities).

This will still work correctly for a Network Admin with the plugin installation privileges since the `is_network_admin()` will catch that and render the correct available actions.

(co-authored by @jsdiaz)

### How to test the changes in this Pull Request:

1. Install Newspack in a Multisite Network environment
2. View the plugins page as a regular Admin user (not a Network Admin)
3. Observe php errors at the top of the page
4. Apply this patch
5. View the plugins page again as the same user
6. Observe no errors

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?