### PR TITLE
fix: updates to accessibility statement

### DIFF
--- a/includes/advanced-settings/class-accessibility-statement-boilerplate.php
+++ b/includes/advanced-settings/class-accessibility-statement-boilerplate.php
@@ -12,7 +12,7 @@
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph {"fontSize":"small"} -->
-<p class="has-small-font-size"><em>We recommend generating your own Accessibility Statement using </em><a href="https://www.w3.org/WAI/planning/statements/generator/#preview" target="_blank" rel="noreferrer noopener"><em>the tool on the W3C website</em></a><em>. If you use this boilerplate text, please review, make edits as needed, and update the highlighted text with your publication's information.</em></p>
+<p class="has-small-font-size"><em>We recommend generating your own Accessibility Statement using <a href="https://href.li/?https://www.w3.org/WAI/planning/statements/generator/#preview" target="_blank" rel="noreferrer noopener">the tool on the W3C website</a>. If you use this boilerplate text, be sure to review, make edits as needed, and update the <strong>highlighted text</strong> with your publication’s information.</em></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group -->
 

--- a/includes/advanced-settings/class-accessibility-statement-boilerplate.php
+++ b/includes/advanced-settings/class-accessibility-statement-boilerplate.php
@@ -6,9 +6,15 @@
  */
 
 ?>
-<!-- wp:paragraph {"backgroundColor":"light-gray","fontSize":"small"} -->
-<p class="has-light-gray-background-color has-background has-small-font-size"><em>We recommend generating your own Accessibility Statement using </em><a href="https://www.w3.org/WAI/planning/statements/generator/#preview" target="_blank" rel="noreferrer noopener"><em>the tool on the W3C website</em></a><em>. If you use this boilerplate text, please review, make edits as needed, and update the highlighted text with your publication's information. <strong>Finally, remove this paragraph before publishing.</strong></em></p>
+<!-- wp:group {"backgroundColor":"light-gray","layout":{"type":"constrained"}} -->
+<div class="wp-block-group has-light-gray-background-color has-background"><!-- wp:paragraph {"fontSize":"small"} -->
+<p class="has-small-font-size"><strong>Remove this statement before publishing.</strong></p>
 <!-- /wp:paragraph -->
+
+<!-- wp:paragraph {"fontSize":"small"} -->
+<p class="has-small-font-size"><em>We recommend generating your own Accessibility Statement using </em><a href="https://www.w3.org/WAI/planning/statements/generator/#preview" target="_blank" rel="noreferrer noopener"><em>the tool on the W3C website</em></a><em>. If you use this boilerplate text, please review, make edits as needed, and update the highlighted text with your publication's information.</em></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->
 
 <!-- wp:heading -->
 <h2 class="wp-block-heading">Conformance Status</h2>
@@ -140,7 +146,7 @@
 <!-- /wp:list-item -->
 
 <!-- wp:list-item -->
-<li>Browser zoom up to 200%%</li>
+<li>Browser zoom up to 200%</li>
 <!-- /wp:list-item --></ul>
 <!-- /wp:list -->
 

--- a/src/wizards/newspack/views/settings/advanced-settings/accessibility-statement.tsx
+++ b/src/wizards/newspack/views/settings/advanced-settings/accessibility-statement.tsx
@@ -169,13 +169,17 @@ export default function AccessibilityStatement( { isFetching }: AccessibilitySta
 
 			<p>
 				{ __( 'An accessibility statement helps your readers understand how your site supports accessibility standards and what to do if they encounter accessibility issues. ', 'newspack-plugin' ) }
-				<ExternalLink href="https://www.w3.org/WAI/planning/statements/">{ __( 'Learn more about what makes a good accessibility statement.', 'newspack-plugin' ) } </ExternalLink>
+				<ExternalLink href="https://www.w3.org/WAI/planning/statements/">{ __( 'What makes a good accessibility statement.', 'newspack-plugin' ) } </ExternalLink>
 			</p>
 
 			<p>
-				{ __( 'The page you create here will include a boilerplate accessibility statement, but we highly recommend you use the W3C Accessibility Statement Generator to create a custom statement. ', 'newspack-plugin' ) }
+				{ __( 'The page you create here will include a boilerplate accessibility statement. ', 'newspack-plugin' ) }
+				<strong>{ __( 'Please review and make edits to ensure it meets the requirements before publishing. ', 'newspack-plugin' ) }</strong>
+				{ __( 'You can also use the W3C Accessibility Statement Generator to create a custom statement. ', 'newspack-plugin' ) }
 				<ExternalLink href="https://www.w3.org/WAI/planning/statements/generator/#create">{ __( 'Try out the Accessibility Statement Generator.', 'newspack-plugin' ) } </ExternalLink>
 			</p>
+
+			<p><ExternalLink href="https://help.newspack.com/revenue/reader-revenue/how-to-add-an-accessibility-statement/">{ __( 'Learn more about this feature in our documentation.', 'newspack-plugin' ) } </ExternalLink></p>
 		</>
 	);
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR makes some changes to the new Accessibility Statement Page functionality based on alpha feedback. Once this is merged, it will need to be cherrypicked into the current alphas.

### How to test the changes in this Pull Request:

1. Apply this PR and run `npm run build`.
2. If you already have an Accessibility Statement page created, delete it. 
3. Navigate to Newspack > Settings > Advanced Settings and scroll to the bottom. Confirm the messaging has been updated to include bolded text ("Please review and make edits to ensure it meets the requirements before publishing.") and includes a link to our docs.
4. Try clicking on the link to the docs and confirm it opens a page on the help site in a new tab.
5. Back on the Accessibility Statement Page page, click 'Create Page' (or if you're testing this for the first time, click "Edit and Publish Page")
6. Confirm the text at the top starts with "Remove this statement before publishing." on its own line. (I also fixed a typo in the body content, `200%%` to `200%`).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->