### PR TITLE
fix: change nonce strategy for data events

### DIFF
--- a/includes/data-events/class-data-events.php
+++ b/includes/data-events/class-data-events.php
@@ -34,9 +34,24 @@ final class Data_Events {
 	const NONCE_EXPIRATION_OPTION = 'newspack_data_events_nonce_expiration';
 
 	/**
-	 * Nonce lifetime in seconds (24 hours).
+	 * Nonce lifetime in seconds (1 hour).
 	 */
-	const NONCE_LIFETIME = 86400; // 24 hours in seconds
+	const NONCE_LIFETIME = 3600; // 1 hour in seconds
+
+	/**
+	 * Grace period in seconds for accepting old nonces.
+	 */
+	const NONCE_GRACE_PERIOD = 10; // 10 seconds
+
+	/**
+	 * Option name for storing the previous nonce.
+	 */
+	const PREVIOUS_NONCE_OPTION = 'newspack_data_events_previous_nonce';
+
+	/**
+	 * Option name for storing the previous nonce expiration.
+	 */
+	const PREVIOUS_NONCE_EXPIRATION_OPTION = 'newspack_data_events_previous_nonce_expiration';
 
 	/**
 	 * Registered callable handlers, keyed by their action name.
@@ -91,6 +106,12 @@ final class Data_Events {
 
 		// If nonce is empty or expired, generate a new one.
 		if ( empty( $nonce ) || $current_time > $expiration ) {
+			// Store the current nonce as previous before generating a new one.
+			if ( ! empty( $nonce ) ) {
+				\update_option( self::PREVIOUS_NONCE_OPTION, $nonce );
+				\update_option( self::PREVIOUS_NONCE_EXPIRATION_OPTION, $current_time + self::NONCE_GRACE_PERIOD );
+			}
+
 			$nonce = self::generate_nonce();
 			$expiration = $current_time + self::NONCE_LIFETIME;
 
@@ -118,8 +139,21 @@ final class Data_Events {
 	 * @return bool Whether the nonce is valid.
 	 */
 	public static function verify_nonce( $nonce ) {
-		$current_nonce = self::get_nonce();
-		return $current_nonce === $nonce;
+		// Check against current nonce.
+		$current_nonce = \get_option( self::NONCE_OPTION, '' );
+		if ( $current_nonce === $nonce ) {
+			return true;
+		}
+
+		// If current nonce doesn't match, check against previous nonce if within grace period.
+		$previous_nonce = \get_option( self::PREVIOUS_NONCE_OPTION, '' );
+		$previous_expiration = \get_option( self::PREVIOUS_NONCE_EXPIRATION_OPTION, 0 );
+
+		if ( $previous_nonce === $nonce && time() <= $previous_expiration ) {
+			return true;
+		}
+
+		return false;
 	}
 
 	/**

--- a/includes/data-events/class-data-events.php
+++ b/includes/data-events/class-data-events.php
@@ -24,6 +24,21 @@ final class Data_Events {
 	const LOGGER_HEADER = 'NEWSPACK-DATA-EVENTS';
 
 	/**
+	 * Option name for storing the nonce.
+	 */
+	const NONCE_OPTION = 'newspack_data_events_nonce';
+
+	/**
+	 * Option name for storing the nonce expiration.
+	 */
+	const NONCE_EXPIRATION_OPTION = 'newspack_data_events_nonce_expiration';
+
+	/**
+	 * Nonce lifetime in seconds (24 hours).
+	 */
+	const NONCE_LIFETIME = 86400; // 24 hours in seconds
+
+	/**
 	 * Registered callable handlers, keyed by their action name.
 	 *
 	 * @var callable[]
@@ -61,17 +76,64 @@ final class Data_Events {
 	}
 
 	/**
+	 * Get the current nonce for data events.
+	 *
+	 * We use a custom nonce implementation to avoid issues with user authentication.
+	 * In some cases, and in some sites, the nonce is created for a user ID but the dispatched request does not have a user ID.
+	 * This implementation generates a nonce that is not tied to a user ID, making it more reliable.
+	 *
+	 * @return string The nonce.
+	 */
+	public static function get_nonce() {
+		$nonce = \get_option( self::NONCE_OPTION, '' );
+		$expiration = \get_option( self::NONCE_EXPIRATION_OPTION, 0 );
+		$current_time = time();
+
+		// If nonce is empty or expired, generate a new one.
+		if ( empty( $nonce ) || $current_time > $expiration ) {
+			$nonce = self::generate_nonce();
+			$expiration = $current_time + self::NONCE_LIFETIME;
+
+			\update_option( self::NONCE_OPTION, $nonce );
+			\update_option( self::NONCE_EXPIRATION_OPTION, $expiration );
+		}
+
+		return $nonce;
+	}
+
+	/**
+	 * Generate a random nonce that's safe for use in URLs.
+	 *
+	 * @return string URL-safe random nonce.
+	 */
+	private static function generate_nonce() {
+		// Generate password with only alphanumeric characters.
+		return \wp_generate_password( 32, false, false );
+	}
+
+	/**
+	 * Verify the provided nonce.
+	 *
+	 * @param string $nonce The nonce to verify.
+	 * @return bool Whether the nonce is valid.
+	 */
+	public static function verify_nonce( $nonce ) {
+		$current_nonce = self::get_nonce();
+		return $current_nonce === $nonce;
+	}
+
+	/**
 	 * Maybe handle an event.
 	 */
 	public static function maybe_handle() {
 		// Don't lock up other requests while processing.
 		session_write_close(); // phpcs:ignore
 
-		if ( ! isset( $_REQUEST['nonce'] ) || ! \wp_verify_nonce( \sanitize_text_field( $_REQUEST['nonce'] ), self::ACTION ) ) {
+		if ( ! isset( $_REQUEST['nonce'] ) || ! self::verify_nonce( \sanitize_text_field( $_REQUEST['nonce'] ) ) ) { // phpcs:ignore
 			\wp_die();
 		}
 
-		$dispatches = isset( $_POST['dispatches'] ) ? $_POST['dispatches'] : null; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$dispatches = isset( $_POST['dispatches'] ) ? $_POST['dispatches'] : null; // phpcs:ignore
 
 		if ( empty( $dispatches ) || ! is_array( $dispatches ) ) {
 			\wp_die();
@@ -384,7 +446,7 @@ final class Data_Events {
 		$url = \add_query_arg(
 			[
 				'action' => self::ACTION,
-				'nonce'  => \wp_create_nonce( self::ACTION ),
+				'nonce'  => self::get_nonce(),
 			],
 			\admin_url( 'admin-ajax.php' )
 		);

--- a/tests/unit-tests/data-events.php
+++ b/tests/unit-tests/data-events.php
@@ -312,4 +312,86 @@ class Newspack_Test_Data_Events extends WP_UnitTestCase {
 			$this->assertNull( Data_Events::current_event(), 'Current event should be null after handling' );
 		}
 	}
+
+	/**
+	 * Test the custom nonce generation and verification.
+	 */
+	public function test_nonce_generation_and_verification() {
+		// Get a nonce.
+		$nonce = Data_Events::get_nonce();
+
+		// Verify the nonce is not empty.
+		$this->assertNotEmpty( $nonce );
+
+		// Verify the nonce passes verification.
+		$this->assertTrue( Data_Events::verify_nonce( $nonce ) );
+
+		// Verify an invalid nonce fails verification.
+		$this->assertFalse( Data_Events::verify_nonce( 'invalid_nonce' ) );
+	}
+
+	/**
+	 * Test that the nonce is URL-safe.
+	 */
+	public function test_nonce_is_url_safe() {
+		$nonce = Data_Events::get_nonce();
+
+		// Verify the nonce only contains alphanumeric characters.
+		$this->assertMatchesRegularExpression( '/^[a-zA-Z0-9]+$/', $nonce );
+
+		// Verify the nonce doesn't change when requested multiple times.
+		$nonce2 = Data_Events::get_nonce();
+		$this->assertEquals( $nonce, $nonce2 );
+	}
+
+	/**
+	 * Test nonce expiration and rotation.
+	 */
+	public function test_nonce_expiration() {
+		// Get initial nonce.
+		$initial_nonce = Data_Events::get_nonce();
+
+		// Manually expire the nonce by setting expiration to past time.
+		update_option( Data_Events::NONCE_EXPIRATION_OPTION, time() - 1 );
+
+		// Get a new nonce - should be different.
+		$new_nonce = Data_Events::get_nonce();
+
+		// Verify the new nonce is different from the initial one.
+		$this->assertNotEquals( $initial_nonce, $new_nonce );
+
+		// Verify the new nonce passes verification.
+		$this->assertTrue( Data_Events::verify_nonce( $new_nonce ) );
+
+		// Verify the old nonce fails verification.
+		$this->assertFalse( Data_Events::verify_nonce( $initial_nonce ) );
+	}
+
+	/**
+	 * Test that the nonce is used in dispatches.
+	 */
+	public function test_nonce_in_dispatches() {
+		$action_name = 'test_nonce_action';
+		Data_Events::register_action( $action_name );
+
+		// Hook into the dispatched action to capture the URL.
+		$captured_url = '';
+		add_filter(
+			'pre_http_request',
+			function( $preempt, $args, $url ) use ( &$captured_url ) {
+				$captured_url = $url;
+				return true; // Short-circuit the request.
+			},
+			10,
+			3
+		);
+
+		// Dispatch an action.
+		Data_Events::dispatch( $action_name, [ 'test' => 'data' ] );
+		Data_Events::execute_queued_dispatches();
+
+		// Verify the URL contains our custom nonce.
+		$nonce = Data_Events::get_nonce();
+		$this->assertStringContainsString( 'nonce=' . $nonce, $captured_url );
+	}
 }

--- a/tests/unit-tests/data-events.php
+++ b/tests/unit-tests/data-events.php
@@ -363,7 +363,13 @@ class Newspack_Test_Data_Events extends WP_UnitTestCase {
 		// Verify the new nonce passes verification.
 		$this->assertTrue( Data_Events::verify_nonce( $new_nonce ) );
 
-		// Verify the old nonce fails verification.
+		// Verify the old nonce passes verification during grace period.
+		$this->assertTrue( Data_Events::verify_nonce( $initial_nonce ) );
+
+		// Expire the grace period.
+		update_option( Data_Events::PREVIOUS_NONCE_EXPIRATION_OPTION, time() - 1 );
+
+		// Now the old nonce should fail verification.
 		$this->assertFalse( Data_Events::verify_nonce( $initial_nonce ) );
 	}
 
@@ -393,5 +399,114 @@ class Newspack_Test_Data_Events extends WP_UnitTestCase {
 		// Verify the URL contains our custom nonce.
 		$nonce = Data_Events::get_nonce();
 		$this->assertStringContainsString( 'nonce=' . $nonce, $captured_url );
+	}
+
+	/**
+	 * Test the nonce grace period functionality.
+	 */
+	public function test_nonce_grace_period() {
+		// Get initial nonce.
+		$initial_nonce = Data_Events::get_nonce();
+
+		// Store the initial nonce and expiration values.
+		$initial_expiration = get_option( Data_Events::NONCE_EXPIRATION_OPTION );
+
+		// Force nonce rotation by setting expiration to past time.
+		update_option( Data_Events::NONCE_EXPIRATION_OPTION, time() - 1 );
+
+		// Get a new nonce - this should trigger rotation and store the old nonce.
+		$new_nonce = Data_Events::get_nonce();
+
+		// Verify we have different nonces.
+		$this->assertNotEquals( $initial_nonce, $new_nonce );
+
+		// Verify the previous nonce was stored.
+		$previous_nonce = get_option( Data_Events::PREVIOUS_NONCE_OPTION );
+		$this->assertEquals( $initial_nonce, $previous_nonce );
+
+		// Verify the previous nonce expiration was set to a future time.
+		$previous_expiration = get_option( Data_Events::PREVIOUS_NONCE_EXPIRATION_OPTION );
+		$this->assertGreaterThan( time(), $previous_expiration, 'Previous nonce expiration should be in the future' );
+
+		// Verify both nonces are valid during the grace period.
+		$this->assertTrue( Data_Events::verify_nonce( $new_nonce ), 'New nonce should be valid' );
+		$this->assertTrue( Data_Events::verify_nonce( $initial_nonce ), 'Old nonce should be valid during grace period' );
+
+		// Expire the grace period.
+		update_option( Data_Events::PREVIOUS_NONCE_EXPIRATION_OPTION, time() - 1 );
+
+		// Verify only the new nonce is valid after grace period.
+		$this->assertTrue( Data_Events::verify_nonce( $new_nonce ), 'New nonce should still be valid' );
+		$this->assertFalse( Data_Events::verify_nonce( $initial_nonce ), 'Old nonce should be invalid after grace period' );
+	}
+
+	/**
+	 * Test that the nonce lifetime is correctly set to 1 hour.
+	 */
+	public function test_nonce_lifetime() {
+		// Get a nonce and check its expiration time.
+		Data_Events::get_nonce();
+		$expiration = get_option( Data_Events::NONCE_EXPIRATION_OPTION );
+
+		// Verify the expiration is set to approximately 1 hour from now.
+		$expected_expiration = time() + Data_Events::NONCE_LIFETIME;
+		$this->assertEqualsWithDelta( $expected_expiration, $expiration, 2, 'Nonce expiration should be set to 1 hour' );
+	}
+
+	/**
+	 * Test that the grace period is correctly set to 10 seconds.
+	 */
+	public function test_grace_period_duration() {
+		// Get initial nonce.
+		$initial_nonce = Data_Events::get_nonce();
+
+		// Force nonce rotation.
+		update_option( Data_Events::NONCE_EXPIRATION_OPTION, time() - 1 );
+		Data_Events::get_nonce();
+
+		// Get the previous nonce expiration.
+		$previous_expiration = get_option( Data_Events::PREVIOUS_NONCE_EXPIRATION_OPTION );
+
+		// Verify the grace period is approximately 10 seconds.
+		$grace_period = $previous_expiration - time();
+		$this->assertEqualsWithDelta( Data_Events::NONCE_GRACE_PERIOD, $grace_period, 2, 'Grace period should be approximately 10 seconds' );
+	}
+
+	/**
+	 * Test that dispatches work with both current and previous nonces during grace period.
+	 */
+	public function test_dispatch_with_grace_period() {
+		$action_name = 'test_grace_period_action';
+		Data_Events::register_action( $action_name );
+
+		// Get initial nonce.
+		$initial_nonce = Data_Events::get_nonce();
+
+		// Force nonce rotation.
+		update_option( Data_Events::NONCE_EXPIRATION_OPTION, time() - 1 );
+		$new_nonce = Data_Events::get_nonce();
+
+		// Hook into the dispatched action to capture the URL.
+		$captured_url = '';
+		add_filter(
+			'pre_http_request',
+			function( $preempt, $args, $url ) use ( &$captured_url ) {
+				$captured_url = $url;
+				return true; // Short-circuit the request.
+			},
+			10,
+			3
+		);
+
+		// Dispatch an action with the new nonce.
+		Data_Events::dispatch( $action_name, [ 'test' => 'data' ] );
+		Data_Events::execute_queued_dispatches();
+
+		// Verify the URL contains the new nonce.
+		$this->assertStringContainsString( 'nonce=' . $new_nonce, $captured_url );
+
+		// Manually verify a request with the old nonce would be accepted.
+		$_REQUEST['nonce'] = $initial_nonce;
+		$this->assertTrue( Data_Events::verify_nonce( $initial_nonce ), 'Old nonce should be valid during grace period' );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR replaces the nonce strategy for data events. In some cases, and in some sites, nonce verification can fail because the user session is not recognized in the dispatched request that handles the events. 

Since we don't really need a nonce per user, this implementation is simpler and more reliable.

### How to test the changes in this Pull Request:

1. Make some actions that will trigger some data events (for example, subscribe to a newsletter or make a purchase while RAS is enabled)
2. Inspect the error log and confirm all the events are being dispatched and handled as usual


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->