### PR TITLE
fix: return to dashboard link

### DIFF
--- a/src/components/src/wizard/index.js
+++ b/src/components/src/wizard/index.js
@@ -117,19 +117,23 @@ const Wizard = ( {
 					<div className="bg-white">
 						<div className="newspack-wizard__header__inner">
 							<div className="newspack-wizard__title">
-								<Button
-									isLink
-									href={ newspack_urls.dashboard }
-									label={ __(
-										'Return to Dashboard',
-										'newspack-plugin'
-									) }
-									showTooltip={ true }
-									icon={ category }
-									iconSize={ 36 }
-								>
+								{ newspack_urls.dashboard !== window.location.href ? (
+									<Button
+										isLink
+										href={ newspack_urls.dashboard }
+										label={ __(
+											'Return to Dashboard',
+											'newspack-plugin'
+										) }
+										showTooltip={ true }
+										icon={ category }
+										iconSize={ 36 }
+									>
+										<NewspackIcon size={ 36 } />
+									</Button>
+								) : (
 									<NewspackIcon size={ 36 } />
-								</Button>
+								) }
 								<div>
 									{ headerText && <h2>{ headerText }</h2> }
 									{ subHeaderText && (

--- a/src/components/src/wizard/index.js
+++ b/src/components/src/wizard/index.js
@@ -100,6 +100,8 @@ const Wizard = ( {
 		];
 	}
 
+	const urlWithoutHash = window.location.href.split('#')[0];
+
 	return (
 		<div ref={ref}>
 			<div
@@ -117,7 +119,7 @@ const Wizard = ( {
 					<div className="bg-white">
 						<div className="newspack-wizard__header__inner">
 							<div className="newspack-wizard__title">
-								{ newspack_urls.dashboard !== window.location.href ? (
+								{ newspack_urls.dashboard !== urlWithoutHash ? (
 									<Button
 										isLink
 										href={ newspack_urls.dashboard }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Currently, when you’re on the Newspack Dashboard and hover over the Newspack symbol in the header, a link appears to “return to the dashboard”, even though you’re already there.

This simple fix checks the window’s URL and removes the link when the user is already on the dashboard page.

### How to test the changes in this Pull Request:

1. Navigate to Newspack Dashboard
2. Check the symbol... notice the link/tooltip
3. Switch to this branch
4. Refresh dashboard

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->