### PR TITLE
feat(memberships): status reevaluation

### DIFF
--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -53,6 +53,8 @@ class Memberships {
 		add_filter( 'wc_memberships_admin_screen_ids', [ __CLASS__, 'admin_screens' ] );
 		add_filter( 'wc_memberships_general_settings', [ __CLASS__, 'wc_memberships_general_settings' ] );
 		add_filter( 'wc_memberships_is_post_public', [ __CLASS__, 'wc_memberships_is_post_public' ] );
+		add_action( 'wc_memberships_user_membership_actions', [ __CLASS__, 'user_membership_meta_box_actions' ], 1, 2 );
+		add_action( 'admin_init', [ __CLASS__, 'handle_reevaluation_request' ] );
 		add_action( 'wp_footer', [ __CLASS__, 'render_overlay_gate' ], 1 );
 		add_action( 'wp_footer', [ __CLASS__, 'render_js' ] );
 		add_filter( 'newspack_popups_assess_has_disabled_popups', [ __CLASS__, 'disable_popups' ] );
@@ -1086,6 +1088,64 @@ class Memberships {
 		}
 
 		return (int) reset( $user_subscriptions );
+	}
+
+	/**
+	 * Handle reevaluation request, triggered by the User Membership meta box action.
+	 * Membership and subscription can get unlinked, this will help the administrator
+	 * resync the membership status after relinking the subscription.
+	 */
+	public static function handle_reevaluation_request() {
+		if ( isset( $_GET['reevaluate'] ) && isset( $_GET['post'] ) && function_exists( 'wcs_get_subscription' ) && function_exists( 'wc_memberships_get_user_membership' ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$subscription    = \wcs_get_subscription( absint( $_GET['reevaluate'] ) );
+			$membership    = \wc_memberships_get_user_membership( absint( $_GET['post'] ) );
+
+			if ( $subscription instanceof \WC_Subscription && $membership ) {
+				$integrations = wc_memberships()->get_integrations_instance();
+				$integration  = $integrations ? $integrations->get_subscriptions_instance() : null;
+				if ( $integration ) {
+					$has_same_status = $integration->has_subscription_same_status( $subscription, $membership );
+					if ( ! $has_same_status ) {
+						$integration->update_related_membership_status(
+							$subscription,
+							$membership,
+							$subscription->get_status()
+						);
+					}
+				}
+
+				wp_safe_redirect( remove_query_arg( 'reevaluate' ) );
+				exit;
+			}
+		}
+	}
+
+	/**
+	 * Adds User Membership meta box actions.
+	 *
+	 * @param array $actions associative array.
+	 * @param int   $user_membership_id \WC_Membership_User_Membership post ID.
+	 * @return array
+	 */
+	public static function user_membership_meta_box_actions( $actions, $user_membership_id ) {
+		$integration  = wc_memberships()->get_integrations_instance()->get_subscriptions_instance();
+		$subscription = $integration ? $integration->get_subscription_from_membership( $user_membership_id ) : null;
+
+		if ( $subscription instanceof \WC_Subscription ) {
+				$actions = array_merge(
+					[
+						'reevaluate' => [
+							'link'              => admin_url( 'post.php?post=' . $user_membership_id . '&action=edit&reevaluate=' . $subscription->get_id() ),
+							'text'              => __( 'Reevaluate status', 'newspack-plugin' ),
+							'custom_attributes' => [
+								'title' => __( 'Reevaluate status based on subscription status.', 'newspack-plugin' ),
+							],
+						],
+					],
+					$actions
+				);
+		}
+		return $actions;
 	}
 }
 Memberships::init();

--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -1097,8 +1097,8 @@ class Memberships {
 	 */
 	public static function handle_reevaluation_request() {
 		if ( isset( $_GET['reevaluate'] ) && isset( $_GET['post'] ) && function_exists( 'wcs_get_subscription' ) && function_exists( 'wc_memberships_get_user_membership' ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$subscription    = \wcs_get_subscription( absint( $_GET['reevaluate'] ) );
-			$membership    = \wc_memberships_get_user_membership( absint( $_GET['post'] ) );
+			$subscription = \wcs_get_subscription( absint( $_GET['reevaluate'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$membership = \wc_memberships_get_user_membership( absint( $_GET['post'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 			if ( $subscription instanceof \WC_Subscription && $membership ) {
 				$integrations = wc_memberships()->get_integrations_instance();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Membership and subscription can get unlinked, this will help the administrator resync the membership status after relinking the subscription.

### How to test the changes in this Pull Request:

1. Get a hold of a membership linked to a subscription
2. Unlink them by removing the `_subscription_id` post meta on the membership
3. Update the subscription status to something else
4. Relink the entities by restating the `_subscription_id` meta
5. Observe that nothing magically happened – the statuses are out of sync
6. Click the "Reevaluate status" button on the user membership edit screen 
7. Observe the statuses are now aligned

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209669282935156