### PR TITLE
fix: update Lite Site URL base

### DIFF
--- a/includes/lite-site/templates/archive.php
+++ b/includes/lite-site/templates/archive.php
@@ -36,7 +36,8 @@
 
 	foreach ( $recent_posts as $current_post ) {
 		printf(
-			'<li><a href="/text/%d">%s</a></li>',
+			'<li><a href="/%s/%d">%s</a></li>',
+			esc_attr( Lite_Site::get_url_base() ),
 			esc_attr( $current_post->ID ),
 			esc_html( $current_post->post_title )
 		);

--- a/includes/lite-site/templates/single.php
+++ b/includes/lite-site/templates/single.php
@@ -24,7 +24,7 @@ if ( ! $current_post ) {
 </head>
 <body>
 	<header class="back">
-		<a href="/text">← <?php esc_html_e( 'Back to posts', 'newspack-plugin' ); ?></a> |
+		<a href="/<?php echo esc_attr( Lite_Site::get_url_base() ); ?>">← <?php esc_html_e( 'Back to posts', 'newspack-plugin' ); ?></a> |
 		<a href="<?php echo esc_url( get_permalink( $current_post ) ); ?>"><?php esc_html_e( 'View full site', 'newspack-plugin' ); ?></a>
 	</header>
 	<h1><?php echo esc_html( $current_post->post_title ); ?></h1>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

https://github.com/Automattic/newspack-plugin/pull/3899 as a hotfix:

This PR updates a couple spots where the default /text URL base was hardcoded for Lite Sites.

See 1200550061930446-as-1209913651614565

### How to test the changes in this Pull Request:

1. Go to WP Admin > Settings > Lite Site, and change the URL base to something custom.
2. View the lite site on the front-end, and try clicking on stories; note that they still bring you to a /text/ URL.
3. Apply this PR and make sure the stories listed now use your updated URL base, and that the works link.
4. On single stories, confirm that the link "Back to posts" points to the right URL.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->