### PR TITLE
hotfix(woocommerce-email): fix the subscription cancellation email

### DIFF
--- a/includes/configuration_managers/class-woocommerce-configuration-manager.php
+++ b/includes/configuration_managers/class-woocommerce-configuration-manager.php
@@ -254,7 +254,11 @@ class WooCommerce_Configuration_Manager extends Configuration_Manager {
 		if ( 'ppcp-gateway' === $gateway_slug && method_exists( 'WooCommerce\PayPalCommerce\PPCP', 'container' ) ) {
 			$paypal = \WooCommerce\PayPalCommerce\PPCP::container();
 			if ( $paypal ) {
-				$env = $paypal->get( 'onboarding.environment' );
+				try {
+					$env = $paypal->get( 'onboarding.environment' ); // woocommerce-paypal-payments@2.9.6.
+				} catch ( \Throwable $th ) {
+					$env = $paypal->get( 'settings.environment' ); // woocommerce-paypal-payments@3.0.0.
+				}
 				if ( $env && $env->current_environment_is( $env::SANDBOX ) ) {
 					$test_mode = true;
 				}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#2463 and #3056 introduced custom WooCommerce emails for new donation order and donation subscription cancellation, respectively. The approach there has a flaw, though – the email is sent when a default WC email's `is_enabled` is called. Thus, an email would be sent not when it was triggered, but when some code checks if it's sendable. This worked for a while, because the is-enabled check coincided with the triggering of the email, but not anymore. 

#### Additionally, https://github.com/Automattic/newspack-plugin/pull/3848 is tacked on here. It should have been a hotfix in the first place, so let's get it in here instead of releasing two consecutive hotfixes.

### How to test the changes in this Pull Request:
 
1. On `release`, ensure `woocommerce-subscriptions@7.3.0` is installed
2. Ensure all emails are enabled in "Reader Revenue" → "Emails"
3. Renew a subscription – this can be done via "Order actions" menu:

<img width="335" alt="image" src="https://github.com/user-attachments/assets/b66dd5e3-cbc1-4d32-9c88-ab6d81050d59" />

4. Observe a "Subscription cancelled" email is sent to the subscriber
5. Switch to this branch, retest, observe that email is no longer sent
6. Now cancel a subscription for real, observe the email is sent
7. Make a new donation, observe an appropriate email is sent

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->