### PR TITLE
fix: update custom byline markup to match regular bylines in theme

### DIFF
--- a/includes/bylines/class-bylines.php
+++ b/includes/bylines/class-bylines.php
@@ -130,10 +130,11 @@ class Bylines {
 	 * Get the post custom byline HTML markup.
 	 *
 	 * @param bool $include_avatars Whether to include avatars in the markup.
+	 * @param bool $byline_wrapper Whether to wrap the byline in a span element.
 	 *
 	 * @return false|string The post custom byline HTML markup or false if not available.
 	 */
-	public static function get_post_byline_html( $include_avatars = true ) {
+	public static function get_post_byline_html( $include_avatars = true, $byline_wrapper = true ) {
 		$byline_is_active = \get_post_meta( \get_the_ID(), self::META_KEY_ACTIVE, true );
 		if ( ! $byline_is_active ) {
 			return false;
@@ -145,6 +146,9 @@ class Bylines {
 		}
 
 		$byline_html = self::replace_author_shortcodes( $byline );
+		if ( $byline_wrapper ) {
+			$byline_html = '<span class="byline">' . $byline_html . '</span>';
+		}
 		if ( $include_avatars ) {
 			$byline_html = self::get_authors_avatars( $byline ) . $byline_html;
 		}
@@ -161,7 +165,7 @@ class Bylines {
 		if ( ! $byline ) {
 			return false;
 		}
-		return '<span class="byline">' . wp_kses_post( $byline ) . '</span>';
+		return wp_kses_post( $byline );
 	}
 
 	/**
@@ -290,7 +294,7 @@ class Bylines {
 			return $byline;
 		}
 
-		$custom_byline = self::get_post_byline_html( false );
+		$custom_byline = self::get_post_byline_html( false, false );
 
 		if ( ! $custom_byline ) {
 			return $byline;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR makes a minor change to the custom markup byline to match the Newspack theme.

Prior to this change, both the avatars and byline text were wrapped in the `<span class="byline">` container. In the theme, only the byline text is wrapped in this container, and the avatars sit outside of it. This is causing a slight mismatch in alignment and text wrapping. 

### How to test the changes in this Pull Request:

1. Set up a post with a custom byline, and one without.
2. Look at each individual post and inspect the byline; note that the post with the standard byline looks like this (with the text vertically centred and the avatar outside of the `byline`):

![CleanShot 2025-07-04 at 09 19 15](https://github.com/user-attachments/assets/dd018fd2-7d7e-4a9b-bfb6-34302882caf7)

```
<div class="entry-meta">
    <span class="author-avatar"><img ...></span>
    <span class="byline">
        <span>by</span>
        <span class="author vcard"><a class="url fn n" href="...">Jane Doe</a></span>
    </span>
    ....
</div>
```

... while the post with the custom byline looks like this (with the text kind of offset, and the avatar inside of the `byline`): 

![CleanShot 2025-07-04 at 09 18 38](https://github.com/user-attachments/assets/24c38f0f-e088-4f3e-9644-d29323b504bb)

```
<div class="entry-meta">
    <span class="byline">
        <span class="author-avatar"><img ...></span>
        by <span class="author vcard"><a class="url fn n" href="...">Author</a></span>
    </span>
    ...
</div>
```




4. Apply this PR.
5. Confirm that the markup for the two different posts matches (with the `author-avatar` outside of the `byline` span).
6. Confirm that the same post's byline markup matches for the Content Loop and Content Carousel blocks.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->