### PR TITLE
fix(woocommerce-memberships): prevent membership expiry if there's another active subscription

### DIFF
--- a/includes/plugins/wc-memberships/class-membership-expiry.php
+++ b/includes/plugins/wc-memberships/class-membership-expiry.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Hanlde WooCommerce Memberships expiry.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+use Newspack\WooCommerce_Connection;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Main class.
+ */
+class Membership_Expiry {
+	/**
+	 * Initialize hooks and filters.
+	 */
+	public static function init() {
+		// Using just this first filter is not enough. Even if the membership cancellation via linked subscription
+		// is prevented, the expiry code is also executed.
+		add_filter( 'wc_memberships_cancel_subscription_linked_membership', [ __CLASS__, 'prevent_membership_expiration' ], 10, 2 );
+		add_filter( 'wc_memberships_expire_user_membership', [ __CLASS__, 'prevent_membership_expiration' ], 10, 2 );
+	}
+
+	/**
+	 * Prevent membership expiration if there are other active subscriptions.
+	 *
+	 * @param bool                                                      $cancel_membership Whether to cancel the membership when the subscription is cancelled (default true).
+	 * @param \WC_Memberships_Integration_Subscriptions_User_Membership $user_membership The subscription-tied membership.
+	 */
+	public static function prevent_membership_expiration( $cancel_membership, $user_membership ) {
+		if ( ! function_exists( 'wcs_get_subscription' ) ) {
+			return $cancel_membership;
+		}
+		$membership_product_id = $user_membership->get_product_id();
+		$active_subscription_ids = WooCommerce_Connection::get_active_subscriptions_for_user( $user_membership->get_user_id() );
+		foreach ( $active_subscription_ids as $subscription_id ) {
+			$subscription = \wcs_get_subscription( $subscription_id );
+			foreach ( $subscription->get_items() as $item ) {
+				if ( $item->get_product()->get_id() == $membership_product_id ) {
+					$user_membership->set_subscription_id( $subscription_id );
+					$parent_order_ids = \wcs_get_subscription( $subscription_id )->get_related_orders( 'ids', [ 'parent' ] );
+					if ( ! empty( $parent_order_ids ) ) {
+						$first_parent_order_id = reset( $parent_order_ids );
+						$user_membership->set_order_id( $first_parent_order_id );
+					}
+					$user_membership->update_status( 'active' );
+					$cancel_membership = false;
+					break;
+				}
+			}
+		}
+
+		return $cancel_membership;
+	}
+}
+Membership_Expiry::init();

--- a/includes/plugins/wc-memberships/class-membership-expiry.php
+++ b/includes/plugins/wc-memberships/class-membership-expiry.php
@@ -48,6 +48,13 @@ class Membership_Expiry {
 						$user_membership->set_order_id( $first_parent_order_id );
 					}
 					$user_membership->update_status( 'active' );
+					$user_membership->add_note(
+						sprintf(
+							/* translators: %s: Subscription ID */
+							__( 'Another active subscription for this product was found (Subscription ID: %s). Expiry prevented.', 'newspack-plugin' ),
+							$subscription_id
+						)
+					);
 					$cancel_membership = false;
 					break;
 				}

--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -75,6 +75,7 @@ class Memberships {
 		include __DIR__ . '/class-block-patterns.php';
 		include __DIR__ . '/class-metering.php';
 		include __DIR__ . '/class-import-export.php';
+		include __DIR__ . '/class-membership-expiry.php';
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

WooCommerce Memberships has the ability to tie a membership to a subscription. If there are multiple subscriptions, the most recent one will be tied to a membership. The status of the membership will be tied to this subscription's status – even if there are other active subscriptions. 

This PR adds special handling for this case – if there is another active subscription (with the same product), upon the tied subscription's cancellation, the membership will be tied to the active subscription.

NPPM-2023

### How to test the changes in this Pull Request:

1. On `trunk`,
1. Set up a subscriptions product granting a membership
1. Buy two subscriptions, confirm one membership has been created
1. Cancel the more recent subscription
1. Observe the membership is expired 🙁
2. Switch to this branch, repeat, observe that the membership remains active and is tied* to the previous order and subscription

\* See "Member since" column in Memberships list UI
 
### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->