### PR TITLE
fix(email-change): improve messaging for in-progress or expired change requests

### DIFF
--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -960,7 +960,7 @@ class WooCommerce_My_Account {
 				\wc_add_notice( $error, 'error' );
 			}
 		} else {
-			\wc_add_notice( $error, 'error' );
+			\wc_add_notice( __( 'This email change request has been cancelled or expired.', 'newspack-plugin' ), 'error' );
 		}
 		\wp_safe_redirect( \wc_get_endpoint_url( 'edit-account', '', \wc_get_page_permalink( 'myaccount' ) ) );
 		exit;
@@ -982,7 +982,7 @@ class WooCommerce_My_Account {
 			\delete_user_meta( \get_current_user_id(), self::PENDING_EMAIL_CHANGE_META );
 			\wc_add_notice( __( 'Your email change request has been cancelled.', 'newspack-plugin' ) );
 		} else {
-			\wc_add_notice( __( 'Something went wrong.', 'newspack-plugin' ), 'error' );
+			\wc_add_notice( __( 'This email change request has been cancelled or expired.', 'newspack-plugin' ), 'error' );
 		}
 		\wp_safe_redirect( \wc_get_endpoint_url( 'edit-account', '', \wc_get_page_permalink( 'myaccount' ) ) );
 		exit;

--- a/includes/reader-revenue/templates/myaccount-edit-account.php
+++ b/includes/reader-revenue/templates/myaccount-edit-account.php
@@ -66,9 +66,26 @@ endif;
 
 	<p class="woocommerce-form-row woocommerce-form-row--wide form-row form-row-wide mt0">
 		<label for="account_email_display"><?php \esc_html_e( 'Email address', 'newspack-plugin' ); ?>
-		<?php if ( $is_email_change_enabled ) : ?>
+		<?php
+		if ( $is_email_change_enabled ) :
+			?>
 		<input type="email" class="woocommerce-Input woocommerce-Input--email input-text" name="newspack_account_email" id="newspack_account_email" autocomplete="email" <?php echo \esc_attr( $is_pending_email_change ? 'disabled' : '' ); ?> value="<?php echo \esc_attr( $display_email ); ?>" />
 		<input type="hidden" class="woocommerce-Input woocommerce-Input--email input-text" name="account_email" id="account_email" autocomplete="email" value="<?php echo \esc_attr( $user->user_email ); ?>" />
+			<?php if ( $is_pending_email_change ) : ?>
+			<span>
+				<em>
+				<?php
+				echo \wp_kses_post(
+					sprintf(
+						// Translators: %s is the account's current email address.
+						__( 'This email address is pending verification. Please verify to complete the change request, or cancel the change to retain the current account email: %s', 'newspack-plugin' ),
+						"<a href='mailto:$user->user_email'>$user->user_email</a>"
+					)
+				);
+				?>
+				</em>
+			</span>
+			<?php endif; ?>
 		<?php else : ?>
 		<input type="email" class="woocommerce-Input woocommerce-Input--email input-text" name="account_email_display" id="account_email_display" autocomplete="email" disabled value="<?php echo \esc_attr( $user->user_email ); ?>" />
 		<input type="hidden" class="woocommerce-Input woocommerce-Input--email input-text" name="account_email" id="account_email" autocomplete="email" value="<?php echo \esc_attr( $user->user_email ); ?>" />


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Improves the messaging shown to users when an email change request is in progress, or after a verification or cancellation request is rejected due to prior cancellation or expiration.

### How to test the changes in this Pull Request:

1. Check out this nranch
2. Sign into My Account as a reader
3. Change the email address and save. Confirm that after the page refreshes, a message is shown under the disabled email address field explaining that a change request is in progress (and confirm that the message sticks around if you reload the page or leave and come back):

<img width="794" alt="Screenshot 2025-04-04 at 5 35 09 PM" src="https://github.com/user-attachments/assets/2b2fa39b-188e-46c7-8953-d8bef9babbba" />

4. Cancel the request by any means.
5. Click on the Confirm and Cancel links from the verification email that was sent after step 3, and confirm that you see a message explaining that the change request has been cancelled:

<img width="787" alt="Screenshot 2025-04-04 at 5 39 22 PM" src="https://github.com/user-attachments/assets/d84d3b03-1766-41e6-b2a9-1832bdbbaf5f" />

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->