### PR TITLE
fix(corrections): Use Corrections Archive template by default

### DIFF
--- a/includes/corrections/class-corrections.php
+++ b/includes/corrections/class-corrections.php
@@ -154,7 +154,7 @@ class Corrections {
 		];
 		$args = array(
 			'labels'              => $labels,
-			'description'         => 'Post type used to store corrections and clarifications.',
+			'description'         => __( 'Post type used to store corrections and clarifications.', 'newspack-plugin' ),
 			'has_archive'         => true,
 			'public'              => false,
 			'publicly_queryable'  => true,

--- a/includes/corrections/class-corrections.php
+++ b/includes/corrections/class-corrections.php
@@ -494,7 +494,7 @@ class Corrections {
 		}
 
 		\register_block_template(
-			'newspack//corrections-archive',
+			'newspack//archive-' . self::POST_TYPE,
 			[
 				'title'       => __( 'Corrections Archive', 'newspack-plugin' ),
 				'description' => __( 'A block template for displaying an archive of corrections.', 'newspack-plugin' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
While testing for https://github.com/Automattic/newspack-plugin/pull/3927#discussion_r2049700262, found that block theme wasn't using the custom archive template.

For Template hierarchy to use plugin's custom template for corrections, we need to explicitly change the name of the custom template for block themes to use it when registering using `register_block_template`.

### How to test the changes in this Pull Request:

1. Checkout to trunk trunk branch.
2. Create few posts with corrections/clarifications.
3. Open a post with corrections, and click on the correction's title to open Corrections archive.
4. Notice it is using default archive template, also note it links to single corrections page using single posts template.
5. Switch to a block theme.
6. Open a post with corrections, and click on the correction's title to open Corrections archive.
7. Confirm it is using the custom Newspack Corrections archive instead of the default Archive page.
8. Confirm the archive page has links to the respective "corrected" pages.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->