### PR TITLE
feat(dashboard): update card style to be more inline with core button card

### DIFF
--- a/src/wizards/newspack/components/quick-actions.tsx
+++ b/src/wizards/newspack/components/quick-actions.tsx
@@ -24,7 +24,7 @@ const QuickActions = () => {
 	return (
 		<div className="newspack-dashboard__section">
 			<h3>{ __( 'Quick actions', 'newspack-plugin' ) }</h3>
-			<Grid style={ { '--np-dash-card-icon-size': '48px' } } columns={ 3 } gutter={ 24 }>
+			<Grid style={ { '--np-dash-card-icon-size': '40px' } } columns={ 3 } gutter={ 24 }>
 				{ quickActions.map( ( action, i ) => {
 					return (
 						<a href={ action.href } key={ i }>

--- a/src/wizards/newspack/views/dashboard/style.scss
+++ b/src/wizards/newspack/views/dashboard/style.scss
@@ -36,14 +36,14 @@
 	align-items: center;
 	background-color: transparent;
 	border-color: wp-colors.$gray-300;
-	border-radius: 2px;
+	border-radius: 4px;
 	display: grid;
 	grid-gap: var(--newspack-wizard-section-child-space);
 	grid-template: "icon text" auto / var(--np-dash-card-icon-size) auto;
 	margin: 0;
 	overflow: hidden;
 	padding: var(--newspack-wizard-section-child-space);
-	transition: border-color 0.15s, background-color 0.15s;
+	transition: border-color 125ms ease-in-out, background-color 125ms ease-in-out;
 
 	h4 {
 		font-size: 16px;
@@ -55,6 +55,7 @@
 	}
 
 	p {
+		color: wp-colors.$gray-700;
 		grid-area: text;
 		line-height: 16px;
 		margin: 0;
@@ -70,33 +71,22 @@
 
 .newspack-dashboard__card-icon {
 	background-color: #{colors.$primary-000};
-	border: 1px solid white;
-	border-radius: 4px;
+	border-radius: 2px;
 	display: grid;
 	fill: var(--wp-admin-theme-color);
 	grid-area: icon;
 	height: var(--np-dash-card-icon-size);
 	width: var(--np-dash-card-icon-size);
 	place-items: center;
-	transform: translateZ(0);
-
-	svg {
-		transition: transform 0.15s ease-in-out;
-	}
 }
 
 a {
-
 	&:hover,
 	&:focus {
 		.newspack-dashboard__card {
-			border-color: var(--wp-admin-theme-color);
-
-			.newspack-dashboard__card-icon {
-				svg {
-					transform: scale(1.25);
-				}
-			}
+			background-color: rgba(colors.$primary-000, 0.25);
+			border-color: transparent;
+			color: var(--wp-admin-theme-color);
 		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The changes are fairly minor, but they bring the dashboard cards more in line with how Core’s button cards behave, especially on hover, where they now receive a very light tint of the primary colour. Core’s button cards use rounded icons, but I’ve kept our current approach and simply inverted the border radii, since the smaller radius should sit inside the larger one.

### How to test the changes in this Pull Request:

1. Check Newspack dashboard
2. Switch to this branch
3. Refresh dashboard

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->