### PR TITLE
fix: remove Mailchimp for WooCommerce from wizard

### DIFF
--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -85,14 +85,6 @@ class Plugin_Manager {
 				'Download'    => 'wporg',
 				'EditPath'    => 'admin.php?page=jetpack',
 			],
-			'mailchimp-for-woocommerce'   => [
-				'Name'        => 'Mailchimp for WooCommerce',
-				'Description' => \esc_html__( 'Connects WooCommerce to Mailchimp to sync your store data, send targeted campaigns to your customers, and sell more stuff.', 'newspack-plugin' ),
-				'Author'      => \esc_html__( 'Mailchimp', 'newspack-plugin' ),
-				'AuthorURI'   => \esc_url( 'https://mailchimp.com' ),
-				'PluginURI'   => \esc_url( 'https://mailchimp.com/connect-your-store/' ),
-				'Download'    => 'wporg',
-			],
 			'newspack-ads'                => [
 				'Name'        => \esc_html__( 'Newspack Ads', 'newspack-plugin' ),
 				'Description' => \esc_html__( 'Ads integration.', 'newspack-plugin' ),

--- a/src/wizards/newsletters/views/settings/index.js
+++ b/src/wizards/newsletters/views/settings/index.js
@@ -437,14 +437,4 @@ const NewslettersSettings = () => {
 	);
 };
 
-export default withWizardScreen( () => (
-	<>
-		<NewslettersSettings />
-		<hr />
-		<h2>{ __( 'WooCommerce Integration', 'newspack-plugin' ) }</h2>
-		<PluginInstaller
-			plugins={ [ 'mailchimp-for-woocommerce' ] }
-			withoutFooterButton
-		/>
-	</>
-) );
+export default withWizardScreen( () => <NewslettersSettings /> );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

p1743438184150559-slack-C015W6BES8J

Removes the Mailchimp from WooCommerce installer from the Newsletters settings wizard.

### How to test the changes in this Pull Request:

1. Visit Newsletters -> Settings
2. Confirm the wizard renders without the "WooCommerce Integration" section
3. Visit the Plugins page and confirm the plugin is also no longer in Newpack's "managed" section

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->