### PR TITLE
fix: add check if product before gating content

### DIFF
--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -659,6 +659,7 @@ class Memberships {
 		if ( get_queried_object_id() !== get_the_ID() ) {
 			return '';
 		}
+
 		self::$gate_rendered = true;
 		return self::get_inline_gate_content();
 	}
@@ -854,7 +855,7 @@ class Memberships {
 	 */
 	public static function user_has_cap( $all_caps, $caps, $args ) {
 		// Bail if Woo Memberships is not active.
-		if ( ! self::is_active() ) {
+		if ( ! self::is_active() || is_product() ) {
 			return $all_caps;
 		}
 
@@ -944,6 +945,7 @@ class Memberships {
 		$has_subscription  = false;
 
 		foreach ( $rules as $rule ) {
+
 			$membership_plan_id = $rule->get_membership_plan_id();
 			$has_subscription   = ! empty( self::get_user_subscription_for_membership_plan( $user_id, $membership_plan_id ) );
 

--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -659,7 +659,6 @@ class Memberships {
 		if ( get_queried_object_id() !== get_the_ID() ) {
 			return '';
 		}
-
 		self::$gate_rendered = true;
 		return self::get_inline_gate_content();
 	}
@@ -945,7 +944,6 @@ class Memberships {
 		$has_subscription  = false;
 
 		foreach ( $rules as $rule ) {
-
 			$membership_plan_id = $rule->get_membership_plan_id();
 			$has_subscription   = ! empty( self::get_user_subscription_for_membership_plan( $user_id, $membership_plan_id ) );
 

--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -854,7 +854,7 @@ class Memberships {
 	 * @return array Filtered capabilities.
 	 */
 	public static function user_has_cap( $all_caps, $caps, $args ) {
-		// Bail if Woo Memberships is not active.
+		// Bail if Woo Memberships is not active or if this is a product.
 		if ( ! self::is_active() || is_product() ) {
 			return $all_caps;
 		}

--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -648,7 +648,7 @@ class Memberships {
 	 */
 	public static function wc_memberships_notice_html( $notice, $message_body, $message_code, $message_args ) {
 		// If the gate is not available, don't mess with the notice.
-		// The is_product() check stops products with discounts from plans from being gated; normally they are not gated.
+		// Membership notices are only displayed on products with discounts from plans. The is_product() check makes sure that still works as normal.
 		if ( ! self::has_gate() || is_product() ) {
 			return $notice;
 		}
@@ -675,7 +675,7 @@ class Memberships {
 	 */
 	public static function wc_memberships_excerpt( $excerpt, $post, $message_code ) {
 		// If the gate is not available, don't mess with the excerpt.
-		// The is_product() check stops products with discounts from plans from being gated; normally they are not gated.
+		// Products with discounts from plans also display this excerpt; the is_product() check makes sure that still works as normal.
 		if ( ! self::has_gate() || is_product() ) {
 			return $excerpt;
 		}

--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -648,7 +648,7 @@ class Memberships {
 	 */
 	public static function wc_memberships_notice_html( $notice, $message_body, $message_code, $message_args ) {
 		// If the gate is not available, don't mess with the notice.
-		if ( ! self::has_gate() ) {
+		if ( ! self::has_gate() || is_product() ) {
 			return $notice;
 		}
 		// Don't show gate unless attached to a specific post.
@@ -674,7 +674,7 @@ class Memberships {
 	 */
 	public static function wc_memberships_excerpt( $excerpt, $post, $message_code ) {
 		// If the gate is not available, don't mess with the excerpt.
-		if ( ! self::has_gate() ) {
+		if ( ! self::has_gate() || is_product() ) {
 			return $excerpt;
 		}
 		// If rendering the content in a loop, don't truncate the excerpt.

--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -648,6 +648,7 @@ class Memberships {
 	 */
 	public static function wc_memberships_notice_html( $notice, $message_body, $message_code, $message_args ) {
 		// If the gate is not available, don't mess with the notice.
+		// The is_product() check stops products with discounts from plans from being gated; normally they are not gated.
 		if ( ! self::has_gate() || is_product() ) {
 			return $notice;
 		}
@@ -674,6 +675,7 @@ class Memberships {
 	 */
 	public static function wc_memberships_excerpt( $excerpt, $post, $message_code ) {
 		// If the gate is not available, don't mess with the excerpt.
+		// The is_product() check stops products with discounts from plans from being gated; normally they are not gated.
 		if ( ! self::has_gate() || is_product() ) {
 			return $excerpt;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR makes sure that products that are included in memberships -- either as limited to members or that have discounts limited to members -- do not get a content gateway.

It also overrides `user_has_cap()` for products; this function was causing all restricted products to return the message `This product is part of your membership, but not yet! It will become available on {date}.`, the message for `product_access_delayed_message` [when a member will get access to a product on a certain date], instead of the one tailored to what's actually happening (like a product being fully restricted to a membership). 

Note: for expediency, you can test https://github.com/Automattic/newspack-theme/pull/2465 at the same time as this one -- it also makes sure the correct membership messaging doesn't look weird!  

See: https://app.asana.com/0/1200550061930446/1209731811855442/f

### How to test the changes in this Pull Request:

1. Set up two products, and make sure to populate the Product Description and Product Short Description. This just makes it easier to see the full issue.
2. Set up a Woo Membership Plan.
3. Under 'Restrict Content', restrict all posts.
4. Under 'Restrict Products', restrict the purchase of at least one product to members only.
5. Under 'Purchasing Discounts', discount at least one specific product. Make sure to set a discount amount, and check the 'Active' checkbox at the end (no comment about how long it took me to figure this out). 
6. Under Newspack > Engagement > Show Advanced Settings, enable and set up the content gate for your membership.
7. In an incognito window, click around posts on your site and confirm that you get the membership gateway.
8. Go to /shop and navigate to view the two products restricted by your membership:

   * Your Restricted Product should show no message, but it will be missing a button to add to cart.
   * Your Purchasing Discount product will show the Short Description, buttons, then full description followed by the Content Gate:

![CleanShot 2025-03-21 at 14 05 56@2x](https://github.com/user-attachments/assets/db69728e-49d0-4e02-8ea0-2fd11db2abb0)

9. Apply this PR.
10. Repeat steps 7 and 8 to confirm that the content gate still works, but is not applied to products. 
   * Your Restricted Product should show a message about the restriction:

![CleanShot 2025-03-21 at 16 22 05@2x](https://github.com/user-attachments/assets/e9f1f87b-179e-4f64-8ae1-027931357fc5)

   * Your Purchasing Discount product should not show the gate, and instead show a message (this screenshot has [this PR applied](https://github.com/Automattic/newspack-theme/pull/2465)).

![CleanShot 2025-03-21 at 14 08 42@2x](https://github.com/user-attachments/assets/95b6809d-f4a0-4673-86d6-5574a5b5893d)

11. Smoke test [the testing steps here](https://github.com/Automattic/newspack-plugin/pull/2623) to make sure the changes to the `user_has_cap()` function doesn't cause issues.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->