### PR TITLE
fix(ga4): ensure gate_post_id and newspack_popup_id are passed to activities

### DIFF
--- a/includes/class-magic-link.php
+++ b/includes/class-magic-link.php
@@ -889,7 +889,22 @@ final class Magic_Link {
 			return self::send_otp_request_response( __( 'Unable to authenticate, try again.', 'newspack-plugin' ), false, [ 'expired' => true ] );
 		}
 
-		return self::send_otp_request_response( __( 'Login successful!', 'newspack-plugin' ), true );
+		/**
+		 * Filters the metadata to be saved for a reader registered via the auth modal.
+		 *
+		 * @param array  $metadata Metadata.
+		 * @param string $email    Email address of the reader.
+		 */
+		$metadata = apply_filters(
+			'newspack_otp_login_metadata',
+			[
+				'email'        => $email,
+				'login_method' => 'otp',
+			],
+			$email
+		);
+
+		return self::send_otp_request_response( __( 'Login successful!', 'newspack-plugin' ), true, [ 'metadata' => $metadata ] );
 	}
 
 	/**

--- a/includes/data-events/class-memberships.php
+++ b/includes/data-events/class-memberships.php
@@ -43,6 +43,7 @@ final class Memberships {
 		add_action( 'woocommerce_checkout_create_order_line_item', [ __CLASS__, 'checkout_create_order_line_item' ], 10, 4 );
 		add_filter( 'newspack_register_reader_metadata', [ __CLASS__, 'register_reader_metadata' ] );
 		add_filter( 'newspack_auth_form_metadata', [ __CLASS__, 'register_reader_metadata' ] );
+		add_filter( 'newspack_otp_login_metadata', [ __CLASS__, 'register_reader_metadata' ] );
 		add_filter( 'newspack_register_reader_form_metadata', [ __CLASS__, 'register_reader_metadata' ] );
 		add_filter( 'newspack_newsletters_subscription_form_metadata', [ __CLASS__, 'register_reader_metadata' ] );
 	}
@@ -86,9 +87,14 @@ final class Memberships {
 	 */
 	public static function register_reader_metadata( $metadata ) {
 		$gate_post_id = filter_input( INPUT_POST, self::METADATA_NAME, FILTER_SANITIZE_NUMBER_INT );
-		if ( ! empty( $gate_post_id ) && isset( $metadata['registration_method'] ) ) {
-			$metadata['gate_post_id']        = $gate_post_id;
-			$metadata['registration_method'] = $metadata['registration_method'] . '-content-gate';
+		if ( ! empty( $gate_post_id ) && ( isset( $metadata['registration_method'] ) || isset( $metadata['login_method'] ) ) ) {
+			$metadata['gate_post_id'] = $gate_post_id;
+			if ( isset( $metadata['registration_method'] ) ) {
+				$metadata['registration_method'] = $metadata['registration_method'] . '-content-gate';
+			}
+			if ( isset( $metadata['login_method'] ) ) {
+				$metadata['login_method'] = $metadata['login_method'] . '-content-gate';
+			}
 		}
 		return $metadata;
 	}

--- a/includes/data-events/class-memberships.php
+++ b/includes/data-events/class-memberships.php
@@ -89,12 +89,6 @@ final class Memberships {
 		$gate_post_id = filter_input( INPUT_POST, self::METADATA_NAME, FILTER_SANITIZE_NUMBER_INT );
 		if ( ! empty( $gate_post_id ) && ( isset( $metadata['registration_method'] ) || isset( $metadata['login_method'] ) ) ) {
 			$metadata['gate_post_id'] = $gate_post_id;
-			if ( isset( $metadata['registration_method'] ) ) {
-				$metadata['registration_method'] = $metadata['registration_method'] . '-content-gate';
-			}
-			if ( isset( $metadata['login_method'] ) ) {
-				$metadata['login_method'] = $metadata['login_method'] . '-content-gate';
-			}
 		}
 		return $metadata;
 	}

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -2116,7 +2116,7 @@ final class Reader_Activation {
 		}
 
 		/**
-		 * Filters the metadata to be saved for a reader registered via the auth modal.
+		 * Filters the metadata to be saved for a reader going through the auth modal.
 		 *
 		 * @param array  $metadata Metadata.
 		 * @param string $email    Email address of the reader.

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -2034,12 +2034,14 @@ final class Reader_Activation {
 		];
 
 		$magic_link_label = self::get_reader_activation_labels( 'magic_link' );
+		$metadata         = [];
+		$message          = false;
 
 		switch ( $action ) {
 			case 'signin':
 				if ( Magic_Link::has_active_token( $user ) ) {
 					$payload['action'] = 'otp';
-					return self::send_auth_form_response( $payload, false );
+					break;
 				}
 				if ( self::is_reader_without_password( $user ) ) {
 					$sent = Magic_Link::send_email( $user, $redirect );
@@ -2047,10 +2049,10 @@ final class Reader_Activation {
 						return self::send_auth_form_response( new \WP_Error( 'unauthorized', \is_wp_error( $sent ) ? $sent->get_error_message() : __( 'We encountered an error sending an authentication link. Please try again.', 'newspack-plugin' ) ) );
 					}
 					$payload['action'] = 'otp';
-					return self::send_auth_form_response( $payload, false );
+					break;
 				} else {
 					$payload['action'] = 'pwd';
-					return self::send_auth_form_response( $payload, false );
+					break;
 				}
 			case 'pwd':
 				if ( empty( $password ) ) {
@@ -2062,15 +2064,17 @@ final class Reader_Activation {
 				}
 				$authenticated            = self::set_current_reader( $user->ID );
 				$payload['authenticated'] = \is_wp_error( $authenticated ) ? 0 : 1;
-				return self::send_auth_form_response( $payload, false );
+				$metadata['login_method'] = 'auth-form-password';
+				break;
 			case 'link':
 				$sent = Magic_Link::send_email( $user, $redirect );
 				if ( true !== $sent ) {
 					return self::send_auth_form_response( new \WP_Error( 'unauthorized', \is_wp_error( $sent ) ? $sent->get_error_message() : __( 'We encountered an error sending an authentication link. Please try again.', 'newspack-plugin' ) ) );
 				}
-				return self::send_auth_form_response( $payload, $magic_link_label );
+				$message = $magic_link_label;
+				break;
 			case 'register':
-				$metadata = [ 'registration_method' => 'auth-form' ];
+				$metadata['registration_method'] = 'auth-form';
 				if ( ! empty( $lists ) ) {
 					$metadata['lists'] = $lists;
 				}
@@ -2080,14 +2084,6 @@ final class Reader_Activation {
 				if ( ! empty( $current_page_url ) ) {
 					$metadata['current_page_url'] = $current_page_url;
 				}
-
-				/**
-				 * Filters the metadata to be saved for a reader registered via the auth modal.
-				 *
-				 * @param array  $metadata Metadata.
-				 * @param string $email    Email address of the reader.
-				 */
-				$metadata = apply_filters( 'newspack_auth_form_metadata', $metadata, $email );
 
 				$user_id = self::register_reader( $email, '', true, $metadata );
 				if ( false === $user_id ) {
@@ -2116,10 +2112,25 @@ final class Reader_Activation {
 
 				$payload['registered']    = 1;
 				$payload['authenticated'] = 1;
-				return self::send_auth_form_response( $payload, false );
+				break;
 		}
-	}
 
+		/**
+		 * Filters the metadata to be saved for a reader registered via the auth modal.
+		 *
+		 * @param array  $metadata Metadata.
+		 * @param string $email    Email address of the reader.
+		 */
+		$metadata = apply_filters( 'newspack_auth_form_metadata', $metadata, $email );
+		if ( isset( $metadata['gate_post_id'] ) ) {
+			$payload['gate_post_id'] = $metadata['gate_post_id'];
+		}
+		if ( isset( $metadata['newspack_popup_id'] ) ) {
+			$payload['newspack_popup_id'] = $metadata['newspack_popup_id'];
+		}
+		$payload['metadata'] = $metadata;
+		return self::send_auth_form_response( $payload, $message );
+	}
 
 	/**
 	 * Check if current reader has its email verified.

--- a/src/blocks/reader-registration/index.php
+++ b/src/blocks/reader-registration/index.php
@@ -202,6 +202,14 @@ function render_block( $attrs, $content ) {
 				<?php endif; ?>
 				<input type="hidden" name="<?php echo esc_attr( FORM_ACTION ); ?>" value="<?php echo esc_attr( FORM_ACTION ); ?>" />
 				<div class="newspack-registration__form-content">
+				<?php
+				/**
+				 * Action to add custom fields before the form fields of the registration block.
+				 *
+				 * @param array $attrs Block attributes.
+				 */
+				do_action( 'newspack_registration_before_form_fields', $attrs );
+				?>
 					<?php
 					if ( ! empty( $lists ) ) {
 						if ( 1 === count( $lists ) && $attrs['hideSubscriptionInput'] ) {

--- a/src/blocks/reader-registration/index.php
+++ b/src/blocks/reader-registration/index.php
@@ -200,15 +200,7 @@ function render_block( $attrs, $content ) {
 				<?php if ( ! empty( $attrs['description'] ) ) : ?>
 					<p class="newspack-registration__description"><?php echo \wp_kses_post( $attrs['description'] ); ?></p>
 				<?php endif; ?>
-				<?php \wp_nonce_field( FORM_ACTION, FORM_ACTION ); ?>
-				<?php
-				/**
-				 * Action to add custom fields before the form fields of the registration block.
-				 *
-				 * @param array $attrs Block attributes.
-				 */
-				do_action( 'newspack_registration_before_form_fields', $attrs );
-				?>
+				<input type="hidden" name="<?php echo esc_attr( FORM_ACTION ); ?>" value="<?php echo esc_attr( FORM_ACTION ); ?>" />
 				<div class="newspack-registration__form-content">
 					<?php
 					if ( ! empty( $lists ) ) {
@@ -377,20 +369,24 @@ function send_form_response( $data, $message = '' ) {
  */
 function process_form() {
 	// No need to process form values if Reader Activation is disabled.
-	if ( ! Reader_Activation::is_enabled() ) {
+	if ( ! Reader_Activation::is_enabled() || \is_user_logged_in() ) {
 		return;
 	}
+
+	$action = filter_input( INPUT_POST, FORM_ACTION, FILTER_SANITIZE_SPECIAL_CHARS );
 
 	// No need to proceed if we don't have the required params.
-	if ( ! isset( $_REQUEST[ FORM_ACTION ] ) || ! \wp_verify_nonce( \sanitize_text_field( $_REQUEST[ FORM_ACTION ] ), FORM_ACTION ) ) {
+	if ( empty( $action ) || $action !== FORM_ACTION ) {
 		return;
 	}
 
+	$honeypot_trap = filter_input( INPUT_POST, 'email', FILTER_SANITIZE_EMAIL );
+
 	// Honeypot trap.
-	if ( ! empty( $_REQUEST['email'] ) ) {
+	if ( ! empty( $honeypot_trap ) ) {
 		return send_form_response(
 			[
-				'email'         => \sanitize_email( $_REQUEST['email'] ),
+				'email'         => \sanitize_email( $honeypot_trap ),
 				'authenticated' => true,
 				'existing_user' => false,
 			]
@@ -411,13 +407,13 @@ function process_form() {
 
 	// Note that that the "true" email address field is called `npe` due to the honeypot strategy.
 	// The honeypot field is called `email` to hopefully capture bots that might be looking for such a field.
-	$email = isset( $_REQUEST['npe'] ) ? \sanitize_email( $_REQUEST['npe'] ) : '';
+	$email = filter_input( INPUT_POST, 'npe', FILTER_SANITIZE_EMAIL );
 	if ( empty( $email ) ) {
 		return send_form_response( new \WP_Error( 'invalid_email', __( 'You must enter a valid email address.', 'newspack-plugin' ) ) );
 	}
 
+	$lists = filter_input( INPUT_POST, 'lists', FILTER_SANITIZE_SPECIAL_CHARS, FILTER_REQUIRE_ARRAY );
 	$metadata = [];
-	$lists    = array_map( 'sanitize_text_field', isset( $_REQUEST['lists'] ) ? $_REQUEST['lists'] : [] );
 	if ( ! empty( $lists ) ) {
 		$metadata['lists'] = $lists;
 	}

--- a/src/blocks/reader-registration/index.php
+++ b/src/blocks/reader-registration/index.php
@@ -377,7 +377,7 @@ function send_form_response( $data, $message = '' ) {
  */
 function process_form() {
 	// No need to process form values if Reader Activation is disabled.
-	if ( ! Reader_Activation::is_enabled() || \is_user_logged_in() ) {
+	if ( ! Reader_Activation::is_enabled() ) {
 		return;
 	}
 

--- a/src/reader-activation-auth/auth-form.js
+++ b/src/reader-activation-auth/auth-form.js
@@ -292,13 +292,20 @@ window.newspackRAS.push( function ( readerActivation ) {
 					}
 				}
 				if ( status === 200 ) {
-					if ( data ) {
+					if ( data?.email ) {
 						readerActivation.setReaderEmail( data.email );
 						readerActivation.setAuthenticated( !! data.authenticated );
+						const activity = { email: data.email };
+						if ( data.metadata?.gate_post_id ) {
+							activity.gate_post_id = data.metadata.gate_post_id;
+						}
+						if ( data.metadata?.newspack_popup_id ) {
+							activity.newspack_popup_id = data.metadata.newspack_popup_id;
+						}
 						if ( data.registered ) {
-							readerActivation.dispatchActivity( 'reader_registered', { email: data.email, registration_method: 'auth-form' } );
+							readerActivation.dispatchActivity( 'reader_registered', { ...activity, registration_method: data.metadata.registration_method || 'auth-form' } );
 						} else if ( data.authenticated ) {
-							readerActivation.dispatchActivity( 'reader_logged_in', { email: data.email, login_method: 'auth-form' } );
+							readerActivation.dispatchActivity( 'reader_logged_in', { ...activity, login_method: data.metadata.login_method || 'auth-form' } );
 						}
 					}
 
@@ -395,8 +402,12 @@ window.newspackRAS.push( function ( readerActivation ) {
 				}
 
 				if ( 'otp' === action ) {
+					const code = { code: body.get( 'otp_code' ) };
+					if ( body.get( 'memberships_content_gate' ) ) {
+						code.memberships_content_gate = body.get( 'memberships_content_gate' );
+					}
 					readerActivation
-						.authenticateOTP( body.get( 'otp_code' ) )
+						.authenticateOTP( code )
 						.then( data => {
 							form.endLoginFlow( data.message, 200, data );
 						} )

--- a/src/reader-activation-auth/auth-form.js
+++ b/src/reader-activation-auth/auth-form.js
@@ -296,11 +296,12 @@ window.newspackRAS.push( function ( readerActivation ) {
 						readerActivation.setReaderEmail( data.email );
 						readerActivation.setAuthenticated( !! data.authenticated );
 						const activity = { email: data.email };
-						if ( data.metadata?.gate_post_id ) {
-							activity.gate_post_id = data.metadata.gate_post_id;
+						const body = new FormData( form );
+						if ( data.metadata?.gate_post_id || body.has( 'memberships_content_gate' ) ) {
+							activity.gate_post_id = data.metadata.gate_post_id || body.get( 'memberships_content_gate' );
 						}
-						if ( data.metadata?.newspack_popup_id ) {
-							activity.newspack_popup_id = data.metadata.newspack_popup_id;
+						if ( data.metadata?.newspack_popup_id || body.has( 'newspack_popup_id' ) ) {
+							activity.newspack_popup_id = data.metadata.newspack_popup_id || body.get( 'newspack_popup_id' );
 						}
 						if ( data.registered ) {
 							readerActivation.dispatchActivity( 'reader_registered', { ...activity, registration_method: data.metadata.registration_method || 'auth-form' } );
@@ -402,12 +403,8 @@ window.newspackRAS.push( function ( readerActivation ) {
 				}
 
 				if ( 'otp' === action ) {
-					const code = { code: body.get( 'otp_code' ) };
-					if ( body.get( 'memberships_content_gate' ) ) {
-						code.memberships_content_gate = body.get( 'memberships_content_gate' );
-					}
 					readerActivation
-						.authenticateOTP( code )
+						.authenticateOTP( body.get( 'otp_code' ) )
 						.then( data => {
 							form.endLoginFlow( data.message, 200, data );
 						} )

--- a/src/reader-activation/index.js
+++ b/src/reader-activation/index.js
@@ -263,11 +263,13 @@ export function getOTPTimeRemaining() {
 /**
  * Authenticate reader using an OTP code.
  *
- * @param {number} code OTP code.
+ * @param {Object} data                          Data.
+ * @param {number} data.code                     OTP code.
+ * @param {number} data.memberships_content_gate Gate post ID.
  *
  * @return {Promise} Promise.
  */
-export function authenticateOTP( code ) {
+export function authenticateOTP( { code, memberships_content_gate } ) {
 	return new Promise( ( resolve, reject ) => {
 		const hash = getOTPHash();
 		const email = getReader()?.email;
@@ -290,6 +292,7 @@ export function authenticateOTP( code ) {
 				email,
 				hash,
 				code,
+				...( memberships_content_gate && { memberships_content_gate } ),
 			} ),
 		} )
 			.then( response => response.json() )

--- a/src/reader-activation/index.js
+++ b/src/reader-activation/index.js
@@ -263,13 +263,11 @@ export function getOTPTimeRemaining() {
 /**
  * Authenticate reader using an OTP code.
  *
- * @param {Object} data                          Data.
- * @param {number} data.code                     OTP code.
- * @param {number} data.memberships_content_gate Gate post ID.
+ * @param {number} code OTP code.
  *
  * @return {Promise} Promise.
  */
-export function authenticateOTP( { code, memberships_content_gate } ) {
+export function authenticateOTP( code ) {
 	return new Promise( ( resolve, reject ) => {
 		const hash = getOTPHash();
 		const email = getReader()?.email;
@@ -292,7 +290,6 @@ export function authenticateOTP( { code, memberships_content_gate } ) {
 				email,
 				hash,
 				code,
-				...( memberships_content_gate && { memberships_content_gate } ),
 			} ),
 		} )
 			.then( response => response.json() )


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes issues with `reader_registered` and `reader_logged_in` activities losing the `gate_post_id` and `newspack_popup_id` params in certain cases.

Also removes nonce verification for the Reader Registration block form, which seems to be resulting in failed registration attempts in some cases where whole-page HTML is served from a cache.

### How to test the changes in this Pull Request:

Follow testing instructions from #3895, preferably using a site that has edge caching enabled. Ensure that:

- After a successful registration by any means from inside a content gate or a Campaigns prompt, the GA events for `np_reader_registration` should have `gate_post_id` or `newspack_popup_id` params attached.
- Events for `np_reader_logged_in` should have `gate_post_id` params if triggered from a `#signin_modal` link inside a content gate, whether using password or OTP.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->