### PR TITLE
feat(collections): register meta for post order in collection

### DIFF
--- a/includes/collections/class-collection-category-taxonomy.php
+++ b/includes/collections/class-collection-category-taxonomy.php
@@ -21,7 +21,7 @@ class Collection_Category_Taxonomy {
 	 *
 	 * @var string
 	 */
-	private const TAXONOMY = 'collection_category';
+	private const TAXONOMY = 'newspack_collection_category';
 
 	/**
 	 * Get the taxonomy for Collection Categories.

--- a/includes/collections/class-collection-section-taxonomy.php
+++ b/includes/collections/class-collection-section-taxonomy.php
@@ -20,14 +20,14 @@ class Collection_Section_Taxonomy {
 	 *
 	 * @var string
 	 */
-	private const TAXONOMY = 'collection_section';
+	private const TAXONOMY = 'newspack_collection_section';
 
 	/**
 	 * Term meta key for ordering.
 	 *
 	 * @var string
 	 */
-	private const ORDER_META_KEY = '_newspack_collection_section_order';
+	private const ORDER_META_KEY = 'newspack_collection_section_order';
 
 	/**
 	 * The column name for the order field.

--- a/includes/collections/class-post-meta.php
+++ b/includes/collections/class-post-meta.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Post Meta handler.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Collections;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Handles the post meta fields and related operations.
+ */
+class Post_Meta {
+
+	/**
+	 * Meta key for storing the order in collection.
+	 *
+	 * @var string
+	 */
+	public const ORDER_META_KEY = 'newspack_order_in_collection';
+
+	/**
+	 * Initialize the meta fields handler.
+	 */
+	public static function init() {
+		add_action( 'init', [ __CLASS__, 'register_meta' ] );
+		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'output_post_meta_data_for_admin_scripts' ] );
+	}
+
+	/**
+	 * Register meta fields for the post post type.
+	 */
+	public static function register_meta() {
+		register_post_meta(
+			'post',
+			self::ORDER_META_KEY,
+			[
+				'type'              => 'integer',
+				'description'       => __( 'Order of the post within a collection.', 'newspack-plugin' ),
+				'single'            => true,
+				'sanitize_callback' => 'absint',
+				'show_in_rest'      => true,
+				'auth_callback'     => [ __CLASS__, 'auth_callback' ],
+			]
+		);
+	}
+
+	/**
+	 * Auth callback for meta fields.
+	 *
+	 * @return bool Whether the user can edit posts.
+	 */
+	public static function auth_callback() {
+		return current_user_can( 'edit_posts' );
+	}
+
+	/**
+	 * Output post meta data for admin scripts.
+	 *
+	 * @param string $hook_suffix The current admin page.
+	 */
+	public static function output_post_meta_data_for_admin_scripts( $hook_suffix ) {
+		if (
+			'post.php' === $hook_suffix &&
+			'post' === get_current_screen()->post_type
+		) {
+			Collections_Data::add_data(
+				'postMeta',
+				[
+					'orderMetaKey' => self::ORDER_META_KEY,
+				]
+			);
+		}
+	}
+}

--- a/includes/optional-modules/class-collections.php
+++ b/includes/optional-modules/class-collections.php
@@ -14,6 +14,7 @@ use Newspack\Collections\Post_Type;
 use Newspack\Collections\Collection_Taxonomy;
 use Newspack\Collections\Collection_Category_Taxonomy;
 use Newspack\Collections\Collection_Section_Taxonomy;
+use Newspack\Collections\Post_Meta;
 
 /**
  * Collections module for managing print editions and other collections.
@@ -43,6 +44,7 @@ class Collections {
 		require_once __DIR__ . '/../collections/class-collection-category-taxonomy.php';
 		require_once __DIR__ . '/../collections/class-collection-section-taxonomy.php';
 		require_once __DIR__ . '/../collections/class-sync.php';
+		require_once __DIR__ . '/../collections/class-post-meta.php';
 
 		// Enqueue admin scripts and styles.
 		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'enqueue_admin_scripts' ] );
@@ -54,6 +56,7 @@ class Collections {
 		Collection_Taxonomy::init();
 		Collection_Category_Taxonomy::init();
 		Collection_Section_Taxonomy::init();
+		Post_Meta::init();
 	}
 
 	/**

--- a/src/collections/admin/index.js
+++ b/src/collections/admin/index.js
@@ -4,3 +4,4 @@
 
 import './section-taxonomy';
 import './collection-meta-panel';
+import './post-meta-panel';

--- a/src/collections/admin/post-meta-panel.js
+++ b/src/collections/admin/post-meta-panel.js
@@ -1,0 +1,63 @@
+import { __ } from '@wordpress/i18n';
+import { registerPlugin } from '@wordpress/plugins';
+import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
+import { TextControl } from '@wordpress/components';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
+import { useCallback } from '@wordpress/element';
+import domReady from '@wordpress/dom-ready';
+
+const PostMetaPanel = ( { metaKey } ) => {
+	const { editPost } = useDispatch( editorStore );
+
+	// Get the current post type and meta data.
+	const { currentPostType, meta = {} } = useSelect( select => {
+		const editor = select( editorStore );
+		return {
+			currentPostType: editor.getCurrentPostType(),
+			meta: editor.getEditedPostAttribute( 'meta' ) || {},
+		};
+	}, [] );
+
+	// Update the meta data.
+	const updateMeta = useCallback(
+		value => {
+			const sanitized = value === '' ? '' : parseInt( value, 10 ) || 0;
+			editPost( { meta: { [ metaKey ]: sanitized } } );
+		},
+		[ editPost, metaKey ]
+	);
+
+	return (
+		// Only render the panel for posts.
+		'post' === currentPostType && (
+			<PluginDocumentSettingPanel
+				name="newspack-post-meta-panel"
+				title={ __( 'Collection Settings', 'newspack-plugin' ) }
+				icon="media-document"
+			>
+				<TextControl
+					label={ __( 'Order', 'newspack-plugin' ) }
+					type="number"
+					value={ meta[ metaKey ] || '' }
+					onChange={ updateMeta }
+					help={ __(
+						'Set the order of this post within a collection.',
+						'newspack-plugin'
+					) }
+					min={ 0 }
+				/>
+			</PluginDocumentSettingPanel>
+		)
+	);
+};
+
+domReady( () => {
+	const { postMeta } = window.newspackCollections || {};
+	if ( postMeta?.orderMetaKey ) {
+		registerPlugin( 'newspack-post-meta-panel', {
+			render: () => <PostMetaPanel metaKey={ postMeta.orderMetaKey } />,
+			icon: 'media-document',
+		} );
+	}
+} );

--- a/tests/unit-tests/collections/class-test-post-meta.php
+++ b/tests/unit-tests/collections/class-test-post-meta.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Unit tests for the Post_Meta class.
+ *
+ * @package Newspack\Tests\Unit\Collections
+ */
+
+namespace Newspack\Tests\Unit\Collections;
+
+use WP_UnitTestCase;
+use Newspack\Collections\Post_Meta;
+
+/**
+ * Test the Post_Meta functionality.
+ */
+class Test_Post_Meta extends WP_UnitTestCase {
+	/**
+	 * Set up the test environment.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		// Register the meta field.
+		Post_Meta::register_meta();
+	}
+
+	/**
+	 * Test that the post meta is registered.
+	 */
+	public function test_post_meta_is_registered() {
+		$meta = get_registered_meta_keys( 'post', 'post' );
+		$this->assertArrayHasKey( Post_Meta::ORDER_META_KEY, $meta, 'Meta key should be registered.' );
+	}
+
+	/**
+	 * Test that the meta is visible in the REST API.
+	 */
+	public function test_post_meta_is_visible_in_rest() {
+		$meta = get_registered_meta_keys( 'post', 'post' );
+		$this->assertTrue( $meta[ Post_Meta::ORDER_META_KEY ]['show_in_rest'], 'Meta key should be visible in REST.' );
+	}
+
+	/**
+	 * Test that the meta is sanitized as a number.
+	 */
+	public function test_post_meta_sanitization() {
+		$post_id = $this->factory()->post->create();
+		update_post_meta( $post_id, Post_Meta::ORDER_META_KEY, '123abc' );
+		$value = get_post_meta( $post_id, Post_Meta::ORDER_META_KEY, true );
+		$this->assertSame( '123', $value, 'Meta value should be sanitized to number.' );
+	}
+
+	/**
+	 * Test that the auth callback works (user can edit posts).
+	 */
+	public function test_post_meta_auth_callback() {
+		$user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $user_id );
+		$this->assertTrue( Post_Meta::auth_callback(), 'Auth callback should return true for user with edit_posts.' );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:
- Add a `Post_Meta` class to register and expose a custom post meta field (`newspack_order_in_collection`) for posts.
- Integrate the meta key with the block editor via a new Collection Settings sidebar panel for setting post order.

Closes NPPD-141.

### How to test the changes in this Pull Request:

1. Activate the Collections module (if not already active).
2. Edit or create a post in the WordPress block editor.
3. Confirm the new "Collection Settings" panel appears in the sidebar (only for posts):
![image](https://github.com/user-attachments/assets/a169886d-3d8b-43b9-a947-6e049ab57c0d)
4. Set a value in the "Order" field and save the post.
5. Verify the value is saved as post meta with the key `newspack_order_in_collection` (check in the database or via REST API).
6. Check REST API (`GET /wp-json/wp/v2/posts/<post_id>`) and confirm that the meta field appears in the response.
7. Optionally, run unit tests and confirm that all tests pass.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?