### PR TITLE
fix: handle missing Mailchimp API key in auth status

### DIFF
--- a/includes/oauth/class-mailchimp-api.php
+++ b/includes/oauth/class-mailchimp-api.php
@@ -82,7 +82,11 @@ class Mailchimp_API {
 	 * @return WP_REST_Response
 	 */
 	public static function api_mailchimp_auth_status() {
-		return self::is_valid_api_key();
+		$is_valid = self::is_valid_api_key();
+		if ( is_wp_error( $is_valid ) && 'no_api_key' === $is_valid->get_error_code() ) {
+			return rest_ensure_response( [] );
+		}
+		return $is_valid;
 	}
 
 	/**
@@ -161,6 +165,9 @@ class Mailchimp_API {
 			// 'newspack_mailchimp_api_key' is a new option introduced to manage MC API key accross Newspack plugins.
 			// Keeping the old option for backwards compatibility.
 			$api_key = \get_option( 'newspack_mailchimp_api_key', get_option( 'newspack_newsletters_mailchimp_api_key' ) );
+			if ( empty( $api_key ) ) {
+				return new \WP_Error( 'no_api_key', __( 'No Mailchimp API Key found.', 'newspack' ) );
+			}
 		}
 		$endpoint = self::get_api_endpoint_from_key( $api_key );
 		if ( ! $endpoint ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Updated the auth status endpoint for the Mailchimp API to return an empty response when no API key is provided, and added error handling to return a specific error code if the API key is missing.

Fixes an issue with the Newspack -> Settings wizard presenting an invalid key error when Mailchimp has not yet been configured:

<img width="1111" alt="image" src="https://github.com/user-attachments/assets/f39b37db-d986-4409-a5b9-b4f277b88b55" />


### How to test the changes in this Pull Request:

1. While on `trunk` start a fresh site and navigate to Newspack -> Settings
2. Confirm you get the "Invalid Mailchimp API Key." as above
3. Checkout this branch and confirm the error is gone
4. Connect an invalid Mailchimp API key and confirm the error renders
5. Connect a valid key and confirm you're connected and no errors are thrown

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209827887027008