### PR TITLE
feat(ras-newsletter): Newsletters list progressive disclosure

### DIFF
--- a/includes/class-newspack-ui-icons.php
+++ b/includes/class-newspack-ui-icons.php
@@ -111,8 +111,8 @@ class Newspack_UI_Icons {
 				<path d="M12 3.2c-4.8 0-8.8 3.9-8.8 8.8 0 4.8 3.9 8.8 8.8 8.8 4.8 0 8.8-3.9 8.8-8.8 0-4.8-4-8.8-8.8-8.8zm0 16c-4 0-7.2-3.3-7.2-7.2C4.8 8 8 4.8 12 4.8s7.2 3.3 7.2 7.2c0 4-3.2 7.2-7.2 7.2zM11 17h2v-6h-2v6zm0-8h2V7h-2v2z"/>
 			</svg>',
 		'arrow-right' =>
-			'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 17 12" width="17" height="12" fill="none">
-				<path d="M10.5 0.5L9.5 1.5L13.2 5.2H0V6.8H13.2L9.5 10.5L10.5 11.5L16.1 6L10.5 0.5Z" fill="#1E1E1E"/>
+			'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false">
+				<path d="m14.5 6.5-1 1 3.7 3.7H4v1.6h13.2l-3.7 3.7 1 1 5.6-5.5z"/>
 			</svg>',
 	);
 }

--- a/includes/class-newspack-ui-icons.php
+++ b/includes/class-newspack-ui-icons.php
@@ -79,36 +79,40 @@ class Newspack_UI_Icons {
 	 * @var array
 	 */
 	public static $ui_icons = array(
-		'account' =>
+		'account'     =>
 			'<svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 				<path fill-rule="evenodd" clip-rule="evenodd" d="M7.25 16.4371C6.16445 15.2755 5.5 13.7153 5.5 12C5.5 8.41015 8.41015 5.5 12 5.5C15.5899 5.5 18.5 8.41015 18.5 12C18.5 13.7153 17.8356 15.2755 16.75 16.4371V16C16.75 14.4812 15.5188 13.25 14 13.25L10 13.25C8.48122 13.25 7.25 14.4812 7.25 16V16.4371ZM8.75 17.6304C9.70606 18.1835 10.8161 18.5 12 18.5C13.1839 18.5 14.2939 18.1835 15.25 17.6304V16C15.25 15.3096 14.6904 14.75 14 14.75L10 14.75C9.30964 14.75 8.75 15.3096 8.75 16V17.6304ZM4 12C4 7.58172 7.58172 4 12 4C16.4183 4 20 7.58172 20 12C20 16.4183 16.4183 20 12 20C7.58172 20 4 16.4183 4 12ZM14 10C14 11.1046 13.1046 12 12 12C10.8954 12 10 11.1046 10 10C10 8.89543 10.8954 8 12 8C13.1046 8 14 8.89543 14 10Z" />
 			</svg>',
-		'check'   =>
+		'check'       =>
 			'<svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 				<path d="M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z" />
 			</svg>',
-		'close'   =>
+		'close'       =>
 			'<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false">
 				<path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z"/>
 			</svg>',
-		'error'   =>
+		'error'       =>
 			'<svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 				<path d="M12 20.8C16.8 20.8 20.8 16.9 20.8 12C20.8 7.2 16.9 3.2 12 3.2C7.2 3.2 3.2 7.1 3.2 12C3.2 16.8 7.2 20.8 12 20.8V20.8ZM12 4.8C16 4.8 19.2 8.1 19.2 12C19.2 16 16 19.2 12 19.2C8 19.2 4.8 15.9 4.8 12C4.8 8 8 4.8 12 4.8ZM13 7H11V13H13L13 7ZM13 15H11V17H13V15Z" />
 			</svg>',
-		'google'  =>
+		'google'      =>
 			'<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
 				<path fill-rule="evenodd" clip-rule="evenodd" d="M19.6 10.227C19.6 9.51801 19.536 8.83701 19.418 8.18201H10V12.05H15.382C15.2706 12.6619 15.0363 13.2448 14.6932 13.7635C14.3501 14.2822 13.9054 14.726 13.386 15.068V17.578H16.618C18.509 15.836 19.6 13.273 19.6 10.228V10.227Z" fill="#4285F4"></path>
 				<path fill-rule="evenodd" clip-rule="evenodd" d="M9.99996 20C12.7 20 14.964 19.105 16.618 17.577L13.386 15.068C12.491 15.668 11.346 16.023 9.99996 16.023C7.39496 16.023 5.18996 14.263 4.40496 11.9H1.06396V14.49C1.89597 16.1468 3.17234 17.5395 4.7504 18.5126C6.32846 19.4856 8.14603 20.0006 9.99996 20Z" fill="#34A853"></path>
 				<path fill-rule="evenodd" clip-rule="evenodd" d="M4.405 11.9C4.205 11.3 4.091 10.66 4.091 10C4.091 9.34001 4.205 8.70001 4.405 8.10001V5.51001H1.064C0.364015 6.90321 -0.000359433 8.44084 2.66054e-07 10C2.66054e-07 11.614 0.386 13.14 1.064 14.49L4.404 11.9H4.405Z" fill="#FBBC05"></path>
 				<path fill-rule="evenodd" clip-rule="evenodd" d="M9.99996 3.977C11.468 3.977 12.786 4.482 13.823 5.473L16.691 2.605C14.959 0.99 12.695 0 9.99996 0C6.08996 0 2.70996 2.24 1.06396 5.51L4.40396 8.1C5.19196 5.736 7.39596 3.977 9.99996 3.977Z" fill="#EA4335"></path>
 			</svg>',
-		'menu'    =>
+		'menu'        =>
 			'<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false">
 				<path d="M5 5v1.5h14V5H5zm0 7.8h14v-1.5H5v1.5zM5 19h14v-1.5H5V19z"/>
 			</svg>',
-		'info'    =>
+		'info'        =>
 			'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false">
 				<path d="M12 3.2c-4.8 0-8.8 3.9-8.8 8.8 0 4.8 3.9 8.8 8.8 8.8 4.8 0 8.8-3.9 8.8-8.8 0-4.8-4-8.8-8.8-8.8zm0 16c-4 0-7.2-3.3-7.2-7.2C4.8 8 8 4.8 12 4.8s7.2 3.3 7.2 7.2c0 4-3.2 7.2-7.2 7.2zM11 17h2v-6h-2v6zm0-8h2V7h-2v2z"/>
+			</svg>',
+		'arrow-right' =>
+			'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 17 12" width="17" height="12" fill="none">
+				<path d="M10.5 0.5L9.5 1.5L13.2 5.2H0V6.8H13.2L9.5 10.5L10.5 11.5L16.1 6L10.5 0.5Z" fill="#1E1E1E"/>
 			</svg>',
 	);
 }

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1639,7 +1639,7 @@ final class Reader_Activation {
 				<form method="post" target="_top">
 					<input type="hidden" name="<?php echo \esc_attr( self::NEWSLETTERS_SIGNUP_FORM_ACTION ); ?>" value="1" />
 					<input type="hidden" name="email_address" value="<?php echo esc_attr( $email_address ); ?>" />
-					
+
 					<div class="newsletter-list-container" data-list-default-size="<?php echo esc_attr( $default_list_size ); ?>">
 					<?php
 					foreach ( $newsletters_lists as $list ) {
@@ -1672,7 +1672,7 @@ final class Reader_Activation {
 					<?php if ( count( $newsletters_lists ) > $default_list_size ) : ?>
 						<button type="button" class="newspack-ui__button newspack-ui__button--wide newspack-ui__button--secondary see-all-button">
 							<span><?php esc_html_e( 'See all', 'newspack-plugin' ); ?></span>
-							<span><?php \Newspack\Newspack_UI_Icons::print_svg( 'arrow-right' ); ?></span>
+							<?php \Newspack\Newspack_UI_Icons::print_svg( 'arrow-right' ); ?>
 						</button>
 					<?php endif; ?>
 					<button type="submit" class="newspack-ui__button newspack-ui__button--wide newspack-ui__button--primary"><?php echo \esc_html( self::get_reader_activation_labels( 'newsletters_continue' ) ); ?></button>

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -352,7 +352,7 @@ final class Reader_Activation {
 			'newsletters_label'                        => self::get_reader_activation_labels( 'newsletters_cta' ),
 			'use_custom_lists'                         => false,
 			'newsletter_lists'                         => [],
-			'newsletter_list_default_size'             => self::get_newsletters_list_default_size(),
+			'newsletter_list_initial_size'             => self::get_newsletters_list_initial_size(),
 			'terms_text'                               => '',
 			'terms_url'                                => '',
 			'sync_esp'                                 => true,
@@ -1697,10 +1697,7 @@ final class Reader_Activation {
 		if ( empty( $newsletters_lists ) ) {
 			return;
 		}
-		$newsletter_list_default_size = self::get_newsletters_list_default_size();
-		if ( empty( $newsletter_list_default_size ) ) {
-			$newsletter_list_default_size = 2;
-		}
+		$newsletter_list_initial_size = self::get_newsletters_list_initial_size();
 		?>
 		<div class="newspack-ui newspack-ui__modal-container newspack-newsletters-signup-modal">
 			<div class="newspack-ui__modal-container__overlay"></div>
@@ -1724,7 +1721,7 @@ final class Reader_Activation {
 							<?php echo esc_html( $email_address ); ?>
 						</span>
 					</p>
-					<?php self::render_newsletters_signup_form( $email_address, $newsletters_lists, $newsletter_list_default_size ); ?>
+					<?php self::render_newsletters_signup_form( $email_address, $newsletters_lists, $newsletter_list_initial_size ); ?>
 				</div>
 			</div>
 		</div>
@@ -2620,8 +2617,8 @@ final class Reader_Activation {
 	 *
 	 * @return int Default list size.
 	 */
-	public static function get_newsletters_list_default_size() {
-		return absint( get_option( self::OPTIONS_PREFIX . 'newsletters_list_default_size', 2 ) );
+	private static function get_newsletters_list_initial_size() {
+		return absint( get_option( self::OPTIONS_PREFIX . 'newsletter_list_initial_size', 2 ) );
 	}
 
 	/**

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -352,6 +352,7 @@ final class Reader_Activation {
 			'newsletters_label'                        => self::get_reader_activation_labels( 'newsletters_cta' ),
 			'use_custom_lists'                         => false,
 			'newsletter_lists'                         => [],
+			'newsletter_list_default_size'             => self::get_newsletters_list_default_size(),
 			'terms_text'                               => '',
 			'terms_url'                                => '',
 			'sync_esp'                                 => true,
@@ -1627,20 +1628,26 @@ final class Reader_Activation {
 	 *
 	 * @param string $email_address     Email address.
 	 * @param array  $newsletters_lists Array of newsletters lists.
+	 * @param int    $default_list_size Default number of lists to show.
 	 *
 	 * @return void
 	 */
-	private static function render_newsletters_signup_form( $email_address, $newsletters_lists ) {
+	private static function render_newsletters_signup_form( $email_address, $newsletters_lists, $default_list_size = 2 ) {
+		$loop_index = 0;
 		?>
 			<div class="newspack-ui newspack-newsletters-signup">
 				<form method="post" target="_top">
 					<input type="hidden" name="<?php echo \esc_attr( self::NEWSLETTERS_SIGNUP_FORM_ACTION ); ?>" value="1" />
 					<input type="hidden" name="email_address" value="<?php echo esc_attr( $email_address ); ?>" />
+					
+					<div class="newsletter-list-container" data-list-default-size="<?php echo esc_attr( $default_list_size ); ?>">
 					<?php
 					foreach ( $newsletters_lists as $list ) {
 						$checkbox_id = sprintf( 'newspack-plugin-list-%s', $list['id'] );
+						$is_hidden = $loop_index <= $default_list_size ? '' : 'hidden';
+						$loop_index++;
 						?>
-						<label class="newspack-ui__input-card" for="<?php echo \esc_attr( $checkbox_id ); ?>">
+						<label class="newspack-ui__input-card <?php echo esc_attr( $is_hidden ); ?>" for="<?php echo \esc_attr( $checkbox_id ); ?>">
 							<input
 								type="checkbox"
 								name="lists[]"
@@ -1660,6 +1667,14 @@ final class Reader_Activation {
 						<?php
 					}
 					?>
+					</div>
+
+					<?php if ( count( $newsletters_lists ) > $default_list_size ) : ?>
+						<button type="button" class="newspack-ui__button newspack-ui__button--wide newspack-ui__button--secondary see-all-button">
+							<span><?php esc_html_e( 'See all', 'newspack-plugin' ); ?></span>
+							<span><?php \Newspack\Newspack_UI_Icons::print_svg( 'arrow-right' ); ?></span>
+						</button>
+					<?php endif; ?>
 					<button type="submit" class="newspack-ui__button newspack-ui__button--wide newspack-ui__button--primary"><?php echo \esc_html( self::get_reader_activation_labels( 'newsletters_continue' ) ); ?></button>
 				</form>
 			</div>
@@ -1681,6 +1696,10 @@ final class Reader_Activation {
 		$newsletters_lists = self::get_post_checkout_newsletter_lists( $email_address );
 		if ( empty( $newsletters_lists ) ) {
 			return;
+		}
+		$newsletter_list_default_size = self::get_newsletters_list_default_size();
+		if ( empty( $newsletter_list_default_size ) ) {
+			$newsletter_list_default_size = 2;
 		}
 		?>
 		<div class="newspack-ui newspack-ui__modal-container newspack-newsletters-signup-modal">
@@ -1705,7 +1724,7 @@ final class Reader_Activation {
 							<?php echo esc_html( $email_address ); ?>
 						</span>
 					</p>
-					<?php self::render_newsletters_signup_form( $email_address, $newsletters_lists ); ?>
+					<?php self::render_newsletters_signup_form( $email_address, $newsletters_lists, $newsletter_list_default_size ); ?>
 				</div>
 			</div>
 		</div>
@@ -2594,6 +2613,15 @@ final class Reader_Activation {
 	 */
 	public static function is_woocommerce_registration_required() {
 		return (bool) \get_option( self::OPTIONS_PREFIX . 'woocommerce_registration_required', false );
+	}
+
+	/**
+	 * Get the default list size for newsletters.
+	 *
+	 * @return int Default list size.
+	 */
+	public static function get_newsletters_list_default_size() {
+		return absint( get_option( self::OPTIONS_PREFIX . 'newsletters_list_default_size', 2 ) );
 	}
 
 	/**

--- a/src/components/src/sortable-newsletter-list-control/index.js
+++ b/src/components/src/sortable-newsletter-list-control/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { Icon, chevronUp, chevronDown, trash } from '@wordpress/icons';
-import { Notice } from '@wordpress/components';
+import { CheckboxControl,Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -42,8 +42,8 @@ export default function SortableNewsletterListControl( {
 							title={ list.name }
 							description={ () => (
 								<>
-									<input
-										type="checkbox"
+									<CheckboxControl
+										label={ __( 'Checked by default', 'newspack-plugin' ) }
 										checked={ selectedList.checked }
 										onChange={ () => {
 											const index = selected.findIndex( ( { id } ) => id === selectedList.id );
@@ -52,11 +52,10 @@ export default function SortableNewsletterListControl( {
 											onChange( newSelected );
 										} }
 									/>
-									{ __( 'Checked by default', 'newspack-plugin' ) }
 								</>
 							) }
 							isSmall
-							actionText={
+							hasWhiteHeader							actionText={
 								<>
 									<Button
 										onClick={ () =>
@@ -64,6 +63,7 @@ export default function SortableNewsletterListControl( {
 										}
 										label={ __( 'Remove', 'newspack-plugin' ) }
 										icon={ trash }
+										isDestructive
 									/>
 								</>
 							}

--- a/src/components/src/sortable-newsletter-list-control/style.scss
+++ b/src/components/src/sortable-newsletter-list-control/style.scss
@@ -1,10 +1,15 @@
 .newspack__newsletter-list-control {
+	grid-column: span 3;
+
 	&__selected {
 		.newspack-card {
 			display: flex;
 			justify-content: center;
 			min-height: 40px;
 			flex-direction: row;
+			&:first-of-type {
+				margin-top: 0 !important;
+			}
 			.newspack-action-card__region {
 				align-items: center;
 				display: flex;
@@ -14,11 +19,16 @@
 			.newspack-action-card__region-top {
 				flex: 1;
 				order: 2;
+
+				.newspack-grid {
+					margin: 0;
+				}
 			}
 			.newspack-action-card__region-children {
-				padding: 12px;
+				padding: 12px !important;
 			}
 		}
+
 	}
 	&__sort-handle {
 		display: flex;

--- a/src/reader-activation-newsletters/newsletters-form.js
+++ b/src/reader-activation-newsletters/newsletters-form.js
@@ -26,29 +26,25 @@ window.newspackRAS.push( function ( readerActivation ) {
 			const newsletterContainer = container.querySelector( '.newsletter-list-container' );
 
 			if ( seeAllButton && newsletterContainer ) {
+				// Remove the "hidden" class from all newsletter items.
 				seeAllButton.addEventListener( 'click', () => {
-					// Remove the "hidden" class from all newsletter items.
 					newsletterContainer.querySelectorAll( '.hidden' ).forEach( ( item ) => {
 						item.classList.remove( 'hidden' );
 					} );
 
-					// Adjust the container's max-height to fit all items.
 					newsletterContainer.style.maxHeight = 'none';
-
-					// Hide the "See all" button after expanding.
 					seeAllButton.style.display = 'none';
 				});
 
-				// Set the initial max-height to show the default number of newsletters + 1 partially visible.
+				// Set the initial height to show partially visible.
 				const listDefaultSize = parseInt( newsletterContainer.dataset.listDefaultSize, 10 );
 				const newsletterItems = newsletterContainer.querySelectorAll( '.newspack-ui__input-card' );
 
 				if ( newsletterItems.length > listDefaultSize ) {
-					const itemHeight = newsletterItems[0].offsetHeight; // Height of a single newsletter item.
-					const gap = 16; // Adjust based on CSS gap/margin between items.
+					const itemHeight = newsletterItems[0].offsetHeight;
+					const gap = 16;
 					const extraSpace = 32; // Additional space for partial visibility.
 
-					// Calculate max-height: visible newsletters + 1 partially visible + gaps + extra space.
 					const maxHeight = ( listDefaultSize * itemHeight ) + ( listDefaultSize * gap ) + extraSpace;
 
 					newsletterContainer.style.maxHeight = `${maxHeight}px`;

--- a/src/reader-activation-newsletters/newsletters-form.js
+++ b/src/reader-activation-newsletters/newsletters-form.js
@@ -41,7 +41,7 @@ window.newspackRAS.push( function ( readerActivation ) {
 				const newsletterItems = newsletterContainer.querySelectorAll( '.newspack-ui__input-card' );
 
 				if ( newsletterItems.length > listDefaultSize ) {
-					const gap = 16;
+					const gap = 12;
 					const extraSpace = 32; // Additional space for partial visibility.
 
 					let totalHeight = 0;

--- a/src/reader-activation-newsletters/newsletters-form.js
+++ b/src/reader-activation-newsletters/newsletters-form.js
@@ -33,8 +33,8 @@ window.newspackRAS.push( function ( readerActivation ) {
 					} );
 
 					newsletterContainer.style.maxHeight = 'none';
-					seeAllButton.style.display = 'none';
-				});
+					seeAllButton.remove();
+				} );
 
 				// Set the initial height to show partially visible.
 				const listDefaultSize = parseInt( newsletterContainer.dataset.listDefaultSize, 10 );

--- a/src/reader-activation-newsletters/newsletters-form.js
+++ b/src/reader-activation-newsletters/newsletters-form.js
@@ -21,6 +21,40 @@ window.newspackRAS.push( function ( readerActivation ) {
 				return;
 			}
 
+			// Handle "See all" button logic.
+			const seeAllButton = container.querySelector( '.see-all-button' );
+			const newsletterContainer = container.querySelector( '.newsletter-list-container' );
+
+			if ( seeAllButton && newsletterContainer ) {
+				seeAllButton.addEventListener( 'click', () => {
+					// Remove the "hidden" class from all newsletter items.
+					newsletterContainer.querySelectorAll( '.hidden' ).forEach( ( item ) => {
+						item.classList.remove( 'hidden' );
+					} );
+
+					// Adjust the container's max-height to fit all items.
+					newsletterContainer.style.maxHeight = 'none';
+
+					// Hide the "See all" button after expanding.
+					seeAllButton.style.display = 'none';
+				});
+
+				// Set the initial max-height to show the default number of newsletters + 1 partially visible.
+				const listDefaultSize = parseInt( newsletterContainer.dataset.listDefaultSize, 10 );
+				const newsletterItems = newsletterContainer.querySelectorAll( '.newspack-ui__input-card' );
+
+				if ( newsletterItems.length > listDefaultSize ) {
+					const itemHeight = newsletterItems[0].offsetHeight; // Height of a single newsletter item.
+					const gap = 16; // Adjust based on CSS gap/margin between items.
+					const extraSpace = 32; // Additional space for partial visibility.
+
+					// Calculate max-height: visible newsletters + 1 partially visible + gaps + extra space.
+					const maxHeight = ( listDefaultSize * itemHeight ) + ( listDefaultSize * gap ) + extraSpace;
+
+					newsletterContainer.style.maxHeight = `${maxHeight}px`;
+				}
+			}
+
 			const handleSubmit = ev => {
 				ev.preventDefault();
 

--- a/src/reader-activation-newsletters/newsletters-form.js
+++ b/src/reader-activation-newsletters/newsletters-form.js
@@ -41,11 +41,17 @@ window.newspackRAS.push( function ( readerActivation ) {
 				const newsletterItems = newsletterContainer.querySelectorAll( '.newspack-ui__input-card' );
 
 				if ( newsletterItems.length > listDefaultSize ) {
-					const itemHeight = newsletterItems[0].offsetHeight;
 					const gap = 16;
 					const extraSpace = 32; // Additional space for partial visibility.
 
-					const maxHeight = ( listDefaultSize * itemHeight ) + ( listDefaultSize * gap ) + extraSpace;
+					let totalHeight = 0;
+					newsletterItems.forEach( ( item, index ) => {
+						if ( index < listDefaultSize ) {
+							totalHeight += item.offsetHeight;
+						}
+					} );
+
+					const maxHeight = totalHeight + ( listDefaultSize * gap ) + extraSpace;
 
 					newsletterContainer.style.maxHeight = `${maxHeight}px`;
 				}

--- a/src/reader-activation-newsletters/style.scss
+++ b/src/reader-activation-newsletters/style.scss
@@ -21,7 +21,7 @@
 			position: relative;
 			transition: max-height 250ms ease-in-out;
 
-			&::before {
+			&:not([style*="none"])::before {
 				background: linear-gradient(to top, white, transparent);
 				bottom: 0;
 				content: "";

--- a/src/reader-activation-newsletters/style.scss
+++ b/src/reader-activation-newsletters/style.scss
@@ -15,6 +15,19 @@
 
 	.newspack-newsletters-signup {
 		margin-top: var(--newspack-ui-spacer-5);
+
+		.newsletter-list-container {
+			overflow: hidden;
+			transition: max-height 0.3s ease-in-out;
+
+			.newspack-ui__input-card.hidden {
+				display: none !important;
+			}
+		}
+
+		.see-all-button {
+			justify-content: space-between;
+		}
 	}
 }
 

--- a/src/reader-activation-newsletters/style.scss
+++ b/src/reader-activation-newsletters/style.scss
@@ -18,7 +18,18 @@
 
 		.newsletter-list-container {
 			overflow: hidden;
-			transition: max-height 0.3s ease-in-out;
+			position: relative;
+			transition: max-height 250ms ease-in-out;
+
+			&::before {
+				background: linear-gradient(to top, white, transparent);
+				bottom: 0;
+				content: "";
+				height: 32px;
+				left: 0;
+				position: absolute;
+				right: 0;
+			}
 
 			.newspack-ui__input-card.hidden {
 				display: none;

--- a/src/reader-activation-newsletters/style.scss
+++ b/src/reader-activation-newsletters/style.scss
@@ -21,12 +21,17 @@
 			transition: max-height 0.3s ease-in-out;
 
 			.newspack-ui__input-card.hidden {
-				display: none !important;
+				display: none;
 			}
 		}
 
 		.see-all-button {
 			justify-content: space-between;
+			margin: var(--newspack-ui-spacer-2) 0 var(--newspack-ui-spacer-5) 0 !important;
+		}
+
+		button[type="submit"] {
+			background: var(--newspack-ui-color-primary);
 		}
 	}
 }

--- a/src/wizards/audience/views/setup/setup.js
+++ b/src/wizards/audience/views/setup/setup.js
@@ -176,12 +176,6 @@ export default withWizardScreen(
 			{ config.enabled && (
 				<Card noBorder>
 					<hr />
-					<SectionHeader
-						title={ __(
-							'Newsletter Subscription Lists',
-							'newspack-plugin'
-						) }
-					/>
 					<ActionCard
 						title={ __(
 							'Present newsletter signup after checkout and registration',
@@ -191,25 +185,24 @@ export default withWizardScreen(
 							'Ask readers to sign up for newsletters after creating an account or completing a purchase.',
 							'newspack-plugin'
 						) }
+						hasGreyHeader={ config.use_custom_lists }
+						isMedium
 						toggleChecked={ config.use_custom_lists }
 						toggleOnChange={ value =>
 							updateConfig( 'use_custom_lists', value )
 						}
-					/>
-					{ config.use_custom_lists && (
-						<>
-							<SectionHeader
-								title={ __(
-									'Select Newsletters',
-									'newspack-plugin'
-								) }
-								heading={ 4 }
-								description={ __(
-									'These newsletters will be displayed on signup.',
-									'newspack-plugin'
-								) }
-							/>
-							<Grid columns={ 3 }>
+					>
+						{ config.use_custom_lists && (
+							<Grid columns={ 4 }>
+								<SortableNewsletterListControl
+									lists={
+										newspackAudience.available_newsletter_lists
+									}
+									selected={ config.newsletter_lists }
+									onChange={ selected =>
+										updateConfig( 'newsletter_lists', selected )
+									}
+								/>
 								<RangeControl
 									min={ 1 }
 									max={ 10 }
@@ -226,17 +219,8 @@ export default withWizardScreen(
 									onChange={ value => updateConfig( 'newsletter_list_initial_size', parseInt( value ) ) }
 								/>
 							</Grid>
-							<SortableNewsletterListControl
-								lists={
-									newspackAudience.available_newsletter_lists
-								}
-								selected={ config.newsletter_lists }
-								onChange={ selected =>
-									updateConfig( 'newsletter_lists', selected )
-								}
-							/>
-						</>
-					) }
+						) }
+					</ActionCard>
 
 					<hr />
 
@@ -266,7 +250,7 @@ export default withWizardScreen(
 							'Configure options for syncing reader data to the connected ESP.',
 							'newspack-plugin'
 						) }
-						hasGreyHeader={ true }
+						hasGreyHeader={ config.sync_esp }
 						isMedium
 						title={ __(
 							'Sync contacts to ESP',

--- a/src/wizards/audience/views/setup/setup.js
+++ b/src/wizards/audience/views/setup/setup.js
@@ -3,7 +3,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { ExternalLink } from '@wordpress/components';
+import { ExternalLink, RangeControl } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
 import { useEffect, useState } from '@wordpress/element';
 
@@ -210,12 +210,12 @@ export default withWizardScreen(
 								) }
 							/>
 							<Grid columns={ 3 }>
-								<TextControl
-									type="number"
+								<RangeControl
 									min={ 1 }
-									placeholder={ 2 }
+									max={ 10 }
+									initialPosition={ 2 }
 									label={ __(
-										'Initial List Size',
+										'Initial list size',
 										'newspack-plugin'
 									) }
 									help={ __(

--- a/src/wizards/audience/views/setup/setup.js
+++ b/src/wizards/audience/views/setup/setup.js
@@ -14,6 +14,7 @@ import {
 	ActionCard,
 	Button,
 	Card,
+	Grid,
 	Notice,
 	PluginInstaller,
 	SectionHeader,
@@ -196,15 +197,45 @@ export default withWizardScreen(
 						}
 					/>
 					{ config.use_custom_lists && (
-						<SortableNewsletterListControl
-							lists={
-								newspackAudience.available_newsletter_lists
-							}
-							selected={ config.newsletter_lists }
-							onChange={ selected =>
-								updateConfig( 'newsletter_lists', selected )
-							}
-						/>
+						<>
+							<SectionHeader
+								title={ __(
+									'Select Newsletters',
+									'newspack-plugin'
+								) }
+								heading={ 4 }
+								description={ __(
+									'These newsletters will be displayed on signup.',
+									'newspack-plugin'
+								) }
+							/>
+							<Grid columns={ 3 }>
+								<TextControl
+									type="number"
+									min={ 1 }
+									placeholder={ 2 }
+									label={ __(
+										'Initial List Size',
+										'newspack-plugin'
+									) }
+									help={ __(
+										'Number of newsletters to show by default on signup.',
+										'newspack-plugin'
+									) }
+									value={ config.newsletter_list_initial_size || '' }
+									onChange={ value => updateConfig( 'newsletter_list_initial_size', parseInt( value ) ) }
+								/>
+							</Grid>
+							<SortableNewsletterListControl
+								lists={
+									newspackAudience.available_newsletter_lists
+								}
+								selected={ config.newsletter_lists }
+								onChange={ selected =>
+									updateConfig( 'newsletter_lists', selected )
+								}
+							/>
+						</>
 					) }
 
 					<hr />
@@ -376,6 +407,8 @@ export default withWizardScreen(
 										config.constant_contact_list_id,
 									use_custom_lists: config.use_custom_lists,
 									newsletter_lists: config.newsletter_lists,
+									newsletter_list_initial_size:
+										config.newsletter_list_initial_size,
 									sync_esp: config.sync_esp,
 									metadata_fields: config.metadata_fields,
 									metadata_prefix: config.metadata_prefix,

--- a/src/wizards/audience/views/setup/setup.js
+++ b/src/wizards/audience/views/setup/setup.js
@@ -219,7 +219,7 @@ export default withWizardScreen(
 										'newspack-plugin'
 									) }
 									help={ __(
-										'Number of newsletters to show by default on signup.',
+										'Number of newsletters initially visible during signup. Additional newsletters will be hidden behind a "See all" button.',
 										'newspack-plugin'
 									) }
 									value={ config.newsletter_list_initial_size || '' }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1208970929679778/1208759817180346/f.

The Newsletters list displayed on the front-end to users to subscribe to during signup needed to be handled more gracefully. As per the discussion on ticket, this PR adds a "See all" button on the newsletter subscribe lists which when clicked displays the entire newsletter list. A setting is added in the Audience Configuration settings page in the "Newsletter Subscription Lists" section to set the number of initial newsletter to be displayed be default, while the rest of the newsletters hides behind the "See all" button.

Setting:-
<img width="482" alt="Screenshot 2025-04-05 at 7 38 21 PM" src="https://github.com/user-attachments/assets/4fb95636-e21a-442a-afc3-eac2ff5fa8c6" />

Front-end:-
<img width="483" alt="Screenshot 2025-04-05 at 7 36 04 PM" src="https://github.com/user-attachments/assets/e6af9a9d-481a-4d0e-b3c7-0313fb1d955d" />



### How to test the changes in this Pull Request:

1. Enable & Configure RAS and also enable the Present newsletter signup after checkout and registration in Audience settings.
2. Go to Newsletter > Settings and add a few Subscription list items with title & description.
3. Set the Initial list size to two or any number.
4. Log in as a guest window and click on Sign In, fill up the form.
5. Observe the newsletter list displaying the number of newsletter as set in the config and show an extra item partially.
6. Click on "See all" to display the entire list.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->