### PR TITLE
fix: make sure fix duplcate fields apply filters

### DIFF
--- a/includes/cli/class-mailchimp.php
+++ b/includes/cli/class-mailchimp.php
@@ -450,11 +450,17 @@ class Mailchimp {
 	 * @return array
 	 */
 	private static function get_fields_to_check_for_duplicates() {
+		/**
+		 * Apply the filters that allow other plugins to add their own fields.
+		 *
+		 * This filter is documented in Newspack\Reader_Activation\Sync\Metadata::get_keys().
+		 */
+		$fields = \apply_filters( 'newspack_ras_metadata_keys', Metadata::get_all_fields() );
 		$fields = array_map(
 			function( $key ) {
 				return Metadata::get_key( $key );
 			},
-			array_keys( Metadata::get_all_fields() )
+			array_keys( $fields )
 		);
 
 		// Additional fields.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The fix duplicate scripts is not accountig for fields added via a filter. This PR fixes it with as little refactor as possible.

### How to test the changes in this Pull Request:

1. Activate Newspack Network
2. Add some debug to the `get_fields_to_check_for_duplicates` method
3. On `trunk` confirm that the `NP_Network Registration Site` field is not present
4. On this branch, confirm it is present - with the `NP_` prefix.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->