### PR TITLE
fix(newsletters): display correct premium lists in modal

### DIFF
--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -1087,5 +1087,24 @@ class Memberships {
 
 		return (int) reset( $user_subscriptions );
 	}
+
+	/**
+	 * Get product Ids for the given membership plan.
+	 *
+	 * @param int $plan_id Membership plan ID.
+	 *
+	 * @return array Product IDs.
+	 */
+	public static function get_product_ids_for_membership_plan( $plan_id ) {
+		if ( ! function_exists( 'wc_memberships_get_membership_plan' ) ) {
+			return [];
+		}
+		$product_ids = [];
+		$plan        = \wc_memberships_get_membership_plan( $plan_id );
+		if ( $plan ) {
+			$product_ids = $plan->get_product_ids();
+		}
+		return $product_ids;
+	}
 }
 Memberships::init();

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -11,6 +11,7 @@ use Newspack\Recaptcha;
 use Newspack\Reader_Activation\Sync;
 use Newspack\Renewal;
 use Newspack\WooCommerce_My_Account;
+use Newspack\Memberships;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -562,6 +563,14 @@ final class Reader_Activation {
 		}
 
 		foreach ( $available_lists as $list_id => $list ) {
+			// Flag any premium lists.
+			if ( method_exists( '\Newspack_Newsletters\Plugins\Woocommerce_Memberships', 'is_subscription_list_tied_to_plan' ) ) {
+				$plan_id = \Newspack_Newsletters\Plugins\Woocommerce_Memberships::is_subscription_list_tied_to_plan( $list['db_id'], true );
+				if ( $plan_id ) {
+					$list['is_restricted'] = true;
+					$list['product_ids']   = Memberships::get_product_ids_for_membership_plan( $plan_id );
+				}
+			}
 			$registration_lists[ $list_id ] = $list;
 		}
 
@@ -1504,7 +1513,11 @@ final class Reader_Activation {
 					foreach ( $newsletters_lists as $list ) {
 						$checkbox_id = sprintf( 'newspack-plugin-list-%s', $list['id'] );
 						?>
-						<label class="newspack-ui__input-card" for="<?php echo \esc_attr( $checkbox_id ); ?>">
+						<label
+							class="newspack-ui__input-card<?php echo isset( $list['is_restricted'] ) && $list['is_restricted'] ? \esc_attr( ' is-restricted-newsletter' ) : ''; ?>"
+							data-product-ids="<?php echo isset( $list['product_ids'] ) ? \esc_attr( implode( ',', $list['product_ids'] ) ) : ''; ?>"
+							for="<?php echo \esc_attr( $checkbox_id ); ?>"
+						>
 							<input
 								type="checkbox"
 								name="lists[]"

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -561,12 +561,14 @@ final class Reader_Activation {
 		if ( empty( $available_lists ) ) {
 			return [];
 		}
-
+		// Filter available lists to only those the reader has access to.
+		// See https://github.com/Automattic/newspack-newsletters/blob/trunk/includes/plugins/woocommerce-memberships/class-woocommerce-memberships.php#L123.
+		$filtered_lists = apply_filters( 'newspack_auth_form_newsletters_lists', $available_lists );
 		foreach ( $available_lists as $list_id => $list ) {
-			// Flag any premium lists.
 			if ( method_exists( '\Newspack_Newsletters\Plugins\Woocommerce_Memberships', 'is_subscription_list_tied_to_plan' ) ) {
 				$plan_id = \Newspack_Newsletters\Plugins\Woocommerce_Memberships::is_subscription_list_tied_to_plan( $list['db_id'], true );
-				if ( $plan_id ) {
+				// If the plan is premium and the reader does not have access, flag it and set the product IDs.
+				if ( $plan_id && ! in_array( $list_id, array_keys( $filtered_lists ), true ) ) {
 					$list['is_restricted'] = true;
 					$list['product_ids']   = Memberships::get_product_ids_for_membership_plan( $plan_id );
 				}

--- a/src/reader-activation-newsletters/newsletters-modal.js
+++ b/src/reader-activation-newsletters/newsletters-modal.js
@@ -102,6 +102,17 @@ export function openNewslettersSignupModal( config = {} ) {
 		}
 	}
 
+	// Handle premium newsletters visibility.
+	const restrictedNewsletters = modal.querySelectorAll( '.is-restricted-newsletter' );
+	restrictedNewsletters.forEach( newsletter => {
+		if ( config?.productId ) {
+			const productIds = newsletter.getAttribute( 'data-product-ids' )?.split( ',' );
+			if ( productIds && productIds.includes( config.productId.toString() ) ) {
+				newsletter.classList.remove( 'is-restricted-newsletter' );
+			}
+		}
+	} );
+
 	modal.setAttribute( 'data-state', 'open' );
 	a11y.trapFocus( modal );
 	if ( window?.newspackReaderActivation?.overlays ) {

--- a/src/reader-activation-newsletters/style.scss
+++ b/src/reader-activation-newsletters/style.scss
@@ -15,6 +15,10 @@
 
 	.newspack-newsletters-signup {
 		margin-top: var(--newspack-ui-spacer-5);
+
+		.is-restricted-newsletter {
+			display: none !important;
+		}
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

See https://newspackp2.wordpress.com/2025/03/10/upcoming-changes-march-17-2025/#comment-13540

This PR fixes an issue where the newsletters modal was incorrectly showing all premium newsletters. We fix this by specifying product ids that should "unlock" the newsletter in the modal before making it visible:

![Screenshot 2025-03-17 at 12 45 54](https://github.com/user-attachments/assets/739155c5-64e9-415e-9243-3d016735c6c7)

### How to test the changes in this Pull Request:

**Requires https://github.com/Automattic/newspack-newsletters/pull/1782 and https://github.com/Automattic/newspack-blocks/pull/2075 to test.**

#### Setup
1. On a test site, set up three Subscription Lists via Newspack > Engagement > Newsletters
2. Set up two subscription products (non-donation) and add two checkout buttons to any page or post for these products
4. Set up two memberships tied to the two subscription products from the previous step, and restricting two of the three subscription lists from the first step, one per membership
5. Set up a third subscription product, not associated with any membership or subscription list and add a third checkout button to the same page or post
6. Enable the post-checkout/auth newsletter modal and add all three subscription lists via Newspack > Engagement > Show Advanced Settings > Newsletter Subscription Lists

#### Testing
1. As a reader, purchase the subscription product not restricting any subscription lists
2. Confirm the newsletters modal appears post-checkout only displaying one of the three subscription lists. Don't signup.
3. As the reader, purchase one of the subscription products restricting a subscription list.
4. Confirm the newsletters modal appears post-checkout displaying:
  - The non-restricted list
  - The restricted list associated with the product you just purchased
5. As the reader, purchase the final subscription product
6. Confirm all three lists appear in the newsletters modal. None should be restricted since you've purchased all products

Bonus: Smoke test the newsletters form post-auth form.


### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->