### PR TITLE
fix: prevent auto-publishing corrections when scheduling posts

### DIFF
--- a/includes/corrections/class-corrections.php
+++ b/includes/corrections/class-corrections.php
@@ -365,10 +365,12 @@ class Corrections {
 		}
 
 		foreach ( $corrections as $correction ) {
+			// If scheduling the post, set correction status to private to prevent core from immediately publishing it.
+			// This ensures the status update isn't skipped when the correction date is in the past, while preserving the original correction date.
 			wp_update_post(
 				[
 					'ID'          => $correction->ID,
-					'post_status' => $new_status,
+					'post_status' => 'future' === $new_status ? 'private' : $new_status,
 				]
 			);
 		}

--- a/tests/unit-tests/corrections.php
+++ b/tests/unit-tests/corrections.php
@@ -640,6 +640,40 @@ class Test_Corrections extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that corrections are set to private when the post is scheduled.
+	 *
+	 * @covers Corrections::update_corrections_status
+	 */
+	public function test_corrections_set_to_private_when_post_scheduled() {
+		$correction = array(
+			'content'  => 'Test correction content',
+			'type'     => 'correction',
+			'date'     => current_time( 'mysql' ),
+			'priority' => 'low',
+		);
+
+		$correction_id = Corrections::add_correction( self::$post_id, $correction );
+		$this->assertNotWPError( $correction_id );
+		$this->assertNotEquals( 0, $correction_id );
+
+		// Schedule the post.
+		$future_date = gmdate( 'Y-m-d H:i:s', strtotime( '+1 day' ) );
+		wp_update_post(
+			array(
+				'ID'            => self::$post_id,
+				'post_status'   => 'future',
+				'post_date'     => $future_date,
+				'post_date_gmt' => $future_date,
+			)
+		);
+
+		// Check that correction status was set to private.
+		$updated_correction = get_post( $correction_id );
+		$this->assertEquals( 'private', $updated_correction->post_status, 'Correction status should be set to private when post is scheduled.' );
+		$this->assertEquals( $correction['date'], $updated_correction->post_date, 'Correction date should be preserved.' );
+	}
+
+	/**
 	 * Test that corrections can be filtered by supported post types.
 	 *
 	 * @covers Corrections::get_supported_post_types


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:
Prevent corrections from being auto-published when the parent post is scheduled due to this core logic:
https://github.com/WordPress/wordpress-develop/blob/6.8.1/src/wp-includes/post.php#L4638-L4642

The code will now attempt to set the correction status to `private` instead of `future` if the parent post is being scheduled to avoid WordPress immediately publishing the correction if its date is in the past.

The other possible approach could be updating the post date of the correction to match its parent future date, but the current approach helps preserve the original correction date across status updates.

### How to test the changes in this Pull Request:

1. Create a post and add one or more corrections with current or past dates.
2. Schedule the post for a future date.
3. Verify that the correction post(s) are updated with a `private` status, not `future`.
4. Optionally, run the test suite and confirm the new unit test `test_corrections_set_to_private_when_post_scheduled` passes.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?