### PR TITLE
feat: remove custom bylines flag

### DIFF
--- a/includes/bylines/class-bylines.php
+++ b/includes/bylines/class-bylines.php
@@ -47,12 +47,12 @@ class Bylines {
 	 * Checks if the feature is enabled.
 	 *
 	 * True when:
-	 * - NEWSPACK_BYLINES_ENABLED is defined and true.
+	 * - NEWSPACK_CUSTOM_BYLINES_DISABLED is not defined or is false.
 	 *
 	 * @return bool True if the feature is enabled, false otherwise.
 	 */
 	public static function is_enabled() {
-		return defined( 'NEWSPACK_BYLINES_ENABLED' ) && NEWSPACK_BYLINES_ENABLED;
+		return ! defined( 'NEWSPACK_CUSTOM_BYLINES_DISABLED' ) || ! NEWSPACK_CUSTOM_BYLINES_DISABLED;
 	}
 
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Remove Custom Bylines from behind a feature flag 

### How to test the changes in this Pull Request:

1. Make sure you don't have `NEWSPACK_BYLINES_ENABLED` defined in your wp-config
2. Confirm custom bylines are enabled by default
3. Define `NEWSPACK_CUSTOM_BYLINES_DISABLED` and confirm it goes away

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->