### PR TITLE
feat(scss): export colors as module for JS consumption

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -15,6 +15,27 @@ module.exports = {
 					'to-rgb'
 				]
 			}
+		],
+		'selector-pseudo-class-no-unknown': [
+			true,
+			{
+				ignorePseudoClasses: ['export']
+			}
+		],
+		'property-no-unknown': [
+			true,
+			{
+				ignoreProperties: [
+					/^primary-/,
+					/^secondary-/,
+					/^tertiary-/,
+					/^quaternary-/,
+					/^neutral-/,
+					/^success-/,
+					/^error-/,
+					/^warning-/
+				]
+			}
 		]
 	}
 };

--- a/src/blocks/correction-box/edit.jsx
+++ b/src/blocks/correction-box/edit.jsx
@@ -18,7 +18,6 @@ import {
 /**
  * Internal dependencies
  */
-import './style.scss';
 import meta from './block.json';
 
 /**

--- a/src/blocks/correction-box/index.js
+++ b/src/blocks/correction-box/index.js
@@ -10,6 +10,7 @@ import { __ } from '@wordpress/i18n';
 import './style.scss';
 import metadata from './block.json';
 import Edit from './edit';
+import colors from '../../shared/scss/_colors.module.scss';
 
 export const title = __( 'Corrections', 'newspack-plugin' );
 
@@ -27,7 +28,7 @@ export const settings = {
 	title,
 	icon: {
 		src: icon,
-		foreground: '#406ebc',
+		foreground: colors['primary-400'],
 	},
 	keywords: [ __( 'clarifications', 'newspack-plugin' ), __( 'updates', 'newspack-plugin' ) ],
 	description: __(

--- a/src/blocks/correction-box/index.js
+++ b/src/blocks/correction-box/index.js
@@ -7,10 +7,10 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import './style.scss';
 import metadata from './block.json';
 import Edit from './edit';
 import colors from '../../shared/scss/_colors.module.scss';
+import './style.scss';
 
 export const title = __( 'Corrections', 'newspack-plugin' );
 

--- a/src/blocks/correction-item/index.js
+++ b/src/blocks/correction-item/index.js
@@ -9,6 +9,7 @@ import { __ } from '@wordpress/i18n';
  */
 import './style.scss';
 import metadata from './block.json';
+import colors from '../../shared/scss/_colors.module.scss';
 
 export const title = __( 'Correction Item', 'newspack-plugin' );
 
@@ -60,7 +61,7 @@ export const settings = {
 	title,
 	icon: {
 		src: icon,
-		foreground: '#406ebc',
+		foreground: colors['primary-400'],
 	},
 	description: __(
 		'Display an archive of all the corrections and clarifications.',

--- a/src/blocks/correction-item/index.js
+++ b/src/blocks/correction-item/index.js
@@ -7,9 +7,9 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import './style.scss';
 import metadata from './block.json';
 import colors from '../../shared/scss/_colors.module.scss';
+import './style.scss';
 
 export const title = __( 'Correction Item', 'newspack-plugin' );
 

--- a/src/blocks/reader-registration/index.js
+++ b/src/blocks/reader-registration/index.js
@@ -9,6 +9,7 @@ import { Path, SVG } from '@wordpress/components';
  */
 import edit from './edit';
 import metadata from './block.json';
+import colors from '../../shared/scss/_colors.module.scss';
 
 export const icon = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
@@ -28,7 +29,7 @@ export { metadata, name };
 export const settings = {
 	icon: {
 		src: icon,
-		foreground: '#406ebc',
+		foreground: colors['primary-400'],
 	},
 	edit,
 	save: () => <div { ...useInnerBlocksProps.save( useBlockProps.save() ) } />,

--- a/src/components/src/modal/style.scss
+++ b/src/components/src/modal/style.scss
@@ -2,7 +2,7 @@
  * Modal
  */
 
-@use "../../../shared/scss/colors" as colors;
+@use "../../../shared/scss/colors.module" as colors;
 
 .newspack-modal {
 	// Color

--- a/src/components/src/newspack-icon/style.scss
+++ b/src/components/src/newspack-icon/style.scss
@@ -2,7 +2,7 @@
  * Newspack Icon
  */
 
-@use "../../../shared/scss/colors";
+@use "../../../shared/scss/colors.module";
 
 .newspack-icon {
 	background: var(--wp-admin-theme-color);

--- a/src/components/src/notice/style.scss
+++ b/src/components/src/notice/style.scss
@@ -4,7 +4,7 @@
 
 @use "sass:color";
 @use "~@wordpress/base-styles/colors" as wp-colors;
-@use "../../../shared/scss/colors";
+@use "../../../shared/scss/colors.module";
 
 .newspack-notice {
 	align-items: center;

--- a/src/components/src/popover/style.scss
+++ b/src/components/src/popover/style.scss
@@ -2,7 +2,7 @@
  * Popover
  */
 
-@use "../../../shared/scss/colors";
+@use "../../../shared/scss/colors.module";
 @use "~@wordpress/base-styles/colors" as wp-colors;
 
 .newspack-popover {

--- a/src/components/src/progress-bar/style.scss
+++ b/src/components/src/progress-bar/style.scss
@@ -2,7 +2,7 @@
  * Progress Bar
  */
 
-@use "../../../shared/scss/colors";
+@use "../../../shared/scss/colors.module";
 @use "~@wordpress/base-styles/colors" as wp-colors;
 
 .newspack-progress-bar {

--- a/src/components/src/radio-control/style.scss
+++ b/src/components/src/radio-control/style.scss
@@ -2,7 +2,7 @@
  * Radio Control
  */
 
-@use "../../../shared/scss/colors";
+@use "../../../shared/scss/colors.module";
 @use "~@wordpress/base-styles/colors" as wp-colors;
 
 .newspack-radio-control {
@@ -24,7 +24,6 @@
 	}
 
 	// Options
-
 	.components-radio-control__option {
 		align-items: center;
 		display: flex;
@@ -40,7 +39,6 @@
 	}
 
 	// Radio
-
 	input[type="radio"] {
 		height: 24px;
 		width: 24px;
@@ -70,14 +68,12 @@
 	}
 
 	// Multiple Radio Controls
-
 	& + & {
 		margin-bottom: 32px;
 		margin-top: -16px;
 	}
 
 	// Multiple Controls
-
 	+ .newspack-select-control,
 	+ .newspack-text-control {
 		margin-bottom: 32px;
@@ -85,7 +81,6 @@
 	}
 
 	// Reset
-
 	.components-base-control__field,
 	.components-base-control__label,
 	.components-base-control__help {

--- a/src/components/src/steps-list-item/style.scss
+++ b/src/components/src/steps-list-item/style.scss
@@ -1,4 +1,4 @@
-@use "../../../shared/scss/colors";
+@use "../../../shared/scss/colors.module";
 @use "~@wordpress/base-styles/colors" as wp-colors;
 
 .steps-list-item {

--- a/src/components/src/steps-list/style.scss
+++ b/src/components/src/steps-list/style.scss
@@ -1,4 +1,4 @@
-@use "../../../shared/scss/colors";
+@use "../../../shared/scss/colors.module";
 @use "~@wordpress/base-styles/colors" as wp-colors;
 
 .steps-list {

--- a/src/components/src/style-card/style.scss
+++ b/src/components/src/style-card/style.scss
@@ -2,7 +2,7 @@
  * Style Card
  */
 
-@use "../../../shared/scss/colors";
+@use "../../../shared/scss/colors.module";
 @use "~@wordpress/base-styles/colors" as wp-colors;
 
 .newspack-style-card {

--- a/src/components/src/style.scss
+++ b/src/components/src/style.scss
@@ -1,5 +1,5 @@
 @use "~@wordpress/base-styles/colors" as wp-colors;
-@use "../../shared/scss/colors" as colors;
+@use "../../shared/scss/colors.module" as colors;
 
 :root {
 	// WP Admin

--- a/src/components/src/web-preview/style.scss
+++ b/src/components/src/web-preview/style.scss
@@ -2,7 +2,7 @@
  * Web Preview
  */
 
-@use "../../../shared/scss/colors";
+@use "../../../shared/scss/colors.module";
 @use "~@wordpress/base-styles/colors" as wp-colors;
 
 .newspack-web-preview {

--- a/src/components/src/with-wizard-screen/style.scss
+++ b/src/components/src/with-wizard-screen/style.scss
@@ -3,7 +3,7 @@
  */
 
 @use "~@wordpress/base-styles/colors" as wp-colors;
-@use "../../../shared/scss/colors";
+@use "../../../shared/scss/colors.module";
 
 .newspack-wizard {
 	// Color

--- a/src/components/src/with-wizard/style.scss
+++ b/src/components/src/with-wizard/style.scss
@@ -3,7 +3,7 @@
  */
 
 @use "~@wordpress/base-styles/colors" as wp-colors;
-@use "../../../shared/scss/colors";
+@use "../../../shared/scss/colors.module";
 
 // Styling for full-page-react Wizards (ignoring admin-header-only wizards).
 body.newspack-wizard-page:not(.newspack-admin-header) {
@@ -65,7 +65,6 @@ svg {
 }
 
 // Blue Screen
-
 .newspack-wizard__blue {
 	#wpwrap {
 		background: var(--wp-admin-theme-color);
@@ -97,7 +96,6 @@ svg {
 }
 
 // Loading
-
 .newspack-wizard__is-loading {
 	background: white;
 	cursor: wait;

--- a/src/newspack-ui/scss/variables/_colors.scss
+++ b/src/newspack-ui/scss/variables/_colors.scss
@@ -1,4 +1,4 @@
-@use "../../../shared/scss/colors";
+@use "../../../shared/scss/colors.module";
 
 :root {
 	// Neutral:

--- a/src/shared/scss/_colors.module.scss
+++ b/src/shared/scss/_colors.module.scss
@@ -109,3 +109,93 @@ $warning-000: #fcf9e8;
 $warning-050: #f5e6ab;
 $warning-300: #dba617;
 $warning-400: #bd8600;
+
+:export {
+	// Primary
+	primary-000: $primary-000;
+	primary-050: $primary-050;
+	primary-100: $primary-100;
+	primary-200: $primary-200;
+	primary-300: $primary-300;
+	primary-400: $primary-400;
+	primary-500: $primary-500;
+	primary-600: $primary-600;
+	primary-700: $primary-700;
+	primary-800: $primary-800;
+	primary-900: $primary-900;
+	primary-1000: $primary-1000;
+
+	// Secondary
+	secondary-000: $secondary-000;
+	secondary-050: $secondary-050;
+	secondary-100: $secondary-100;
+	secondary-200: $secondary-200;
+	secondary-300: $secondary-300;
+	secondary-400: $secondary-400;
+	secondary-500: $secondary-500;
+	secondary-600: $secondary-600;
+	secondary-700: $secondary-700;
+	secondary-800: $secondary-800;
+	secondary-900: $secondary-900;
+	secondary-1000: $secondary-1000;
+
+	// Tertiary
+	tertiary-000: $tertiary-000;
+	tertiary-050: $tertiary-050;
+	tertiary-100: $tertiary-100;
+	tertiary-200: $tertiary-200;
+	tertiary-300: $tertiary-300;
+	tertiary-400: $tertiary-400;
+	tertiary-500: $tertiary-500;
+	tertiary-600: $tertiary-600;
+	tertiary-700: $tertiary-700;
+	tertiary-800: $tertiary-800;
+	tertiary-900: $tertiary-900;
+	tertiary-1000: $tertiary-1000;
+
+	// Quaternary
+	quaternary-000: $quaternary-000;
+	quaternary-050: $quaternary-050;
+	quaternary-100: $quaternary-100;
+	quaternary-200: $quaternary-200;
+	quaternary-300: $quaternary-300;
+	quaternary-400: $quaternary-400;
+	quaternary-500: $quaternary-500;
+	quaternary-600: $quaternary-600;
+	quaternary-700: $quaternary-700;
+	quaternary-800: $quaternary-800;
+	quaternary-900: $quaternary-900;
+	quaternary-1000: $quaternary-1000;
+
+	// Neutral
+	neutral-000: $neutral-000;
+	neutral-050: $neutral-050;
+	neutral-100: $neutral-100;
+	neutral-200: $neutral-200;
+	neutral-300: $neutral-300;
+	neutral-400: $neutral-400;
+	neutral-500: $neutral-500;
+	neutral-600: $neutral-600;
+	neutral-700: $neutral-700;
+	neutral-800: $neutral-800;
+	neutral-900: $neutral-900;
+	neutral-1000: $neutral-1000;
+
+	// Success
+	success-000: $success-000;
+	success-050: $success-050;
+	success-500: $success-500;
+	success-600: $success-600;
+
+	// Error
+	error-000: $error-000;
+	error-050: $error-050;
+	error-500: $error-500;
+	error-600: $error-600;
+
+	// Warning
+	warning-000: $warning-000;
+	warning-050: $warning-050;
+	warning-300: $warning-300;
+	warning-400: $warning-400;
+}

--- a/src/wizards/audience/views/campaigns/analytics/style.scss
+++ b/src/wizards/audience/views/campaigns/analytics/style.scss
@@ -3,7 +3,7 @@
  */
 
 @use "~@wordpress/base-styles/colors" as wp-colors;
-@use "../../../../../shared/scss/colors";
+@use "../../../../../shared/scss/colors.module";
 
 .newspack-campaigns-wizard-analytics {
 	&__wrapper {

--- a/src/wizards/audience/views/campaigns/campaigns/style.scss
+++ b/src/wizards/audience/views/campaigns/campaigns/style.scss
@@ -3,7 +3,7 @@
  */
 
 @use "~@wordpress/base-styles/colors" as wp-colors;
-@use "../../../../../shared/scss/colors";
+@use "../../../../../shared/scss/colors.module";
 
 .newspack-campaigns__campaign-group {
 	&__card {

--- a/src/wizards/audience/views/campaigns/segments/style.scss
+++ b/src/wizards/audience/views/campaigns/segments/style.scss
@@ -1,5 +1,5 @@
 @use "~@wordpress/base-styles/colors" as wp-colors;
-@use "../../../../../shared/scss/colors";
+@use "../../../../../shared/scss/colors.module";
 
 .newspack-campaigns-wizard-segments {
 	&__list {

--- a/src/wizards/handoff-banner/style.scss
+++ b/src/wizards/handoff-banner/style.scss
@@ -2,7 +2,7 @@
  * Handoff Banner
  */
 
-@use "../../shared/scss/colors";
+@use "../../shared/scss/colors.module";
 @use "~@wordpress/base-styles/colors" as wp-colors;
 
 #newspack-handoff-banner {

--- a/src/wizards/newspack/views/dashboard/style.scss
+++ b/src/wizards/newspack/views/dashboard/style.scss
@@ -3,7 +3,7 @@
  */
 
 @use "~@wordpress/base-styles/colors" as wp-colors;
-@use "../../../../shared/scss/colors";
+@use "../../../../shared/scss/colors.module";
 
 .newspack-wizard__content {
 	margin: 0;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds an `:export` pseudo-class to the colors stylesheet (renamed "module.colors") so it can be us imported into React components. See https://github.com/Automattic/newspack-plugin/pull/3893#pullrequestreview-2761046725

### How to test the changes in this Pull Request:

1. Switch to this branch
2. Check if you see the colours on the dashboard correctly
3. Navigate to the post editor, try adding the reader registration block (and you can check corrections if you have them enabled). Does the icon have the Primary 400 colour?

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->