### PR TITLE
fix: ensure my-account is working w/out woocommerce

### DIFF
--- a/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php
+++ b/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php
@@ -88,6 +88,9 @@ class My_Account_UI_V1 {
 	 * Enqueue assets.
 	 */
 	public static function enqueue_assets() {
+		if ( ! function_exists( 'wc_get_account_endpoint_url' ) ) {
+			return;
+		}
 		$script_data = [
 			'myAccountUrl' => wc_get_account_endpoint_url( 'dashboard' ),
 			'labels'       => [

--- a/includes/reader-activation/sync/class-esp-sync.php
+++ b/includes/reader-activation/sync/class-esp-sync.php
@@ -196,7 +196,7 @@ class ESP_Sync extends Sync {
 	 */
 	public static function get_contact_data( $user_id ) {
 		if ( ! class_exists( '\WC_Customer' ) ) {
-			return;
+			return new \WP_Error( 'newspack_esp_sync_contact', __( 'WC_Customer class unavailable.', 'newspack-plugin' ) );
 		}
 		$user = \get_userdata( $user_id );
 

--- a/includes/reader-activation/sync/class-esp-sync.php
+++ b/includes/reader-activation/sync/class-esp-sync.php
@@ -195,6 +195,9 @@ class ESP_Sync extends Sync {
 	 * @return array|\WP_Error The contact data or WP_Error.
 	 */
 	public static function get_contact_data( $user_id ) {
+		if ( ! class_exists( '\WC_Customer' ) ) {
+			return;
+		}
 		$user = \get_userdata( $user_id );
 
 		$customer = new \WC_Customer( $user_id );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Some code does not account for WooCommerce being inactive. 

### How to test the changes in this Pull Request:

1. On `trunk`
2. Set `NEWSPACK_MY_ACCOUNT_VERSION` to `1.0.0` to get the new My Account UI
3. Deactivate WooCommerce
4. Observe a hard crash on homepage
5. Switch to this branch, observe the homepage loading

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->