### PR TITLE
feat(collections): add collection meta fields

### DIFF
--- a/includes/collections/class-collection-category-taxonomy.php
+++ b/includes/collections/class-collection-category-taxonomy.php
@@ -21,7 +21,7 @@ class Collection_Category_Taxonomy {
 	 *
 	 * @var string
 	 */
-	private const TAXONOMY = 'collection_category';
+	private const TAXONOMY = 'newspack_collection_category';
 
 	/**
 	 * Get the taxonomy for Collection Categories.

--- a/includes/collections/class-collection-meta.php
+++ b/includes/collections/class-collection-meta.php
@@ -1,0 +1,161 @@
+<?php
+/**
+ * Collection Meta Fields handler.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Collections;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Handles the Collection meta fields and related operations.
+ */
+class Collection_Meta {
+
+	/**
+	 * Meta key prefix.
+	 *
+	 * @var string
+	 */
+	public const PREFIX = 'newspack_collection_';
+
+	/**
+	 * Get meta keys.
+	 *
+	 * @return array {
+	 *     Array of post meta definitions.
+	 *
+	 *     @type string $type              The type of data associated with this meta key.
+	 *     @type string $label             A human-readable label of the data attached to this meta key.
+	 *     @type string $description       A description of the data attached to this meta key.
+	 *     @type bool   $single            Whether the meta key has one value per object, or an array of values per object.
+	 *     @type string $sanitize_callback A function or method to call when sanitizing `$meta_key` data.
+	 *     @type array  $show_in_rest      Show in REST configuration.
+	 * }
+	 */
+	public static function get_metas() {
+		return [
+			'file_attachment' => [
+				'type'              => 'integer',
+				'label'             => __( 'File upload', 'newspack-plugin' ),
+				'single'            => true,
+				'sanitize_callback' => 'absint',
+				'show_in_rest'      => true,
+			],
+			'file_link'       => [
+				'type'              => 'string',
+				'label'             => __( 'External file URL', 'newspack-plugin' ),
+				'description'       => __( 'Externally hosted PDF or file URL.', 'newspack-plugin' ),
+				'single'            => true,
+				'sanitize_callback' => 'esc_url_raw',
+				'show_in_rest'      => [
+					'schema' => [
+						'format' => 'uri',
+					],
+				],
+			],
+			'volume'          => [
+				'type'              => 'string',
+				'label'             => __( 'Volume', 'newspack-plugin' ),
+				'single'            => true,
+				'sanitize_callback' => 'sanitize_text_field',
+				'show_in_rest'      => true,
+			],
+			'issue_number'    => [
+				'type'              => 'string',
+				'label'             => __( 'Issue Number', 'newspack-plugin' ),
+				'single'            => true,
+				'sanitize_callback' => 'sanitize_text_field',
+				'show_in_rest'      => true,
+			],
+			'issue_date'      => [
+				'type'              => 'string',
+				'label'             => __( 'Issue Date', 'newspack-plugin' ),
+				'description'       => __( 'Issue date as a string (e.g., "Spring 2025", "January 2025")', 'newspack-plugin' ),
+				'single'            => true,
+				'sanitize_callback' => 'sanitize_text_field',
+				'show_in_rest'      => true,
+			],
+			'subscribe_link'  => [
+				'type'              => 'string',
+				'label'             => __( 'Subscription URL', 'newspack-plugin' ),
+				'single'            => true,
+				'sanitize_callback' => 'esc_url_raw',
+				'show_in_rest'      => [
+					'schema' => [
+						'format' => 'uri',
+					],
+				],
+			],
+			'order_link'      => [
+				'type'              => 'string',
+				'label'             => __( 'Order URL', 'newspack-plugin' ),
+				'single'            => true,
+				'sanitize_callback' => 'esc_url_raw',
+				'show_in_rest'      => [
+					'schema' => [
+						'format' => 'uri',
+					],
+				],
+			],
+		];
+	}
+
+	/**
+	 * Get meta definitions to be passed to the frontend.
+	 *
+	 * @return array Meta keys array.
+	 */
+	public static function get_frontend_meta_definitions() {
+		$metas = self::get_metas();
+
+		return array_combine(
+			array_keys( $metas ),
+			array_map(
+				fn( $key ) => [
+					'key'   => self::PREFIX . $key,
+					'type'  => 'uri' === ( $metas[ $key ]['show_in_rest']['schema']['format'] ?? null ) ? 'url' : 'text',
+					'label' => $metas[ $key ]['label'] ?? null,
+					'help'  => $metas[ $key ]['description'] ?? null,
+				],
+				array_keys( $metas )
+			)
+		);
+	}
+
+	/**
+	 * Initialize the meta fields handler.
+	 */
+	public static function init() {
+		add_action( 'init', [ __CLASS__, 'register_meta' ] );
+	}
+
+	/**
+	 * Register meta fields for the collection post type.
+	 */
+	public static function register_meta() {
+		foreach ( self::get_metas() as $key => $meta ) {
+			register_post_meta(
+				Post_Type::get_post_type(),
+				self::PREFIX . $key,
+				array_merge(
+					$meta,
+					[
+						'auth_callback' => [ __CLASS__, 'auth_callback' ],
+					]
+				)
+			);
+		}
+	}
+
+	/**
+	 * Auth callback for meta fields.
+	 *
+	 * @return bool Whether the user can edit posts.
+	 */
+	public static function auth_callback() {
+		return current_user_can( 'edit_posts' );
+	}
+}

--- a/includes/collections/class-collection-section-taxonomy.php
+++ b/includes/collections/class-collection-section-taxonomy.php
@@ -20,14 +20,14 @@ class Collection_Section_Taxonomy {
 	 *
 	 * @var string
 	 */
-	private const TAXONOMY = 'collection_section';
+	private const TAXONOMY = 'newspack_collection_section';
 
 	/**
 	 * Term meta key for ordering.
 	 *
 	 * @var string
 	 */
-	private const ORDER_META_KEY = '_newspack_collection_section_order';
+	private const ORDER_META_KEY = 'newspack_collection_section_order';
 
 	/**
 	 * The column name for the order field.

--- a/includes/collections/class-post-meta.php
+++ b/includes/collections/class-post-meta.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Post Meta handler.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Collections;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Handles the post meta fields and related operations.
+ */
+class Post_Meta {
+
+	/**
+	 * Meta key for storing the order in collection.
+	 *
+	 * @var string
+	 */
+	public const ORDER_META_KEY = 'newspack_order_in_collection';
+
+	/**
+	 * Initialize the meta fields handler.
+	 */
+	public static function init() {
+		add_action( 'init', [ __CLASS__, 'register_meta' ] );
+		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'output_post_meta_data_for_admin_scripts' ] );
+	}
+
+	/**
+	 * Register meta fields for the post post type.
+	 */
+	public static function register_meta() {
+		register_post_meta(
+			'post',
+			self::ORDER_META_KEY,
+			[
+				'type'              => 'integer',
+				'description'       => __( 'Order of the post within a collection.', 'newspack-plugin' ),
+				'single'            => true,
+				'sanitize_callback' => 'absint',
+				'show_in_rest'      => true,
+				'auth_callback'     => [ __CLASS__, 'auth_callback' ],
+			]
+		);
+	}
+
+	/**
+	 * Auth callback for meta fields.
+	 *
+	 * @return bool Whether the user can edit posts.
+	 */
+	public static function auth_callback() {
+		return current_user_can( 'edit_posts' );
+	}
+
+	/**
+	 * Output post meta data for admin scripts.
+	 *
+	 * @param string $hook_suffix The current admin page.
+	 */
+	public static function output_post_meta_data_for_admin_scripts( $hook_suffix ) {
+		if (
+			'post.php' === $hook_suffix &&
+			'post' === get_current_screen()->post_type
+		) {
+			Collections_Data::add_data(
+				'postMeta',
+				[
+					'orderMetaKey' => self::ORDER_META_KEY,
+				]
+			);
+		}
+	}
+}

--- a/includes/collections/class-post-type.php
+++ b/includes/collections/class-post-type.php
@@ -27,6 +27,13 @@ class Post_Type {
 	private const POST_TYPE = 'newspack_collection';
 
 	/**
+	 * Order column name (using default WP menu order column).
+	 *
+	 * @var string
+	 */
+	private const ORDER_COLUMN_NAME = 'menu_order';
+
+	/**
 	 * Get the hooks for collection custom post type operations.
 	 * Same structure as the add_action() parameters.
 	 *
@@ -58,11 +65,23 @@ class Post_Type {
 	}
 
 	/**
+	 * Get the translated column heading.
+	 *
+	 * @return string The translated column heading.
+	 */
+	public static function get_order_column_heading() {
+		return __( 'Order', 'newspack-plugin' );
+	}
+
+	/**
 	 * Initialize the post type handler.
 	 */
 	public static function init() {
 		add_action( 'init', [ __CLASS__, 'register_post_type' ] );
 		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'output_collection_meta_data_for_admin_scripts' ] );
+		add_action( 'manage_' . self::get_post_type() . '_posts_columns', [ __CLASS__, 'add_order_column' ] );
+		add_action( 'manage_' . self::get_post_type() . '_posts_custom_column', [ __CLASS__, 'display_order_column' ], 10, 2 );
+		add_filter( 'manage_edit-' . self::get_post_type() . '_sortable_columns', [ __CLASS__, 'make_order_column_sortable' ] );
 		self::register_hooks();
 		Collection_Meta::init();
 	}
@@ -97,11 +116,45 @@ class Post_Type {
 			'public'       => true,
 			'show_in_rest' => true,
 			'menu_icon'    => 'dashicons-portfolio',
-			'supports'     => [ 'title', 'editor', 'thumbnail', 'custom-fields' ],
+			'supports'     => [ 'title', 'editor', 'thumbnail', 'custom-fields', 'page-attributes' ],
 			'has_archive'  => true,
 		];
 
 		register_post_type( self::get_post_type(), $args );
+	}
+
+	/**
+	 * Add menu order column to the admin list view.
+	 *
+	 * @param array $columns The existing columns.
+	 * @return array Modified columns array.
+	 */
+	public static function add_order_column( $columns ) {
+		$columns[ self::ORDER_COLUMN_NAME ] = self::get_order_column_heading();
+		return $columns;
+	}
+
+	/**
+	 * Display the menu order value in the custom column.
+	 *
+	 * @param string $column_name The name of the column.
+	 * @param int    $post_id     The post ID.
+	 */
+	public static function display_order_column( $column_name, $post_id ) {
+		if ( self::ORDER_COLUMN_NAME === $column_name ) {
+			echo esc_html( get_post_field( self::ORDER_COLUMN_NAME, $post_id ) );
+		}
+	}
+
+	/**
+	 * Make the menu order column sortable.
+	 *
+	 * @param array $columns The sortable columns.
+	 * @return array Modified sortable columns array.
+	 */
+	public static function make_order_column_sortable( $columns ) {
+		$columns[ self::ORDER_COLUMN_NAME ] = self::ORDER_COLUMN_NAME;
+		return $columns;
 	}
 
 	/**

--- a/includes/collections/class-post-type.php
+++ b/includes/collections/class-post-type.php
@@ -11,6 +11,8 @@ use Newspack\Collections\Traits\Hook_Management_Trait;
 
 defined( 'ABSPATH' ) || exit;
 
+require_once __DIR__ . '/class-collection-meta.php';
+
 /**
  * Handles the Collections custom post type and related operations.
  */
@@ -60,7 +62,9 @@ class Post_Type {
 	 */
 	public static function init() {
 		add_action( 'init', [ __CLASS__, 'register_post_type' ] );
+		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'output_collection_meta_data_for_admin_scripts' ] );
 		self::register_hooks();
+		Collection_Meta::init();
 	}
 
 	/**
@@ -93,9 +97,30 @@ class Post_Type {
 			'public'       => true,
 			'show_in_rest' => true,
 			'menu_icon'    => 'dashicons-portfolio',
+			'supports'     => [ 'title', 'editor', 'thumbnail', 'custom-fields' ],
 			'has_archive'  => true,
 		];
 
 		register_post_type( self::get_post_type(), $args );
+	}
+
+	/**
+	 * Output collection meta data for admin scripts.
+	 *
+	 * @param string $hook_suffix The current admin page.
+	 */
+	public static function output_collection_meta_data_for_admin_scripts( $hook_suffix ) {
+		if (
+			'post.php' === $hook_suffix &&
+			self::get_post_type() === get_current_screen()->post_type
+		) {
+			Collections_Data::add_data(
+				'collectionPostType',
+				[
+					'postType' => self::get_post_type(),
+					'postMeta' => Collection_Meta::get_frontend_meta_definitions(),
+				]
+			);
+		}
 	}
 }

--- a/includes/optional-modules/class-collections.php
+++ b/includes/optional-modules/class-collections.php
@@ -44,8 +44,9 @@ class Collections {
 		require_once __DIR__ . '/../collections/class-collection-section-taxonomy.php';
 		require_once __DIR__ . '/../collections/class-sync.php';
 
-		// Enqueue admin scripts.
+		// Enqueue admin scripts and styles.
 		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'enqueue_admin_scripts' ] );
+		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'enqueue_admin_styles' ] );
 
 		// Initialize classes.
 		Collections_Data::init();
@@ -80,9 +81,21 @@ class Collections {
 		wp_enqueue_script(
 			Collections_Data::SCRIPT_NAME_ADMIN,
 			\Newspack\Newspack::plugin_url() . '/dist/collections-admin.js',
-			[ 'jquery' ],
+			[ 'jquery', 'wp-i18n', 'wp-plugins', 'wp-edit-post', 'wp-components', 'wp-element', 'wp-data', 'wp-editor', 'wp-api-fetch' ],
 			NEWSPACK_PLUGIN_VERSION,
 			true
+		);
+	}
+
+	/**
+	 * Enqueue admin styles.
+	 */
+	public static function enqueue_admin_styles() {
+		wp_enqueue_style(
+			Collections_Data::SCRIPT_NAME_ADMIN,
+			\Newspack\Newspack::plugin_url() . '/dist/collections-admin.css',
+			[],
+			NEWSPACK_PLUGIN_VERSION
 		);
 	}
 }

--- a/includes/optional-modules/class-collections.php
+++ b/includes/optional-modules/class-collections.php
@@ -14,6 +14,7 @@ use Newspack\Collections\Post_Type;
 use Newspack\Collections\Collection_Taxonomy;
 use Newspack\Collections\Collection_Category_Taxonomy;
 use Newspack\Collections\Collection_Section_Taxonomy;
+use Newspack\Collections\Post_Meta;
 
 /**
  * Collections module for managing print editions and other collections.
@@ -43,6 +44,7 @@ class Collections {
 		require_once __DIR__ . '/../collections/class-collection-category-taxonomy.php';
 		require_once __DIR__ . '/../collections/class-collection-section-taxonomy.php';
 		require_once __DIR__ . '/../collections/class-sync.php';
+		require_once __DIR__ . '/../collections/class-post-meta.php';
 
 		// Enqueue admin scripts and styles.
 		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'enqueue_admin_scripts' ] );
@@ -54,6 +56,7 @@ class Collections {
 		Collection_Taxonomy::init();
 		Collection_Category_Taxonomy::init();
 		Collection_Section_Taxonomy::init();
+		Post_Meta::init();
 	}
 
 	/**

--- a/src/collections/admin/collection-meta-panel.js
+++ b/src/collections/admin/collection-meta-panel.js
@@ -162,7 +162,7 @@ domReady( () => {
 	const { collectionPostType } = window.newspackCollections || {};
 
 	if ( collectionPostType?.postType && collectionPostType?.postMeta ) {
-		registerPlugin( `${ collectionPostType.postType }-meta`, {
+		registerPlugin( 'newspack-collection-meta-panel', {
 			render: () => (
 				<CollectionMetaPanel
 					postType={ collectionPostType.postType }

--- a/src/collections/admin/collection-meta-panel.js
+++ b/src/collections/admin/collection-meta-panel.js
@@ -1,0 +1,175 @@
+/**
+ * Collection meta fields functionality.
+ */
+
+import { __ } from '@wordpress/i18n';
+import { registerPlugin } from '@wordpress/plugins';
+import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
+import { TextControl } from '@wordpress/components';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useState, useCallback, useEffect } from '@wordpress/element';
+import { store as editorStore } from '@wordpress/editor';
+import { domReady } from '../../utils';
+
+import CollectionMetaUploadField from './collection-meta-upload-field';
+import './collection-meta-panel.scss';
+
+const VALIDATION_LOCK_KEY = 'collection-meta-validation';
+
+/**
+ * Check if a string is a valid URL.
+ *
+ * @param {string} value The URL to validate.
+ * @return {boolean} Whether the URL is valid.
+ */
+const isValidUrl = value => {
+	try {
+		new URL( value );
+		return true;
+	} catch {
+		return false;
+	}
+};
+
+const CollectionMetaPanel = ( { postType, postMetaDefinitions } ) => {
+	const [ fieldErrors, setFieldErrors ] = useState( {} );
+	const { editPost, lockPostSaving, unlockPostSaving } =
+		useDispatch( editorStore );
+
+	// Get the current post type and meta data.
+	const { currentPostType, meta = {} } = useSelect( select => {
+		const editor = select( editorStore );
+		return {
+			currentPostType: editor.getCurrentPostType(),
+			meta: editor.getEditedPostAttribute( 'meta' ) || {},
+		};
+	}, [] );
+
+	// Update the meta data.
+	const updateMeta = useCallback(
+		( key, value ) => {
+			editPost( { meta: { [ key ]: value } } );
+		},
+		[ editPost ]
+	);
+
+	// Remove an error for a specific field.
+	const removeFieldError = useCallback( key => {
+		setFieldErrors( prev =>
+			Object.fromEntries(
+				Object.entries( prev ).filter( ( [ k ] ) => k !== key )
+			)
+		);
+	}, [] );
+
+	// Lock or unlock the post saving based on the field errors.
+	useEffect( () => {
+		const hasErrors = Object.keys( fieldErrors ).length > 0;
+		if ( hasErrors ) {
+			lockPostSaving( VALIDATION_LOCK_KEY );
+		} else {
+			unlockPostSaving( VALIDATION_LOCK_KEY );
+		}
+	}, [ fieldErrors, lockPostSaving, unlockPostSaving ] );
+
+	// Handle the fields blur event.
+	const handleMetaBlur = useCallback(
+		( key, value, type ) => {
+			if ( ! value ) {
+				updateMeta( key, null );
+				removeFieldError( key );
+				return;
+			}
+
+			if ( type === 'url' ) {
+				setFieldErrors( prev => {
+					if ( ! value || isValidUrl( value ) ) {
+						removeFieldError( key );
+						return prev;
+					}
+					return {
+						...prev,
+						[ key ]: __(
+							'Please enter a valid URL.',
+							'newspack-plugin'
+						),
+					};
+				} );
+			}
+		},
+		[ updateMeta, removeFieldError ]
+	);
+
+	return (
+		// Only render the panel if the post type matches the current post type.
+		postType === currentPostType && (
+			<PluginDocumentSettingPanel
+				name="newspack-collections-meta-panel"
+				title={ __( 'Collection Details', 'newspack-plugin' ) }
+				className="newspack-collections-meta-panel"
+				icon="media-document"
+			>
+				<div className="collection-meta-fields">
+					{ Object.entries( postMetaDefinitions ).map(
+						( [ name, def ] ) => {
+							if ( name === 'file_attachment' ) {
+								return (
+									<CollectionMetaUploadField
+										key={ def.key }
+										metaKey={ def.key }
+										label={ def.label }
+										meta={ meta }
+										updateMeta={ updateMeta }
+										lockPostSaving={ lockPostSaving }
+										unlockPostSaving={ unlockPostSaving }
+									/>
+								);
+							}
+
+							const hasError = !! fieldErrors[ def.key ];
+							return (
+								<TextControl
+									key={ def.key }
+									label={ def.label }
+									help={ fieldErrors[ def.key ] || def.help }
+									value={ meta[ def.key ] || '' }
+									type={ def.type }
+									onChange={ value =>
+										updateMeta( def.key, value )
+									}
+									onBlur={ event =>
+										handleMetaBlur(
+											def.key,
+											event.target.value,
+											def.type
+										)
+									}
+									className={
+										hasError ? 'meta-field-error' : ''
+									}
+								/>
+							);
+						}
+					) }
+				</div>
+			</PluginDocumentSettingPanel>
+		)
+	);
+};
+
+// Register the plugin if the collection meta definitions are available.
+domReady( () => {
+	const { collectionPostType } = window.newspackCollections || {};
+
+	if ( collectionPostType?.postType && collectionPostType?.postMeta ) {
+		registerPlugin( `${ collectionPostType.postType }-meta`, {
+			render: () => (
+				<CollectionMetaPanel
+					postType={ collectionPostType.postType }
+					postMetaDefinitions={ collectionPostType.postMeta }
+				/>
+			),
+			icon: 'media-document',
+		} );
+	}
+} );

--- a/src/collections/admin/collection-meta-panel.scss
+++ b/src/collections/admin/collection-meta-panel.scss
@@ -1,0 +1,64 @@
+/**
+ * Collection meta fields styles.
+ */
+
+.newspack-collections-meta-panel {
+	.collection-meta-fields {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+
+		.meta-field-error {
+			input {
+				border-color: var(--newspack-ui-color-error-50);
+			}
+
+			.components-base-control__help {
+				color: var(--newspack-ui-color-error-50);
+			}
+		}
+
+	}
+
+	.upload-controls {
+		display: flex;
+		flex-direction: column;
+
+		.components-spinner {
+			display: block;
+			margin: 0 auto 26px;
+		}
+
+		.uploaded-file {
+			display: flex;
+			justify-content: center;
+			align-items: center;
+			margin-bottom: 0.8rem;
+
+			.dashicons-pdf {
+				font-size: 1.8rem;
+				width: auto;
+				height: auto;
+				display: inline-block;
+			}
+		}
+
+		.upload-actions {
+			display: flex;
+			gap: 10px;
+
+			button {
+				justify-content: center;
+				width: 100%;
+			}
+		}
+
+		&.has-uploaded-file {
+			.upload-actions {
+				button {
+					flex: 1;
+				}
+			}
+		}
+	}
+}

--- a/src/collections/admin/collection-meta-upload-field.js
+++ b/src/collections/admin/collection-meta-upload-field.js
@@ -1,0 +1,170 @@
+import { __ } from '@wordpress/i18n';
+import { MediaUpload } from '@wordpress/block-editor';
+import {
+	Button,
+	Spinner,
+	Notice,
+	BaseControl,
+	useBaseControlProps,
+	ExternalLink,
+	Dashicon,
+} from '@wordpress/components';
+import { useEffect, useCallback, useState } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+import PropTypes from 'prop-types';
+
+export default function CollectionMetaUploadField( {
+	metaKey,
+	meta,
+	updateMeta,
+	lockPostSaving,
+	unlockPostSaving,
+	...baseProps
+} ) {
+	const { baseControlProps, controlProps } = useBaseControlProps( baseProps );
+	const [ attachment, setAttachment ] = useState( null );
+	const [ isUploading, setIsUploading ] = useState( false );
+	const [ isInitialLoading, setIsInitialLoading ] = useState( true );
+	const [ uploadError, setUploadError ] = useState( null );
+
+	const handleFileRemoval = useCallback( () => {
+		setAttachment( null );
+		setUploadError( null );
+		updateMeta( metaKey, null );
+	}, [ updateMeta, metaKey, setUploadError ] );
+
+	const handleMediaSelect = useCallback(
+		media => {
+			if ( media && media.mime === 'application/pdf' ) {
+				setUploadError( null );
+				if ( attachment && media.id === attachment.id ) {
+					setIsUploading( false );
+					return;
+				}
+				setIsUploading( true );
+				setAttachment( media );
+				updateMeta( metaKey, media.id );
+				setIsUploading( false );
+			} else {
+				setUploadError(
+					__( 'Please upload a PDF file.', 'newspack-plugin' )
+				);
+				setIsUploading( false );
+			}
+		},
+		[ attachment, metaKey, setIsUploading, setUploadError, updateMeta ]
+	);
+
+	useEffect( () => {
+		if ( meta[ metaKey ] ) {
+			setIsInitialLoading( true );
+			lockPostSaving();
+			apiFetch( {
+				path: `/wp/v2/media/${ meta[ metaKey ] }`,
+			} )
+				.then( media => {
+					setAttachment( media );
+					setUploadError( null );
+					unlockPostSaving();
+				} )
+				.catch( () => {
+					setAttachment( null );
+					setUploadError(
+						__(
+							'Error loading file. Please try uploading again.',
+							'newspack-plugin'
+						)
+					);
+					updateMeta( metaKey, '' );
+					unlockPostSaving();
+				} )
+				.finally( () => {
+					setIsInitialLoading( false );
+					setIsUploading( false );
+				} );
+		} else {
+			setIsInitialLoading( false );
+		}
+	}, [
+		meta[ metaKey ],
+		updateMeta,
+		metaKey,
+		lockPostSaving,
+		unlockPostSaving,
+	] );
+
+	return (
+		<BaseControl
+			{ ...baseControlProps }
+			className={ `upload-controls ${
+				attachment ? 'has-uploaded-file' : ''
+			}` }
+		>
+			{ uploadError && (
+				<Notice
+					status="error"
+					isDismissible={ false }
+					className="upload-error"
+				>
+					{ uploadError }
+				</Notice>
+			) }
+			{ ( isUploading || isInitialLoading ) && <Spinner /> }
+			{ attachment && ! isInitialLoading && (
+				<div className="uploaded-file">
+					<Dashicon icon="pdf" />
+					<ExternalLink
+						href={ attachment.source_url }
+						target="_blank"
+					>
+						{ attachment.title?.rendered || attachment.source_url }
+					</ExternalLink>
+				</div>
+			) }
+			<div className="upload-actions">
+				<MediaUpload
+					onSelect={ handleMediaSelect }
+					allowedTypes={ [ 'application/pdf' ] }
+					value={ attachment ? attachment.id : null }
+					render={ ( { open } ) => (
+						<Button
+							isSecondary
+							onClick={ open }
+							disabled={ isUploading || isInitialLoading }
+							aria-label={
+								attachment
+									? __( 'Replace file', 'newspack-plugin' )
+									: __( 'Upload file', 'newspack-plugin' )
+							}
+							{ ...controlProps }
+						>
+							{ attachment
+								? __( 'Replace file', 'newspack-plugin' )
+								: __( 'Upload file', 'newspack-plugin' ) }
+						</Button>
+					) }
+				/>
+				{ attachment && (
+					<Button
+						isDestructive
+						isSecondary
+						onClick={ handleFileRemoval }
+						disabled={ isUploading || isInitialLoading }
+						aria-label={ __( 'Remove file', 'newspack-plugin' ) }
+					>
+						{ __( 'Remove file', 'newspack-plugin' ) }
+					</Button>
+				) }
+			</div>
+		</BaseControl>
+	);
+}
+
+CollectionMetaUploadField.propTypes = {
+	metaKey: PropTypes.string.isRequired,
+	meta: PropTypes.object.isRequired,
+	updateMeta: PropTypes.func.isRequired,
+	lockPostSaving: PropTypes.func.isRequired,
+	unlockPostSaving: PropTypes.func.isRequired,
+	label: PropTypes.string.isRequired,
+};

--- a/src/collections/admin/index.js
+++ b/src/collections/admin/index.js
@@ -4,3 +4,4 @@
 
 import './section-taxonomy';
 import './collection-meta-panel';
+import './post-meta-panel';

--- a/src/collections/admin/index.js
+++ b/src/collections/admin/index.js
@@ -3,3 +3,4 @@
  */
 
 import './section-taxonomy';
+import './collection-meta-panel';

--- a/src/collections/admin/post-meta-panel.js
+++ b/src/collections/admin/post-meta-panel.js
@@ -1,0 +1,63 @@
+import { __ } from '@wordpress/i18n';
+import { registerPlugin } from '@wordpress/plugins';
+import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
+import { TextControl } from '@wordpress/components';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
+import { useCallback } from '@wordpress/element';
+import domReady from '@wordpress/dom-ready';
+
+const PostMetaPanel = ( { metaKey } ) => {
+	const { editPost } = useDispatch( editorStore );
+
+	// Get the current post type and meta data.
+	const { currentPostType, meta = {} } = useSelect( select => {
+		const editor = select( editorStore );
+		return {
+			currentPostType: editor.getCurrentPostType(),
+			meta: editor.getEditedPostAttribute( 'meta' ) || {},
+		};
+	}, [] );
+
+	// Update the meta data.
+	const updateMeta = useCallback(
+		value => {
+			const sanitized = value === '' ? '' : parseInt( value, 10 ) || 0;
+			editPost( { meta: { [ metaKey ]: sanitized } } );
+		},
+		[ editPost, metaKey ]
+	);
+
+	return (
+		// Only render the panel for posts.
+		'post' === currentPostType && (
+			<PluginDocumentSettingPanel
+				name="newspack-post-meta-panel"
+				title={ __( 'Collection Settings', 'newspack-plugin' ) }
+				icon="media-document"
+			>
+				<TextControl
+					label={ __( 'Order', 'newspack-plugin' ) }
+					type="number"
+					value={ meta[ metaKey ] || '' }
+					onChange={ updateMeta }
+					help={ __(
+						'Set the order of this post within a collection.',
+						'newspack-plugin'
+					) }
+					min={ 0 }
+				/>
+			</PluginDocumentSettingPanel>
+		)
+	);
+};
+
+domReady( () => {
+	const { postMeta } = window.newspackCollections || {};
+	if ( postMeta?.orderMetaKey ) {
+		registerPlugin( 'newspack-post-meta-panel', {
+			render: () => <PostMetaPanel metaKey={ postMeta.orderMetaKey } />,
+			icon: 'media-document',
+		} );
+	}
+} );

--- a/tests/unit-tests/collections/class-test-collection-meta.php
+++ b/tests/unit-tests/collections/class-test-collection-meta.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Tests for the Collection_Meta class.
+ *
+ * @package Newspack\Tests
+ */
+
+namespace Newspack\Tests;
+
+use WP_UnitTestCase;
+use Newspack\Collections\Collection_Meta;
+use Newspack\Collections\Post_Type;
+
+/**
+ * Test the Collection_Meta class.
+ */
+class Test_Collection_Meta extends WP_UnitTestCase {
+
+	/**
+	 * Expected meta keys.
+	 *
+	 * @var array
+	 */
+	private const EXPECTED_META_KEYS = [
+		'file_attachment',
+		'file_link',
+		'volume',
+		'issue_number',
+		'issue_date',
+		'subscribe_link',
+		'order_link',
+	];
+
+	/**
+	 * Test get_metas returns expected structure.
+	 *
+	 * @covers \Newspack\Collections\Collection_Meta::get_metas
+	 */
+	public function test_get_metas() {
+		$required_properties = [ 'type', 'label', 'single', 'sanitize_callback', 'show_in_rest' ];
+		$metas               = Collection_Meta::get_metas();
+
+		// Test that we have all expected meta keys.
+		$this->assertEquals( self::EXPECTED_META_KEYS, array_keys( $metas ) );
+
+		// Test that all required properties are present.
+		foreach ( $metas as $key => $meta ) {
+			foreach ( $required_properties as $property ) {
+				$this->assertArrayHasKey( $property, $meta, 'Meta "' . $property . '" definition is missing for "' . $key . '"' );
+				$this->assertNotEmpty( $meta[ $property ], 'Meta "' . $property . '" definition is empty for "' . $key . '"' );
+			}
+		}
+	}
+
+	/**
+	 * Test get_frontend_meta_definitions returns expected structure.
+	 *
+	 * @covers \Newspack\Collections\Collection_Meta::get_frontend_meta_definitions
+	 */
+	public function test_get_frontend_meta_definitions() {
+		$required_properties = [ 'key', 'type', 'label' ];
+		$definitions         = Collection_Meta::get_frontend_meta_definitions();
+
+		// Test that we have all expected meta keys.
+		$this->assertEquals( self::EXPECTED_META_KEYS, array_keys( $definitions ) );
+
+		// Test that all required properties are present.
+		foreach ( $definitions as $key => $definition ) {
+			foreach ( $required_properties as $property ) {
+				$this->assertArrayHasKey( $property, $definition, 'Meta "' . $property . '" definition is missing for "' . $key . '"' );
+				$this->assertNotEmpty( $definition[ $property ], 'Meta "' . $property . '" definition is empty for "' . $key . '"' );
+			}
+		}
+	}
+
+	/**
+	 * Test meta registration.
+	 *
+	 * @covers \Newspack\Collections\Collection_Meta::init
+	 */
+	public function test_register_meta() {
+		// Initialize the post type and register the meta.
+		Post_Type::init();
+		Collection_Meta::register_meta();
+
+		// Get registered meta.
+		$registered_meta = get_registered_meta_keys( 'post', Post_Type::get_post_type() );
+
+		// Test that our meta keys are registered and have the correct values.
+		foreach ( Collection_Meta::get_metas() as $key => $meta ) {
+			$meta_key = Collection_Meta::PREFIX . $key;
+			$this->assertArrayHasKey( $meta_key, $registered_meta, 'Meta key "' . $meta_key . '" is not registered' );
+			foreach ( $meta as $property => $value ) {
+				$this->assertEquals( $value, $registered_meta[ $meta_key ][ $property ], 'Meta key "' . $meta_key . '" has incorrect value for property "' . $property . '"' );
+			}
+		}
+	}
+
+	/**
+	 * Test auth callback.
+	 *
+	 * @covers \Newspack\Collections\Collection_Meta::auth_callback
+	 */
+	public function test_auth_callback() {
+		// Test with admin user.
+		$admin_user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_user_id );
+		$this->assertTrue( Collection_Meta::auth_callback(), 'Admin user should be able to edit collection meta' );
+
+		// Test with subscriber.
+		$subscriber_user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		wp_set_current_user( $subscriber_user_id );
+		$this->assertFalse( Collection_Meta::auth_callback(), 'Subscriber user should not be able to edit collection meta' );
+
+		// Test with no user.
+		wp_set_current_user( 0 );
+		$this->assertFalse( Collection_Meta::auth_callback(), 'Empty user should not be able to edit collection meta' );
+	}
+}

--- a/tests/unit-tests/collections/class-test-post-meta.php
+++ b/tests/unit-tests/collections/class-test-post-meta.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Unit tests for the Post_Meta class.
+ *
+ * @package Newspack\Tests\Unit\Collections
+ */
+
+namespace Newspack\Tests\Unit\Collections;
+
+use WP_UnitTestCase;
+use Newspack\Collections\Post_Meta;
+
+/**
+ * Test the Post_Meta functionality.
+ */
+class Test_Post_Meta extends WP_UnitTestCase {
+	/**
+	 * Set up the test environment.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		// Register the meta field.
+		Post_Meta::register_meta();
+	}
+
+	/**
+	 * Test that the post meta is registered.
+	 */
+	public function test_post_meta_is_registered() {
+		$meta = get_registered_meta_keys( 'post', 'post' );
+		$this->assertArrayHasKey( Post_Meta::ORDER_META_KEY, $meta, 'Meta key should be registered.' );
+	}
+
+	/**
+	 * Test that the meta is visible in the REST API.
+	 */
+	public function test_post_meta_is_visible_in_rest() {
+		$meta = get_registered_meta_keys( 'post', 'post' );
+		$this->assertTrue( $meta[ Post_Meta::ORDER_META_KEY ]['show_in_rest'], 'Meta key should be visible in REST.' );
+	}
+
+	/**
+	 * Test that the meta is sanitized as a number.
+	 */
+	public function test_post_meta_sanitization() {
+		$post_id = $this->factory()->post->create();
+		update_post_meta( $post_id, Post_Meta::ORDER_META_KEY, '123abc' );
+		$value = get_post_meta( $post_id, Post_Meta::ORDER_META_KEY, true );
+		$this->assertSame( '123', $value, 'Meta value should be sanitized to number.' );
+	}
+
+	/**
+	 * Test that the auth callback works (user can edit posts).
+	 */
+	public function test_post_meta_auth_callback() {
+		$user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $user_id );
+		$this->assertTrue( Post_Meta::auth_callback(), 'Auth callback should return true for user with edit_posts.' );
+	}
+}

--- a/tests/unit-tests/collections/class-test-post-type.php
+++ b/tests/unit-tests/collections/class-test-post-type.php
@@ -19,6 +19,24 @@ class Test_Post_Type extends WP_UnitTestCase {
 	use Traits\Trait_Collections_Test;
 
 	/**
+	 * The order column name accessible via reflection.
+	 *
+	 * @var string
+	 */
+	protected static $order_column_name;
+
+	/**
+	 * Access private constants via reflection once.
+	 */
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
+		// Use reflection to access the private constants.
+		$reflection              = new \ReflectionClass( Post_Type::class );
+		self::$order_column_name = $reflection->getConstant( 'ORDER_COLUMN_NAME' );
+	}
+
+	/**
 	 * Set up the test environment.
 	 */
 	public function set_up() {
@@ -121,5 +139,109 @@ class Test_Post_Type extends WP_UnitTestCase {
 		$current_screen = null; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		wp_deregister_script( Collections_Data::SCRIPT_NAME_ADMIN );
 		( new \ReflectionClass( Collections_Data::class ) )->setStaticPropertyValue( 'data', [] );
+	}
+
+	/**
+	 * Test that the order column is added to the admin list view.
+	 *
+	 * @covers \Newspack\Collections\Post_Type::add_order_column
+	 */
+	public function test_add_order_column() {
+		$columns = [
+			'cb'    => '<input type="checkbox" />',
+			'title' => 'Title',
+			'date'  => 'Date',
+		];
+
+		$result = Post_Type::add_order_column( $columns );
+
+		$this->assertArrayHasKey( self::$order_column_name, $result, 'Order column should be added.' );
+		$this->assertEquals( Post_Type::get_order_column_heading(), $result[ self::$order_column_name ], 'Order column should have the correct heading.' );
+		$this->assertEquals( 'Title', $result['title'], 'Title column should be preserved.' );
+		$this->assertEquals( 'Date', $result['date'], 'Date column should be preserved.' );
+	}
+
+	/**
+	 * Test that the order column displays the correct value.
+	 *
+	 * @covers \Newspack\Collections\Post_Type::display_order_column
+	 */
+	public function test_display_order_column() {
+		$post_id = $this->create_test_collection( [ self::$order_column_name => 42 ] );
+
+		// Capture the output.
+		ob_start();
+		Post_Type::display_order_column( self::$order_column_name, $post_id );
+		$output = ob_get_clean();
+
+		$this->assertEquals( '42', $output, 'Order column should display the correct menu order value.' );
+
+		// Test with a different column name.
+		ob_start();
+		Post_Type::display_order_column( 'title', $post_id );
+		$output = ob_get_clean();
+
+		$this->assertEmpty( $output, 'Non-order column should not output anything.' );
+	}
+
+	/**
+	 * Test that the order column is sortable.
+	 *
+	 * @covers \Newspack\Collections\Post_Type::make_order_column_sortable
+	 */
+	public function test_make_order_column_sortable() {
+		$columns = [
+			'title' => 'Title',
+			'date'  => 'Date',
+		];
+
+		$result = Post_Type::make_order_column_sortable( $columns );
+
+		$this->assertArrayHasKey( self::$order_column_name, $result, 'Order column should be added to sortable columns.' );
+		$this->assertEquals( self::$order_column_name, $result[ self::$order_column_name ], 'Order column should be sortable by menu_order.' );
+		$this->assertEquals( 'Title', $result['title'], 'Title column should be preserved.' );
+		$this->assertEquals( 'Date', $result['date'], 'Date column should be preserved.' );
+	}
+
+	/**
+	 * Test that collections can be ordered by menu_order.
+	 *
+	 * @covers \Newspack\Collections\Post_Type::register_post_type
+	 */
+	public function test_collections_menu_order() {
+		// Create collections with different menu orders.
+		$post1 = $this->create_test_collection(
+			[
+				'post_title'             => 'First Collection',
+				self::$order_column_name => 10,
+			]
+		);
+		$post2 = $this->create_test_collection(
+			[
+				'post_title'             => 'Second Collection',
+				self::$order_column_name => 5,
+			]
+		);
+		$post3 = $this->create_test_collection(
+			[
+				'post_title'             => 'Third Collection',
+				self::$order_column_name => 15,
+			]
+		);
+
+		// Query posts ordered by menu_order.
+		$query = new \WP_Query(
+			[
+				'post_type'      => Post_Type::get_post_type(),
+				'orderby'        => self::$order_column_name,
+				'order'          => 'ASC',
+				'posts_per_page' => -1,
+			]
+		);
+
+		$this->assertCount( 3, $query->posts, 'Should find all three collections.' );
+		$this->assertEquals( $post2, $query->posts[0]->ID, 'Second collection should be first (menu_order: 5).' );
+		$this->assertEquals( $post1, $query->posts[1]->ID, 'First collection should be second (menu_order: 10).' );
+		$this->assertEquals( $post3, $query->posts[2]->ID, 'Third collection should be last (menu_order: 15).' );
 	}
 }

--- a/tests/unit-tests/collections/class-test-post-type.php
+++ b/tests/unit-tests/collections/class-test-post-type.php
@@ -9,6 +9,8 @@ namespace Newspack\Tests\Unit\Collections;
 
 use WP_UnitTestCase;
 use Newspack\Collections\Post_Type;
+use Newspack\Collections\Collections_Data;
+use Newspack\Collections\Collection_Meta;
 
 /**
  * Test the Collections Post Type functionality.
@@ -85,10 +87,39 @@ class Test_Post_Type extends WP_UnitTestCase {
 
 		// Create a collection post.
 		$post_id = $this->create_test_collection( $args );
-		$post = get_post( $post_id );
+		$post    = get_post( $post_id );
 
 		$this->assertEquals( Post_Type::get_post_type(), $post->post_type, 'Post should be a collection.' );
 		$this->assertEquals( $args['post_title'], $post->post_title, 'Post title should be set correctly.' );
 		$this->assertEquals( $args['post_name'], $post->post_name, 'Post slug should be set correctly.' );
+	}
+
+	/**
+	 * Test that collection meta data is output for admin scripts.
+	 *
+	 * @covers \Newspack\Collections\Post_Type::output_collection_meta_data_for_admin_scripts
+	 */
+	public function test_output_collection_meta_data_for_admin_scripts() {
+		global $current_screen, $wp_scripts;
+
+		// Set up the current screen.
+		$current_screen = (object) [ 'post_type' => Post_Type::get_post_type() ]; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		// Call the method with post.php hook.
+		Post_Type::output_collection_meta_data_for_admin_scripts( 'post.php' );
+
+		// Register the test script.
+		wp_register_script( Collections_Data::SCRIPT_NAME_ADMIN, 'test.js', [], '1.0.0', true );
+		Collections_Data::localize_data();
+
+		// Get the localized data.
+		$script                    = $wp_scripts->registered[ Collections_Data::SCRIPT_NAME_ADMIN ];
+		$frontend_meta_definitions = wp_json_encode( Collection_Meta::get_frontend_meta_definitions() );
+		$this->assertStringContainsString( $frontend_meta_definitions, $script->extra['data'], 'Localized data should match the added data.' );
+
+		// Clean up.
+		$current_screen = null; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		wp_deregister_script( Collections_Data::SCRIPT_NAME_ADMIN );
+		( new \ReflectionClass( Collections_Data::class ) )->setStaticPropertyValue( 'data', [] );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds custom post meta fields to the Collections CPT:

1. Added a new "Collection Details" panel in the post editor for Collections posts, with support for file uploads, external file URLs, volume, issue details, and subscription/order links.
2. Implemented dynamic meta field handling, based on a single configuration. The backend configuration is forwarded to the frontend, so there's a single source of truth.
3. Added comprehensive unit tests, which also dynamically validate the fields' configuration.

Closes NPPD-140.

### How to test the changes in this Pull Request:

1. Enable the Collections module in Newspack settings.
2. Create a new Collection post.
3. Verify the new "Collection Details" panel appears in the post editor:
![image](https://github.com/user-attachments/assets/b763bd19-5c3c-4aee-ba16-dec4cf0fc07b)
4. Test each meta field:
   - Upload a PDF file and verify it appears:
     - Verify that it only lets you upload PDFs.
     - Verify that removing/replacing files correctly updates the attachment ID.
     - Verify that the file name is correct:     
![image](https://github.com/user-attachments/assets/6dafd6d6-2a1c-4f16-a06b-32f334ba1e37)

   - Add an external file URL.
   - Add volume, issue number, and issue date.
   - Add subscription and order URLs.
   - Verify that the Save post button is disabled if there are validation errors.
5. Verify all fields are properly saved and displayed.
6. Verify that WP core menu ordering is enabled and works for collections:
   - Set the menu order for a collection using quick edit in the collection list.
   - Set the menu order in the post editor using the three dots menu:  
![image](https://github.com/user-attachments/assets/4b7d08ec-14d6-4d3e-975e-cd55a578e7e0)
   - Click on the order column in the collection list in the admin and verify that they get sorted correctly.
7. Test with different user roles to verify authorization.
8. Run the test suite to verify all tests pass.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?