### PR TITLE
fix(jetpack): handle the related posts max age option

### DIFF
--- a/includes/plugins/class-jetpack.php
+++ b/includes/plugins/class-jetpack.php
@@ -31,37 +31,37 @@ class Jetpack {
 	 * @var string[]
 	 */
 	public static $default_active_modules = [
-		/** 
+		/**
 		 * Assets CDN
 		 *
 		 * @link https://jetpack.com/support/site-accelerator/
 		 */
 		'photon-cdn',
-		/** 
+		/**
 		 * Image CDN
 		 *
 		 * @link https://jetpack.com/support/site-accelerator/
 		 */
 		'photon',
-		/** 
+		/**
 		 * Contact Form
 		 *
 		 * @link https://jetpack.com/support/contact-form/
 		 */
 		'contact-form',
-		/** 
-		 * Brute Force Protection. 
+		/**
+		 * Brute Force Protection.
 		 *
 		 * @link https://jetpack.com/support/protect/
 		 */
 		'protect',
-		/** 
-		 * JSON API 
+		/**
+		 * JSON API
 		 *
 		 * @link https://jetpack.com/support/json-api/
 		 */
 		'json-api',
-		/** 
+		/**
 		 * Notifications
 		 *
 		 * @link https://jetpack.com/support/notifications/
@@ -158,6 +158,9 @@ class Jetpack {
 		// Set Jetpack default modules on Newspack setup.
 		add_action( 'add_option_newspack_setup_complete', [ __CLASS__, 'set_default_modules' ], 10, 2 );
 		add_action( 'update_option_newspack_setup_complete', [ __CLASS__, 'set_default_modules' ], 10, 2 );
+
+		// Modify the related posts timeframe.
+		add_filter( 'jetpack_relatedposts_filter_date_range', [ __CLASS__, 'restrict_age_of_related_posts' ] );
 	}
 
 	/**
@@ -307,12 +310,28 @@ class Jetpack {
 	 *
 	 * @param string $old_val_or_opt_name If adding will be opt name. If updating will be old value.
 	 * @param string $new_val Value correlated to update/add.
-	 * @return void 
+	 * @return void
 	 */
 	public static function set_default_modules( string $old_val_or_opt_name, string $new_val ) {
 		if ( $new_val === '1' ) {
 			update_option( 'jetpack_active_modules', static::$default_active_modules );
 		}
+	}
+
+	/**
+	 * Restrict the age of related content shown by Jetpack Related Posts.
+	 *
+	 * @param array $date_range Array of start and end dates.
+	 * @return array Filtered array of start/end dates.
+	 */
+	public static function restrict_age_of_related_posts( $date_range ) {
+		$related_posts_max_age = get_option( ( new \Newspack\Wizards\Newspack\Recirculation_Section() )->related_posts_option );
+		if ( is_numeric( $related_posts_max_age ) && 0 < $related_posts_max_age ) {
+			$date_range['from'] = strtotime( '-' . $related_posts_max_age . ' months' );
+			$date_range['to']   = time();
+		}
+
+		return $date_range;
 	}
 }
 Jetpack::init();

--- a/includes/plugins/class-jetpack.php
+++ b/includes/plugins/class-jetpack.php
@@ -325,7 +325,7 @@ class Jetpack {
 	 * @return array Filtered array of start/end dates.
 	 */
 	public static function restrict_age_of_related_posts( $date_range ) {
-		$related_posts_max_age = get_option( ( new \Newspack\Wizards\Newspack\Recirculation_Section() )->related_posts_option );
+		$related_posts_max_age = get_option( Wizards\Newspack\Recirculation_Section::RELATED_POSTS_OPTION );
 		if ( is_numeric( $related_posts_max_age ) && 0 < $related_posts_max_age ) {
 			$date_range['from'] = strtotime( '-' . $related_posts_max_age . ' months' );
 			$date_range['to']   = time();

--- a/includes/wizards/newspack/class-recirculation-section.php
+++ b/includes/wizards/newspack/class-recirculation-section.php
@@ -31,12 +31,12 @@ class Recirculation_Section extends Wizard_Section {
 	 *
 	 * @var string
 	 */
-	protected $related_posts_option = 'newspack_related_posts_max_age';
-	
+	public $related_posts_option = 'newspack_related_posts_max_age';
+
 	/**
 	 * Register Wizard Section specific endpoints.
 	 *
-	 * @return void 
+	 * @return void
 	 */
 	public function register_rest_routes() {
 		register_rest_route(

--- a/includes/wizards/newspack/class-recirculation-section.php
+++ b/includes/wizards/newspack/class-recirculation-section.php
@@ -31,7 +31,7 @@ class Recirculation_Section extends Wizard_Section {
 	 *
 	 * @var string
 	 */
-	public $related_posts_option = 'newspack_related_posts_max_age';
+	const RELATED_POSTS_OPTION = 'newspack_related_posts_max_age';
 
 	/**
 	 * Register Wizard Section specific endpoints.
@@ -71,7 +71,7 @@ class Recirculation_Section extends Wizard_Section {
 		return rest_ensure_response(
 			[
 				'relatedPostsEnabled' => $jetpack_configuration_manager->is_related_posts_enabled(),
-				'relatedPostsMaxAge'  => get_option( $this->related_posts_option, 0 ),
+				'relatedPostsMaxAge'  => get_option( self::RELATED_POSTS_OPTION, 0 ),
 			]
 		);
 	}
@@ -86,7 +86,7 @@ class Recirculation_Section extends Wizard_Section {
 		$args = $request->get_params();
 
 		if ( is_numeric( $args['relatedPostsMaxAge'] ) && 0 <= $args['relatedPostsMaxAge'] ) {
-			update_option( $this->related_posts_option, $args['relatedPostsMaxAge'] );
+			update_option( self::RELATED_POSTS_OPTION, $args['relatedPostsMaxAge'] );
 		} else {
 			return new WP_Error(
 				'newspack_related_posts_invalid_arg',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The option to change the Jetpack Related Posts feature maximum age was not handled. This PR reinstates the handling.

A casualty of the https://github.com/Automattic/newspack-plugin/pull/3857 epic PR. 

### How to test the changes in this Pull Request:

_Look in Asana for (alternative) internal testing instructions._ 

1. On `trunk`,
1. On a site with Jetpack connected, visit Newspack → Settings → Display Settings
2. Enable "Related Posts" and set Maximum Age Of Related Content In Months to “6”
3. View a post or execute `(new Jetpack_RelatedPosts())->get_for_post_id(<post-id>, []);`, observe that you may get posts older than 6 months 
4. Switch to this branch, observe that only posts published less than 6 months ago are returned

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210134334697036