### PR TITLE
fix(ia): dashboard header bg color

### DIFF
--- a/includes/wizards/newspack/class-newspack-dashboard.php
+++ b/includes/wizards/newspack/class-newspack-dashboard.php
@@ -248,11 +248,10 @@ class Newspack_Dashboard extends Wizard {
 	 */
 	public function get_local_data() {
 		$site_name = get_bloginfo( 'name' );
-		$colors = newspack_get_theme_colors();
 		$local_data = [
 			'settings'     => [
 				'siteName'      => $site_name,
-				'headerBgColor' => $colors['primary_color'] ?? '',
+				'headerBgColor' => get_theme_mod( 'primary_color_hex', '#f0f0f0' ),
 			],
 			'sections'     => $this->get_dashboard(),
 			'plugins'      => get_plugins(),

--- a/includes/wizards/newspack/class-newspack-dashboard.php
+++ b/includes/wizards/newspack/class-newspack-dashboard.php
@@ -248,11 +248,11 @@ class Newspack_Dashboard extends Wizard {
 	 */
 	public function get_local_data() {
 		$site_name = get_bloginfo( 'name' );
-		$theme_mods = get_theme_mods();
+		$colors = newspack_get_theme_colors();
 		$local_data = [
 			'settings'     => [
 				'siteName'      => $site_name,
-				'headerBgColor' => $theme_mods['header_color_hex'] ?? '',
+				'headerBgColor' => $colors['primary_color'] ?? '',
 			],
 			'sections'     => $this->get_dashboard(),
 			'plugins'      => get_plugins(),

--- a/src/components/src/box-contrast/index.tsx
+++ b/src/components/src/box-contrast/index.tsx
@@ -26,7 +26,12 @@ const BoxContrast = ( {
 	isInverted?: boolean;
 	className?: string;
 } ) => {
-	const contrastColor = getContrast( hexColor );
+	let contrastColor;
+	if ( hexColor === '#f0f0f0' ) {
+		contrastColor = '#1e1e1e';
+	} else {
+		contrastColor = getContrast( hexColor );
+	}
 	const style = isInverted
 		? { color: hexColor, backgoundColor: contrastColor }
 		: { backgroundColor: hexColor, color: contrastColor };


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

1205919985867982-as-1209481431941380/f

Switch the Dashboard's header background color to the site's primary color.

### How to test the changes in this Pull Request:

1. Navigate to Newspack -> Settings -> Theme and Brand 
2. Change your primary color and save
3. Navigate to Newspack -> Dashboard and confirm the color is applied to the header background

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->