### PR TITLE
fix: update path to verify template in WooCommerce My Account class

### DIFF
--- a/includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php
+++ b/includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php
@@ -791,7 +791,7 @@ class WooCommerce_My_Account {
 			\add_action(
 				'woocommerce_account_content',
 				function() {
-					include __DIR__ . '/templates/myaccount-verify.php';
+					include __DIR__ . '/templates/verify.php';
 				}
 			);
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

I was getting a blank page and an error because the path to the verify template for my account is no longer valid. #3974 renamed the template but didn't update the path.

![CleanShot 2025-05-26 at 11 17 59@2x](https://github.com/user-attachments/assets/5dc5e211-d795-4945-be0b-691929361482)

### How to test the changes in this Pull Request:

1. Create a new user
2. On `trunk`, go to `my-account/edit-account` and see the blank template area
3. Now switch to this branch, and reload the page. You should see content.



### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->