### PR TITLE
feat(corrections): Modal UX Enchancements

### DIFF
--- a/src/other-scripts/corrections-modal/index.js
+++ b/src/other-scripts/corrections-modal/index.js
@@ -146,6 +146,13 @@ const CorrectionsModal = () => {
 		setNewCorrectionType( 'correction' );
 	};
 
+	// Remove unsaved corrections.
+	const removeUnsavedCorrections = () => {
+		setCorrections( corrections.filter( ( correction ) => ! correction.isNew ) );
+		setNewCorrection( '' );
+		setNewCorrectionType( 'correction' );
+	};
+
 	// Update an existing correction.
 	const updateCorrection = ( correctionId, postContent, type, date, location ) => {
 		setCorrections( corrections.map( ( correction ) => {
@@ -403,6 +410,7 @@ const CorrectionsModal = () => {
 									onClick={ () => {
 										setIsOpen( false )
 										setIsAddingCorrection( false );
+										removeUnsavedCorrections();
 									} }
 								>
 									{ __( 'Cancel', 'newspack-plugin' ) }

--- a/src/other-scripts/corrections-modal/style.scss
+++ b/src/other-scripts/corrections-modal/style.scss
@@ -28,6 +28,10 @@
 		flex-direction: row-reverse;
 		gap: 8px;
 		margin: 24px 0 0;
+		position: sticky;
+		bottom: 0;
+		background-color: wp-colors.$white;
+		padding: 16px 0 24px 0;
 	}
 }
 
@@ -42,5 +46,11 @@
 
 	&-modal-overlay {
 		z-index: 99999;
+	}
+
+	&-modal {
+		.components-modal__content {
+			padding-bottom: 0;
+		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Addresses https://github.com/Automattic/newspack-plugin/pull/3835#issuecomment-2743383245 .

- Make the Corrections Modal primary actions sticky.
- Clear the unsaved corrections on clicking cancel.

### How to test the changes in this Pull Request:

1. Create post > Click manage Corrections & Clarifications in sidebar.
2. Add a few corrections, notice on scrolling through correction log the Correction actions ( Cancel, Add New Corrections, Save & Close ) buttons are sticky to the bottom.
3. Save the corrections, Open Modal, add a new correction click cancel instead of save.
4. Open Modal again, notice the added correction is cleared out from the log.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->