### PR TITLE
feat(corrections): hotfix removal of feature flag (#3866)

### DIFF
--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -19,7 +19,7 @@ final class Blocks {
 	public static function init() {
 		require_once NEWSPACK_ABSPATH . 'src/blocks/reader-registration/index.php';
 
-		if ( wp_is_block_theme() && class_exists( 'Newspack\Corrections' ) && defined( 'NEWSPACK_CORRECTIONS_ENABLED' ) && NEWSPACK_CORRECTIONS_ENABLED ) {
+		if ( wp_is_block_theme() && class_exists( 'Newspack\Corrections' ) ) {
 			require_once NEWSPACK_ABSPATH . 'src/blocks/correction-box/class-correction-box-block.php';
 			require_once NEWSPACK_ABSPATH . 'src/blocks/correction-item/class-correction-item-block.php';
 		}
@@ -53,7 +53,7 @@ final class Blocks {
 				'reader_activation_url'   => Reader_Activation::get_setting( 'terms_url' ),
 				'has_recaptcha'           => Recaptcha::can_use_captcha(),
 				'recaptcha_url'           => admin_url( 'admin.php?page=newspack-settings' ),
-				'corrections_enabled'     => wp_is_block_theme() && class_exists( 'Newspack\Corrections' ) && defined( 'NEWSPACK_CORRECTIONS_ENABLED' ) && NEWSPACK_CORRECTIONS_ENABLED,
+				'corrections_enabled'     => wp_is_block_theme() && class_exists( 'Newspack\Corrections' ),
 			]
 		);
 		\wp_enqueue_style(

--- a/includes/corrections/README.md
+++ b/includes/corrections/README.md
@@ -8,11 +8,11 @@ When you enable this feature, a new meta box will be added to the post editor sc
 
 ## Usage
 
-This feature can be enabled by adding the following constant to your `wp-config.php`:
-
-```php
-define( 'NEWSPACK_CORRECTIONS_ENABLED', true );
-```
+This feature is enabled by default. Start adding corrections to your posts by following these steps:
+1. Click on Manage Corrections in Corrections & Clarifications Menu.
+2. Click on Add New Correction.
+3. Fill in the correction details.
+4. Click on Save & Close.
 
 ## Data
 

--- a/includes/corrections/class-corrections.php
+++ b/includes/corrections/class-corrections.php
@@ -50,9 +50,6 @@ class Corrections {
 	 * Initializes the class.
 	 */
 	public static function init() {
-		if ( ! self::is_enabled() ) {
-			return;
-		}
 		add_action( 'init', [ __CLASS__, 'register_post_type' ] );
 		add_filter( 'the_content', [ __CLASS__, 'output_corrections_on_post' ] );
 		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'wp_enqueue_scripts' ] );
@@ -61,19 +58,6 @@ class Corrections {
 		add_action( 'admin_init', [ __CLASS__, 'register_corrections_block_patterns' ] );
 		add_action( 'init', [ __CLASS__, 'register_corrections_template' ] );
 	}
-
-	/**
-	 * Checks if the feature is enabled.
-	 *
-	 * True when:
-	 * - NEWSPACK_CORRECTIONS_ENABLED is defined and true.
-	 *
-	 * @return bool True if the feature is enabled, false otherwise.
-	 */
-	public static function is_enabled() {
-		return defined( 'NEWSPACK_CORRECTIONS_ENABLED' ) && NEWSPACK_CORRECTIONS_ENABLED;
-	}
-
 
 	/**
 	 * Enqueue scripts and styles.

--- a/tests/unit-tests/corrections.php
+++ b/tests/unit-tests/corrections.php
@@ -27,22 +27,9 @@ class Test_Corrections extends WP_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 
-		if ( ! defined( 'NEWSPACK_CORRECTIONS_ENABLED' ) ) {
-			define( 'NEWSPACK_CORRECTIONS_ENABLED', true );
-		}
-
 		Corrections::init();
 
 		self::$post_id = $this->factory()->post->create( [ 'post_type' => 'post' ] );
-	}
-
-	/**
-	 * Test that the corrections feature is enabled.
-	 *
-	 * @covers Corrections::is_enabled
-	 */
-	public function test_is_enabled() {
-		$this->assertTrue( Corrections::is_enabled() );
 	}
 
 	/**


### PR DESCRIPTION
Hotfix version of #3866. This should enable the new Corrections/Clarifications features by default.

To test, follow [instructions for adding corrections and clarifications](https://help.newspack.com/corrections-clarifications/) and confirm the features are available without the `NEWSPACK_CORRECTIONS_ENABLED` constant being defined in wp-config.php.