### PR TITLE
feat: add compatibility to network in custom bylines

### DIFF
--- a/includes/bylines/class-bylines.php
+++ b/includes/bylines/class-bylines.php
@@ -37,6 +37,10 @@ class Bylines {
 		add_filter( 'pre_newspack_posted_by', [ __CLASS__, 'pre_newspack_posted_by' ] );
 		add_filter( 'newspack_blocks_post_authors', [ __CLASS__, 'newspack_blocks_post_authors' ] );
 		add_filter( 'newspack_blocks_post_byline', [ __CLASS__, 'newspack_blocks_post_byline' ] );
+
+		// Newspack Network compatibility.
+		add_filter( 'newspack_network_distributed_post_meta', [ __CLASS__, 'newspack_network_distributed_post_meta' ], 10, 2 );
+		add_action( 'newspack_network_incoming_post_inserted', [ __CLASS__, 'newspack_network_incoming_post_inserted' ], 10, 3 );
 	}
 
 	/**
@@ -293,6 +297,70 @@ class Bylines {
 		}
 
 		return $custom_byline;
+	}
+
+	/**
+	 * Filters the post meta data for distribution and add a new method with a mapping of author IDs to author emails.
+	 *
+	 * @param array   $meta The post meta data.
+	 * @param WP_Post $post The post object.
+	 */
+	public static function newspack_network_distributed_post_meta( $meta, $post ) {
+		$byline_is_active = \get_post_meta( \get_the_ID(), self::META_KEY_ACTIVE, true );
+		if ( ! $byline_is_active ) {
+			return $meta;
+		}
+
+		$byline = \get_post_meta( $post->ID, self::META_KEY_BYLINE, true );
+
+		$author_ids = self::extract_author_ids_from_shortcode( $byline );
+
+		if ( empty( $author_ids ) ) {
+			return $meta;
+		}
+
+		$mapping = [];
+		// create a mapping of author IDs to author emails.
+		foreach ( $author_ids as $author_id ) {
+			$mapping[ $author_id ] = get_the_author_meta( 'user_email', $author_id );
+		}
+
+		$meta['_newspack_byline_network_authors'] = [ wp_json_encode( $mapping ) ];
+
+		return $meta;
+	}
+
+	/**
+	 * After an incoming post is inserted, update the IDs with the IDs in the target site, based on the mapping that was sent.
+	 *
+	 * @param int   $post_id   The post ID.
+	 * @param bool  $is_linked Whether the post is linked.
+	 * @param array $payload   The post payload.
+	 */
+	public static function newspack_network_incoming_post_inserted( $post_id, $is_linked, $payload ) {
+		if ( ! $is_linked ) {
+			return;
+		}
+
+		$byline = \get_post_meta( $post_id, self::META_KEY_BYLINE, true );
+
+		$mapping = get_post_meta( $post_id, '_newspack_byline_network_authors', true );
+
+		$mapping = json_decode( $mapping, true );
+
+		if ( empty( $mapping ) ) {
+			return;
+		}
+
+		foreach ( $mapping as $author_id => $author_email ) {
+			$local_user = get_user_by( 'email', $author_email );
+			if ( ! $local_user ) {
+				continue;
+			}
+			$byline = str_replace( 'id=' . $author_id, 'id=' . $local_user->ID, $byline );
+		}
+
+		update_post_meta( $post_id, self::META_KEY_BYLINE, $byline );
 	}
 }
 Bylines::init();

--- a/includes/bylines/class-bylines.php
+++ b/includes/bylines/class-bylines.php
@@ -342,7 +342,7 @@ class Bylines {
 			return;
 		}
 
-		$byline = \get_post_meta( $post_id, self::META_KEY_BYLINE, true );
+		$byline = get_post_meta( $post_id, self::META_KEY_BYLINE, true );
 
 		$mapping = get_post_meta( $post_id, '_newspack_byline_network_authors', true );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This makes custom bylines work with Newspack Network.

When the post is being distributed, it will add a mapping with user IDs and emails to the post meta of the distributed post. On the other end, the target site will modify the custom byline to make sure it points to the correct users on the other side.

### How to test the changes in this Pull Request:

1. Create a new post and distribute it (or use an existing one)
2. Add a custom Byline and save
3. Check that in the target site the post displays the correct byline, pointing to the correct author
4. Confirm that the ID of that author is different in each site, but that the `[author id=x` shortcode points to different IDs in each site

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->