### PR TITLE
fix(reader-revenue): fatal when using woocommerce-paypal-payments@3.0.0

### DIFF
--- a/includes/configuration_managers/class-woocommerce-configuration-manager.php
+++ b/includes/configuration_managers/class-woocommerce-configuration-manager.php
@@ -254,7 +254,11 @@ class WooCommerce_Configuration_Manager extends Configuration_Manager {
 		if ( 'ppcp-gateway' === $gateway_slug && method_exists( 'WooCommerce\PayPalCommerce\PPCP', 'container' ) ) {
 			$paypal = \WooCommerce\PayPalCommerce\PPCP::container();
 			if ( $paypal ) {
-				$env = $paypal->get( 'onboarding.environment' );
+				try {
+					$env = $paypal->get( 'onboarding.environment' ); // woocommerce-paypal-payments@2.9.6.
+				} catch ( \Throwable $th ) {
+					$env = $paypal->get( 'settings.environment' ); // woocommerce-paypal-payments@3.0.0.
+				}
 				if ( $env && $env->current_environment_is( $env::SANDBOX ) ) {
 					$test_mode = true;
 				}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

`woocommerce-paypal-payments@3.0.0` change some internals which we use. This change will ensure Newspack supports both legacy and new versions.  

### How to test the changes in this Pull Request:

1. Install and activate `woocommerce-paypal-payments` with the latest version
2. Load the Reader Revenue wizard, observe no fatal error (`/wp-admin/admin.php?page=newspack-reader-revenue-wizard#/payment-methods` should load fine)
3. Downgrade* and reload – observe all is still well

\* `wp --skip-plugins --skip-themes  plugin install --activate woocommerce-paypal-payments --version=2.9.6 --force`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209723811724348