### PR TITLE
fix(wizards): react render strategy and ref forwarding

### DIFF
--- a/src/components/src/wizard/index.js
+++ b/src/components/src/wizard/index.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies.
  */
 import { useSelect } from '@wordpress/data';
-import { useState } from '@wordpress/element';
+import { useState, forwardRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { category } from '@wordpress/icons';
 
@@ -25,7 +25,6 @@ import {
 } from '../';
 import Router from '../proxied-imports/router';
 import registerStore, { WIZARD_STORE_NAMESPACE } from './store';
-import { useWizardData } from './store/utils';
 import WizardError from './components/WizardError';
 
 registerStore();
@@ -63,7 +62,7 @@ const Wizard = ( {
 	renderAboveSections,
 	requiredPlugins = [],
 	isInitialFetchTriggered = true,
-} ) => {
+}, ref ) => {
 	const isLoading = useSelect( select =>
 		select( WIZARD_STORE_NAMESPACE ).isLoading()
 	);
@@ -102,7 +101,7 @@ const Wizard = ( {
 	}
 
 	return (
-		<>
+		<div ref={ref}>
 			<div
 				className={ classnames(
 					isLoading
@@ -177,12 +176,8 @@ const Wizard = ( {
 				</HashRouter>
 			</div>
 			{ ! isLoading && <Footer simple={ hasSimpleFooter } /> }
-		</>
+		</div>
 	);
 };
 
-Wizard.useWizardData = useWizardData;
-
-Wizard.STORE_NAMESPACE = WIZARD_STORE_NAMESPACE;
-
-export default Wizard;
+export default forwardRef( Wizard );

--- a/src/wizards/advertising/index.js
+++ b/src/wizards/advertising/index.js
@@ -7,7 +7,12 @@ import '../../shared/js/public-path';
 /**
  * WordPress dependencies.
  */
-import { Component, render, Fragment, createElement } from '@wordpress/element';
+import {
+	Component,
+	createRoot,
+	Fragment,
+	createElement,
+} from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -58,10 +63,13 @@ class AdvertisingWizard extends Component {
 							{
 								advertisingData: {
 									...response,
-									adUnits: response.ad_units.reduce( ( result, value ) => {
-										result[ value.id ] = value;
-										return result;
-									}, {} ),
+									adUnits: response.ad_units.reduce(
+										( result, value ) => {
+											result[ value.id ] = value;
+											return result;
+										},
+										{}
+									),
 								},
 							},
 							() => {
@@ -118,7 +126,10 @@ class AdvertisingWizard extends Component {
 	deleteAdUnit = id => {
 		if (
 			utils.confirmAction(
-				__( 'Are you sure you want to archive this ad unit?', 'newspack-plugin' )
+				__(
+					'Are you sure you want to archive this ad unit?',
+					'newspack-plugin'
+				)
 			)
 		) {
 			return this.updateWithAPI( {
@@ -169,10 +180,15 @@ class AdvertisingWizard extends Component {
 							exact
 							render={ () => (
 								<Providers
-									headerText={ __( 'Advertising / Display Ads', 'newspack-plugin' ) }
+									headerText={ __(
+										'Advertising / Display Ads',
+										'newspack-plugin'
+									) }
 									services={ services }
 									toggleService={ this.toggleService }
-									fetchAdvertisingData={ this.fetchAdvertisingData }
+									fetchAdvertisingData={
+										this.fetchAdvertisingData
+									}
 									tabbedNavigation={ tabs }
 								/>
 							) }
@@ -181,7 +197,10 @@ class AdvertisingWizard extends Component {
 							path="/placements"
 							render={ () => (
 								<Placements
-									headerText={ __( 'Advertising / Display Ads', 'newspack-plugin' ) }
+									headerText={ __(
+										'Advertising / Display Ads',
+										'newspack-plugin'
+									) }
 									tabbedNavigation={ tabs }
 								/>
 							) }
@@ -205,7 +224,10 @@ class AdvertisingWizard extends Component {
 							path="/settings"
 							render={ () => (
 								<Settings
-									headerText={ __( 'Advertising / Display Ads', 'newspack-plugin' ) }
+									headerText={ __(
+										'Advertising / Display Ads',
+										'newspack-plugin'
+									) }
 									tabbedNavigation={ tabs }
 								/>
 							) }
@@ -225,7 +247,9 @@ class AdvertisingWizard extends Component {
 									serviceData={ services.google_ad_manager }
 									onDelete={ id => this.deleteAdUnit( id ) }
 									wizardApiFetch={ wizardApiFetch }
-									fetchAdvertisingData={ this.fetchAdvertisingData }
+									fetchAdvertisingData={
+										this.fetchAdvertisingData
+									}
 									updateWithAPI={ this.updateWithAPI }
 									tabbedNavigation={ tabs }
 								/>
@@ -235,8 +259,14 @@ class AdvertisingWizard extends Component {
 							path={ `/google_ad_manager/${ CREATE_AD_ID_PARAM }` }
 							render={ routeProps => (
 								<AdUnit
-									headerText={ __( 'Add New Ad Unit', 'newspack-plugin' ) }
-									subHeaderText={ __( 'Allows you to place ads on your site', 'newspack-plugin' ) }
+									headerText={ __(
+										'Add New Ad Unit',
+										'newspack-plugin'
+									) }
+									subHeaderText={ __(
+										'Allows you to place ads on your site',
+										'newspack-plugin'
+									) }
 									adUnit={
 										adUnits[ 0 ] || {
 											id: 0,
@@ -253,7 +283,9 @@ class AdvertisingWizard extends Component {
 									onSave={ id =>
 										this.saveAdUnit( id )
 											.then( () => {
-												routeProps.history.push( '/google_ad_manager' );
+												routeProps.history.push(
+													'/google_ad_manager'
+												);
 											} )
 											.catch( () => {} )
 									}
@@ -268,7 +300,10 @@ class AdvertisingWizard extends Component {
 								const adId = routeProps.match.params.id;
 								return (
 									<AdUnit
-										headerText={ __( 'Edit Ad Unit', 'newspack-plugin' ) }
+										headerText={ __(
+											'Edit Ad Unit',
+											'newspack-plugin'
+										) }
 										subHeaderText={ __(
 											'Allows you to place ads on your site',
 											'newspack-plugin'
@@ -278,7 +313,9 @@ class AdvertisingWizard extends Component {
 										onChange={ this.onAdUnitChange }
 										onSave={ id =>
 											this.saveAdUnit( id ).then( () => {
-												routeProps.history.push( '/google_ad_manager' );
+												routeProps.history.push(
+													'/google_ad_manager'
+												);
 											} )
 										}
 										onCancel={ this.onAdUnitCancel }
@@ -295,7 +332,6 @@ class AdvertisingWizard extends Component {
 	}
 }
 
-render(
-	createElement( withWizard( AdvertisingWizard, [ 'newspack-ads' ] ) ),
-	document.getElementById( 'newspack-ads-display-ads' )
+createRoot( document.getElementById( 'newspack-ads-display-ads' ) ).render(
+	createElement( withWizard( AdvertisingWizard, [ 'newspack-ads' ] ) )
 );

--- a/src/wizards/audience/components/billing-fields/index.tsx
+++ b/src/wizards/audience/components/billing-fields/index.tsx
@@ -8,19 +8,21 @@ import { CheckboxControl } from '@wordpress/components';
 /**
  * Internal dependencies.
  */
-import { Button, Grid, Wizard } from '../../../../components/src';
+import { Button, Grid } from '../../../../components/src';
+import { useWizardData } from '../../../../components/src/wizard/store/utils';
+import { WIZARD_STORE_NAMESPACE } from '../../../../components/src/wizard/store';
 import WizardsSection from '../../../wizards-section';
 
 const BillingFields = () => {
-	const wizardData = Wizard.useWizardData(
+	const wizardData = useWizardData(
 		'newspack-audience/billing-fields'
 	);
 	const { updateWizardSettings, saveWizardSettings } = useDispatch(
-		Wizard.STORE_NAMESPACE
+		WIZARD_STORE_NAMESPACE
 	);
 	const isQuietLoading = useSelect(
 		( select: any ) =>
-			select( Wizard.STORE_NAMESPACE ).isQuietLoading() ?? false,
+			select( WIZARD_STORE_NAMESPACE ).isQuietLoading() ?? false,
 		[]
 	);
 

--- a/src/wizards/audience/components/checkout-configuration/index.tsx
+++ b/src/wizards/audience/components/checkout-configuration/index.tsx
@@ -8,19 +8,21 @@ import { ToggleControl, TextareaControl } from '@wordpress/components';
 /**
  * Internal dependencies.
  */
-import { Button, Grid, Wizard } from '../../../../components/src';
+import { Button, Grid } from '../../../../components/src';
+import { useWizardData } from '../../../../components/src/wizard/store/utils';
+import { WIZARD_STORE_NAMESPACE } from '../../../../components/src/wizard/store';
 import WizardsSection from '../../../wizards-section';
 
 const DATA_STORE_KEY = 'newspack-audience/checkout-configuration';
 
 function CheckoutConfiguration() {
-	const config = Wizard.useWizardData( DATA_STORE_KEY );
+	const config = useWizardData( DATA_STORE_KEY );
 	const { updateWizardSettings, saveWizardSettings } = useDispatch(
-		Wizard.STORE_NAMESPACE
+		WIZARD_STORE_NAMESPACE
 	);
 	const isQuietLoading = useSelect(
 		( select: any ) =>
-			select( Wizard.STORE_NAMESPACE ).isQuietLoading() ?? false,
+			select( WIZARD_STORE_NAMESPACE ).isQuietLoading() ?? false,
 		[]
 	);
 

--- a/src/wizards/audience/components/cover-fees-settings/index.js
+++ b/src/wizards/audience/components/cover-fees-settings/index.js
@@ -13,13 +13,14 @@ import {
 	Button,
 	Grid,
 	TextControl,
-	Wizard,
 } from '../../../../components/src';
 import { AUDIENCE_DONATIONS_WIZARD_SLUG } from '../../constants';
+import { useWizardData } from '../../../../components/src/wizard/store/utils';
+import { WIZARD_STORE_NAMESPACE } from '../../../../components/src/wizard/store';
 
 export const CoverFeesSettings = () => {
-	const { additional_settings: settings = {} } = Wizard.useWizardData( AUDIENCE_DONATIONS_WIZARD_SLUG );
-	const { updateWizardSettings } = useDispatch( Wizard.STORE_NAMESPACE );
+	const { additional_settings: settings = {} } = useWizardData( AUDIENCE_DONATIONS_WIZARD_SLUG );
+	const { updateWizardSettings } = useDispatch( WIZARD_STORE_NAMESPACE );
 	const changeHandler = ( key, value ) =>
 		updateWizardSettings( {
 			slug: AUDIENCE_DONATIONS_WIZARD_SLUG,
@@ -27,7 +28,7 @@ export const CoverFeesSettings = () => {
 			value,
 		} );
 
-	const { saveWizardSettings } = useDispatch( Wizard.STORE_NAMESPACE );
+	const { saveWizardSettings } = useDispatch( WIZARD_STORE_NAMESPACE );
 	const onSave = () =>
 		saveWizardSettings( {
 			slug: AUDIENCE_DONATIONS_WIZARD_SLUG,

--- a/src/wizards/audience/components/nrh-settings/index.js
+++ b/src/wizards/audience/components/nrh-settings/index.js
@@ -13,14 +13,15 @@ import {
 	Button,
 	Grid,
 	TextControl,
-	Wizard,
 } from '../../../../components/src';
+import { useWizardData } from '../../../../components/src/wizard/store/utils';
+import { WIZARD_STORE_NAMESPACE } from '../../../../components/src/wizard/store';
 import WizardsSection from '../../../wizards-section';
 
 const NRHSettings = () => {
 	const [ selectedPage, setSelectedPage ] = useState( null );
-	const wizardData = Wizard.useWizardData( 'newspack-audience/payment' );
-	const { updateWizardSettings, saveWizardSettings } = useDispatch( Wizard.STORE_NAMESPACE );
+	const wizardData = useWizardData( 'newspack-audience/payment' );
+	const { updateWizardSettings, saveWizardSettings } = useDispatch( WIZARD_STORE_NAMESPACE );
 
 	useEffect( () => {
 		if ( wizardData?.platform_data?.donor_landing_page ) {

--- a/src/wizards/audience/components/payment-methods/index.js
+++ b/src/wizards/audience/components/payment-methods/index.js
@@ -8,7 +8,8 @@ import { ExternalLink } from '@wordpress/components';
  * Internal dependencies
  */
 import { Stripe } from './stripe';
-import { Notice, Wizard } from '../../../../components/src';
+import { Notice } from '../../../../components/src';
+import { useWizardData } from '../../../../components/src/wizard/store/utils';
 import WizardsSection from '../../../wizards-section';
 import { PaymentGateway } from './payment-gateway';
 import './style.scss';
@@ -20,7 +21,7 @@ const PaymentGateways = () => {
 		errors = [],
 		plugin_status,
 		platform_data = {},
-	} = Wizard.useWizardData( 'newspack-audience/payment' );
+	} = useWizardData( 'newspack-audience/payment' );
 	if ( false === plugin_status || 'wc' !== platform_data?.platform ) {
 		return null;
 	}

--- a/src/wizards/audience/components/payment-methods/payment-gateway.js
+++ b/src/wizards/audience/components/payment-methods/payment-gateway.js
@@ -8,16 +8,13 @@ import { useDispatch, useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import {
-	ActionCard,
-	Button,
-	Wizard,
-} from '../../../../components/src';
+import { ActionCard, Button } from '../../../../components/src';
+import { WIZARD_STORE_NAMESPACE } from '../../../../components/src/wizard/store';
 
 export const PaymentGateway = ( { gateway } ) => {
-	const isLoading = useSelect( select => select( Wizard.STORE_NAMESPACE ).isLoading() );
-	const isQuietLoading = useSelect( select => select( Wizard.STORE_NAMESPACE ).isQuietLoading() );
-	const { updateWizardSettings } = useDispatch( Wizard.STORE_NAMESPACE );
+	const isLoading = useSelect( select => select( WIZARD_STORE_NAMESPACE ).isLoading() );
+	const isQuietLoading = useSelect( select => select( WIZARD_STORE_NAMESPACE ).isQuietLoading() );
+	const { updateWizardSettings } = useDispatch( WIZARD_STORE_NAMESPACE );
 	const changeHandler = ( key, value ) =>
 		updateWizardSettings( {
 			slug: 'newspack-audience/payment',
@@ -25,7 +22,7 @@ export const PaymentGateway = ( { gateway } ) => {
 			value,
 		} );
 
-	const { saveWizardSettings } = useDispatch( Wizard.STORE_NAMESPACE );
+	const { saveWizardSettings } = useDispatch( WIZARD_STORE_NAMESPACE );
 	const onSave = () =>
 		saveWizardSettings( {
 			slug: 'newspack-audience/payment',

--- a/src/wizards/audience/components/payment-methods/stripe.js
+++ b/src/wizards/audience/components/payment-methods/stripe.js
@@ -8,16 +8,13 @@ import { useDispatch, useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import {
-	ActionCard,
-	Button,
-	Wizard,
-} from '../../../../components/src';
+import { ActionCard, Button } from '../../../../components/src';
+import { WIZARD_STORE_NAMESPACE } from '../../../../components/src/wizard/store';
 
 export const Stripe = ( { stripe } ) => {
-	const isLoading = useSelect( select => select( Wizard.STORE_NAMESPACE ).isLoading() );
-	const isQuietLoading = useSelect( select => select( Wizard.STORE_NAMESPACE ).isQuietLoading() );
-	const { updateWizardSettings } = useDispatch( Wizard.STORE_NAMESPACE );
+	const isLoading = useSelect( select => select( WIZARD_STORE_NAMESPACE ).isLoading() );
+	const isQuietLoading = useSelect( select => select( WIZARD_STORE_NAMESPACE ).isQuietLoading() );
+	const { updateWizardSettings } = useDispatch( WIZARD_STORE_NAMESPACE );
 	const changeHandler = ( key, value ) =>
 		updateWizardSettings( {
 			slug: 'newspack-audience/payment',
@@ -25,7 +22,7 @@ export const Stripe = ( { stripe } ) => {
 			value,
 		} );
 
-	const { saveWizardSettings } = useDispatch( Wizard.STORE_NAMESPACE );
+	const { saveWizardSettings } = useDispatch( WIZARD_STORE_NAMESPACE );
 	const onSave = () =>
 		saveWizardSettings( {
 			slug: 'newspack-audience/payment',

--- a/src/wizards/audience/components/payment-methods/woopayments.js
+++ b/src/wizards/audience/components/payment-methods/woopayments.js
@@ -8,16 +8,13 @@ import { useDispatch, useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import {
-	ActionCard,
-	Button,
-	Wizard,
-} from '../../../../components/src';
+import { ActionCard, Button } from '../../../../components/src';
+import { WIZARD_STORE_NAMESPACE } from '../../../../components/src/wizard/store';
 
 export const PaymentGateway = ( { gateway } ) => {
-	const isLoading = useSelect( select => select( Wizard.STORE_NAMESPACE ).isLoading() );
-	const isQuietLoading = useSelect( select => select( Wizard.STORE_NAMESPACE ).isQuietLoading() );
-	const { updateWizardSettings } = useDispatch( Wizard.STORE_NAMESPACE );
+	const isLoading = useSelect( select => select( WIZARD_STORE_NAMESPACE ).isLoading() );
+	const isQuietLoading = useSelect( select => select( WIZARD_STORE_NAMESPACE ).isQuietLoading() );
+	const { updateWizardSettings } = useDispatch( WIZARD_STORE_NAMESPACE );
 	const changeHandler = ( key, value ) =>
 		updateWizardSettings( {
 			slug: 'newspack-audience/payment',
@@ -25,7 +22,7 @@ export const PaymentGateway = ( { gateway } ) => {
 			value,
 		} );
 
-	const { saveWizardSettings } = useDispatch( Wizard.STORE_NAMESPACE );
+	const { saveWizardSettings } = useDispatch( WIZARD_STORE_NAMESPACE );
 	const onSave = () =>
 		saveWizardSettings( {
 			slug: 'newspack-audience/payment',

--- a/src/wizards/audience/components/platform/index.js
+++ b/src/wizards/audience/components/platform/index.js
@@ -7,16 +7,18 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { Card, PluginInstaller, SelectControl, Wizard } from '../../../../components/src';
+import { Card, PluginInstaller, SelectControl } from '../../../../components/src';
 import { NEWSPACK, NRH, OTHER } from '../../constants';
 import WizardsSection from '../../../wizards-section';
+import { useWizardData } from '../../../../components/src/wizard/store/utils';
+import { WIZARD_STORE_NAMESPACE } from '../../../../components/src/wizard/store';
 
 /**
  * Platform Selection  Screen Component
  */
 const Platform = () => {
-	const wizardData = Wizard.useWizardData( 'newspack-audience/payment' );
-	const { saveWizardSettings, updateWizardSettings } = useDispatch( Wizard.STORE_NAMESPACE );
+	const wizardData = useWizardData( 'newspack-audience/payment' );
+	const { saveWizardSettings, updateWizardSettings } = useDispatch( WIZARD_STORE_NAMESPACE );
 	return (
 		<WizardsSection>
 			<Card noBorder>

--- a/src/wizards/audience/components/salesforce/index.js
+++ b/src/wizards/audience/components/salesforce/index.js
@@ -7,7 +7,8 @@ import { parse } from 'qs';
  * WordPress dependencies.
  */
 import { __ } from '@wordpress/i18n';
-import { ClipboardButton, ExternalLink } from '@wordpress/components';
+import { Button, ExternalLink } from '@wordpress/components';
+import { useCopyToClipboard } from '@wordpress/compose';
 import { useState, useEffect } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
@@ -15,16 +16,25 @@ import { addQueryArgs } from '@wordpress/url';
 /**
  * Internal dependencies.
  */
-import { PluginSettings, Notice, Wizard } from '../../../../components/src';
+import { PluginSettings, Notice } from '../../../../components/src';
+import { useWizardData } from '../../../../components/src/wizard/store/utils';
+import { WIZARD_STORE_NAMESPACE } from '../../../../components/src/wizard/store';
 
 const Salesforce = () => {
 	const { salesforce_redirect_url: redirectUrl } = window?.newspackAudience || {};
-	const [ hasCopied, setHasCopied ] = useState( false );
-	const salesforceData = Wizard.useWizardData( 'newspack-audience/salesforce' );
+	const salesforceData = useWizardData( 'newspack-audience/salesforce' );
 	const [ isConnected, setIsConnected ] = useState( salesforceData.refresh_token );
 	const [ error, setError ] = useState( null );
 
-	const { saveWizardSettings, wizardApiFetch } = useDispatch( Wizard.STORE_NAMESPACE );
+	const { createNotice } = useDispatch( 'core/notices' );
+	const copyRef = useCopyToClipboard( redirectUrl, () => {
+		createNotice( 'info', __( 'Redirect URL copied to clipboard.', 'newspack-plugin' ), {
+			isDismissible: true,
+			type: 'snackbar',
+		} );
+	} );
+
+	const { saveWizardSettings, wizardApiFetch } = useDispatch( WIZARD_STORE_NAMESPACE );
 	const saveAllSettings = value =>
 		saveWizardSettings( {
 			slug: 'newspack-audience/salesforce',
@@ -158,16 +168,12 @@ const Salesforce = () => {
 							'newspack-plugin'
 						) }
 
-						<ClipboardButton
+						<Button
+							ref={ copyRef }
 							className="newspack-button is-link"
-							text={ redirectUrl }
-							onCopy={ () => setHasCopied( true ) }
-							onFinishCopy={ () => setHasCopied( false ) }
 						>
-							{ hasCopied
-								? __( 'copied to clipboard!', 'newspack-plugin' )
-								: __( 'copy to clipboard', 'newspack-plugin' ) }
-						</ClipboardButton>
+							{ __( 'copy to clipboard', 'newspack-plugin' ) }
+						</Button>
 
 						{ __(
 							') into the “Callback URL” field in the Connected App’s settings. ',

--- a/src/wizards/audience/views/campaigns/index.js
+++ b/src/wizards/audience/views/campaigns/index.js
@@ -8,7 +8,7 @@ import '../../../../shared/js/public-path';
 /**
  * WordPress dependencies.
  */
-import { Component  } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 

--- a/src/wizards/audience/views/donations/configuration/index.tsx
+++ b/src/wizards/audience/views/donations/configuration/index.tsx
@@ -17,8 +17,9 @@ import {
 	SectionHeader,
 	SelectControl,
 	TextControl,
-	Wizard,
 } from '../../../../../components/src';
+import { useWizardData } from '../../../../../components/src/wizard/store/utils';
+import { WIZARD_STORE_NAMESPACE } from '../../../../../components/src/wizard/store';
 import WizardsTab from '../../../../wizards-tab';
 import { AUDIENCE_DONATIONS_WIZARD_SLUG } from '../../../constants';
 import { CoverFeesSettings } from '../../../components/cover-fees-settings';
@@ -49,10 +50,10 @@ const FREQUENCY_SLUGS: FrequencySlug[] = Object.keys(
 ) as FrequencySlug[];
 
 export const DonationAmounts = () => {
-	const wizardData = Wizard.useWizardData(
+	const wizardData = useWizardData(
 		AUDIENCE_DONATIONS_WIZARD_SLUG
 	) as AudienceDonationsWizardData;
-	const { updateWizardSettings } = useDispatch( Wizard.STORE_NAMESPACE );
+	const { updateWizardSettings } = useDispatch( WIZARD_STORE_NAMESPACE );
 
 	if ( ! wizardData.donation_data || 'errors' in wizardData.donation_data ) {
 		return null;
@@ -341,10 +342,10 @@ export const DonationAmounts = () => {
 };
 
 const Donation = () => {
-	const wizardData = Wizard.useWizardData(
+	const wizardData = useWizardData(
 		AUDIENCE_DONATIONS_WIZARD_SLUG
 	) as AudienceDonationsWizardData;
-	const { saveWizardSettings } = useDispatch( Wizard.STORE_NAMESPACE );
+	const { saveWizardSettings } = useDispatch( WIZARD_STORE_NAMESPACE );
 	const onSaveDonationSettings = () =>
 		saveWizardSettings( {
 			slug: AUDIENCE_DONATIONS_WIZARD_SLUG,

--- a/src/wizards/audience/views/donations/index.js
+++ b/src/wizards/audience/views/donations/index.js
@@ -9,16 +9,17 @@ import values from 'lodash/values';
  * WordPress dependencies.
  */
 import { __ } from '@wordpress/i18n';
-
+import { forwardRef } from '@wordpress/element';
 /**
  * Internal dependencies.
  */
 import { Wizard, Notice, withWizard } from '../../../../components/src';
+import { useWizardData } from '../../../../components/src/wizard/store/utils';
 import Configuration from './configuration';
 import { AUDIENCE_DONATIONS_WIZARD_SLUG, OTHER } from '../../constants';
 
-const AudienceDonations = () => {
-	const { platform_data, donation_data } = Wizard.useWizardData( AUDIENCE_DONATIONS_WIZARD_SLUG );
+const AudienceDonations = ( props, ref ) => {
+	const { platform_data, donation_data } = useWizardData( AUDIENCE_DONATIONS_WIZARD_SLUG );
 	const usedPlatform = platform_data?.platform;
 	const sections = [
 		{
@@ -34,13 +35,14 @@ const AudienceDonations = () => {
 			sections={ sections }
 			apiSlug={ AUDIENCE_DONATIONS_WIZARD_SLUG }
 			renderAboveSections={ () =>
-				values( donation_data?.errors ).map( ( error, i ) => (
-					<Notice key={ i } isError noticeText={ error } />
-				) )
-			}
+			values( donation_data?.errors ).map( ( error, i ) => (
+				<Notice key={ i } isError noticeText={ error } />
+			) )
+		}
 			requiredPlugins={ [ 'newspack-blocks' ] }
+			ref={ ref }
 		/>
 	);
 };
 
-export default withWizard( AudienceDonations );
+export default withWizard( forwardRef( AudienceDonations ) );

--- a/src/wizards/audience/views/setup/index.js
+++ b/src/wizards/audience/views/setup/index.js
@@ -7,7 +7,7 @@
  * WordPress dependencies.
  */
 import { __ } from '@wordpress/i18n';
-import { useEffect, useState } from '@wordpress/element';
+import { useEffect, useState, forwardRef } from '@wordpress/element';
 
 /**
  * Internal dependencies.
@@ -22,7 +22,7 @@ import Payment from './payment';
 
 const { HashRouter, Redirect, Route, Switch } = Router;
 
-function AudienceWizard( { confirmAction, pluginRequirements, wizardApiFetch } ) {
+function AudienceWizard( { confirmAction, pluginRequirements, wizardApiFetch }, ref ) {
 	const [ inFlight, setInFlight ] = useState( false );
 	const [ config, setConfig ] = useState( {} );
 	const [ prerequisites, setPrerequisites ] = useState( null );
@@ -157,7 +157,7 @@ function AudienceWizard( { confirmAction, pluginRequirements, wizardApiFetch } )
 	};
 
 	return (
-		<>
+		<div ref={ref}>
 			<HashRouter hashType="slash">
 				<Switch>
 					{ pluginRequirements }
@@ -195,8 +195,8 @@ function AudienceWizard( { confirmAction, pluginRequirements, wizardApiFetch } )
 					<Redirect to="/" />
 				</Switch>
 			</HashRouter>
-		</>
+		</div>
 	);
 }
 
-export default withWizard( AudienceWizard );
+export default withWizard( forwardRef( AudienceWizard ) );

--- a/src/wizards/audience/views/setup/payment.js
+++ b/src/wizards/audience/views/setup/payment.js
@@ -7,9 +7,9 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies.
  */
 import {
-	Wizard,
 	withWizardScreen,
 } from '../../../../components/src';
+import { useWizardData } from '../../../../components/src/wizard/store/utils';
 import WizardsTab from '../../../wizards-tab';
 import Platform from '../../components/platform';
 import PaymentGateways from '../../components/payment-methods';
@@ -18,7 +18,7 @@ import BillingFields from '../../components/billing-fields';
 import CheckoutConfiguration from '../../components/checkout-configuration';
 
 export default withWizardScreen( function () {
-	const data = Wizard.useWizardData( 'newspack-audience/payment' );
+	const data = useWizardData( 'newspack-audience/payment' );
 	return (
 		<WizardsTab
 			title={ __( 'Checkout & Payment', 'newspack-plugin' ) }

--- a/src/wizards/audience/views/subscriptions/index.tsx
+++ b/src/wizards/audience/views/subscriptions/index.tsx
@@ -2,6 +2,7 @@
  * WordPress dependencies.
  */
 import { __ } from '@wordpress/i18n';
+import { forwardRef } from '@wordpress/element';
 
 /**
  * Internal dependencies.
@@ -12,7 +13,7 @@ import WizardSection from '../../../wizards-section';
 
 const subscriptionTabs = window.newspackAudienceSubscriptions.tabs;
 
-function AudienceSubscriptions() {
+function AudienceSubscriptions( props: Record<string, any>, ref: React.ForwardedRef<HTMLDivElement> ) {
 	const tabs = subscriptionTabs.map( tab => {
 		const render = () => (
 			<WizardsTab title={ tab.title }>
@@ -42,8 +43,9 @@ function AudienceSubscriptions() {
 			) }
 			sections={ tabs }
 			requiredPlugins={ [ 'woocommerce', 'woocommerce-memberships' ] }
+			ref={ ref }
 		/>
 	);
 }
 
-export default withWizard( AudienceSubscriptions );
+export default withWizard( forwardRef( AudienceSubscriptions ) );

--- a/src/wizards/index.tsx
+++ b/src/wizards/index.tsx
@@ -8,7 +8,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { render, lazy, Suspense } from '@wordpress/element';
+import { createRoot, lazy, Suspense } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -117,7 +117,7 @@ const AdminPages = () => {
 };
 
 if ( rootElement && pageParam in components ) {
-	render( <AdminPages />, rootElement );
+	createRoot( rootElement ).render( <AdminPages /> );
 } else {
 	// eslint-disable-next-line no-console
 	console.error( `${ pageParam } not found!` );

--- a/src/wizards/setup/index.js
+++ b/src/wizards/setup/index.js
@@ -3,7 +3,7 @@ import '../../shared/js/public-path';
 /**
  * WordPress dependencies.
  */
-import { Fragment, render, createElement } from '@wordpress/element';
+import { render, createElement, forwardRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -49,9 +49,9 @@ const ROUTES = [
 	},
 ];
 
-const SetupWizard = ( { wizardApiFetch, setError } ) => {
+const SetupWizard = ( { wizardApiFetch, setError }, ref ) => {
 	return (
-		<Fragment>
+		<div ref={ref}>
 			{ newspack_aux_data.has_completed_setup && (
 				<Notice isWarning className="ma0">
 					{ __(
@@ -89,11 +89,11 @@ const SetupWizard = ( { wizardApiFetch, setError } ) => {
 					);
 				} ) }
 			</HashRouter>
-		</Fragment>
+		</div>
 	);
 };
 
 render(
-	createElement( withWizard( SetupWizard, [] ), { simpleFooter: true } ),
+	createElement( withWizard( forwardRef( SetupWizard ), [] ), { simpleFooter: true } ),
 	document.getElementById( 'newspack-setup-wizard' )
 );

--- a/src/wizards/setup/views/services/ReaderRevenue.js
+++ b/src/wizards/setup/views/services/ReaderRevenue.js
@@ -14,11 +14,11 @@ import { __ } from '@wordpress/i18n';
  */
 import Platform from '../../../audience/components/platform';
 import { DonationAmounts } from '../../../audience/views/donations/configuration';
-import { Wizard } from '../../../../components/src';
+import { useWizardData } from '../../../../components/src/wizard/store/utils';
 import { AUDIENCE_DONATIONS_WIZARD_SLUG } from '../../../audience/constants';
 
 const ReaderRevenue = ( { className } ) => {
-	const wizardData = Wizard.useWizardData( AUDIENCE_DONATIONS_WIZARD_SLUG );
+	const wizardData = useWizardData( AUDIENCE_DONATIONS_WIZARD_SLUG );
 	return (
 		<div className={ classnames( className, { 'o-50': isEmpty( wizardData ) } ) }>
 			<Platform />

--- a/src/wizards/setup/views/services/index.js
+++ b/src/wizards/setup/views/services/index.js
@@ -16,7 +16,8 @@ import apiFetch from '@wordpress/api-fetch';
 /**
  * Internal dependencies
  */
-import { withWizardScreen, Wizard, ActionCard, hooks } from '../../../../components/src';
+import { withWizardScreen, ActionCard, hooks } from '../../../../components/src';
+import { useWizardData } from '../../../../components/src/wizard/store/utils';
 import ReaderRevenue from './ReaderRevenue';
 import { Settings as NewslettersSettings } from '../../../newsletters/views/settings';
 import GAMOnboarding from '../../../advertising/components/onboarding';
@@ -57,7 +58,7 @@ const Services = ( { renderPrimaryButton } ) => {
 	const [ services, updateServices ] = hooks.useObjectState( SERVICES_LIST );
 	const [ isLoading, setIsLoading ] = useState( true );
 	const slugs = keys( services );
-	const wizardData = Wizard.useWizardData( AUDIENCE_DONATIONS_WIZARD_SLUG );
+	const wizardData = useWizardData( AUDIENCE_DONATIONS_WIZARD_SLUG );
 
 	useEffect( () => {
 		apiFetch( {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -160,6 +160,8 @@ const webpackConfig = getBaseWebpackConfig( {
 	entry,
 } );
 
+webpackConfig.output.chunkFilename = '[name].[contenthash].js';
+
 // Overwrite default optimisation.
 webpackConfig.optimization.splitChunks.cacheGroups.commons = {
 	name: 'commons',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Change our react app rendering strategy to `createRoot()`, fixing the following deprecation warning:

```
Warning: ReactDOM.render is no longer supported in React 18. Use createRoot instead. Until you switch to the new API, your app will behave as if it's running React 17
```

It also addresses ref forwarding issues for function components under the `withWizard()` HOC.

```
react-dom.js:73 Warning: Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()?
```

To address this, the `Wizard` component required a small refactor to be encapsulated in `forwardRef()`, which then required the `useWizardData` and `STORE_NAMESPACE` to no longer be appended to the component function. This is a good change; this is not a good way to export dependencies.

92c5fad8488784a7e79af34f15522bdcc37527ee introduces the `contenthash` to the asset chunk's filename to deal with cached assets coming from [the lazy load strategy](https://github.com/Automattic/newspack-plugin/blob/a8a590cb2b4514e7cb248e086c8464fec5b84461/src/wizards/index.tsx).

### How to test the changes in this Pull Request:

Navigate **all wizards** and confirm they render as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->