### PR TITLE
feat(woocommerce): log error notices

### DIFF
--- a/includes/class-logger.php
+++ b/includes/class-logger.php
@@ -89,8 +89,8 @@ class Logger {
 	 * @param string $type      The type of log. Defaults to 'error'.
 	 * @param string $log_level The Log level.
 	 */
-	public static function newspack_log( $code, $message, $data, $type = 'error', $log_level = 2 ) {
-		$email = '';
+	public static function newspack_log( $code, $message, $data = [], $type = 'error', $log_level = 2 ) {
+		$email = wp_get_current_user()->user_email;
 		if ( isset( $data['user_email'] ) ) {
 			$email = $data['user_email'];
 			unset( $data['user_email'] );
@@ -100,6 +100,15 @@ class Logger {
 			$file = $data['file'];
 			unset( $data['file'] );
 		}
+		$data = array_merge(
+			$data,
+			[
+				// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__HTTP_USER_AGENT__
+				'user_agent' => isset( $_SERVER['HTTP_USER_AGENT'] ) ? sanitize_text_field( $_SERVER['HTTP_USER_AGENT'] ) : 'N/A',
+				'referrer'   => isset( $_SERVER['HTTP_REFERER'] ) ? esc_url( $_SERVER['HTTP_REFERER'] ) : 'N/A',
+				// phpcs:enable
+			]
+		);
 		do_action(
 			'newspack_log',
 			$code,

--- a/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-connection.php
@@ -31,6 +31,7 @@ class WooCommerce_Connection {
 	 * @codeCoverageIgnore
 	 */
 	public static function init() {
+		include_once __DIR__ . '/class-woocommerce-logs.php';
 		include_once __DIR__ . '/class-woocommerce-cli.php';
 		include_once __DIR__ . '/class-woocommerce-cover-fees.php';
 		include_once __DIR__ . '/class-woocommerce-order-utm.php';

--- a/includes/reader-revenue/woocommerce/class-woocommerce-logs.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-logs.php
@@ -26,6 +26,10 @@ class WooCommerce_Logs {
 	 * @param string $message The error message.
 	 */
 	public static function log_error_notices( $message ) {
+		// Only log if there is a message.
+		if ( empty( $message ) ) {
+			return $message;
+		}
 		$data = [
 			'wc_cart' => WC()->cart->get_cart_contents(),
 		];

--- a/includes/reader-revenue/woocommerce/class-woocommerce-logs.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-logs.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Log WooCommerce events
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class for logging WooCommerce events.
+ */
+class WooCommerce_Logs {
+	/**
+	 * Initialize the class.
+	 */
+	public static function init() {
+		add_filter( 'woocommerce_add_error', [ __CLASS__, 'log_error_notices' ] );
+	}
+
+	/**
+	 * Log error notices.
+	 *
+	 * @param string $message The error message.
+	 */
+	public static function log_error_notices( $message ) {
+		Logger::newspack_log( 'newspack_woocommerce_error_notice', $message );
+		return $message;
+	}
+}
+WooCommerce_Logs::init();

--- a/includes/reader-revenue/woocommerce/class-woocommerce-logs.php
+++ b/includes/reader-revenue/woocommerce/class-woocommerce-logs.php
@@ -26,7 +26,10 @@ class WooCommerce_Logs {
 	 * @param string $message The error message.
 	 */
 	public static function log_error_notices( $message ) {
-		Logger::newspack_log( 'newspack_woocommerce_error_notice', $message );
+		$data = [
+			'wc_cart' => WC()->cart->get_cart_contents(),
+		];
+		Logger::newspack_log( 'newspack_woocommerce_error_notice', $message, $data );
 		return $message;
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Log WooCommerce error notices, which is the primary error handling across Woo features. This includes My Account form validation, cart, and checkout issues. The payload will include the cart contents as `wc_cart`.

This PR also adds the user referrer and user agent to always be sent as part of the log payload.

### How to test the changes in this Pull Request:

1. Donate or purchase a subscription and use the following card number so it's declined: `4100000000000019`
2. Confirm you were unable to complete the checkout
3. Confirm a log entry was pushed with the following `error_code`: `newspack_woocommerce_error_notice`
4. Confirm the log entry has the following message: `Error: Your card was declined.` and the `extra` property includes the correct agent, referrer, and `wc_cart` information

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->