### PR TITLE
Add sticky post support to lite site

### DIFF
--- a/includes/lite-site/templates/archive.php
+++ b/includes/lite-site/templates/archive.php
@@ -34,16 +34,16 @@ namespace Newspack;
 		$query_args['category__in'] = $categories;
 	}
 
-	$recent_posts = get_posts( $query_args );
-
 	// Render sticky posts prominently at the top.
 	$sticky_post_ids_option = get_option( 'sticky_posts' );
 	$sticky_post_ids        = [];
 	if ( ! empty( $sticky_post_ids_option ) ) {
 		$sticky_post_ids = array_values( $sticky_post_ids_option );
-		$sticky_posts    = get_posts( [
-			'post__in' => $sticky_post_ids,
-		] );
+		$sticky_posts    = get_posts(
+			[
+				'post__in' => $sticky_post_ids,
+			]
+		);
 		foreach ( $sticky_posts as $sticky_post ) {
 			printf(
 				'<li><h3><a href="/%s/%d">%s</a></h3></li>',
@@ -54,6 +54,7 @@ namespace Newspack;
 		}
 	}
 
+	$recent_posts = get_posts( $query_args );
 	foreach ( $recent_posts as $current_post ) {
 		if ( ! in_array( $current_post->ID, $sticky_post_ids ) ) {
 			printf(

--- a/includes/lite-site/templates/archive.php
+++ b/includes/lite-site/templates/archive.php
@@ -56,10 +56,12 @@ namespace Newspack;
 
 	foreach ( $all_posts as $current_post ) {
 		printf(
-			'<li><a href="/%s/%d">%s</a></li>',
+			'<li>%s<a href="/%s/%d">%s</a>%s</li>',
+			in_array( $current_post->ID, $sticky_post_ids, true ) ? '<h3>' : '',
 			esc_attr( Lite_Site::get_url_base() ),
 			esc_attr( $current_post->ID ),
-			esc_html( $current_post->post_title )
+			esc_html( $current_post->post_title ),
+			in_array( $current_post->ID, $sticky_post_ids, true ) ? '</h3>' : ''
 		);
 	}
 	?>

--- a/includes/lite-site/templates/archive.php
+++ b/includes/lite-site/templates/archive.php
@@ -44,26 +44,23 @@ namespace Newspack;
 				'post__in' => $sticky_post_ids,
 			]
 		);
-		foreach ( $sticky_posts as $sticky_post ) {
-			printf(
-				'<li><h3><a href="/%s/%d">%s</a></h3></li>',
-				esc_attr( Lite_Site::get_url_base() ),
-				esc_attr( $sticky_post->ID ),
-				esc_html( $sticky_post->post_title )
-			);
-		}
 	}
 
 	$recent_posts = get_posts( $query_args );
-	foreach ( $recent_posts as $current_post ) {
-		if ( ! in_array( $current_post->ID, $sticky_post_ids ) ) {
-			printf(
-				'<li><a href="/%s/%d">%s</a></li>',
-				esc_attr( Lite_Site::get_url_base() ),
-				esc_attr( $current_post->ID ),
-				esc_html( $current_post->post_title )
-			);
-		}
+
+	$all_posts = array_merge( $sticky_posts, $recent_posts );
+
+	$all_posts = array_unique( $all_posts, SORT_REGULAR );
+
+	$all_posts = array_slice( $all_posts, 0, Lite_Site::get_number_of_posts() );
+
+	foreach ( $all_posts as $current_post ) {
+		printf(
+			'<li><a href="/%s/%d">%s</a></li>',
+			esc_attr( Lite_Site::get_url_base() ),
+			esc_attr( $current_post->ID ),
+			esc_html( $current_post->post_title )
+		);
 	}
 	?>
 	</ul>

--- a/includes/lite-site/templates/archive.php
+++ b/includes/lite-site/templates/archive.php
@@ -36,13 +36,33 @@ namespace Newspack;
 
 	$recent_posts = get_posts( $query_args );
 
+	// Render sticky posts prominently at the top.
+	$sticky_post_ids_option = get_option( 'sticky_posts' );
+	$sticky_post_ids        = [];
+	if ( ! empty( $sticky_post_ids_option ) ) {
+		$sticky_post_ids = array_values( $sticky_post_ids_option );
+		$sticky_posts    = get_posts( [
+			'post__in' => $sticky_post_ids,
+		] );
+		foreach ( $sticky_posts as $sticky_post ) {
+			printf(
+				'<li><h3><a href="/%s/%d">%s</a></h3></li>',
+				esc_attr( Lite_Site::get_url_base() ),
+				esc_attr( $sticky_post->ID ),
+				esc_html( $sticky_post->post_title )
+			);
+		}
+	}
+
 	foreach ( $recent_posts as $current_post ) {
-		printf(
-			'<li><a href="/%s/%d">%s</a></li>',
-			esc_attr( Lite_Site::get_url_base() ),
-			esc_attr( $current_post->ID ),
-			esc_html( $current_post->post_title )
-		);
+		if ( ! in_array( $current_post->ID, $sticky_post_ids ) ) {
+			printf(
+				'<li><a href="/%s/%d">%s</a></li>',
+				esc_attr( Lite_Site::get_url_base() ),
+				esc_attr( $current_post->ID ),
+				esc_html( $current_post->post_title )
+			);
+		}
 	}
 	?>
 	</ul>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Note: This is a hotfix, but doesn't necessarily have to be if you disagree :)

A publisher generally needs the lite site mode for urgent breaking news (wildfires, etc.). In this situation, they're going to want/need to put the relevant breaking news story prominently at the top of the lite site. Currently it just displays the last X posts chronologically, so there isn't a way to feature the "Here's the latest coverage about this event!" post. This PR adds support for sticky posts to lite sites. That seems like a straightforward solution.

### How to test the changes in this Pull Request:

1. Enable the Lite Site feature. Make some posts sticky.
2. They should be featured prominently at the top of the lite version:

<img width="779" alt="Screenshot 2025-06-20 at 11 02 23 AM" src="https://github.com/user-attachments/assets/453b479d-f17d-4440-ba94-23b286997caf" />

4. They should NOT affect content loop block or anything else that already has other ways of featuring content prominently.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->