### PR TITLE
feat(rss): Skip non-distributable images

### DIFF
--- a/includes/optional-modules/class-rss.php
+++ b/includes/optional-modules/class-rss.php
@@ -39,6 +39,7 @@ class RSS {
 		add_action( 'atom_entry', [ __CLASS__, 'add_extra_tags' ] );
 		add_filter( 'the_excerpt_rss', [ __CLASS__, 'maybe_remove_content_featured_image' ], 1 );
 		add_filter( 'the_content_feed', [ __CLASS__, 'maybe_remove_content_featured_image' ], 1 );
+		add_filter( 'the_content_feed', [ __CLASS__, 'maybe_remove_non_distributable_images' ], 1 );
 		add_filter( 'the_content_feed', [ __CLASS__, 'maybe_add_tracking_snippets' ], 1 );
 		add_filter( 'wpseo_include_rss_footer', [ __CLASS__, 'maybe_suppress_yoast' ] );
 		add_action( 'rss2_ns', [ __CLASS__, 'maybe_inject_yahoo_namespace' ] );
@@ -69,25 +70,26 @@ class RSS {
 	 */
 	public static function get_feed_settings( $feed_post = null ) {
 		$default_settings = [
-			'category_include'        => [],
-			'category_exclude'        => [],
-			'use_image_tags'          => false,
-			'use_media_tags'          => false,
-			'use_updated_tags'        => false,
-			'use_tags_tags'           => false,
-			'full_content'            => true,
-			'num_items_in_feed'       => 10,
-			'offset'                  => 0,
-			'timeframe'               => false,
-			'content_featured_image'  => false,
-			'suppress_yoast'          => false,
-			'yahoo_namespace'         => false,
-			'update_frequency'        => false,
-			'use_post_id_as_guid'     => false,
-			'cdata_titles'            => false,
-			'republication_tracker'   => false,
-			'only_republishable'      => false,
-			'custom_tracking_snippet' => '',
+			'category_include'          => [],
+			'category_exclude'          => [],
+			'use_image_tags'            => false,
+			'use_media_tags'            => false,
+			'use_updated_tags'          => false,
+			'use_tags_tags'             => false,
+			'full_content'              => true,
+			'num_items_in_feed'         => 10,
+			'offset'                    => 0,
+			'timeframe'                 => false,
+			'content_featured_image'    => false,
+			'suppress_yoast'            => false,
+			'yahoo_namespace'           => false,
+			'update_frequency'          => false,
+			'use_post_id_as_guid'       => false,
+			'cdata_titles'              => false,
+			'republication_tracker'     => false,
+			'only_republishable'        => false,
+			'only_distributable_images' => false,
+			'custom_tracking_snippet'   => '',
 		];
 
 		if ( ! $feed_post ) {
@@ -393,6 +395,16 @@ class RSS {
 						<input type="checkbox" name="only_republishable" value="1" <?php checked( $settings['only_republishable'] ); ?> />
 					</td>
 				</tr>
+				<tr>
+					<th>
+						<?php esc_html_e( 'Skip non-distributable images', 'newspack-plugin' ); ?>
+						<p class="description"><?php echo esc_html_x( 'When toggled on, images not marked as distributable will be excluded from feed content.', 'help text for remove non-distributable images setting', 'newspack-plugin' ); ?></p>
+					</th>
+					<td>
+						<input type="hidden" name="only_distributable_images" value="0" />
+						<input type="checkbox" name="only_distributable_images" value="1" <?php checked( $settings['only_distributable_images'] ); ?> />
+					</td>
+				</tr>
 			<?php endif; ?>
 		</table>
 
@@ -604,6 +616,8 @@ class RSS {
 			$only_republishable             = filter_input( INPUT_POST, 'only_republishable', FILTER_SANITIZE_NUMBER_INT );
 			$settings['only_republishable'] = (bool) $only_republishable;
 
+			$only_distributable_images             = filter_input( INPUT_POST, 'only_distributable_images', FILTER_SANITIZE_NUMBER_INT );
+			$settings['only_distributable_images'] = (bool) $only_distributable_images;
 		}
 
 		update_post_meta( $feed_post_id, self::FEED_SETTINGS_META, $settings );
@@ -834,6 +848,42 @@ class RSS {
 		if ( ! $settings['content_featured_image'] ) {
 			remove_filter( 'the_excerpt_rss', [ 'Newspack\RSS_Add_Image', 'thumbnails_in_rss' ] );
 			remove_filter( 'the_content_feed', [ 'Newspack\RSS_Add_Image', 'thumbnails_in_rss' ] );
+		}
+
+		return $content;
+	}
+
+	/**
+	 * Filter feed content to remove non-distributable images if needed.
+	 *
+	 * @param string $content Feed content.
+	 * @return string Modified $content.
+	 */
+	public static function maybe_remove_non_distributable_images( $content ) {
+		$settings = self::get_feed_settings();
+		if ( ! $settings || ! self::is_republication_tracker_plugin_active() || empty( $settings['only_distributable_images'] ) ) {
+			return $content;
+		}
+
+		// Find all images with wp-image-{id} class.
+		preg_match_all( '/<img[^>]+class="[^"]*wp-image-(\d+)[^"]*"[^>]*>/', $content, $matches );
+		$found_images = [];
+
+		// Check each image to see if it can be distributed.
+		foreach ( $matches[1] as $key => $attachment_id ) {
+			if ( ! get_post_meta( $attachment_id, Newspack_Image_Credits::MEDIA_CREDIT_CAN_DISTRIBUTE_META, true ) ) {
+				$found_images[] = [ $attachment_id, $matches[0][ $key ] ];
+			}
+		}
+
+		// Remove the non-distributable images.
+		foreach ( $found_images as [ $attachment_id, $found_image ] ) {
+			// Remove the figure and figcaption of $found_image using regex.
+			$pattern = '/<figure[^>]*>' . preg_quote( $found_image, '/' ) . '.*?<\/figure>/s';
+			$content = preg_replace( $pattern, "<!-- Non-distributable image removed from RSS feed ({$attachment_id}) -->", $content );
+
+			// Also remove the lone image if it's not wrapped in a figure.
+			$content = str_replace( $found_image, "<!-- Non-distributable image removed from RSS feed ({$attachment_id}) -->", $content );
 		}
 
 		return $content;

--- a/includes/optional-modules/class-rss.php
+++ b/includes/optional-modules/class-rss.php
@@ -865,25 +865,10 @@ class RSS {
 			return $content;
 		}
 
-		// Find all images with wp-image-{id} class.
-		preg_match_all( '/<img[^>]+class="[^"]*wp-image-(\d+)[^"]*"[^>]*>/', $content, $matches );
-		$found_images = [];
-
-		// Check each image to see if it can be distributed.
-		foreach ( $matches[1] as $key => $attachment_id ) {
-			if ( ! get_post_meta( $attachment_id, Newspack_Image_Credits::MEDIA_CREDIT_CAN_DISTRIBUTE_META, true ) ) {
-				$found_images[] = [ $attachment_id, $matches[0][ $key ] ];
-			}
-		}
-
-		// Remove the non-distributable images.
-		foreach ( $found_images as [ $attachment_id, $found_image ] ) {
-			// Remove the figure and figcaption of $found_image using regex.
-			$pattern = '/<figure[^>]*>' . preg_quote( $found_image, '/' ) . '.*?<\/figure>/s';
-			$content = preg_replace( $pattern, "<!-- Non-distributable image removed from RSS feed ({$attachment_id}) -->", $content );
-
-			// Also remove the lone image if it's not wrapped in a figure.
-			$content = str_replace( $found_image, "<!-- Non-distributable image removed from RSS feed ({$attachment_id}) -->", $content );
+		if ( class_exists( '\Republication_Tracker_Tool_Content' ) && 
+			method_exists( '\Republication_Tracker_Tool_Content', 'remove_non_distributable_images' )
+		) {
+			return \Republication_Tracker_Tool_Content::remove_non_distributable_images( $content, true );
 		}
 
 		return $content;

--- a/includes/optional-modules/class-rss.php
+++ b/includes/optional-modules/class-rss.php
@@ -397,8 +397,12 @@ class RSS {
 				</tr>
 				<tr>
 					<th>
-						<?php esc_html_e( 'Skip non-distributable images', 'newspack-plugin' ); ?>
-						<p class="description"><?php echo esc_html_x( 'When toggled on, images not marked as distributable will be excluded from feed content.', 'help text for remove non-distributable images setting', 'newspack-plugin' ); ?></p>
+						<?php esc_html_e( 'Include only distributable images', 'newspack-plugin' ); ?>
+						<p class="description">
+							<?php echo esc_html_x( 'When toggled on, images not marked as distributable will be excluded from feed content.', 'help text for remove non-distributable images setting', 'newspack-plugin' ); ?>
+							<br/>
+							<?php esc_html_e( 'Note: this will respect the same settings for distributable images RTT uses for other distributiion purposes', 'newspack-plugin' ); ?>
+						</p>
 					</th>
 					<td>
 						<input type="hidden" name="only_distributable_images" value="0" />
@@ -868,7 +872,7 @@ class RSS {
 		if ( class_exists( '\Republication_Tracker_Tool_Content' ) && 
 			method_exists( '\Republication_Tracker_Tool_Content', 'remove_non_distributable_images' )
 		) {
-			return \Republication_Tracker_Tool_Content::remove_non_distributable_images( $content, true );
+			return \Republication_Tracker_Tool_Content::remove_non_distributable_images( $content );
 		}
 
 		return $content;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/1/26890605006346/project/1210562189110460/task/1210629622176531?focus=true .

Adds a new option to RSS feeds that allows publishers to exclude non-distributable images from feed content. The filtering of content uses the same logic as the RTT plugin.

### How to test the changes in this Pull Request:

1. Create a post and add few images - Make sure to add distributable (Can distribute? checked on media) & non-distributable images.
2. Create Feeds from Admin > RSS Feeds.
3. Check for new option - Remove non-distributable images.
4. Enable the option > Click Update > Open the feed url.
5. Check the Distributable image is appearing and non-distributable image is skipped.
6. Also test this option is available only when RTT plugin is active.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->