### PR TITLE
fix: hide modal content gate when checkout is opened

### DIFF
--- a/src/memberships-gate/gate.js
+++ b/src/memberships-gate/gate.js
@@ -42,6 +42,7 @@ function initReloadHandler() {
 	window.newspackRAS = window.newspackRAS || [];
 	window.newspackRAS.push( function( ras ) {
 		let reload = false;
+
 		const refreshPage = function( ev ) {
 			// When a new reader is registered, which may or may not happen inside an overlay.
 			if (
@@ -61,6 +62,9 @@ function initReloadHandler() {
 					( 'checkout_completed' === lastActivity.action || 'reader_registered' === lastActivity.action || 'reader_logged_in' === lastActivity.action )
 				) {
 					reload = true;
+					// Add a CSS class to the body so we can keep the overlay content gate hidden while the page refreshes.
+					document.body.classList.add( 'newspack-memberships__gate-passed' );
+
 				} else {
 					reload = false;
 					handleDismissed();

--- a/src/memberships-gate/gate.scss
+++ b/src/memberships-gate/gate.scss
@@ -82,11 +82,8 @@
 	}
 }
 
-.newspack-modal-checkout-open,
-.newspack-signin {
-	.newspack-memberships {
-		&__overlay-gate {
-			display: none !important;
-		}
+body:has(.newspack-ui__modal-container[data-state="open"]) {
+	.newspack-memberships__overlay-gate {
+		display: none !important;
 	}
 }

--- a/src/memberships-gate/gate.scss
+++ b/src/memberships-gate/gate.scss
@@ -82,8 +82,12 @@
 	}
 }
 
-body:has(.newspack-ui__modal-container[data-state="open"]) {
-	.newspack-memberships__overlay-gate {
-		display: none !important;
+// Hide the gate while the sign in or checkout modals are open.
+body {
+	&:has(.newspack-ui__modal-container[data-state="open"]),
+	&.newspack-memberships__gate-passed {
+		.newspack-memberships__overlay-gate {
+			display: none !important;
+		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR updates some CSS that was used to hide the modal content gate when the Audience Development Sign In or any state of the Modal Checkout was open (variation picker, checkout, thank you, newsletter modal).

It also adds a CSS class to the body when a purchase/sign up would normally refresh the page, so the gate can be hidden while that's happening.

See: 1200550061930446-as-1209980970331853

### How to test the changes in this Pull Request:

1. Set up a Woo Membership that restricts content.
2. Set up two products to purchase to get access to that membership: one a regular subscription product, and one a variable subscription product.
3. Set up a Content Gate, and set it to display as an overlay. Add two checkout button blocks, one for each of your subscription products.
4. In an incognito window, view a post that shows the gate, and click on one of the checkout button blocks. Note that the gate is still visible behind the checkout:

![CleanShot 2025-04-29 at 16 57 49](https://github.com/user-attachments/assets/e0a6587d-a7f2-4992-86ff-f73a738aca06)

5. Apply this PR and run `npm run build`.
6. In an incognito window, try to purchase one of the memberships from the gate; confirm that the content gate modal is hidden while the checkout is open.
7. Close the checkout modal without completing the purchase, and make sure the content gate comes back. 
8. Try checking out with the button that opens the variation picker, and confirm the gate goes away.

![CleanShot 2025-04-29 at 17 01 03@2x](https://github.com/user-attachments/assets/908be80e-a872-42c9-9820-9d3df79cfd34)

9. Complete a purchase of the membership product, and confirm that when you're done, the modal checkout will close but the gate doesn't come back while the page is reloading (you'll still only see the excerpt until the page refreshes). 
10. Under Audience > Checkout & Payment, enable "Require sign in or create account before checkout". 
11. In the incognito window repeat the above steps: confirm that the content gate goes away while the sign in modal is opened, and will come back when you close the sign in modal without filling it in, but not when you complete a transaction.
12. Under Audience > Configuration, enable "Present newsletter signup after checkout and registration" and turn on a couple lists.
13. In the incognito window, run one more checkout and confirm that the content gate is still hidden when the newsletters modal is open, but that it doesn't come back when you click 'Continue' on that modal or just close it. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209980970331853