### PR TITLE
fix: ensure compatibility with woo memberships 1.27.2

### DIFF
--- a/includes/plugins/wc-memberships/class-metering.php
+++ b/includes/plugins/wc-memberships/class-metering.php
@@ -36,7 +36,7 @@ class Metering {
 	 */
 	public static function init() {
 		add_action( 'init', [ __CLASS__, 'register_meta' ] );
-		add_action( 'wp', [ __CLASS__, 'handle_restriction' ], 9 );
+		add_action( 'wp', [ __CLASS__, 'handle_restriction' ], 5 ); // Before Woo Memberships' restriction handler, which was lowered to 9 in 1.27.2.
 		add_action( 'wp_footer', [ __CLASS__, 'enqueue_scripts' ] );
 		add_filter( 'newspack_reader_activity_article_view', [ __CLASS__, 'get_article_view' ], 20 );
 	}
@@ -131,7 +131,8 @@ class Metering {
 		// Remove the default restriction handler from 'SkyVerge\WooCommerce\Memberships\Restrictions\Posts::restrict_post'.
 		if ( self::is_metering() ) {
 			$restriction_instance = \wc_memberships()->get_restrictions_instance()->get_posts_restrictions_instance();
-			\remove_action( 'wp', spl_object_hash( $restriction_instance ) . 'handle_restriction_modes' );
+			\remove_action( 'wp', spl_object_hash( $restriction_instance ) . 'handle_restriction_modes', 9 );
+			\remove_action( 'wp', spl_object_hash( $restriction_instance ) . 'handle_restriction_modes' ); // For compatibility with Woo Memberships < 1.27.2.
 			\add_filter( 'wc_memberships_restrictable_comment_types', '__return_empty_array' );
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Woocommerce Memberhisps lowered the priority of the hook it uses to restrict content, which made our own hooks to break. The result was that we were unable to apply metering to the posts and all posts were being restricted in the first visit.

Also, our JS was correctly removing the content gate before all the free articles have been read, so the end result was just a post with one or two paragraphs.

### How to test the changes in this Pull Request:

1. Install the latest Woo Memberships (1.27.2)
2. Create a content gate with metering for anonymous visitor
3. On `trunk` notice that the content is trimmed on the first visit
4. Checkout this branch and see that the content is not trimmed, only when you read all the allowed articles
5. See that the content gate renders as expected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->