### PR TITLE
fix(notices): fix PHP notice from early translation

### DIFF
--- a/includes/class-donations.php
+++ b/includes/class-donations.php
@@ -45,13 +45,6 @@ class Donations {
 	];
 
 	/**
-	 * Donation product WC name;
-	 *
-	 * @var string
-	 */
-	private static $donation_product_name = '';
-
-	/**
 	 * Cached status of the current request - is it a WC page.
 	 *
 	 * @var string
@@ -64,7 +57,6 @@ class Donations {
 	 * @codeCoverageIgnore
 	 */
 	public static function init() {
-		self::$donation_product_name = __( 'Donate', 'newspack-plugin' );
 
 		// Process donation request.
 		add_action( 'wp_ajax_modal_checkout_request', [ __CLASS__, 'process_donation_request' ] );
@@ -537,7 +529,10 @@ class Donations {
 		if ( ! $parent_product ) {
 			$parent_product = new \WC_Product_Grouped();
 		}
-		$parent_product->set_name( self::$donation_product_name );
+
+		$donation_product_name = __( 'Donate', 'newspack-plugin' );
+
+		$parent_product->set_name( $donation_product_name );
 		$parent_product->set_catalog_visibility( 'hidden' );
 		$parent_product->set_virtual( true );
 		$parent_product->set_downloadable( true );
@@ -557,14 +552,14 @@ class Donations {
 			}
 
 			/* translators: %s: Product name */
-			$product_name = sprintf( __( '%s: One-Time', 'newspack' ), self::$donation_product_name );
+			$product_name = sprintf( __( '%s: One-Time', 'newspack' ), $donation_product_name );
 			if ( 'month' === $frequency ) {
 				/* translators: %s: Product name */
-				$product_name = sprintf( __( '%s: Monthly', 'newspack' ), self::$donation_product_name );
+				$product_name = sprintf( __( '%s: Monthly', 'newspack' ), $donation_product_name );
 			}
 			if ( 'year' === $frequency ) {
 				/* translators: %s: Product name */
-				$product_name = sprintf( __( '%s: Yearly', 'newspack' ), self::$donation_product_name );
+				$product_name = sprintf( __( '%s: Yearly', 'newspack' ), $donation_product_name );
 			}
 
 			if ( $is_recurring ) {


### PR DESCRIPTION
* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:
 This fixes a PHP notice that was bugging me. The translation was called before WP was ready in `init()` (which fires way before init):

> **Notice**: Function _load_textdomain_just_in_time was called **incorrectly**. Translation loading for the `newspack-plugin` domain was triggered too early. This is usually an indicator for some code in the plugin or theme running too early. Translations should be loaded at the `init` action or later. Please see [Debugging in WordPress](https://developer.wordpress.org/advanced-administration/debug/debug-wordpress/) for more information. (This message was added in version 6.7.0.) in **/Users/ckj/Dev/sites/block/wp-includes/functions.php** on line **6121**  

Since the variable was private and only used in one method, I just made it a var in the function instead.

### How to test the changes in this Pull Request:

1. Make sure PHP displays notices.
2. Before checking out the branch, go to a post (both backend and frontend has the error) and see the notice.
3. Now check out the branch and see that it is gone.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?