### PR TITLE
fix: remove import and route for Suppression

### DIFF
--- a/src/wizards/advertising/index.js
+++ b/src/wizards/advertising/index.js
@@ -15,7 +15,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { withWizard, utils } from '../../components/src';
 import Router from '../../components/src/proxied-imports/router';
-import { AdUnit, AdUnits, Providers, Settings, Placements, Suppression } from './views';
+import { AdUnit, AdUnits, Providers, Settings, Placements } from './views';
 import { getSizes } from './components/ad-unit-size-control';
 import './style.scss';
 
@@ -183,21 +183,6 @@ class AdvertisingWizard extends Component {
 								<Placements
 									headerText={ __( 'Advertising / Display Ads', 'newspack-plugin' ) }
 									tabbedNavigation={ tabs }
-								/>
-							) }
-						/>
-						<Route
-							path="/suppression"
-							render={ () => (
-								<Suppression
-									headerText={ __( 'Advertising / Suppression', 'newspack-plugin' ) }
-									subHeaderText={ __(
-										'Allows you to manage site-wide ad suppression',
-										'newspack-plugin'
-									) }
-									tabbedNavigation={ tabs }
-									config={ advertisingData.suppression }
-									onChange={ config => this.updateAdSuppression( config ) }
 								/>
 							) }
 						/>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#3881 moved the ad suppression settings from a separate page to the Advertising > Settings wizard page, but didn't remove the import from the old component path or the route for the separate page. This PR cleans up those unneeded items.

Not a hotfix because the extra code doesn't cause any issues, so it's not urgent to remove.

### How to test the changes in this Pull Request:

1. On `trunk`, observe a webpack build error:

```
WARNING in ./src/wizards/advertising/index.js 178:44-55
export 'Suppression' (imported as 'Suppression') was not found in './views' (possible exports: AdUnit, AdUnits, Placements, Providers, Settings)
```

2. Check out this branch, rebuild assets, and visit Advertising > Settings
3. Confirm that the "Suppression settings" card appears on this page and correctly shows/saves its settings
4. Confirm no other build errors or JS console errors in the Advertising wizard pages

### Other information:

* [x ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->