### PR TITLE
fix(esp-sync): account for wp errors in email change sync

### DIFF
--- a/includes/reader-activation/sync/class-esp-sync.php
+++ b/includes/reader-activation/sync/class-esp-sync.php
@@ -196,6 +196,8 @@ class ESP_Sync extends Sync {
 	 * Get contact data for syncing.
 	 *
 	 * @param int $user_id The user ID.
+	 *
+	 * @return array|\WP_Error The contact data or WP_Error.
 	 */
 	public static function get_contact_data( $user_id ) {
 		$user = \get_userdata( $user_id );
@@ -304,7 +306,7 @@ class ESP_Sync extends Sync {
 			return;
 		}
 		$contact = self::get_contact_data( $user_id );
-		if ( ! $contact ) {
+		if ( ! $contact || is_wp_error( $contact ) ) {
 			return;
 		}
 		$list_id          = Reader_Activation::get_esp_master_list_id();


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

While working on https://github.com/Automattic/newspack-newsletters/pull/1787, I realized it was possible for `get_contact_data` to return a `WP_Error`. This fix accounts for this case.

### How to test the changes in this Pull Request:

Code review should be enough.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->