### PR TITLE
fix(modal-checkout): endpoint to refresh newsletter lists via REST

### DIFF
--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1575,7 +1575,7 @@ final class Reader_Activation {
 		if ( ! self::is_newsletters_signup_available() ) {
 			return;
 		}
-		if ( empty( $email_address ) ) {
+		if ( ! is_email( $email_address ) ) {
 			$email_address = self::get_logged_in_reader_email_address();
 		}
 		$newsletters_lists = self::get_post_checkout_newsletter_lists( $email_address );

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -233,11 +233,17 @@ final class Reader_Activation {
 	public static function register_routes() {
 		\register_rest_route(
 			NEWSPACK_API_NAMESPACE,
-			'/reader-newsletter-signup-lists',
+			'/reader-newsletter-signup-lists/(?P<email_address>[\a-z]+)',
 			[
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => [ __CLASS__, 'api_render_newsletters_signup_form' ],
-				'permission_callback' => '__return_true', // TODO: this needs to be restricted to logged-in users and include nonce verification
+				'permission_callback' => '__return_true',
+				'args'                => [
+					'email_address' => [
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_email',
+					],
+				],
 			]
 		);
 	}
@@ -584,9 +590,10 @@ final class Reader_Activation {
 		/**
 		 * Filters the newsletters lists that should be rendered after checkout.
 		 *
-		 * @param array $registration_lists Array of newsletter lists.
+		 * @param array  $registration_lists Array of newsletter lists.
+		 * @param string $email_address      Email address.
 		 */
-		return apply_filters( 'newspack_post_registration_newsletters_lists', $registration_lists );
+		return apply_filters( 'newspack_post_registration_newsletters_lists', $registration_lists, $email_address );
 	}
 
 	/**
@@ -1504,11 +1511,13 @@ final class Reader_Activation {
 	/**
 	 * Fetch HTML for the post-checkout newsletter signup modal.
 	 *
+	 * @param WP_REST_Request $request The REST request.
+	 *
 	 * @return WP_REST_Response
 	 */
-	public static function api_render_newsletters_signup_form() {
+	public static function api_render_newsletters_signup_form( $request ) {
 		ob_start();
-		self::render_newsletters_signup_modal();
+		self::render_newsletters_signup_modal( $request['email_address'] );
 		$html = trim( ob_get_clean() );
 		return new \WP_REST_Response( [ 'html' => $html ] );
 	}
@@ -1559,13 +1568,16 @@ final class Reader_Activation {
 
 	/**
 	 * Renders the newsletter signup modal.
+	 *
+	 * @param string $email_address Email address. Optional, defaults to the logged-in reader's email address.
 	 */
-	public static function render_newsletters_signup_modal() {
+	public static function render_newsletters_signup_modal( $email_address = '' ) {
 		if ( ! self::is_newsletters_signup_available() ) {
 			return;
 		}
-
-		$email_address = self::get_logged_in_reader_email_address();
+		if ( empty( $email_address ) ) {
+			$email_address = self::get_logged_in_reader_email_address();
+		}
 		$newsletters_lists = self::get_post_checkout_newsletter_lists( $email_address );
 		if ( empty( $newsletters_lists ) ) {
 			return;

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -89,6 +89,7 @@ final class Reader_Activation {
 		\add_action( 'woocommerce_customer_reset_password', [ __CLASS__, 'login_after_password_reset' ] );
 
 		if ( self::is_enabled() ) {
+			\add_action( 'rest_api_init', [ __CLASS__, 'register_routes' ] );
 			\add_action( 'clear_auth_cookie', [ __CLASS__, 'clear_auth_intention_cookie' ] );
 			\add_action( 'clear_auth_cookie', [ __CLASS__, 'clear_auth_reader_cookie' ] );
 			\add_action( 'set_auth_cookie', [ __CLASS__, 'clear_auth_intention_cookie' ] );
@@ -224,6 +225,21 @@ final class Reader_Activation {
 				NEWSPACK_PLUGIN_VERSION
 			);
 		}
+	}
+
+	/**
+	 * Register routes.
+	 */
+	public static function register_routes() {
+		\register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/reader-newsletter-signup-lists',
+			[
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ __CLASS__, 'api_render_newsletters_signup_form' ],
+				'permission_callback' => '__return_true', // TODO: this needs to be restricted to logged-in users and include nonce verification
+			]
+		);
 	}
 
 	/**
@@ -1485,6 +1501,17 @@ final class Reader_Activation {
 		<?php
 	}
 
+	/**
+	 * Fetch HTML for the post-checkout newsletter signup modal.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public static function api_render_newsletters_signup_form() {
+		ob_start();
+		self::render_newsletters_signup_modal();
+		$html = trim( ob_get_clean() );
+		return new \WP_REST_Response( [ 'html' => $html ] );
+	}
 
 	/**
 	 * Renders newsletters signup form.
@@ -1538,7 +1565,7 @@ final class Reader_Activation {
 			return;
 		}
 
-		$email_address     = self::get_logged_in_reader_email_address();
+		$email_address = self::get_logged_in_reader_email_address();
 		$newsletters_lists = self::get_post_checkout_newsletter_lists( $email_address );
 		if ( empty( $newsletters_lists ) ) {
 			return;

--- a/src/reader-activation-newsletters/index.js
+++ b/src/reader-activation-newsletters/index.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { openNewslettersSignupModal } from './newsletters-modal';
+import { openNewslettersSignupModal, refreshNewslettersSignupModal } from './newsletters-modal';
 
 import { domReady } from '../utils';
 
@@ -12,5 +12,6 @@ window.newspackRAS.push( readerActivation => {
 	domReady( function () {
 		/** Expose the openNewslettersSignupModal function to the RAS scope */
 		readerActivation._openNewslettersSignupModal = openNewslettersSignupModal;
+		readerActivation.refreshNewslettersSignupModal = refreshNewslettersSignupModal;
 	} );
 } );

--- a/src/reader-activation-newsletters/newsletters-form.js
+++ b/src/reader-activation-newsletters/newsletters-form.js
@@ -16,15 +16,12 @@ window.newspackRAS.push( function ( readerActivation ) {
 		}
 
 		containers.forEach( container => {
-			const form = container.querySelector( 'form' );
+			let form = container.querySelector( 'form' );
 			if ( ! form ) {
 				return;
 			}
 
-			/**
-			 * Handle newsletters signup form submission.
-			 */
-			form.addEventListener( 'submit', ev => {
+			const handleSubmit = ev => {
 				ev.preventDefault();
 
 				if ( form.classList.contains( 'processing' ) ) {
@@ -56,6 +53,24 @@ window.newspackRAS.push( function ( readerActivation ) {
 					form.classList.remove( 'processing' );
 					form.querySelector( 'button' ).removeAttribute( 'disabled' );
 				} );
+			}
+
+			/**
+			 * Handle newsletters signup form submission.
+			 */
+			form.addEventListener( 'submit', handleSubmit );
+
+			/**
+			 * Handle container refresh.
+			 */
+			container.addEventListener( 'newspack:refresh', () => {
+				form = container.querySelector( 'form' );
+				if ( ! form ) {
+					return;
+				}
+				// Make sure we aren't adding multiple event listeners to the form.
+				form.removeEventListener( 'submit', handleSubmit );
+				form.addEventListener( 'submit', handleSubmit );
 			} );
 		} );
 	} );

--- a/src/reader-activation-newsletters/newsletters-modal.js
+++ b/src/reader-activation-newsletters/newsletters-modal.js
@@ -31,7 +31,19 @@ export function refreshNewslettersSignupModal( email ) {
 						.json()
 						.then( ( { html } ) => {
 							if ( html ) {
-								modal.outerHTML = html;
+								// Create dom node from html.
+								const parser = new DOMParser();
+								const doc = parser.parseFromString( html, 'text/html' );
+								// Remove existing form.
+								const existingForm = container.querySelector( 'form' );
+								if ( existingForm ) {
+									existingForm.remove();
+								}
+								// Append new form.
+								const newForm = doc.querySelector( '.newspack-newsletters-signup form' );
+								if ( newForm ) {
+									container.appendChild( newForm );
+								}
 							}
 						} );
 			} );

--- a/src/reader-activation-newsletters/newsletters-modal.js
+++ b/src/reader-activation-newsletters/newsletters-modal.js
@@ -11,7 +11,13 @@ export function getModalContainer() {
 	);
 }
 
-export function refreshNewslettersSignupModal() {
+/**
+ * Refresh the newsletters signup modal content.
+ *
+ * @param {string} email The email address to populate in the modal.
+ * @return {void}
+ */
+export function refreshNewslettersSignupModal( email ) {
 	const container = getModalContainer();
 	if ( ! container ) {
 		return;
@@ -19,13 +25,13 @@ export function refreshNewslettersSignupModal() {
 
 	const modal = container.closest( '.newspack-newsletters-signup-modal' );
 	if ( modal ) {
-		fetch( '/wp-json/newspack/v1/reader-newsletter-signup-lists' )
+		fetch( `/wp-json/newspack/v1/reader-newsletter-signup-lists/${ email }` )
 			.then( res => {
 				res
 						.json()
 						.then( ( { html } ) => {
 							if ( html ) {
-								modal.innerHTML = html;
+								modal.outerHTML = html;
 							}
 						} );
 			} );

--- a/src/reader-activation-newsletters/newsletters-modal.js
+++ b/src/reader-activation-newsletters/newsletters-modal.js
@@ -11,6 +11,27 @@ export function getModalContainer() {
 	);
 }
 
+export function refreshNewslettersSignupModal() {
+	const container = getModalContainer();
+	if ( ! container ) {
+		return;
+	}
+
+	const modal = container.closest( '.newspack-newsletters-signup-modal' );
+	if ( modal ) {
+		fetch( '/wp-json/newspack/v1/reader-newsletter-signup-lists' )
+			.then( res => {
+				res
+						.json()
+						.then( ( { html } ) => {
+							if ( html ) {
+								modal.innerHTML = html;
+							}
+						} );
+			} );
+	}
+}
+
 /**
  * Open the newsletters signup modal.
  *

--- a/src/reader-activation-newsletters/newsletters-modal.js
+++ b/src/reader-activation-newsletters/newsletters-modal.js
@@ -31,19 +31,18 @@ export function refreshNewslettersSignupModal( email ) {
 						.json()
 						.then( ( { html } ) => {
 							if ( html ) {
-								// Create dom node from html.
 								const parser = new DOMParser();
 								const doc = parser.parseFromString( html, 'text/html' );
-								// Remove existing form.
 								const existingForm = container.querySelector( 'form' );
 								if ( existingForm ) {
 									existingForm.remove();
 								}
-								// Append new form.
 								const newForm = doc.querySelector( '.newspack-newsletters-signup form' );
 								if ( newForm ) {
 									container.appendChild( newForm );
 								}
+								// Dispatch refresh event on the container.
+								container.dispatchEvent( new Event( 'newspack:refresh' ) );
 							}
 						} );
 			} );


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

See https://newspackp2.wordpress.com/2025/03/10/upcoming-changes-march-17-2025/#comment-13540

This PR fixes an issue where the newsletters modal was incorrectly showing all premium newsletters.

![Screenshot 2025-03-17 at 12 45 54](https://github.com/user-attachments/assets/739155c5-64e9-415e-9243-3d016735c6c7)

### How to test the changes in this Pull Request:

**Requires https://github.com/Automattic/newspack-blocks/pull/2080 and https://github.com/Automattic/newspack-newsletters/pull/1783 to test.**

#### Setup
1. On a test site, set up three Subscription Lists via Newspack > Engagement > Newsletters
2. Set up two subscription products (non-donation) and add two checkout buttons to any page or post for these products
4. Set up two memberships tied to the two subscription products from the previous step, and restricting two of the three subscription lists from the first step, one per membership
5. Set up a third subscription product, not associated with any membership or subscription list and add a third checkout button to the same page or post
6. Enable the post-checkout/auth newsletter modal and add all three subscription lists via Newspack > Engagement > Show Advanced Settings > Newsletter Subscription Lists

#### Testing
1. As a reader, purchase the subscription product not restricting any subscription lists
2. Confirm the newsletters modal appears post-checkout only displaying one of the three subscription lists. Don't signup.
3. As the reader, purchase one of the subscription products restricting a subscription list.
4. Confirm the newsletters modal appears post-checkout displaying:
  - The non-restricted list
  - The restricted list associated with the product you just purchased
5. As the reader, purchase the final subscription product
6. Confirm all three lists appear in the newsletters modal. None should be restricted since you've purchased all products

Bonus: Smoke test the newsletters form post-registration.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->