### PR TITLE
fix: add white background to Newspack admin screens

### DIFF
--- a/src/admin/style.scss
+++ b/src/admin/style.scss
@@ -142,6 +142,10 @@ h1 {
 /**
  * Wizards
  */
+#wpwrap:has(.newspack-wizard__content) {
+	background: #fff;
+}
+
 // Only apply styles if there are sections and is immediate descendent.
 .newspack-wizard__content:has(> .newspack-wizard__sections) {
 	margin: 0;

--- a/src/admin/style.scss
+++ b/src/admin/style.scss
@@ -142,7 +142,7 @@ h1 {
 /**
  * Wizards
  */
-#wpwrap:has(.newspack-wizard__content) {
+#wpbody:has(.newspack-wizard__content) {
 	background: #fff;
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR explicitly sets a background colour on the #wpbody element on Newspack screens to override plugins that may be changing it. I went with this selector because it's "closest" to the content while still spanning the height of the page. 

See: 1200550061930446-as-1209866390785149

### How to test the changes in this Pull Request:

1. Install and activate the [Media Library Folders](https://en-ca.wordpress.org/plugins/media-library-plus/) plugin.
2. Go to the Newspack dashboard and note the colour:

![CleanShot 2025-04-11 at 08 40 34](https://github.com/user-attachments/assets/52d436a8-1823-46bb-89a8-dd93f27174ca)

3. Apply this PR and run `npm run build`.
4. Click around in the Newspack dashboard and confirm that screens that have custom Newspack UI elements have a white background. Screens that don't -- like standard WP Admin screens and even Newspack screens with standard WordPress UI elements, like the 'All Newsletters' page -- should not.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->