### PR TITLE
fix(emails): add missing HTML markup in the change-email-cancel template

### DIFF
--- a/includes/templates/reader-activation-emails/change-email-cancel.php
+++ b/includes/templates/reader-activation-emails/change-email-cancel.php
@@ -250,6 +250,12 @@ $email_html = '
 					<div style="margin:0px auto;max-width:488px;"><table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"><tbody><tr><td style="direction:ltr;font-size:0px;padding:0;text-align:center;"><!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:488px;" ><![endif]-->
 						<div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"><table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%"><tbody><tr><td style="vertical-align:top;padding:12px;"><table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%"><tbody><tr><td align="left" style="font-size:0px;padding:0;word-break:break-word;"><div style="font-family:Arial;font-size:12px;line-height:1.5;text-align:left;color:' . esc_attr( $primary_text_color ) . ';"><p class="has-small-font-size">*SITE_CONTACT*<br> ' . sprintf( /* Translators: s: link to site url. */ __( 'You received this email because you requested to update your email address for %s', 'newspack-plugin' ), '<a style="color:' . esc_attr( $primary_text_color ) . ' !important" href="*SITE_URL*" target="_blank">*SITE_URL*</a>' ) . '</p></div></td></tr></tbody></table></td></tr></tbody></table></div><!--[if mso | IE]></td></tr></table><![endif]--></td></tr></tbody></table></div><!--[if mso | IE]></td></tr></table></td></tr></table><![endif]--></td></tr></tbody></table></div><!--[if mso | IE]></td></tr></table><![endif]-->
 			</div>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</div>
 		</body>
 	</html>';
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The "Email change requested" template had missing HTML closing tags, resulting in a malformatted email payload. While it might not matter much for most email clients, it messed with the E2E tests. 

### How to test the changes in this Pull Request:

1. On `trunk`, 
2. Reset the "Email change requested" email:

<img width="1118" alt="image" src="https://github.com/user-attachments/assets/f93cdefa-af9e-47ee-a67c-5da21c3099d0" />

3. Note the post ID (via the "Edit" link)
4. Get the email payload: `wp post meta get <post-id> newspack_email_html`
5. Validate it in https://validator.w3.org/#validate_by_input
6. Observe "Unclosed element" errors
7. Switch to this branch, reset the email, get the meta from the new post, validate again
8. Observe no "Unclosed element" errors

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->