### PR TITLE
feat: add Subscription Confirmation checkboxes for FTC compliance

### DIFF
--- a/includes/plugins/woocommerce-subscriptions/class-subscriptions-confirmation.php
+++ b/includes/plugins/woocommerce-subscriptions/class-subscriptions-confirmation.php
@@ -59,7 +59,7 @@ class Subscriptions_Confirmation {
 
 		if ( Reader_Activation::is_terms_confirmation_enabled() ) {
 			if ( ! isset( $_POST['newspack_subscription_terms_confirmation'] ) || '1' !== $_POST['newspack_subscription_terms_confirmation'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
-				wc_add_notice( esc_html__( 'You must agree to the terms & conditions before proceeding.', 'newspack-plugin' ), 'error' );
+				wc_add_notice( esc_html__( 'You must agree to the Terms & Conditions before proceeding.', 'newspack-plugin' ), 'error' );
 			}
 		}
 	}
@@ -84,6 +84,7 @@ class Subscriptions_Confirmation {
 		}
 		return $label;
 	}
+
 	/**
 	 * Add either the Subscription Confirmation or Terms & Conditions checkbox to the WooCommerce checkout form when enabled and when the cart contains a subscription product.
 	 */

--- a/includes/plugins/woocommerce-subscriptions/class-subscriptions-confirmation.php
+++ b/includes/plugins/woocommerce-subscriptions/class-subscriptions-confirmation.php
@@ -90,7 +90,7 @@ class Subscriptions_Confirmation {
 				array(
 					'type'     => 'checkbox',
 					'class'    => array( 'form-row-wide', 'newspack-subscription-confirmation-checkbox' ),
-					'label'    => '<span>' . Reader_Activation::get_terms_confirmation_text() . ' <a href="' . esc_url( Reader_Activation::get_terms_confirmation_link() ) . '">' . esc_html__( 'Read More', 'newspack-plugin' ) . '</a></span>',
+					'label'    => Reader_Activation::get_terms_confirmation_text(),
 					'required' => true,
 				)
 			);

--- a/includes/plugins/woocommerce-subscriptions/class-subscriptions-confirmation.php
+++ b/includes/plugins/woocommerce-subscriptions/class-subscriptions-confirmation.php
@@ -18,7 +18,7 @@ class Subscriptions_Confirmation {
 	 * Initialize hooks and filters.
 	 */
 	public static function init() {
-		if ( ! WooCommerce_Subscriptions::is_active() ) {
+		if ( ! class_exists( 'WooCommerce_Subscriptions' ) || ! WooCommerce_Subscriptions::is_active() ) {
 			return;
 		}
 		add_action( 'woocommerce_review_order_before_submit', [ __CLASS__, 'add_subscription_confirmation_checkboxes' ] );

--- a/includes/plugins/woocommerce-subscriptions/class-subscriptions-confirmation.php
+++ b/includes/plugins/woocommerce-subscriptions/class-subscriptions-confirmation.php
@@ -18,7 +18,7 @@ class Subscriptions_Confirmation {
 	 * Initialize hooks and filters.
 	 */
 	public static function init() {
-		if ( ! class_exists( 'WooCommerce_Subscriptions' ) || ! WooCommerce_Subscriptions::is_active() ) {
+		if ( ! class_exists( '\Newspack\WooCommerce_Subscriptions' ) || ! WooCommerce_Subscriptions::is_active() ) {
 			return;
 		}
 		add_action( 'woocommerce_review_order_before_submit', [ __CLASS__, 'add_subscription_confirmation_checkboxes' ] );

--- a/includes/plugins/woocommerce-subscriptions/class-subscriptions-confirmation.php
+++ b/includes/plugins/woocommerce-subscriptions/class-subscriptions-confirmation.php
@@ -21,8 +21,8 @@ class Subscriptions_Confirmation {
 		if ( ! WooCommerce_Subscriptions::is_enabled() ) {
 			return;
 		}
-		add_action( 'woocommerce_review_order_before_submit', [ __CLASS__, 'add_subscription_confirmation_checkbox' ] );
-		add_action( 'woocommerce_checkout_process', [ __CLASS__, 'validate_subscription_confirmation_checkbox' ] );
+		add_action( 'woocommerce_review_order_before_submit', [ __CLASS__, 'add_subscription_confirmation_checkboxes' ] );
+		add_action( 'woocommerce_checkout_process', [ __CLASS__, 'validate_subscription_confirmation_checkboxes' ] );
 	}
 
 	/**
@@ -43,36 +43,57 @@ class Subscriptions_Confirmation {
 	}
 
 	/**
-	 * Make sure the subscription confirmation checkbox is checked before checkout can be completed.
+	 * Make sure the subscription confirmation or Terms & Conditions checkboxes are checked before checkout can be completed.
 	 */
-	public static function validate_subscription_confirmation_checkbox() {
+	public static function validate_subscription_confirmation_checkboxes() {
 		// Skip validation if we don't have a subscription in the cart, or if we're on the first screen of the modal checkout.
 		if ( ! self::has_subscription_in_cart() || ( isset( $_POST['is_validation_only'] ) && '1' === $_POST['is_validation_only'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
 			return;
 		}
 
-		if ( ! isset( $_POST['newspack_subscription_confirmation'] ) || '1' !== $_POST['newspack_subscription_confirmation'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
-			wc_add_notice( esc_html__( 'You must agree to the subscription terms before proceeding.', 'newspack-plugin' ), 'error' );
+		if ( Reader_Activation::is_subscription_confirmation_enabled() ) {
+			if ( ! isset( $_POST['newspack_subscription_confirmation'] ) || '1' !== $_POST['newspack_subscription_confirmation'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+				wc_add_notice( esc_html__( 'You must agree to the subscription terms before proceeding.', 'newspack-plugin' ), 'error' );
+			}
+		}
+
+		if ( Reader_Activation::is_terms_confirmation_enabled() ) {
+			if ( ! isset( $_POST['newspack_subscription_terms_confirmation'] ) || '1' !== $_POST['newspack_subscription_terms_confirmation'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+				wc_add_notice( esc_html__( 'You must agree to the terms & conditions before proceeding.', 'newspack-plugin' ), 'error' );
+			}
 		}
 	}
 
 	/**
-	 * Add a checkbox to the WooCommerce checkout form when enabled and when the cart contains a subscription product.
-	 * This checkbox will appear before the submit button.
+	 * Add either the Subscription Confirmation or Terms & Conditions checkbox to the WooCommerce checkout form when enabled and when the cart contains a subscription product.
 	 */
-	public static function add_subscription_confirmation_checkbox() {
-		if ( ! Reader_Activation::is_subscription_confirmation_enabled() || ! self::has_subscription_in_cart() ) {
+	public static function add_subscription_confirmation_checkboxes() {
+		if ( ! self::has_subscription_in_cart() ) {
 			return;
 		}
 
-		woocommerce_form_field(
-			'newspack_subscription_confirmation',
-			array(
-				'type'     => 'checkbox',
-				'class'    => array( 'form-row-wide', 'newspack-subscription-confirmation-checkbox' ),
-				'label'    => Reader_Activation::get_subscription_confirmation_text(),
-				'required' => true,
-			)
-		);
+		if ( Reader_Activation::is_subscription_confirmation_enabled() ) {
+			woocommerce_form_field(
+				'newspack_subscription_confirmation',
+				array(
+					'type'     => 'checkbox',
+					'class'    => array( 'form-row-wide', 'newspack-subscription-confirmation-checkbox' ),
+					'label'    => Reader_Activation::get_subscription_confirmation_text(),
+					'required' => true,
+				)
+			);
+		}
+
+		if ( Reader_Activation::is_terms_confirmation_enabled() ) {
+			woocommerce_form_field(
+				'newspack_subscription_terms_confirmation',
+				array(
+					'type'     => 'checkbox',
+					'class'    => array( 'form-row-wide', 'newspack-subscription-confirmation-checkbox' ),
+					'label'    => '<span>' . Reader_Activation::get_terms_confirmation_text() . ' <a href="' . esc_url( Reader_Activation::get_terms_confirmation_link() ) . '">' . esc_html__( 'Read More', 'newspack-plugin' ) . '</a></span>',
+					'required' => true,
+				)
+			);
+		}
 	}
 }

--- a/includes/plugins/woocommerce-subscriptions/class-subscriptions-confirmation.php
+++ b/includes/plugins/woocommerce-subscriptions/class-subscriptions-confirmation.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * WooCommerce Subscriptions Confirmation class for FTC compliance.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Main class.
+ */
+class Subscriptions_Confirmation {
+
+	/**
+	 * Initialize hooks and filters.
+	 */
+	public static function init() {
+		if ( ! WooCommerce_Subscriptions::is_enabled() ) {
+			return;
+		}
+		add_action( 'woocommerce_review_order_before_submit', [ __CLASS__, 'add_subscription_confirmation_checkbox' ] );
+		add_action( 'woocommerce_checkout_process', [ __CLASS__, 'validate_subscription_confirmation_checkbox' ] );
+	}
+
+	/**
+	 * Check if the cart contains any subscription products.
+	 *
+	 * @return boolean Returns whether or not the cart contains a subscription product.
+	 */
+	private static function has_subscription_in_cart() {
+		if ( ! WC()->cart ) {
+			return false;
+		}
+		foreach ( WC()->cart->get_cart() as $cart_item ) {
+			if ( \WC_Subscriptions_Product::is_subscription( $cart_item['data'] ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Make sure the subscription confirmation checkbox is checked before checkout can be completed.
+	 */
+	public static function validate_subscription_confirmation_checkbox() {
+		// Skip validation if we don't have a subscription in the cart, or if we're on the first screen of the modal checkout.
+		if ( ! self::has_subscription_in_cart() || ( isset( $_POST['is_validation_only'] ) && '1' === $_POST['is_validation_only'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+			return;
+		}
+
+		if ( ! isset( $_POST['newspack_subscription_confirmation'] ) || '1' !== $_POST['newspack_subscription_confirmation'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+			wc_add_notice( esc_html__( 'You must agree to the subscription terms before proceeding.', 'newspack-plugin' ), 'error' );
+		}
+	}
+
+	/**
+	 * Add a checkbox to the WooCommerce checkout form when enabled and when the cart contains a subscription product.
+	 * This checkbox will appear before the submit button.
+	 */
+	public static function add_subscription_confirmation_checkbox() {
+		if ( ! Reader_Activation::is_subscription_confirmation_enabled() || ! self::has_subscription_in_cart() ) {
+			return;
+		}
+
+		woocommerce_form_field(
+			'newspack_subscription_confirmation',
+			array(
+				'type'     => 'checkbox',
+				'class'    => array( 'form-row-wide', 'newspack-subscription-confirmation-checkbox' ),
+				'label'    => Reader_Activation::get_subscription_confirmation_text(),
+				'required' => true,
+			)
+		);
+	}
+}

--- a/includes/plugins/woocommerce-subscriptions/class-subscriptions-confirmation.php
+++ b/includes/plugins/woocommerce-subscriptions/class-subscriptions-confirmation.php
@@ -18,7 +18,7 @@ class Subscriptions_Confirmation {
 	 * Initialize hooks and filters.
 	 */
 	public static function init() {
-		if ( ! WooCommerce_Subscriptions::is_enabled() ) {
+		if ( ! WooCommerce_Subscriptions::is_active() ) {
 			return;
 		}
 		add_action( 'woocommerce_review_order_before_submit', [ __CLASS__, 'add_subscription_confirmation_checkboxes' ] );

--- a/includes/plugins/woocommerce-subscriptions/class-subscriptions-confirmation.php
+++ b/includes/plugins/woocommerce-subscriptions/class-subscriptions-confirmation.php
@@ -65,6 +65,26 @@ class Subscriptions_Confirmation {
 	}
 
 	/**
+	 * Generate the label for the Terms & Conditions confirmation checkbox.
+	 *
+	 * @return string Returns the label for the Terms & Conditions confirmation checkbox.
+	 */
+	public static function generate_terms_confirmation_label() {
+		$label = Reader_Activation::get_terms_confirmation_text();
+		$url = Reader_Activation::get_terms_confirmation_url();
+		if ( $url ) {
+			if ( strpos( $label, '{{' ) !== false && strpos( $label, '}}' ) !== false ) {
+				// If the text includes {{ }}, replace it with the link.
+				$label = str_replace( '{{', '<a target="_blank" href="' . $url . '">', $label );
+				$label = str_replace( '}}', '</a>', $label );
+			} else {
+				// If the text doesn't include {{ }}, link the whole text string.
+				$label = '<a target="_blank" href="' . $url . '">' . $label . '</a>';
+			}
+		}
+		return $label;
+	}
+	/**
 	 * Add either the Subscription Confirmation or Terms & Conditions checkbox to the WooCommerce checkout form when enabled and when the cart contains a subscription product.
 	 */
 	public static function add_subscription_confirmation_checkboxes() {
@@ -90,7 +110,7 @@ class Subscriptions_Confirmation {
 				array(
 					'type'     => 'checkbox',
 					'class'    => array( 'form-row-wide', 'newspack-subscription-confirmation-checkbox' ),
-					'label'    => Reader_Activation::get_terms_confirmation_text(),
+					'label'    => self::generate_terms_confirmation_label(),
 					'required' => true,
 				)
 			);

--- a/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
+++ b/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
@@ -27,10 +27,12 @@ class WooCommerce_Subscriptions {
 		include_once __DIR__ . '/class-on-hold-duration.php';
 		include_once __DIR__ . '/class-renewal.php';
 		include_once __DIR__ . '/class-subscriptions-meta.php';
+		include_once __DIR__ . '/class-subscriptions-confirmation.php';
 
 		On_Hold_Duration::init();
 		Renewal::init();
 		Subscriptions_Meta::init();
+		Subscriptions_Confirmation::init();
 	}
 
 

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -373,7 +373,6 @@ final class Reader_Activation {
 			'woocommerce_subscription_confirmation_text'   => self::get_subscription_confirmation_text(),
 			'woocommerce_enable_terms_confirmation'        => false,
 			'woocommerce_terms_confirmation_text'          => self::get_terms_confirmation_text(),
-			'woocommerce_terms_confirmation_link'          => self::get_terms_confirmation_link(),
 		];
 
 		/**
@@ -2696,19 +2695,7 @@ final class Reader_Activation {
 	public static function get_terms_confirmation_text() {
 		return \get_option(
 			self::OPTIONS_PREFIX . 'woocommerce_terms_confirmation_text',
-			__( 'I have read and accept the Terms & Conditions.', 'newspack-plugin' )
-		);
-	}
-
-	/**
-	 * Get the link for the Terms & Conditions confirmation checkbox.
-	 *
-	 * @return string The link for the Terms & Conditions confirmation checkbox.
-	 */
-	public static function get_terms_confirmation_link() {
-		return \get_option(
-			self::OPTIONS_PREFIX . 'woocommerce_terms_confirmation_link',
-			__( '#', 'newspack-plugin' )
+			__( 'I have read and accept the <a href="#">Terms & Conditions</a>.', 'newspack-plugin' )
 		);
 	}
 
@@ -2727,7 +2714,6 @@ final class Reader_Activation {
 			'woocommerce_subscription_confirmation_text'   => self::get_subscription_confirmation_text(),
 			'woocommerce_enable_terms_confirmation'        => self::is_terms_confirmation_enabled(),
 			'woocommerce_terms_confirmation_text'          => self::get_terms_confirmation_text(),
-			'woocommerce_terms_confirmation_link'          => self::get_terms_confirmation_link(),
 		];
 	}
 }

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -372,6 +372,8 @@ final class Reader_Activation {
 			'woocommerce_enable_subscription_confirmation' => false,
 			'woocommerce_subscription_confirmation_text'   => self::get_subscription_confirmation_text(),
 			'woocommerce_enable_terms_confirmation'        => false,
+			'woocommerce_terms_confirmation_text'          => self::get_terms_confirmation_text(),
+			'woocommerce_terms_confirmation_link'          => self::get_terms_confirmation_link(),
 		];
 
 		/**
@@ -2678,6 +2680,39 @@ final class Reader_Activation {
 	}
 
 	/**
+	 * Return if the Terms & Conditions confirmation checkbox is enabled.
+	 *
+	 * @return bool Whether the Terms & Conditions confirmation checkbox is enabled.
+	 */
+	public static function is_terms_confirmation_enabled() {
+		return (bool) \get_option( self::OPTIONS_PREFIX . 'woocommerce_enable_terms_confirmation', false );
+	}
+
+	/**
+	 * Get the text label for the Terms & Conditions confirmation checkbox.
+	 *
+	 * @return string Returns either the default text label or a customized one.
+	 */
+	public static function get_terms_confirmation_text() {
+		return \get_option(
+			self::OPTIONS_PREFIX . 'woocommerce_terms_confirmation_text',
+			__( 'I have read and accept the Terms & Conditions.', 'newspack-plugin' )
+		);
+	}
+
+	/**
+	 * Get the link for the Terms & Conditions confirmation checkbox.
+	 *
+	 * @return string The link for the Terms & Conditions confirmation checkbox.
+	 */
+	public static function get_terms_confirmation_link() {
+		return \get_option(
+			self::OPTIONS_PREFIX . 'woocommerce_terms_confirmation_link',
+			__( '#', 'newspack-plugin' )
+		);
+	}
+
+	/**
 	 * Get the checkout configuration.
 	 *
 	 * @return array The checkout configuration.
@@ -2690,6 +2725,9 @@ final class Reader_Activation {
 			'woocommerce_post_checkout_registration_success_text' => self::get_post_checkout_registration_success_text(),
 			'woocommerce_enable_subscription_confirmation' => self::is_subscription_confirmation_enabled(),
 			'woocommerce_subscription_confirmation_text'   => self::get_subscription_confirmation_text(),
+			'woocommerce_enable_terms_confirmation'        => self::is_terms_confirmation_enabled(),
+			'woocommerce_terms_confirmation_text'          => self::get_terms_confirmation_text(),
+			'woocommerce_terms_confirmation_link'          => self::get_terms_confirmation_link(),
 		];
 	}
 }

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -373,6 +373,7 @@ final class Reader_Activation {
 			'woocommerce_subscription_confirmation_text'   => self::get_subscription_confirmation_text(),
 			'woocommerce_enable_terms_confirmation'        => false,
 			'woocommerce_terms_confirmation_text'          => self::get_terms_confirmation_text(),
+			'woocommerce_terms_confirmation_url'           => self::get_terms_confirmation_url(),
 		];
 
 		/**
@@ -2695,8 +2696,17 @@ final class Reader_Activation {
 	public static function get_terms_confirmation_text() {
 		return \get_option(
 			self::OPTIONS_PREFIX . 'woocommerce_terms_confirmation_text',
-			__( 'I have read and accept the <a href="#">Terms & Conditions</a>.', 'newspack-plugin' )
+			__( 'I have read and accept the {{Terms & Conditions}}.', 'newspack-plugin' )
 		);
+	}
+
+	/**
+	 * Get the URL for the Terms & Conditions confirmation checkbox.
+	 *
+	 * @return string Returns the URL for the Terms & Conditions confirmation checkbox.
+	 */
+	public static function get_terms_confirmation_url() {
+		return \get_option( self::OPTIONS_PREFIX . 'woocommerce_terms_confirmation_url', '' );
 	}
 
 	/**
@@ -2714,6 +2724,7 @@ final class Reader_Activation {
 			'woocommerce_subscription_confirmation_text'   => self::get_subscription_confirmation_text(),
 			'woocommerce_enable_terms_confirmation'        => self::is_terms_confirmation_enabled(),
 			'woocommerce_terms_confirmation_text'          => self::get_terms_confirmation_text(),
+			'woocommerce_terms_confirmation_url'           => self::get_terms_confirmation_url(),
 		];
 	}
 }

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -346,29 +346,32 @@ final class Reader_Activation {
 	 */
 	private static function get_settings_config() {
 		$settings_config = [
-			'enabled'                                  => false,
-			'enabled_account_link'                     => true,
-			'account_link_menu_locations'              => [ 'tertiary-menu' ],
-			'newsletters_label'                        => self::get_reader_activation_labels( 'newsletters_cta' ),
-			'use_custom_lists'                         => false,
-			'newsletter_lists'                         => [],
-			'terms_text'                               => '',
-			'terms_url'                                => '',
-			'sync_esp'                                 => true,
-			'metadata_prefix'                          => Sync\Metadata::get_prefix(),
-			'metadata_fields'                          => Sync\Metadata::get_fields(),
-			'sync_esp_delete'                          => true,
-			'active_campaign_master_list'              => '',
-			'constant_contact_list_id'                 => '',
-			'mailchimp_audience_id'                    => '',
-			'mailchimp_reader_default_status'          => 'transactional',
-			'sender_name'                              => Emails::get_from_name(),
-			'sender_email_address'                     => Emails::get_from_email(),
-			'contact_email_address'                    => Emails::get_reply_to_email(),
-			'woocommerce_registration_required'        => false,
-			'woocommerce_checkout_privacy_policy_text' => self::get_checkout_privacy_policy_text(),
-			'woocommerce_post_checkout_success_text'   => self::get_post_checkout_success_text(),
+			'enabled'                                      => false,
+			'enabled_account_link'                         => true,
+			'account_link_menu_locations'                  => [ 'tertiary-menu' ],
+			'newsletters_label'                            => self::get_reader_activation_labels( 'newsletters_cta' ),
+			'use_custom_lists'                             => false,
+			'newsletter_lists'                             => [],
+			'terms_text'                                   => '',
+			'terms_url'                                    => '',
+			'sync_esp'                                     => true,
+			'metadata_prefix'                              => Sync\Metadata::get_prefix(),
+			'metadata_fields'                              => Sync\Metadata::get_fields(),
+			'sync_esp_delete'                              => true,
+			'active_campaign_master_list'                  => '',
+			'constant_contact_list_id'                     => '',
+			'mailchimp_audience_id'                        => '',
+			'mailchimp_reader_default_status'              => 'transactional',
+			'sender_name'                                  => Emails::get_from_name(),
+			'sender_email_address'                         => Emails::get_from_email(),
+			'contact_email_address'                        => Emails::get_reply_to_email(),
+			'woocommerce_registration_required'            => false,
+			'woocommerce_checkout_privacy_policy_text'     => self::get_checkout_privacy_policy_text(),
+			'woocommerce_post_checkout_success_text'       => self::get_post_checkout_success_text(),
 			'woocommerce_post_checkout_registration_success_text' => self::get_post_checkout_registration_success_text(),
+			'woocommerce_enable_subscription_confirmation' => false,
+			'woocommerce_subscription_confirmation_text'   => self::get_subscription_confirmation_text(),
+			'woocommerce_enable_terms_confirmation'        => false,
 		];
 
 		/**
@@ -2651,16 +2654,42 @@ final class Reader_Activation {
 	}
 
 	/**
+	 * Return if the Subscription confirmation checkbox is enabled.
+	 *
+	 * @return bool Whether the subscription confirmation checkbox is enabled.
+	 */
+	public static function is_subscription_confirmation_enabled() {
+		return (bool) \get_option( self::OPTIONS_PREFIX . 'woocommerce_enable_subscription_confirmation', false );
+	}
+
+	/**
+	 * Get the text label for the subscription confirmation checkbox.
+	 *
+	 * @return string Returns either the default text label or a customized one.
+	 */
+	public static function get_subscription_confirmation_text() {
+		return \get_option(
+			self::OPTIONS_PREFIX . 'woocommerce_subscription_confirmation_text',
+			__(
+				'I understand this is a recurring subscription and that I can cancel anytime through the My Account Page.',
+				'newspack-plugin'
+			)
+		);
+	}
+
+	/**
 	 * Get the checkout configuration.
 	 *
 	 * @return array The checkout configuration.
 	 */
 	public static function get_checkout_configuration() {
 		return [
-			'woocommerce_registration_required'        => self::is_woocommerce_registration_required(),
-			'woocommerce_post_checkout_success_text'   => self::get_post_checkout_success_text(),
-			'woocommerce_checkout_privacy_policy_text' => self::get_checkout_privacy_policy_text(),
+			'woocommerce_registration_required'            => self::is_woocommerce_registration_required(),
+			'woocommerce_post_checkout_success_text'       => self::get_post_checkout_success_text(),
+			'woocommerce_checkout_privacy_policy_text'     => self::get_checkout_privacy_policy_text(),
 			'woocommerce_post_checkout_registration_success_text' => self::get_post_checkout_registration_success_text(),
+			'woocommerce_enable_subscription_confirmation' => self::is_subscription_confirmation_enabled(),
+			'woocommerce_subscription_confirmation_text'   => self::get_subscription_confirmation_text(),
 		];
 	}
 }

--- a/includes/wizards/audience/class-audience-wizard.php
+++ b/includes/wizards/audience/class-audience-wizard.php
@@ -876,8 +876,10 @@ class Audience_Wizard extends Wizard {
 	public function api_get_subscription_settings() {
 		$settings = [
 			'woocommerce_enable_subscription_confirmation' => get_option( \Newspack\Reader_Activation::OPTIONS_PREFIX . 'woocommerce_enable_subscription_confirmation', false ),
-			'woocommerce_subscription_confirmation_text'   => get_option( 'woocommerce_subscription_confirmation_text', Reader_Activation::get_subscription_confirmation_text() ),
-			'woocommerce_enable_terms_confirmation'        => get_option( 'woocommerce_enable_terms_confirmation', false ),
+			'woocommerce_subscription_confirmation_text'   => get_option( \Newspack\Reader_Activation::OPTIONS_PREFIX . 'woocommerce_subscription_confirmation_text', Reader_Activation::get_subscription_confirmation_text() ),
+			'woocommerce_enable_terms_confirmation'        => get_option( \Newspack\Reader_Activation::OPTIONS_PREFIX . 'woocommerce_enable_terms_confirmation', false ),
+			'woocommerce_terms_confirmation_text'          => get_option( \Newspack\Reader_Activation::OPTIONS_PREFIX . 'woocommerce_terms_confirmation_text', Reader_Activation::get_terms_confirmation_text() ),
+			'woocommerce_terms_confirmation_link'          => get_option( \Newspack\Reader_Activation::OPTIONS_PREFIX . 'woocommerce_terms_confirmation_link', Reader_Activation::get_terms_confirmation_link() ),
 		];
 		return rest_ensure_response( $settings );
 	}
@@ -900,11 +902,19 @@ class Audience_Wizard extends Wizard {
 		}
 
 		if ( isset( $params['woocommerce_subscription_confirmation_text'] ) ) {
-			update_option( 'woocommerce_subscription_confirmation_text', sanitize_text_field( $params['woocommerce_subscription_confirmation_text'] ) );
+			update_option( \Newspack\Reader_Activation::OPTIONS_PREFIX . 'woocommerce_subscription_confirmation_text', sanitize_text_field( $params['woocommerce_subscription_confirmation_text'] ) );
 		}
 
 		if ( isset( $params['woocommerce_enable_terms_confirmation'] ) ) {
-			update_option( 'woocommerce_enable_terms_confirmation', (bool) $params['woocommerce_enable_terms_confirmation'] );
+			update_option( \Newspack\Reader_Activation::OPTIONS_PREFIX . 'woocommerce_enable_terms_confirmation', (bool) $params['woocommerce_enable_terms_confirmation'] );
+		}
+
+		if ( isset( $params['woocommerce_terms_confirmation_text'] ) ) {
+			update_option( \Newspack\Reader_Activation::OPTIONS_PREFIX . 'woocommerce_terms_confirmation_text', sanitize_text_field( $params['woocommerce_terms_confirmation_text'] ) );
+		}
+
+		if ( isset( $params['woocommerce_terms_confirmation_link'] ) ) {
+			update_option( \Newspack\Reader_Activation::OPTIONS_PREFIX . 'woocommerce_terms_confirmation_link', sanitize_text_field( $params['woocommerce_terms_confirmation_link'] ) );
 		}
 
 		return $this->api_get_subscription_settings();

--- a/includes/wizards/audience/class-audience-wizard.php
+++ b/includes/wizards/audience/class-audience-wizard.php
@@ -879,7 +879,6 @@ class Audience_Wizard extends Wizard {
 			'woocommerce_subscription_confirmation_text'   => get_option( \Newspack\Reader_Activation::OPTIONS_PREFIX . 'woocommerce_subscription_confirmation_text', Reader_Activation::get_subscription_confirmation_text() ),
 			'woocommerce_enable_terms_confirmation'        => get_option( \Newspack\Reader_Activation::OPTIONS_PREFIX . 'woocommerce_enable_terms_confirmation', false ),
 			'woocommerce_terms_confirmation_text'          => get_option( \Newspack\Reader_Activation::OPTIONS_PREFIX . 'woocommerce_terms_confirmation_text', Reader_Activation::get_terms_confirmation_text() ),
-			'woocommerce_terms_confirmation_link'          => get_option( \Newspack\Reader_Activation::OPTIONS_PREFIX . 'woocommerce_terms_confirmation_link', Reader_Activation::get_terms_confirmation_link() ),
 		];
 		return rest_ensure_response( $settings );
 	}
@@ -910,11 +909,7 @@ class Audience_Wizard extends Wizard {
 		}
 
 		if ( isset( $params['woocommerce_terms_confirmation_text'] ) ) {
-			update_option( \Newspack\Reader_Activation::OPTIONS_PREFIX . 'woocommerce_terms_confirmation_text', sanitize_text_field( $params['woocommerce_terms_confirmation_text'] ) );
-		}
-
-		if ( isset( $params['woocommerce_terms_confirmation_link'] ) ) {
-			update_option( \Newspack\Reader_Activation::OPTIONS_PREFIX . 'woocommerce_terms_confirmation_link', sanitize_text_field( $params['woocommerce_terms_confirmation_link'] ) );
+			update_option( \Newspack\Reader_Activation::OPTIONS_PREFIX . 'woocommerce_terms_confirmation_text', wp_kses_post( $params['woocommerce_terms_confirmation_text'] ) );
 		}
 
 		return $this->api_get_subscription_settings();

--- a/includes/wizards/audience/class-audience-wizard.php
+++ b/includes/wizards/audience/class-audience-wizard.php
@@ -879,6 +879,7 @@ class Audience_Wizard extends Wizard {
 			'woocommerce_subscription_confirmation_text'   => get_option( \Newspack\Reader_Activation::OPTIONS_PREFIX . 'woocommerce_subscription_confirmation_text', Reader_Activation::get_subscription_confirmation_text() ),
 			'woocommerce_enable_terms_confirmation'        => get_option( \Newspack\Reader_Activation::OPTIONS_PREFIX . 'woocommerce_enable_terms_confirmation', false ),
 			'woocommerce_terms_confirmation_text'          => get_option( \Newspack\Reader_Activation::OPTIONS_PREFIX . 'woocommerce_terms_confirmation_text', Reader_Activation::get_terms_confirmation_text() ),
+			'woocommerce_terms_confirmation_url'           => get_option( \Newspack\Reader_Activation::OPTIONS_PREFIX . 'woocommerce_terms_confirmation_url', Reader_Activation::get_terms_confirmation_url() ),
 		];
 		return rest_ensure_response( $settings );
 	}
@@ -909,7 +910,11 @@ class Audience_Wizard extends Wizard {
 		}
 
 		if ( isset( $params['woocommerce_terms_confirmation_text'] ) ) {
-			update_option( \Newspack\Reader_Activation::OPTIONS_PREFIX . 'woocommerce_terms_confirmation_text', wp_kses_post( $params['woocommerce_terms_confirmation_text'] ) );
+			update_option( \Newspack\Reader_Activation::OPTIONS_PREFIX . 'woocommerce_terms_confirmation_text', sanitize_text_field( $params['woocommerce_terms_confirmation_text'] ) );
+		}
+
+		if ( isset( $params['woocommerce_terms_confirmation_url'] ) ) {
+			update_option( \Newspack\Reader_Activation::OPTIONS_PREFIX . 'woocommerce_terms_confirmation_url', sanitize_url( $params['woocommerce_terms_confirmation_url'] ) );
 		}
 
 		return $this->api_get_subscription_settings();

--- a/includes/wizards/audience/class-audience-wizard.php
+++ b/includes/wizards/audience/class-audience-wizard.php
@@ -353,6 +353,25 @@ class Audience_Wizard extends Wizard {
 			]
 		);
 
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->slug . '/subscription-settings',
+			[
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'api_get_subscription_settings' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+			]
+		);
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->slug . '/subscription-settings',
+			[
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => [ $this, 'api_update_subscription_settings' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+			]
+		);
+
 		// Save Stripe info.
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
@@ -847,5 +866,47 @@ class Audience_Wizard extends Wizard {
 		}
 
 		return $submenu_file;
+	}
+
+	/**
+	 * Get subscription settings.
+	 *
+	 * @return WP_REST_Response Response with the settings.
+	 */
+	public function api_get_subscription_settings() {
+		$settings = [
+			'woocommerce_enable_subscription_confirmation' => get_option( \Newspack\Reader_Activation::OPTIONS_PREFIX . 'woocommerce_enable_subscription_confirmation', false ),
+			'woocommerce_subscription_confirmation_text'   => get_option( 'woocommerce_subscription_confirmation_text', Reader_Activation::get_subscription_confirmation_text() ),
+			'woocommerce_enable_terms_confirmation'        => get_option( 'woocommerce_enable_terms_confirmation', false ),
+		];
+		return rest_ensure_response( $settings );
+	}
+
+	/**
+	 * Update subscription settings.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response Response with the updated settings.
+	 */
+	public function api_update_subscription_settings( $request ) {
+		$wc_installed = 'active' === Plugin_Manager::get_managed_plugin_status( 'woocommerce' );
+		if ( ! $wc_installed ) {
+			return $this->api_get_subscription_settings();
+		}
+
+		$params = $request->get_params();
+		if ( isset( $params['woocommerce_enable_subscription_confirmation'] ) ) {
+			update_option( \Newspack\Reader_Activation::OPTIONS_PREFIX . 'woocommerce_enable_subscription_confirmation', (bool) $params['woocommerce_enable_subscription_confirmation'] );
+		}
+
+		if ( isset( $params['woocommerce_subscription_confirmation_text'] ) ) {
+			update_option( 'woocommerce_subscription_confirmation_text', sanitize_text_field( $params['woocommerce_subscription_confirmation_text'] ) );
+		}
+
+		if ( isset( $params['woocommerce_enable_terms_confirmation'] ) ) {
+			update_option( 'woocommerce_enable_terms_confirmation', (bool) $params['woocommerce_enable_terms_confirmation'] );
+		}
+
+		return $this->api_get_subscription_settings();
 	}
 }

--- a/src/newspack-ui/scss/elements/forms/_labels.scss
+++ b/src/newspack-ui/scss/elements/forms/_labels.scss
@@ -55,6 +55,10 @@
 				grid-row-start: 1;
 			}
 		}
+
+		a {
+			text-decoration: underline;
+		}
 	}
 
 	&__label-optional {

--- a/src/wizards/audience/components/subscription-settings/index.tsx
+++ b/src/wizards/audience/components/subscription-settings/index.tsx
@@ -3,7 +3,8 @@
  */
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { ToggleControl, TextareaControl } from '@wordpress/components';
+import { ToggleControl, TextareaControl, TextControl } from '@wordpress/components';
+import { Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies.
@@ -26,14 +27,63 @@ function SubscriptionSettings() {
 		[]
 	);
 
-	const onChange = ( value: any, key: string ) =>
+	// Toggle between the Subscription confirmation and Terms & Conditions confirmation.
+	// Only one can be enabled at a time.
+	const onChange = ( value: any, key: string ) => {
+		// If enabling Subscription confirmation, disable terms confirmation.
+		if ( key === 'woocommerce_enable_subscription_confirmation' && value ) {
+			updateWizardSettings( {
+				slug: DATA_STORE_KEY,
+				path: ['woocommerce_enable_terms_confirmation'],
+				value: false,
+			} );
+		}
+		// If enabling terms confirmation, disable subscription confirmation.
+		if ( key === 'woocommerce_enable_terms_confirmation' && value ) {
+			updateWizardSettings( {
+				slug: DATA_STORE_KEY,
+				path: ['woocommerce_enable_subscription_confirmation'],
+				value: false,
+			} );
+		}
+
+		// Update the original setting.
 		updateWizardSettings( {
 			slug: DATA_STORE_KEY,
 			path: [ key ],
 			value,
 		} );
+	};
 
+	// When saving, if any of the text fields are empty, set the default text.
 	function onSave() {
+		// Use the default text when the Subscription Confirmation label is empty.
+		if ( ! config.woocommerce_subscription_confirmation_text ) {
+			updateWizardSettings( {
+				slug: DATA_STORE_KEY,
+				path: ['woocommerce_subscription_confirmation_text'],
+				value: __( 'I understand this is a recurring subscription and that I can cancel anytime through the My Account Page.', 'newspack-plugin' ),
+			} );
+		}
+
+		// Use the default text when the Terms & Conditions confirmation label is empty.
+		if ( ! config.woocommerce_terms_confirmation_text ) {
+			updateWizardSettings({
+				slug: DATA_STORE_KEY,
+				path: ['woocommerce_terms_confirmation_text'],
+				value: __( 'I have read and accept the Terms & Conditions.', 'newspack-plugin' ),
+			} );
+		}
+
+		// Use the default URL when the Terms & Conditions link is empty.
+		if ( ! config.woocommerce_terms_confirmation_link ) {
+			updateWizardSettings({
+				slug: DATA_STORE_KEY,
+				path: ['woocommerce_terms_confirmation_link'],
+				value: __( '#', 'newspack-plugin' ),
+			} );
+		}
+
 		saveWizardSettings( {
 			slug: DATA_STORE_KEY,
 		} );
@@ -41,14 +91,16 @@ function SubscriptionSettings() {
 
 	return (
 		<WizardsSection
-			title={ __( 'Subscription Settings', 'newspack-plugin' ) }
+			title={ __( 'Subscription', 'newspack-plugin' ) }
+			description={ __(
+				'Manage the settings for subscription transparency and compliance.',
+				'newspack-plugin'
+			) }
 			className={ isQuietLoading ? 'is-fetching' : '' }
 		>
+
 			<ToggleControl
-				label={ __(
-					'Enable subscription confirmation checkbox',
-					'newspack-plugin'
-				) }
+				label={ __( 'Enable subscription confirmation checkbox', 'newspack-plugin' ) }
 				help={ __(
 					'Display a separate checkbox at checkout to confirm the user understands this is a recurring subscription and they can cancel anytime.',
 					'newspack-plugin'
@@ -62,35 +114,43 @@ function SubscriptionSettings() {
 
 			{ config.woocommerce_enable_subscription_confirmation && (
 				<TextareaControl
-					label={ __(
-						'Label',
-						'newspack-plugin'
-					) }
+					label={ __( 'Label', 'newspack-plugin' ) }
 					value={ config.woocommerce_subscription_confirmation_text }
 					onChange={ value =>
-						onChange(
-							value,
-							'woocommerce_subscription_confirmation_text'
-						)
+						onChange( value, 'woocommerce_subscription_confirmation_text' )
 					}
 				/>
 			) }
 
 			<ToggleControl
-				label={ __(
-					'Enable Terms & Conditions confirmation checkbox',
-					'newspack-plugin'
-				) }
+				label={ __( 'Enable Terms & Conditions confirmation checkbox', 'newspack-plugin' ) }
 				help={ __(
 					"Display the 'I have read and accept the Terms & Conditions' checkbox at checkout. Ensure the Terms & Conditions include subscription details to comply with the FTC guidelines.",
 					'newspack-plugin'
 				) }
 				checked={ config.woocommerce_enable_terms_confirmation ?? false }
-				onChange={ value =>
-					onChange( value, 'woocommerce_enable_terms_confirmation' )
-				}
+				onChange={ value => onChange( value, 'woocommerce_enable_terms_confirmation' ) }
 				disabled={ isQuietLoading }
 			/>
+
+			{ config.woocommerce_enable_terms_confirmation && (
+				<Fragment>
+					<TextareaControl
+						label={ __( 'Label', 'newspack-plugin' ) }
+						value={ config.woocommerce_terms_confirmation_text }
+						onChange={ value =>
+							onChange( value, 'woocommerce_terms_confirmation_text' )
+						}
+					/>
+					<TextControl
+						label={ __( 'URL for Terms & Conditions page', 'newspack-plugin' ) }
+						value={ config.woocommerce_terms_confirmation_link }
+						onChange={ value =>
+							onChange( value, 'woocommerce_terms_confirmation_link' )
+						}
+					/>
+				</Fragment>
+			) }
 
 			<div className="newspack-buttons-card">
 				<Button

--- a/src/wizards/audience/components/subscription-settings/index.tsx
+++ b/src/wizards/audience/components/subscription-settings/index.tsx
@@ -1,0 +1,110 @@
+/**
+ * WordPress dependencies.
+ */
+import { useDispatch, useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { ToggleControl, TextareaControl } from '@wordpress/components';
+
+/**
+ * Internal dependencies.
+ */
+import { Button, Grid } from '../../../../components/src';
+import { useWizardData } from '../../../../components/src/wizard/store/utils';
+import { WIZARD_STORE_NAMESPACE } from '../../../../components/src/wizard/store';
+import WizardsSection from '../../../wizards-section';
+
+const DATA_STORE_KEY = 'newspack-audience/subscription-settings';
+
+function SubscriptionSettings() {
+	const config = useWizardData( DATA_STORE_KEY );
+	const { updateWizardSettings, saveWizardSettings } = useDispatch(
+		WIZARD_STORE_NAMESPACE
+	);
+	const isQuietLoading = useSelect(
+		( select: any ) =>
+			select( WIZARD_STORE_NAMESPACE ).isQuietLoading() ?? false,
+		[]
+	);
+
+	const onChange = ( value: any, key: string ) =>
+		updateWizardSettings( {
+			slug: DATA_STORE_KEY,
+			path: [ key ],
+			value,
+		} );
+
+	function onSave() {
+		saveWizardSettings( {
+			slug: DATA_STORE_KEY,
+		} );
+	}
+
+	return (
+		<WizardsSection
+			title={ __( 'Subscription Settings', 'newspack-plugin' ) }
+			className={ isQuietLoading ? 'is-fetching' : '' }
+		>
+			<ToggleControl
+				label={ __(
+					'Enable subscription confirmation checkbox',
+					'newspack-plugin'
+				) }
+				help={ __(
+					'Display a separate checkbox at checkout to confirm the user understands this is a recurring subscription and they can cancel anytime.',
+					'newspack-plugin'
+				) }
+				checked={ config.woocommerce_enable_subscription_confirmation ?? false }
+				onChange={ value =>
+					onChange( value, 'woocommerce_enable_subscription_confirmation' )
+				}
+				disabled={ isQuietLoading }
+			/>
+
+			{ config.woocommerce_enable_subscription_confirmation && (
+				<TextareaControl
+					label={ __(
+						'Label',
+						'newspack-plugin'
+					) }
+					value={ config.woocommerce_subscription_confirmation_text }
+					onChange={ value =>
+						onChange(
+							value,
+							'woocommerce_subscription_confirmation_text'
+						)
+					}
+				/>
+			) }
+
+			<ToggleControl
+				label={ __(
+					'Enable Terms & Conditions confirmation checkbox',
+					'newspack-plugin'
+				) }
+				help={ __(
+					"Display the 'I have read and accept the Terms & Conditions' checkbox at checkout. Ensure the Terms & Conditions include subscription details to comply with the FTC guidelines.",
+					'newspack-plugin'
+				) }
+				checked={ config.woocommerce_enable_terms_confirmation ?? false }
+				onChange={ value =>
+					onChange( value, 'woocommerce_enable_terms_confirmation' )
+				}
+				disabled={ isQuietLoading }
+			/>
+
+			<div className="newspack-buttons-card">
+				<Button
+					variant="primary"
+					onClick={ onSave }
+					disabled={ isQuietLoading }
+				>
+					{ isQuietLoading
+						? __( 'Saving…', 'newspack-plugin' )
+						: __( 'Save Settings', 'newspack-plugin' ) }
+				</Button>
+			</div>
+		</WizardsSection>
+	);
+}
+
+export default SubscriptionSettings;

--- a/src/wizards/audience/components/subscription-settings/index.tsx
+++ b/src/wizards/audience/components/subscription-settings/index.tsx
@@ -3,13 +3,13 @@
  */
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { ToggleControl, TextareaControl, TextControl } from '@wordpress/components';
+import { ToggleControl, TextareaControl } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies.
  */
-import { Button } from '../../../../components/src';
+import { Button, Grid } from '../../../../components/src';
 import { useWizardData } from '../../../../components/src/wizard/store/utils';
 import { WIZARD_STORE_NAMESPACE } from '../../../../components/src/wizard/store';
 import WizardsSection from '../../../wizards-section';
@@ -71,16 +71,7 @@ function SubscriptionSettings() {
 			updateWizardSettings({
 				slug: DATA_STORE_KEY,
 				path: ['woocommerce_terms_confirmation_text'],
-				value: __( 'I have read and accept the Terms & Conditions.', 'newspack-plugin' ),
-			} );
-		}
-
-		// Use the default URL when the Terms & Conditions link is empty.
-		if ( ! config.woocommerce_terms_confirmation_link ) {
-			updateWizardSettings({
-				slug: DATA_STORE_KEY,
-				path: ['woocommerce_terms_confirmation_link'],
-				value: __( '#', 'newspack-plugin' ),
+				value: __( 'I have read and accept the <a href="#">Terms & Conditions</a>.', 'newspack-plugin' ),
 			} );
 		}
 
@@ -99,58 +90,55 @@ function SubscriptionSettings() {
 			className={ isQuietLoading ? 'is-fetching' : '' }
 		>
 
-			<ToggleControl
-				label={ __( 'Enable subscription confirmation checkbox', 'newspack-plugin' ) }
-				help={ __(
-					'Display a separate checkbox at checkout to confirm the user understands this is a recurring subscription and they can cancel anytime.',
-					'newspack-plugin'
-				) }
-				checked={ config.woocommerce_enable_subscription_confirmation ?? false }
-				onChange={ value =>
-					onChange( value, 'woocommerce_enable_subscription_confirmation' )
-				}
-				disabled={ isQuietLoading }
-			/>
-
-			{ config.woocommerce_enable_subscription_confirmation && (
-				<TextareaControl
-					label={ __( 'Label', 'newspack-plugin' ) }
-					value={ config.woocommerce_subscription_confirmation_text }
-					onChange={ value =>
-						onChange( value, 'woocommerce_subscription_confirmation_text' )
-					}
-				/>
-			) }
-
-			<ToggleControl
-				label={ __( 'Enable Terms & Conditions confirmation checkbox', 'newspack-plugin' ) }
-				help={ __(
-					"Display the 'I have read and accept the Terms & Conditions' checkbox at checkout. Ensure the Terms & Conditions include subscription details to comply with the FTC guidelines.",
-					'newspack-plugin'
-				) }
-				checked={ config.woocommerce_enable_terms_confirmation ?? false }
-				onChange={ value => onChange( value, 'woocommerce_enable_terms_confirmation' ) }
-				disabled={ isQuietLoading }
-			/>
-
-			{ config.woocommerce_enable_terms_confirmation && (
-				<Fragment>
-					<TextareaControl
-						label={ __( 'Label', 'newspack-plugin' ) }
-						value={ config.woocommerce_terms_confirmation_text }
+				<Grid columns={ 1 }>
+					<Grid columns={ 1 } gutter={ 8 }>
+						<ToggleControl
+							label={ __( 'Enable subscription confirmation checkbox', 'newspack-plugin' ) }
+						help={ __(
+							'Display a separate checkbox at checkout to confirm the user understands this is a recurring subscription and they can cancel anytime.',
+							'newspack-plugin'
+						) }
+						checked={ config.woocommerce_enable_subscription_confirmation ?? false }
 						onChange={ value =>
-							onChange( value, 'woocommerce_terms_confirmation_text' )
+							onChange( value, 'woocommerce_enable_subscription_confirmation' )
 						}
+						disabled={ isQuietLoading }
 					/>
-					<TextControl
-						label={ __( 'URL for Terms & Conditions page', 'newspack-plugin' ) }
-						value={ config.woocommerce_terms_confirmation_link }
-						onChange={ value =>
-							onChange( value, 'woocommerce_terms_confirmation_link' )
-						}
+
+					{ config.woocommerce_enable_subscription_confirmation && (
+						<TextareaControl
+							label={ __( 'Label', 'newspack-plugin' ) }
+							value={ config.woocommerce_subscription_confirmation_text }
+							onChange={ value =>
+								onChange( value, 'woocommerce_subscription_confirmation_text' )
+							}
+						/>
+					) }
+				</Grid>
+
+				<Grid columns={ 1 } gutter={ 8 }>
+					<ToggleControl
+						label={ __( 'Enable Terms & Conditions confirmation checkbox', 'newspack-plugin' ) }
+						help={ __(
+							"Display the 'I have read and accept the Terms & Conditions' checkbox at checkout. Ensure the Terms & Conditions include subscription details to comply with the FTC guidelines.",
+							'newspack-plugin'
+						) }
+						checked={ config.woocommerce_enable_terms_confirmation ?? false }
+						onChange={ value => onChange( value, 'woocommerce_enable_terms_confirmation' ) }
+						disabled={ isQuietLoading }
 					/>
-				</Fragment>
-			) }
+
+					{ config.woocommerce_enable_terms_confirmation && (
+						<TextareaControl
+							label={ __( 'Label', 'newspack-plugin' ) }
+							value={ config.woocommerce_terms_confirmation_text }
+							onChange={ value =>
+								onChange( value, 'woocommerce_terms_confirmation_text' )
+							}
+						/>
+					) }
+				</Grid>
+			</Grid>
 
 			<div className="newspack-buttons-card">
 				<Button

--- a/src/wizards/audience/components/subscription-settings/index.tsx
+++ b/src/wizards/audience/components/subscription-settings/index.tsx
@@ -8,7 +8,7 @@ import { ToggleControl, TextareaControl } from '@wordpress/components';
 /**
  * Internal dependencies.
  */
-import { Button, Grid } from '../../../../components/src';
+import { Button } from '../../../../components/src';
 import { useWizardData } from '../../../../components/src/wizard/store/utils';
 import { WIZARD_STORE_NAMESPACE } from '../../../../components/src/wizard/store';
 import WizardsSection from '../../../wizards-section';

--- a/src/wizards/audience/components/subscription-settings/index.tsx
+++ b/src/wizards/audience/components/subscription-settings/index.tsx
@@ -4,7 +4,6 @@
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { ToggleControl, TextareaControl } from '@wordpress/components';
-import { Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies.

--- a/src/wizards/audience/components/subscription-settings/index.tsx
+++ b/src/wizards/audience/components/subscription-settings/index.tsx
@@ -4,7 +4,6 @@
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { ToggleControl, TextareaControl, TextControl } from '@wordpress/components';
-import { Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies.
@@ -127,7 +126,7 @@ function SubscriptionSettings() {
 					<ToggleControl
 						label={ __( 'Enable Terms & Conditions confirmation checkbox', 'newspack-plugin' ) }
 						help={ __(
-							"Display the 'I have read and accept the Terms & Conditions' checkbox at checkout. Text wrapped in {{ }} will be linked to the URL provided below. Ensure the Terms & Conditions include subscription details to comply with the FTC guidelines.",
+							"Display the 'I have read and accept the Terms & Conditions' checkbox at checkout. Ensure the Terms & Conditions include subscription details to comply with the FTC guidelines.",
 							'newspack-plugin'
 						) }
 						checked={ config.woocommerce_enable_terms_confirmation ?? false }
@@ -136,10 +135,14 @@ function SubscriptionSettings() {
 					/>
 
 					{ config.woocommerce_enable_terms_confirmation && (
-						<Fragment>
+						<Grid>
 							<TextareaControl
 								label={ __( 'Label', 'newspack-plugin' ) }
 								value={ config.woocommerce_terms_confirmation_text }
+								help={ __(
+									'Text wrapped in {{ }} will be linked to the page set in the URL field.',
+									'newspack-plugin'
+								) }
 								onChange={ value =>
 									onChange( value, 'woocommerce_terms_confirmation_text' )
 								}
@@ -151,7 +154,7 @@ function SubscriptionSettings() {
 									onChange( value, 'woocommerce_terms_confirmation_url' )
 								}
 							/>
-						</Fragment>
+						</Grid>
 					) }
 				</Grid>
 			</Grid>

--- a/src/wizards/audience/components/subscription-settings/index.tsx
+++ b/src/wizards/audience/components/subscription-settings/index.tsx
@@ -3,7 +3,8 @@
  */
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { ToggleControl, TextareaControl } from '@wordpress/components';
+import { ToggleControl, TextareaControl, TextControl } from '@wordpress/components';
+import { Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies.
@@ -70,8 +71,15 @@ function SubscriptionSettings() {
 			updateWizardSettings({
 				slug: DATA_STORE_KEY,
 				path: ['woocommerce_terms_confirmation_text'],
-				value: __( 'I have read and accept the <a href="#">Terms & Conditions</a>.', 'newspack-plugin' ),
+				value: __( 'I have read and accept the {{Terms & Conditions}}.', 'newspack-plugin' ),
 			} );
+		}
+
+		// Make sure the URL is populated when Terms & Conditions confirmation is enabled.
+		if ( config.woocommerce_enable_terms_confirmation && ! config.woocommerce_terms_confirmation_url ) {
+			// eslint-disable-next-line no-alert
+			alert( __( 'Please provide a URL for the Terms & Conditions page.', 'newspack-plugin' ) );
+			return;
 		}
 
 		saveWizardSettings( {
@@ -119,7 +127,7 @@ function SubscriptionSettings() {
 					<ToggleControl
 						label={ __( 'Enable Terms & Conditions confirmation checkbox', 'newspack-plugin' ) }
 						help={ __(
-							"Display the 'I have read and accept the Terms & Conditions' checkbox at checkout. Ensure the Terms & Conditions include subscription details to comply with the FTC guidelines.",
+							"Display the 'I have read and accept the Terms & Conditions' checkbox at checkout. Text wrapped in {{ }} will be linked to the URL provided below. Ensure the Terms & Conditions include subscription details to comply with the FTC guidelines.",
 							'newspack-plugin'
 						) }
 						checked={ config.woocommerce_enable_terms_confirmation ?? false }
@@ -128,13 +136,22 @@ function SubscriptionSettings() {
 					/>
 
 					{ config.woocommerce_enable_terms_confirmation && (
-						<TextareaControl
-							label={ __( 'Label', 'newspack-plugin' ) }
-							value={ config.woocommerce_terms_confirmation_text }
-							onChange={ value =>
-								onChange( value, 'woocommerce_terms_confirmation_text' )
-							}
-						/>
+						<Fragment>
+							<TextareaControl
+								label={ __( 'Label', 'newspack-plugin' ) }
+								value={ config.woocommerce_terms_confirmation_text }
+								onChange={ value =>
+									onChange( value, 'woocommerce_terms_confirmation_text' )
+								}
+							/>
+							<TextControl
+								label={ __( 'URL', 'newspack-plugin' ) }
+								value={ config.woocommerce_terms_confirmation_url }
+								onChange={ value =>
+									onChange( value, 'woocommerce_terms_confirmation_url' )
+								}
+							/>
+						</Fragment>
 					) }
 				</Grid>
 			</Grid>

--- a/src/wizards/audience/views/setup/payment.js
+++ b/src/wizards/audience/views/setup/payment.js
@@ -16,6 +16,7 @@ import PaymentGateways from '../../components/payment-methods';
 import NRHSettings from '../../components/nrh-settings';
 import BillingFields from '../../components/billing-fields';
 import CheckoutConfiguration from '../../components/checkout-configuration';
+import SubscriptionSettings from '../../components/subscription-settings';
 
 export default withWizardScreen( function () {
 	const data = useWizardData( 'newspack-audience/payment' );
@@ -31,6 +32,7 @@ export default withWizardScreen( function () {
 			{ data?.platform_data?.platform === 'wc' && <PaymentGateways /> }
 			{ data?.platform_data?.platform === 'wc' && <BillingFields /> }
 			{ data?.platform_data?.platform === 'nrh' && <NRHSettings /> }
+			<SubscriptionSettings />
 			<CheckoutConfiguration />
 		</WizardsTab>
 	);

--- a/src/wizards/audience/views/setup/payment.js
+++ b/src/wizards/audience/views/setup/payment.js
@@ -20,6 +20,7 @@ import SubscriptionSettings from '../../components/subscription-settings';
 
 export default withWizardScreen( function () {
 	const data = useWizardData( 'newspack-audience/payment' );
+
 	return (
 		<WizardsTab
 			title={ __( 'Checkout & Payment', 'newspack-plugin' ) }
@@ -33,7 +34,7 @@ export default withWizardScreen( function () {
 			{ data?.platform_data?.platform === 'wc' && <BillingFields /> }
 			{ data?.platform_data?.platform === 'nrh' && <NRHSettings /> }
 			<CheckoutConfiguration />
-			<SubscriptionSettings />
+			{ data?.platform_data?.platform === 'wc' && <SubscriptionSettings /> }
 		</WizardsTab>
 	);
 } );

--- a/src/wizards/audience/views/setup/payment.js
+++ b/src/wizards/audience/views/setup/payment.js
@@ -32,8 +32,8 @@ export default withWizardScreen( function () {
 			{ data?.platform_data?.platform === 'wc' && <PaymentGateways /> }
 			{ data?.platform_data?.platform === 'wc' && <BillingFields /> }
 			{ data?.platform_data?.platform === 'nrh' && <NRHSettings /> }
-			<SubscriptionSettings />
 			<CheckoutConfiguration />
+			<SubscriptionSettings />
 		</WizardsTab>
 	);
 } );

--- a/src/wizards/audience/views/setup/setup.js
+++ b/src/wizards/audience/views/setup/setup.js
@@ -381,6 +381,8 @@ export default withWizardScreen(
 									metadata_prefix: config.metadata_prefix,
 									woocommerce_registration_required: config.woocommerce_registration_required,
 									woocommerce_checkout_privacy_policy_text: config.woocommerce_checkout_privacy_policy_text,
+									woocommerce_subscription_confirmation_text: config.woocommerce_subscription_confirmation_text,
+									woocommerce_terms_confirmation_text: config.woocommerce_terms_confirmation_text,
 									woocommerce_post_checkout_success_text: config.woocommerce_post_checkout_success_text,
 									woocommerce_post_checkout_registration_success_text: config.woocommerce_post_checkout_registration_success_text,
 								} );

--- a/src/wizards/audience/views/setup/setup.js
+++ b/src/wizards/audience/views/setup/setup.js
@@ -383,6 +383,9 @@ export default withWizardScreen(
 									woocommerce_checkout_privacy_policy_text: config.woocommerce_checkout_privacy_policy_text,
 									woocommerce_enable_subscription_confirmation: config.woocommerce_enable_subscription_confirmation,
 									woocommerce_subscription_confirmation_text: config.woocommerce_subscription_confirmation_text,
+									woocommerce_enable_terms_confirmation: config.woocommerce_enable_terms_confirmation,
+									woocommerce_terms_confirmation_text: config.woocommerce_terms_confirmation_text,
+									woocommerce_terms_confirmation_link: config.woocommerce_terms_confirmation_link,
 									woocommerce_post_checkout_success_text: config.woocommerce_post_checkout_success_text,
 									woocommerce_post_checkout_registration_success_text: config.woocommerce_post_checkout_registration_success_text,
 								} );

--- a/src/wizards/audience/views/setup/setup.js
+++ b/src/wizards/audience/views/setup/setup.js
@@ -381,8 +381,8 @@ export default withWizardScreen(
 									metadata_prefix: config.metadata_prefix,
 									woocommerce_registration_required: config.woocommerce_registration_required,
 									woocommerce_checkout_privacy_policy_text: config.woocommerce_checkout_privacy_policy_text,
+									woocommerce_enable_subscription_confirmation: config.woocommerce_enable_subscription_confirmation,
 									woocommerce_subscription_confirmation_text: config.woocommerce_subscription_confirmation_text,
-									woocommerce_terms_confirmation_text: config.woocommerce_terms_confirmation_text,
 									woocommerce_post_checkout_success_text: config.woocommerce_post_checkout_success_text,
 									woocommerce_post_checkout_registration_success_text: config.woocommerce_post_checkout_registration_success_text,
 								} );

--- a/src/wizards/audience/views/setup/setup.js
+++ b/src/wizards/audience/views/setup/setup.js
@@ -385,6 +385,7 @@ export default withWizardScreen(
 									woocommerce_subscription_confirmation_text: config.woocommerce_subscription_confirmation_text,
 									woocommerce_enable_terms_confirmation: config.woocommerce_enable_terms_confirmation,
 									woocommerce_terms_confirmation_text: config.woocommerce_terms_confirmation_text,
+									woocommerce_terms_confirmation_url: config.woocommerce_terms_confirmation_url,
 									woocommerce_post_checkout_success_text: config.woocommerce_post_checkout_success_text,
 									woocommerce_post_checkout_registration_success_text: config.woocommerce_post_checkout_registration_success_text,
 								} );

--- a/src/wizards/audience/views/setup/setup.js
+++ b/src/wizards/audience/views/setup/setup.js
@@ -385,7 +385,6 @@ export default withWizardScreen(
 									woocommerce_subscription_confirmation_text: config.woocommerce_subscription_confirmation_text,
 									woocommerce_enable_terms_confirmation: config.woocommerce_enable_terms_confirmation,
 									woocommerce_terms_confirmation_text: config.woocommerce_terms_confirmation_text,
-									woocommerce_terms_confirmation_link: config.woocommerce_terms_confirmation_link,
 									woocommerce_post_checkout_success_text: config.woocommerce_post_checkout_success_text,
 									woocommerce_post_checkout_registration_success_text: config.woocommerce_post_checkout_registration_success_text,
 								} );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds some Subscription options to the Audience > Configuration > Checkout & Payment page to help sites meet FTC compliance. 

This PR needs to be tested along with https://github.com/Automattic/newspack-blocks/pull/2117, which adjust some styles on the Newspack Blocks side of things.

See 1200550061930446-as-1208929637924603

### How to test the changes in this Pull Request:

1. Apply this PR and https://github.com/Automattic/newspack-blocks/pull/2117, and run `npm run build` for both. 
2. Make sure your test site is using WooCommerce as the Reader Revenue platform, and that WooCommerce Subscriptions is enabled. You'll need some non-subscription and subscription products set up to test
3. Navigate to Audience > Configuration > Checkout & Payment, and confirm there's a new Subscription section at the bottom. It should have two options, one for enabling a subscription confirmation checkbox, and one for enabling a Terms & Conditions checkbox. Both should be off by default:

![CleanShot 2025-05-06 at 15 39 47](https://github.com/user-attachments/assets/1bad5858-4095-4689-a4d5-c1be2085b3ef)

4. Toggle on the "Enable subscription confirmation checkbox", and confirm you now get a text area to edit the text label. It should be prepopulated with some default text:

![CleanShot 2025-05-06 at 15 40 59@2x](https://github.com/user-attachments/assets/e058e888-8147-4882-919d-ccb571d75cfc)

5. Click 'Save Settings'.
6. On the front-end, run through a checkout using a subscription product -- this can be from the Checkout Button block, or a Monthly or Annual donation from the Donate Block. 
7. On the second screen of the checkout, confirm that you get the Subscription Confirmation checkbox at the bottom. The "Place Order" button should also be greyed out while this checkbox isn't selected:

<img width="500" src="https://github.com/user-attachments/assets/a8c48a0b-4797-4c51-bc32-4a00675baa49">

8. Fill out some test payment details, check the Subscription Confirmation box, and confirm you can check out. 
9. Repeat the above with a non-subscription product and confirm that you don't get the Subscription Confirmation checkbox.
10. Navigate back to Audience > Configuration > Checkout & Payment, and try changing the text label for the Subscription Confirmation checkbox.
11. Click Save Settings, then repeat step 6 and 7 and confirm that your updated text appears.
12. Navigate back to Audience > Configuration > Checkout & Payment, and toggle on "Enable Terms & Conditions confirmation checkbox". "Enable subscription confirmation checkbox" should automatically toggle off, and its Label field should be hidden; a two new label fields should appear below the "Enable Terms & Conditions confirmation checkbox" toggle, one for a label that's populated, and one for a URL that's not:

![CleanShot 2025-05-07 at 12 45 00@2x](https://github.com/user-attachments/assets/0de6ea8c-6454-46b6-9f3a-26226b9244e5)

13. Try clicking 'Save Settings' without making edits, and confirm you get an alert that you need to populate the URL:

<img width="500" src="https://github.com/user-attachments/assets/3fe92912-3afc-460e-8971-cf3a654096d5">

14. Add a URL and click 'Save Settings'.
15. Retest steps 6 and 7 to confirm this checkbox now appears, including the link. Like with the Subscription Confirmation checkbox, the Place Order button should be greyed out and not let you submit the form until it's checked. When you click the link, it should open your T&C page in a new window:

<img width="500" src="https://github.com/user-attachments/assets/b6ffc7ad-a63f-45ad-bdc7-c78deb100564" />

15. Navigate back to Audience > Configuration > Checkout & Payment and try clearing all the text in either label field, and click 'Save Settings'. Confirm when you do this that the textfield is repopulated with the default text so it doesn't let you leave it empty.
16. Try changing the text label for the Terms & Conditions checkbox, including moving the link and click save. Confirm this is applied to the front-end.
17. Try changing the text label to remove the `{{ }}` entirely. Confirm that the whole label is now linked: 

<img width="500" src="https://github.com/user-attachments/assets/c0b777f7-0ae3-4158-a9e3-8873986af3a4">

18. Lastly, make sure you can complete a checkout, including checking the Terms & Conditions box. 
19. You'll need a non-donation subscription product to test this next bit: navigate to the /shop page on your site, and run through a checkout. Confirm that you see your Terms & Conditions checkbox at the bottom of the checkout page (though it doesn't have any form-blocking JS fanciness).

![CleanShot 2025-05-07 at 10 42 41@2x](https://github.com/user-attachments/assets/56cf167c-8845-48e2-8490-afb7e7422203)

20. Try to complete your checkout without checking the checkbox and confirm that you get a standard WooCommerce error and that you can't complete the purchase:

![CleanShot 2025-05-06 at 15 58 03@2x](https://github.com/user-attachments/assets/d615e8b1-ca61-48f5-b762-cd5dd391a79f)

22. Repeat the above with a non-subscription product (and make sure you don't have any other subscription products in the cart anymore). Confirm you don't get the checkbox at the bottom.
23. Lastly, navigate back to Audience > Configuration > Checkout & Payment and repeat the /shop testing steps with the Subscription Confirmation checkbox enabled. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208929637924603