### PR TITLE
fix: make front end not dependent on coauthors plus

### DIFF
--- a/includes/bylines/class-bylines.php
+++ b/includes/bylines/class-bylines.php
@@ -135,30 +135,6 @@ class Bylines {
 	}
 
 	/**
-	 * Return the author in use into the custom byline.
-	 *
-	 * @return array $authors  Array of authors.
-	 */
-	public static function authors_on_byline() {
-		global $coauthors_plus;
-		$authors = [];
-		$byline_is_active = \get_post_meta( \get_the_ID(), self::META_KEY_ACTIVE, true );
-		$byline = \get_post_meta( \get_the_ID(), self::META_KEY_BYLINE, true );
-
-		if ( ! $byline_is_active || ! $byline ) {
-			return [];
-		}
-
-		$author_ids = self::extract_author_ids_from_shortcode( $byline );
-
-		foreach ( $author_ids as $author_id ) {
-			$authors[] = $coauthors_plus->get_coauthor_by( 'user_nicename', get_the_author_meta( 'user_nicename', $author_id ) );
-		}
-
-		return $authors;
-	}
-
-	/**
 	 * Outputs the byline on the post.
 	 *
 	 * @return false|string The post content with the byline prepended.
@@ -211,12 +187,7 @@ class Bylines {
 		$avatars = '';
 
 		foreach ( $author_ids as $author_id ) {
-			$author = $coauthors_plus->get_coauthor_by( 'user_nicename', get_the_author_meta( 'user_nicename', $author_id ) );
-
-			// avatar_img_tag is a property added by Newspack Network plugin to distributed posts.
-			$author_avatar = $author->avatar_img_tag ?? coauthors_get_avatar( $author, 80 );
-
-			$avatars .= '<span class="author-avatar">' . wp_kses( $author_avatar, self::AVATAR_ARGS ) . '</span>';
+			$avatars .= '<span class="author-avatar">' . get_avatar( $author_id ) . '</span>';
 		}
 
 		return $avatars;

--- a/includes/bylines/class-bylines.php
+++ b/includes/bylines/class-bylines.php
@@ -25,19 +25,6 @@ class Bylines {
 	 */
 	const META_KEY_BYLINE = '_newspack_byline';
 
-	const AVATAR_ARGS = array(
-		'img'      => array(
-			'class'  => true,
-			'src'    => true,
-			'alt'    => true,
-			'width'  => true,
-			'height' => true,
-			'data-*' => true,
-			'srcset' => true,
-		),
-		'noscript' => array(),
-	);
-
 	/**
 	 * Initializes the class.
 	 */
@@ -181,8 +168,6 @@ class Bylines {
 	 * @param string $byline  Byline with author shortcodes on it.
 	 */
 	public static function get_authors_avatars( $byline ) {
-		global $coauthors_plus;
-
 		$author_ids = self::extract_author_ids_from_shortcode( $byline );
 		$avatars = '';
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Make sure the custom bylines output works without CoAuthors Plus.

NOTE: Custom Bylines should NOT support Guest Authors

### How to test the changes in this Pull Request:

1. `define( 'NEWSPACK_BYLINES_ENABLED', true );`
2. With CAP active, create a custom byline with a few authors
3. Visit the front end and confirm you see it
4. Deactivate co-authors plus and confirm the front end looks just the same

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->