### PR TITLE
fix(campaigns): segments: min/max values for articles read count defaults

### DIFF
--- a/src/components/src/settings/MinMaxSetting.js
+++ b/src/components/src/settings/MinMaxSetting.js
@@ -10,8 +10,8 @@ import { CheckboxControl } from '@wordpress/components';
 import { TextControl } from '../';
 
 const MinMaxSetting = ( {
-	min = 0,
-	max= 100,
+	min,
+	max,
 	onChangeMin,
 	onChangeMax,
 	minPlaceholder,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Changes in https://github.com/Automattic/newspack-plugin/pull/3818/commits/be618880a62f50f4254e8e702abeb89f557712e9 have caused segmentation settings to default to maximum of 100. This PR fixes that, reinstating the lack of default values for these settings.  

<img width="821" alt="image" src="https://github.com/user-attachments/assets/11566cb5-d625-48f4-b101-173de041f925" />


### How to test the changes in this Pull Request:

1. On `trunk`, 
2. Create a new segment in Audience → Campaigns
3. Observe that the values of articles read are set to maximum of 100
4. Switch to this branch, repeat, observe there are no default values for these settings

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->