### PR TITLE
feat(donations): update notice style and type

### DIFF
--- a/src/components/src/notice/style.scss
+++ b/src/components/src/notice/style.scss
@@ -13,7 +13,7 @@
 	display: flex;
 	justify-content: flex-start;
 	margin: 32px 0;
-	padding: 6px 8px;
+	padding: 8px 12px;
 
 	> svg {
 		display: block;
@@ -42,7 +42,7 @@
 	}
 
 	&__is-error {
-		background: color.adjust(wp-colors.$alert-red, $lightness: 51%);
+		background: color.adjust(wp-colors.$alert-red, $lightness: 35%);
 
 		> svg {
 			fill: wp-colors.$alert-red;
@@ -51,7 +51,7 @@
 	}
 
 	&__is-handoff {
-		background: color.adjust(wp-colors.$alert-yellow, $lightness: 30%);
+		background: color.adjust(wp-colors.$alert-yellow, $lightness: 35%);
 		margin-top: 0;
 		position: sticky;
 		top: 46px;
@@ -71,7 +71,7 @@
 	}
 
 	&__is-success {
-		background: color.adjust(wp-colors.$alert-green, $lightness: 42%);
+		background: color.adjust(wp-colors.$alert-green, $lightness: 45%);
 
 		> svg {
 			fill: wp-colors.$alert-green;
@@ -79,7 +79,7 @@
 	}
 
 	&__is-warning {
-		background: color.adjust(wp-colors.$alert-yellow, $lightness: 30%);
+		background: color.adjust(wp-colors.$alert-yellow, $lightness: 35%);
 
 		> svg {
 			fill: wp-colors.$alert-yellow;

--- a/src/components/src/style.scss
+++ b/src/components/src/style.scss
@@ -24,6 +24,10 @@
 	&:empty {
 		display: none;
 	}
+
+	+ .newspack-card {
+		margin-top: 64px;
+	}
 }
 
 // Checkboxes

--- a/src/wizards/audience/views/donations/configuration/index.tsx
+++ b/src/wizards/audience/views/donations/configuration/index.tsx
@@ -381,14 +381,16 @@ const Donation = () => {
 								'Your donations landing page is published.',
 								'newspack-plugin'
 							) }
+							style={ { marginBottom: '64px' } }
 						/>
 					) : (
 						<Notice
-							isError
+							isWarning
 							noticeText={ __(
 								'Your donations landing page is not yet published.',
 								'newspack-plugin'
 							) }
+							style={ { marginBottom: '64px' } }
 						/>
 					) }
 				</>
@@ -399,9 +401,6 @@ const Donation = () => {
 					{ __( 'Save Settings', 'newspack-plugin' ) }
 				</Button>
 			</div>
-			<SectionHeader
-				title={ __( 'Additional Settings', 'newspack-plugin' ) }
-			/>
 			<CoverFeesSettings />
 		</WizardsTab>
 	);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This is a small visual update that came up during the PDC review.

When the donation page isn't published, we currently display an `error` notice. This is scary... instead let's use a `warning`. I've also slightly tweaked the background colour and padding so it's more inline with Core's notice.

### How to test the changes in this Pull Request:

1. Make sure your donation page is unpublished
2. Visit the donation configuration page. See "error" at the top.
3. Switch to this branch.
4. "Error" should now be a "warning".

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->