### PR TITLE
Fix: remove design link

### DIFF
--- a/includes/class-patches.php
+++ b/includes/class-patches.php
@@ -20,7 +20,7 @@ class Patches {
 		add_filter( 'wpseo_enhanced_slack_data', [ __CLASS__, 'use_cap_for_slack_preview' ] );
 		add_action( 'admin_menu', [ __CLASS__, 'add_patterns_menu_link' ] );
 		add_action( 'admin_menu', [ __CLASS__, 'add_pattern_categories_menu_link' ] );
-		add_action( 'admin_menu', [ __CLASS__, 'remove_core_patterns_menu_link' ] );
+		add_action( 'admin_menu', [ __CLASS__, 'remove_core_appearance_menu_links' ] );
 		add_action( 'manage_edit-wp_block_columns', [ __CLASS__, 'add_custom_columns' ] );
 		add_action( 'manage_edit-wp_block_sortable_columns', [ __CLASS__, 'add_sortable_columns' ] );
 		add_action( 'manage_wp_block_posts_custom_column', [ __CLASS__, 'custom_column_content' ], 10, 2 );
@@ -120,10 +120,15 @@ class Patches {
 	}
 
 	/**
-	 * Remove the Core Patterns link, which redirects to the Site Editor as of WordPress 6.6.
+	 * Remove some site editor links from the Appearance menu:
+	 * - The Appearance > Patterns link added in WordPress 6.6.
+	 * - The Appearance > Design link added in WordPress 6.8.
+	 *
+	 * Once WordPress 6.8 is released, the code to remove the Patterns link can be removed.
 	 */
-	public static function remove_core_patterns_menu_link() {
+	public static function remove_core_appearance_menu_links() {
 		remove_submenu_page( 'themes.php', 'site-editor.php?path=/patterns' );
+		remove_submenu_page( 'themes.php', 'site-editor.php' );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR removes the new Appearance > Design menu item added in WordPress 6.8.

This is an update to the Appearance > Patterns menu added in WordPress 6.6; the Design menu now has the Patterns menu item underneath it, plus an additional Style link.

When the Patterns link was originally added, [we hid it](https://github.com/Automattic/newspack-plugin/pull/3236) because we'd already added a link to a WP Admin-style page under Posts, and worried it would cause confusion (the new page also used the Site Editor, which is new to our pubs and could cause a support burden). 

With the change in 6.8, I think the risk of confusion is lower, but I also ran into a couple Newspack-specific bugs when testing -- for example, campaign popups are triggered on some of the screens under Patterns but their close buttons don't work there. And the Styles view isn't entirely accurate (it's not pulling in our theme styles consistently), and it occasionally throws an editor error. I'd like to dig into both of these, but for timing, let's hide the new link until I have time to test. 

Once WordPress 6.8 is released, the original code hiding just the Appearance > Patterns link can be removed. 

### How to test the changes in this Pull Request:

1. Apply this PR on a site running the latest WP 6.8 RC, and confirm you don't have a WP Admin > Appearance > Design link.
2. Apply this PR on a site running the latest WP release (6.7.2), and confirm you don't have a WP Admin > Appearance > Patterns link.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->