### PR TITLE
feat(collections): add optional collections module

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -146,6 +146,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/newspack/class-seo-section.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/newspack/class-pixels-section.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/newspack/class-recirculation-section.php';
+		include_once NEWSPACK_ABSPATH . 'includes/wizards/newspack/class-collections-section.php';
 
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-setup-wizard.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-components-demo.php';
@@ -213,6 +214,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/optional-modules/class-rss.php';
 		include_once NEWSPACK_ABSPATH . 'includes/optional-modules/class-media-partners.php';
 		include_once NEWSPACK_ABSPATH . 'includes/optional-modules/class-woo-member-commenting.php';
+		include_once NEWSPACK_ABSPATH . 'includes/optional-modules/class-collections.php';
 
 		if ( Donations::is_platform_nrh() ) {
 			include_once NEWSPACK_ABSPATH . 'includes/class-nrh.php';

--- a/includes/optional-modules/class-collections.php
+++ b/includes/optional-modules/class-collections.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Collections module.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Collections module for managing print editions and other collections.
+ */
+class Collections {
+	/**
+	 * Module name for the optional modules system.
+	 *
+	 * @var string
+	 */
+	const MODULE_NAME = 'collections';
+
+	/**
+	 * Initialize the module.
+	 */
+	public static function init() {
+		// Only initialize if the feature is enabled and the module is active.
+		if ( ! self::is_feature_enabled() || ! Optional_Modules::is_optional_module_active( self::MODULE_NAME ) ) {
+			return;
+		}
+
+		// Register hooks and filters.
+		add_action( 'init', [ __CLASS__, 'register_post_type' ] );
+		add_action( 'init', [ __CLASS__, 'register_taxonomies' ] );
+	}
+
+	/**
+	 * Register the Collections custom post type.
+	 */
+	public static function register_post_type() {
+		// TODO: Implement post type registration.
+	}
+
+	/**
+	 * Register the Collections and Sections taxonomies.
+	 */
+	public static function register_taxonomies() {
+		// TODO: Implement taxonomy registration.
+	}
+
+	/**
+	 * Whether the Collections module is enabled.
+	 *
+	 * @return bool True if Collections is enabled.
+	 */
+	public static function is_feature_enabled() {
+		// Check if the feature is enabled.
+		$is_enabled = defined( 'NEWSPACK_COLLECTIONS_ENABLED' ) ? constant( 'NEWSPACK_COLLECTIONS_ENABLED' ) : false;
+
+		/**
+		 * Filters whether the Collections feature is enabled.
+		 *
+		 * @param bool $is_enabled Whether the Collections module is enabled.
+		 */
+		return apply_filters( 'newspack_collections_enabled', $is_enabled );
+	}
+}
+
+// Initialize the module.
+Collections::init();

--- a/includes/optional-modules/class-optional-modules.php
+++ b/includes/optional-modules/class-optional-modules.php
@@ -37,6 +37,7 @@ class Optional_Modules {
 			self::MODULE_ENABLED_PREFIX . 'rss'            => false,
 			self::MODULE_ENABLED_PREFIX . 'media-partners' => false,
 			self::MODULE_ENABLED_PREFIX . 'woo-member-commenting' => false,
+			self::MODULE_ENABLED_PREFIX . 'collections'    => false,
 		];
 		return wp_parse_args( get_option( self::OPTION_NAME ), $default_settings );
 	}
@@ -62,7 +63,7 @@ class Optional_Modules {
 	 * @return array List of available optional modules.
 	 */
 	public static function get_available_optional_modules(): array {
-		return [ 'rss', 'woo-member-commenting' ];
+		return [ 'rss', 'woo-member-commenting', 'collections' ];
 	}
 
 	/**

--- a/includes/wizards/newspack/class-collections-section.php
+++ b/includes/wizards/newspack/class-collections-section.php
@@ -43,7 +43,7 @@ class Collections_Section {
 					'callback'            => [ __CLASS__, 'api_update_settings' ],
 					'permission_callback' => [ $this, 'api_permissions_check' ],
 					'args'                => [
-						'module_enabled_collections' => [
+						Optional_Modules::MODULE_ENABLED_PREFIX . 'collections' => [
 							'required'          => true,
 							'sanitize_callback' => 'rest_sanitize_boolean',
 						],
@@ -68,7 +68,7 @@ class Collections_Section {
 	 */
 	public static function api_update_settings( $request ) {
 		$settings = Optional_Modules::get_settings();
-		$settings['module_enabled_collections'] = $request->get_param( 'module_enabled_collections' );
+		$settings[ Optional_Modules::MODULE_ENABLED_PREFIX . 'collections' ] = $request->get_param( Optional_Modules::MODULE_ENABLED_PREFIX . 'collections' );
 		update_option( Optional_Modules::OPTION_NAME, $settings );
 		return Optional_Modules::get_settings();
 	}

--- a/includes/wizards/newspack/class-collections-section.php
+++ b/includes/wizards/newspack/class-collections-section.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Collections Section Object.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Wizards\Newspack;
+
+use Newspack\Optional_Modules;
+use WP_REST_Server;
+
+/**
+ * Collections Section Object.
+ *
+ * @package Newspack\Wizards\Newspack
+ */
+class Collections_Section {
+	/**
+	 * Containing wizard slug.
+	 *
+	 * @var string
+	 */
+	protected $wizard_slug = 'newspack-settings';
+
+	/**
+	 * Register Wizard Section specific endpoints.
+	 *
+	 * @return void
+	 */
+	public function register_rest_routes() {
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->wizard_slug . '/collections',
+			[
+				[
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => [ __CLASS__, 'api_get_settings' ],
+					'permission_callback' => [ $this, 'api_permissions_check' ],
+				],
+				[
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => [ __CLASS__, 'api_update_settings' ],
+					'permission_callback' => [ $this, 'api_permissions_check' ],
+					'args'                => [
+						'module_enabled_collections' => [
+							'required'          => true,
+							'sanitize_callback' => 'rest_sanitize_boolean',
+						],
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Get settings.
+	 */
+	public static function api_get_settings() {
+		return Optional_Modules::get_settings();
+	}
+
+	/**
+	 * Update settings.
+	 *
+	 * @param \WP_REST_Request $request Full details about the request.
+	 * @return array
+	 */
+	public static function api_update_settings( $request ) {
+		$settings = Optional_Modules::get_settings();
+		$settings['module_enabled_collections'] = $request->get_param( 'module_enabled_collections' );
+		update_option( Optional_Modules::OPTION_NAME, $settings );
+		return Optional_Modules::get_settings();
+	}
+
+	/**
+	 * Permissions check for the API.
+	 *
+	 * @return bool
+	 */
+	public function api_permissions_check() {
+		return current_user_can( 'manage_options' );
+	}
+}
+
+// Register the routes on rest_api_init.
+add_action( 'rest_api_init', [ new \Newspack\Wizards\Newspack\Collections_Section(), 'register_rest_routes' ] );

--- a/includes/wizards/newspack/class-newspack-settings.php
+++ b/includes/wizards/newspack/class-newspack-settings.php
@@ -105,6 +105,11 @@ class Newspack_Settings extends Wizard {
 				'label' => __( 'Display Settings', 'newspack-plugin' ),
 			],
 		];
+		if ( \Newspack\Collections::is_feature_enabled() ) {
+			$newspack_settings['collections'] = [
+				'label' => __( 'Collections', 'newspack-plugin' ),
+			];
+		}
 		if ( defined( 'NEWSPACK_MULTIBRANDED_SITE_PLUGIN_FILE' ) ) {
 			$newspack_settings['additional-brands'] = [
 				'label'          => __( 'Additional Brands', 'newspack-plugin' ),

--- a/src/wizards/newspack/types/index.d.ts
+++ b/src/wizards/newspack/types/index.d.ts
@@ -96,6 +96,7 @@ declare global {
 				};
 			};
 			'display-settings': WizardTab;
+			collections: WizardTab;
 		};
 		newspack_aux_data: {
 			is_debug_mode: boolean;

--- a/src/wizards/newspack/views/settings/collections/index.tsx
+++ b/src/wizards/newspack/views/settings/collections/index.tsx
@@ -1,0 +1,61 @@
+/**
+ * Settings Collections: Global settings for Collections module.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import WizardsActionCard from '../../../../wizards-action-card';
+import useWizardApiFetchToggle from '../../../../hooks/use-wizard-api-fetch-toggle';
+
+/**
+ * Collections settings component.
+ */
+function Collections() {
+	const {
+		description,
+		apiData,
+		isFetching,
+		actionText,
+		apiFetchToggle,
+		errorMessage,
+	} = useWizardApiFetchToggle< { module_enabled_collections: boolean } >( {
+		path: '/newspack/v1/wizard/newspack-settings/collections',
+		apiNamespace: 'newspack-settings/collections',
+		refreshOn: [ 'POST' ],
+		data: {
+			module_enabled_collections: false,
+		},
+		description: __(
+			'Manage print editions and other collections of content with custom ordering and organization.',
+			'newspack-plugin'
+		),
+	} );
+
+	return (
+		<div className="newspack-wizard__sections">
+			<h1>{ __( 'Collections Settings', 'newspack-plugin' ) }</h1>
+			<WizardsActionCard
+				title={ __( 'Collections Module', 'newspack-plugin' ) }
+				description={ description }
+				disabled={ isFetching }
+				actionText={ actionText }
+				error={ errorMessage }
+				toggleChecked={ apiData.module_enabled_collections }
+				toggleOnChange={ ( value: boolean ) =>
+					apiFetchToggle(
+						{ ...apiData, module_enabled_collections: value },
+						true
+					)
+				}
+			/>
+		</div>
+	);
+}
+
+export default Collections;

--- a/src/wizards/newspack/views/settings/sections.tsx
+++ b/src/wizards/newspack/views/settings/sections.tsx
@@ -15,6 +15,7 @@ import Connections from './connections';
 import Syndication from './syndication';
 import DisplaySettings from './display-settings';
 import ThemeAndBrand from './theme-and-brand';
+import Collections from './collections';
 
 type SectionKeys = keyof typeof settingsTabs;
 
@@ -31,6 +32,7 @@ const sectionComponents: Partial<
 	seo: Seo,
 	'theme-and-brand': ThemeAndBrand,
 	'display-settings': DisplaySettings,
+	collections: Collections,
 	default: () => <h2>🚫 { __( 'Not found' ) }</h2>,
 };
 

--- a/tests/unit-tests/collections-section.php
+++ b/tests/unit-tests/collections-section.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Unit tests for the Collections_Section wizard class.
+ *
+ * @package Newspack\Tests
+ * @covers \Newspack\Wizards\Newspack\Collections_Section
+ */
+
+use Newspack\Wizards\Newspack\Collections_Section;
+use Newspack\Optional_Modules;
+use WP_UnitTestCase;
+
+/**
+ * Tests for the Collections_Section wizard class.
+ */
+class Newspack_Test_Collections_Section extends WP_UnitTestCase {
+
+	/**
+	 * Clean up settings before each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+		delete_option( Optional_Modules::OPTION_NAME );
+	}
+
+	/**
+	 * Test that the class can be instantiated.
+	 *
+	 * @covers \Newspack\Wizards\Newspack\Collections_Section
+	 */
+	public function test_class_can_be_instantiated() {
+		$section = new Collections_Section();
+		$this->assertInstanceOf( Collections_Section::class, $section );
+	}
+
+	/**
+	 * Test that api_get_settings returns an array with the expected key.
+	 *
+	 * @covers \Newspack\Wizards\Newspack\Collections_Section::api_get_settings
+	 */
+	public function test_api_get_settings_returns_array() {
+		$result = Collections_Section::api_get_settings();
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( Optional_Modules::MODULE_ENABLED_PREFIX . 'collections', $result );
+	}
+
+	/**
+	 * Test that api_update_settings updates the option and returns the new settings.
+	 *
+	 * @covers \Newspack\Wizards\Newspack\Collections_Section::api_update_settings
+	 */
+	public function test_api_update_settings_updates_option() {
+		$request = new WP_REST_Request();
+		$request->set_param( Optional_Modules::MODULE_ENABLED_PREFIX . 'collections', true );
+		$result = Collections_Section::api_update_settings( $request );
+		$this->assertTrue( $result[ Optional_Modules::MODULE_ENABLED_PREFIX . 'collections' ] );
+		$settings = get_option( Optional_Modules::OPTION_NAME );
+		$this->assertTrue( $settings[ Optional_Modules::MODULE_ENABLED_PREFIX . 'collections' ] );
+	}
+
+	/**
+	 * Test that permissions check returns true for admin users.
+	 *
+	 * @covers \Newspack\Wizards\Newspack\Collections_Section::api_permissions_check
+	 */
+	public function test_api_permissions_check_for_admin() {
+		// Simulate admin user.
+		$user_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $user_id );
+		$section = new Collections_Section();
+		$this->assertTrue( $section->api_permissions_check() );
+	}
+
+	/**
+	 * Test that permissions check returns false for non-admin users.
+	 *
+	 * @covers \Newspack\Wizards\Newspack\Collections_Section::api_permissions_check
+	 */
+	public function test_api_permissions_check_for_non_admin() {
+		// Simulate subscriber user.
+		$user_id = $this->factory->user->create( [ 'role' => 'subscriber' ] );
+		wp_set_current_user( $user_id );
+		$section = new Collections_Section();
+		$this->assertFalse( $section->api_permissions_check() );
+	}
+}

--- a/tests/unit-tests/collections.php
+++ b/tests/unit-tests/collections.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Unit tests for the Collections module.
+ *
+ * @package Newspack\Tests
+ * @covers \Newspack\Collections
+ */
+
+use Newspack\Collections;
+use WP_UnitTestCase;
+
+/**
+ * Tests for the Collections module.
+ */
+class Newspack_Test_Collections extends WP_UnitTestCase {
+
+	/**
+	 * Remove all filters before each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+		remove_all_filters( 'newspack_collections_enabled' );
+	}
+
+	/**
+	 * Test that the Collections class exists.
+	 *
+	 * @covers \Newspack\Collections
+	 */
+	public function test_class_exists() {
+		self::assertTrue( class_exists( '\Newspack\Collections' ), 'Collections class should exist.' );
+	}
+
+	/**
+	 * Test that the feature is disabled by default.
+	 *
+	 * @covers \Newspack\Collections::is_feature_enabled
+	 */
+	public function test_is_feature_enabled_default_false() {
+		self::assertFalse( Collections::is_feature_enabled(), 'Feature should be disabled by default.' );
+	}
+
+	/**
+	 * Test that the feature is enabled when the constant is set to true.
+	 *
+	 * @covers \Newspack\Collections::is_feature_enabled
+	 */
+	public function test_is_feature_enabled_constant_true() {
+		define( 'NEWSPACK_COLLECTIONS_ENABLED', true );
+		self::assertTrue( Collections::is_feature_enabled(), 'Feature should be enabled when constant is true.' );
+	}
+
+	/**
+	 * Test that the feature is enabled when the filter returns true.
+	 *
+	 * @covers \Newspack\Collections::is_feature_enabled
+	 */
+	public function test_is_feature_enabled_filter_true() {
+		add_filter( 'newspack_collections_enabled', '__return_true' );
+		self::assertTrue( Collections::is_feature_enabled(), 'Feature should be enabled by filter.' );
+		remove_all_filters( 'newspack_collections_enabled' );
+	}
+}

--- a/tests/unit-tests/optional-modules.php
+++ b/tests/unit-tests/optional-modules.php
@@ -29,6 +29,7 @@ class Newspack_Test_Settings extends WP_UnitTestCase {
 				'module_enabled_rss'                   => false,
 				'module_enabled_media-partners'        => false,
 				'module_enabled_woo-member-commenting' => false,
+				'module_enabled_collections'           => false,
 			],
 			'Default settings are as expected.'
 		);
@@ -47,6 +48,20 @@ class Newspack_Test_Settings extends WP_UnitTestCase {
 				'module_enabled_rss'                   => true,
 				'module_enabled_media-partners'        => false,
 				'module_enabled_woo-member-commenting' => false,
+				'module_enabled_collections'           => false,
+			],
+			'Settings is updated.'
+		);
+
+		$request->set_param( 'module_enabled_collections', true );
+		Syndication::api_update_settings( $request );
+		self::assertEquals(
+			Optional_Modules::get_settings(),
+			[
+				'module_enabled_rss'                   => true,
+				'module_enabled_media-partners'        => false,
+				'module_enabled_woo-member-commenting' => false,
+				'module_enabled_collections'           => true,
 			],
 			'Settings is updated.'
 		);
@@ -59,6 +74,7 @@ class Newspack_Test_Settings extends WP_UnitTestCase {
 				'module_enabled_rss'                   => true,
 				'module_enabled_media-partners'        => false,
 				'module_enabled_woo-member-commenting' => false,
+				'module_enabled_collections'           => true,
 			],
 			'A non-existent setting is not saved.'
 		);
@@ -87,6 +103,27 @@ class Newspack_Test_Settings extends WP_UnitTestCase {
 			Optional_Modules::is_optional_module_active( 'rss' ),
 			false,
 			'RSS module is deactivated.'
+		);
+
+		// Test collections module activation.
+		self::assertEquals(
+			Optional_Modules::is_optional_module_active( 'collections' ),
+			false,
+			'Collections module is not active by default.'
+		);
+
+		Optional_Modules::activate_optional_module( 'collections' );
+		self::assertEquals(
+			Optional_Modules::is_optional_module_active( 'collections' ),
+			true,
+			'Collections module is active after being activated.'
+		);
+
+		Optional_Modules::deactivate_optional_module( 'collections' );
+		self::assertEquals(
+			Optional_Modules::is_optional_module_active( 'collections' ),
+			false,
+			'Collections module is deactivated.'
 		);
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

- **Introduce the Collections module:** Adds a new module skeleton for managing print editions and other collections.
- **Settings and activation:** Integrates Collections into the optional modules system, allowing activation/deactivation and settings management.
- **Admin settings UI integration:** Adds a Collections section to the Newspack settings wizard. Includes the needed REST API endpoints and a frontend settings panel (with only one switch for toggling the module for now). Further global options will be added later to this view.
- **TypeScript:** Updates type definitions to support the new Collections section.
- **Unit tests:** Adds PHPUnit tests for the Collections module and settings section.

Closes [NPPD-144](https://linear.app/a8c/issue/NPPD-144/create-plugin-module).

### How to test the changes in this Pull Request:
1.  Add the feature flag to your `wp-config.php` file:
```php
define( 'NEWSPACK_COLLECTIONS_ENABLED', true );
```
2. Go to Newspack > Settings in the WordPress admin and verify that a new "Collections" section appears.
3. Toggle the Collections module on/off and verify the setting is saved and reflected in the UI.
4. Review the REST API endpoints for `/wp-json/newspack/v1/wizard/newspack-settings/collections` to verify that settings can be read and updated.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?