### PR TITLE
fix(bylines): get CAP data from the plugin's store

### DIFF
--- a/includes/bylines/class-bylines.php
+++ b/includes/bylines/class-bylines.php
@@ -81,10 +81,9 @@ class Bylines {
 			'newspack-bylines',
 			'newspackBylines',
 			[
-				'metaKeyActive'             => self::META_KEY_ACTIVE,
-				'metaKeyByline'             => self::META_KEY_BYLINE,
-				'siteUrl'                   => \get_site_url(),
-				'is_co_authors_plus_active' => is_plugin_active( 'co-authors-plus/co-authors-plus.php' ),
+				'metaKeyActive' => self::META_KEY_ACTIVE,
+				'metaKeyByline' => self::META_KEY_BYLINE,
+				'siteUrl'       => \get_site_url(),
 			]
 		);
 		\wp_enqueue_style(

--- a/src/bylines/index.js
+++ b/src/bylines/index.js
@@ -238,16 +238,17 @@ const BylinesSettingsPanel = () => {
 		select( 'core/editor' )
 	);
 
-	/** Fetch post author from core */
+	/** Fetch post author(s) */
 	const { postAuthor, coAuthors } = useSelect( select => {
 		const { getUser } = select( coreStore );
 		const _authorId = getEditedPostAttribute( 'author' );
 
 		return {
 			postAuthor: getUser( _authorId, BASE_QUERY ),
-			coAuthors: postId
-				? select( 'cap/authors' ).getAuthors( postId )
-				: [],
+			coAuthors:
+				postId && select( 'cap/authors' )
+					? select( 'cap/authors' ).getAuthors( postId )
+					: [],
 		};
 	} );
 

--- a/src/bylines/index.js
+++ b/src/bylines/index.js
@@ -15,7 +15,6 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
 import { __ } from '@wordpress/i18n';
 import { registerPlugin } from '@wordpress/plugins';
-import apiFetch from '@wordpress/api-fetch';
 import { Icon, plus } from '@wordpress/icons';
 import { store as coreStore } from '@wordpress/core-data';
 
@@ -222,13 +221,9 @@ const BylinesSettingsPanel = () => {
 
 	const [ cursorPos, setCursorPos ] = useState( null );
 
-	/** coAuthors fetched from co-Authors Plus */
-	const [ coAuthors, setCoAuthors ] = useState( [] );
-
 	/** Reference to contenteditable element to add event listners */
 	const editableRef = useRef( null );
 
-	const noticesDispatch = useDispatch( 'core/notices' );
 	const { editPost } = useDispatch( 'core/editor' );
 
 	/** Current post data */
@@ -244,14 +239,33 @@ const BylinesSettingsPanel = () => {
 	);
 
 	/** Fetch post author from core */
-	const { postAuthor } = useSelect( select => {
+	const { postAuthor, coAuthors } = useSelect( select => {
 		const { getUser } = select( coreStore );
 		const _authorId = getEditedPostAttribute( 'author' );
 
 		return {
 			postAuthor: getUser( _authorId, BASE_QUERY ),
+			coAuthors: postId
+				? select( 'cap/authors' ).getAuthors( postId )
+				: [],
 		};
 	} );
+
+	/**
+	 * Set tokens when authors change.
+	 */
+	useEffect( () => {
+		if ( coAuthors?.length ) {
+			setTokens(
+				coAuthors.map( author => ( {
+					id: parseInt( author.id ),
+					name: author.display,
+				} ) )
+			);
+		} else {
+			setTokens( [ postAuthor ] );
+		}
+	}, [ coAuthors, postAuthor ] );
 
 	/** Toggle if custom byline is enabled */
 	const [ isEnabled, setIsEnabled ] = useState(
@@ -292,19 +306,6 @@ const BylinesSettingsPanel = () => {
 		);
 
 		setTokensInUse( inUse );
-	};
-
-	/**
-	 * Transform coAuthors into an object expected to be used as tokens
-	 * in the format of { id: int; name: string }.
-	 *
-	 * @param {Object} Authors Co-authors fetched from Co-Author Plus API.
-	 * @return {Object}        Co-authors transformed into tokens object: { id: int; name: string }
-	 */
-	const transformAuthorsToTokens = Authors => {
-		return Object.values( Authors ).map( value => {
-			return { id: value.id, name: value.display_name };
-		} );
 	};
 
 	/**
@@ -362,20 +363,6 @@ const BylinesSettingsPanel = () => {
 	};
 
 	/**
-	 * Handle Error
-	 *
-	 * @param {Error} error
-	 */
-	function handleError( error ) {
-		if ( 'AbortError' === error.name ) {
-			return;
-		}
-		noticesDispatch.createErrorNotice( error.message, {
-			isDismissible: true,
-		} );
-	}
-
-	/**
 	 * Insert the default custom byline.
 	 * Used when the custom byline setting is first enabled.
 	 */
@@ -423,57 +410,6 @@ const BylinesSettingsPanel = () => {
 			insertDefaultByline();
 		}
 	};
-
-	/**
-	 * Set tokens when coAuthors change.
-	 */
-	useEffect( () => {
-		if ( coAuthors ) {
-			setTokens( coAuthors );
-		}
-	}, [ coAuthors ] );
-
-	/**
-	 * Fetch co-authors from Co-Authors Plus.
-	 */
-	useEffect( () => {
-		if ( ! postId ) {
-			return;
-		}
-
-		// If Co-Authors Plus is active, use their authors
-		if ( newspackBylines.is_co_authors_plus_active ) {
-			const controller = new AbortController();
-
-			apiFetch( {
-				path: `/coauthors/v1/coauthors?post_id=${ postId }`,
-				signal: controller.signal,
-			} )
-				.then( transformAuthorsToTokens )
-				.then( setCoAuthors )
-				.catch( handleError );
-
-			return () => {
-				controller.abort();
-			};
-		}
-	}, [ postId ] );
-
-	/**
-	 * Use core post author if Co-Authors Plus is not active
-	 */
-	useEffect( () => {
-		// If Co-Author Plus is active, return
-		if ( newspackBylines.is_co_authors_plus_active ) {
-			return;
-		}
-
-		if ( postAuthor === undefined ) {
-			return;
-		}
-
-		setCoAuthors( [ postAuthor ] );
-	}, [ postAuthor ] );
 
 	/**
 	 * Initialize the contenteditable element.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Refactors the Co-Authors integration to use the plugin's store instead of a custom API request. This allows the bylines feature to be aware of the edited data and the byline text can be edited along with the author configuration without the need for a post save or page refresh.

This change requires a small patch to CAP, which I'm proposing here: https://github.com/Automattic/Co-Authors-Plus/pull/1110

The authors' data doesn't include its ID in the store, which we need. Ideally, this should be added to the plugin. If that's not possible, we can implement our own react hook to fetch the ID while still leveraging the store for live changes.

### How to test the changes in this Pull Request:

1. Make sure you are running https://github.com/Automattic/Co-Authors-Plus/pull/1110
2. Edit a post and confirm you can edit the custom byline
3. Tweak the authors, remove some and add others and **do not save**
4. Edit the byline and confirm the available tokens reflect the edited authors
5. Save changes, refresh the editor, and confirm all changes persisted and you are able to make changes to the byline with the saved tokens
6. Deactivate CAP, edit a post and confirm you can edit the custom byline of a post

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->