### PR TITLE
fix: sync correction status with parent post status

### DIFF
--- a/includes/corrections/class-corrections.php
+++ b/includes/corrections/class-corrections.php
@@ -52,6 +52,31 @@ class Corrections {
 		add_action( 'rest_api_init', [ __CLASS__, 'register_rest_routes' ] );
 		add_action( 'admin_init', [ __CLASS__, 'register_corrections_block_patterns' ] );
 		add_action( 'init', [ __CLASS__, 'register_corrections_template' ] );
+		add_action( 'transition_post_status', [ __CLASS__, 'update_corrections_status' ], 10, 3 );
+	}
+
+	/**
+	 * Get supported post types.
+	 *
+	 * @return array Array of supported post types slugs.
+	 */
+	public static function get_supported_post_types() {
+		/**
+		 * Filter to allow other post types to support Newspack Corrections and Clarifications.
+		 *
+		 * @param array $supported_post_types Array of supported post types slugs.
+		 */
+		return apply_filters( 'newspack_corrections_supported_post_types', [ 'post' ] );
+	}
+
+	/**
+	 * Check if a post type is supported.
+	 *
+	 * @param string $post_type The post type slug.
+	 * @return bool Whether the post type is supported.
+	 */
+	public static function is_supported_post_type( $post_type ) {
+		return in_array( $post_type, self::get_supported_post_types(), true );
 	}
 
 	/**
@@ -71,14 +96,7 @@ class Corrections {
 
 		$screen = get_current_screen();
 
-		/**
-		 * Filter to allow other post types to support Newspack Corrections and clarifications.
-		 *
-		 * @param array $supported_post_types Array of supported post types slugs.
-		 */
-		$supported_post_types = apply_filters( 'newspack_corrections_supported_post_types', [ 'post' ] );
-
-		if ( empty( $screen ) || 'post' !== $screen->base || ! in_array( $screen->post_type, $supported_post_types, true ) ) {
+		if ( empty( $screen ) || 'post' !== $screen->base || ! self::is_supported_post_type( $screen->post_type ) ) {
 			return;
 		}
 
@@ -168,7 +186,7 @@ class Corrections {
 			'taxonomies'          => [],
 			'menu_icon'           => 'dashicons-edit',
 		);
-		\register_post_type( self::POST_TYPE, $args );
+		\register_post_type( self::POST_TYPE, $args ); // phpcs:ignore WordPress.NamingConventions.ValidPostTypeSlug.NotStringLiteral
 
 		$rewrite_rules_updated_option_name = 'newspack_corrections_rewrite_rules_updated';
 		if ( get_option( $rewrite_rules_updated_option_name ) !== true ) {
@@ -225,7 +243,7 @@ class Corrections {
 			// ID will be null if it's a new correction.
 			if ( ! empty( $correction_id ) ) {
 				// Update existing correction.
-				self::update_correction( $correction_id, $correction );
+				self::update_correction( $post_id, $correction_id, $correction );
 				$processed_ids[] = $correction_id;
 			} else {
 				// Create new correction.
@@ -264,7 +282,7 @@ class Corrections {
 				'post_content' => sanitize_textarea_field( $correction['content'] ),
 				'post_date'    => sanitize_text_field( $correction['date'] ),
 				'post_type'    => self::POST_TYPE,
-				'post_status'  => 'publish',
+				'post_status'  => get_post_status( $post_id ),
 				'meta_input'   => [
 					self::CORRECTION_POST_ID_META   => $post_id,
 					self::CORRECTIONS_TYPE_META     => $correction['type'],
@@ -284,10 +302,11 @@ class Corrections {
 	 * @return array The corrections.
 	 */
 	public static function get_corrections( $post_id ) {
-		$corrections = get_posts(
+		$corrections = get_posts( // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.get_posts_get_posts
 			[
 				'posts_per_page' => -1,
 				'post_type'      => self::POST_TYPE,
+				'post_status'    => 'any',
 				'meta_key'       => self::CORRECTION_POST_ID_META, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 				'meta_value'     => $post_id, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 				'orderby'        => 'date',
@@ -308,21 +327,51 @@ class Corrections {
 	/**
 	 * Update correction.
 	 *
+	 * @param int   $post_id       the post id.
 	 * @param int   $correction_id the post id.
 	 * @param array $correction    the correction.
 	 */
-	public static function update_correction( $correction_id, $correction ) {
+	public static function update_correction( $post_id, $correction_id, $correction ) {
 		wp_update_post(
 			[
 				'ID'           => $correction_id,
 				'post_content' => sanitize_textarea_field( $correction['content'] ),
 				'post_date'    => sanitize_text_field( $correction['date'] ),
+				'post_status'  => get_post_status( $post_id ),
 				'meta_input'   => [
 					self::CORRECTIONS_TYPE_META     => $correction['type'],
 					self::CORRECTIONS_PRIORITY_META => $correction['priority'],
 				],
 			]
 		);
+	}
+
+	/**
+	 * Update corrections status when the post status changes.
+	 *
+	 * @param string  $new_status The new post status.
+	 * @param string  $old_status The old post status.
+	 * @param WP_Post $post The post object.
+	 */
+	public static function update_corrections_status( $new_status, $old_status, $post ) {
+		if ( $new_status === $old_status || ! self::is_supported_post_type( $post->post_type ) ) {
+			return;
+		}
+
+		$corrections = self::get_corrections( $post->ID );
+
+		if ( empty( $corrections ) ) {
+			return;
+		}
+
+		foreach ( $corrections as $correction ) {
+			wp_update_post(
+				[
+					'ID'          => $correction->ID,
+					'post_status' => $new_status,
+				]
+			);
+		}
 	}
 
 	/**

--- a/tests/unit-tests/corrections.php
+++ b/tests/unit-tests/corrections.php
@@ -383,7 +383,7 @@ class Test_Corrections extends WP_UnitTestCase {
 			'priority' => 'high',
 		);
 
-		Corrections::update_correction( $correction_id, $updated_data );
+		Corrections::update_correction( self::$post_id, $correction_id, $updated_data );
 
 		$updated_correction = get_post( $correction_id );
 		$this->assertInstanceOf( 'WP_Post', $updated_correction, 'Expected a WP_Post object for the updated correction.' );
@@ -595,5 +595,71 @@ class Test_Corrections extends WP_UnitTestCase {
 			Corrections::get_correction_type( $clarification_id ),
 			'Should return "Clarification" for clarification type'
 		);
+	}
+
+	/**
+	 * Test that corrections status is updated when post status changes.
+	 *
+	 * @covers Corrections::update_corrections_status
+	 */
+	public function test_update_corrections_status() {
+		$correction = array(
+			'content'  => 'Test correction content',
+			'type'     => 'correction',
+			'date'     => current_time( 'mysql' ),
+			'priority' => 'low',
+		);
+
+		$correction_id = Corrections::add_correction( self::$post_id, $correction );
+		$this->assertNotWPError( $correction_id );
+		$this->assertNotEquals( 0, $correction_id );
+
+		// Change post status to draft.
+		wp_update_post(
+			array(
+				'ID'          => self::$post_id,
+				'post_status' => 'draft',
+			)
+		);
+
+		// Check that correction status was updated.
+		$updated_correction = get_post( $correction_id );
+		$this->assertEquals( 'draft', $updated_correction->post_status, 'Correction status should match post status.' );
+
+		// Change post status back to publish.
+		wp_update_post(
+			array(
+				'ID'          => self::$post_id,
+				'post_status' => 'publish',
+			)
+		);
+
+		// Check that correction status was updated again.
+		$updated_correction = get_post( $correction_id );
+		$this->assertEquals( 'publish', $updated_correction->post_status, 'Correction status should match post status.' );
+	}
+
+	/**
+	 * Test that corrections can be filtered by supported post types.
+	 *
+	 * @covers Corrections::get_supported_post_types
+	 * @covers Corrections::is_supported_post_type
+	 */
+	public function test_get_supported_post_types() {
+		$supported_types = Corrections::get_supported_post_types();
+		$this->assertIsArray( $supported_types );
+		$this->assertContains( 'post', $supported_types );
+
+		// Test the filter.
+		add_filter(
+			'newspack_corrections_supported_post_types',
+			function( $types ) {
+				$types[] = 'test_post_type';
+				return $types;
+			}
+		);
+
+		$filtered_types = Corrections::get_supported_post_types();
+		$this->assertContains( 'test_post_type', $filtered_types );
 	}
 }


### PR DESCRIPTION
Prevents corrections from being publicly visible when a parent post is unpublished or private.

### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR ensures that the visibility of corrections and clarifications is properly synced with their parent post's status. When a post is unpublished, made private, or trashed, its associated corrections will now automatically update to match the post's status, preventing them from being publicly visible in the corrections archive or showing orphaned data.

Existing corrections status won't be automatically updated after these changes are released until the post is updated to change the status or any change is made to the corrections.

### How to test the changes in this Pull Request:

1. Create a new post and add a correction to it.
2. Visit the Corrections archive page (`https://<yoursite>/corrections/`) and verify the correction is visible.
3. Change the post status to private or draft.
4. Visit the Corrections archive page again and verify the correction is no longer visible.
5. Change the post status back to published and verify the correction becomes visible again.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210150206359599