### PR TITLE
fix(image-404-handling): handle 404 from other sites

### DIFF
--- a/includes/class-default-image.php
+++ b/includes/class-default-image.php
@@ -30,6 +30,8 @@ class Default_Image {
 		add_filter( 'attachment_fields_to_save', [ __CLASS__, 'save_attachement_settings' ], 10, 2 );
 		add_filter( 'attachment_fields_to_edit', [ __CLASS__, 'add_attachment_field' ], 10, 2 );
 		add_action( 'template_redirect', [ __CLASS__, 'handle_not_found_image' ] );
+		add_action( 'wp_head', [ __CLASS__, 'add_404_image_handler_function' ] );
+		add_filter( 'the_content', [ __CLASS__, 'add_onerror_to_images' ] );
 	}
 
 	/**
@@ -85,6 +87,55 @@ class Default_Image {
 		}
 
 		return $post;
+	}
+
+	/**
+	 * Add JavaScript function to handle 404 images.
+	 * If an image is served from a different domain, the `template_redirect` action won't catch a 404.
+	 * Adding a JS fallback ensures all images will have the default applied.
+	 *
+	 * Note that a better approach would be to use `img.addEventListener` here, instead of
+	 * adding the `onerror` attribute in `add_onerror_to_images` method, but
+	 * the event listener way for some reason did not work in testing. This solution
+	 * is less elegant, but more robust.
+	 */
+	public static function add_404_image_handler_function() {
+		$default_image_url = get_option( self::OPTION_NAME );
+		if ( ! empty( $default_image_url ) ) {
+			echo '<script>
+				function newspackHandleImageError(img) {
+					if (!img.dataset.defaultImageHandled) {
+						img.dataset.defaultImageHandled = true;
+						img.src = "' . esc_js( $default_image_url ) . '";
+					}
+				}
+			</script>';
+		}
+	}
+
+	/**
+	 * Add the onerror attribute to all img elements in the content.
+	 *
+	 * @param string $content The post content.
+	 * @return string Modified content with onerror attributes.
+	 */
+	public static function add_onerror_to_images( $content ) {
+		$content = preg_replace_callback(
+			'/<img[^>]+>/i',
+			function ( $matches ) {
+				if ( strpos( $matches[0], 'onerror=' ) === false ) {
+					return preg_replace(
+						'/<img/',
+						'<img onerror="if (typeof newspackHandleImageError === \'function\') newspackHandleImageError(this);"',
+						$matches[0],
+						1
+					);
+				}
+				return $matches[0];
+			},
+			$content
+		);
+		return $content;
 	}
 }
 Default_Image::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an issue with #3811 – it's written to only handle images hosted by the site. This PR fixes it, so _any_ not-found image will be replaced by the fallback (default) image. 

This is an alpha-hotfix, since the changes are already on `alpha` branch.

### How to test the changes in this Pull Request:

1. Repeat testing steps from #3811, but also use a broken image link to a different site. `https://nothing.here/image` would suffice.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->