### PR TITLE
fix(menu): don't hide sponsors menu if the user can't see the newspack dashboard

### DIFF
--- a/includes/wizards/advertising/class-advertising-sponsors.php
+++ b/includes/wizards/advertising/class-advertising-sponsors.php
@@ -57,7 +57,7 @@ class Advertising_Sponsors extends Wizard {
 	/**
 	 * Use a late priority for this wizard's menu adjustments so they happen
 	 * after the Sponsors Plugin is done adding it's menu items.
-	 * 
+	 *
 	 * @var int.
 	 */
 	protected $admin_menu_priority = 11;
@@ -66,6 +66,10 @@ class Advertising_Sponsors extends Wizard {
 	 * Advertising_Sponsors Constructor.
 	 */
 	public function __construct() {
+		if ( ! current_user_can( $this->capability ) ) {
+			return;
+		}
+
 		if ( ! is_plugin_active( 'newspack-sponsors/newspack-sponsors.php' ) ) {
 			return;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an issue with the menu.

### How to test the changes in this Pull Request:

1. On `trunk`, ensure you have `newspack-sponsors` plugin active
2. Create a new Editor user and log in as them
3. Observe there's no "Advertising" menu item, and no "Sponsors" menu item
4. Switch to this branch, observe the "Sponsors" menu item is visible 
5. Log in as the Administrator, observe the "Advertising → Sponsors" menu item is visible, and "Sponsors" menu item is not visible

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->