### PR TITLE
fix: remove non-existent filter

### DIFF
--- a/includes/plugins/class-woocommerce-gateway-stripe.php
+++ b/includes/plugins/class-woocommerce-gateway-stripe.php
@@ -18,8 +18,6 @@ class WooCommerce_Gateway_Stripe {
 	 * Initialize hooks and filters.
 	 */
 	public static function init() {
-		add_filter( 'wc_stripe_intent_metadata', [ __CLASS__, 'add_transaction_metadata' ], 10, 2 );
-
 		/**
 		 * Disable Stripe Express Checkout feature flags.
 		 * This is a workaround for the Stripe Express Checkout feature flags


### PR DESCRIPTION
3b7ee8ebd3c1 was a bad merge, it re-added a line that was removed in 59296184c013

Related: https://github.com/Automattic/newspack-plugin/pull/3976

## To test

1. On `trunk`,
1. Try to make a donation using the Donate block, with Stripe gateway
2. Observe it failing, switch to this branch, test again
