### PR TITLE
fix(corrections): Limit CPT to posts only

### DIFF
--- a/includes/corrections/class-corrections.php
+++ b/includes/corrections/class-corrections.php
@@ -37,11 +37,6 @@ class Corrections {
 	const CORRECTIONS_TYPE_META = 'newspack_corrections_type';
 
 	/**
-	 * Supported post types.
-	 */
-	const SUPPORTED_POST_TYPES = [ 'article_legacy', 'content_type_blog', 'post', 'press_release' ];
-
-	/**
 	 * REST route for corrections.
 	 */
 	const REST_ROUTE = '/corrections';
@@ -75,7 +70,15 @@ class Corrections {
 		}
 
 		$screen = get_current_screen();
-		if ( empty( $screen ) || 'post' !== $screen->base || ! in_array( $screen->post_type, self::SUPPORTED_POST_TYPES, true ) ) {
+
+		/**
+		 * Filter to allow other post types to support Newspack Corrections and clarifications.
+		 *
+		 * @param array $supported_post_types Array of supported post types slugs.
+		 */
+		$supported_post_types = apply_filters( 'newspack_corrections_supported_post_types', [ 'post' ] );
+
+		if ( empty( $screen ) || 'post' !== $screen->base || ! in_array( $screen->post_type, $supported_post_types, true ) ) {
 			return;
 		}
 
@@ -155,11 +158,11 @@ class Corrections {
 			'has_archive'         => true,
 			'public'              => false,
 			'publicly_queryable'  => true,
-			'exclude_from_search' => false,
+			'exclude_from_search' => true,
 			'query_var'           => true,
 			'rewrite'             => [ 'slug' => 'corrections' ],
 			'show_ui'             => false,
-			'show_in_nav_menus'   => true,
+			'show_in_nav_menus'   => false,
 			'show_in_rest'        => true,
 			'supports'            => $supports,
 			'taxonomies'          => [],

--- a/includes/corrections/class-corrections.php
+++ b/includes/corrections/class-corrections.php
@@ -75,7 +75,7 @@ class Corrections {
 		}
 
 		$screen = get_current_screen();
-		if ( empty( $screen ) || $screen->base !== 'post' || ! in_array( $screen->post_type, self::SUPPORTED_POST_TYPES, true ) ) {
+		if ( empty( $screen ) || 'post' !== $screen->base || ! in_array( $screen->post_type, self::SUPPORTED_POST_TYPES, true ) ) {
 			return;
 		}
 

--- a/includes/corrections/class-corrections.php
+++ b/includes/corrections/class-corrections.php
@@ -150,18 +150,20 @@ class Corrections {
 			'item_link_description'    => __( 'A link to a correction.', 'newspack-plugin' ),
 		];
 		$args = array(
-			'labels'             => $labels,
-			'description'        => 'Post type used to store corrections and clarifications.',
-			'has_archive'        => true,
-			'public'             => false,
-			'publicly_queryable' => true,
-			'query_var'          => true,
-			'rewrite'            => [ 'slug' => 'corrections' ],
-			'show_ui'            => false,
-			'show_in_rest'       => true,
-			'supports'           => $supports,
-			'taxonomies'         => [],
-			'menu_icon'          => 'dashicons-edit',
+			'labels'              => $labels,
+			'description'         => 'Post type used to store corrections and clarifications.',
+			'has_archive'         => true,
+			'public'              => false,
+			'publicly_queryable'  => true,
+			'exclude_from_search' => false,
+			'query_var'           => true,
+			'rewrite'             => [ 'slug' => 'corrections' ],
+			'show_ui'             => false,
+			'show_in_nav_menus'   => true,
+			'show_in_rest'        => true,
+			'supports'            => $supports,
+			'taxonomies'          => [],
+			'menu_icon'           => 'dashicons-edit',
 		);
 		\register_post_type( self::POST_TYPE, $args );
 

--- a/includes/corrections/class-corrections.php
+++ b/includes/corrections/class-corrections.php
@@ -74,6 +74,11 @@ class Corrections {
 			return;
 		}
 
+		$screen = get_current_screen();
+		if ( empty( $screen ) || $screen->base !== 'post' || ! in_array( $screen->post_type, self::SUPPORTED_POST_TYPES, true ) ) {
+			return;
+		}
+
 		\wp_enqueue_script(
 			'newspack-corrections-modal',
 			Newspack::plugin_url() . '/dist/other-scripts/corrections-modal.js',

--- a/includes/corrections/class-corrections.php
+++ b/includes/corrections/class-corrections.php
@@ -145,18 +145,18 @@ class Corrections {
 			'item_link_description'    => __( 'A link to a correction.', 'newspack-plugin' ),
 		];
 		$args = array(
-			'labels'           => $labels,
-			'description'      => 'Post type used to store corrections and clarifications.',
-			'has_archive'      => true,
-			'public'           => true,
-			'public_queryable' => true,
-			'query_var'        => true,
-			'rewrite'          => [ 'slug' => 'corrections' ],
-			'show_ui'          => false,
-			'show_in_rest'     => true,
-			'supports'         => $supports,
-			'taxonomies'       => [],
-			'menu_icon'        => 'dashicons-edit',
+			'labels'             => $labels,
+			'description'        => 'Post type used to store corrections and clarifications.',
+			'has_archive'        => true,
+			'public'             => false,
+			'publicly_queryable' => true,
+			'query_var'          => true,
+			'rewrite'            => [ 'slug' => 'corrections' ],
+			'show_ui'            => false,
+			'show_in_rest'       => true,
+			'supports'           => $supports,
+			'taxonomies'         => [],
+			'menu_icon'          => 'dashicons-edit',
 		);
 		\register_post_type( self::POST_TYPE, $args );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Addresses https://app.asana.com/1/26890605006346/task/1209996963457664?focus=true.

This PR ensures the Corrections and Clarifications panel is only displayed for the post post type. Previously, it could appear publicly as a conventional CPT applicable of Content Gate.

To resolve this:
- The custom post type registration for Content Gate is now set to 'public' => false.
- Also added checks to ensure corrections modal to supported post types.

| Before | After |
|--------|--------|
| <img width="1432" alt="Screenshot 2025-04-17 at 3 01 47 PM" src="https://github.com/user-attachments/assets/d15c2a83-c388-468e-8462-bb4b77a3e913" /> | <img width="1096" alt="Screenshot 2025-04-17 at 3 00 59 PM" src="https://github.com/user-attachments/assets/4547f9e6-27eb-496a-8329-817567ad68c5" /> | 

### How to test the changes in this Pull Request:

1. Open configuration screen for any of the content gate content.
2. Notice Corrections not available as a CPT applicable to content gate.
3. Create or edit a post of type post or the supported post type — the Corrections and Clarifications panel should appear.
4. Open any random Page editor screen. 
5. Confirm the panel should not appear.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->