### PR TITLE
fix(google-login): handle google oauth disabled state in the editor

### DIFF
--- a/includes/oauth/class-google-oauth.php
+++ b/includes/oauth/class-google-oauth.php
@@ -466,10 +466,10 @@ class Google_OAuth {
 	}
 
 	/**
-	 * Is OAuth configured?
+	 * Is Google OAuth configured?
 	 */
 	public static function is_oauth_configured() {
-		return OAuth::is_proxy_configured( 'google' );
+		return OAuth::is_proxy_configured( 'google' ) && ( ! defined( 'NEWSPACK_DISABLE_GOOGLE_OAUTH' ) || ! NEWSPACK_DISABLE_GOOGLE_OAUTH );
 	}
 }
 new Google_OAuth();

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1920,7 +1920,7 @@ final class Reader_Activation {
 	 * If Google is connected to the site, this can be overridden by setting the `NEWSPACK_DISABLE_GOOGLE_OAUTH` environment constant.
 	 */
 	public static function render_third_party_auth() {
-		if ( ! Google_OAuth::is_oauth_configured() || ( defined( 'NEWSPACK_DISABLE_GOOGLE_OAUTH' ) && NEWSPACK_DISABLE_GOOGLE_OAUTH ) ) {
+		if ( ! Google_OAuth::is_oauth_configured() ) {
 			return;
 		}
 		?>
@@ -2219,7 +2219,7 @@ final class Reader_Activation {
 				return false;
 			}
 
-			// Don't send OTP email for newsletter signup, or if the reader has a password set. 
+			// Don't send OTP email for newsletter signup, or if the reader has a password set.
 			if ( self::is_reader_without_password( $existing_user ) &&
 				( ! isset( $metadata['registration_method'] ) || false === strpos( $metadata['registration_method'], 'newsletters-subscription' ) )
 			) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

When `NEWSPACK_DISABLE_GOOGLE_OAUTH` environment variable is configured, its effect were only visible on the front-end. This PR adds handling of it to the post editor.

### How to test the changes in this Pull Request:

1. On `trunk`,
2. Configure Google OAuth by providing `NEWSPACK_GOOGLE_OAUTH_PROXY` env variable
3. Add `NEWSPACK_DISABLE_GOOGLE_OAUTH` env variable with `true` value
4. Load a post editor and insert a Read Registration block
5. Observe Google button is still visible
6. Switch to this branch, reload editor, observe there's no Google button
7. Remove the env variable, observe the Google button is rendered

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210051336945374