### PR TITLE
feat(bylines): useAuthorTokens() hook with user entity validation

### DIFF
--- a/includes/bylines/class-bylines.php
+++ b/includes/bylines/class-bylines.php
@@ -81,10 +81,9 @@ class Bylines {
 			'newspack-bylines',
 			'newspackBylines',
 			[
-				'metaKeyActive'             => self::META_KEY_ACTIVE,
-				'metaKeyByline'             => self::META_KEY_BYLINE,
-				'siteUrl'                   => \get_site_url(),
-				'is_co_authors_plus_active' => is_plugin_active( 'co-authors-plus/co-authors-plus.php' ),
+				'metaKeyActive' => self::META_KEY_ACTIVE,
+				'metaKeyByline' => self::META_KEY_BYLINE,
+				'siteUrl'       => \get_site_url(),
 			]
 		);
 		\wp_enqueue_style(

--- a/src/bylines/index.js
+++ b/src/bylines/index.js
@@ -4,12 +4,7 @@
  * WordPress dependencies
  */
 import { Button, Modal, ToggleControl } from '@wordpress/components';
-import {
-	useCallback,
-	useMemo,
-	useState,
-	useRef,
-} from '@wordpress/element';
+import { useCallback, useMemo, useState, useRef } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
 import { __ } from '@wordpress/i18n';

--- a/src/bylines/index.js
+++ b/src/bylines/index.js
@@ -238,16 +238,17 @@ const BylinesSettingsPanel = () => {
 		select( 'core/editor' )
 	);
 
-	/** Fetch post author from core */
+	/** Fetch post author(s) */
 	const { postAuthor, coAuthors } = useSelect( select => {
 		const { getUser } = select( coreStore );
 		const _authorId = getEditedPostAttribute( 'author' );
 
 		return {
 			postAuthor: getUser( _authorId, BASE_QUERY ),
-			coAuthors: postId
-				? select( 'cap/authors' ).getAuthors( postId )
-				: [],
+			coAuthors:
+				postId && select( 'cap/authors' )
+					? select( 'cap/authors' ).getAuthors( postId )
+					: [],
 		};
 	} );
 

--- a/src/bylines/index.js
+++ b/src/bylines/index.js
@@ -7,7 +7,6 @@ import { Button, Modal, ToggleControl } from '@wordpress/components';
 import {
 	useCallback,
 	useMemo,
-	useEffect,
 	useState,
 	useRef,
 } from '@wordpress/element';
@@ -105,6 +104,41 @@ const transformByline = element => {
 
 	return clonebylineElement.innerHTML;
 };
+
+/**
+ * Get the author tokens for a post.
+ *
+ * @param {number} postId The post ID.
+ *
+ * @return {Object[]} The author tokens.
+ */
+function useAuthorTokens( postId ) {
+	const { postAuthor, coAuthors } = useSelect( select => {
+		return {
+			postAuthor: select( coreStore ).getUser(
+				select( 'core/editor' ).getEditedPostAttribute( 'author' ),
+				BASE_QUERY
+			),
+			coAuthors:
+				postId && select( 'cap/authors' )
+					? select( 'cap/authors' ).getAuthors( postId )
+					: [],
+		};
+	} );
+
+	// Only return valid user entities for co-authors. No guest authors.
+	const validCoAuthors = useSelect( select => {
+		return coAuthors
+			.map( item => select( coreStore ).getUser( item.id, BASE_QUERY ) )
+			.filter( Boolean );
+	} );
+
+	if ( validCoAuthors?.length ) {
+		return validCoAuthors;
+	}
+
+	return [ postAuthor ];
+}
 
 /**
  * Component for the custom byline modal.
@@ -213,9 +247,6 @@ const Tokens = ( { tokens, tokensInUse, insertToken } ) => {
  * The byline settings panel component.
  */
 const BylinesSettingsPanel = () => {
-	/** Tokens with authors assigned to the post */
-	const [ tokens, setTokens ] = useState( [] );
-
 	/** Tokens that are in use by the custom byline */
 	const [ tokensInUse, setTokensInUse ] = useState( [] );
 
@@ -234,39 +265,11 @@ const BylinesSettingsPanel = () => {
 		[]
 	);
 
+	const tokens = useAuthorTokens( postId );
+
 	const { getEditedPostAttribute } = useSelect( select =>
 		select( 'core/editor' )
 	);
-
-	/** Fetch post author(s) */
-	const { postAuthor, coAuthors } = useSelect( select => {
-		const { getUser } = select( coreStore );
-		const _authorId = getEditedPostAttribute( 'author' );
-
-		return {
-			postAuthor: getUser( _authorId, BASE_QUERY ),
-			coAuthors:
-				postId && select( 'cap/authors' )
-					? select( 'cap/authors' ).getAuthors( postId )
-					: [],
-		};
-	} );
-
-	/**
-	 * Set tokens when authors change.
-	 */
-	useEffect( () => {
-		if ( coAuthors?.length ) {
-			setTokens(
-				coAuthors.map( author => ( {
-					id: parseInt( author.id ),
-					name: author.display,
-				} ) )
-			);
-		} else {
-			setTokens( [ postAuthor ] );
-		}
-	}, [ coAuthors, postAuthor ] );
 
 	/** Toggle if custom byline is enabled */
 	const [ isEnabled, setIsEnabled ] = useState(

--- a/src/bylines/index.js
+++ b/src/bylines/index.js
@@ -121,18 +121,13 @@ function useAuthorTokens( postId ) {
 		};
 	} );
 
-	// Only return valid user entities for co-authors. No guest authors.
-	const validCoAuthors = useSelect( select => {
+	if ( coAuthors.length ) {
 		return coAuthors
-			.map( item => {
-				const user = select( coreStore ).getUser( item.id, BASE_QUERY );
-				return user?.name === item.display ? user : null;
-			} )
-			.filter( Boolean );
-	} );
-
-	if ( validCoAuthors?.length ) {
-		return validCoAuthors;
+			.filter( author => author.userType === 'wpuser' )
+			.map( author => ( {
+				id: parseInt( author.id ),
+				name: author.display,
+			} ) );
 	}
 
 	return [ postAuthor ];

--- a/src/bylines/index.js
+++ b/src/bylines/index.js
@@ -124,7 +124,10 @@ function useAuthorTokens( postId ) {
 	// Only return valid user entities for co-authors. No guest authors.
 	const validCoAuthors = useSelect( select => {
 		return coAuthors
-			.map( item => select( coreStore ).getUser( item.id, BASE_QUERY ) )
+			.map( item => {
+				const user = select( coreStore ).getUser( item.id, BASE_QUERY );
+				return user?.name === item.display ? user : null;
+			} )
 			.filter( Boolean );
 	} );
 

--- a/src/bylines/index.js
+++ b/src/bylines/index.js
@@ -15,7 +15,6 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
 import { __ } from '@wordpress/i18n';
 import { registerPlugin } from '@wordpress/plugins';
-import apiFetch from '@wordpress/api-fetch';
 import { Icon, plus } from '@wordpress/icons';
 import { store as coreStore } from '@wordpress/core-data';
 
@@ -222,13 +221,9 @@ const BylinesSettingsPanel = () => {
 
 	const [ cursorPos, setCursorPos ] = useState( null );
 
-	/** coAuthors fetched from co-Authors Plus */
-	const [ coAuthors, setCoAuthors ] = useState( [] );
-
 	/** Reference to contenteditable element to add event listners */
 	const editableRef = useRef( null );
 
-	const noticesDispatch = useDispatch( 'core/notices' );
 	const { editPost } = useDispatch( 'core/editor' );
 
 	/** Current post data */
@@ -244,14 +239,33 @@ const BylinesSettingsPanel = () => {
 	);
 
 	/** Fetch post author from core */
-	const { postAuthor } = useSelect( select => {
+	const { postAuthor, coAuthors } = useSelect( select => {
 		const { getUser } = select( coreStore );
 		const _authorId = getEditedPostAttribute( 'author' );
 
 		return {
 			postAuthor: getUser( _authorId, BASE_QUERY ),
+			coAuthors: postId
+				? select( 'cap/authors' ).getAuthors( postId )
+				: [],
 		};
 	} );
+
+	/**
+	 * Set tokens when authors change.
+	 */
+	useEffect( () => {
+		if ( coAuthors?.length ) {
+			setTokens(
+				coAuthors.map( author => ( {
+					id: parseInt( author.id ),
+					name: author.display,
+				} ) )
+			);
+		} else {
+			setTokens( [ postAuthor ] );
+		}
+	}, [ coAuthors, postAuthor ] );
 
 	/** Toggle if custom byline is enabled */
 	const [ isEnabled, setIsEnabled ] = useState(
@@ -292,19 +306,6 @@ const BylinesSettingsPanel = () => {
 		);
 
 		setTokensInUse( inUse );
-	};
-
-	/**
-	 * Transform coAuthors into an object expected to be used as tokens
-	 * in the format of { id: int; name: string }.
-	 *
-	 * @param {Object} Authors Co-authors fetched from Co-Author Plus API.
-	 * @return {Object}        Co-authors transformed into tokens object: { id: int; name: string }
-	 */
-	const transformAuthorsToTokens = Authors => {
-		return Object.values( Authors ).map( value => {
-			return { id: value.id, name: value.display_name };
-		} );
 	};
 
 	/**
@@ -362,20 +363,6 @@ const BylinesSettingsPanel = () => {
 	};
 
 	/**
-	 * Handle Error
-	 *
-	 * @param {Error} error
-	 */
-	function handleError( error ) {
-		if ( 'AbortError' === error.name ) {
-			return;
-		}
-		noticesDispatch.createErrorNotice( error.message, {
-			isDismissible: true,
-		} );
-	}
-
-	/**
 	 * Insert the default custom byline.
 	 * Used when the custom byline setting is first enabled.
 	 */
@@ -423,57 +410,6 @@ const BylinesSettingsPanel = () => {
 			insertDefaultByline();
 		}
 	};
-
-	/**
-	 * Set tokens when coAuthors change.
-	 */
-	useEffect( () => {
-		if ( coAuthors ) {
-			setTokens( coAuthors );
-		}
-	}, [ coAuthors ] );
-
-	/**
-	 * Fetch co-authors from Co-Authors Plus.
-	 */
-	useEffect( () => {
-		if ( ! postId ) {
-			return;
-		}
-
-		// If Co-Authors Plus is active, use their authors
-		if ( newspackBylines.is_co_authors_plus_active ) {
-			const controller = new AbortController();
-
-			apiFetch( {
-				path: `/coauthors/v1/coauthors?post_id=${ postId }`,
-				signal: controller.signal,
-			} )
-				.then( transformAuthorsToTokens )
-				.then( setCoAuthors )
-				.catch( handleError );
-
-			return () => {
-				controller.abort();
-			};
-		}
-	}, [ postId ] );
-
-	/**
-	 * Use core post author if Co-Authors Plus is not active
-	 */
-	useEffect( () => {
-		// If Co-Author Plus is active, return
-		if ( newspackBylines.is_co_authors_plus_active ) {
-			return;
-		}
-
-		if ( postAuthor === undefined ) {
-			return;
-		}
-
-		setCoAuthors( [ postAuthor ] );
-	}, [ postAuthor ] );
 
 	/**
 	 * Initialize the contenteditable element.


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Depends on https://github.com/Automattic/Co-Authors-Plus/pull/1110 and #3906.

Introduces a `useAuthorTokens()` hook with additional validation so only valid user entities can be a byline token. This is primarily to prevent CAP's Guest Author feature from being used in the bylines.

### How to test the changes in this Pull Request:

1. Make sure you are running https://github.com/Automattic/Co-Authors-Plus/pull/1110
2. Draft a post with an author, guest contributor, and guest author
3. Edit the byline and confirm only the author and guest contributor are available tokens
4. Save the changes and confirm it persists

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->