### PR TITLE
fix: lite site error without sticky posts

### DIFF
--- a/includes/lite-site/templates/archive.php
+++ b/includes/lite-site/templates/archive.php
@@ -37,6 +37,7 @@ namespace Newspack;
 	// Render sticky posts prominently at the top.
 	$sticky_post_ids_option = get_option( 'sticky_posts' );
 	$sticky_post_ids        = [];
+	$sticky_posts           = [];
 	if ( ! empty( $sticky_post_ids_option ) ) {
 		$sticky_post_ids = array_values( $sticky_post_ids_option );
 		$sticky_posts    = get_posts(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a fatal in Lite sites when there are no sticky posts

### How to test the changes in this Pull Request:

1. Turn on lite sites
2. `wp option delete sticky_posts`
3. Visit the lite site and make sure there are no errors

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->