### PR TITLE
fix: skip image error handler inside scripts

### DIFF
--- a/includes/class-default-image.php
+++ b/includes/class-default-image.php
@@ -120,22 +120,37 @@ class Default_Image {
 	 * @return string Modified content with onerror attributes.
 	 */
 	public static function add_onerror_to_images( $content ) {
-		$content = preg_replace_callback(
-			'/<img[^>]+>/i',
-			function ( $matches ) {
-				if ( strpos( $matches[0], 'onerror=' ) === false ) {
-					return preg_replace(
-						'/<img/',
-						'<img onerror="if (typeof newspackHandleImageError === \'function\') newspackHandleImageError(this);"',
-						$matches[0],
-						1
-					);
-				}
-				return $matches[0];
-			},
-			$content
-		);
-		return $content;
+		// First, split the content into parts that are inside script tags and parts that are not.
+		$parts = preg_split( '/(<script[^>]*>.*?<\/script>)/is', $content, -1, PREG_SPLIT_DELIM_CAPTURE );
+
+		$modified_content = '';
+		foreach ( $parts as $part ) {
+			// If this part is inside a script tag, don't modify it.
+			if ( preg_match( '/^<script[^>]*>.*?<\/script>$/is', $part ) ) {
+				$modified_content .= $part;
+				continue;
+			}
+
+			// For non-script parts, process image tags.
+			$part = preg_replace_callback(
+				'/<img[^>]+>/i',
+				function ( $matches ) {
+					if ( strpos( $matches[0], 'onerror=' ) === false ) {
+						return preg_replace(
+							'/<img/',
+							'<img onerror="if (typeof newspackHandleImageError === \'function\') newspackHandleImageError(this);"',
+							$matches[0],
+							1
+						);
+					}
+					return $matches[0];
+				},
+				$part
+			);
+			$modified_content .= $part;
+		}
+
+		return $modified_content;
 	}
 }
 Default_Image::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Prevent the image error handler from replacing the markup strings inside script tags, causing a js crash.

### How to test the changes in this Pull Request:

1. While on trunk, create a post with an image and an HTML block with the following:

```
<script>
var markup = '<img src="https://picsum.photos/500" />';
</script>
```

2. Visit the page and confirm you get a js crash
4. Checkout this branch, refresh the page and confirm you don't get the crash
5. Confirm the error handler is present for the image but not for the img markup inside the script

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->