### PR TITLE
fix: remove extra space above empty help text

### DIFF
--- a/src/blocks/reader-registration/editor.scss
+++ b/src/blocks/reader-registration/editor.scss
@@ -88,6 +88,10 @@
 				}
 			}
 		}
+
+		.newspack-ui__helper-text:empty {
+			margin: 0;
+		}
 	}
 
 	&__inputs,

--- a/src/blocks/reader-registration/editor.scss
+++ b/src/blocks/reader-registration/editor.scss
@@ -88,10 +88,6 @@
 				}
 			}
 		}
-
-		.newspack-ui__helper-text:empty {
-			margin: 0;
-		}
 	}
 
 	&__inputs,

--- a/src/blocks/reader-registration/style.scss
+++ b/src/blocks/reader-registration/style.scss
@@ -88,6 +88,10 @@
 				}
 			}
 		}
+
+		.newspack-ui__helper-text:empty {
+			margin: 0;
+		}
 	}
 
 	&__inputs {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes a small visual issue noticed when testing WP 6.8: when you enable Newsletter List descriptions in the Reader Registration block but a specific list doesn't have one, it leave a bit of a gap.

Note: I opted to fix this by removing the margin when the description is empty because it looks like we use the presence of the helper text to determine whether the descriptions are on, and so whether each newsletter should be displayed in its own bordered container or not. I didn't want to break that bit!

See 1209694846565575-as-1209865636087213

### How to test the changes in this Pull Request:

1. Set up Audience Development on your test site, and make sure to have at least two newsletter lists available. Make sure neither has a description set.
2. Add the Reader Registration block to a page, and enable more than one newsletter list & set them to show their descriptions. 
3. Note the misalignment of the text:

![CleanShot 2025-04-09 at 13 00 13](https://github.com/user-attachments/assets/05c9eea3-fc6c-4e17-8f40-dd694d389506)

4. Apply this PR and run `npm run build`.
5. Confirm that the spacing around the label looks better on the front-end (in an incognito window) and in the editor:

![CleanShot 2025-04-09 at 12 56 13](https://github.com/user-attachments/assets/d225b39d-c0ea-4c35-bb16-cf2166189767)

6. Edit your lists and add a description to at least one; make sure the description is spaced away from the Newsletter name:

![CleanShot 2025-04-09 at 12 57 44](https://github.com/user-attachments/assets/a526b05c-a2de-48fc-89ff-abf75c9592fb)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->