### PR TITLE
fix: avoid warning for network event

### DIFF
--- a/includes/data-events/connectors/class-esp-connector.php
+++ b/includes/data-events/connectors/class-esp-connector.php
@@ -41,7 +41,10 @@ class ESP_Connector extends Reader_Activation\ESP_Sync {
 		Data_Events::register_handler( [ __CLASS__, 'subscription_renewal_attempt' ], 'subscription_renewal_attempt' );
 		Data_Events::register_handler( [ __CLASS__, 'newsletter_updated' ], 'newsletter_subscribed' );
 		Data_Events::register_handler( [ __CLASS__, 'newsletter_updated' ], 'newsletter_updated' );
-		Data_Events::register_handler( [ __CLASS__, 'network_new_reader' ], 'network_new_reader' );
+
+		if ( class_exists( 'Newspack_Network\Initializer' ) ) {
+			Data_Events::register_handler( [ __CLASS__, 'network_new_reader' ], 'network_new_reader' );
+		}
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

[Closes # .](https://github.com/Automattic/newspack-plugin/pull/3901) introduced some warnings in case you register a handler to an event that was not created.

In the plugin, we are registering a handler to an event that is only created if the Network plugin is active. We don't want to fire warning for those.

### How to test the changes in this Pull Request:

1. On `trunk` deactivate Newspack network and confirm you see the error in the logs:

```
[DATA EVENTS][Newspack\Data_Events::register_handler]: ATTENTION: Data Event handler for action "network_new_reader" was not properly registered: Action not registered.
```

2. Checkout this branch and confirm the errors are gone
3. Add some debugging to where the handler is registered and make sure it is still registered when you activate the Network plugin again

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->