### PR TITLE
Fix: RAS OTP Autocomplete feature

### DIFF
--- a/src/reader-activation-auth/otp-input.js
+++ b/src/reader-activation-auth/otp-input.js
@@ -74,7 +74,7 @@ domReady( function () {
 				const otpDigit = ev.target.value.trim();
 				if ( otpDigit.match( /^[0-9]$/ ) ) {
 					values[ i ] = otpDigit;
-					const next = inputContainer.querySelector(`[data-index="${i + 1}"]`);
+					const next  = inputContainer.querySelector(`[data-index="${i + 1}"]`);
 					if (next) {
 						next.focus();
 					}

--- a/src/reader-activation-auth/otp-input.js
+++ b/src/reader-activation-auth/otp-input.js
@@ -25,7 +25,7 @@ domReady( function () {
 			digit.setAttribute( 'type', 'text' );
 			digit.setAttribute( 'maxlength', '1' );
 			digit.setAttribute( 'pattern', '[0-9]' );
-			digit.setAttribute( 'autocomplete', 'off' );
+			digit.setAttribute( 'autocomplete', 0 === i ? 'one-time-code' : 'off' );
 			digit.setAttribute( 'inputmode', 'numeric' );
 			digit.setAttribute( 'data-index', i );
 			digit.addEventListener( 'keydown', ev => {
@@ -71,8 +71,13 @@ domReady( function () {
 				}
 			} );
 			digit.addEventListener( 'input', ev => {
-				if ( ev.target.value.match( /^[0-9]$/ ) ) {
-					values[ i ] = ev.target.value;
+				const otpDigit = ev.target.value.trim();
+				if ( otpDigit.match( /^[0-9]$/ ) ) {
+					values[ i ] = otpDigit;
+					const next = inputContainer.querySelector(`[data-index="${i + 1}"]`);
+					if (next) {
+						next.focus();
+					}
 				} else {
 					ev.target.value = '';
 				}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes: https://app.asana.com/0/1208970929679778/1207509651211057/f

### How to test the changes in this Pull Request:

1. Add `add_filter( 'newspack_reader_activation_enabled', '__return_true' );` 
2. Open site in incognito on Mobile
3. Create a new account and logout
4. Try login with the created account
5. Autofill OTP from Keyboard

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->