### PR TITLE
fix: saving name when registering user refs NPPM-2071

### DIFF
--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -2335,6 +2335,14 @@ final class Reader_Activation {
 		// If we don't have a display name, make it match the nicename.
 		if ( empty( $user_data['display_name'] ) ) {
 			$user_data['display_name'] = $user_nicename;
+		} else {
+			$name_fragments = explode( ' ', $user_data['display_name'], 2 );
+			$user_data['first_name'] = $name_fragments[0] ?? '';
+			if ( isset( $name_fragments[1] ) ) {
+				$user_data['last_name'] = $name_fragments[1];
+			} else {
+				$user_data['last_name'] = '';
+			}
 		}
 
 		if ( empty( $user_data['user_pass'] ) ) {
@@ -2344,13 +2352,13 @@ final class Reader_Activation {
 		}
 
 		$user_data = array_merge(
-			$user_data,
 			[
 				'user_login'    => $user_nicename,
 				'user_nicename' => $user_nicename,
 				'display_name'  => $user_nicename,
 				'user_pass'     => $password,
-			]
+			],
+			$user_data
 		);
 
 		// Check if a user with this login exists.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes how we register user names on RAS

### How to test the changes in this Pull Request:

1. Set up a Newsletter Subscription block with first and last name fields
2. Set up Audience Management (RAS)
3. As an anonymous visitor, subscribe to a newsletter and fill in first and last  name
4. As an admin, check that the new user has correct display, first and last names set in their profile
5. Test leaving one or both name fields empty

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->