### PR TITLE
fix: allow guest contributors to have empty archives

### DIFF
--- a/includes/class-patches.php
+++ b/includes/class-patches.php
@@ -351,6 +351,7 @@ class Patches {
 					'editor',
 					'author',
 					'contributor',
+					Guest_Contributor_Role::CONTRIBUTOR_NO_EDIT_ROLE_NAME,
 				]
 			);
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Allow Guest Contributors to have empty archive pages

### How to test the changes in this Pull Request:

1. Create a Guest Contributor user with no posts
2. Visit its archive page and confirm it loads the regular author archives, and not a generic 404 page


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->