### PR TITLE
test: fix unit tests based on dates relative to "now"

### DIFF
--- a/tests/unit-tests/woocommerce-cli.php
+++ b/tests/unit-tests/woocommerce-cli.php
@@ -48,8 +48,8 @@ class Newspack_Test_WooCommerce_Cli extends WP_UnitTestCase {
 				'billing_interval' => 1,
 				'total'            => 10, // Amount of recurring payment.
 				'dates'            => [
-					'start'        => gmdate( 'Y-m-d H:i:s', strtotime( '-6 month' ) ),
-					'next_payment' => gmdate( 'Y-m-d H:i:s', strtotime( '+10 day' ) ),
+					'start'        => gmdate( 'Y-m-d H:i:s', strtotime( 'first day of -6 month' ) ),
+					'next_payment' => gmdate( 'Y-m-d H:i:s', strtotime( 'first day of +1 month' ) ),
 				],
 				'orders'           => [
 					wc_create_order(
@@ -57,7 +57,7 @@ class Newspack_Test_WooCommerce_Cli extends WP_UnitTestCase {
 							'customer_id'    => self::$user_id,
 							'status'         => 'completed',
 							'total'          => 10,
-							'date_completed' => gmdate( 'Y-m-d H:i:s', strtotime( '-1 month' ) ),
+							'date_completed' => gmdate( 'Y-m-d H:i:s', strtotime( 'first day of -1 month' ) ),
 						]
 					),
 				],
@@ -79,7 +79,7 @@ class Newspack_Test_WooCommerce_Cli extends WP_UnitTestCase {
 				'billing_interval' => 1,
 				'total'            => 10, // Amount of recurring payment.
 				'dates'            => [
-					'start' => gmdate( 'Y-m-d H:i:s', strtotime( '-6 month' ) ),
+					'start' => gmdate( 'Y-m-d H:i:s', strtotime( 'first day of -6 month' ) ),
 				],
 			]
 		);
@@ -114,7 +114,7 @@ class Newspack_Test_WooCommerce_Cli extends WP_UnitTestCase {
 				'billing_interval' => 1,
 				'total'            => 10, // Amount of recurring payment.
 				'dates'            => [
-					'start' => gmdate( 'Y-m-d H:i:s', strtotime( '-6 month' ) ),
+					'start' => gmdate( 'Y-m-d H:i:s', strtotime( 'first day of -6 month' ) ),
 				],
 				'orders'           => [
 					wc_create_order(
@@ -122,7 +122,7 @@ class Newspack_Test_WooCommerce_Cli extends WP_UnitTestCase {
 							'customer_id'    => self::$user_id,
 							'status'         => 'completed',
 							'total'          => 10,
-							'date_completed' => gmdate( 'Y-m-d H:i:s', strtotime( '-3 month' ) ),
+							'date_completed' => gmdate( 'Y-m-d H:i:s', strtotime( 'first day of -3 month' ) ),
 						]
 					),
 				],
@@ -159,8 +159,8 @@ class Newspack_Test_WooCommerce_Cli extends WP_UnitTestCase {
 				'billing_interval' => 1,
 				'total'            => 10, // Amount of recurring payment.
 				'dates'            => [
-					'start' => gmdate( 'Y-m-d H:i:s', strtotime( '-6 month' ) ),
-					'end'   => gmdate( 'Y-m-d H:i:s', strtotime( '+3 day' ) ),
+					'start' => gmdate( 'Y-m-d H:i:s', strtotime( 'first day of -6 month' ) ),
+					'end'   => gmdate( 'Y-m-d H:i:s', strtotime( 'last day of' ) ),
 				],
 			]
 		);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a set of unit tests that rely on future/past dates relative to the current time. The unit tests currently fail when the current date is the 31st of the month, as PHP's relative time calculation by month can vary: for example `-6 month` from March 31 will result in a date of October 1, which for the purposes of the script being tested is not quite 6 months ago.

This PR ensures that mock subscription start/end dates are set relative to the 1st of the month so that all relative date calculations are consistent no matter what date it is.

### How to test the changes in this Pull Request:

1. Ensure that unit tests are passing 👇 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->