### PR TITLE
WC Stripe: disable Link/Apple Pay/Google Pay by default

### DIFF
--- a/includes/plugins/class-woocommerce-gateway-stripe.php
+++ b/includes/plugins/class-woocommerce-gateway-stripe.php
@@ -21,12 +21,12 @@ class WooCommerce_Gateway_Stripe {
 		add_filter( 'wc_stripe_intent_metadata', [ __CLASS__, 'add_transaction_metadata' ], 10, 2 );
 
 		/**
-		 * Disable Stripe Express Checkout feature flag.
-		 * This is a workaround for the Stripe Express Checkout feature flag
+		 * Disable Stripe Express Checkout feature flags.
+		 * This is a workaround for the Stripe Express Checkout feature flags
 		 * being enabled by default on new installs.
 		 */
 		add_filter( 'pre_update_option__wcstripe_feature_ece', [ __CLASS__, 'disable_express_checkout_feature_flag' ], 9, 2 );
-		add_filter( 'pre_update_option_woocommerce_stripe_settings', [ __CLASS__, 'disable_express_checkout_in_main_settings' ], 9, 2 );
+		add_filter( 'pre_update_option_woocommerce_stripe_settings', [ __CLASS__, 'disable_express_checkout_in_main_settings' ], 11, 2 );
 	}
 
 	/**
@@ -140,12 +140,29 @@ class WooCommerce_Gateway_Stripe {
 	 */
 	public static function disable_express_checkout_in_main_settings( $settings, $old_settings ) {
 		/**
-		 * If the old strip settings are empty, it means this is a new install
-		 * Save the settings as 'no' to prevent the Stripe Express Checkout from being enabled.
+		 * If the old strip settings are empty, it means this is a new install.
 		 */
-		if ( empty( $old_settings ) && 'yes' === $settings['payment_request'] ) {
+		if ( ! empty( $old_settings ) ) {
+			return $settings;
+		}
+
+		// Disable Apple Pay/Google Pay for new installs.
+		if ( 'yes' === $settings['payment_request'] ) {
 			$settings['payment_request'] = 'no';
 		}
+
+		// Disable Link by Stripe for new installs.
+		if (
+			is_array( $settings['upe_checkout_experience_accepted_payments'] ) &&
+			! empty( $settings['upe_checkout_experience_accepted_payments'] ) &&
+			in_array( 'link', $settings['upe_checkout_experience_accepted_payments'], true )
+		) {
+			$settings['upe_checkout_experience_accepted_payments'] = array_diff(
+				$settings['upe_checkout_experience_accepted_payments'],
+				[ 'link' ]
+			);
+		}
+
 		return $settings;
 	}
 }

--- a/includes/plugins/class-woocommerce-gateway-stripe.php
+++ b/includes/plugins/class-woocommerce-gateway-stripe.php
@@ -19,6 +19,14 @@ class WooCommerce_Gateway_Stripe {
 	 */
 	public static function init() {
 		add_filter( 'wc_stripe_intent_metadata', [ __CLASS__, 'add_transaction_metadata' ], 10, 2 );
+
+		/**
+		 * Disable Stripe Express Checkout feature flag.
+		 * This is a workaround for the Stripe Express Checkout feature flag
+		 * being enabled by default on new installs.
+		 */
+		add_filter( 'pre_update_option__wcstripe_feature_ece', [ __CLASS__, 'disable_express_checkout_feature_flag' ], 9, 2 );
+		add_filter( 'pre_update_option_woocommerce_stripe_settings', [ __CLASS__, 'disable_express_checkout_in_main_settings' ], 9, 2 );
 	}
 
 	/**
@@ -103,6 +111,42 @@ class WooCommerce_Gateway_Stripe {
 		}
 
 		return $metadata;
+	}
+
+	/**
+	 * Disable Stripe Express Checkout feature flag.
+	 *
+	 * @param array $flag Stripe Express Checkout feature flag.
+	 * @param array $old_value Old Stripe Express Checkout feature flag.
+	 * @return string
+	 */
+	public static function disable_express_checkout_feature_flag( $flag, $old_value ) {
+		/**
+		 * If the Stripe Express Checkout feature flag is empty, it means this is a new install.
+		 * Save the settings as 'no' to prevent the Stripe Express Checkout from being enabled.
+		 */
+		if ( empty( $old_value ) && 'yes' === $flag ) {
+			$flag = 'no';
+		}
+		return $flag;
+	}
+
+	/**
+	 * Disable Stripe Express Checkout in main settings.
+	 *
+	 * @param array $settings Stripe settings.
+	 * @param array $old_settings Old Stripe settings.
+	 * @return array
+	 */
+	public static function disable_express_checkout_in_main_settings( $settings, $old_settings ) {
+		/**
+		 * If the old strip settings are empty, it means this is a new install
+		 * Save the settings as 'no' to prevent the Stripe Express Checkout from being enabled.
+		 */
+		if ( empty( $old_settings ) && 'yes' === $settings['payment_request'] ) {
+			$settings['payment_request'] = 'no';
+		}
+		return $settings;
 	}
 }
 WooCommerce_Gateway_Stripe::init();

--- a/includes/plugins/class-woocommerce-gateway-stripe.php
+++ b/includes/plugins/class-woocommerce-gateway-stripe.php
@@ -140,7 +140,7 @@ class WooCommerce_Gateway_Stripe {
 	 */
 	public static function disable_express_checkout_in_main_settings( $settings, $old_settings ) {
 		/**
-		 * If the old strip settings are empty, it means this is a new install.
+		 * If the old stripe settings are empty, it means this is a new install.
 		 */
 		if ( ! empty( $old_settings ) ) {
 			return $settings;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/1/26890605006346/project/1209102263738351/task/1209403196706994?focus=true.

There are no filters to filter the default value of these options, hence hooking onto the pre options saving, if the values are being saved for the first time we disable the respective payment methods ( Apple Pay / Google Pay & Link by Stripe) which are covered under Express Checkout Elements in WC Stripe Payment gateway plugin. This code will run only once when it is a fresh install following this code is not executed and works as per the flow of WC Stripe Payements.

### How to test the changes in this Pull Request:

1. Freshly Install WooCommerce Stripe Gateway.
2. Start set up for connecting to Stripe account.
3. After connecting, Switch to Payment methods tab and notice the Express Checkout payments disabled by default.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->