### PR TITLE
fix: sync membership status to ESP when reader deletes account

### DIFF
--- a/includes/data-events/listeners.php
+++ b/includes/data-events/listeners.php
@@ -47,6 +47,24 @@ Data_Events::register_listener(
 	}
 );
 
+
+/**
+ * For when a reader is deleted, syncs the membership status update to the ESP.
+ */
+Data_Events::register_listener(
+	'delete_user',
+	'reader_delete_sync',
+	function( $user_id, $reassign, $user ) {
+		if ( ! Reader_Activation::is_user_reader( $user ) ) {
+			return;
+		}
+		return [
+			'user_id' => $user_id,
+			'user'    => $user,
+		];
+	}
+);
+
 /**
  * For when a reader registers via Woo.
  */

--- a/includes/reader-activation/sync/class-esp-sync.php
+++ b/includes/reader-activation/sync/class-esp-sync.php
@@ -273,11 +273,14 @@ class ESP_Sync extends Sync {
 
 		foreach ( self::$queued_syncs as $email => $queued_sync ) {
 			$user = get_user_by( 'email', $email );
-			if ( ! $user ) {
-				continue;
+			$contact = null;
+			if ( $user ) {
+				// For existing users, get fresh contact data.
+				$contact = self::get_contact_data( $user->ID );
+			} else {
+				// For deleted users, try to use the queued contact data directly; $user will return nothing.
+				$contact = $queued_sync['contact'];
 			}
-
-			$contact = self::get_contact_data( $user->ID );
 			if ( ! $contact ) {
 				continue;
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR makes sure a reader's NP_Membership Status is updated to the ESP when a user deletes their account. 

I went down a bit of a rabbit hole with this one, thinking the missing information sent by `reader_delete_sync()` was causing it not to sync to the ESP. It turns out it was actually because the user no longer existed by the time `run_queued_syncs()` was run, so `self::get_contact_data( $user->ID )` wasn't returning anything for them. 

I ended up trying to grab more user info before delete with `store_user_data_before_deletion()` to fix what I originally thought the issue was. I've left that in place in case it's better to send as much info to the ESP as possible, but the NP_Membership Status update seems to work without it by just sending the stuff under `// If we don't have anything stored, send what we can.`.

See NPPM-387.

### How to test the changes in this Pull Request:

1. Start with a test set connected to either ActiveCampaign or MailChimp, and make sure it's set to sync reader data to the ESP under Audience > Configuration. 
2. Set up a membership product for readers to purchase, and add a Checkout button block to a page for that product. 
3. In an incognito window, run through a checkout with the membership product. 
4. When complete, confirm your reader's information was synced to the ESP:

![CleanShot 2025-05-28 at 11 03 00](https://github.com/user-attachments/assets/2417bb7b-6576-4939-a6c4-f6da1ff16a7b)

5. Back in your incognito window, go to My Account > Delete Account. Follow the steps (getting the deletion email, following the link, and clicking the "Delete Account" button). 
6. Check your ESP; note the account still has a NP_Membership Status of `active`, even though the account was deleted. 
7. Apply this PR.
8. Repeat steps 3-6; on step 6, confirm that your reader's NP_Membership Status was updated to `user-deleted`:

![CleanShot 2025-05-28 at 11 11 06](https://github.com/user-attachments/assets/00157728-6ab4-4034-a12b-0fc4a90706d2)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->