### PR TITLE
fix(stripe-gateway): transaction metadata

### DIFF
--- a/includes/plugins/class-woocommerce-gateway-stripe.php
+++ b/includes/plugins/class-woocommerce-gateway-stripe.php
@@ -18,7 +18,24 @@ class WooCommerce_Gateway_Stripe {
 	 * Initialize hooks and filters.
 	 */
 	public static function init() {
-		add_filter( 'wc_stripe_intent_metadata', [ __CLASS__, 'add_transaction_metadata' ], 10, 2 );
+		add_filter( 'wc_stripe_generate_payment_request', [ __CLASS__, 'add_payment_request_metadata' ], 10, 2 );
+		add_filter( 'wc_stripe_intent_metadata', [ __CLASS__, 'add_intent_metadata' ], 10, 2 );
+	}
+
+	/**
+	 * Add metadata to a Stripe transaction.
+	 *
+	 * @param array    $post_data Payment request data.
+	 * @param WC_Order $order Order being processed.
+	 */
+	public static function add_payment_request_metadata( $post_data, $order ) {
+		if ( isset( $post_data['metadata'] ) ) {
+			$post_data['metadata'] = self::add_intent_metadata(
+				$post_data['metadata'],
+				$order
+			);
+		}
+		return $post_data;
 	}
 
 	/**
@@ -29,7 +46,7 @@ class WooCommerce_Gateway_Stripe {
 	 *
 	 * @return array Array of keyed metadata values.
 	 */
-	public static function add_transaction_metadata( $metadata, $order ) {
+	public static function add_intent_metadata( $metadata, $order ) {
 		// Skip orders with multiple products.
 		if ( $order->get_item_count() > 1 ) {
 			return $metadata;
@@ -87,7 +104,7 @@ class WooCommerce_Gateway_Stripe {
 
 		// Add subscription data.
 		if ( function_exists( 'wcs_get_subscriptions_for_order' ) && function_exists( 'wcs_order_contains_renewal' ) ) {
-			$related_subscriptions = \wcs_get_subscriptions_for_order( $order );
+			$related_subscriptions = \wcs_get_subscriptions_for_order( $order, [ 'order_type' => 'any' ] );
 			if ( ! empty( $related_subscriptions ) ) {
 				// In theory, there should be just one subscription per renewal.
 				$subscription = reset( $related_subscriptions );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Changes in #3903 did not handle subscription renewals. This PR fixes it. 

### How to test the changes in this Pull Request:

1. Connect the Stripe payment gateway in WooCommerce
2. Set up a membership plan to which the access is granted upon a purchase
3. As a reader, purchase this item
4. In Stripe, observe that the transaction has the following metadata: `Product`, `Transaction Type`, `Membership Type` with relevant values
5. Renew the subscription from the WP admin
6. Observe that the new transaction in Stripe also has the metadata 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209056767424005