### PR TITLE
feat: update colors and add all design system variables

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -6,4 +6,15 @@ module.exports = {
 		'scripts/**',
 	],
 	extends: [ './node_modules/newspack-scripts/config/stylelint.config.js' ],
+	rules: {
+		'function-no-unknown': [
+			true,
+			{
+				ignoreFunctions: [
+					'color.adjust',
+					'to-rgb'
+				]
+			}
+		]
+	}
 };

--- a/src/components/src/modal/style.scss
+++ b/src/components/src/modal/style.scss
@@ -7,11 +7,11 @@
 .newspack-modal {
 	// Color
 	--wp-admin-theme-color: #{colors.$primary-600};
-	--wp-admin-theme-color--rgb: rgb(#{colors.$primary-600--rgb});
+	--wp-admin-theme-color--rgb: #{colors.$primary-100--rgb};
 	--wp-admin-theme-color-darker-10: #{colors.$primary-700};
-	--wp-admin-theme-color-darker-10--rgb: rgb(#{colors.$primary-700--rgb});
+	--wp-admin-theme-color-darker-10--rgb: #{colors.$primary-700--rgb};
 	--wp-admin-theme-color-darker-20: #{colors.$primary-800};
-	--wp-admin-theme-color-darker-20--rgb: rgb(#{colors.$primary-800--rgb});
+	--wp-admin-theme-color-darker-20--rgb: #{colors.$primary-800--rgb};
 
 	@media screen and ( min-width: 744px ) {
 		max-width: 680px;

--- a/src/components/src/modal/style.scss
+++ b/src/components/src/modal/style.scss
@@ -7,7 +7,7 @@
 .newspack-modal {
 	// Color
 	--wp-admin-theme-color: #{colors.$primary-600};
-	--wp-admin-theme-color--rgb: #{colors.$primary-100--rgb};
+	--wp-admin-theme-color--rgb: #{colors.$primary-600--rgb};
 	--wp-admin-theme-color-darker-10: #{colors.$primary-700};
 	--wp-admin-theme-color-darker-10--rgb: #{colors.$primary-700--rgb};
 	--wp-admin-theme-color-darker-20: #{colors.$primary-800};

--- a/src/components/src/style.scss
+++ b/src/components/src/style.scss
@@ -4,11 +4,11 @@
 :root {
 	// WP Admin
 	--wp-admin-theme-color: #{colors.$primary-600};
-	--wp-admin-theme-color--rgb: rgb(#{colors.$primary-600--rgb});
+	--wp-admin-theme-color--rgb: #{colors.$primary-600--rgb};
 	--wp-admin-theme-color-darker-10: #{colors.$primary-700};
-	--wp-admin-theme-color-darker-10--rgb: rgb(#{colors.$primary-700--rgb});
+	--wp-admin-theme-color-darker-10--rgb: #{colors.$primary-700--rgb};
 	--wp-admin-theme-color-darker-20: #{colors.$primary-800};
-	--wp-admin-theme-color-darker-20--rgb: rgb(#{colors.$primary-800--rgb});
+	--wp-admin-theme-color-darker-20--rgb: #{colors.$primary-800--rgb};
 }
 
 // Buttons Card

--- a/src/components/src/web-preview/style.scss
+++ b/src/components/src/web-preview/style.scss
@@ -8,13 +8,13 @@
 .newspack-web-preview {
 	// Color
 	--wp-admin-theme-color: #{colors.$primary-600};
-	--wp-admin-theme-color--rgb: rgb(#{colors.$primary-600--rgb});
+	--wp-admin-theme-color--rgb: #{colors.$primary-600--rgb};
 	--wp-admin-theme-color-darker-10: #{colors.$primary-700};
-	--wp-admin-theme-color-darker-10--rgb: rgb(#{colors.$primary-700--rgb});
+	--wp-admin-theme-color-darker-10--rgb: #{colors.$primary-700--rgb};
 	--wp-admin-theme-color-darker-20: #{colors.$primary-800};
-	--wp-admin-theme-color-darker-20--rgb: rgb(#{colors.$primary-800--rgb});
+	--wp-admin-theme-color-darker-20--rgb: #{colors.$primary-800--rgb};
 
-	background: rgba(black, 0.7);
+	background: #{colors.$neutral-700};
 	box-sizing: border-box;
 	height: 100%;
 	left: 0;

--- a/src/components/src/with-wizard-screen/style.scss
+++ b/src/components/src/with-wizard-screen/style.scss
@@ -8,11 +8,11 @@
 .newspack-wizard {
 	// Color
 	--wp-admin-theme-color: #{colors.$primary-600};
-	--wp-admin-theme-color--rgb: rgb(#{colors.$primary-600--rgb});
+	--wp-admin-theme-color--rgb: #{colors.$primary-600--rgb};
 	--wp-admin-theme-color-darker-10: #{colors.$primary-700};
-	--wp-admin-theme-color-darker-10--rgb: rgb(#{colors.$primary-700--rgb});
+	--wp-admin-theme-color-darker-10--rgb: #{colors.$primary-700--rgb};
 	--wp-admin-theme-color-darker-20: #{colors.$primary-800};
-	--wp-admin-theme-color-darker-20--rgb: rgb(#{colors.$primary-800--rgb});
+	--wp-admin-theme-color-darker-20--rgb: #{colors.$primary-800--rgb};
 
 	color: wp-colors.$gray-900;
 

--- a/src/newspack-ui/scss/variables/_colors.scss
+++ b/src/newspack-ui/scss/variables/_colors.scss
@@ -1,49 +1,51 @@
+@use "../../../shared/scss/colors";
+
 :root {
 	// Neutral:
-	--newspack-ui-color-neutral-0: #fff;
-	--newspack-ui-color-neutral-5: #f7f7f7;
-	--newspack-ui-color-neutral-10: #f0f0f0;
-	--newspack-ui-color-neutral-20: #e0e0e0;
-	--newspack-ui-color-neutral-30: #ddd;
-	--newspack-ui-color-neutral-40: #ccc;
-	--newspack-ui-color-neutral-50: #949494;
-	--newspack-ui-color-neutral-60: #6c6c6c;
-	--newspack-ui-color-neutral-70: #00000070;
-	--newspack-ui-color-neutral-80: #3e3e3e;
-	--newspack-ui-color-neutral-90: #1e1e1e;
-	--newspack-ui-color-neutral-100: #000;
+	--newspack-ui-color-neutral-0: #{colors.$neutral-000};
+	--newspack-ui-color-neutral-5: #{colors.$neutral-050};
+	--newspack-ui-color-neutral-10: #{colors.$neutral-100};
+	--newspack-ui-color-neutral-20: #{colors.$neutral-200};
+	--newspack-ui-color-neutral-30: #{colors.$neutral-300};
+	--newspack-ui-color-neutral-40: #{colors.$neutral-400};
+	--newspack-ui-color-neutral-50: #{colors.$neutral-500};
+	--newspack-ui-color-neutral-60: #{colors.$neutral-600};
+	--newspack-ui-color-neutral-70: #{colors.$neutral-700};
+	--newspack-ui-color-neutral-80: #{colors.$neutral-800};
+	--newspack-ui-color-neutral-90: #{colors.$neutral-900};
+	--newspack-ui-color-neutral-100: #{colors.$neutral-1000};
 
 	// Primary:
-	--newspack-ui-color-primary-0: #dfe7f4;
-	--newspack-ui-color-primary-5: #bfcfe9;
-	--newspack-ui-color-primary-10: #9fb6dd;
-	--newspack-ui-color-primary-20: #809ed2;
-	--newspack-ui-color-primary-30: #6086c7;
-	--newspack-ui-color-primary-40: #406ebc;
-	--newspack-ui-color-primary-50: #2055b0;
-	--newspack-ui-color-primary-60: #003da5;
-	--newspack-ui-color-primary-70: #00296e;
-	--newspack-ui-color-primary-80: #001f53;
-	--newspack-ui-color-primary-90: #001437;
-	--newspack-ui-color-primary-100: #000a1c;
+	--newspack-ui-color-primary-0: #{colors.$primary-000};
+	--newspack-ui-color-primary-5: #{colors.$primary-050};
+	--newspack-ui-color-primary-10: #{colors.$primary-100};
+	--newspack-ui-color-primary-20: #{colors.$primary-200};
+	--newspack-ui-color-primary-30: #{colors.$primary-300};
+	--newspack-ui-color-primary-40: #{colors.$primary-400};
+	--newspack-ui-color-primary-50: #{colors.$primary-500};
+	--newspack-ui-color-primary-60: #{colors.$primary-600};
+	--newspack-ui-color-primary-70: #{colors.$primary-700};
+	--newspack-ui-color-primary-80: #{colors.$primary-800};
+	--newspack-ui-color-primary-90: #{colors.$primary-900};
+	--newspack-ui-color-primary-100: #{colors.$primary-1000};
 
 	// Success:
-	--newspack-ui-color-success-0: #edfaef;
-	--newspack-ui-color-success-5: #b8e6bf;
-	--newspack-ui-color-success-50: #008a20;
-	--newspack-ui-color-success-60: #007017;
+	--newspack-ui-color-success-0: #{colors.$success-000};
+	--newspack-ui-color-success-5: #{colors.$success-050};
+	--newspack-ui-color-success-50: #{colors.$success-500};
+	--newspack-ui-color-success-60: #{colors.$success-600};
 
 	// Error:
-	--newspack-ui-color-error-0: #fcf0f1;
-	--newspack-ui-color-error-5: #facfd2;
-	--newspack-ui-color-error-50: #d63638;
-	--newspack-ui-color-error-60: #b32d2e;
+	--newspack-ui-color-error-0: #{colors.$error-000};
+	--newspack-ui-color-error-5: #{colors.$error-050};
+	--newspack-ui-color-error-50: #{colors.$error-500};
+	--newspack-ui-color-error-60: #{colors.$error-600};
 
 	//Warning:
-	--newspack-ui-color-warning-0: #fcf9e8;
-	--newspack-ui-color-warning-5: #f5e6ab;
-	--newspack-ui-color-warning-30: #dba617;
-	--newspack-ui-color-warning-40: #bd8600;
+	--newspack-ui-color-warning-0: #{colors.$warning-000};
+	--newspack-ui-color-warning-5: #{colors.$warning-050};
+	--newspack-ui-color-warning-30: #{colors.$warning-300};
+	--newspack-ui-color-warning-40: #{colors.$warning-400};
 
 	// Theme variables - from the classic theme; overridden in class-newspack-ui.php for block theme.
 	// TODO: commented out for now with the assumption all should be blue when used.

--- a/src/shared/scss/_colors.scss
+++ b/src/shared/scss/_colors.scss
@@ -1,4 +1,14 @@
-// HEX
+/**
+ * Colors
+ */
+
+@use "sass:color";
+
+@function to-rgb($color) {
+	@return color.red($color) + ", " + color.green($color) + ", " + color.blue($color);
+}
+
+// Primary: Hex
 $primary-000: #dfe7f4;
 $primary-050: #bfcfe9;
 $primary-100: #9fb6dd;
@@ -12,16 +22,90 @@ $primary-800: #001f53;
 $primary-900: #001437;
 $primary-1000: #000a1c;
 
-// RGB
-$primary-000--rgb: 223, 231, 244;
-$primary-050--rgb: 191, 207, 233;
-$primary-100--rgb: 159, 182, 221;
-$primary-200--rgb: 128, 158, 210;
-$primary-300--rgb: 96, 134, 199;
-$primary-400--rgb: 64, 110, 188;
-$primary-500--rgb: 32, 85, 176;
-$primary-600--rgb: 0, 61, 165;
-$primary-700--rgb: 0, 41, 110;
-$primary-800--rgb: 0, 31, 83;
-$primary-900--rgb: 0, 20, 55;
-$primary-1000--rgb: 0, 10, 28;
+// Primary: RGB
+$primary-000--rgb: to-rgb($primary-000);
+$primary-050--rgb: to-rgb($primary-050);
+$primary-100--rgb: to-rgb($primary-100);
+$primary-200--rgb: to-rgb($primary-200);
+$primary-300--rgb: to-rgb($primary-300);
+$primary-400--rgb: to-rgb($primary-400);
+$primary-500--rgb: to-rgb($primary-500);
+$primary-600--rgb: to-rgb($primary-600);
+$primary-700--rgb: to-rgb($primary-700);
+$primary-800--rgb: to-rgb($primary-800);
+$primary-900--rgb: to-rgb($primary-900);
+$primary-1000--rgb: to-rgb($primary-1000);
+
+// Secondary
+$secondary-000: #eff9f2;
+$secondary-050: #ddf3e3;
+$secondary-100: #c8ecd4;
+$secondary-200: #b1e6c3;
+$secondary-300: #95dfaf;
+$secondary-400: #6fd898;
+$secondary-500: #26d07c;
+$secondary-600: #1fb36a;
+$secondary-700: #1ba25f;
+$secondary-800: #178e53;
+$secondary-900: #117644;
+$secondary-1000: #09552f;
+
+// Tertiary
+$tertiary-000: #fff4f6;
+$tertiary-050: #fee8ed;
+$tertiary-100: #fedbe3;
+$tertiary-200: #fcded8;
+$tertiary-300: #fdbfcd;
+$tertiary-400: #fcaec0;
+$tertiary-500: #fc9bb3;
+$tertiary-600: #d9859a;
+$tertiary-700: #c5788b;
+$tertiary-800: #ad697a;
+$tertiary-900: #905665;
+$tertiary-1000: #683d48;
+
+// Quaternary
+$quaternary-000: #fff5ee;
+$quaternary-050: #ffeadc;
+$quaternary-100: #ffdec7;
+$quaternary-200: #ffd1af;
+$quaternary-300: #ffc392;
+$quaternary-400: #ffb46a;
+$quaternary-500: #ffa300;
+$quaternary-600: #dc8c00;
+$quaternary-700: #c77e00;
+$quaternary-800: #af6e00;
+$quaternary-900: #925b00;
+$quaternary-1000: #6a4100;
+
+// Neutral
+$neutral-000: #fff;
+$neutral-050: #f7f7f7;
+$neutral-100: #f0f0f0;
+$neutral-200: #e0e0e0;
+$neutral-300: #ddd;
+$neutral-400: #ccc;
+$neutral-500: #949494;
+$neutral-600: #6c6c6c;
+$neutral-700: #000000b3;
+$neutral-800: #3e3e3e;
+$neutral-900: #1e1e1e;
+$neutral-1000: #000;
+
+// Success
+$success-000: #edfaef;
+$success-050: #b8e6bf;
+$success-500: #008a20;
+$success-600: #007017;
+
+// Error
+$error-000: #fcf0f1;
+$error-050: #facfd2;
+$error-500: #d63638;
+$error-600: #b32d2e;
+
+//Warning
+$warning-000: #fcf9e8;
+$warning-050: #f5e6ab;
+$warning-300: #dba617;
+$warning-400: #bd8600;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds all the different colour variables of our Design System to the shared colours SCSS file.
It also simplifies how we used to output the RGB value for the Primary colour.
And replaces newspack-ui's root hardcoded variables with the SCSS variables.

### How to test the changes in this Pull Request:

1. Check the various wizards and newspack-ui (RAS-ACC) to see the current colours
2. Switch to this branch
3. Check again, nothing should be affected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->