### PR TITLE
fix: delete contact by email address, not user ID

### DIFF
--- a/includes/data-events/connectors/class-esp-connector.php
+++ b/includes/data-events/connectors/class-esp-connector.php
@@ -191,10 +191,15 @@ class ESP_Connector extends Reader_Activation\ESP_Sync {
 	 * @param int   $client_id ID of the client that triggered the event.
 	 */
 	public static function reader_deleted( $timestamp, $data, $client_id ) {
-		if ( true === Reader_Activation::get_setting( 'sync_esp_delete' ) && isset( $data['user']['data']['user_email'] ) ) {
-			$result = Newspack_Newsletters_Contacts::delete( $data['user']['data']['user_email'], 'RAS Reader deleted' );
-			return $result;
+		if ( ! isset( $data['user']['data']['user_email'] ) ) {
+			return;
 		}
+		if ( true === Reader_Activation::get_setting( 'sync_esp_delete' ) ) {
+			$result = Newspack_Newsletters_Contacts::delete( $data['user']['data']['user_email'], 'RAS Reader deleted' );
+		} else {
+			$result = Newspack_Newsletters_Contacts::update_lists( $data['user']['data']['user_email'], [], 'Reader account deleted' );
+		}
+		return $result;
 	}
 
 	/**

--- a/includes/data-events/connectors/class-esp-connector.php
+++ b/includes/data-events/connectors/class-esp-connector.php
@@ -191,8 +191,9 @@ class ESP_Connector extends Reader_Activation\ESP_Sync {
 	 * @param int   $client_id ID of the client that triggered the event.
 	 */
 	public static function reader_deleted( $timestamp, $data, $client_id ) {
-		if ( true === Reader_Activation::get_setting( 'sync_esp_delete' ) ) {
-			return Newspack_Newsletters_Contacts::delete( $data['user_id'], 'RAS Reader deleted' );
+		if ( true === Reader_Activation::get_setting( 'sync_esp_delete' ) && isset( $data['user']['data']['user_email'] ) ) {
+			$result = Newspack_Newsletters_Contacts::delete( $data['user']['data']['user_email'], 'RAS Reader deleted' );
+			return $result;
 		}
 	}
 

--- a/src/wizards/audience/views/setup/setup.js
+++ b/src/wizards/audience/views/setup/setup.js
@@ -3,7 +3,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { ExternalLink, RangeControl } from '@wordpress/components';
+import { CheckboxControl, ExternalLink, RangeControl } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
 import { useEffect, useState } from '@wordpress/element';
 
@@ -326,6 +326,16 @@ export default withWizardScreen(
 										} }
 									/>
 								) }
+
+								<SectionHeader
+									title={ __( 'Sync user account deletion', 'newspack-plugin' ) }
+									description={ __( 'If enabled, the contact will be deleted from the ESP when a user account is deleted. If disabled, the contact will be unsubscribed from all lists, but not deleted.', 'newspack-plugin' ) }
+								/>
+								<CheckboxControl
+									label={ __( 'Sync user account deletion', 'newspack-plugin' ) }
+									checked={ config.sync_esp_delete }
+									onChange={ value => updateConfig( 'sync_esp_delete', value ) }
+								/>
 								<MetadataFields
 									availableFields={
 										newspackAudience.esp_metadata_fields ||
@@ -394,6 +404,7 @@ export default withWizardScreen(
 									newsletter_list_initial_size:
 										config.newsletter_list_initial_size,
 									sync_esp: config.sync_esp,
+									sync_esp_delete: config.sync_esp_delete,
 									metadata_fields: config.metadata_fields,
 									metadata_prefix: config.metadata_prefix,
 									woocommerce_registration_required: config.woocommerce_registration_required,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

When a user deletes their account, we should unsubscribe them from any newsletter lists and also delete them from the ESP, if the `sync_esp_delete` option is enabled.

Because of a logical error in the Newsletters plugin, currently the contact is not deleted nor unsubscribed from lists when they delete their user account. By the time the `Newspack_Newsletters_Contacts::delete()` method is called, the `$user` account will no longer exist, so this method will always return a `newspack_newsletters_invalid_user error`.

This PR adds UI to control the `sync_esp_delete` option because this fix will result in different behavior. `sync_esp_delete` is `true` by default but there's no UI to change this setting. If publishers want to retain contacts in their ESP lists but simply unsubscribe them upon account deletion, they will now need to update this setting in Audience configuration.

### How to test the changes in this Pull Request:

1. Check out this branch and https://github.com/Automattic/newspack-newsletters/pull/1837.
2. As an admin, visit **Audience > Configuration** and find the "Sync contacts to ESP" settings box (toggle it on if it's not enabled). Confirm that there's a new checkbox setting here to "Sync user account deletion" toggled on by default, and that it persists if you toggle it off or on and save/refresh. Set it toggled ON for now.

<img width="1087" alt="Screenshot 2025-05-29 at 4 25 48 PM" src="https://github.com/user-attachments/assets/0eb8ce98-03fd-4132-8567-5cec9b854840" />

3. In an incognito session, register for a reader account and sign up to at least one newsletter list.
4. In the connected ESP, confirm that the user is synced as a contact.
5. As the reader, visit My Account and complete the Delete Account flow.
6. In the connected ESP, confirm that the user's contact is deleted (or archived, in Mailchimp). 
7. In Audience configuration, toggle OFF "Sync user account deletion" and save.
8. Repeat steps 3–6 as a new reader, but this time confirm that instead of being deleted, the contact is simply unsubscribed from all lists.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->