### PR TITLE
fix(corrections): rewrite rule flush check

### DIFF
--- a/includes/corrections/class-corrections.php
+++ b/includes/corrections/class-corrections.php
@@ -171,7 +171,7 @@ class Corrections {
 		\register_post_type( self::POST_TYPE, $args );
 
 		$rewrite_rules_updated_option_name = 'newspack_corrections_rewrite_rules_updated';
-		if ( get_option( $rewrite_rules_updated_option_name ) !== true ) {
+		if ( get_option( $rewrite_rules_updated_option_name ) !== 'true' ) {
 			flush_rewrite_rules(); //phpcs:ignore
 			update_option( $rewrite_rules_updated_option_name, true );
 		}

--- a/includes/corrections/class-corrections.php
+++ b/includes/corrections/class-corrections.php
@@ -171,7 +171,7 @@ class Corrections {
 		\register_post_type( self::POST_TYPE, $args );
 
 		$rewrite_rules_updated_option_name = 'newspack_corrections_rewrite_rules_updated';
-		if ( get_option( $rewrite_rules_updated_option_name ) !== 'true' ) {
+		if ( get_option( $rewrite_rules_updated_option_name ) !== '1' ) {
 			flush_rewrite_rules(); //phpcs:ignore
 			update_option( $rewrite_rules_updated_option_name, true );
 		}

--- a/includes/corrections/class-corrections.php
+++ b/includes/corrections/class-corrections.php
@@ -171,7 +171,7 @@ class Corrections {
 		\register_post_type( self::POST_TYPE, $args );
 
 		$rewrite_rules_updated_option_name = 'newspack_corrections_rewrite_rules_updated';
-		if ( get_option( $rewrite_rules_updated_option_name ) !== '1' ) {
+		if ( false === get_option( $rewrite_rules_updated_option_name ) ) {
 			flush_rewrite_rules(); //phpcs:ignore
 			update_option( $rewrite_rules_updated_option_name, true );
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The rewrite rules are flushed on every page load. This fixes the option check to only run if the option doesn't exist.

### How to test the changes in this Pull Request:

1. While on release, confirm the option is updated and the rewrite rules are flushed every page load
2. Checkout this branch and run `wp option delete newspack_corrections_rewrite_rules_updated`
3. Reload the page and confirm the option gets updated and rewrite rules are flushed
4. Reload again and confirm it no longer updates

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
<!-- Mark completed items with an [x] -->