### PR TITLE
fix(ia): render all emails on template reset

### DIFF
--- a/includes/wizards/audience/class-audience-donations.php
+++ b/includes/wizards/audience/class-audience-donations.php
@@ -335,7 +335,9 @@ class Audience_Donations extends Wizard {
 			);
 		}
 
-		return rest_ensure_response( Emails::get_emails( array_values( Reader_Revenue_Emails::EMAIL_TYPES ), false ) );
+		return rest_ensure_response(
+			Emails::get_emails( Reader_Activation::is_enabled() ? [] : array_values( Reader_Revenue_Emails::EMAIL_TYPES ), false )
+		);
 	}
 
 	/**

--- a/includes/wizards/audience/class-audience-wizard.php
+++ b/includes/wizards/audience/class-audience-wizard.php
@@ -472,7 +472,9 @@ class Audience_Wizard extends Wizard {
 			);
 		}
 
-		return rest_ensure_response( Emails::get_emails( array_values( Reader_Activation_Emails::EMAIL_TYPES ), false ) );
+		return rest_ensure_response(
+			Emails::get_emails( Reader_Activation::is_enabled() ? [] : array_values( Reader_Revenue_Emails::EMAIL_TYPES ), false )
+		);
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This fixes an issue where resetting an email template in Newspack > Settings > Emails would only render Woo templates on success:

![Screenshot 2025-03-27 at 14 33 26](https://github.com/user-attachments/assets/320a45d3-83d7-4a79-8195-8904b7bfb994)


### How to test the changes in this Pull Request:

1. Ensure Audience Management is setup
2. Go to Newspack > Settings > Emails
3. Reset any template
4. On `trunk`, only Woo related email templates will remain. On this branch all email templates will remain

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->