### PR TITLE
feat: add manual option to mark subscriptions as giftable

### DIFF
--- a/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions-gifting.php
+++ b/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions-gifting.php
@@ -19,6 +19,7 @@ class WooCommerce_Subscriptions_Gifting {
 	public static function init() {
 		\add_filter( 'wcsg_new_recipient_account_details_fields', [ __CLASS__, 'new_recipient_fields' ] );
 		\add_filter( 'wcsg_require_shipping_address_for_virtual_products', '__return_false' );
+		\add_filter( 'wcsg_is_giftable_product', [ __CLASS__, 'is_giftable_product' ], 10, 2 );
 		\add_filter( 'default_option_woocommerce_subscriptions_gifting_gifting_checkbox_text', [ __CLASS__, 'default_gifting_checkbox_text' ] );
 		\add_filter( 'newpack_reader_activation_reader_is_without_password', [ __CLASS__, 'is_reader_without_password' ], 10, 2 );
 	}
@@ -79,6 +80,32 @@ class WooCommerce_Subscriptions_Gifting {
 			return 'true' === $user_needs_account_update;
 		}
 		return $is_reader_without_password;
+	}
+
+	/**
+	 * Filter to check if a product is giftable.
+	 *
+	 * @param bool        $is_giftable Whether the product is giftable.
+	 * @param \WC_Product $product The product object.
+	 *
+	 * @return bool
+	 */
+	public static function is_giftable_product( $is_giftable, $product ) {
+		// Check if gifting is enabled for this product.
+		$allow_gifting = get_post_meta( $product->get_id(), '_newspack_allow_gifting', true );
+		if ( 'yes' !== $allow_gifting ) {
+			return false;
+		}
+
+		// Check if product is a subscription type, just in case.
+		$product_type = $product->get_type();
+		if ( ! in_array( $product_type, [ 'subscription', 'variable-subscription' ] ) ) {
+			return false;
+		}
+
+		// Check if subscription limit is set to 'no' (no limit), just in case.
+		$subscription_limit = get_post_meta( $product->get_id(), '_subscription_limit', true );
+		return 'no' === $subscription_limit;
 	}
 }
 WooCommerce_Subscriptions_Gifting::init();

--- a/includes/plugins/woocommerce/class-woocommerce-products.php
+++ b/includes/plugins/woocommerce/class-woocommerce-products.php
@@ -49,7 +49,8 @@ class WooCommerce_Products {
 	 * @return array Keyed array of custom product options.
 	 */
 	public static function get_custom_options() {
-		return [
+
+		$custom_options = [
 			'newspack_autocomplete_orders' => [
 				'id'            => '_newspack_autocomplete_orders',
 				'wrapper_class' => '',
@@ -59,6 +60,19 @@ class WooCommerce_Products {
 				'product_types' => [ 'simple', 'variation', 'subscription', 'subscription_variation' ],
 			],
 		];
+
+		if ( \Newspack\WooCommerce_Subscriptions_Gifting::is_active() ) {
+			// Don't limit by product type so we can show/hide it based on product settings.
+			$custom_options['newspack_allow_gifting'] = [
+				'id'            => '_newspack_allow_gifting',
+				'wrapper_class' => '',
+				'label'         => __( 'Allow to be gifted', 'newspack-plugin' ),
+				'description'   => __( 'Allow this subscription product to be gifted to another reader.', 'newspack-plugin' ),
+				'default'       => 'no',
+			];
+		}
+
+		return $custom_options;
 	}
 
 	/**

--- a/src/other-scripts/custom-product-options/index.js
+++ b/src/other-scripts/custom-product-options/index.js
@@ -34,7 +34,7 @@
 		if ( 'no' === $subscriptionLimit && ( $productType === 'subscription' || $productType === 'variable-subscription' ) ) {
 			$giftingLabel.show();
 
-			// Restore previous state of the checkboxif it exists
+			// Restore previous state of the checkbox from this product edit session, if it exists.
 			const previousState = $giftingCheckbox.data( 'previous-state' );
 			if ( previousState !== undefined ) {
 				// If undefined, switch it to the default (unchecked) state.
@@ -42,7 +42,7 @@
 				$giftingCheckbox.removeData( 'previous-state' );
 			}
 		} else {
-			// Store current state before hiding.
+			// Store current state before unchecking the checkbox and hiding it.
 			$giftingCheckbox.data( 'previous-state', $giftingCheckbox.prop( 'checked' ) );
 			$giftingCheckbox.prop( 'checked', false );
 			$giftingLabel.hide();
@@ -53,9 +53,9 @@
 	$( document ).ready( function() {
 		handleGiftingCheckbox();
 
-		// Update when subscription limit changes.
+		// Update when the subscription limit changes.
 		$( '#_subscription_limit' ).on( 'change', handleGiftingCheckbox );
-		// Update when product type changes (switching to and away from subscription products).
+		// Update when the product type changes (switching to and away from subscription products).
 		$( '#product-type' ).on( 'change', handleGiftingCheckbox );
 	} );
 } )( jQuery );

--- a/src/other-scripts/custom-product-options/index.js
+++ b/src/other-scripts/custom-product-options/index.js
@@ -1,5 +1,5 @@
 /* globals jQuery */
-( function( $ ) {
+( function ( $ ) {
 	if ( ! $ ) {
 		return;
 	}

--- a/src/other-scripts/custom-product-options/index.js
+++ b/src/other-scripts/custom-product-options/index.js
@@ -1,8 +1,12 @@
 /* globals jQuery */
-( function ( $ ) {
+( function( $ ) {
 	if ( ! $ ) {
 		return;
 	}
+
+	/**
+	 * Hide the 'Virtual' checkbox for variable products.
+	 */
 	$( '#variable_product_options' ).on( 'change', 'input.variable_is_virtual', function ( e ) {
 		$( e.currentTarget )
 			.closest( '.woocommerce_variation' )
@@ -15,5 +19,43 @@
 				.find( '.show_if_variation_virtual' )
 				.show();
 		}
+	} );
+
+	/**
+	 * Handle 'Allow to be gifted' checkbox visibility and state.
+	 */
+	function handleGiftingCheckbox() {
+		const $giftingCheckbox = $( '#_newspack_allow_gifting' );
+		const $subscriptionLimit = $( '#_subscription_limit' ).val();
+		const $productType = $( '#product-type' ).val();
+		const $giftingLabel = $giftingCheckbox.closest( 'label' );
+
+		// If there's no subscription limit and the product type is subscription-related, show the gifting checkbox.
+		if ( 'no' === $subscriptionLimit && ( $productType === 'subscription' || $productType === 'variable-subscription' ) ) {
+			$giftingLabel.show();
+
+			// Restore previous state of the checkboxif it exists
+			const previousState = $giftingCheckbox.data( 'previous-state' );
+			if ( previousState !== undefined ) {
+				// If undefined, switch it to the default (unchecked) state.
+				$giftingCheckbox.prop( 'checked', previousState );
+				$giftingCheckbox.removeData( 'previous-state' );
+			}
+		} else {
+			// Store current state before hiding.
+			$giftingCheckbox.data( 'previous-state', $giftingCheckbox.prop( 'checked' ) );
+			$giftingCheckbox.prop( 'checked', false );
+			$giftingLabel.hide();
+		}
+	}
+
+	// Initialize when document is ready.
+	$( document ).ready( function() {
+		handleGiftingCheckbox();
+
+		// Update when subscription limit changes.
+		$( '#_subscription_limit' ).on( 'change', handleGiftingCheckbox );
+		// Update when product type changes (switching to and away from subscription products).
+		$( '#product-type' ).on( 'change', handleGiftingCheckbox );
 	} );
 } )( jQuery );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a 'Allow to be gifted' checkbox to products when:

* They are a subscription or variable subscription product
* When WooCommerce Subscriptions Gifting is installed and enabled, and
* When 'Limit Subscription' is set to 'Do not limit'. 

This checkbox is disabled by default, so all subscription products will not be considered 'giftable' by default.

This allows us to set up some more nuanced subscription gifting that works with our own subscription limitations (one per customer), and that won't clash with existing products. 

See NPPM-385.

### How to test the changes in this Pull Request:

1. Apply this PR and run `npm run build`.
2. Make sure you have Woo Subscriptions and Woo Subscriptions Gifting installed and activated on your site. 
3. Create a new product. Note the default checkbox options:

![CleanShot 2025-06-10 at 11 22 49](https://github.com/user-attachments/assets/b3d6199b-5b11-4eac-ae05-c2d900f6d1e2)

4. Switch the product type to 'Subscription' or 'Variable Subscription' and comfirm you now have an 'Allow to be gifted' checkbox in the mix. It should be unchecked by default:

![CleanShot 2025-06-10 at 11 28 31](https://github.com/user-attachments/assets/e53cb42b-74be-4ec3-b13a-db942bdebf33)

5. Navigate to the 'Advanced' tab, and change 'Limit subscription' away from 'Do not limit'. Confirm that the 'Allow to be gifted' checkbox goes away. Switch it back to 'Do not limit'.
6. Make sure our show/hide behaviour works nicely: try checking the checkbox, switching the product back to a simple product, switching back to a subscription product, and confirm that it "remembers" its state while making the initial edits.
7. Fully set up and publish two subscription products, one with 'Allow to be gifted' checked, and one with 'Allow to be gifted' unchecked (so if you've checked it and change it to a simple product then back, it remains checked).
8. Run through a checkout on the front end with each product; confirm you get the 'This purchase is a gift' checkbox only on the product where it's allowed:

![CleanShot 2025-06-10 at 11 51 49](https://github.com/user-attachments/assets/359d7a99-74be-40c7-8818-c1720249dac9)

9. View the individual product pages for each of the products; confirm that the 'This purchase is a gift' checkbox only appears when 'Allow to be gifted' is enabled on the product: 

![CleanShot 2025-06-10 at 11 57 34](https://github.com/user-attachments/assets/c240db2e-1fcc-4b71-9003-737edce32c4f)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->