### PR TITLE
fix(email-change): persist success / error messages after redirect

### DIFF
--- a/includes/class-donations.php
+++ b/includes/class-donations.php
@@ -1115,6 +1115,9 @@ class Donations {
 	 * @return bool
 	 */
 	public static function disable_coupons( $enabled ) {
+		if ( ! did_action( 'woocommerce_after_register_post_type' ) ) {
+			return $enabled;
+		}
 		if ( is_admin() ) {
 			return $enabled;
 		}

--- a/includes/reader-revenue/my-account/class-woocommerce-my-account.php
+++ b/includes/reader-revenue/my-account/class-woocommerce-my-account.php
@@ -936,7 +936,8 @@ class WooCommerce_My_Account {
 		if ( ! $secret ) {
 			return;
 		}
-		$error     = __( 'Something went wrong.', 'newspack-plugin' );
+		$message   = __( 'Your email address has been successfully updated.', 'newspack-plugin' );
+		$is_error  = false;
 		$user_id   = \get_current_user_id();
 		$new_email = \get_user_meta( $user_id, self::PENDING_EMAIL_CHANGE_META, true );
 		$old_email = \wp_get_current_user()->user_email;
@@ -955,14 +956,27 @@ class WooCommerce_My_Account {
 				self::maybe_sync_email_change_with_stripe( $user_id, $new_email );
 				self::sync_email_change_with_esp( $user_id, $new_email, $old_email );
 				\delete_user_meta( $user_id, self::PENDING_EMAIL_CHANGE_META );
-				\wc_add_notice( __( 'Your email address has been successfully updated.', 'newspack-plugin' ) );
 			} else {
-				\wc_add_notice( $error, 'error' );
+				$message  = __( 'Something went wrong.', 'newspack-plugin' );
+				$is_error = true;
 			}
 		} else {
-			\wc_add_notice( __( 'This email change request has been cancelled or expired.', 'newspack-plugin' ), 'error' );
+			$message  = __( 'This email change request has been cancelled or expired.', 'newspack-plugin' );
+			$is_error = true;
 		}
-		\wp_safe_redirect( \wc_get_endpoint_url( 'edit-account', '', \wc_get_page_permalink( 'myaccount' ) ) );
+		\wp_safe_redirect(
+			\add_query_arg(
+				[
+					'message'  => $message,
+					'is_error' => $is_error,
+				],
+				\wc_get_endpoint_url(
+					'edit-account',
+					'',
+					\wc_get_page_permalink( 'myaccount' )
+				)
+			)
+		);
 		exit;
 	}
 
@@ -978,13 +992,27 @@ class WooCommerce_My_Account {
 			return;
 		}
 		$current_email = \wp_get_current_user()->user_email;
+		$message       = __( 'Your email address change request has been cancelled.', 'newspack-plugin' );
+		$is_error      = false;
 		if ( \wp_hash( $current_email ) === $secret ) {
 			\delete_user_meta( \get_current_user_id(), self::PENDING_EMAIL_CHANGE_META );
-			\wc_add_notice( __( 'Your email change request has been cancelled.', 'newspack-plugin' ) );
 		} else {
-			\wc_add_notice( __( 'This email change request has been cancelled or expired.', 'newspack-plugin' ), 'error' );
+			$message  = __( 'This email change request has been cancelled or expired.', 'newspack-plugin' );
+			$is_error = true;
 		}
-		\wp_safe_redirect( \wc_get_endpoint_url( 'edit-account', '', \wc_get_page_permalink( 'myaccount' ) ) );
+		\wp_safe_redirect(
+			\add_query_arg(
+				[
+					'message'  => $message,
+					'is_error' => $is_error,
+				],
+				\wc_get_endpoint_url(
+					'edit-account',
+					'',
+					\wc_get_page_permalink( 'myaccount' )
+				)
+			)
+		);
 		exit;
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a hard-to-replicate bug that sometimes causes the verification and error messages that should be shown after confirming or cancelling a pending email change request to not appear.

Also fixes a PHP warning that I saw during testing, which was first addressed in #2822 and #2805, but is still thrown under some conditions.

### How to test the changes in this Pull Request:

I haven't figured out the exact conditions to replicate the issue where the messages don't appear after confirming or cancelling, but I did verify that this fix works on an afflicted production site. To test, log into a verified reader account and update the email address in My Account, then confirm or cancel the request and confirm that you see the message in the UI as well as appended as a URL-encoded `message` param on the URL.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->