### PR TITLE
fix(recaptcha-v2): clone Place Order button for all checkouts, not just modal

### DIFF
--- a/includes/class-recaptcha.php
+++ b/includes/class-recaptcha.php
@@ -30,6 +30,9 @@ final class Recaptcha {
 		\add_action( 'woocommerce_checkout_after_customer_details', [ __CLASS__, 'add_recaptcha_v3_to_checkout' ] );
 		\add_action( 'woocommerce_add_payment_method_form_bottom', [ __CLASS__, 'add_recaptcha_v3_to_checkout' ] );
 
+		// Clone the Place Order button so we can attach the reCAPTCHA widget to it without triggering other third-party extensions' event listeners.
+		\add_filter( 'woocommerce_order_button_html', [ __CLASS__, 'order_button_html' ], 10 );
+
 		// Verify reCAPTCHA on checkout submission.
 		\add_action( 'woocommerce_checkout_process', [ __CLASS__, 'verify_recaptcha_on_checkout' ] );
 
@@ -507,6 +510,24 @@ final class Recaptcha {
 			} );
 		</script>
 		<?php
+	}
+
+	/**
+	 * Clone the Place Order button so we can attach the reCAPTCHA widget to it without triggering other third-party extensions' event listeners.
+	 *
+	 * @param string $html The button html.
+	 *
+	 * @return string The modified button html.
+	 */
+	public static function order_button_html( $html ) {
+		if ( self::can_use_captcha( 'v2' ) ) {
+			$cloned_button    = preg_replace( '/type="submit"/', 'type="button"', $html );
+			$cloned_button    = preg_replace( '/id="place_order"/', '', $html );
+			$cloned_button    = preg_replace( '/name=".*?"/', 'id="place_order_clone"', $html );
+			$html = $cloned_button . $html;
+		}
+
+		return $html;
 	}
 
 	/**

--- a/includes/class-recaptcha.php
+++ b/includes/class-recaptcha.php
@@ -31,7 +31,7 @@ final class Recaptcha {
 		\add_action( 'woocommerce_add_payment_method_form_bottom', [ __CLASS__, 'add_recaptcha_v3_to_checkout' ] );
 
 		// Clone the Place Order button so we can attach the reCAPTCHA widget to it without triggering other third-party extensions' event listeners.
-		\add_filter( 'woocommerce_order_button_html', [ __CLASS__, 'order_button_html' ], 10 );
+		\add_filter( 'woocommerce_order_button_html', [ __CLASS__, 'order_button_html' ], 999 );
 
 		// Verify reCAPTCHA on checkout submission.
 		\add_action( 'woocommerce_checkout_process', [ __CLASS__, 'verify_recaptcha_on_checkout' ] );

--- a/src/other-scripts/recaptcha/style.scss
+++ b/src/other-scripts/recaptcha/style.scss
@@ -34,3 +34,19 @@
 		}
 	}
 }
+
+body:not(.newspack-ui) .woocommerce #payment,
+body:not(.newspack-ui) .woocommerce-page #payment {
+	/* stylelint-disable-next-line selector-id-pattern */
+	#place_order_clone {
+		@media only screen and (max-width: 768px) {
+			width: 100% !important;
+		}
+		float: right;
+
+		/* stylelint-disable-next-line selector-id-pattern */
+		& + #place_order {
+			display: none;
+		}
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#3692 fixed a conflict between the reCAPTCHA v2 widget and other WooCommerce extensions (such as the [ELEX Address Verification plugin](https://wordpress.org/plugins/address-validation-address-auto-complete/)) that attach event listeners to the Place Order button, but did so for Newspack's modal checkout template only. This conflict still exists in standard Woo checkouts, where reCAPTCHA v2 might still be active alongside conflicting Woo extensions.

This PR (and https://github.com/Automattic/newspack-blocks/pull/2111) moves the code that adds the clone button from the Blocks plugin to this plugin's `Recaptcha` class, and adds the clone in its own filter callback so that it can be added in any Woo checkout context, not just Newspack's modal checkout.

### How to test the changes in this Pull Request:

1. Connect your test site to reCAPTCHA v2 and enable a Woo extension plugin which also attaches its own event listeners to the Place Order button. To test with [ELEX](https://wordpress.org/plugins/address-validation-address-auto-complete/), install the plugin, then sign up for a free EasyPost account to obtain a test API key (or DM me for a key you can use) and enter the key in the API credentials screen (`https://siteurl/wp-admin/admin.php?page=wc-settings&tab=elex_address_autocomplete_validation&section=elex-api-credentials`). Also make sure to enable address validation via EasyPost in the Address Validation settings page:

<img width="820" alt="Screenshot 2025-01-21 at 12 25 31 PM" src="https://github.com/user-attachments/assets/c69ed045-ef77-4405-a90b-04e1b46535a8" />

2. As a reader, start a checkout from your site's Shop page so that it goes through the standard Woo checkout flow instead of modal checkout.
3. On `release`, attempt to complete the checkout and observe that clicking "Place order" triggers ELEX's address validation, but not reCAPTCHA's widget, and that after passing address validation, the checkout fails with an error message `Please complete the challenge to continue`.
4. Check out this branch and https://github.com/Automattic/newspack-blocks/pull/2111.
5. Refresh the checkout page and try completing checkout again. This time confirm that the reCAPTCHA v2 widget runs first, then ELEX address validation after completing the reCAPTCHA challenge, then a successful checkout completion.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->