### PR TITLE
fix(guest-contributors): return them in authors query

### DIFF
--- a/includes/plugins/co-authors-plus/class-guest-contributor-role.php
+++ b/includes/plugins/co-authors-plus/class-guest-contributor-role.php
@@ -74,6 +74,8 @@ class Guest_Contributor_Role {
 		\add_filter( 'allow_password_reset', [ __CLASS__, 'disable_feature' ], 10, 2 );
 		\add_filter( 'woocommerce_current_user_can_edit_customer_meta_fields', [ __CLASS__, 'disable_feature' ], 10, 2 );
 
+		\add_filter( 'rest_user_query', [ __CLASS__, 'filter_rest_user_query' ], 10, 2 );
+
 		// Only if Members plugin is not active, because it has its own UI for roles.
 		if ( ! class_exists( 'Members_Plugin' ) ) {
 			// Add UI to the user profile to assign the custom role.
@@ -548,6 +550,21 @@ class Guest_Contributor_Role {
 			}
 		}
 		return $value;
+	}
+
+	/**
+	 * Modify the REST API user query to include users with the custom capability.
+	 *
+	 * @param array           $args    The query arguments.
+	 * @param WP_REST_Request $request The request object.
+	 * @return array Modified query arguments.
+	 */
+	public static function filter_rest_user_query( $args, $request ) {
+		if ( isset( $args['who'] ) && $args['who'] === 'authors' && current_user_can( 'list_users' ) ) {
+			unset( $args['who'] );
+			$args['capability__in'] = [ 'edit_posts', self::ASSIGNABLE_TO_POSTS_CAPABILITY_NAME ];
+		}
+		return $args;
 	}
 }
 Guest_Contributor_Role::initialize();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Guest Contributors feature will work without `co-authors-plus` installed, but only to the extent of adding Guest Contributor users. This PR fixes that, making Guest Contributor assignable to posts when `co-authors-plus` plugin is inactive.

### How to test the changes in this Pull Request:

1. Deactivate `co-authors-plus`
2. Add a Guest Contributor
3. Edit a post, observe the Guest Contributor can be assigned to posts

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209770626348528