### PR TITLE
fix: hide campaigns menu when the Newspack Campaigns plugin is deactivated

### DIFF
--- a/includes/wizards/audience/class-audience-campaigns.php
+++ b/includes/wizards/audience/class-audience-campaigns.php
@@ -105,14 +105,16 @@ class Audience_Campaigns extends Wizard {
 	 * Add Audience top-level and Campaigns subpage to the /wp-admin menu.
 	 */
 	public function add_page() {
-		add_submenu_page(
-			$this->parent_slug,
-			$this->get_name(),
-			esc_html__( 'Campaigns', 'newspack-plugin' ),
-			$this->capability,
-			$this->slug,
-			[ $this, 'render_wizard' ]
-		);
+		if ( class_exists( 'Newspack_Popups' ) ) {
+			add_submenu_page(
+				$this->parent_slug,
+				$this->get_name(),
+				esc_html__( 'Campaigns', 'newspack-plugin' ),
+				$this->capability,
+				$this->slug,
+				[ $this, 'render_wizard' ]
+			);
+		}
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:
This PR adds a conditional check to ensure the Campaigns menu item only appears in the WordPress admin menu when the Newspack Campaigns plugin is activated.

The change wraps the menu registration in a `class_exists` check, which means the Campaigns menu will only be visible when the required plugin is active. This prevents confusion and application errors by not showing admin pages for functionality that isn't available.

### How to test the changes in this Pull Request:

1. Checkout this branch and navigate to Plugins admin screen (`/wp-admin/plugins.php`).
2. Activate/deactivate the Newspack Campaigns plugin and ensure that the Audience > Campaigns sidebar menu shows only when the plugin is activated.
3. Validate that when the plugin is deactivated, also a `Sorry, you are not allowed to access this page.` message appears when attempting to directly navigate to `/wp-admin/admin.php?page=newspack-audience-campaigns`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209953327198006