### PR TITLE
feat(collections): register collection category taxonomy

### DIFF
--- a/includes/collections/class-collection-category-taxonomy.php
+++ b/includes/collections/class-collection-category-taxonomy.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Collection Categories Taxonomy handler.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Collections;
+
+use Newspack\Collections\Post_Type;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Handles the Collection Categories taxonomy and related operations.
+ */
+class Collection_Category_Taxonomy {
+
+	/**
+	 * Taxonomy for Collection Categories.
+	 *
+	 * @var string
+	 */
+	private const TAXONOMY = 'collection_category';
+
+	/**
+	 * Get the taxonomy for Collection Categories.
+	 *
+	 * @return string The taxonomy name.
+	 */
+	public static function get_taxonomy() {
+		return self::TAXONOMY;
+	}
+
+	/**
+	 * Initialize the taxonomy handler.
+	 */
+	public static function init() {
+		add_action( 'init', [ __CLASS__, 'register_taxonomy' ] );
+		add_action( 'manage_' . Post_Type::get_post_type() . '_posts_columns', [ __CLASS__, 'set_taxonomy_column_name' ] );
+	}
+
+	/**
+	 * Register the Collection Categories taxonomy.
+	 */
+	public static function register_taxonomy() {
+		$labels = array(
+			'name'              => _x( 'Collection Categories', 'taxonomy general name', 'newspack-plugin' ),
+			'singular_name'     => _x( 'Collection Category', 'taxonomy singular name', 'newspack-plugin' ),
+			'search_items'      => __( 'Search Collection Categories', 'newspack-plugin' ),
+			'all_items'         => __( 'All Collection Categories', 'newspack-plugin' ),
+			'parent_item'       => __( 'Parent Collection Category', 'newspack-plugin' ),
+			'parent_item_colon' => __( 'Parent Collection Category:', 'newspack-plugin' ),
+			'edit_item'         => __( 'Edit Collection Category', 'newspack-plugin' ),
+			'update_item'       => __( 'Update Collection Category', 'newspack-plugin' ),
+			'add_new_item'      => __( 'Add New Collection Category', 'newspack-plugin' ),
+			'new_item_name'     => __( 'New Collection Category Name', 'newspack-plugin' ),
+			'menu_name'         => __( 'Categories', 'newspack-plugin' ),
+		);
+
+		$args = array(
+			'labels'            => $labels,
+			'description'       => __( 'Taxonomy for categorizing collections.', 'newspack-plugin' ),
+			'public'            => true,
+			'show_admin_column' => true,
+			'hierarchical'      => true,
+			'show_in_rest'      => true,
+		);
+
+		register_taxonomy( self::get_taxonomy(), array( Post_Type::get_post_type() ), $args );
+	}
+
+	/**
+	 * Set the taxonomy column name in the admin post list table.
+	 * Used to simplify the column name to "Categories" instead of "Collection Categories".
+	 *
+	 * @param array $posts_columns An associative array of column headings.
+	 * @return array The modified columns array.
+	 */
+	public static function set_taxonomy_column_name( $posts_columns ) {
+		if ( isset( $posts_columns[ 'taxonomy-' . self::get_taxonomy() ] ) ) {
+			$posts_columns[ 'taxonomy-' . self::get_taxonomy() ] = __( 'Categories', 'newspack-plugin' );
+		}
+
+		return $posts_columns;
+	}
+}

--- a/includes/collections/class-collection-category-taxonomy.php
+++ b/includes/collections/class-collection-category-taxonomy.php
@@ -44,7 +44,7 @@ class Collection_Category_Taxonomy {
 	 * Register the Collection Categories taxonomy.
 	 */
 	public static function register_taxonomy() {
-		$labels = array(
+		$labels = [
 			'name'              => _x( 'Collection Categories', 'taxonomy general name', 'newspack-plugin' ),
 			'singular_name'     => _x( 'Collection Category', 'taxonomy singular name', 'newspack-plugin' ),
 			'search_items'      => __( 'Search Collection Categories', 'newspack-plugin' ),
@@ -56,18 +56,17 @@ class Collection_Category_Taxonomy {
 			'add_new_item'      => __( 'Add New Collection Category', 'newspack-plugin' ),
 			'new_item_name'     => __( 'New Collection Category Name', 'newspack-plugin' ),
 			'menu_name'         => __( 'Categories', 'newspack-plugin' ),
-		);
+		];
 
-		$args = array(
+		$args = [
 			'labels'            => $labels,
 			'description'       => __( 'Taxonomy for categorizing collections.', 'newspack-plugin' ),
 			'public'            => true,
 			'show_admin_column' => true,
-			'hierarchical'      => true,
 			'show_in_rest'      => true,
-		);
+		];
 
-		register_taxonomy( self::get_taxonomy(), array( Post_Type::get_post_type() ), $args );
+		register_taxonomy( self::get_taxonomy(), [ Post_Type::get_post_type() ], $args );
 	}
 
 	/**

--- a/includes/optional-modules/class-collections.php
+++ b/includes/optional-modules/class-collections.php
@@ -12,10 +12,12 @@ defined( 'ABSPATH' ) || exit;
 require_once __DIR__ . '/../collections/traits/trait-hook-management.php';
 require_once __DIR__ . '/../collections/class-post-type.php';
 require_once __DIR__ . '/../collections/class-collection-taxonomy.php';
+require_once __DIR__ . '/../collections/class-collection-category-taxonomy.php';
 require_once __DIR__ . '/../collections/class-sync.php';
 
 use Newspack\Collections\Post_Type;
 use Newspack\Collections\Collection_Taxonomy;
+use Newspack\Collections\Collection_Category_Taxonomy;
 
 /**
  * Collections module for managing print editions and other collections.
@@ -39,6 +41,7 @@ class Collections {
 
 		Post_Type::init();
 		Collection_Taxonomy::init();
+		Collection_Category_Taxonomy::init();
 	}
 
 	/**

--- a/tests/unit-tests/collections/class-test-collection-category-taxonomy.php
+++ b/tests/unit-tests/collections/class-test-collection-category-taxonomy.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Unit tests for the Collection Category Taxonomy handler.
+ *
+ * @package Newspack\Tests
+ * @covers \Newspack\Collections\Collection_Category_Taxonomy
+ */
+
+namespace Newspack\Tests\Unit\Collections;
+
+use WP_UnitTestCase;
+use Newspack\Collections\Collection_Category_Taxonomy;
+use Newspack\Collections\Post_Type;
+
+/**
+ * Test the Collection Category Taxonomy functionality.
+ */
+class Test_Collection_Category_Taxonomy extends WP_UnitTestCase {
+	use Traits\Trait_Collections_Test;
+
+	/**
+	 * Set up the test environment.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		// Register post type and taxonomy directly as the WP environment is already initialized.
+		Post_Type::register_post_type();
+		Collection_Category_Taxonomy::register_taxonomy();
+	}
+
+	/**
+	 * Test that the taxonomy is registered.
+	 *
+	 * @covers \Newspack\Collections\Collection_Category_Taxonomy::register_taxonomy
+	 */
+	public function test_taxonomy_registration() {
+		$taxonomy = get_taxonomy( Collection_Category_Taxonomy::get_taxonomy() );
+		$this->assertNotNull( $taxonomy, 'Taxonomy should be registered.' );
+		$this->assertEquals( 'Collection Categories', $taxonomy->labels->name, 'Taxonomy label should be "Collection Categories".' );
+		$this->assertTrue( $taxonomy->public, 'Taxonomy should be public.' );
+		$this->assertContains( Post_Type::get_post_type(), $taxonomy->object_type, 'Taxonomy should be associated with collection post type.' );
+	}
+
+	/**
+	 * Test that a collection category term can be created.
+	 *
+	 * @covers \Newspack\Collections\Collection_Category_Taxonomy::register_taxonomy
+	 */
+	public function test_create_collection_category() {
+		$args = [
+			'name' => 'Test Category',
+			'slug' => 'test-category',
+		];
+
+		$term = wp_insert_term( $args['name'], Collection_Category_Taxonomy::get_taxonomy(), $args );
+		$this->assertNotWPError( $term, 'Term should be created successfully.' );
+
+		$created_term = get_term( $term['term_id'], Collection_Category_Taxonomy::get_taxonomy() );
+		$this->assertEquals( $args['name'], $created_term->name, 'Term name should be set correctly.' );
+		$this->assertEquals( $args['slug'], $created_term->slug, 'Term slug should be set correctly.' );
+	}
+
+	/**
+	 * Test that set_taxonomy_column_name changes the taxonomy column label to 'Categories'.
+	 *
+	 * @covers \Newspack\Collections\Collection_Category_Taxonomy::set_taxonomy_column_name
+	 */
+	public function test_set_taxonomy_column_name() {
+		$columns = [
+			'cb'    => '<input type="checkbox" />',
+			'title' => 'Title',
+			'taxonomy-' . Collection_Category_Taxonomy::get_taxonomy() => 'Collection Categories',
+			'date'  => 'Date',
+		];
+
+		$result = Collection_Category_Taxonomy::set_taxonomy_column_name( $columns );
+
+		$this->assertEquals(
+			'Categories',
+			$result[ 'taxonomy-' . Collection_Category_Taxonomy::get_taxonomy() ],
+			'The taxonomy column label should be changed to "Categories".'
+		);
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

- Register a Collection Categories taxonomy for the Collections custom post type.
- Customize the admin post list table column header for this taxonomy to display as "Categories" instead of "Collection Categories".

Closes [NPPD-385](https://linear.app/a8c/issue/NPPD-385/create-a-colllection-category-taxonomy).

### How to test the changes in this Pull Request:

1. Activate the Collections module. You should now see a new Categories menu item inside Collections.:
![image](https://github.com/user-attachments/assets/219d7672-7bee-4fc5-a716-b8fc56f5ce00)
2. In the admin, go to the Collections post list table.
3. Confirm that the taxonomy column header appears and that clicking the categories filters the collections accordingly.
4. Create and assign Collection Categories to Collection posts from the admin screen or from the block editor panel. Supports hierarchical terms:
![image](https://github.com/user-attachments/assets/808db7cb-6734-4801-8ea6-8403be3024d8)
5. Confirm that categories are created, assigned, and displayed as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?