### PR TITLE
fix(admin-menu): handle newsletter ads permissions

### DIFF
--- a/includes/wizards/class-newsletters-wizard.php
+++ b/includes/wizards/class-newsletters-wizard.php
@@ -80,9 +80,22 @@ class Newsletters_Wizard extends Wizard {
 		];
 
 		// Menu removals.
-		remove_action( 'admin_menu', [ Newspack_Newsletters_Ads::class, 'add_ads_page' ] );
 		remove_action( 'admin_menu', [ Newspack_Newsletters_Settings::class, 'add_plugin_page' ] );
 		remove_action( 'admin_menu', [ Newspack_Newsletters_Tracking_Admin::class, 'add_settings_page' ] );
+
+		// Customize the Newsletter ads menu titles.
+		add_filter(
+			'newspack_newsletters_ads_page_title',
+			function() {
+				return __( 'Newsletters Advertising', 'newspack-plugin' );
+			}
+		);
+		add_filter(
+			'newspack_newsletters_ads_menu_title',
+			function() {
+				return __( 'Advertising', 'newspack-plugin' );
+			}
+		);
 
 		// Hooks: admin_menu/add_page, admin_enqueue_scripts/enqueue_scripts_and_styles, admin_body_class/add_body_class .
 		parent::__construct();
@@ -285,15 +298,6 @@ class Newsletters_Wizard extends Wizard {
 		remove_submenu_page( 'edit.php?post_type=' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT, 'edit-tags.php?taxonomy=post_tag&amp;post_type=' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT );
 		remove_submenu_page( 'edit.php?post_type=' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT, 'edit-tags.php?taxonomy=' . Newspack_Newsletters_Ads::ADVERTISER_TAX . '&amp;post_type=' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT );
 
-		// Re-add Ads (Advertising) item with updated title. ( See 'remove_action' above. See Newsletters Plugin: Newspack_Newsletters_Ads > 'add_ads_page' ) .
-		add_submenu_page(
-			'edit.php?post_type=' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
-			__( 'Newsletters Advertising', 'newspack-plugin' ),
-			__( 'Advertising', 'newspack-plugin' ),
-			'edit_others_posts', // As defined in original callback.
-			'/edit.php?post_type=' . Newspack_Newsletters_Ads::CPT
-		);
-
 		add_submenu_page(
 			'edit.php?post_type=' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
 			__( 'Newsletters Settings', 'newspack-plugin' ),
@@ -400,20 +404,28 @@ class Newsletters_Wizard extends Wizard {
 	private function get_tabs() {
 
 		if ( in_array( $this->get_screen_slug(), [ 'newspack_nl_ads_cpt', 'newspack_nl_advertiser' ], true ) ) {
+			// Check if user can access newsletters to determine tab URLs.
+			$newsletters_post_type_object = get_post_type_object( Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT );
+			$can_edit_newsletters = current_user_can( $newsletters_post_type_object->cap->edit_posts );
 
-			return [
+			$tabs = [
 				[
 					'textContent' => esc_html__( 'Ads', 'newspack-plugin' ),
 					'href'        => admin_url( 'edit.php?post_type=newspack_nl_ads_cpt' ),
 				],
-				[
+			];
+
+			// Only show Advertisers tab if user can edit newsletters (otherwise it won't be accessible).
+			if ( $can_edit_newsletters ) {
+				$tabs[] = [
 					'textContent'   => esc_html__( 'Advertisers', 'newspack-plugin' ),
 					'href'          => admin_url( 'edit-tags.php?taxonomy=newspack_nl_advertiser&post_type=newspack_nl_cpt' ),
 					// also force selected tab for url: term.php?taxonomy=newspack_nl_advertiser&tag_ID=32&post_type=newspack_nl_cpt...
 					'forceSelected' => ( 'newspack_nl_advertiser' === $this->get_screen_slug() ),
-				],
-			];
+				];
+			}
 
+			return $tabs;
 		}
 
 		return [];
@@ -479,13 +491,18 @@ class Newsletters_Wizard extends Wizard {
 	 * @return string
 	 */
 	public function submenu_file( $submenu_file ) {
+		// Check if user can access newsletters to determine where ads menu is placed.
+		$newsletters_post_type_object = get_post_type_object( Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT );
+		$can_edit_newsletters = current_user_can( $newsletters_post_type_object->cap->edit_posts );
+
 		// Move newsletter ads menu file.
 		if ( ! empty( $submenu_file ) && strpos( $submenu_file, 'newspack_nl_ads_cpt' ) !== false ) {
-			return 'edit.php?post_type=newspack_nl_ads_cpt';
+			// If user can edit newsletters, ads are in submenu. Otherwise, they're top-level.
+			return $can_edit_newsletters ? 'edit.php?post_type=newspack_nl_ads_cpt' : $submenu_file;
 		}
 		// Move newsletter ads taxonomy menu submenu_file.
 		if ( ! empty( $submenu_file ) && strpos( $submenu_file, 'newspack_nl_advertiser' ) !== false ) {
-			return 'edit.php?post_type=newspack_nl_ads_cpt';
+			return $can_edit_newsletters ? 'edit.php?post_type=newspack_nl_ads_cpt' : $submenu_file;
 		}
 
 		// Move new newsletter menu submenu_file.
@@ -509,13 +526,22 @@ class Newsletters_Wizard extends Wizard {
 	 * @return string
 	 */
 	public function parent_file( $parent_file ) {
+		// Check if user can access newsletters to determine where ads menu is placed.
+		$newsletters_post_type_object = get_post_type_object( Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT );
+		$can_edit_newsletters = current_user_can( $newsletters_post_type_object->cap->edit_posts );
+
 		if (
 			strpos( $parent_file, 'newspack_nl_ads_cpt' ) !== false || // Newsletter Ads.
-			strpos( $parent_file, 'newspack_nl_advertiser' ) !== false || // Newsletter Advertisers.
-			strpos( $parent_file, 'newspack_nl_list' ) !== false          // Newsletter Subscription Lists.
+			strpos( $parent_file, 'newspack_nl_advertiser' ) !== false    // Newsletter Advertisers.
 		) {
+			// If user can edit newsletters, ads appear under newsletters menu. Otherwise, they're top-level.
+			return $can_edit_newsletters ? 'edit.php?post_type=newspack_nl_cpt' : $parent_file;
+		}
+
+		if ( strpos( $parent_file, 'newspack_nl_list' ) !== false ) { // Newsletter Subscription Lists.
 			return 'edit.php?post_type=newspack_nl_cpt';
 		}
+
 		return $parent_file;
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

See https://github.com/Automattic/newspack-newsletters/pull/1807


Part of NPPM-336

### How to test the changes in this Pull Request:

_Follow instructions in https://github.com/Automattic/newspack-newsletters/pull/1807_

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->