### PR TITLE
fix(log): ensure `user_email` is always a string

### DIFF
--- a/includes/class-logger.php
+++ b/includes/class-logger.php
@@ -116,7 +116,7 @@ class Logger {
 			[
 				'type'       => $type,
 				'data'       => $data,
-				'user_email' => $email ? $email : '', // always cast to string.
+				'user_email' => (string) $email,
 				'file'       => $file,
 				'log_level'  => $log_level,
 			]

--- a/includes/class-logger.php
+++ b/includes/class-logger.php
@@ -116,7 +116,7 @@ class Logger {
 			[
 				'type'       => $type,
 				'data'       => $data,
-				'user_email' => $email,
+				'user_email' => $email ? $email : '', // always cast to string.
 				'file'       => $file,
 				'log_level'  => $log_level,
 			]


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

If the user email is not in `$data` and the user is not logged in, the value of `$email` will be `false` (from `wp_get_current_user()->user_email`). The `user_email` property must always be a string; otherwise, the log does not reach the server.

### How to test the changes in this Pull Request:

1. While on `release`, make sure you have newspack-manager active and Jetpack connected
2. Run `wp eval "Newspack\Logger::newspack_log( 'test', 'test' );"`
3. Confirm the entry never reaches the server
4. Checkout this branch and run the same command
5. Confirm the entry reaches the server

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->