### PR TITLE
feat(corrections): Modal UX Enchancements

### DIFF
--- a/src/other-scripts/corrections-modal/index.js
+++ b/src/other-scripts/corrections-modal/index.js
@@ -146,6 +146,13 @@ const CorrectionsModal = () => {
 		setNewCorrectionType( 'correction' );
 	};
 
+	// Remove unsaved corrections.
+	const removeUnsavedCorrections = () => {
+		setCorrections( corrections.filter( ( correction ) => ! correction.isNew ) );
+		setNewCorrection( '' );
+		setNewCorrectionType( 'correction' );
+	};
+
 	// Update an existing correction.
 	const updateCorrection = ( correctionId, postContent, type, date, location ) => {
 		setCorrections( corrections.map( ( correction ) => {
@@ -403,6 +410,7 @@ const CorrectionsModal = () => {
 									onClick={ () => {
 										setIsOpen( false )
 										setIsAddingCorrection( false );
+										removeUnsavedCorrections();
 									} }
 								>
 									{ __( 'Cancel', 'newspack-plugin' ) }

--- a/src/other-scripts/corrections-modal/index.js
+++ b/src/other-scripts/corrections-modal/index.js
@@ -183,6 +183,14 @@ const CorrectionsModal = () => {
 			setSaveError( error.message );
 		} finally {
 			setIsSaving(false);
+			createNotice(
+				'success',
+				__( 'Changes have been saved successfully.', 'newspack-plugin' ),
+				{
+					type: 'snackbar',
+					isDismissible: true,
+				}
+			);
 		}
 	};
 
@@ -214,6 +222,9 @@ const CorrectionsModal = () => {
 					className="newspack-corrections-modal"
 					overlayClassName="newspack-corrections-modal-overlay"
 					size="medium"
+					isDismissible={ false }
+					shouldCloseOnClickOutside={ false }
+					shouldCloseOnEsc={ false }
 				>
 					{ saveError && <p className="error-message">{ saveError }</p> }
 

--- a/src/other-scripts/corrections-modal/index.js
+++ b/src/other-scripts/corrections-modal/index.js
@@ -13,9 +13,9 @@ import {
 	Card,
 	CardHeader,
 	CardBody,
-	Snackbar,
 } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { store as noticesStore } from '@wordpress/notices';
 import { PluginDocumentSettingPanel } from '@wordpress/editor';
 import { useState, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -88,7 +88,11 @@ const CorrectionsModal = () => {
 	const [ newCorrectionLocation, setNewCorrectionLocation ] = useState( 'bottom' );
 	const [ isDatePopoverOpen, setIsDatePopoverOpen ] = useState( null );
 	const [ isAddingCorrection, setIsAddingCorrection ] = useState( false );
-	const [ displayNotice, setDisplayNotice ] = useState( false );
+
+	/**
+	 * Prepare actions.
+	 */
+	const { createNotice } = useDispatch( noticesStore );
 
 	// Fetch corrections when modal opens
 	useEffect( () => {
@@ -206,6 +210,7 @@ const CorrectionsModal = () => {
 					title={ __( 'Corrections & Clarifications', 'newspack-plugin' ) }
 					onRequestClose={ () => setIsOpen( false ) }
 					className="newspack-corrections-modal"
+					overlayClassName="newspack-corrections-modal-overlay"
 					size="medium"
 				>
 					{ ! isAddingCorrection && corrections.length > 0 ? (
@@ -215,20 +220,6 @@ const CorrectionsModal = () => {
 							<CardHeader>
 								{ __( 'Corrections log', 'newspack-plugin' ) }
 							</CardHeader>
-							{	displayNotice &&
-								<Snackbar
-									className="correction-success-notice"
-									onRemove={ () => setDisplayNotice( false ) }
-									actions={ [
-										{
-											label: __( 'Add More', 'newspack-plugin' ),
-											onClick: () => setIsAddingCorrection( ! isAddingCorrection ),
-										},
-									] }
-								>
-									{ __( 'Correction has been added successfully.', 'newspack-plugin' ) }
-								</Snackbar>
-							}
 							<CardBody>
 							{ corrections.map( ( correction ) => (
 									<div key={correction.ID} className="correction-item">
@@ -329,7 +320,14 @@ const CorrectionsModal = () => {
 									onClick={ () => {
 										saveCorrection();
 										setIsAddingCorrection( false );
-										setDisplayNotice( true );
+										createNotice(
+											'success',
+											__( 'Corrections added successfully.', 'newspack-plugin' ),
+											{
+												type: 'snackbar',
+												isDismissible: true,
+											}
+										);
 									} }
 									disabled={ ! newCorrection }
 								/>

--- a/src/other-scripts/corrections-modal/index.js
+++ b/src/other-scripts/corrections-modal/index.js
@@ -5,20 +5,18 @@ import apiFetch from '@wordpress/api-fetch';
 import {
 	BaseControl,
 	Button,
+	DateTimePicker,
 	Modal,
+	Notice,
 	Popover,
 	SelectControl,
 	TextareaControl,
-	DateTimePicker,
-	Card,
-	CardHeader,
-	CardBody,
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
 import { PluginDocumentSettingPanel } from '@wordpress/editor';
 import { useState, useEffect } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { calendar } from '@wordpress/icons';
 import { registerPlugin } from '@wordpress/plugins';
 
@@ -207,173 +205,199 @@ const CorrectionsModal = () => {
 
 			{ isOpen && (
 				<Modal
-					title={ __( 'Corrections & Clarifications', 'newspack-plugin' ) }
+					title={
+						isAddingCorrection
+							? __( 'Add New Correction', 'newspack-plugin' )
+							: __( 'Corrections & Clarifications', 'newspack-plugin' )
+					}
 					onRequestClose={ () => setIsOpen( false ) }
 					className="newspack-corrections-modal"
 					overlayClassName="newspack-corrections-modal-overlay"
 					size="medium"
 				>
-					{ ! isAddingCorrection && corrections.length > 0 ? (
-						<Card
-							className="correction-panel"
+					{ saveError && <p className="error-message">{ saveError }</p> }
+
+					{ ! isAddingCorrection && corrections.length === 0 && (
+						<Notice
+							status="warning"
+							isDismissible={ false }
 						>
-							<CardHeader>
-								{ __( 'Corrections log', 'newspack-plugin' ) }
-							</CardHeader>
-							<CardBody>
+							{ __( 'No corrections or clarifications have been added.', 'newspack-plugin' ) }
+						</Notice>
+					) }
+
+					{ ! isAddingCorrection && corrections.length > 0 && (
+						<>
 							{ corrections.map( ( correction ) => (
-									<div key={correction.ID} className="correction-item">
-										<div>
-											<SelectControl
-												label={ __( 'Type', 'newspack-plugin' ) }
-												value={ correction.type }
-												options={ types }
-												onChange={ ( value ) => updateCorrection( correction.ID, correction.post_content, value, correction.date, correction.location ) }
+								<div key={correction.ID} className="correction-item">
+									<div>
+										<SelectControl
+											label={ __( 'Type', 'newspack-plugin' ) }
+											value={ correction.type }
+											options={ types }
+											onChange={ ( value ) => updateCorrection( correction.ID, correction.post_content, value, correction.date, correction.location ) }
+											__next40pxDefaultSize
+										/>
+										<SelectControl
+											label={ __( 'Location', 'newspack-plugin' ) }
+											value={ correction.location }
+											options={ locations }
+											onChange={ ( value ) => updateCorrection( correction.ID, correction.post_content, correction.type, correction.date, value ) }
+											__next40pxDefaultSize
+										/>
+										<BaseControl
+											id={ `correction-date-${correction.ID}` }
+											label={ __( 'Date', 'newspack-plugin' ) }
+										>
+											<Button
+												variant="secondary"
+												className="correction-date-button"
+												onClick={ () => setIsDatePopoverOpen( correction.ID ) }
+												icon={ calendar}
+												iconPosition="right"
 												__next40pxDefaultSize
-											/>
-											<SelectControl
-												label={ __( 'Location', 'newspack-plugin' ) }
-												value={ correction.location }
-												options={ locations }
-												onChange={ ( value ) => updateCorrection( correction.ID, correction.post_content, correction.type, correction.date, value ) }
-												__next40pxDefaultSize
-											/>
-											<BaseControl
-												id={ `correction-date-${correction.ID}` }
-												label={ __( 'Date', 'newspack-plugin' ) }
 											>
-												<Button
-													variant="secondary"
-													className="correction-date-button"
-													onClick={ () => setIsDatePopoverOpen( correction.ID ) }
-													icon={ calendar}
-													iconPosition="right"
-													__next40pxDefaultSize
-												>
-													{ new Date( correction.date ).toLocaleString() }
-												</Button>
-											</BaseControl>
-											{ isDatePopoverOpen === correction.ID && (
-												<Popover
-													className="correction-date-popover"
-													position="bottom center"
-													onClose={ () => setIsDatePopoverOpen( null ) }
-												>
-													<DateTimePicker
-														label={ __( 'Date', 'newspack-plugin' ) }
-														className='correction-date'
-														is12Hour={ true }
-														currentDate={ new Date( correction.date ) }
-														onChange={ ( value ) => updateCorrection( correction.ID, correction.post_content, correction.type, value, correction.location ) }
-													/>
-												</Popover>
-											) }
-										</div>
-										<TextareaControl
-											label={ __( 'Description', 'newspack-plugin' ) }
-											rows={ 3 }
-											value={ correction.post_content }
-											onChange={ ( value ) => updateCorrection( correction.ID, value, correction.type, correction.date, correction.location ) }
-										/>
-										<Button
-											text={ __( 'Delete', 'newspack-plugin' ) }
-											variant="secondary"
-											onClick={ () => deleteCorrection( correction.ID ) }
-											isDestructive
-										/>
+												{ new Date( correction.date ).toLocaleString() }
+											</Button>
+										</BaseControl>
+										{ isDatePopoverOpen === correction.ID && (
+											<Popover
+												className="correction-date-popover"
+												position="bottom center"
+												onClose={ () => setIsDatePopoverOpen( null ) }
+											>
+												<DateTimePicker
+													label={ __( 'Date', 'newspack-plugin' ) }
+													className='correction-date'
+													is12Hour={ true }
+													currentDate={ new Date( correction.date ) }
+													onChange={ ( value ) => updateCorrection( correction.ID, correction.post_content, correction.type, value, correction.location ) }
+												/>
+											</Popover>
+										) }
 									</div>
-								) )
-							}
-							</CardBody>
-						</Card>
-					) : null }
+									<TextareaControl
+										label={ __( 'Description', 'newspack-plugin' ) }
+										rows={ 3 }
+										value={ correction.post_content }
+										onChange={ ( value ) => updateCorrection( correction.ID, value, correction.type, correction.date, correction.location ) }
+									/>
+									<Button
+										text={ __( 'Delete', 'newspack-plugin' ) }
+										variant="secondary"
+										onClick={ () => {
+											deleteCorrection( correction.ID );
+											createNotice(
+												'success',
+												sprintf(
+													// Translators: Type of correction.
+													__( '%s deleted successfully.', 'newspack-plugin' ),
+													correction.type.replace( /^./, char => char.toUpperCase() )
+												),
+												{
+													type: 'snackbar',
+													isDismissible: true,
+												}
+											);
+										} }
+										isDestructive
+									/>
+								</div>
+							) ) }
+						</>
+					) }
 
 					{ ! isSaving && isAddingCorrection && (
-						<Card className="correction-item">
-							<CardHeader>
-								{ __( 'Add new correction', 'newspack-plugin' ) }
-							</CardHeader>
-							<CardBody>
-								<SelectControl
-									label={ __( 'Type', 'newspack-plugin' ) }
-									value={ newCorrectionType }
-									options={ types }
-									onChange={ ( value ) => setNewCorrectionType( value ) }
-									__next40pxDefaultSize
-								/>
-								<SelectControl
-									label={ __( 'Location', 'newspack-plugin' ) }
-									value={ newCorrectionLocation }
-									options={ locations }
-									onChange={ ( value ) => setNewCorrectionLocation( value ) }
-									__next40pxDefaultSize
-								/>
-								<TextareaControl
-									label={ __( 'Description', 'newspack-plugin' ) }
-									rows={ 3 }
-									value={ newCorrection }
-									onChange={ ( value ) => setNewCorrection( value ) }
-								/>
+						<>
+							<SelectControl
+								label={ __( 'Type', 'newspack-plugin' ) }
+								value={ newCorrectionType }
+								options={ types }
+								onChange={ ( value ) => setNewCorrectionType( value ) }
+								__next40pxDefaultSize
+							/>
+							<SelectControl
+								label={ __( 'Location', 'newspack-plugin' ) }
+								value={ newCorrectionLocation }
+								options={ locations }
+								onChange={ ( value ) => setNewCorrectionLocation( value ) }
+								__next40pxDefaultSize
+							/>
+							<TextareaControl
+								label={ __( 'Description', 'newspack-plugin' ) }
+								rows={ 3 }
+								value={ newCorrection }
+								onChange={ ( value ) => setNewCorrection( value ) }
+							/>
+						</>
+					) }
+
+					<div className="correction-actions">
+						{ ! isSaving && isAddingCorrection ? (
+							<>
 								<Button
 									text={ __( 'Add', 'newspack-plugin' ) }
-									variant="secondary"
+									variant="primary"
 									onClick={ () => {
 										saveCorrection();
 										setIsAddingCorrection( false );
 										createNotice(
 											'success',
-											__( 'Corrections added successfully.', 'newspack-plugin' ),
+											sprintf(
+												// Translators: Type of correction.
+												__( '%s added successfully.', 'newspack-plugin' ),
+												newCorrectionType.replace( /^./, char => char.toUpperCase() )
+											),
 											{
 												type: 'snackbar',
 												isDismissible: true,
 											}
 										);
 									} }
+									isBusy={ isSaving }
 									disabled={ ! newCorrection }
 								/>
 								<Button
-									text={ __( 'Cancel', 'newspack-plugin' ) }
+									text={ __( 'Go back', 'newspack-plugin' ) }
 									variant="tertiary"
 									onClick={ () => setIsAddingCorrection( false ) }
 								/>
-							</CardBody>
-						</Card>
-					) }
-
-					{ saveError && <p className="error-message">{ saveError }</p> }
-
-					<div className="correction-actions">
-						<Button
-							variant="primary"
-							onClick={ () => {
-								saveCorrection();
-								setIsSaving( true );
-								setIsAddingCorrection( false );
-							} }
-							isBusy={ isSaving }
-						>
-							{ isSaving
-								? __( 'Saving…', 'newspack-plugin' )
-								: __( 'Save & close', 'newspack-plugin' ) }
-						</Button>
-						<Button
-							variant="secondary"
-							disabled={ isAddingCorrection }
-							onClick={ () => {
-								setIsAddingCorrection( ! isAddingCorrection );
-							} }
-						>
-							{ __( 'Add New', 'newspack-plugin' ) }
-						</Button>
-						<Button
-							variant="tertiary"
-							onClick={ () => {
-								setIsOpen( false )
-								setIsAddingCorrection( false );
-							} }
-						>
-							{ __( 'Cancel', 'newspack-plugin' ) }
-						</Button>
+							</>
+						) : (
+							<>
+								<Button
+									variant="primary"
+									onClick={ () => {
+										saveCorrection();
+										setIsSaving( true );
+										setIsAddingCorrection( false );
+									} }
+									isBusy={ isSaving }
+								>
+									{ isSaving
+										? __( 'Saving…', 'newspack-plugin' )
+										: __( 'Save & close', 'newspack-plugin' ) }
+								</Button>
+								<Button
+									variant="secondary"
+									disabled={ isAddingCorrection }
+									onClick={ () => {
+										setIsAddingCorrection( ! isAddingCorrection );
+									} }
+								>
+									{ __( 'Add new correction', 'newspack-plugin' ) }
+								</Button>
+								<Button
+									variant="tertiary"
+									onClick={ () => {
+										setIsOpen( false )
+										setIsAddingCorrection( false );
+									} }
+								>
+									{ __( 'Cancel', 'newspack-plugin' ) }
+								</Button>
+							</>
+						) }
 					</div>
 				</Modal>
 			) }

--- a/src/other-scripts/corrections-modal/index.js
+++ b/src/other-scripts/corrections-modal/index.js
@@ -13,7 +13,7 @@ import {
 	Card,
 	CardHeader,
 	CardBody,
-	withNotices,
+	Snackbar,
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { PluginDocumentSettingPanel } from '@wordpress/editor';
@@ -70,7 +70,7 @@ const saveData = async ( postId, payload ) => {
  *
  * @return {JSX.Element} The corrections modal component.
  */
-const CorrectionsModal = withNotices( ( { noticeUI, noticeOperations } ) => {
+const CorrectionsModal = () => {
 	/**
 	 * Get the current post ID.
 	 */
@@ -88,6 +88,7 @@ const CorrectionsModal = withNotices( ( { noticeUI, noticeOperations } ) => {
 	const [ newCorrectionLocation, setNewCorrectionLocation ] = useState( 'bottom' );
 	const [ isDatePopoverOpen, setIsDatePopoverOpen ] = useState( null );
 	const [ isAddingCorrection, setIsAddingCorrection ] = useState( false );
+	const [ displayNotice, setDisplayNotice ] = useState( false );
 
 	// Fetch corrections when modal opens
 	useEffect( () => {
@@ -183,17 +184,6 @@ const CorrectionsModal = withNotices( ( { noticeUI, noticeOperations } ) => {
 		}
 	};
 
-	// Add correction success notice.
-	const triggerCorrectionSuccessNotice = () => {
-		noticeOperations.removeAllNotices();
-		noticeOperations.createNotice(
-			{
-				status: 'success',
-				content: __( 'New correction added.', 'newspack-plugin' ),
-			}
-		);
-	}
-
 	return (
 		<>
 			<PluginDocumentSettingPanel
@@ -225,8 +215,21 @@ const CorrectionsModal = withNotices( ( { noticeUI, noticeOperations } ) => {
 							<CardHeader>
 								{ __( 'Corrections log', 'newspack-plugin' ) }
 							</CardHeader>
+							{	displayNotice &&
+								<Snackbar
+									className="correction-success-notice"
+									onRemove={ () => setDisplayNotice( false ) }
+									actions={ [
+										{
+											label: __( 'Add More', 'newspack-plugin' ),
+											onClick: () => setIsAddingCorrection( ! isAddingCorrection ),
+										},
+									] }
+								>
+									{ __( 'Correction has been added successfully.', 'newspack-plugin' ) }
+								</Snackbar>
+							}
 							<CardBody>
-							{ noticeUI }
 							{ corrections.map( ( correction ) => (
 									<div key={correction.ID} className="correction-item">
 										<div>
@@ -326,7 +329,7 @@ const CorrectionsModal = withNotices( ( { noticeUI, noticeOperations } ) => {
 									onClick={ () => {
 										saveCorrection();
 										setIsAddingCorrection( false );
-										triggerCorrectionSuccessNotice();
+										setDisplayNotice( true );
 									} }
 									disabled={ ! newCorrection }
 								/>
@@ -378,7 +381,7 @@ const CorrectionsModal = withNotices( ( { noticeUI, noticeOperations } ) => {
 			) }
 		</>
 	);
-} );
+};
 
 registerPlugin( 'newspack-corrections', {
 	render: CorrectionsModal,

--- a/src/other-scripts/corrections-modal/index.js
+++ b/src/other-scripts/corrections-modal/index.js
@@ -6,11 +6,14 @@ import {
 	BaseControl,
 	Button,
 	Modal,
-	PanelBody,
 	Popover,
 	SelectControl,
 	TextareaControl,
 	DateTimePicker,
+	Card,
+	CardHeader,
+	CardBody,
+	withNotices,
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { PluginDocumentSettingPanel } from '@wordpress/editor';
@@ -67,7 +70,7 @@ const saveData = async ( postId, payload ) => {
  *
  * @return {JSX.Element} The corrections modal component.
  */
-const CorrectionsModal = () => {
+const CorrectionsModal = withNotices( ( { noticeUI, noticeOperations } ) => {
 	/**
 	 * Get the current post ID.
 	 */
@@ -84,6 +87,7 @@ const CorrectionsModal = () => {
 	const [ newCorrectionType, setNewCorrectionType ] = useState( 'correction' );
 	const [ newCorrectionLocation, setNewCorrectionLocation ] = useState( 'bottom' );
 	const [ isDatePopoverOpen, setIsDatePopoverOpen ] = useState( null );
+	const [ isAddingCorrection, setIsAddingCorrection ] = useState( false );
 
 	// Fetch corrections when modal opens
 	useEffect( () => {
@@ -179,6 +183,17 @@ const CorrectionsModal = () => {
 		}
 	};
 
+	// Add correction success notice.
+	const triggerCorrectionSuccessNotice = () => {
+		noticeOperations.removeAllNotices();
+		noticeOperations.createNotice(
+			{
+				status: 'success',
+				content: __( 'New correction added.', 'newspack-plugin' ),
+			}
+		);
+	}
+
 	return (
 		<>
 			<PluginDocumentSettingPanel
@@ -203,12 +218,15 @@ const CorrectionsModal = () => {
 					className="newspack-corrections-modal"
 					size="medium"
 				>
-					{ corrections.length > 0 ? (
-						<PanelBody
-							title={ __( 'Corrections log', 'newspack-plugin' ) }
-							initialOpen={ true }
+					{ ! isAddingCorrection && corrections.length > 0 ? (
+						<Card
 							className="correction-panel"
 						>
+							<CardHeader>
+								{ __( 'Corrections log', 'newspack-plugin' ) }
+							</CardHeader>
+							<CardBody>
+							{ noticeUI }
 							{ corrections.map( ( correction ) => (
 									<div key={correction.ID} className="correction-item">
 										<div>
@@ -272,16 +290,16 @@ const CorrectionsModal = () => {
 									</div>
 								) )
 							}
-						</PanelBody>
+							</CardBody>
+						</Card>
 					) : null }
 
-					{ ! isSaving && (
-						<PanelBody
-							title={ __( 'Add new correction', 'newspack-plugin' ) }
-							initialOpen={ false }
-							className="correction-panel"
-						>
-							<div className="correction-item">
+					{ ! isSaving && isAddingCorrection && (
+						<Card className="correction-item">
+							<CardHeader>
+								{ __( 'Add new correction', 'newspack-plugin' ) }
+							</CardHeader>
+							<CardBody>
 								<SelectControl
 									label={ __( 'Type', 'newspack-plugin' ) }
 									value={ newCorrectionType }
@@ -305,11 +323,20 @@ const CorrectionsModal = () => {
 								<Button
 									text={ __( 'Add', 'newspack-plugin' ) }
 									variant="secondary"
-									onClick={ saveCorrection }
+									onClick={ () => {
+										saveCorrection();
+										setIsAddingCorrection( false );
+										triggerCorrectionSuccessNotice();
+									} }
 									disabled={ ! newCorrection }
 								/>
-							</div>
-						</PanelBody>
+								<Button
+									text={ __( 'Cancel', 'newspack-plugin' ) }
+									variant="tertiary"
+									onClick={ () => setIsAddingCorrection( false ) }
+								/>
+							</CardBody>
+						</Card>
 					) }
 
 					{ saveError && <p className="error-message">{ saveError }</p> }
@@ -320,6 +347,7 @@ const CorrectionsModal = () => {
 							onClick={ () => {
 								saveCorrection();
 								setIsSaving( true );
+								setIsAddingCorrection( false );
 							} }
 							isBusy={ isSaving }
 						>
@@ -328,9 +356,19 @@ const CorrectionsModal = () => {
 								: __( 'Save & close', 'newspack-plugin' ) }
 						</Button>
 						<Button
+							variant="secondary"
+							disabled={ isAddingCorrection }
+							onClick={ () => {
+								setIsAddingCorrection( ! isAddingCorrection );
+							} }
+						>
+							{ __( 'Add New', 'newspack-plugin' ) }
+						</Button>
+						<Button
 							variant="tertiary"
 							onClick={ () => {
 								setIsOpen( false )
+								setIsAddingCorrection( false );
 							} }
 						>
 							{ __( 'Cancel', 'newspack-plugin' ) }
@@ -340,7 +378,7 @@ const CorrectionsModal = () => {
 			) }
 		</>
 	);
-};
+} );
 
 registerPlugin( 'newspack-corrections', {
 	render: CorrectionsModal,

--- a/src/other-scripts/corrections-modal/style.scss
+++ b/src/other-scripts/corrections-modal/style.scss
@@ -28,6 +28,10 @@
 		flex-direction: row-reverse;
 		gap: 8px;
 		margin: 24px 0 0;
+		position: sticky;
+		bottom: 0;
+		background-color: wp-colors.$white;
+		padding: 16px 0 24px 0;
 	}
 }
 
@@ -42,5 +46,11 @@
 
 	&-modal-overlay {
 		z-index: 99999;
+	}
+
+	&-modal {
+		.components-modal__content {
+			padding-bottom: 0;
+		}
 	}
 }

--- a/src/other-scripts/corrections-modal/style.scss
+++ b/src/other-scripts/corrections-modal/style.scss
@@ -34,6 +34,12 @@
 		gap: 8px;
 		margin: 24px 0 0;
 	}
+
+	&-success-notice {
+		width: auto;
+		margin: 10px;
+		background: var(--newspack-ui-color-success-60);
+	}
 }
 
 .newspack-corrections-panel {

--- a/src/other-scripts/corrections-modal/style.scss
+++ b/src/other-scripts/corrections-modal/style.scss
@@ -1,11 +1,6 @@
 @use "~@wordpress/base-styles/colors" as wp-colors;
 
 .correction {
-	&-panel {
-		border-left: 1px solid wp-colors.$gray-200;
-		border-right: 1px solid wp-colors.$gray-200;
-	}
-
 	&-item + &-item {
 		border-top: 1px solid wp-colors.$gray-300;
 		padding-top: 16px;

--- a/src/other-scripts/corrections-modal/style.scss
+++ b/src/other-scripts/corrections-modal/style.scss
@@ -34,17 +34,18 @@
 		gap: 8px;
 		margin: 24px 0 0;
 	}
-
-	&-success-notice {
-		width: auto;
-		margin: 10px;
-		background: var(--newspack-ui-color-success-60);
-	}
 }
 
-.newspack-corrections-panel {
-	.components-button.is-secondary {
-		justify-content: center;
-		width: 100%;
+.newspack-corrections {
+
+	&-panel {
+		.components-button.is-secondary {
+			justify-content: center;
+			width: 100%;
+		}
+	}
+
+	&-modal-overlay {
+		z-index: 99999;
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Addresses https://github.com/Automattic/newspack-plugin/pull/3835#issuecomment-2743383245 .

- Make the Corrections Modal primary actions sticky.
- Clear the unsaved corrections on clicking cancel.

### How to test the changes in this Pull Request:

1. Create post > Click manage Corrections & Clarifications in sidebar.
2. Add a few corrections, notice on scrolling through correction log the Correction actions ( Cancel, Add New Corrections, Save & Close ) buttons are sticky to the bottom.
3. Save the corrections, Open Modal, add a new correction click cancel instead of save.
4. Open Modal again, notice the added correction is cleared out from the log.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->