### PR TITLE
chore: prevent PHP Notice about translations loading too early

### DIFF
--- a/includes/optional-modules/class-rss.php
+++ b/includes/optional-modules/class-rss.php
@@ -26,7 +26,7 @@ class RSS {
 		}
 
 		// Backend.
-		self::register_feed_cpt();
+		add_action( 'init', [ __CLASS__, 'register_feed_cpt' ] );
 		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'enqueue_autocomplete_scripts' ] );
 		add_action( 'save_post_' . self::FEED_CPT, [ __CLASS__, 'save_settings' ] );
 		add_filter( 'manage_' . self::FEED_CPT . '_posts_columns', [ __CLASS__, 'columns_head' ] );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Some code called the i18n function too early, triggering a PHP Notice. Might be WP 6.8 related (tested on `6.8-RC1`)

### How to test the changes in this Pull Request:

1. On `trunk`, observe a PHP Notice logged: `PHP Notice:  Function _load_textdomain_just_in_time was called <strong>incorrectly</strong>. Translation loading for the <code>newspack-plugin</code> domain was triggered too early.`
2. Switch to this branch, observe no notice logged.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->