### PR TITLE
feat(collections): frontend templates

### DIFF
--- a/includes/collections/class-cache.php
+++ b/includes/collections/class-cache.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * Cache manager class.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Collections;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class for Collections cache operations.
+ */
+class Cache {
+
+	public const CACHE_GROUP     = 'newspack_collections';
+	public const YEARS_CACHE_KEY = 'available_years';
+	public const POSTS_CACHE_KEY = 'posts_in_collection_';
+
+	/**
+	 * Initialize cache invalidation hooks.
+	 */
+	public static function init() {
+		// Clear cache when posts are modified (handles both collections and regular posts).
+		add_action( 'save_post', [ __CLASS__, 'clear_cache_on_post_change' ] );
+		add_action( 'delete_post', [ __CLASS__, 'clear_cache_on_post_change' ] );
+		add_action( 'wp_trash_post', [ __CLASS__, 'clear_cache_on_post_change' ] );
+		add_action( 'untrash_post', [ __CLASS__, 'clear_cache_on_post_change' ] );
+
+		// Clear cache when collection taxonomies are created, edited, or deleted.
+		add_action( 'create_term', [ __CLASS__, 'clear_cache_on_term_change' ], 10, 3 );
+		add_action( 'edit_term', [ __CLASS__, 'clear_cache_on_term_change' ], 10, 3 );
+		add_action( 'delete_term', [ __CLASS__, 'clear_cache_on_term_change' ], 10, 3 );
+
+		// Clear cache when term relationships change (posts assigned to collections).
+		add_action( 'set_object_terms', [ __CLASS__, 'clear_cache_on_term_relationship_change' ], 10, 4 );
+
+		// Clear cache when post meta that affects collection posts changes.
+		add_action( 'updated_post_meta', [ __CLASS__, 'clear_cache_on_meta_change' ], 10, 3 );
+		add_action( 'added_post_meta', [ __CLASS__, 'clear_cache_on_meta_change' ], 10, 4 );
+		add_action( 'deleted_post_meta', [ __CLASS__, 'clear_cache_on_meta_change' ], 10, 4 );
+	}
+
+	/**
+	 * Get versioned cache key for collection posts.
+	 *
+	 * @param int $collection_id Collection post ID.
+	 * @return string Versioned cache key.
+	 */
+	public static function get_posts_cache_key( $collection_id ) {
+		return self::POSTS_CACHE_KEY . $collection_id . ':' . wp_cache_get_last_changed( self::CACHE_GROUP );
+	}
+
+	/**
+	 * Clear cache entries.
+	 *
+	 * @param string   $type          Cache type: 'years', 'posts', 'all'. Default is 'all'.
+	 * @param int|null $collection_id Optional collection ID for specific post cache.
+	 */
+	public static function clear_cache( $type = 'all', $collection_id = null ) {
+		switch ( $type ) {
+			case 'years':
+				wp_cache_delete( self::YEARS_CACHE_KEY, self::CACHE_GROUP );
+				break;
+			case 'posts':
+				if ( $collection_id ) {
+					// Clear specific collection posts cache.
+					wp_cache_delete( self::get_posts_cache_key( $collection_id ), self::CACHE_GROUP );
+				} else {
+					// Clear all collection posts cache by bumping last_changed.
+					wp_cache_set_last_changed( self::CACHE_GROUP );
+				}
+				break;
+			case 'all':
+				wp_cache_delete( self::YEARS_CACHE_KEY, self::CACHE_GROUP );
+				wp_cache_set_last_changed( self::CACHE_GROUP );
+				break;
+		}
+	}
+
+	/**
+	 * Clear cache when any post is modified (handles both collection and regular posts).
+	 *
+	 * @param int $post_id The post ID.
+	 */
+	public static function clear_cache_on_post_change( $post_id ) {
+		$post_type = get_post_type( $post_id );
+
+		// If this is a collection post, clear years cache and specific collection cache.
+		if ( Post_Type::get_post_type() === $post_type ) {
+			self::clear_cache( 'years' );
+			self::clear_cache( 'posts', $post_id );
+		} elseif ( 'post' === $post_type ) {
+			// For regular posts, clear cache for all collections this post belongs to.
+			$collections = Query_Helper::get_post_collections( $post_id, true );
+			foreach ( $collections as $collection ) {
+				self::clear_cache( 'posts', $collection->ID );
+			}
+		}
+	}
+
+	/**
+	 * Clear cache for taxonomy-related changes.
+	 *
+	 * @param string    $taxonomy Taxonomy slug.
+	 * @param int|array $term_ids Term ID(s) - single int or array of ints.
+	 */
+	private static function clear_cache_for_taxonomy( $taxonomy, $term_ids ) {
+		if ( Collection_Category_Taxonomy::get_taxonomy() === $taxonomy ) {
+			self::clear_cache( 'years' );
+		} elseif ( Collection_Taxonomy::get_taxonomy() === $taxonomy ) {
+			self::clear_cache( 'years' );
+			// Clear cache for collections linked to these terms.
+			$term_ids = is_array( $term_ids ) ? $term_ids : [ $term_ids ];
+			foreach ( $term_ids as $term_id ) {
+				$collection_id = Sync::get_collection_linked_to_term( $term_id );
+				if ( $collection_id ) {
+					self::clear_cache( 'posts', $collection_id );
+				}
+			}
+		} elseif ( Collection_Section_Taxonomy::get_taxonomy() === $taxonomy ) {
+			// Section changes affect post organization, clear all collection posts cache.
+			self::clear_cache( 'posts' );
+		}
+	}
+
+	/**
+	 * Clear cache when collection taxonomies are modified.
+	 *
+	 * @param int    $term_id  Term ID.
+	 * @param int    $tt_id    Term taxonomy ID.
+	 * @param string $taxonomy Taxonomy slug.
+	 */
+	public static function clear_cache_on_term_change( $term_id, $tt_id, $taxonomy ) {
+		self::clear_cache_for_taxonomy( $taxonomy, $term_id );
+	}
+
+	/**
+	 * Clear cache when term relationships change for collections.
+	 *
+	 * @param int    $object_id Object ID.
+	 * @param array  $terms     An array of object terms.
+	 * @param array  $tt_ids    An array of term taxonomy IDs.
+	 * @param string $taxonomy  Taxonomy slug.
+	 */
+	public static function clear_cache_on_term_relationship_change( $object_id, $terms, $tt_ids, $taxonomy ) {
+		self::clear_cache_for_taxonomy( $taxonomy, $terms );
+
+		// Clear cache for the affected post (both collection and regular posts).
+		self::clear_cache_on_post_change( $object_id );
+	}
+
+	/**
+	 * Clear cache when post meta that affects collection posts changes.
+	 *
+	 * @param int    $meta_id    ID of updated metadata entry.
+	 * @param int    $object_id  Object ID.
+	 * @param string $meta_key   Meta key.
+	 */
+	public static function clear_cache_on_meta_change( $meta_id, $object_id, $meta_key ) {
+		$post_type = get_post_type( $object_id );
+
+		// Clear cache when relevant meta keys change.
+		if ( in_array( $post_type, [ 'post', Post_Type::get_post_type() ], true ) && str_contains( $meta_key, Post_Meta::$prefix ) ) {
+			self::clear_cache_on_post_change( $object_id );
+		}
+	}
+}

--- a/includes/collections/class-cache.php
+++ b/includes/collections/class-cache.php
@@ -93,9 +93,9 @@ class Cache {
 			self::clear_cache( 'posts', $post_id );
 		} elseif ( 'post' === $post_type ) {
 			// For regular posts, clear cache for all collections this post belongs to.
-			$collections = Query_Helper::get_post_collections( $post_id, true );
+			$collections = Query_Helper::get_post_collections( $post_id );
 			foreach ( $collections as $collection ) {
-				self::clear_cache( 'posts', $collection->ID );
+				self::clear_cache( 'posts', $collection );
 			}
 		}
 	}

--- a/includes/collections/class-content-inserter.php
+++ b/includes/collections/class-content-inserter.php
@@ -1,0 +1,311 @@
+<?php
+/**
+ * Collections Content Inserter.
+ *
+ * @package Newspack\Collections
+ */
+
+namespace Newspack\Collections;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Content inserter class for Collections indicators.
+ */
+class Content_Inserter {
+
+	/**
+	 * The maximum number of collections to render by default in the post content indicator.
+	 *
+	 * @var int
+	 */
+	public const MAX_COLLECTIONS_TO_RENDER = 1;
+
+	/**
+	 * The block number to insert the indicator after.
+	 *
+	 * @var int
+	 */
+	public const INSERT_AFTER_BLOCK_NUMBER = 2;
+
+	/**
+	 * Whether we've already inserted indicators into the content.
+	 * Prevents duplicate execution.
+	 *
+	 * @var boolean
+	 */
+	public static $the_content_has_rendered = false;
+
+	/**
+	 * The collections the current post is in.
+	 *
+	 * @var WP_Post[]
+	 */
+	public static $post_collections = [];
+
+	/**
+	 * Initialize hooks.
+	 */
+	public static function init() {
+		// Use template_redirect as it runs on the frontend before wp_enqueue_scripts.
+		add_action( 'template_redirect', [ __CLASS__, 'check_if_post_is_in_collection' ] );
+	}
+
+	/**
+	 * Check if the post is in a collection and add a filter for the post content.
+	 */
+	public static function check_if_post_is_in_collection() {
+		if ( ! is_singular( 'post' ) ) {
+			return;
+		}
+
+		$post = get_post();
+		if ( ! $post ) {
+			return;
+		}
+
+		$collections = Query_Helper::get_post_collections( $post );
+		if ( empty( $collections ) ) {
+			return;
+		}
+
+		// Sort by post date descending.
+		usort(
+			$collections,
+			function ( $a, $b ) {
+				return get_the_date( 'U', $b ) - get_the_date( 'U', $a );
+			}
+		);
+
+		self::$post_collections = $collections;
+		Enqueuer::add_data( 'post_is_in_collections', true );
+		add_filter( 'the_content', [ __CLASS__, 'maybe_insert_collection_indicators' ], 1 );
+	}
+
+	/**
+	 * Maybe insert collection indicators into post content.
+	 *
+	 * @param string $content The post content.
+	 * @return string The modified content.
+	 */
+	public static function maybe_insert_collection_indicators( $content ) {
+		if ( self::$the_content_has_rendered || ! in_the_loop() || empty( trim( $content ) ) ) {
+			return $content;
+		}
+		$post_style = Settings::get_setting( 'post_indicator_style', 'default' );
+
+		switch ( $post_style ) {
+			case 'card':
+				// Insert indicator at the specified position.
+				$content_with_indicators = self::insert_after_nth_block(
+					$content,
+					self::build_card_html( self::$post_collections )
+				);
+				break;
+			case 'default':
+			default:
+				// Insert indicator at the end of the content.
+				$content_with_indicators = $content . self::build_default_indicator_html( self::$post_collections );
+				break;
+		}
+
+		self::$the_content_has_rendered = true;
+
+		/**
+		 * Filters the content with collection indicators inserted.
+		 *
+		 * @param string          $content_with_indicators The content with indicators.
+		 * @param string          $content                 The original content.
+		 * @param string          $post_style              The post style.
+		 * @param int[]|WP_Post[] $collections             The collections.
+		 */
+		return apply_filters( 'newspack_collections_content_with_indicators', $content_with_indicators, $content, $post_style, self::$post_collections );
+	}
+
+	/**
+	 * Build the card HTML using output buffering.
+	 *
+	 * @param int[]|WP_Post[] $collections The collection objects.
+	 * @param int             $limit       The number of collections to render. Default is self::MAX_COLLECTIONS_TO_RENDER.
+	 * @return string The card HTML.
+	 */
+	public static function build_card_html( $collections, $limit = self::MAX_COLLECTIONS_TO_RENDER ) {
+		if ( empty( $collections ) ) {
+			return '';
+		}
+
+		$collections  = is_array( $collections ) ? array_slice( $collections, 0, $limit ) : [];
+		$card_message = Settings::get_setting(
+			'card_message',
+			__( "Keep reading. There's plenty more to discover.", 'newspack-plugin' )
+		);
+		ob_start();
+
+		foreach ( $collections as $collection ) {
+			$collection_link  = get_permalink( $collection );
+			$collection_title = get_the_title( $collection );
+
+			// Get collection image.
+			$image_html = Template_Helper::render_image(
+				$collection,
+				false,
+				[ 144, 192 ] // 2x of a 72px width.
+			);
+			?>
+			<!-- wp:group {"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
+			<div class="collection-card wp-block-group">
+				<!-- wp:separator -->
+				<hr class="wp-block-separator has-light-gray-background-color has-background is-style-wide"/>
+				<!-- /wp:separator -->
+
+				<!-- wp:columns -->
+				<div class="collection-card__columns wp-block-columns">
+					<div class="collection-card__content-column wp-block-column is-vertically-aligned-center">
+						<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+						<div class="wp-block-group">
+							<?php echo wp_kses_post( $image_html ); ?>
+							<p>
+								<strong>Browse <?php echo esc_html( $collection_title ); ?></strong>
+								<br>
+								<?php echo esc_html( $card_message ); ?>
+							</p>
+						</div>
+						<!-- /wp:group -->
+					</div>
+
+					<div class="wp-block-column collection-card__buttons-column is-vertically-aligned-center">
+						<?php
+						echo wp_kses_post(
+							Template_Helper::render_cta(
+								[
+									'url'   => $collection_link,
+									'label' => __( 'See more', 'newspack-plugin' ),
+								]
+							)
+						);
+						?>
+					</div>
+				</div>
+				<!-- /wp:columns -->
+
+				<!-- wp:separator -->
+				<hr class="wp-block-separator has-light-gray-background-color has-background is-style-wide"/>
+				<!-- /wp:separator -->
+			</div>
+			<!-- /wp:group -->
+			<?php
+		}
+
+		$card_html = do_blocks( ob_get_clean() );
+
+		/**
+		 * Filters the collection card HTML.
+		 *
+		 * @param string          $card_html   The card HTML.
+		 * @param int[]|WP_Post[] $collections The collections.
+		 */
+		return apply_filters( 'newspack_collections_card_html', $card_html, $collections );
+	}
+
+	/**
+	 * Insert content after the nth block using block parsing.
+	 *
+	 * @param string $content     The content.
+	 * @param string $insert_html The HTML to insert.
+	 * @param int    $nth_block   The block number (1-based). Default is self::INSERT_AFTER_BLOCK_NUMBER.
+	 * @return string The modified content.
+	 */
+	public static function insert_after_nth_block( $content, $insert_html, $nth_block = self::INSERT_AFTER_BLOCK_NUMBER ) {
+		$parsed_blocks = parse_blocks( $content );
+
+		// Filter out empty blocks.
+		$blocks_to_skip_empty = [
+			'core/paragraph',
+			'core/heading',
+			'core/list',
+			'core/quote',
+			'core/html',
+			'core/freeform',
+		];
+
+		$parsed_blocks = array_values(
+			array_filter(
+				$parsed_blocks,
+				function ( $block ) use ( $blocks_to_skip_empty ) {
+					$null_block_name     = null === $block['blockName'];
+					$is_skip_empty_block = in_array( $block['blockName'], $blocks_to_skip_empty, true );
+					$is_empty            = empty( trim( $block['innerHTML'] ) );
+					return ! ( $is_empty && ( $null_block_name || $is_skip_empty_block ) );
+				}
+			)
+		);
+
+		// If we don't have enough blocks, append at the end.
+		if ( count( $parsed_blocks ) < $nth_block ) {
+			return $content . $insert_html;
+		}
+
+		// Insert after the nth block.
+		$rendered_content = '';
+		foreach ( $parsed_blocks as $index => $block ) {
+			$rendered_content .= $block['innerHTML'];
+
+			// Insert after the nth block (index is 0-based).
+			if ( $index === $nth_block - 1 ) {
+				$rendered_content .= $insert_html;
+			}
+		}
+
+		return $rendered_content;
+	}
+
+	/**
+	 * Build the default indicator HTML.
+	 *
+	 * @param int[]|WP_Post[] $collections The collections.
+	 * @param int|null        $limit       The number of collections to render. Default is null (show all).
+	 * @return string The indicator HTML.
+	 */
+	public static function build_default_indicator_html( $collections, $limit = null ) {
+		if ( ! is_array( $collections ) ) {
+			return '';
+		}
+
+		if ( $limit ) {
+			$collections = array_slice( $collections, 0, $limit );
+		}
+
+		if ( empty( $collections ) ) {
+			return '';
+		}
+
+		$collection_links = array_map(
+			function ( $collection ) {
+				return sprintf(
+					'<a href="%s">%s</a>',
+					esc_url( get_permalink( $collection ) ),
+					esc_html( get_the_title( $collection ) )
+				);
+			},
+			$collections
+		);
+
+		$indicator_html = sprintf(
+			'<p class="collection-link has-small-font-size">%s</p>',
+			wp_sprintf(
+				/* translators: %l is replaced with the collection name(s) */
+				__( 'This article appears in %l.', 'newspack-plugin' ),
+				$collection_links
+			)
+		);
+
+		/**
+		 * Filters the collection default indicator HTML.
+		 *
+		 * @param string          $indicator_html The indicator HTML.
+		 * @param int[]|WP_Post[] $collections    The collections.
+		 * @param int             $limit          The number of collections rendered. If a falsey value, all collections were rendered.
+		 */
+		return apply_filters( 'newspack_collections_default_indicator_html', $indicator_html, $collections, $limit );
+	}
+}

--- a/includes/collections/class-query-helper.php
+++ b/includes/collections/class-query-helper.php
@@ -14,81 +14,8 @@ defined( 'ABSPATH' ) || exit;
  */
 class Query_Helper {
 
-	public const COVER_SECTION   = 'cover';
-	public const YEARS_CACHE_KEY = 'available_years_data';
-	public const POSTS_CACHE_KEY = 'posts_in_collection_';
-	public const CACHE_GROUP     = 'newspack_collections';
+	public const COVER_SECTION = 'cover';
 
-	/**
-	 * Initialize cache invalidation hooks.
-	 */
-	public static function init() {
-		// Clear cache when collections are saved, deleted, or status changes.
-		add_action( 'save_post_' . Post_Type::get_post_type(), [ __CLASS__, 'clear_cache_on_collection_change' ] );
-		add_action( 'delete_post', [ __CLASS__, 'clear_cache_on_collection_change' ] );
-		add_action( 'wp_trash_post', [ __CLASS__, 'clear_cache_on_collection_change' ] );
-		add_action( 'untrash_post', [ __CLASS__, 'clear_cache_on_collection_change' ] );
-
-		// Clear cache when collection categories are created, edited, or deleted.
-		add_action( 'create_term', [ __CLASS__, 'clear_cache_on_term_change' ], 10, 3 );
-		add_action( 'edit_term', [ __CLASS__, 'clear_cache_on_term_change' ], 10, 3 );
-		add_action( 'delete_term', [ __CLASS__, 'clear_cache_on_term_change' ], 10, 3 );
-
-		// Clear cache when term relationships change (posts assigned to collections).
-		add_action( 'set_object_terms', [ __CLASS__, 'clear_cache_on_term_relationship_change' ], 10, 4 );
-	}
-
-	/**
-	 * Clear the available years cache.
-	 */
-	public static function clear_available_years_cache() {
-		wp_cache_delete( self::YEARS_CACHE_KEY, self::CACHE_GROUP );
-	}
-
-	/**
-	 * Clear cache when a collection post is modified.
-	 *
-	 * @param int $post_id The post ID.
-	 */
-	public static function clear_cache_on_collection_change( $post_id ) {
-		if ( get_post_type( $post_id ) === Post_Type::get_post_type() ) {
-			self::clear_available_years_cache();
-		}
-	}
-
-	/**
-	 * Clear cache when collection taxonomies are modified.
-	 *
-	 * @param int    $term_id  Term ID.
-	 * @param int    $tt_id    Term taxonomy ID.
-	 * @param string $taxonomy Taxonomy slug.
-	 */
-	public static function clear_cache_on_term_change( $term_id, $tt_id, $taxonomy ) {
-		if (
-			Collection_Category_Taxonomy::get_taxonomy() === $taxonomy ||
-			Collection_Taxonomy::get_taxonomy() === $taxonomy
-		) {
-			self::clear_available_years_cache();
-		}
-	}
-
-	/**
-	 * Clear cache when term relationships change for collections.
-	 *
-	 * @param int    $object_id Object ID.
-	 * @param array  $terms     An array of object terms.
-	 * @param array  $tt_ids    An array of term taxonomy IDs.
-	 * @param string $taxonomy  Taxonomy slug.
-	 */
-	public static function clear_cache_on_term_relationship_change( $object_id, $terms, $tt_ids, $taxonomy ) {
-		if (
-			Collection_Category_Taxonomy::get_taxonomy() === $taxonomy ||
-			Collection_Taxonomy::get_taxonomy() === $taxonomy ||
-			Post_Type::get_post_type() === get_post_type( $object_id )
-		) {
-			self::clear_available_years_cache();
-		}
-	}
 
 	/**
 	 * Get available years from published collections for filtering.
@@ -98,7 +25,7 @@ class Query_Helper {
 	 */
 	public static function get_available_years( $selected_category = '' ) {
 		// Try to get from cache first.
-		$cached_data    = wp_cache_get( self::YEARS_CACHE_KEY, self::CACHE_GROUP );
+		$cached_data    = wp_cache_get( Cache::YEARS_CACHE_KEY, Cache::CACHE_GROUP );
 		$category_years = [];
 
 		if ( ! empty( $cached_data[ $selected_category ] ) && is_array( $cached_data[ $selected_category ] ) ) {
@@ -153,7 +80,7 @@ class Query_Helper {
 				unset( $years );
 			}
 
-			wp_cache_set( self::YEARS_CACHE_KEY, $years_data, self::CACHE_GROUP );
+			wp_cache_set( Cache::YEARS_CACHE_KEY, $years_data, Cache::CACHE_GROUP );
 			$category_years = $years_data[ $selected_category ] ?? [];
 		}
 
@@ -327,15 +254,15 @@ class Query_Helper {
 	 */
 	public static function get_collection_posts( $collection_id ) {
 		// Try to get from cache first.
-		$cache_key   = self::POSTS_CACHE_KEY . $collection_id;
-		$cached_data = wp_cache_get( $cache_key, self::CACHE_GROUP );
+		$cache_key   = Cache::get_posts_cache_key( $collection_id );
+		$cached_data = wp_cache_get( $cache_key, Cache::CACHE_GROUP );
 
 		if ( false !== $cached_data ) {
 			return $cached_data;
 		}
 
 		// Get the linked collection term.
-		$linked_term_id = get_post_meta( $collection_id, Sync::LINKED_TERM_META_KEY, true );
+		$linked_term_id = Sync::get_term_linked_to_collection( $collection_id );
 		if ( ! $linked_term_id ) {
 			return [];
 		}
@@ -477,9 +404,57 @@ class Query_Helper {
 			$post_ids_by_section[ $section_slug ] = wp_list_pluck( $section_posts, 'ID' );
 		}
 
-		wp_cache_set( $cache_key, $post_ids_by_section, self::CACHE_GROUP );
+		wp_cache_set( $cache_key, $post_ids_by_section, Cache::CACHE_GROUP );
 
 		return $post_ids_by_section;
+	}
+
+	/**
+	 * Get collections that a post belongs to.
+	 *
+	 * @param int  $post_id      The post ID.
+	 * @param bool $return_posts Whether to return collection posts or just terms. Default false (terms).
+	 * @param bool $single       Whether to return only the first occurrence. Default false.
+	 * @return array Array of collection terms or collection posts.
+	 */
+	public static function get_post_collections( $post_id, $return_posts = false, $single = false ) {
+		$collection_terms = get_the_terms( $post_id, Collection_Taxonomy::get_taxonomy() );
+
+		if ( empty( $collection_terms ) || is_wp_error( $collection_terms ) ) {
+			return [];
+		}
+
+		// Slice early if we only need one result.
+		if ( $single ) {
+			$collection_terms = array_slice( $collection_terms, 0, 1 );
+		}
+
+		if ( ! $return_posts ) {
+			$result = $collection_terms;
+		} else {
+			// Get collection posts linked to these terms.
+			$collections = [];
+			foreach ( $collection_terms as $term ) {
+				$collection_id = Sync::get_collection_linked_to_term( $term->term_id );
+				if ( $collection_id ) {
+					$collections[] = $collection_id;
+				}
+			}
+
+			// Remove duplicates and get post objects.
+			$collections = array_unique( $collections );
+			$result      = array_map( 'get_post', $collections );
+		}
+
+		/**
+		 * Filters the collections for a post.
+		 *
+		 * @param array $result       Array of collection terms or posts.
+		 * @param int   $post_id      The post ID.
+		 * @param bool  $return_posts Whether collection posts were returned.
+		 * @param bool  $single       Whether only single result was requested.
+		 */
+		return apply_filters( 'newspack_collections_post_collections', $result, $post_id, $return_posts, $single );
 	}
 
 	/**

--- a/includes/collections/class-query-helper.php
+++ b/includes/collections/class-query-helper.php
@@ -98,61 +98,72 @@ class Query_Helper {
 	 */
 	public static function get_available_years( $selected_category = '' ) {
 		// Try to get from cache first.
-		$cached_data = wp_cache_get( self::YEARS_CACHE_KEY, self::CACHE_GROUP );
-		if ( false !== $cached_data && isset( $cached_data[ $selected_category ] ) ) {
-			return $cached_data[ $selected_category ];
-		}
+		$cached_data    = wp_cache_get( self::YEARS_CACHE_KEY, self::CACHE_GROUP );
+		$category_years = [];
 
-		global $wpdb;
+		if ( ! empty( $cached_data[ $selected_category ] ) && is_array( $cached_data[ $selected_category ] ) ) {
+			$category_years = $cached_data[ $selected_category ];
+		} elseif ( ! empty( $cached_data[''] ) && is_array( $cached_data[''] ) ) {
+			$category_years = $cached_data[''];
+		} else {
+			global $wpdb;
 
-		// Get all years with their associated categories in one query.
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
-		$results = $wpdb->get_results(
-			$wpdb->prepare(
-				"SELECT DISTINCT YEAR(p.post_date) as year, t.slug as category
-				FROM {$wpdb->posts} p
-				INNER JOIN {$wpdb->term_relationships} tr ON p.ID = tr.object_id
-				INNER JOIN {$wpdb->term_taxonomy} tt ON tr.term_taxonomy_id = tt.term_taxonomy_id
-				INNER JOIN {$wpdb->terms} t ON tt.term_id = t.term_id
-				WHERE tt.taxonomy = %s
-				AND p.post_type = %s
-				AND p.post_status = 'publish'
-				ORDER BY year DESC",
-				Collection_Category_Taxonomy::get_taxonomy(),
-				Post_Type::get_post_type()
-			)
-		);
+			// Get all years with their associated categories in one query.
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+			$results = $wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT DISTINCT YEAR(p.post_date) as year, t.slug as category
+					FROM {$wpdb->posts} p
+					LEFT JOIN {$wpdb->term_relationships} tr ON p.ID = tr.object_id AND EXISTS (
+						SELECT 1 FROM {$wpdb->term_taxonomy} tt2
+						WHERE tr.term_taxonomy_id = tt2.term_taxonomy_id
+						AND tt2.taxonomy = %s
+					)
+					LEFT JOIN {$wpdb->term_taxonomy} tt ON tr.term_taxonomy_id = tt.term_taxonomy_id
+					LEFT JOIN {$wpdb->terms} t ON tt.term_id = t.term_id
+					WHERE p.post_type = %s
+					AND p.post_status = 'publish'
+					ORDER BY year DESC",
+					Collection_Category_Taxonomy::get_taxonomy(),
+					Post_Type::get_post_type()
+				)
+			);
 
-		$years_data = [ '' => [] ]; // Initialize with empty category (all years).
+			$years_data = [ '' => [] ]; // Initialize with empty category (all years).
 
-		foreach ( $results as $result ) {
-			$year = intval( $result->year );
-			if ( $year ) {
-				// Add to "all years" (empty category).
-				if ( ! in_array( $year, $years_data[''], true ) ) {
-					$years_data[''][] = $year;
-				}
-
-				// Add to specific category if it exists.
-				if ( $result->category ) {
-					if ( ! isset( $years_data[ $result->category ] ) ) {
-						$years_data[ $result->category ] = [];
+			if ( is_array( $results ) ) {
+				foreach ( $results as $result ) {
+					$year = (int) $result->year;
+					if ( ! $year ) {
+						continue;
 					}
-					if ( ! in_array( $year, $years_data[ $result->category ], true ) ) {
+
+					$years_data[''][] = $year;
+
+					if ( $result->category ) {
 						$years_data[ $result->category ][] = $year;
 					}
 				}
+
+				// Sort all arrays in descending order and ensure uniqueness.
+				foreach ( $years_data as &$years ) {
+					$years = array_unique( $years );
+					rsort( $years );
+				}
+				unset( $years );
 			}
+
+			wp_cache_set( self::YEARS_CACHE_KEY, $years_data, self::CACHE_GROUP );
+			$category_years = $years_data[ $selected_category ] ?? [];
 		}
 
-		// Sort all arrays in descending order.
-		foreach ( $years_data as &$years ) {
-			rsort( $years );
-		}
-
-		wp_cache_set( self::YEARS_CACHE_KEY, $years_data, self::CACHE_GROUP );
-
-		return $years_data[ $selected_category ] ?? [];
+		/**
+		 * Filters the available years for a given collection category.
+		 *
+		 * @param array  $category_years    Array of years.
+		 * @param string $selected_category Selected category slug.
+		 */
+		return apply_filters( 'newspack_collections_available_years', (array) $category_years, $selected_category );
 	}
 
 	/**
@@ -177,7 +188,11 @@ class Query_Helper {
 		 */
 		$categories = apply_filters( 'newspack_collections_collection_categories', $categories );
 
-		if ( is_wp_error( $categories ) ) {
+		if (
+			is_wp_error( $categories ) ||
+			! is_array( $categories ) ||
+			( ! empty( $categories ) && ! $categories[0] instanceof \WP_Term )
+		) {
 			return [];
 		}
 

--- a/includes/collections/class-query-helper.php
+++ b/includes/collections/class-query-helper.php
@@ -14,8 +14,12 @@ defined( 'ABSPATH' ) || exit;
  */
 class Query_Helper {
 
+	/**
+	 * Cover section (virtual) slug.
+	 *
+	 * @var string
+	 */
 	public const COVER_SECTION = 'cover';
-
 
 	/**
 	 * Get available years from published collections for filtering.
@@ -199,7 +203,7 @@ class Query_Helper {
 			'order_link'     => __( 'Order', 'newspack' ),
 		];
 
-		return array_values(
+		$ctas = array_values(
 			array_filter(
 				array_map(
 					function ( $key ) use ( $post_id, $cta_keys ) {
@@ -232,6 +236,14 @@ class Query_Helper {
 				)
 			)
 		);
+
+		/**
+		 * Filters the hierarchical CTAs.
+		 *
+		 * @param array $ctas    Array of hierarchical CTAs.
+		 * @param int   $post_id The post ID.
+		 */
+		return apply_filters( 'newspack_collections_hierarchical_ctas', $ctas, $post_id );
 	}
 
 	/**
@@ -249,27 +261,35 @@ class Query_Helper {
 	 *    - Posts without `newspack_collection_post_order` meta (newest to oldest)
 	 *    - Posts with `newspack_collection_post_order` meta (by ascending order value)
 	 *
-	 * @param int $collection_id Collection post ID.
+	 * @param int|WP_Post $collection Collection post ID or post object.
 	 * @return array Array of post IDs organized by section slug.
 	 */
-	public static function get_collection_posts( $collection_id ) {
+	public static function get_collection_posts( $collection ) {
+		$collection_id = $collection instanceof \WP_Post ? $collection->ID : $collection;
+
 		// Try to get from cache first.
 		$cache_key   = Cache::get_posts_cache_key( $collection_id );
 		$cached_data = wp_cache_get( $cache_key, Cache::CACHE_GROUP );
 
 		if ( false !== $cached_data ) {
-			return $cached_data;
+			/**
+			 * Filters the collection posts organized by section.
+			 *
+			 * @param array          $post_ids_by_section Array of post IDs organized by section slug.
+			 * @param int|\WP_Post   $collection           Collection post ID or post object.
+			 */
+			return apply_filters( 'newspack_collections_posts_by_section', $cached_data, $collection );
 		}
 
 		// Get the linked collection term.
 		$linked_term_id = Sync::get_term_linked_to_collection( $collection_id );
 		if ( ! $linked_term_id ) {
-			return [];
+			return apply_filters( 'newspack_collections_posts_by_section', [], $collection );
 		}
 
 		$term = get_term( $linked_term_id, Collection_Taxonomy::get_taxonomy() );
 		if ( ! $term || is_wp_error( $term ) ) {
-			return [];
+			return apply_filters( 'newspack_collections_posts_by_section', [], $collection );
 		}
 
 		// Get posts in this collection.
@@ -291,7 +311,7 @@ class Query_Helper {
 		);
 
 		if ( empty( $posts ) ) {
-			return [];
+			return apply_filters( 'newspack_collections_posts_by_section', [], $collection );
 		}
 
 		// Organize posts by section.
@@ -406,7 +426,7 @@ class Query_Helper {
 
 		wp_cache_set( $cache_key, $post_ids_by_section, Cache::CACHE_GROUP );
 
-		return $post_ids_by_section;
+		return apply_filters( 'newspack_collections_posts_by_section', $post_ids_by_section, $collection );
 	}
 
 	/**
@@ -462,15 +482,22 @@ class Query_Helper {
 	 * @return string The section name.
 	 */
 	public static function get_section_name( $section_slug ) {
+		$section_name = $section_slug;
+
 		if ( ! empty( $section_slug ) ) {
 			$section_term = get_term_by( 'slug', $section_slug, Collection_Section_Taxonomy::get_taxonomy() );
 			if ( $section_term && ! is_wp_error( $section_term ) ) {
-				return $section_term->name;
+				$section_name = $section_term->name;
 			}
 		}
 
-		// Fallback to the slug if the term is not found.
-		return $section_slug;
+		/**
+		 * Filters the section name.
+		 *
+		 * @param string $section_name The section name.
+		 * @param string $section_slug The section slug.
+		 */
+		return apply_filters( 'newspack_collections_section_name', $section_name, $section_slug );
 	}
 
 	/**
@@ -487,7 +514,7 @@ class Query_Helper {
 			[
 				'post_type'      => Post_Type::get_post_type(),
 				'post_status'    => 'publish',
-				'posts_per_page' => $limit + count( $exclude ),
+				'posts_per_page' => $limit + ( is_array( $exclude ) ? count( $exclude ) : 0 ),
 				'orderby'        => 'date',
 				'order'          => 'DESC',
 			]
@@ -497,13 +524,20 @@ class Query_Helper {
 			return [];
 		}
 
-		$filtered = array_filter(
+		$filtered = empty( $exclude ) ? $collections : array_filter(
 			$collections,
 			function ( $post ) use ( $exclude ) {
 				return ! in_array( $post->ID, $exclude, true );
 			}
 		);
 
-		return array_slice( $filtered, 0, $limit );
+		/**
+		 * Filters the recent collections.
+		 *
+		 * @param array $recent  Array of recent collection posts.
+		 * @param array $exclude Array of excluded collection IDs.
+		 * @param int   $limit   Number of items returned.
+		 */
+		return apply_filters( 'newspack_collections_recent', array_slice( $filtered, 0, $limit ), $exclude, $limit );
 	}
 }

--- a/includes/collections/class-query-helper.php
+++ b/includes/collections/class-query-helper.php
@@ -412,12 +412,14 @@ class Query_Helper {
 	/**
 	 * Get collections that a post belongs to.
 	 *
-	 * @param int  $post_id      The post ID.
-	 * @param bool $return_posts Whether to return collection posts or just terms. Default false (terms).
-	 * @param bool $single       Whether to return only the first occurrence. Default false.
+	 * @param int|WP_Post $post         Post ID or post object.
+	 * @param bool        $return_posts Whether to return collection post objects or just the IDs. Default false (IDs).
+	 * @param bool        $single       Whether to return only the first occurrence. Default false.
 	 * @return array Array of collection terms or collection posts.
 	 */
-	public static function get_post_collections( $post_id, $return_posts = false, $single = false ) {
+	public static function get_post_collections( $post, $return_posts = false, $single = false ) {
+		$post_id = $post instanceof \WP_Post ? $post->ID : $post;
+
 		$collection_terms = get_the_terms( $post_id, Collection_Taxonomy::get_taxonomy() );
 
 		if ( empty( $collection_terms ) || is_wp_error( $collection_terms ) ) {
@@ -429,32 +431,28 @@ class Query_Helper {
 			$collection_terms = array_slice( $collection_terms, 0, 1 );
 		}
 
-		if ( ! $return_posts ) {
-			$result = $collection_terms;
-		} else {
-			// Get collection posts linked to these terms.
-			$collections = [];
-			foreach ( $collection_terms as $term ) {
-				$collection_id = Sync::get_collection_linked_to_term( $term->term_id );
-				if ( $collection_id ) {
-					$collections[] = $collection_id;
-				}
+		// Get collection posts linked to these terms.
+		$collections = [];
+		foreach ( $collection_terms as $term ) {
+			$collection_id = Sync::get_collection_linked_to_term( $term->term_id );
+			if ( $collection_id ) {
+				$collections[] = $collection_id;
 			}
-
-			// Remove duplicates and get post objects.
-			$collections = array_unique( $collections );
-			$result      = array_map( 'get_post', $collections );
 		}
+
+		// There shouldn't be duplicates, but just in case.
+		$collections = array_unique( $collections );
+		$result      = $return_posts ? array_map( 'get_post', $collections ) : $collections;
 
 		/**
 		 * Filters the collections for a post.
 		 *
-		 * @param array $result       Array of collection terms or posts.
-		 * @param int   $post_id      The post ID.
-		 * @param bool  $return_posts Whether collection posts were returned.
-		 * @param bool  $single       Whether only single result was requested.
+		 * @param array       $result       Array of collection post objects or IDs.
+		 * @param int|WP_Post $post         Post ID or post object.
+		 * @param bool        $return_posts Whether collection post objects were returned.
+		 * @param bool        $single       Whether only single result was requested.
 		 */
-		return apply_filters( 'newspack_collections_post_collections', $result, $post_id, $return_posts, $single );
+		return apply_filters( 'newspack_collections_post_collections', $result, $post, $return_posts, $single );
 	}
 
 	/**

--- a/includes/collections/class-query-helper.php
+++ b/includes/collections/class-query-helper.php
@@ -15,7 +15,8 @@ defined( 'ABSPATH' ) || exit;
 class Query_Helper {
 
 	public const COVER_SECTION   = 'cover';
-	public const YEARS_CACHE_KEY = 'newspack_collections_years_data';
+	public const YEARS_CACHE_KEY = 'available_years_data';
+	public const POSTS_CACHE_KEY = 'posts_in_collection_';
 	public const CACHE_GROUP     = 'newspack_collections';
 
 	/**
@@ -309,9 +310,17 @@ class Query_Helper {
 	 *    - Posts with `newspack_collection_post_order` meta (by ascending order value)
 	 *
 	 * @param int $collection_id Collection post ID.
-	 * @return array Array of posts organized by section slug.
+	 * @return array Array of post IDs organized by section slug.
 	 */
 	public static function get_collection_posts( $collection_id ) {
+		// Try to get from cache first.
+		$cache_key   = self::POSTS_CACHE_KEY . $collection_id;
+		$cached_data = wp_cache_get( $cache_key, self::CACHE_GROUP );
+
+		if ( false !== $cached_data ) {
+			return $cached_data;
+		}
+
 		// Get the linked collection term.
 		$linked_term_id = get_post_meta( $collection_id, Sync::LINKED_TERM_META_KEY, true );
 		if ( ! $linked_term_id ) {
@@ -448,7 +457,16 @@ class Query_Helper {
 			}
 		);
 
-		return $sections;
+		// Cache post IDs.
+		$post_ids_by_section = [];
+
+		foreach ( $sections as $section_slug => $section_posts ) {
+			$post_ids_by_section[ $section_slug ] = wp_list_pluck( $section_posts, 'ID' );
+		}
+
+		wp_cache_set( $cache_key, $post_ids_by_section, self::CACHE_GROUP );
+
+		return $post_ids_by_section;
 	}
 
 	/**

--- a/includes/collections/class-query-helper.php
+++ b/includes/collections/class-query-helper.php
@@ -187,37 +187,35 @@ class Query_Helper {
 	/**
 	 * Get processed CTAs from a collection post.
 	 *
-	 * @param int      $post_id The post ID.
-	 * @param int|null $limit Optional limit on the number of CTAs.
+	 * @param int      $post_id     The post ID.
+	 * @param int|null $limit       Optional limit on the number of CTAs.
+	 * @param bool     $hierarchical Whether to include hierarchical CTAs. Default is true.
 	 * @return array Array of processed CTAs with 'url' and 'label' keys.
 	 */
-	public static function get_ctas( $post_id, $limit = null ) {
+	public static function get_ctas( $post_id, $limit = null, $hierarchical = true ) {
 		$ctas = Collection_Meta::get( $post_id, 'ctas' );
 
-		if ( ! is_array( $ctas ) || empty( $ctas ) ) {
+		if ( ! is_array( $ctas ) ) {
+			$ctas = [];
+		}
+
+		// Add hierarchical CTAs if enabled and there's room.
+		if ( $hierarchical && ( null === $limit || count( $ctas ) < $limit ) ) {
+			$hierarchical_ctas = self::get_hierarchical_ctas( $post_id );
+			$ctas              = array_merge( $ctas, $hierarchical_ctas );
+		}
+
+		if ( empty( $ctas ) ) {
 			return [];
 		}
 
-		$cta_count = count( $ctas );
-
-		if ( null !== $limit && $cta_count >= $limit ) {
+		// Apply limit to final result if specified.
+		if ( null !== $limit ) {
 			$ctas = array_slice( $ctas, 0, $limit );
-		} else {
-			// If there's room for more CTAs, get the hierarchical CTAs.
-			$remaining         = null !== $limit ? $limit - $cta_count : null;
-			$hierarchical_ctas = self::get_hierarchical_ctas( $post_id );
-
-			// If there's a limit, slice the hierarchical CTAs to the limit.
-			if ( null !== $remaining ) {
-				$hierarchical_ctas = array_slice( $hierarchical_ctas, 0, $remaining );
-			}
-
-			// Merge the hierarchical CTAs into the existing CTAs.
-			$ctas = array_merge( $ctas, $hierarchical_ctas );
 		}
 
 		// Process the CTAs.
-		return array_values(
+		$ctas = array_values(
 			array_filter(
 				array_map(
 					function ( $cta ) {
@@ -231,20 +229,20 @@ class Query_Helper {
 							$url = $cta['url'];
 						}
 
-						if ( $label && $url ) {
-							return [
-								'url'   => $url,
-								'label' => $label,
-								'class' => $class,
-							];
-						}
-
-						return null;
+						return ( $label && $url ) ? compact( 'url', 'label', 'class' ) : null;
 					},
 					$ctas
 				)
 			)
 		);
+
+		/**
+		 * Filters the collection CTAs.
+		 *
+		 * @param array $ctas Array of collection CTAs.
+		 * @param int   $post_id The post ID.
+		 */
+		return apply_filters( 'newspack_collections_ctas', $ctas, $post_id );
 	}
 
 	/**

--- a/includes/collections/class-query-helper.php
+++ b/includes/collections/class-query-helper.php
@@ -133,13 +133,14 @@ class Query_Helper {
 	/**
 	 * Get processed CTAs from a collection post.
 	 *
-	 * @param int      $post_id     The post ID.
-	 * @param int|null $limit       Optional limit on the number of CTAs.
-	 * @param bool     $hierarchical Whether to include hierarchical CTAs. Default is true.
+	 * @param int|WP_Post $post         The post ID or post object.
+	 * @param int|null    $limit        Optional limit on the number of CTAs.
+	 * @param bool        $hierarchical Whether to include hierarchical CTAs. Default is true.
 	 * @return array Array of processed CTAs with 'url' and 'label' keys.
 	 */
-	public static function get_ctas( $post_id, $limit = null, $hierarchical = true ) {
-		$ctas = Collection_Meta::get( $post_id, 'ctas' );
+	public static function get_ctas( $post, $limit = null, $hierarchical = true ) {
+		$post_id = $post instanceof \WP_Post ? $post->ID : $post;
+		$ctas    = Collection_Meta::get( $post_id, 'ctas' );
 
 		if ( ! is_array( $ctas ) ) {
 			$ctas = [];
@@ -199,8 +200,8 @@ class Query_Helper {
 	 */
 	public static function get_hierarchical_ctas( $post_id ) {
 		$cta_keys = [
-			'subscribe_link' => __( 'Subscribe', 'newspack' ),
-			'order_link'     => __( 'Order', 'newspack' ),
+			'subscribe_link' => __( 'Subscribe', 'newspack-plugin' ),
+			'order_link'     => __( 'Order', 'newspack-plugin' ),
 		];
 
 		$ctas = array_values(

--- a/includes/collections/class-settings.php
+++ b/includes/collections/class-settings.php
@@ -17,19 +17,94 @@ class Settings {
 	/**
 	 * Option name for all collection settings.
 	 */
-	const OPTION_NAME = 'newspack_collections_settings';
+	public const OPTION_NAME = 'newspack_collections_settings';
 
 	/**
-	 * Settings fields and their defaults.
+	 * Posts per page options.
 	 */
-	const FIELDS = [
-		'custom_naming_enabled' => false,
-		'custom_name'           => '',
-		'custom_singular_name'  => '',
-		'custom_slug'           => '',
-		'subscribe_link'        => '',
-		'order_link'            => '',
-	];
+	public const POSTS_PER_PAGE_OPTIONS = [ 12, 18, 24 ];
+
+	/**
+	 * Get fields definitions to be used in the REST API.
+	 *
+	 * @param string $return_type Whether to return only the default values, keys, or all. Returns all the configuration by default.
+	 * @return array Fields definitions.
+	 */
+	public static function get_rest_args( $return_type = 'all' ) {
+		$fields = [
+			'custom_naming_enabled' => [
+				'required'          => false,
+				'default'           => false,
+				'sanitize_callback' => 'rest_sanitize_boolean',
+			],
+			'custom_name'           => [
+				'required'          => false,
+				'default'           => '',
+				'sanitize_callback' => 'sanitize_text_field',
+			],
+			'custom_singular_name'  => [
+				'required'          => false,
+				'default'           => '',
+				'sanitize_callback' => 'sanitize_text_field',
+			],
+			'custom_slug'           => [
+				'required'          => false,
+				'default'           => '',
+				'sanitize_callback' => function ( $value ) {
+					return sanitize_title( is_string( $value ) ? $value : '' );
+				},
+			],
+			'subscribe_link'        => [
+				'required'          => false,
+				'default'           => '',
+				'sanitize_callback' => 'esc_url_raw',
+			],
+			'order_link'            => [
+				'required'          => false,
+				'default'           => '',
+				'sanitize_callback' => 'esc_url_raw',
+			],
+			'post_indicator_style'  => [
+				'required'          => false,
+				'default'           => 'default',
+				'sanitize_callback' => 'sanitize_text_field',
+			],
+			'card_message'          => [
+				'required'          => false,
+				'default'           => '',
+				'sanitize_callback' => 'sanitize_text_field',
+			],
+			'posts_per_page'        => [
+				'required'          => false,
+				'default'           => 12,
+				'sanitize_callback' => function ( $value ) {
+					$value = intval( $value );
+					return in_array( $value, self::POSTS_PER_PAGE_OPTIONS, true ) ? $value : 12;
+				},
+			],
+			'highlight_latest'      => [
+				'required'          => false,
+				'default'           => false,
+				'sanitize_callback' => 'rest_sanitize_boolean',
+			],
+		];
+
+		switch ( $return_type ) {
+			case 'defaults':
+				$fields = array_map(
+					function ( $field ) {
+						return $field['default'];
+					},
+					$fields
+				);
+				break;
+			case 'keys':
+				$fields = array_keys( $fields );
+				break;
+		}
+
+		return $fields;
+	}
 
 	/**
 	 * Get all collection settings with defaults applied.
@@ -38,8 +113,9 @@ class Settings {
 	 */
 	public static function get_settings() {
 		$collection_settings = get_option( self::OPTION_NAME, [] );
+		$defaults            = self::get_rest_args( 'defaults' );
 
-		return wp_parse_args( $collection_settings, self::FIELDS );
+		return wp_parse_args( $collection_settings, $defaults );
 	}
 
 	/**
@@ -127,42 +203,6 @@ class Settings {
 	}
 
 	/**
-	 * Get REST API args for collection fields.
-	 *
-	 * @return array REST API arguments.
-	 */
-	public static function get_rest_args() {
-		return [
-			'custom_naming_enabled' => [
-				'required'          => false,
-				'sanitize_callback' => 'rest_sanitize_boolean',
-			],
-			'custom_name'           => [
-				'required'          => false,
-				'sanitize_callback' => 'sanitize_text_field',
-			],
-			'custom_singular_name'  => [
-				'required'          => false,
-				'sanitize_callback' => 'sanitize_text_field',
-			],
-			'custom_slug'           => [
-				'required'          => false,
-				'sanitize_callback' => function ( $value ) {
-					return sanitize_title( is_string( $value ) ? $value : '' );
-				},
-			],
-			'subscribe_link'        => [
-				'required'          => false,
-				'sanitize_callback' => 'esc_url_raw',
-			],
-			'order_link'            => [
-				'required'          => false,
-				'sanitize_callback' => 'esc_url_raw',
-			],
-		];
-	}
-
-	/**
 	 * Update collection settings from REST request.
 	 * Conditionally flushes rewrite rules when there are changes that will affect the post type or taxonomy slugs.
 	 *
@@ -173,7 +213,7 @@ class Settings {
 		$settings         = self::get_settings();
 		$updated_settings = [];
 
-		foreach ( array_keys( self::FIELDS ) as $key ) {
+		foreach ( self::get_rest_args( 'keys' ) as $key ) {
 			if ( ! $request->has_param( $key ) ) {
 				continue;
 			}

--- a/includes/collections/class-sync.php
+++ b/includes/collections/class-sync.php
@@ -208,7 +208,7 @@ class Sync {
 			return;
 		}
 
-		$linked_term_id = get_post_meta( $post_id, self::LINKED_TERM_META_KEY, true );
+		$linked_term_id = self::get_term_linked_to_collection( $post_id );
 
 		if ( $linked_term_id ) {
 			self::sync_collection_changes_to_term( $post_id, $linked_term_id );
@@ -251,7 +251,7 @@ class Sync {
 			return false;
 		}
 
-		$linked_term_id = get_post_meta( $post_id, self::LINKED_TERM_META_KEY, true );
+		$linked_term_id = self::get_term_linked_to_collection( $post_id );
 		if ( ! $linked_term_id || ! Collection_Taxonomy::term_exists( (int) $linked_term_id ) ) {
 			return false;
 		}
@@ -297,7 +297,7 @@ class Sync {
 			return false;
 		}
 
-		$linked_term_id = get_post_meta( $post_id, self::LINKED_TERM_META_KEY, true );
+		$linked_term_id = self::get_term_linked_to_collection( $post_id );
 		if ( ! $linked_term_id || ! Collection_Taxonomy::term_exists( (int) $linked_term_id ) ) {
 			return false;
 		}
@@ -318,7 +318,7 @@ class Sync {
 		}
 
 		// Check if term already has a linked post.
-		$post_id = get_term_meta( $term_id, self::LINKED_POST_META_KEY, true );
+		$post_id = self::get_collection_linked_to_term( $term_id );
 		if ( $post_id ) {
 			return false;
 		}
@@ -333,7 +333,7 @@ class Sync {
 	 * @return bool|void True on success, false on failure. Void if no changes were made.
 	 */
 	public static function handle_term_edited( $term_id ) {
-		$post_id = get_term_meta( $term_id, self::LINKED_POST_META_KEY, true );
+		$post_id = self::get_collection_linked_to_term( $term_id );
 		if ( ! $post_id ) {
 			return;
 		}
@@ -358,7 +358,7 @@ class Sync {
 			return;
 		}
 
-		$post_id = get_term_meta( $term, self::LINKED_POST_META_KEY, true );
+		$post_id = self::get_collection_linked_to_term( $term );
 		if ( ! $post_id ) {
 			return;
 		}
@@ -382,5 +382,27 @@ class Sync {
 		Post_Type::register_hooks();
 
 		return $result;
+	}
+
+	/**
+	 * Get collection ID linked to a specific term.
+	 *
+	 * @param int $term_id The term ID.
+	 * @return int|null Collection ID or null if no collection is linked.
+	 */
+	public static function get_collection_linked_to_term( $term_id ) {
+		$collection_id = get_term_meta( $term_id, self::LINKED_POST_META_KEY, true );
+		return $collection_id ? (int) $collection_id : null;
+	}
+
+	/**
+	 * Get term ID linked to a specific collection.
+	 *
+	 * @param int $collection_id Collection ID.
+	 * @return int|null Term ID or null if no term is linked.
+	 */
+	public static function get_term_linked_to_collection( $collection_id ) {
+		$term_id = get_post_meta( $collection_id, self::LINKED_TERM_META_KEY, true );
+		return $term_id ? (int) $term_id : null;
 	}
 }

--- a/includes/collections/class-template-helper.php
+++ b/includes/collections/class-template-helper.php
@@ -1,0 +1,351 @@
+<?php
+/**
+ * Collections Template Helper.
+ *
+ * @package Newspack\Collections
+ */
+
+namespace Newspack\Collections;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Template helper class for Collections rendering and hooks.
+ */
+class Template_Helper {
+
+	/**
+	 * Initialize hooks.
+	 */
+	public static function init() {
+		add_filter( 'template_include', [ __CLASS__, 'template_include' ] );
+		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'enqueue_assets' ], 5 );
+		add_action( 'pre_get_posts', [ __CLASS__, 'archive_filters' ] );
+		add_filter( 'redirect_canonical', [ __CLASS__, 'prevent_year_redirect' ] );
+		add_filter( 'jetpack_relatedposts_filter_enabled_for_request', [ __CLASS__, 'disable_jetpack_related_posts' ] );
+	}
+
+	/**
+	 * Override template loading for Collections pages to use plugin templates as fallback.
+	 * Follows WordPress template hierarchy - theme templates take precedence.
+	 *
+	 * @param string $template The path of the template to include.
+	 * @return string The path of the template to include.
+	 */
+	public static function template_include( $template ) {
+		// Determine the template name based on the post type.
+		$template_name = match ( true ) {
+			is_post_type_archive( Post_Type::get_post_type() ) => 'archive-newspack-collection.php',
+			is_singular( Post_Type::get_post_type() )          => 'single-newspack-collection.php',
+			default                                            => '',
+		};
+
+		if ( $template_name ) {
+			$resolved_template = self::resolve_template( $template_name );
+			$template          = $resolved_template ? $resolved_template : $template;
+		}
+
+		/**
+		 * Filters the template path for Collections pages.
+		 *
+		 * @param string $template      The template path.
+		 * @param string $template_name The name of the template file.
+		 */
+		return apply_filters( 'newspack_collections_template_include', $template, $template_name );
+	}
+
+	/**
+	 * Resolve template by checking theme and plugin locations.
+	 *
+	 * @param string $template_name The name of the template file.
+	 * @return string The resolved template path or empty string.
+	 */
+	private static function resolve_template( $template_name ) {
+		$theme_template = locate_template( $template_name );
+		if ( $theme_template ) {
+			return $theme_template;
+		}
+
+		$plugin_template = plugin_dir_path( __DIR__ ) . 'templates/collections/' . $template_name;
+
+		return file_exists( $plugin_template ) ? $plugin_template : '';
+	}
+
+	/**
+	 * Trigger frontend asset loading for Collections pages.
+	 */
+	public static function enqueue_assets() {
+		if (
+			is_post_type_archive( Post_Type::get_post_type() ) ||
+			is_singular( Post_Type::get_post_type() )
+		) {
+			Enqueuer::add_data( 'is_collection', true ); // Any data will trigger the enqueuing.
+		}
+	}
+
+	/**
+	 * Modify Collections archive query to apply filters.
+	 *
+	 * @param WP_Query $query The WP_Query instance.
+	 */
+	public static function archive_filters( $query ) {
+		if ( ! is_admin() && $query->is_main_query() && is_post_type_archive( Post_Type::get_post_type() ) ) {
+			return;
+		}
+
+		// Set posts per page.
+		$query->set( 'posts_per_page', 24 ); // TODO: Make this a global setting.
+
+		// Handle category filtering.
+		$category = isset( $_GET['category'] ) ? sanitize_text_field( $_GET['category'] ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( ! empty( $category ) ) {
+			$tax_query = [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
+				[
+					'taxonomy' => Collection_Category_Taxonomy::get_taxonomy(),
+					'field'    => 'slug',
+					'terms'    => $category,
+				],
+			];
+			$query->set( 'tax_query', $tax_query );
+		}
+
+		// Handle year filtering.
+		$year = isset( $_GET['year'] ) ? sanitize_text_field( $_GET['year'] ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( ! empty( $year ) ) {
+			$query->set(
+				'date_query',
+				[
+					[
+						'year' => intval( $year ),
+					],
+				]
+			);
+		}
+	}
+
+	/**
+	 * Prevent year archive redirects on collection archive pages.
+	 *
+	 * @param string $redirect_url The redirect URL.
+	 * @return string|false The redirect URL or false to prevent redirect.
+	 */
+	public static function prevent_year_redirect( $redirect_url ) {
+		// Check if we're on a collection archive page with year parameter.
+		if ( is_post_type_archive( Post_Type::get_post_type() ) && isset( $_GET['year'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return false;
+		}
+
+		return $redirect_url;
+	}
+
+	/**
+	 * Disable Jetpack related posts for collections.
+	 *
+	 * @param bool $enabled Should Related Posts be enabled on the current page.
+	 * @return bool Whether Related Posts should be enabled on the current page.
+	 */
+	public static function disable_jetpack_related_posts( $enabled ) {
+		if ( is_singular( Post_Type::get_post_type() ) ) {
+			return false;
+		}
+
+		return $enabled;
+	}
+
+	/**
+	 * Render a collection image.
+	 *
+	 * @param int|WP_Post $post      The post object or ID.
+	 * @param bool        $permalink Whether to wrap the image in a permalink.
+	 * @return string The rendered image HTML.
+	 */
+	public static function render_image( $post, $permalink = true ) {
+		$image = has_post_thumbnail( $post )
+			? get_the_post_thumbnail( $post, 'full' )
+			: '<div class="collection-placeholder has-light-gray-background-color" aria-hidden="true"></div>';
+
+		if ( $permalink ) {
+			$image = sprintf(
+				'<a href="%s">%s</a>',
+				esc_url( get_permalink( $post ) ),
+				$image
+			);
+		}
+
+		$html = sprintf( '<figure class="collection-image">%s</figure>', $image );
+
+		/**
+		 * Filter the rendered collection image HTML.
+		 *
+		 * @param string      $html      The complete image HTML.
+		 * @param int|WP_Post $post      The post.
+		 * @param bool        $permalink Whether the image is wrapped in a permalink.
+		 */
+		return apply_filters( 'newspack_collections_render_image', $html, $post, $permalink );
+	}
+
+	/**
+	 * Get formatted collection metadata text.
+	 *
+	 * @param int $post_id Post ID.
+	 * @param int $lines   Number of lines to output (1 = inline, 2 = stacked). Default 2.
+	 * @return string Formatted metadata text.
+	 */
+	public static function render_meta_text( $post_id, $lines = 2 ) {
+		$meta_parts = [];
+		$volume     = Collection_Meta::get( $post_id, 'volume' );
+		$number     = Collection_Meta::get( $post_id, 'number' );
+		$period     = Collection_Meta::get( $post_id, 'period' );
+
+		if ( $period ) {
+			$meta_parts[] = esc_html( $period );
+		}
+
+		$vol_number = [];
+
+		if ( $volume ) {
+			$vol_number[] = sprintf( 'Vol. %s', esc_html( $volume ) );
+		}
+
+		if ( $number ) {
+			$vol_number[] = sprintf( 'No. %s', esc_html( $number ) );
+		}
+
+		if ( $vol_number ) {
+			$meta_parts[] = implode( ' / ', $vol_number );
+		}
+
+		$separator = 1 === $lines ? ' / ' : '<br>';
+		$meta_text = implode( $separator, $meta_parts );
+
+		/**
+		 * Filters the meta text for a collection.
+		 *
+		 * @param string $meta_text The meta text.
+		 * @param int    $post_id   Post ID.
+		 * @param int    $lines     Number of lines to output.
+		 */
+		$meta_text = apply_filters( 'newspack_collections_render_meta_text', $meta_text, $post_id, $lines );
+
+		if ( ! empty( $meta_text ) ) {
+			return sprintf(
+				'<p class="has-medium-gray-color has-text-color has-link-color has-small-font-size">%s</p>',
+				wp_kses_post( $meta_text )
+			);
+		}
+
+		return '';
+	}
+
+	/**
+	 * Render a CTA button.
+	 *
+	 * @param array $cta {
+	 *     The CTA data.
+	 *
+	 *     @type string $url   The URL of the CTA.
+	 *     @type string $label The label of the CTA.
+	 *     @type string $class The class of the CTA.
+	 * }
+	 * @return string The rendered CTA button.
+	 */
+	public static function render_cta( $cta ) {
+		/**
+		 * Filters the CTA button data before rendering.
+		 *
+		 * @param array $cta {
+		 *     The CTA data.
+		 *
+		 *     @type string $url   The URL of the CTA.
+		 *     @type string $label The label of the CTA.
+		 *     @type string $class The class of the CTA.
+		 * }
+		 */
+		$cta = apply_filters( 'newspack_collections_render_cta', $cta );
+
+		if ( ! $cta || ! $cta['url'] || ! $cta['label'] ) {
+			return '';
+		}
+
+		$html = sprintf(
+			'<div class="collection-cta %1$s">
+				<a class="wp-block-button__link has-dark-gray-color has-light-gray-background-color has-text-color has-background has-link-color wp-element-button" href="%2$s">%3$s</a>
+			</div>',
+			esc_attr( $cta['class'] ?? '' ),
+			esc_url( $cta['url'] ?? '' ),
+			esc_html( $cta['label'] ?? '' )
+		);
+
+		/**
+		 * Filters the CTA button HTML.
+		 *
+		 * @param string $html The CTA button HTML.
+		 * @param array  $cta  The CTA data.
+		 */
+		return apply_filters( 'newspack_collections_cta_html', $html, $cta );
+	}
+
+	/**
+	 * Render articles block.
+	 * Reuses the Content Loop block.
+	 *
+	 * @param array  $post_ids       Array of post IDs.
+	 * @param string $section_header The header of the section.
+	 * @param bool   $show_image     Whether to show the image.
+	 * @param int    $columns        The number of columns.
+	 * @param int    $type_scale     The type scale.
+	 * @return string The rendered articles block.
+	 */
+	public static function render_articles( $post_ids, $section_header = '', $show_image = true, $columns = 2, $type_scale = 3 ) {
+		if ( empty( $post_ids ) ) {
+			return '';
+		}
+
+		$attrs = [
+			'sectionHeader' => $section_header,
+			'showImage'     => $show_image,
+			'className'     => 'is-style-default',
+			'showDate'      => false,
+			'showAvatar'    => false,
+			'postLayout'    => 'grid',
+			'columns'       => $columns,
+			'mediaPosition' => 'left',
+			'specificPosts' => $post_ids,
+			'typeScale'     => $type_scale,
+			'imageScale'    => 1,
+			'specificMode'  => true,
+		];
+
+		/**
+		 * Filters the attributes before rendering the content loop block for posts in a section.
+		 *
+		 * @param array $attrs The attributes for the articles block.
+		 */
+		$attrs = apply_filters( 'newspack_collections_render_articles_attrs', $attrs );
+
+		return render_block(
+			[
+				'blockName' => 'newspack-blocks/homepage-articles',
+				'attrs'     => $attrs,
+			]
+		);
+	}
+
+	/**
+	 * Render a see all Collections link.
+	 *
+	 * @return string The rendered see all link.
+	 */
+	public static function render_see_all_link() {
+		$link  = get_post_type_archive_link( Post_Type::get_post_type() );
+		$label = __( 'See all', 'newspack' );
+		$html  = sprintf( '<a href="%s">%s</a>', esc_url( $link ), esc_html( $label ) );
+
+		/**
+		 * Filters the see all link HTML.
+		 *
+		 * @param string $html The see all link HTML.
+		 */
+		return apply_filters( 'newspack_collections_see_all_link_html', $html );
+	}
+}

--- a/includes/collections/class-template-helper.php
+++ b/includes/collections/class-template-helper.php
@@ -155,19 +155,21 @@ class Template_Helper {
 	/**
 	 * Render a collection image.
 	 *
-	 * @param int|WP_Post $post      The post object or ID.
-	 * @param bool        $permalink Whether to wrap the image in a permalink.
+	 * @param int|WP_Post  $post      The post object or ID.
+	 * @param bool|string  $permalink Whether to wrap the image in a permalink. If a string, it will be used as the URL. Otherwise, the permalink will be generated from the post.
+	 * @param string|int[] $size      Optional. Image size. Accepts any registered image size name, or an array of width and height values in pixels (in that order). Default 'post-thumbnail'.
+	 * @param string|array $attr      Optional. Query string or array of attributes to add to the image. Default empty.
 	 * @return string The rendered image HTML.
 	 */
-	public static function render_image( $post, $permalink = true ) {
+	public static function render_image( $post, $permalink = true, $size = 'post-thumbnail', $attr = '' ) {
 		$image = has_post_thumbnail( $post )
-			? get_the_post_thumbnail( $post, 'full' )
+			? get_the_post_thumbnail( $post, $size, $attr )
 			: '<div class="collection-placeholder has-light-gray-background-color" aria-hidden="true"></div>';
 
 		if ( $permalink ) {
 			$image = sprintf(
 				'<a href="%s">%s</a>',
-				esc_url( get_permalink( $post ) ),
+				is_string( $permalink ) ? $permalink : esc_url( get_permalink( $post ) ),
 				$image
 			);
 		}
@@ -177,11 +179,13 @@ class Template_Helper {
 		/**
 		 * Filter the rendered collection image HTML.
 		 *
-		 * @param string      $html      The complete image HTML.
-		 * @param int|WP_Post $post      The post.
-		 * @param bool        $permalink Whether the image is wrapped in a permalink.
+		 * @param string       $html      The complete image HTML.
+		 * @param int|WP_Post  $post      The post.
+		 * @param bool         $permalink Whether the image is wrapped in a permalink.
+		 * @param string|int[] $size      The image size.
+		 * @param string|array $attr      The image attributes.
 		 */
-		return apply_filters( 'newspack_collections_render_image', $html, $post, $permalink );
+		return apply_filters( 'newspack_collections_render_image', $html, $post, $permalink, $size, $attr );
 	}
 
 	/**

--- a/includes/collections/class-template-helper.php
+++ b/includes/collections/class-template-helper.php
@@ -15,10 +15,18 @@ defined( 'ABSPATH' ) || exit;
 class Template_Helper {
 
 	/**
+	 * The directory where the collection template parts are located.
+	 *
+	 * @var string
+	 */
+	public const TEMPLATE_PARTS_DIR = 'collections/parts/';
+
+	/**
 	 * Initialize hooks.
 	 */
 	public static function init() {
 		add_filter( 'template_include', [ __CLASS__, 'template_include' ] );
+		add_action( 'get_template_part', [ __CLASS__, 'load_template_part' ], 10, 4 );
 		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'enqueue_assets' ], 5 );
 		add_action( 'pre_get_posts', [ __CLASS__, 'archive_filters' ] );
 		add_filter( 'redirect_canonical', [ __CLASS__, 'prevent_year_redirect' ] );
@@ -72,6 +80,52 @@ class Template_Helper {
 	}
 
 	/**
+	 * Override template part loading for Collections pages to use plugin templates as fallback.
+	 * Follows WordPress template hierarchy - theme template parts take precedence.
+	 *
+	 * @param string   $slug      The slug name for the generic template.
+	 * @param string   $name      The name of the specialized template or an empty string if there is none.
+	 * @param string[] $templates Array of template names.
+	 * @param array    $args      Additional arguments passed to the template.
+	 */
+	public static function load_template_part( $slug, $name, $templates, $args ) {
+		if ( ! str_starts_with( $slug, self::TEMPLATE_PARTS_DIR ) ) {
+			return;
+		}
+
+		// Build the template file path.
+		$template_file = ( $name ? "{$slug}-{$name}" : $slug ) . '.php';
+
+		// Look in theme first.
+		$theme_template = locate_template( $template_file );
+		if ( $theme_template ) {
+			return;
+		}
+
+		/**
+		 * Filters the fallback plugin template path before attempting to load it.
+		 *
+		 * @param string $plugin_template Path to the plugin template.
+		 * @param string $template_file   Relative template file name.
+		 * @param string $slug            The slug name for the generic template.
+		 * @param string $name            The name of the specialized template or an empty string if there is none.
+		 * @param array  $args            Additional arguments passed to the template.
+		 */
+		$plugin_template = apply_filters(
+			'newspack_collections_plugin_template_part',
+			plugin_dir_path( __DIR__ ) . "templates/{$template_file}",
+			$template_file,
+			$slug,
+			$name,
+			$args
+		);
+
+		if ( file_exists( $plugin_template ) ) {
+			load_template( $plugin_template, false, $args );
+		}
+	}
+
+	/**
 	 * Trigger frontend asset loading for Collections pages.
 	 */
 	public static function enqueue_assets() {
@@ -94,7 +148,8 @@ class Template_Helper {
 		}
 
 		// Set posts per page.
-		$query->set( 'posts_per_page', 24 ); // TODO: Make this a global setting.
+		$posts_per_page = Settings::get_setting( 'posts_per_page' );
+		$query->set( 'posts_per_page', $posts_per_page );
 
 		// Handle category filtering.
 		$category = isset( $_GET['category'] ) ? sanitize_text_field( $_GET['category'] ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
@@ -191,11 +246,12 @@ class Template_Helper {
 	/**
 	 * Get formatted collection metadata text.
 	 *
-	 * @param int $post_id Post ID.
-	 * @param int $lines   Number of lines to output (1 = inline, 2 = stacked). Default 2.
+	 * @param int|WP_Post $post  Post ID or post object.
+	 * @param int         $lines Number of lines to output (1 = inline, 2 = stacked). Default 2.
 	 * @return string Formatted metadata text.
 	 */
-	public static function render_meta_text( $post_id, $lines = 2 ) {
+	public static function render_meta_text( $post, $lines = 2 ) {
+		$post_id    = $post instanceof \WP_Post ? $post->ID : $post;
 		$meta_parts = [];
 		$volume     = Collection_Meta::get( $post_id, 'volume' );
 		$number     = Collection_Meta::get( $post_id, 'number' );
@@ -342,7 +398,7 @@ class Template_Helper {
 	 */
 	public static function render_see_all_link() {
 		$link  = get_post_type_archive_link( Post_Type::get_post_type() );
-		$label = __( 'See all', 'newspack' );
+		$label = __( 'See all', 'newspack-plugin' );
 		$html  = sprintf( '<a href="%s">%s</a>', esc_url( $link ), esc_html( $label ) );
 
 		/**
@@ -351,5 +407,15 @@ class Template_Helper {
 		 * @param string $html The see all link HTML.
 		 */
 		return apply_filters( 'newspack_collections_see_all_link_html', $html );
+	}
+
+	/**
+	 * Render a separator.
+	 *
+	 * @param string $class_name Optional class for the separator.
+	 * @return string The separator HTML.
+	 */
+	public static function render_separator( $class_name = '' ) {
+		return '<hr class="has-light-gray-background-color has-background is-style-wide ' . esc_attr( $class_name ) . '"/>';
 	}
 }

--- a/includes/collections/class-template-helper.php
+++ b/includes/collections/class-template-helper.php
@@ -89,7 +89,7 @@ class Template_Helper {
 	 * @param WP_Query $query The WP_Query instance.
 	 */
 	public static function archive_filters( $query ) {
-		if ( ! is_admin() && $query->is_main_query() && is_post_type_archive( Post_Type::get_post_type() ) ) {
+		if ( is_admin() || ! $query->is_main_query() || ! is_post_type_archive( Post_Type::get_post_type() ) ) {
 			return;
 		}
 

--- a/includes/optional-modules/class-collections.php
+++ b/includes/optional-modules/class-collections.php
@@ -18,6 +18,7 @@ use Newspack\Collections\Collection_Section_Taxonomy;
 use Newspack\Collections\Post_Meta;
 use Newspack\Collections\Cache;
 use Newspack\Collections\Template_Helper;
+use Newspack\Collections\Content_Inserter;
 
 /**
  * Collections module for managing print editions and other collections.
@@ -47,6 +48,7 @@ class Collections {
 		Post_Meta::init();
 		Cache::init();
 		Template_Helper::init();
+		Content_Inserter::init();
 	}
 
 	/**

--- a/includes/optional-modules/class-collections.php
+++ b/includes/optional-modules/class-collections.php
@@ -16,7 +16,7 @@ use Newspack\Collections\Collection_Taxonomy;
 use Newspack\Collections\Collection_Category_Taxonomy;
 use Newspack\Collections\Collection_Section_Taxonomy;
 use Newspack\Collections\Post_Meta;
-use Newspack\Collections\Query_Helper;
+use Newspack\Collections\Cache;
 use Newspack\Collections\Template_Helper;
 
 /**
@@ -45,7 +45,7 @@ class Collections {
 		Collection_Category_Taxonomy::init();
 		Collection_Section_Taxonomy::init();
 		Post_Meta::init();
-		Query_Helper::init();
+		Cache::init();
 		Template_Helper::init();
 	}
 

--- a/includes/optional-modules/class-collections.php
+++ b/includes/optional-modules/class-collections.php
@@ -17,6 +17,7 @@ use Newspack\Collections\Collection_Category_Taxonomy;
 use Newspack\Collections\Collection_Section_Taxonomy;
 use Newspack\Collections\Post_Meta;
 use Newspack\Collections\Query_Helper;
+use Newspack\Collections\Template_Helper;
 
 /**
  * Collections module for managing print editions and other collections.
@@ -45,6 +46,7 @@ class Collections {
 		Collection_Section_Taxonomy::init();
 		Post_Meta::init();
 		Query_Helper::init();
+		Template_Helper::init();
 	}
 
 	/**

--- a/includes/templates/collections/archive-newspack-collection.php
+++ b/includes/templates/collections/archive-newspack-collection.php
@@ -48,21 +48,22 @@ do_action( 'newspack_collections_archive_start' );
 					</select>
 				</div>
 
-				<div class="collections-filter__select">
-					<label for="category"><?php esc_html_e( 'Publication:', 'newspack' ); ?></label>
-					<select name="category" id="category">
-						<option value="" <?php selected( $selected_category, '' ); ?>><?php esc_html_e( 'All', 'newspack' ); ?></option>
-						<?php
-							$categories = Query_Helper::get_collection_categories();
+				<?php
+				$categories = Query_Helper::get_collection_categories();
 
-						if ( ! empty( $categories ) ) {
-							foreach ( $categories as $category ) {
-								echo '<option value="' . esc_attr( $category->slug ) . '" ' . selected( $selected_category, $category->slug, false ) . '>' . esc_html( $category->name ) . '</option>';
-							}
-						}
-						?>
-					</select>
-				</div>
+				if ( count( $categories ) > 1 ) :
+					?>
+					<div class="collections-filter__select">
+						<label for="category"><?php esc_html_e( 'Publication:', 'newspack' ); ?></label>
+						<select name="category" id="category">
+							<option value="" <?php selected( $selected_category, '' ); ?>><?php esc_html_e( 'All', 'newspack' ); ?></option>
+							<?php foreach ( $categories as $category ) : ?>
+								<option value="<?php echo esc_attr( $category->slug ); ?>" <?php selected( $selected_category, $category->slug ); ?>><?php echo esc_html( $category->name ); ?></option>
+							<?php endforeach; ?>
+							?>
+						</select>
+					</div>
+				<?php endif; ?>
 
 			</form> <!-- .collections-filter -->
 

--- a/includes/templates/collections/archive-newspack-collection.php
+++ b/includes/templates/collections/archive-newspack-collection.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * The template for displaying Collections archives.
+ *
+ * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
+ *
+ * @package Newspack\Collections
+ *
+ * @phpcs:disable WordPress.Security.NonceVerification.Recommended
+ */
+
+use Newspack\Collections\Query_Helper;
+use Newspack\Collections\Settings;
+use Newspack\Collections\Template_Helper;
+
+get_header();
+?>
+
+<section id="primary" class="content-area">
+	<header class="page-header">
+		<h1 class="page-title"><?php echo esc_html( Settings::get_collection_label() ); ?></h1>
+	</header><!-- .page-header -->
+
+	<main id="main" class="site-main">
+
+		<?php if ( have_posts() ) : ?>
+
+			<!-- Filter controls -->
+			<form class="collections-filter" method="get">
+				<?php
+				$selected_year     = isset( $_GET['year'] ) ? sanitize_text_field( $_GET['year'] ) : '';
+				$selected_category = isset( $_GET['category'] ) ? sanitize_text_field( $_GET['category'] ) : '';
+				$available_years   = Query_Helper::get_available_years( $selected_category );
+				?>
+
+				<div class="collections-filter__select">
+					<label for="year"><?php esc_html_e( 'Year:', 'newspack' ); ?></label>
+					<select name="year" id="year">
+						<option value="" <?php selected( $selected_year, '' ); ?>><?php esc_html_e( 'All', 'newspack' ); ?></option>
+						<?php foreach ( $available_years as $available_year ) : ?>
+							<option value="<?php echo esc_attr( $available_year ); ?>" <?php selected( $selected_year, $available_year ); ?>><?php echo esc_html( $available_year ); ?></option>
+						<?php endforeach; ?>
+					</select>
+				</div>
+
+				<div class="collections-filter__select">
+					<label for="category"><?php esc_html_e( 'Publication:', 'newspack' ); ?></label>
+					<select name="category" id="category">
+						<option value="" <?php selected( $selected_category, '' ); ?>><?php esc_html_e( 'All', 'newspack' ); ?></option>
+						<?php
+							$categories = Query_Helper::get_collection_categories();
+
+						if ( ! empty( $categories ) ) {
+							foreach ( $categories as $category ) {
+								echo '<option value="' . esc_attr( $category->slug ) . '" ' . selected( $selected_category, $category->slug, false ) . '>' . esc_html( $category->name ) . '</option>';
+							}
+						}
+						?>
+					</select>
+				</div>
+
+			</form> <!-- .collections-filter -->
+
+			<!-- Collections grid -->
+			<div class="collections-grid collections-grid--previous">
+				<?php
+				while ( have_posts() ) :
+					the_post();
+					?>
+
+					<div class="collection-item">
+						<?php echo wp_kses_post( Template_Helper::render_image( $post ) ); ?>
+
+						<div class="collection-content">
+							<h3 class="has-normal-font-size">
+								<a href="<?php the_permalink(); ?>"><?php the_title(); ?></a>
+							</h3>
+
+							<?php echo wp_kses_post( Template_Helper::render_meta_text( get_the_ID() ) ); ?>
+						</div>
+
+						<?php
+						$ctas = Query_Helper::get_ctas( get_the_ID(), 1 );
+						if ( ! empty( $ctas ) ) :
+							?>
+							<div class="collection-buttons">
+								<?php foreach ( $ctas as $cta ) : ?>
+									<?php echo wp_kses_post( Template_Helper::render_cta( $cta ) ); ?>
+								<?php endforeach; ?>
+							</div>
+						<?php endif; ?>
+					</div>
+
+				<?php endwhile; ?>
+			</div> <!-- .collections-grid -->
+
+			<?php
+			// Use Newspack theme navigation if it exists, otherwise use core navigation.
+			if ( function_exists( 'newspack_the_posts_navigation' ) ) {
+				newspack_the_posts_navigation();
+			} else {
+				the_posts_navigation();
+			}
+
+		else :
+			get_template_part( 'template-parts/content/content', 'none' );
+
+		endif;
+		?>
+
+	</main><!-- #main -->
+
+</section><!-- #primary -->
+
+<?php
+get_footer();

--- a/includes/templates/collections/archive-newspack-collection.php
+++ b/includes/templates/collections/archive-newspack-collection.php
@@ -14,6 +14,11 @@ use Newspack\Collections\Settings;
 use Newspack\Collections\Template_Helper;
 
 get_header();
+
+/**
+ * Fires at the start of the collections archive template.
+ */
+do_action( 'newspack_collections_archive_start' );
 ?>
 
 <section id="primary" class="content-area">
@@ -61,11 +66,22 @@ get_header();
 
 			</form> <!-- .collections-filter -->
 
+			<?php
+			/**
+			 * Fires after the filter controls in the archive template.
+			 *
+			 * @param string $selected_year     The selected year filter.
+			 * @param string $selected_category The selected category filter.
+			 */
+			do_action( 'newspack_collections_archive_after_filters', $selected_year, $selected_category );
+			?>
+
 			<!-- Collections grid -->
-			<div class="collections-grid collections-grid--previous">
+			<div class="collections-grid">
 				<?php
 				while ( have_posts() ) :
 					the_post();
+					$collection_id = get_the_ID();
 					?>
 
 					<div class="collection-item">
@@ -76,11 +92,11 @@ get_header();
 								<a href="<?php the_permalink(); ?>"><?php the_title(); ?></a>
 							</h3>
 
-							<?php echo wp_kses_post( Template_Helper::render_meta_text( get_the_ID() ) ); ?>
+							<?php echo wp_kses_post( Template_Helper::render_meta_text( $collection_id ) ); ?>
 						</div>
 
 						<?php
-						$ctas = Query_Helper::get_ctas( get_the_ID(), 1 );
+						$ctas = Query_Helper::get_ctas( $collection_id, 1 );
 						if ( ! empty( $ctas ) ) :
 							?>
 							<div class="collection-buttons">
@@ -91,10 +107,23 @@ get_header();
 						<?php endif; ?>
 					</div>
 
-				<?php endwhile; ?>
+					<?php
+					/**
+					 * Fires after each collection item in the archive grid.
+					 *
+					 * @param int $collection_id The collection post ID.
+					 */
+					do_action( 'newspack_collections_archive_after_item', $collection_id );
+				endwhile;
+				?>
 			</div> <!-- .collections-grid -->
 
 			<?php
+			/**
+			 * Fires before the navigation in the archive template.
+			 */
+			do_action( 'newspack_collections_archive_before_navigation' );
+
 			// Use Newspack theme navigation if it exists, otherwise use core navigation.
 			if ( function_exists( 'newspack_the_posts_navigation' ) ) {
 				newspack_the_posts_navigation();
@@ -113,4 +142,9 @@ get_header();
 </section><!-- #primary -->
 
 <?php
+/**
+ * Fires at the end of the collections archive template.
+ */
+do_action( 'newspack_collections_archive_end' );
+
 get_footer();

--- a/includes/templates/collections/archive-newspack-collection.php
+++ b/includes/templates/collections/archive-newspack-collection.php
@@ -28,7 +28,24 @@ do_action( 'newspack_collections_archive_start' );
 
 	<main id="main" class="site-main">
 
-		<?php if ( have_posts() ) : ?>
+		<?php
+		if ( have_posts() ) :
+			// Render the intro section only if it's the first page of results and "Highlight Most Recent Collection" setting is enabled.
+			if ( ! is_paged() && Settings::get_setting( 'highlight_latest' ) ) :
+				get_template_part(
+					Template_Helper::TEMPLATE_PARTS_DIR . 'newspack-collection-intro',
+					null,
+					[
+						'is_latest' => true,
+						'permalink' => true,
+					]
+				);
+
+				// Advance the loop to the next post so it doesn't render twice.
+				the_post();
+				echo wp_kses_post( Template_Helper::render_separator( 'is-latest-collection' ) );
+			endif;
+			?>
 
 			<!-- Filter controls -->
 			<form class="collections-filter" method="get">
@@ -39,9 +56,9 @@ do_action( 'newspack_collections_archive_start' );
 				?>
 
 				<div class="collections-filter__select">
-					<label for="year"><?php esc_html_e( 'Year:', 'newspack' ); ?></label>
+					<label for="year"><?php esc_html_e( 'Year:', 'newspack-plugin' ); ?></label>
 					<select name="year" id="year">
-						<option value="" <?php selected( $selected_year, '' ); ?>><?php esc_html_e( 'All', 'newspack' ); ?></option>
+						<option value="" <?php selected( $selected_year, '' ); ?>><?php esc_html_e( 'All', 'newspack-plugin' ); ?></option>
 						<?php foreach ( $available_years as $available_year ) : ?>
 							<option value="<?php echo esc_attr( $available_year ); ?>" <?php selected( $selected_year, $available_year ); ?>><?php echo esc_html( $available_year ); ?></option>
 						<?php endforeach; ?>
@@ -54,9 +71,9 @@ do_action( 'newspack_collections_archive_start' );
 				if ( count( $categories ) > 1 ) :
 					?>
 					<div class="collections-filter__select">
-						<label for="category"><?php esc_html_e( 'Publication:', 'newspack' ); ?></label>
+						<label for="category"><?php esc_html_e( 'Publication:', 'newspack-plugin' ); ?></label>
 						<select name="category" id="category">
-							<option value="" <?php selected( $selected_category, '' ); ?>><?php esc_html_e( 'All', 'newspack' ); ?></option>
+							<option value="" <?php selected( $selected_category, '' ); ?>><?php esc_html_e( 'All', 'newspack-plugin' ); ?></option>
 							<?php foreach ( $categories as $category ) : ?>
 								<option value="<?php echo esc_attr( $category->slug ); ?>" <?php selected( $selected_category, $category->slug ); ?>><?php echo esc_html( $category->name ); ?></option>
 							<?php endforeach; ?>
@@ -68,6 +85,8 @@ do_action( 'newspack_collections_archive_start' );
 			</form> <!-- .collections-filter -->
 
 			<?php
+			echo wp_kses_post( Template_Helper::render_separator() );
+
 			/**
 			 * Fires after the filter controls in the archive template.
 			 *

--- a/includes/templates/collections/parts/newspack-collection-intro.php
+++ b/includes/templates/collections/parts/newspack-collection-intro.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Template part for the Collection intro section.
+ *
+ * @package Newspack\Collections
+ */
+
+use Newspack\Collections\Query_Helper;
+use Newspack\Collections\Template_Helper;
+
+$collection       = ( $args['collection'] ?? null ); // Allow overriding the collection post object by passing it as an argument.
+$collection       = $collection instanceof WP_Post ? $collection : get_post( $collection ); // The collection argument could be either post object or post ID.
+$is_latest        = ( $args['is_latest'] ?? false );
+$collection_title = get_the_title( $collection );
+$permalink        = match ( true ) { // Allow overriding the permalink by passing it as a string or a boolean argument.
+	is_string( $args['permalink'] ?? null )  => $args['permalink'],               // If the argument is a string, use it as the permalink.
+	( $args['permalink'] ?? false ) === true => get_the_permalink( $collection ), // If a `true` boolean, use the collection permalink.
+	default                                  => false,                            // If not provided (or if a falsey value), don't use a permalink.
+};
+
+/**
+ * Fires before the collection intro section.
+ *
+ * @param WP_Post $collection The collection post.
+ */
+do_action( 'newspack_collections_intro_before', $collection );
+?>
+
+<!-- Intro Section -->
+<div class="collection-intro">
+
+	<!-- Cover Card -->
+	<div class="collection-intro__card">
+		<?php
+		/**
+		 * Fires before the collection image card in the intro section.
+		 *
+		 * @param WP_Post $collection The collection post.
+		 */
+		do_action( 'newspack_collections_intro_image_card', $collection );
+
+		echo wp_kses_post( Template_Helper::render_image( $collection, $permalink ) );
+		?>
+	</div>
+
+	<!-- Content -->
+	<div class="collection-intro__content">
+		<?php
+		/**
+		 * Fires before the collection meta in the intro content section.
+		 *
+		 * @param WP_Post $collection The collection post.
+		 */
+		do_action( 'newspack_collections_intro_before_meta', $collection );
+		?>
+
+		<div class="collection-intro__content__meta">
+			<?php if ( $is_latest ) : ?>
+				<h6 class="wp-block-heading latest-collection-heading has-primary-color has-text-color has-link-color has-normal-font-size"><?php echo esc_html_e( 'Latest', 'newspack-plugin' ); ?></h6>
+			<?php endif; ?>
+			<h1>
+				<?php if ( $permalink ) : ?>
+					<a href="<?php echo esc_url( $permalink ); ?>">
+						<?php echo wp_kses_post( $collection_title ); ?>
+					</a>
+				<?php else : ?>
+					<?php echo wp_kses_post( $collection_title ); ?>
+				<?php endif; ?>
+			</h1>
+			<?php echo wp_kses_post( Template_Helper::render_meta_text( $collection, 1 ) ); ?>
+		</div>
+
+		<div class="collection-intro__content__description">
+			<?php
+			/**
+			 * Fires before the collection description in the intro section.
+			 *
+			 * @param WP_Post $collection The collection post.
+			 */
+			do_action( 'newspack_collections_intro_before_description', $collection );
+
+			echo wp_kses_post( get_the_content( null, false, $collection ) );
+			?>
+		</div>
+
+		<?php
+		$ctas = Query_Helper::get_ctas( $collection );
+		if ( $ctas ) :
+			?>
+			<div class="collection-buttons">
+				<?php foreach ( $ctas as $cta ) : ?>
+					<?php echo wp_kses_post( Template_Helper::render_cta( $cta ) ); ?>
+				<?php endforeach; ?>
+			</div>
+		<?php endif; ?>
+	</div>
+</div>
+
+<?php
+/**
+ * Fires after the collection intro section.
+ *
+ * @param WP_Post $collection The collection post.
+ */
+do_action( 'newspack_collections_intro_after', $collection );
+?>

--- a/includes/templates/collections/single-newspack-collection.php
+++ b/includes/templates/collections/single-newspack-collection.php
@@ -1,0 +1,170 @@
+<?php
+/**
+ * The template for displaying single Collections
+ *
+ * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
+ *
+ * @package Newspack\Collections
+ */
+
+use Newspack\Collections\Query_Helper;
+use Newspack\Collections\Template_Helper;
+
+get_header();
+?>
+
+<section id="primary" class="content-area">
+
+	<main id="main" class="site-main">
+
+		<?php
+		while ( have_posts() ) :
+			the_post();
+			$collection_id = get_the_ID();
+
+			/**
+			 * Fires at the start of the single collection template.
+			 *
+			 * @param WP_Post $post The collection post.
+			 */
+			do_action( 'newspack_collections_single_start', $post );
+			?>
+
+			<!-- Intro Section -->
+			<div class="collection-intro">
+
+				<!-- Cover Card -->
+				<div class="collection-intro__card">
+					<?php echo wp_kses_post( Template_Helper::render_image( $post, false ) ); ?>
+				</div>
+
+				<!-- Content -->
+				<div class="collection-intro__content">
+					<div class="collection-intro__content__meta">
+						<h1><?php the_title(); ?></h1>
+						<?php echo wp_kses_post( Template_Helper::render_meta_text( $collection_id, 1 ) ); ?>
+					</div>
+
+					<?php
+					/**
+					 * Fires after the collection meta in the intro section.
+					 *
+					 * @param int $collection_id The collection post ID.
+					 */
+					do_action( 'newspack_collections_single_after_meta', $collection_id );
+					?>
+
+					<div class="collection-intro__content__description">
+						<?php the_content(); ?>
+					</div>
+
+					<?php
+					$ctas = Query_Helper::get_ctas( $collection_id );
+					if ( $ctas ) :
+						?>
+						<div class="collection-buttons">
+							<?php foreach ( $ctas as $cta ) : ?>
+								<?php echo wp_kses_post( Template_Helper::render_cta( $cta ) ); ?>
+							<?php endforeach; ?>
+						</div>
+					<?php endif; ?>
+				</div>
+			</div>
+
+			<?php
+			/**
+			 * Fires after the collection intro section.
+			 *
+			 * @param int $collection_id The collection post ID.
+			 */
+			do_action( 'newspack_collections_single_after_intro', $collection_id );
+			?>
+
+			<hr class="has-light-gray-background-color has-background is-style-wide"/>
+
+			<?php
+			// Get posts in this collection organized by sections.
+			$collection_posts = Query_Helper::get_collection_posts( $collection_id );
+
+			if ( $collection_posts ) :
+				foreach ( $collection_posts as $section_slug => $post_ids ) :
+					/**
+					 * Filters the post IDs in a section before rendering.
+					 *
+					 * @param array  $post_ids      The post IDs in this section.
+					 * @param string $section_slug  The section slug.
+					 * @param int    $collection_id The collection post ID.
+					 */
+					$post_ids = apply_filters( 'newspack_collections_single_section_posts', $post_ids, $section_slug, $collection_id );
+
+					if ( empty( $post_ids ) ) {
+						continue;
+					}
+
+					$is_cover     = Query_Helper::COVER_SECTION === $section_slug;
+					$section_name = $is_cover
+						? ( count( $post_ids ) > 1 ? __( 'Cover Stories', 'newspack' ) : __( 'Cover Story', 'newspack' ) )
+						: Query_Helper::get_section_name( $section_slug );
+					$show_image   = ! $is_cover;
+					$columns      = $is_cover ? 1 : 2;
+					$type_scale   = $is_cover ? 5 : 3;
+					?>
+					<div class="collection-section <?php echo esc_attr( $is_cover ? 'is-cover-section' : '' ); ?>">
+						<?php echo wp_kses_post( Template_Helper::render_articles( $post_ids, $section_name, $show_image, $columns, $type_scale ) ); ?>
+					</div>
+					<?php
+				endforeach;
+			endif;
+
+			// Get recent collections (excluding current).
+			$recent_collections = Query_Helper::get_recent( [ $collection_id ], 6 );
+
+			if ( $recent_collections ) :
+				?>
+				<hr class="has-light-gray-background-color has-background is-style-wide"/>
+
+				<!-- Recent Collections Section -->
+				<div class="collections-recent">
+					<div class="collections-recent__header">
+						<h2><?php esc_html_e( 'Recent', 'newspack' ); ?></h2>
+						<p class="has-medium-gray-color has-text-color has-link-color has-small-font-size">
+							<?php echo wp_kses_post( Template_Helper::render_see_all_link() ); ?>
+						</p>
+					</div>
+
+					<div class="collections-recent__grid">
+						<?php foreach ( $recent_collections as $collection ) : ?>
+							<div class="collection-item">
+								<?php echo wp_kses_post( Template_Helper::render_image( $collection ) ); ?>
+
+								<div class="collection-content">
+									<h3 class="has-normal-font-size">
+										<a href="<?php echo esc_url( get_permalink( $collection->ID ) ); ?>">
+											<?php echo esc_html( get_the_title( $collection->ID ) ); ?>
+										</a>
+									</h3>
+
+									<?php echo wp_kses_post( Template_Helper::render_meta_text( $collection->ID ) ); ?>
+								</div>
+							</div>
+						<?php endforeach; ?>
+					</div>
+				</div> <!-- .collections-recent -->
+			<?php endif; ?>
+
+			<?php
+			/**
+			 * Fires at the end of the single collection template.
+			 *
+			 * @param WP_Post $post The collection post.
+			 */
+			do_action( 'newspack_collections_single_end', $post );
+		endwhile;
+		?>
+
+	</main><!-- #main -->
+
+</section><!-- #primary -->
+
+<?php
+get_footer();

--- a/includes/templates/collections/single-newspack-collection.php
+++ b/includes/templates/collections/single-newspack-collection.php
@@ -28,61 +28,18 @@ get_header();
 			 * @param WP_Post $post The collection post.
 			 */
 			do_action( 'newspack_collections_single_start', $post );
-			?>
 
-			<!-- Intro Section -->
-			<div class="collection-intro">
+			get_template_part( Template_Helper::TEMPLATE_PARTS_DIR . 'newspack-collection-intro' );
 
-				<!-- Cover Card -->
-				<div class="collection-intro__card">
-					<?php echo wp_kses_post( Template_Helper::render_image( $post, false ) ); ?>
-				</div>
-
-				<!-- Content -->
-				<div class="collection-intro__content">
-					<div class="collection-intro__content__meta">
-						<h1><?php the_title(); ?></h1>
-						<?php echo wp_kses_post( Template_Helper::render_meta_text( $collection_id, 1 ) ); ?>
-					</div>
-
-					<?php
-					/**
-					 * Fires after the collection meta in the intro section.
-					 *
-					 * @param int $collection_id The collection post ID.
-					 */
-					do_action( 'newspack_collections_single_after_meta', $collection_id );
-					?>
-
-					<div class="collection-intro__content__description">
-						<?php the_content(); ?>
-					</div>
-
-					<?php
-					$ctas = Query_Helper::get_ctas( $collection_id );
-					if ( $ctas ) :
-						?>
-						<div class="collection-buttons">
-							<?php foreach ( $ctas as $cta ) : ?>
-								<?php echo wp_kses_post( Template_Helper::render_cta( $cta ) ); ?>
-							<?php endforeach; ?>
-						</div>
-					<?php endif; ?>
-				</div>
-			</div>
-
-			<?php
 			/**
 			 * Fires after the collection intro section.
 			 *
 			 * @param int $collection_id The collection post ID.
 			 */
 			do_action( 'newspack_collections_single_after_intro', $collection_id );
-			?>
 
-			<hr class="has-light-gray-background-color has-background is-style-wide"/>
+			echo wp_kses_post( Template_Helper::render_separator( 'is-latest-collection' ) );
 
-			<?php
 			// Get posts in this collection organized by sections.
 			$collection_posts = Query_Helper::get_collection_posts( $collection_id );
 
@@ -103,7 +60,7 @@ get_header();
 
 					$is_cover     = Query_Helper::COVER_SECTION === $section_slug;
 					$section_name = $is_cover
-						? ( count( $post_ids ) > 1 ? __( 'Cover Stories', 'newspack' ) : __( 'Cover Story', 'newspack' ) )
+						? ( count( $post_ids ) > 1 ? __( 'Cover Stories', 'newspack-plugin' ) : __( 'Cover Story', 'newspack-plugin' ) )
 						: Query_Helper::get_section_name( $section_slug );
 					$show_image   = ! $is_cover;
 					$columns      = $is_cover ? 1 : 2;
@@ -120,13 +77,13 @@ get_header();
 			$recent_collections = Query_Helper::get_recent( [ $collection_id ], 6 );
 
 			if ( $recent_collections ) :
+				echo wp_kses_post( Template_Helper::render_separator( 'is-latest-collection' ) );
 				?>
-				<hr class="has-light-gray-background-color has-background is-style-wide"/>
 
 				<!-- Recent Collections Section -->
 				<div class="collections-recent">
 					<div class="collections-recent__header">
-						<h2><?php esc_html_e( 'Recent', 'newspack' ); ?></h2>
+						<h2><?php esc_html_e( 'Recent', 'newspack-plugin' ); ?></h2>
 						<p class="has-medium-gray-color has-text-color has-link-color has-small-font-size">
 							<?php echo wp_kses_post( Template_Helper::render_see_all_link() ); ?>
 						</p>

--- a/src/collections/frontend/_archive.scss
+++ b/src/collections/frontend/_archive.scss
@@ -1,9 +1,14 @@
 @use "breakpoints" as bp;
+@use "intro";
 
 /* Collections archive template styles */
 .post-type-archive-newspack_collection {
 	main#main {
 		width: 100%;
+	}
+
+	hr {
+		margin: 16px 0;
 	}
 
 	.collections-filter {

--- a/src/collections/frontend/_archive.scss
+++ b/src/collections/frontend/_archive.scss
@@ -1,0 +1,81 @@
+@use "breakpoints" as bp;
+
+/* Collections archive template styles */
+.post-type-archive-newspack_collection {
+	main#main {
+		width: 100%;
+	}
+
+	.collections-filter {
+		font-size: var(--newspack-theme-font-size-base-sm);
+		gap: 16px;
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: right;
+		margin-bottom: 16px;
+
+		&__select {
+			align-items: center;
+			display: inline-flex;
+			flex: 1 1 100%;
+			flex-wrap: wrap;
+			gap: 0.5em;
+
+			select {
+				width: 100%;
+			}
+
+			@media #{bp.$media-sm-up} {
+				flex: 1;
+			}
+
+			@media #{bp.$media-md-up} {
+				flex: 0 0 auto;
+
+				select {
+					width: 128px;
+				}
+			}
+		}
+	}
+
+	.collections-grid {
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		gap: 32px;
+		margin-top: 32px;
+
+		&--introduction__card {
+			grid-column: span 1;
+		}
+
+		&__content {
+			grid-column: span 5;
+		}
+
+		&__meta {
+			margin-bottom: 24px;
+
+			h2 {
+				margin: 0 0 8px 0;
+			}
+
+			p {
+				margin: 0;
+			}
+		}
+
+		@media #{bp.$media-sm-up} {
+			grid-template-columns: repeat(3, minmax(0, 1fr));
+			gap: 16px;
+		}
+
+		@media #{bp.$media-md-up} {
+			gap: 32px;
+		}
+
+		@media #{bp.$media-lg-up} {
+			grid-template-columns: repeat(6, minmax(0, 1fr));
+		}
+	}
+}

--- a/src/collections/frontend/_breakpoints.scss
+++ b/src/collections/frontend/_breakpoints.scss
@@ -1,0 +1,19 @@
+// *********************************
+// Newspack Collections breakpoints
+// *********************************
+
+// Base breakpoint values for newspack-collections.
+$breakpoint-xs: 0;
+$breakpoint-sm: 600px;
+$breakpoint-md: 782px;
+$breakpoint-lg: 960px;
+
+// Media query strings.
+$media-sm-up: "screen and (min-width: #{$breakpoint-sm})";
+$media-md-up: "screen and (min-width: #{$breakpoint-md})";
+$media-lg-up: "screen and (min-width: #{$breakpoint-lg})";
+
+$media-xs-only: "screen and (max-width: #{$breakpoint-sm - 1px})";
+$media-sm-only: "screen and (min-width: #{$breakpoint-sm}) and (max-width: #{$breakpoint-md - 1px})";
+$media-md-only: "screen and (min-width: #{$breakpoint-md}) and (max-width: #{$breakpoint-lg - 1px})";
+$media-lg-only: "screen and (min-width: #{$breakpoint-lg})";

--- a/src/collections/frontend/_common.scss
+++ b/src/collections/frontend/_common.scss
@@ -1,0 +1,57 @@
+@use "breakpoints";
+
+/* Common collection elements */
+.collection-buttons {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+}
+
+.collection-image {
+	a {
+		display: block;
+		width: 100%;
+	}
+
+	img {
+		width: 100%;
+		height: auto;
+		display: block;
+		aspect-ratio: 3 / 4;
+		object-fit: cover;
+	}
+}
+
+.collection-placeholder {
+	aspect-ratio: 3 / 4;
+}
+
+.collection-item {
+	display: flex;
+	flex-direction: column;
+
+	.collection-content {
+		h3 {
+			margin: 24px 0 0;
+
+			a {
+				color: var(--newspack-theme-color-text-main);
+			}
+		}
+	}
+}
+
+.collection-cta {
+	width: 100%;
+
+	&.cta--subscribe_link {
+		a {
+			background-color: var(--newspack-primary-color);
+			color: var(--newspack-primary-contrast-color);
+		}
+	}
+
+	@media #{breakpoints.$media-sm-up} {
+		width: auto;
+	}
+}

--- a/src/collections/frontend/_intro.scss
+++ b/src/collections/frontend/_intro.scss
@@ -1,0 +1,66 @@
+@use "breakpoints" as bp;
+
+/* Collection intro styles */
+.collection-intro {
+	display: grid;
+	grid-template-columns: 1fr;
+	padding-bottom: 16px;
+	gap: 16px;
+
+	h1 {
+		margin: 0;
+		font-size: var(--newspack-theme-font-size-lg);
+
+		@media #{bp.$media-md-up} {
+			font-size: var(--newspack-theme-font-size-xl);
+		}
+	}
+
+	&__card {
+		grid-column: span 1;
+	}
+
+	&__content {
+		grid-column: auto;
+
+		&__meta {
+			display: flex;
+			flex-direction: column;
+			gap: 0.5em;
+
+			.latest-collection-heading {
+				margin: 0;
+				text-transform: uppercase;
+			}
+
+			a {
+				color: var(--newspack-theme-color-text-main);
+			}
+
+			p {
+				margin: 0;
+			}
+		}
+
+		&__description {
+			margin: 32px 0;
+		}
+	}
+
+	@media #{bp.$media-sm-up} {
+		grid-template-columns: repeat(3, minmax(0, 1fr));
+
+		&__content {
+			grid-column: span 2;
+		}
+	}
+
+	@media #{bp.$media-lg-up} {
+		grid-template-columns: repeat(6, minmax(0, 1fr));
+		gap: 32px;
+
+		&__content {
+			grid-column: span 5;
+		}
+	}
+}

--- a/src/collections/frontend/_post-indicator.scss
+++ b/src/collections/frontend/_post-indicator.scss
@@ -1,0 +1,38 @@
+@use "breakpoints" as bp;
+
+/* Collection post indicators styles */
+.entry-content {
+	> p.collection-link {
+		color: var(--newspack-theme-color-text-light, var(--wp--preset--color--contrast-3));
+		margin-bottom: -24px;
+
+		a {
+			color: inherit;
+		}
+	}
+}
+
+.collection-card {
+	&__columns,
+	&__content-column .wp-block-group {
+		gap: calc(var(--wp--preset--spacing--20) + 0.5em) !important;
+	}
+
+	&__columns {
+		padding: var(--wp--preset--spacing--20) 0;
+	}
+
+	.collection-image {
+		width: 72px;
+	}
+
+	@media #{bp.$media-md-up} {
+		&__content-column {
+			flex-basis: 75% !important;
+		}
+
+		&__buttons-column {
+			flex-basis: 25% !important;
+		}
+	}
+}

--- a/src/collections/frontend/_single.scss
+++ b/src/collections/frontend/_single.scss
@@ -1,65 +1,11 @@
 @use "breakpoints" as bp;
+@use "intro";
 
 /* Single collection template styles */
 .single-newspack_collection {
-	h1 {
-		margin: 0;
-		font-size: var(--newspack-theme-font-size-lg);
-
-		@media #{bp.$media-md-up} {
-			font-size: var(--newspack-theme-font-size-xl);
-		}
-	}
-
 	hr {
 		flex: 0 0 100%;
 		margin: 32px 0 62px;
-	}
-
-	.collection-intro {
-		display: grid;
-		grid-template-columns: 1fr;
-		padding-bottom: 16px;
-		gap: 16px;
-
-		&__card {
-			grid-column: span 1;
-		}
-
-		&__content {
-			grid-column: auto;
-
-			&__meta {
-				display: flex;
-				flex-direction: column;
-				gap: 0.5em;
-
-				p {
-					margin: 0;
-				}
-			}
-
-			&__description {
-				margin: 32px 0;
-			}
-		}
-
-		@media #{bp.$media-sm-up} {
-			grid-template-columns: repeat(3, minmax(0, 1fr));
-
-			&__content {
-				grid-column: span 2;
-			}
-		}
-
-		@media #{bp.$media-lg-up} {
-			grid-template-columns: repeat(6, minmax(0, 1fr));
-			gap: 32px;
-
-			&__content {
-				grid-column: span 5;
-			}
-		}
 	}
 
 	.collection-section {

--- a/src/collections/frontend/_single.scss
+++ b/src/collections/frontend/_single.scss
@@ -1,0 +1,156 @@
+@use "breakpoints" as bp;
+
+/* Single collection template styles */
+.single-newspack_collection {
+	h1 {
+		margin: 0;
+		font-size: var(--newspack-theme-font-size-lg);
+
+		@media #{bp.$media-md-up} {
+			font-size: var(--newspack-theme-font-size-xl);
+		}
+	}
+
+	hr {
+		flex: 0 0 100%;
+		margin: 32px 0 62px;
+	}
+
+	.collection-intro {
+		display: grid;
+		grid-template-columns: 1fr;
+		padding-bottom: 16px;
+		gap: 16px;
+
+		&__card {
+			grid-column: span 1;
+		}
+
+		&__content {
+			grid-column: auto;
+
+			&__meta {
+				display: flex;
+				flex-direction: column;
+				gap: 0.5em;
+
+				p {
+					margin: 0;
+				}
+			}
+
+			&__description {
+				margin: 32px 0;
+			}
+		}
+
+		@media #{bp.$media-sm-up} {
+			grid-template-columns: repeat(3, minmax(0, 1fr));
+
+			&__content {
+				grid-column: span 2;
+			}
+		}
+
+		@media #{bp.$media-lg-up} {
+			grid-template-columns: repeat(6, minmax(0, 1fr));
+			gap: 32px;
+
+			&__content {
+				grid-column: span 5;
+			}
+		}
+	}
+
+	.collection-section {
+		margin: 0 0 32px;
+
+		.entry-title {
+			font-size: var(--newspack-theme-font-size-base);
+		}
+
+		&.is-cover-section {
+			.entry-title {
+				font-size: var(--newspack-theme-font-size-lg);
+			}
+		}
+
+		&:not(.is-cover-section) {
+			p {
+				font-size: var(--newspack-theme-font-size-sm);
+			}
+		}
+
+		.wp-block-newspack-blocks-homepage-articles {
+			margin: 0;
+
+			article {
+				display: block;
+
+				@media #{bp.$media-lg-up} {
+					display: flex;
+				}
+			}
+		}
+
+		.article-section-title {
+			border: none;
+			margin: 0 0 calc(0.5em - var(--wpnbha-col-gap));
+			padding: 0;
+
+			span {
+				font-size: var(--newspack-theme-font-size-base);
+			}
+		}
+	}
+
+	.collections-recent {
+		&__header {
+			display: flex;
+			justify-content: space-between;
+			align-items: flex-end;
+			width: 100%;
+			flex-wrap: wrap;
+			margin-bottom: 16px;
+
+			h2,
+			p {
+				margin: 0;
+			}
+
+			a {
+				text-decoration: underline;
+			}
+		}
+
+		&__grid {
+			display: grid;
+			gap: 16px;
+			grid-template-columns: repeat(2, minmax(0, 1fr));
+
+			// 4 items on small screens.
+			> *:nth-child(n+5) {
+				display: none;
+			}
+
+			// 3 items on medium screens.
+			@media #{bp.$media-sm-up} {
+				grid-template-columns: repeat(3, minmax(0, 1fr));
+
+				> *:nth-child(n+4) {
+					display: none;
+				}
+			}
+
+			// 6 items on large screens.
+			@media #{bp.$media-lg-up} {
+				grid-template-columns: repeat(6, minmax(0, 1fr));
+				gap: 32px;
+
+				> *:nth-child(n+4) {
+					display: block;
+				}
+			}
+		}
+	}
+}

--- a/src/collections/frontend/collection-archive-filters.js
+++ b/src/collections/frontend/collection-archive-filters.js
@@ -1,0 +1,52 @@
+/**
+ * Newspack Collections JavaScript functionality.
+ */
+
+import { domReady } from '../../utils';
+
+class CollectionArchiveFilters {
+	/**
+	 * Class constructor.
+	 */
+	constructor() {
+		const form = document.querySelector( '.collections-filter' );
+
+		if ( form ) {
+			form.addEventListener( 'change', event => this.handleFiltersChange( event ) );
+		}
+	}
+
+	/**
+	 * Handle filtering interactions on the collections archive page.
+	 *
+	 * @param {Event} event The event object.
+	 */
+	handleFiltersChange( event ) {
+		event.preventDefault();
+
+		const url = new URL( window.location.href );
+
+		// Remove pagination from the URL.
+		url.pathname = url.pathname.replace( /\/page\/\d+\/?$/, '/' );
+
+		// Build new query parameters.
+		const params = new URLSearchParams();
+		const yearField = document.getElementById( 'year' );
+		const categoryField = document.getElementById( 'category' );
+
+		if ( yearField?.value ) {
+			params.set( 'year', yearField.value );
+		}
+
+		if ( categoryField?.value ) {
+			params.set( 'category', categoryField.value );
+		}
+
+		url.search = params.toString();
+		window.location.href = url.toString();
+	}
+}
+
+domReady( () => {
+	new CollectionArchiveFilters();
+} );

--- a/src/collections/frontend/index.js
+++ b/src/collections/frontend/index.js
@@ -1,0 +1,6 @@
+/**
+ * Collections frontend functionality.
+ */
+
+import './collection-archive-filters';
+import './style.scss';

--- a/src/collections/frontend/style.scss
+++ b/src/collections/frontend/style.scss
@@ -6,3 +6,4 @@
 @use "common";
 @use "archive";
 @use "single";
+@use "post-indicator";

--- a/src/collections/frontend/style.scss
+++ b/src/collections/frontend/style.scss
@@ -1,0 +1,8 @@
+/* ****************************
+ * Collections frontend styles
+ * ****************************
+ */
+
+@use "common";
+@use "archive";
+@use "single";

--- a/src/components/src/select-control/ButtonGroupControl.js
+++ b/src/components/src/select-control/ButtonGroupControl.js
@@ -14,11 +14,12 @@ import { BaseControl, Button, ButtonGroup } from '@wordpress/components';
  */
 import { hooks } from '..';
 
-const ButtonGroupControl = ( { buttonOptions, buttonSmall, className, hideLabelFromVision, label, onChange, value } ) => {
+const ButtonGroupControl = ( { buttonOptions, buttonSmall, className, help, hideLabelFromVision, label, onChange, value } ) => {
 	const id = hooks.useUniqueId( 'button-group' );
 	return (
 		<BaseControl
 			label={ label }
+			help={ help }
 			hideLabelFromVision={ hideLabelFromVision }
 			id={ id.current }
 			className={ classnames( className, 'components-select-control' ) }

--- a/src/wizards/newspack/views/settings/collections/index.tsx
+++ b/src/wizards/newspack/views/settings/collections/index.tsx
@@ -2,21 +2,19 @@
  * Settings Collections: Global settings for Collections module.
  */
 
-/**
- * WordPress dependencies
- */
 import { __ } from '@wordpress/i18n';
 import { useState, useEffect } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
+import { ToggleControl } from '@wordpress/components';
+import WizardSection from '../../../../wizards-section';
 import WizardsActionCard from '../../../../wizards-action-card';
 import useWizardApiFetchToggle from '../../../../hooks/use-wizard-api-fetch-toggle';
-import { TextControl, Button, Grid } from '../../../../../components/src';
+import { TextControl, SelectControl, Button, Grid } from '../../../../../components/src';
 import CustomNamingCard from './custom-naming-card';
 
-// Default values for collections settings
+// Collections per page options.
+const COLLECTIONS_PER_PAGE_OPTIONS = [ 12, 18, 24 ];
+
+// Default values for collections settings.
 const DEFAULT_COLLECTIONS_SETTINGS: CollectionsSettingsData = {
 	custom_naming_enabled: false,
 	custom_name: '',
@@ -24,6 +22,10 @@ const DEFAULT_COLLECTIONS_SETTINGS: CollectionsSettingsData = {
 	custom_slug: '',
 	subscribe_link: '',
 	order_link: '',
+	post_indicator_style: 'default',
+	card_message: __( "Keep reading. There's plenty more to discover.", 'newspack-plugin' ),
+	posts_per_page: 12,
+	highlight_latest: false,
 };
 
 // Helper function to extract collection settings from API data with defaults.
@@ -92,28 +94,96 @@ function Collections() {
 				<>
 					<CustomNamingCard settings={ settings } isSaving={ isSavingSettings } onChange={ updateSetting } />
 
-					<Grid columns={ 2 } gutter={ 32 }>
-						<TextControl
-							label={ __( 'Subscription URL', 'newspack-plugin' ) }
-							help={ __(
-								'URL for the "Subscribe" button that will be displayed in the Collections archive pages when no subscription URL is set for the Collection or its parent category.',
-								'newspack-plugin'
+					<WizardSection
+						title={ __( 'Global CTAs', 'newspack-plugin' ) }
+						description={ __(
+							'Renderd in Collections-related pages. Can be overridden on a per-category or per-collection basis.',
+							'newspack-plugin'
+						) }
+					>
+						<Grid columns={ 2 } gutter={ 32 }>
+							<TextControl
+								label={ __( 'Subscription URL', 'newspack-plugin' ) }
+								help={ __(
+									'URL for the "Subscribe" button that will be displayed in the Collections archive page when no subscription URL is set for the Collection or its parent category.',
+									'newspack-plugin'
+								) }
+								value={ settings.subscribe_link }
+								onChange={ ( value: string ) => updateSetting( 'subscribe_link', value ) }
+								placeholder={ `e.g., https://${ window.location.hostname }/subscribe` }
+							/>
+							<TextControl
+								label={ __( 'Order URL', 'newspack-plugin' ) }
+								help={ __(
+									'URL for the "Order" button that will be displayed in the Collections archive page when no order URL is set for the Collection or its parent category.',
+									'newspack-plugin'
+								) }
+								value={ settings.order_link }
+								onChange={ ( value: string ) => updateSetting( 'order_link', value ) }
+								placeholder={ `e.g., https://${ window.location.hostname }/order` }
+							/>
+						</Grid>
+					</WizardSection>
+
+					<WizardSection
+						title={ __( 'Collections Archive', 'newspack-plugin' ) }
+						description={ __( 'Customize the Collections archive page.', 'newspack-plugin' ) }
+					>
+						<Grid columns={ 2 } gutter={ 32 }>
+							<SelectControl
+								label={ __( 'Collections per page', 'newspack-plugin' ) }
+								help={ __( 'Number of collections to display per page in the Collections archive page.', 'newspack-plugin' ) }
+								value={ settings.posts_per_page }
+								onChange={ ( value: number ) => updateSetting( 'posts_per_page', value ) }
+								buttonOptions={ COLLECTIONS_PER_PAGE_OPTIONS.map( option => ( {
+									label: option.toString(),
+									value: option,
+								} ) ) }
+							/>
+							<ToggleControl
+								label={ __( 'Highlight Most Recent Collection', 'newspack-plugin' ) }
+								help={ __(
+									'Feature the latest Collection prominently at the top of the archive page, showcasing its content and any associated CTAs.',
+									'newspack-plugin'
+								) }
+								checked={ settings.highlight_latest }
+								onChange={ ( value: boolean ) => updateSetting( 'highlight_latest', value ) }
+							/>
+						</Grid>
+					</WizardSection>
+
+					<WizardSection
+						title={ __( 'Collection Posts', 'newspack-plugin' ) }
+						description={ __( 'Customize post single pages when they belong to a collection.', 'newspack-plugin' ) }
+					>
+						<Grid columns={ 2 } gutter={ 32 }>
+							<SelectControl
+								label={ __( 'Collection Indicator Style', 'newspack-plugin' ) }
+								help={ __(
+									'How collection indicators should be displayed on posts. When choosing the default style, an indicator with a link will be displayed at the bottom of the post content.',
+									'newspack-plugin'
+								) }
+								value={ settings.post_indicator_style }
+								onChange={ ( value: string ) => updateSetting( 'post_indicator_style', value ) }
+								buttonOptions={ [
+									{ label: __( 'Default', 'newspack-plugin' ), value: 'default' },
+									{ label: __( 'Card', 'newspack-plugin' ), value: 'card' },
+								] }
+							/>
+							{ settings.post_indicator_style === 'card' && (
+								<TextControl
+									label={ __( 'Card Message', 'newspack-plugin' ) }
+									help={ __(
+										'Custom message displayed in the card style indicator, along with the featured image and a button to view the collection.',
+										'newspack-plugin'
+									) }
+									value={ settings.card_message }
+									onChange={ ( value: string ) => updateSetting( 'card_message', value ) }
+									placeholder={ DEFAULT_COLLECTIONS_SETTINGS.card_message }
+								/>
 							) }
-							value={ settings.subscribe_link }
-							onChange={ ( value: string ) => updateSetting( 'subscribe_link', value ) }
-							placeholder={ `e.g., https://${ window.location.hostname }/subscribe` }
-						/>
-						<TextControl
-							label={ __( 'Order URL', 'newspack-plugin' ) }
-							help={ __(
-								'URL for the "Order" button that will be displayed in the Collections archive pages when no order URL is set for the Collection or its parent category.',
-								'newspack-plugin'
-							) }
-							value={ settings.order_link }
-							onChange={ ( value: string ) => updateSetting( 'order_link', value ) }
-							placeholder={ `e.g., https://${ window.location.hostname }/order` }
-						/>
-					</Grid>
+						</Grid>
+					</WizardSection>
 
 					<div className="newspack-buttons-card">
 						<Button variant="primary" onClick={ handleSaveSettings } disabled={ isSavingSettings }>

--- a/src/wizards/newspack/views/settings/collections/types.d.ts
+++ b/src/wizards/newspack/views/settings/collections/types.d.ts
@@ -7,6 +7,10 @@ type CollectionsSettingsData = {
 	custom_slug: string;
 	subscribe_link: string;
 	order_link: string;
+	post_indicator_style: string;
+	card_message: string;
+	posts_per_page: number;
+	highlight_latest: boolean;
 };
 
 type FieldChangeHandler< T > = < K extends keyof T >( key: K, value: T[ K ] ) => void;

--- a/tests/unit-tests/collections/class-test-cache.php
+++ b/tests/unit-tests/collections/class-test-cache.php
@@ -1,0 +1,188 @@
+<?php
+/**
+ * Tests for the Cache class.
+ *
+ * @package Newspack\Tests\Unit\Collections
+ */
+
+namespace Newspack\Tests\Unit\Collections;
+
+use Newspack\Collections\Post_Type;
+use Newspack\Collections\Post_Meta;
+use Newspack\Collections\Collection_Meta;
+use Newspack\Collections\Collection_Taxonomy;
+use Newspack\Collections\Cache;
+use Newspack\Collections\Sync;
+
+/**
+ * Tests for the Cache class.
+ */
+class Test_Cache extends \WP_UnitTestCase {
+	use Traits\Trait_Collections_Test;
+
+	/**
+	 * Set up the test environment.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		Post_Type::init();
+		Collection_Meta::register_meta();
+		Post_Meta::register_meta();
+		Collection_Taxonomy::register_taxonomy();
+
+		// Flush cache before each test.
+		wp_cache_flush();
+	}
+
+	/**
+	 * Test get_posts_cache_key generates correct key.
+	 *
+	 * @covers \Newspack\Collections\Cache::get_posts_cache_key
+	 */
+	public function test_get_posts_cache_key() {
+		$collection_id = 123;
+		$cache_key     = Cache::get_posts_cache_key( $collection_id );
+
+		$this->assertIsString( $cache_key, 'Cache key should be a string.' );
+		$this->assertStringStartsWith( Cache::POSTS_CACHE_KEY . $collection_id . ':', $cache_key, 'Cache key should match the expected format.' );
+	}
+
+	/**
+	 * Test cache clearing for years.
+	 *
+	 * @covers \Newspack\Collections\Cache::clear_cache
+	 */
+	public function test_clear_cache_years() {
+		wp_cache_set( Cache::YEARS_CACHE_KEY, [ 'test' => 'data' ], Cache::CACHE_GROUP );
+
+		// Clear years cache.
+		Cache::clear_cache( 'years' );
+
+		$this->assertFalse( wp_cache_get( Cache::YEARS_CACHE_KEY, Cache::CACHE_GROUP ), 'Cache should be cleared.' );
+	}
+
+	/**
+	 * Test cache clearing for specific collection posts.
+	 *
+	 * @covers \Newspack\Collections\Cache::clear_cache
+	 */
+	public function test_clear_cache_posts() {
+		$collection_id = 123;
+		$cache_key     = Cache::get_posts_cache_key( $collection_id );
+
+		// Set some cache data.
+		wp_cache_set( $cache_key, [ 'test' => 'data' ], Cache::CACHE_GROUP );
+
+		// Clear specific collection cache.
+		Cache::clear_cache( 'posts', $collection_id );
+
+		$this->assertFalse( wp_cache_get( $cache_key, Cache::CACHE_GROUP ), "Cache for collection $collection_id should be cleared." );
+	}
+
+	/**
+	 * Test cache clearing for all posts.
+	 *
+	 * @covers \Newspack\Collections\Cache::clear_cache
+	 */
+	public function test_clear_cache_all_posts() {
+		$collection_id_1 = 123;
+		$collection_id_2 = 456;
+		$cache_key_1     = Cache::get_posts_cache_key( $collection_id_1 );
+		$cache_key_2     = Cache::get_posts_cache_key( $collection_id_2 );
+
+		// Set some cache data.
+		wp_cache_set( $cache_key_1, [ 'test' => 'data' ], Cache::CACHE_GROUP );
+		wp_cache_set( $cache_key_2, [ 'test' => 'data' ], Cache::CACHE_GROUP );
+
+		// Get initial last_changed.
+		$initial_last_changed = wp_cache_get_last_changed( Cache::CACHE_GROUP );
+
+		// Clear all posts cache.
+		Cache::clear_cache( 'posts' );
+
+		// Verify last_changed was bumped.
+		$new_last_changed = wp_cache_get_last_changed( Cache::CACHE_GROUP );
+		$this->assertNotEquals( $initial_last_changed, $new_last_changed, 'Last changed timestamp should be bumped.' );
+
+		// Verify cache keys are different and that new cache keys don't exist.
+		$new_cache_key_1 = Cache::get_posts_cache_key( $collection_id_1 );
+		$new_cache_key_2 = Cache::get_posts_cache_key( $collection_id_2 );
+		$this->assertNotEquals( $cache_key_1, $new_cache_key_1, "Cache key for collection $collection_id_1 should be different." );
+		$this->assertNotEquals( $cache_key_2, $new_cache_key_2, "Cache key for collection $collection_id_2 should be different." );
+		$this->assertFalse( wp_cache_get( $new_cache_key_1, Cache::CACHE_GROUP ), "Cache for collection $new_cache_key_1 should not exist." );
+		$this->assertFalse( wp_cache_get( $new_cache_key_2, Cache::CACHE_GROUP ), "Cache for collection $new_cache_key_2 should not exist." );
+	}
+
+	/**
+	 * Test clear_cache_on_post_change with collection post.
+	 *
+	 * @covers \Newspack\Collections\Cache::clear_cache_on_post_change
+	 */
+	public function test_clear_cache_on_post_change_with_collection() {
+		$collection_id = $this->create_test_collection();
+
+		// Set some cache data.
+		wp_cache_set( Cache::YEARS_CACHE_KEY, [ 'test' => 'data' ], Cache::CACHE_GROUP );
+		$cache_key = Cache::get_posts_cache_key( $collection_id );
+		wp_cache_set( $cache_key, [ 'test' => 'data' ], Cache::CACHE_GROUP );
+
+		// Clear cache for collection post.
+		Cache::clear_cache_on_post_change( $collection_id );
+
+		// Verify years cache is cleared.
+		$this->assertFalse( wp_cache_get( Cache::YEARS_CACHE_KEY, Cache::CACHE_GROUP ), 'Years cache should be cleared.' );
+
+		// Verify posts cache key changed.
+		$new_cache_key = Cache::get_posts_cache_key( $collection_id );
+		$this->assertEquals( $cache_key, $new_cache_key, "Cache key for collection $collection_id should be the same." );
+		$this->assertFalse( wp_cache_get( $new_cache_key, Cache::CACHE_GROUP ), "Cache for collection $collection_id should be cleared." );
+	}
+
+	/**
+	 * Test clear_cache_on_post_change ignores non-collection posts.
+	 *
+	 * @covers \Newspack\Collections\Cache::clear_cache_on_post_change
+	 */
+	public function test_clear_cache_on_post_change_ignores_unrelated_posts() {
+		$regular_post_id = self::factory()->post->create();
+
+		$data = [ 'test' => 'data' ];
+		wp_cache_set( Cache::YEARS_CACHE_KEY, $data, Cache::CACHE_GROUP );
+
+		// Try to clear cache for regular post that's not in any collection.
+		Cache::clear_cache_on_post_change( $regular_post_id );
+
+		$this->assertEquals( $data, wp_cache_get( Cache::YEARS_CACHE_KEY, Cache::CACHE_GROUP ), 'Years cache should not be cleared for regular posts.' );
+	}
+
+	/**
+	 * Test clear_cache_on_meta_change clears cache for relevant meta keys.
+	 *
+	 * @covers \Newspack\Collections\Cache::clear_cache_on_meta_change
+	 */
+	public function test_clear_cache_on_meta_change() {
+		$collection_id = $this->create_test_collection();
+		$data          = [ 'test' => 'data' ];
+
+		// Set cache data.
+		wp_cache_set( Cache::YEARS_CACHE_KEY, $data, Cache::CACHE_GROUP );
+
+		// Test with relevant meta key - should clear cache.
+		Cache::clear_cache_on_meta_change( 1, $collection_id, Collection_Meta::$prefix . 'test' );
+		$this->assertFalse( wp_cache_get( Cache::YEARS_CACHE_KEY, Cache::CACHE_GROUP ), 'Years cache should be cleared for relevant meta.' );
+
+		// Reset cache and test with irrelevant meta key - should not clear cache.
+		wp_cache_set( Cache::YEARS_CACHE_KEY, $data, Cache::CACHE_GROUP );
+		Cache::clear_cache_on_meta_change( 2, $collection_id, 'irrelevant_meta_without_prefix' );
+		$this->assertEquals( $data, wp_cache_get( Cache::YEARS_CACHE_KEY, Cache::CACHE_GROUP ), 'Cache should not be cleared for irrelevant meta.' );
+
+		// Test with regular post in collection.
+		$post_id = self::factory()->post->create();
+		wp_set_object_terms( $post_id, Sync::get_term_linked_to_collection( $collection_id ), Collection_Taxonomy::get_taxonomy() );
+		wp_cache_set( Cache::get_posts_cache_key( $collection_id ), $data, Cache::CACHE_GROUP );
+		Cache::clear_cache_on_meta_change( 3, $post_id, Post_Meta::$prefix . 'is_cover_story' );
+		$this->assertEquals( $data, wp_cache_get( Cache::YEARS_CACHE_KEY, Cache::CACHE_GROUP ), 'Years cache should not be cleared.' );
+		$this->assertFalse( wp_cache_get( Cache::get_posts_cache_key( $collection_id ), Cache::CACHE_GROUP ), 'Post cache should be cleared.' );
+	}
+}

--- a/tests/unit-tests/collections/class-test-content-inserter.php
+++ b/tests/unit-tests/collections/class-test-content-inserter.php
@@ -1,0 +1,321 @@
+<?php
+/**
+ * Tests for the Content_Inserter class.
+ *
+ * @package Newspack\Tests\Unit\Collections
+ */
+
+namespace Newspack\Tests\Unit\Collections;
+
+use Newspack\Collections\Content_Inserter;
+use Newspack\Collections\Post_Type;
+use Newspack\Collections\Collection_Taxonomy;
+use Newspack\Collections\Sync;
+use Newspack\Collections\Enqueuer;
+
+/**
+ * Tests for the Content_Inserter class.
+ */
+class Test_Content_Inserter extends \WP_UnitTestCase {
+	use Traits\Trait_Collections_Test;
+	use Traits\Trait_Enqueuer_Test;
+
+	/**
+	 * Set up the test environment.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		Post_Type::init();
+		Collection_Taxonomy::register_taxonomy();
+	}
+
+	/**
+	 * Tear down the test environment.
+	 */
+	public function tear_down() {
+		parent::tear_down();
+
+		$this->reset_content_inserter_state();
+		remove_all_filters( 'the_content' );
+	}
+
+	/**
+	 * Reset Content_Inserter static state using reflection.
+	 */
+	private function reset_content_inserter_state() {
+		$reflection = new \ReflectionClass( Content_Inserter::class );
+		$reflection->setStaticPropertyValue( 'the_content_has_rendered', false );
+		$reflection->setStaticPropertyValue( 'post_collections', [] );
+	}
+
+	/**
+	 * Test check_if_post_is_in_collection behavior.
+	 *
+	 * @covers \Newspack\Collections\Content_Inserter::check_if_post_is_in_collection
+	 */
+	public function test_check_if_post_is_in_collection() {
+		$filter_name     = 'the_content';
+		$filter_function = [ Content_Inserter::class, 'maybe_insert_collection_indicators' ];
+
+		// Non-singular page should not add filter.
+		$this->go_to( home_url() );
+		Content_Inserter::check_if_post_is_in_collection();
+		$this->assertFalse( has_filter( $filter_name, $filter_function ), 'Filter should not be added on non-singular pages.' );
+
+		// Reset state.
+		$this->reset_content_inserter_state();
+
+		// Singular post with no collections should not add filter.
+		$post_id = self::factory()->post->create();
+		$this->go_to( get_permalink( $post_id ) );
+		Content_Inserter::check_if_post_is_in_collection();
+		$this->assertFalse( has_filter( $filter_name, $filter_function ), 'Filter should not be added when post is not in collections.' );
+
+		// Reset state.
+		$this->reset_content_inserter_state();
+
+		// Singular post with collections should add filter and enqueuer data.
+		$collection_id = $this->create_test_collection();
+
+		// Get the linked term and assign post to collection.
+		$term_id = Sync::get_term_linked_to_collection( $collection_id );
+		wp_set_object_terms( $post_id, $term_id, Collection_Taxonomy::get_taxonomy() );
+
+		$this->go_to( get_permalink( $post_id ) );
+		Content_Inserter::check_if_post_is_in_collection();
+
+		// Should add filter since post is in a collection.
+		$this->assertNotFalse( has_filter( $filter_name, $filter_function ), 'Filter should be added when post is in collections.' );
+
+		// Should add enqueuer data.
+		$enqueuer_data = Enqueuer::get_data();
+		$this->assertArrayHasKey( 'post_is_in_collections', $enqueuer_data, 'Enqueuer data should indicate post is in collections.' );
+		$this->assertTrue( $enqueuer_data['post_is_in_collections'], 'Post should be marked as being in collections.' );
+
+		// Clean up.
+		$this->reset_enqueuer_data();
+	}
+
+	/**
+	 * Test maybe_insert_collection_indicators early returns.
+	 *
+	 * @covers \Newspack\Collections\Content_Inserter::maybe_insert_collection_indicators
+	 */
+	public function test_maybe_insert_collection_indicators_early_returns() {
+		$content = '<p>Test content</p>';
+
+		// Test when already rendered.
+		$reflection = new \ReflectionClass( Content_Inserter::class );
+		$reflection->setStaticPropertyValue( 'the_content_has_rendered', true );
+
+		$result = Content_Inserter::maybe_insert_collection_indicators( $content );
+		$this->assertEquals( $content, $result, 'Content should be unchanged when already rendered.' );
+
+		// Reset state.
+		$this->reset_content_inserter_state();
+
+		// Test with empty content.
+		$result = Content_Inserter::maybe_insert_collection_indicators( '' );
+		$this->assertEquals( '', $result, 'Empty content should remain unchanged.' );
+	}
+
+	/**
+	 * Test maybe_insert_collection_indicators with default style.
+	 *
+	 * @covers \Newspack\Collections\Content_Inserter::maybe_insert_collection_indicators
+	 * @covers \Newspack\Collections\Content_Inserter::build_default_indicator_html
+	 */
+	public function test_maybe_insert_collection_indicators_default_style() {
+		$collection_id_1 = $this->create_test_collection( [ 'post_title' => 'Test Collection 1' ] );
+		$collection_id_2 = $this->create_test_collection( [ 'post_title' => 'Test Collection 2' ] );
+
+		// Set up collections for the inserter.
+		$reflection = new \ReflectionClass( Content_Inserter::class );
+		$reflection->setStaticPropertyValue( 'post_collections', [ $collection_id_1, $collection_id_2 ] );
+
+		// Mock in_the_loop() to return true.
+		global $wp_query;
+		$wp_query->in_the_loop = true;
+
+		$content = '<p>Test content paragraph.</p>';
+		$result  = Content_Inserter::maybe_insert_collection_indicators( $content );
+
+		$this->assertStringContainsString( $content, $result, 'Original content should be preserved.' );
+		$this->assertStringContainsString( 'This article appears in', $result, 'Default indicator text should be present.' );
+		$this->assertStringContainsString( get_the_title( $collection_id_1 ), $result, 'Collection title should be present.' );
+		$this->assertStringContainsString( get_permalink( $collection_id_2 ), $result, 'Collection link should be present.' );
+	}
+
+	/**
+	 * Test maybe_insert_collection_indicators with card style.
+	 *
+	 * @covers \Newspack\Collections\Content_Inserter::maybe_insert_collection_indicators
+	 * @covers \Newspack\Collections\Content_Inserter::build_card_html
+	 */
+	public function test_maybe_insert_collection_indicators_card_style() {
+		$collection_title = 'Test Collection';
+		$collection_id    = $this->create_test_collection( [ 'post_title' => $collection_title ] );
+
+		// Set up collections for the inserter.
+		$reflection = new \ReflectionClass( Content_Inserter::class );
+		$reflection->setStaticPropertyValue( 'post_collections', [ $collection_id ] );
+
+		// Mock settings to use card style.
+		$card_message = 'Custom card message';
+		add_filter(
+			'pre_option_newspack_collections_settings',
+			function () use ( $card_message ) {
+				return [
+					'post_indicator_style' => 'card',
+					'card_message'         => $card_message,
+				];
+			}
+		);
+
+		// Mock in_the_loop() to return true.
+		global $wp_query;
+		$wp_query->in_the_loop = true;
+
+		$content = '<p>First paragraph.</p><p>Second paragraph.</p><p>Third paragraph.</p>';
+		$result  = Content_Inserter::maybe_insert_collection_indicators( $content );
+
+		$this->assertStringContainsString( 'First paragraph', $result, 'First paragraph should be preserved.' );
+		$this->assertStringContainsString( 'Second paragraph', $result, 'Second paragraph should be preserved.' );
+		$this->assertStringContainsString( 'Browse ' . $collection_title, $result, 'Collection title should be present in card.' );
+		$this->assertStringContainsString( $card_message, $result, 'Custom card message should be present.' );
+		$this->assertStringContainsString( 'See more', $result, 'See more button should be present.' );
+
+		// Clean up.
+		remove_all_filters( 'pre_option_newspack_collections_settings' );
+	}
+
+	/**
+	 * Test maybe_insert_collection_indicators prevents double execution.
+	 *
+	 * @covers \Newspack\Collections\Content_Inserter::maybe_insert_collection_indicators
+	 */
+	public function test_maybe_insert_collection_indicators_prevents_double_execution() {
+		$collection_id = $this->create_test_collection( [ 'post_title' => 'Test Collection' ] );
+
+		// Set up collections for the inserter.
+		$reflection = new \ReflectionClass( Content_Inserter::class );
+		$reflection->setStaticPropertyValue( 'post_collections', [ $collection_id ] );
+
+		// Mock in_the_loop() to return true.
+		global $wp_query;
+		$wp_query->in_the_loop = true;
+
+		$content = '<p>Test content.</p>';
+
+		// First call should add indicators.
+		$result1 = Content_Inserter::maybe_insert_collection_indicators( $content );
+		$this->assertStringContainsString( 'This article appears in', $result1, 'First call should add indicators.' );
+
+		// Second call should not add indicators again.
+		$result2 = Content_Inserter::maybe_insert_collection_indicators( $content );
+		$this->assertEquals( $content, $result2, 'Second call should not modify content.' );
+	}
+
+	/**
+	 * Test build_card_html respects limit parameter.
+	 *
+	 * @covers \Newspack\Collections\Content_Inserter::build_card_html
+	 */
+	public function test_build_card_html_respects_limit() {
+		$collection_id_1 = $this->create_test_collection( [ 'post_title' => 'Collection 1' ] );
+		$collection_id_2 = $this->create_test_collection( [ 'post_title' => 'Collection 2' ] );
+
+		$result = Content_Inserter::build_card_html( [ $collection_id_1, $collection_id_2 ], 1 );
+
+		$this->assertStringContainsString( 'Collection 1', $result, 'First collection should be present.' );
+		$this->assertStringNotContainsString( 'Collection 2', $result, 'Second collection should not be present due to limit.' );
+	}
+
+	/**
+	 * Test insert_after_nth_block with insufficient blocks.
+	 *
+	 * @covers \Newspack\Collections\Content_Inserter::insert_after_nth_block
+	 */
+	public function test_insert_after_nth_block_insufficient_blocks() {
+		$content     = '<p>Only one paragraph.</p>';
+		$insert_html = '<div>Inserted content</div>';
+		$result      = Content_Inserter::insert_after_nth_block( $content, $insert_html, 3 );
+
+		// Should append at the end since there aren't 3 blocks.
+		$this->assertStringContainsString( $content, $result, 'Original content should be preserved.' );
+		$this->assertStringEndsWith( $insert_html, $result, 'Insert HTML should be appended at the end.' );
+	}
+
+	/**
+	 * Test insert_after_nth_block behavior with different content types.
+	 *
+	 * @covers \Newspack\Collections\Content_Inserter::insert_after_nth_block
+	 */
+	public function test_insert_after_nth_block() {
+		$insert_html = '<div>Inserted content</div>';
+
+		// Test HTML content.
+		$html_content = '<p>First paragraph.</p><p>Second paragraph.</p>';
+		$html_result  = Content_Inserter::insert_after_nth_block( $html_content, $insert_html, 2 );
+		$this->assertEquals( $html_content . $insert_html, $html_result, 'HTML content should append at end when insufficient blocks detected.' );
+
+		// Test Gutenberg blocks.
+		$block_content = "<!-- wp:paragraph -->\n<p>First paragraph.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Second paragraph.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Third paragraph.</p>\n<!-- /wp:paragraph -->";
+		$block_result  = Content_Inserter::insert_after_nth_block( $block_content, $insert_html, 2 );
+
+		$this->assertStringContainsString( '<p>First paragraph.</p>', $block_result, 'First paragraph should be present.' );
+		$this->assertStringContainsString( '<p>Second paragraph.</p>', $block_result, 'Second paragraph should be present.' );
+		$this->assertStringContainsString( $insert_html, $block_result, 'Inserted content should be present.' );
+		$this->assertStringContainsString( '<p>Third paragraph.</p>', $block_result, 'Third paragraph should be present.' );
+
+		// Verify proper insertion order for Gutenberg blocks.
+		$second_pos = strpos( $block_result, '<p>Second paragraph.</p>' );
+		$insert_pos = strpos( $block_result, $insert_html );
+		$third_pos  = strpos( $block_result, '<p>Third paragraph.</p>' );
+
+		$this->assertGreaterThan( $second_pos, $insert_pos, 'Inserted content should come after second paragraph.' );
+		$this->assertLessThan( $third_pos, $insert_pos, 'Inserted content should come before third paragraph.' );
+	}
+
+	/**
+	 * Test build_default_indicator_html with empty collections.
+	 *
+	 * @covers \Newspack\Collections\Content_Inserter::build_default_indicator_html
+	 */
+	public function test_build_default_indicator_html_empty() {
+		$result = Content_Inserter::build_default_indicator_html( [] );
+		$this->assertEmpty( $result, 'Empty collections should return empty string.' );
+	}
+
+	/**
+	 * Test build_default_indicator_html with valid collections.
+	 *
+	 * @covers \Newspack\Collections\Content_Inserter::build_default_indicator_html
+	 */
+	public function test_build_default_indicator_html_with_collections() {
+		$collection_title = 'Test Collection';
+		$collection_id    = $this->create_test_collection( [ 'post_title' => $collection_title ] );
+
+		$result = Content_Inserter::build_default_indicator_html( [ $collection_id ] );
+
+		$this->assertStringContainsString( 'This article appears in', $result, 'Default indicator text should be present.' );
+		$this->assertStringContainsString( $collection_title, $result, 'Collection title should be present.' );
+		$this->assertStringContainsString( get_permalink( $collection_id ), $result, 'Collection permalink should be present.' );
+	}
+
+	/**
+	 * Test build_default_indicator_html respects limit parameter.
+	 *
+	 * @covers \Newspack\Collections\Content_Inserter::build_default_indicator_html
+	 */
+	public function test_build_default_indicator_html_respects_limit() {
+		$collection_id_1 = $this->create_test_collection( [ 'post_title' => 'Collection 1' ] );
+		$collection_id_2 = $this->create_test_collection( [ 'post_title' => 'Collection 2' ] );
+
+		$result = Content_Inserter::build_default_indicator_html( [ $collection_id_1, $collection_id_2 ], 1 );
+
+		$this->assertStringContainsString( 'Collection 1', $result, 'First collection should be present.' );
+		$this->assertStringNotContainsString( 'Collection 2', $result, 'Second collection should not be present due to limit.' );
+	}
+}

--- a/tests/unit-tests/collections/class-test-enqueuer.php
+++ b/tests/unit-tests/collections/class-test-enqueuer.php
@@ -15,15 +15,15 @@ use Newspack\Collections\Enqueuer;
  * Test the Collections Enqueuer functionality.
  */
 class Test_Enqueuer extends WP_UnitTestCase {
-	/**
-	 * Set up the test environment.
-	 */
-	public function set_up() {
-		parent::set_up();
+	use Traits\Trait_Enqueuer_Test;
 
-		// Reset the data every time via reflection.
-		$reflection = new \ReflectionClass( Enqueuer::class );
-		$reflection->setStaticPropertyValue( 'data', [] );
+	/**
+	 * Tear down the test environment.
+	 */
+	public function tear_down() {
+		parent::tear_down();
+
+		$this->cleanup_enqueuer_state();
 	}
 
 	/**

--- a/tests/unit-tests/collections/class-test-post-type.php
+++ b/tests/unit-tests/collections/class-test-post-type.php
@@ -18,6 +18,7 @@ use Newspack\Collections\Settings;
  */
 class Test_Post_Type extends WP_UnitTestCase {
 	use Traits\Trait_Collections_Test;
+	use Traits\Trait_Enqueuer_Test;
 
 	/**
 	 * The order column name accessible via reflection.
@@ -138,8 +139,8 @@ class Test_Post_Type extends WP_UnitTestCase {
 
 		// Clean up.
 		$current_screen = null; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-		wp_deregister_script( Enqueuer::SCRIPT_NAME_ADMIN );
-		( new \ReflectionClass( Enqueuer::class ) )->setStaticPropertyValue( 'data', [] );
+		$this->cleanup_enqueued_assets_for_script( Enqueuer::SCRIPT_NAME_ADMIN );
+		$this->reset_enqueuer_data();
 	}
 
 	/**

--- a/tests/unit-tests/collections/class-test-query-helper.php
+++ b/tests/unit-tests/collections/class-test-query-helper.php
@@ -366,11 +366,11 @@ class Test_Query_Helper extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test get_post_collections with terms.
+	 * Test get_post_collections with IDs.
 	 *
 	 * @covers \Newspack\Collections\Query_Helper::get_post_collections
 	 */
-	public function test_get_post_collections_with_terms() {
+	public function test_get_post_collections_with_ids() {
 		$collection_id = $this->create_test_collection();
 		$post_id       = self::factory()->post->create();
 
@@ -380,12 +380,12 @@ class Test_Query_Helper extends \WP_UnitTestCase {
 		// Assign post to collection.
 		wp_set_object_terms( $post_id, $term_id, Collection_Taxonomy::get_taxonomy() );
 
-		$collection_terms = Query_Helper::get_post_collections( $post_id );
+		$collection_ids = Query_Helper::get_post_collections( $post_id );
 
-		$this->assertIsArray( $collection_terms, 'Collection terms should be an array.' );
-		$this->assertCount( 1, $collection_terms, 'There should be one collection term.' );
-		$this->assertInstanceOf( \WP_Term::class, $collection_terms[0], 'The first collection term should be an instance of WP_Term.' );
-		$this->assertEquals( $term_id, $collection_terms[0]->term_id, 'The first collection term should have the term ID ' . $term_id );
+		$this->assertIsArray( $collection_ids, 'Collection IDs should be an array.' );
+		$this->assertCount( 1, $collection_ids, 'There should be one collection ID.' );
+		$this->assertIsInt( $collection_ids[0], 'The first collection ID should be an integer.' );
+		$this->assertEquals( $collection_id, $collection_ids[0], 'The first collection ID should be ' . $collection_id );
 	}
 
 	/**
@@ -429,11 +429,11 @@ class Test_Query_Helper extends \WP_UnitTestCase {
 		wp_set_object_terms( $post_id, [ $term_id_1, $term_id_2 ], Collection_Taxonomy::get_taxonomy() );
 
 		// Test single = true returns only one result.
-		$collection_terms = Query_Helper::get_post_collections( $post_id, false, true );
+		$collection_terms = Query_Helper::get_post_collections( $post_id, true, true );
 
 		$this->assertIsArray( $collection_terms, 'Collection terms should be an array.' );
 		$this->assertCount( 1, $collection_terms, 'There should be one collection term.' );
-		$this->assertInstanceOf( \WP_Term::class, $collection_terms[0], 'The first collection term should be an instance of WP_Term.' );
+		$this->assertInstanceOf( \WP_Post::class, $collection_terms[0], 'The first collection term should be an instance of WP_Post.' );
 	}
 
 	/**

--- a/tests/unit-tests/collections/class-test-query-helper.php
+++ b/tests/unit-tests/collections/class-test-query-helper.php
@@ -1,0 +1,576 @@
+<?php
+/**
+ * Tests for the Query_Helper class.
+ *
+ * @package Newspack\Tests\Unit\Collections
+ */
+
+namespace Newspack\Tests\Unit\Collections;
+
+use Newspack\Collections\Post_Type;
+use Newspack\Collections\Collection_Meta;
+use Newspack\Collections\Collection_Taxonomy;
+use Newspack\Collections\Collection_Category_Taxonomy;
+use Newspack\Collections\Collection_Section_Taxonomy;
+use Newspack\Collections\Post_Meta;
+use Newspack\Collections\Query_Helper;
+use Newspack\Collections\Sync;
+
+/**
+ * Tests for the Query_Helper class.
+ */
+class Test_Query_Helper extends \WP_UnitTestCase {
+	use Traits\Trait_Collections_Test;
+
+	/**
+	 * Set up the test environment.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		Post_Type::init();
+		Collection_Meta::register_meta();
+		Post_Meta::register_meta();
+		Collection_Taxonomy::register_taxonomy();
+		Collection_Category_Taxonomy::register_taxonomy();
+		Collection_Category_Taxonomy::register_meta();
+		Collection_Section_Taxonomy::register_taxonomy();
+		Collection_Section_Taxonomy::register_meta();
+	}
+
+	/**
+	 * Test get_available_years with no collections.
+	 *
+	 * @covers \Newspack\Collections\Query_Helper::get_available_years
+	 */
+	public function test_get_available_years_empty() {
+		$years = Query_Helper::get_available_years();
+
+		$this->assertIsArray( $years, 'Years should be an array.' );
+		$this->assertEmpty( $years, 'Years should be empty.' );
+	}
+
+	/**
+	 * Test get_available_years with collections but no categories.
+	 *
+	 * @covers \Newspack\Collections\Query_Helper::get_available_years
+	 */
+	public function test_get_available_years_no_categories() {
+		// Create collections from different years.
+		$this->create_test_collection(
+			[
+				'post_title' => 'Collection 2023',
+				'post_date'  => '2023-06-15 12:00:00',
+			]
+		);
+		$this->create_test_collection(
+			[
+				'post_title' => 'Collection 2024',
+				'post_date'  => '2024-03-20 10:00:00',
+			]
+		);
+
+		$years = Query_Helper::get_available_years();
+
+		$this->assertIsArray( $years, 'Years should be an array.' );
+		$this->assertContains( 2023, $years, '2023 should be in years array.' );
+		$this->assertContains( 2024, $years, '2024 should be in years array.' );
+
+		// Years should be sorted in descending order.
+		$this->assertEquals( [ 2024, 2023 ], array_values( $years ), 'Years should be sorted in descending order.' );
+	}
+
+	/**
+	 * Test get_available_years with multiple categories.
+	 *
+	 * @covers \Newspack\Collections\Query_Helper::get_available_years
+	 */
+	public function test_get_available_years_with_categories() {
+		// Create test categories.
+		$this->set_current_user_role( 'administrator' );
+		$sports_category = wp_insert_term( 'Sports', Collection_Category_Taxonomy::get_taxonomy() );
+		$news_category   = wp_insert_term( 'News', Collection_Category_Taxonomy::get_taxonomy() );
+		$this->assertNotWPError( $sports_category, 'Sports category should be created.' );
+		$this->assertNotWPError( $news_category, 'News category should be created.' );
+
+		// Create collections in different years for different categories.
+		$sports_collection_2022 = $this->create_test_collection(
+			[
+				'post_title' => 'Sports Collection 2022',
+				'post_date'  => '2022-05-15 10:00:00',
+			]
+		);
+		$sports_collection_2023 = $this->create_test_collection(
+			[
+				'post_title' => 'Sports Collection 2023',
+				'post_date'  => '2023-08-20 14:00:00',
+			]
+		);
+		$news_collection_2023   = $this->create_test_collection(
+			[
+				'post_title' => 'News Collection 2023',
+				'post_date'  => '2023-12-01 12:00:00',
+			]
+		);
+		$news_collection_2024   = $this->create_test_collection(
+			[
+				'post_title' => 'News Collection 2024',
+				'post_date'  => '2024-01-15 09:00:00',
+			]
+		);
+
+		// Assign collections to categories.
+		wp_set_object_terms( $sports_collection_2022, $sports_category['term_id'], Collection_Category_Taxonomy::get_taxonomy() );
+		wp_set_object_terms( $sports_collection_2023, $sports_category['term_id'], Collection_Category_Taxonomy::get_taxonomy() );
+		wp_set_object_terms( $news_collection_2023, $news_category['term_id'], Collection_Category_Taxonomy::get_taxonomy() );
+		wp_set_object_terms( $news_collection_2024, $news_category['term_id'], Collection_Category_Taxonomy::get_taxonomy() );
+
+		// Test sports category years.
+		$sports_term  = get_term( $sports_category['term_id'] );
+		$sports_years = Query_Helper::get_available_years( $sports_term->slug );
+
+		$this->assertIsArray( $sports_years, 'Sports years should be an array.' );
+		$this->assertContains( 2022, $sports_years, '2022 should be in sports years.' );
+		$this->assertContains( 2023, $sports_years, '2023 should be in sports years.' );
+		$this->assertNotContains( 2024, $sports_years, '2024 should not be in sports years.' );
+
+		// Test news category years.
+		$news_term  = get_term( $news_category['term_id'] );
+		$news_years = Query_Helper::get_available_years( $news_term->slug );
+
+		$this->assertIsArray( $news_years, 'News years should be an array.' );
+		$this->assertContains( 2023, $news_years, '2023 should be in news years.' );
+		$this->assertContains( 2024, $news_years, '2024 should be in news years.' );
+		$this->assertNotContains( 2022, $news_years, '2022 should not be in news years.' );
+
+		// Test all years (no category filter).
+		$all_years = Query_Helper::get_available_years();
+
+		$this->assertIsArray( $all_years, 'All years should be an array.' );
+		$this->assertContains( 2022, $all_years, '2022 should be in all years.' );
+		$this->assertContains( 2023, $all_years, '2023 should be in all years.' );
+		$this->assertContains( 2024, $all_years, '2024 should be in all years.' );
+
+		// Should be sorted in descending order.
+		$this->assertEquals( [ 2024, 2023, 2022 ], array_values( $all_years ), 'All years should be sorted in descending order.' );
+	}
+
+	/**
+	 * Test get_collection_categories with no collections or categories.
+	 *
+	 * @covers \Newspack\Collections\Query_Helper::get_collection_categories
+	 */
+	public function test_get_collection_categories_empty() {
+		$categories = Query_Helper::get_collection_categories();
+
+		$this->assertIsArray( $categories, 'Categories should be an array.' );
+		$this->assertEmpty( $categories, 'Categories should be empty.' );
+	}
+
+	/**
+	 * Test get_collection_categories with a single category.
+	 *
+	 * @covers \Newspack\Collections\Query_Helper::get_collection_categories
+	 */
+	public function test_get_collection_categories() {
+		$this->set_current_user_role( 'administrator' );
+		$term_data = wp_insert_term( 'Test Category', Collection_Category_Taxonomy::get_taxonomy() );
+		$this->assertNotWPError( $term_data, 'Test category should be created.' );
+
+		// Create a test collection and assign it to the category.
+		// Otherwise, the method will not return the category as it's hiding empty terms ('hide_empty' => true).
+		$collection_id = $this->create_test_collection();
+		wp_set_object_terms( $collection_id, $term_data['term_id'], Collection_Category_Taxonomy::get_taxonomy() );
+
+		$categories = Query_Helper::get_collection_categories();
+
+		$this->assertIsArray( $categories, 'Categories should be an array.' );
+		$this->assertCount( 1, $categories, 'There should be one category.' );
+		$this->assertInstanceOf( \WP_Term::class, $categories[0], 'The first category should be an instance of WP_Term.' );
+		$this->assertEquals( 'Test Category', $categories[0]->name, 'The first category should be named "Test Category".' );
+	}
+
+	/**
+	 * Test get_ctas with no CTAs.
+	 *
+	 * @covers \Newspack\Collections\Query_Helper::get_ctas
+	 */
+	public function test_get_ctas_empty() {
+		$collection_id = $this->create_test_collection();
+
+		$ctas = Query_Helper::get_ctas( $collection_id );
+
+		$this->assertIsArray( $ctas, 'CTAs should be an array.' );
+		$this->assertEmpty( $ctas, 'CTAs should be empty.' );
+	}
+
+	/**
+	 * Test get_ctas with limit.
+	 *
+	 * @covers \Newspack\Collections\Query_Helper::get_ctas
+	 */
+	public function test_get_ctas_with_limit() {
+		$collection_id = $this->create_test_collection();
+
+		// Mock CTAs data.
+		$ctas_data = [
+			[
+				'type'  => 'link',
+				'label' => 'CTA 1',
+				'url'   => 'https://example.com/1',
+			],
+			[
+				'type'  => 'link',
+				'label' => 'CTA 2',
+				'url'   => 'https://example.com/2',
+			],
+			[
+				'type'  => 'link',
+				'label' => 'CTA 3',
+				'url'   => 'https://example.com/3',
+			],
+		];
+
+		Collection_Meta::set( $collection_id, 'ctas', $ctas_data );
+
+		$ctas = Query_Helper::get_ctas( $collection_id, 2 );
+
+		$this->assertIsArray( $ctas, 'CTAs should be an array.' );
+		$this->assertCount( 2, $ctas, 'There should be two CTAs.' );
+		$this->assertEquals( $ctas_data[0]['label'], $ctas[0]['label'], 'The first CTA should be labeled ' . $ctas_data[0]['label'] );
+		$this->assertEquals( $ctas_data[1]['label'], $ctas[1]['label'], 'The second CTA should be labeled ' . $ctas_data[1]['label'] );
+	}
+
+	/**
+	 * Test get_collection_posts with no posts.
+	 *
+	 * @covers \Newspack\Collections\Query_Helper::get_collection_posts
+	 */
+	public function test_get_collection_posts_empty() {
+		$collection_id = $this->create_test_collection();
+
+		$collection_posts = Query_Helper::get_collection_posts( $collection_id );
+
+		$this->assertIsArray( $collection_posts, 'Collection posts should be an array.' );
+		$this->assertEmpty( $collection_posts, 'Collection posts should be empty.' );
+	}
+
+	/**
+	 * Test get_collection_posts basic functionality.
+	 *
+	 * @covers \Newspack\Collections\Query_Helper::get_collection_posts
+	 */
+	public function test_get_collection_posts() {
+		$collection_id = $this->create_test_collection();
+		$term_id       = Sync::get_term_linked_to_collection( $collection_id );
+
+		// Create posts and assign them to the collection.
+		$post_id_1 = self::factory()->post->create( [ 'post_title' => 'Post 1' ] );
+		$post_id_2 = self::factory()->post->create( [ 'post_title' => 'Post 2' ] );
+		wp_set_object_terms( $post_id_1, $term_id, Collection_Taxonomy::get_taxonomy() );
+		wp_set_object_terms( $post_id_2, $term_id, Collection_Taxonomy::get_taxonomy() );
+
+		$collection_posts = Query_Helper::get_collection_posts( $collection_id );
+
+		$this->assertIsArray( $collection_posts, 'Collection posts should be an array.' );
+		$this->assertArrayHasKey( '', $collection_posts, 'Posts without sections should be in the array.' );
+		$this->assertContains( $post_id_1, $collection_posts[''], 'Post 1 should be in the array.' );
+		$this->assertContains( $post_id_2, $collection_posts[''], 'Post 2 should be in the array.' );
+	}
+
+	/**
+	 * Test get_collection_posts with cover stories and sections.
+	 *
+	 * @covers \Newspack\Collections\Query_Helper::get_collection_posts
+	 */
+	public function test_get_collection_posts_with_sections_and_cover() {
+		$collection_id = $this->create_test_collection();
+		$term_id       = Sync::get_term_linked_to_collection( $collection_id );
+
+		// Create section terms.
+		$this->set_current_user_role( 'administrator' );
+		$sports_section = wp_insert_term(
+			'Sports',
+			Collection_Section_Taxonomy::get_taxonomy(),
+			[
+				'slug' => 'sports',
+			] 
+		);
+		$news_section   = wp_insert_term(
+			'News',
+			Collection_Section_Taxonomy::get_taxonomy(),
+			[
+				'slug' => 'news',
+			] 
+		);
+		$this->assertNotWPError( $sports_section, 'Sports section should be created.' );
+		$this->assertNotWPError( $news_section, 'News section should be created.' );
+
+		// Create posts with different classifications.
+		$cover_post      = self::factory()->post->create( [ 'post_title' => 'Cover Story' ] );
+		$sports_post     = self::factory()->post->create( [ 'post_title' => 'Sports Post' ] );
+		$news_post       = self::factory()->post->create( [ 'post_title' => 'News Post' ] );
+		$no_section_post = self::factory()->post->create( [ 'post_title' => 'No Section Post' ] );
+
+		// Assign posts to collection.
+		wp_set_object_terms( $cover_post, $term_id, Collection_Taxonomy::get_taxonomy() );
+		wp_set_object_terms( $sports_post, $term_id, Collection_Taxonomy::get_taxonomy() );
+		wp_set_object_terms( $news_post, $term_id, Collection_Taxonomy::get_taxonomy() );
+		wp_set_object_terms( $no_section_post, $term_id, Collection_Taxonomy::get_taxonomy() );
+
+		// Assign sections to posts.
+		wp_set_object_terms( $sports_post, $sports_section['term_id'], Collection_Section_Taxonomy::get_taxonomy() );
+		wp_set_object_terms( $news_post, $news_section['term_id'], Collection_Section_Taxonomy::get_taxonomy() );
+
+		// Mark cover post as cover story.
+		Post_Meta::set( $cover_post, 'is_cover_story', true );
+
+		$collection_posts = Query_Helper::get_collection_posts( $collection_id );
+
+		$this->assertIsArray( $collection_posts, 'Collection posts should be an array.' );
+
+		// Test cover section exists and contains cover post.
+		$this->assertArrayHasKey( 'cover', $collection_posts, 'Cover section should be in the array.' );
+		$this->assertContains( $cover_post, $collection_posts['cover'], 'Cover post should be in the cover section.' );
+
+		// Test sports section exists and contains sports post.
+		$this->assertArrayHasKey( 'sports', $collection_posts, 'Sports section should be in the array.' );
+		$this->assertContains( $sports_post, $collection_posts['sports'], 'Sports post should be in the sports section.' );
+
+		// Test news section exists and contains news post.
+		$this->assertArrayHasKey( 'news', $collection_posts, 'News section should be in the array.' );
+		$this->assertContains( $news_post, $collection_posts['news'], 'News post should be in the news section.' );
+
+		// Test no-section posts are in empty key.
+		$this->assertArrayHasKey( '', $collection_posts, 'Posts without sections should be in the array.' );
+		$this->assertContains( $no_section_post, $collection_posts[''], 'No section post should be in the array.' );
+
+		// Verify cover post is not in any other section.
+		$this->assertNotContains( $cover_post, $collection_posts[''], 'Cover post should not be in the array.' );
+		$this->assertNotContains( $cover_post, $collection_posts['sports'], 'Cover post should not be in the sports section.' );
+		$this->assertNotContains( $cover_post, $collection_posts['news'], 'Cover post should not be in the news section.' );
+	}
+
+	/**
+	 * Test get_post_collections with no collections.
+	 *
+	 * @covers \Newspack\Collections\Query_Helper::get_post_collections
+	 */
+	public function test_get_post_collections_empty() {
+		$post_id = self::factory()->post->create();
+
+		$result = Query_Helper::get_post_collections( $post_id );
+
+		$this->assertIsArray( $result, 'Result should be an array.' );
+		$this->assertEmpty( $result, 'Result should be empty.' );
+	}
+
+	/**
+	 * Test get_post_collections with terms.
+	 *
+	 * @covers \Newspack\Collections\Query_Helper::get_post_collections
+	 */
+	public function test_get_post_collections_with_terms() {
+		$collection_id = $this->create_test_collection();
+		$post_id       = self::factory()->post->create();
+
+		// Get the linked term.
+		$term_id = Sync::get_term_linked_to_collection( $collection_id );
+
+		// Assign post to collection.
+		wp_set_object_terms( $post_id, $term_id, Collection_Taxonomy::get_taxonomy() );
+
+		$collection_terms = Query_Helper::get_post_collections( $post_id );
+
+		$this->assertIsArray( $collection_terms, 'Collection terms should be an array.' );
+		$this->assertCount( 1, $collection_terms, 'There should be one collection term.' );
+		$this->assertInstanceOf( \WP_Term::class, $collection_terms[0], 'The first collection term should be an instance of WP_Term.' );
+		$this->assertEquals( $term_id, $collection_terms[0]->term_id, 'The first collection term should have the term ID ' . $term_id );
+	}
+
+	/**
+	 * Test get_post_collections with posts.
+	 *
+	 * @covers \Newspack\Collections\Query_Helper::get_post_collections
+	 */
+	public function test_get_post_collections_with_posts() {
+		$collection_id = $this->create_test_collection();
+		$post_id       = self::factory()->post->create();
+
+		// Get the linked term.
+		$term_id = Sync::get_term_linked_to_collection( $collection_id );
+
+		// Assign post to collection.
+		wp_set_object_terms( $post_id, $term_id, Collection_Taxonomy::get_taxonomy() );
+
+		$collection_posts = Query_Helper::get_post_collections( $post_id, true );
+
+		$this->assertIsArray( $collection_posts, 'Collection posts should be an array.' );
+		$this->assertCount( 1, $collection_posts, 'There should be one collection post.' );
+		$this->assertInstanceOf( \WP_Post::class, $collection_posts[0], 'The first collection post should be an instance of WP_Post.' );
+		$this->assertEquals( $collection_id, $collection_posts[0]->ID, 'The first collection post should have the collection ID ' . $collection_id );
+	}
+
+	/**
+	 * Test get_post_collections with single parameter.
+	 *
+	 * @covers \Newspack\Collections\Query_Helper::get_post_collections
+	 */
+	public function test_get_post_collections_single_result() {
+		$collection_id_1 = $this->create_test_collection( [ 'post_title' => 'Collection 1' ] );
+		$collection_id_2 = $this->create_test_collection( [ 'post_title' => 'Collection 2' ] );
+		$post_id         = self::factory()->post->create();
+
+		// Get the linked terms.
+		$term_id_1 = Sync::get_term_linked_to_collection( $collection_id_1 );
+		$term_id_2 = Sync::get_term_linked_to_collection( $collection_id_2 );
+
+		// Assign post to both collections.
+		wp_set_object_terms( $post_id, [ $term_id_1, $term_id_2 ], Collection_Taxonomy::get_taxonomy() );
+
+		// Test single = true returns only one result.
+		$collection_terms = Query_Helper::get_post_collections( $post_id, false, true );
+
+		$this->assertIsArray( $collection_terms, 'Collection terms should be an array.' );
+		$this->assertCount( 1, $collection_terms, 'There should be one collection term.' );
+		$this->assertInstanceOf( \WP_Term::class, $collection_terms[0], 'The first collection term should be an instance of WP_Term.' );
+	}
+
+	/**
+	 * Test get_post_collections filter.
+	 *
+	 * @covers \Newspack\Collections\Query_Helper::get_post_collections
+	 */
+	public function test_get_post_collections_filter() {
+		$collection_id = $this->create_test_collection();
+		$post_id       = self::factory()->post->create();
+
+		// Get the linked term.
+		$term_id = Sync::get_term_linked_to_collection( $collection_id );
+
+		// Assign post to collection.
+		wp_set_object_terms( $post_id, $term_id, Collection_Taxonomy::get_taxonomy() );
+
+		// Add filter to modify result.
+		$filter_called = false;
+		add_filter(
+			'newspack_collections_post_collections',
+			function ( $result, $test_post_id, $return_posts, $single ) use ( $post_id, &$filter_called ) {
+				$filter_called = true;
+				$this->assertEquals( $post_id, $test_post_id, 'Test post ID should be ' . $post_id );
+				$this->assertFalse( $return_posts, 'Return posts should be false.' );
+				$this->assertFalse( $single, 'Single should be false.' );
+				return [];
+			},
+			10,
+			4
+		);
+
+		$collection_posts = Query_Helper::get_post_collections( $post_id );
+
+		$this->assertTrue( $filter_called, 'Filter should be called.' );
+		$this->assertEmpty( $collection_posts, 'Collection posts should be empty.' );
+
+		// Clean up.
+		remove_all_filters( 'newspack_collections_post_collections' );
+	}
+
+	/**
+	 * Test get_section_name with empty slug.
+	 *
+	 * @covers \Newspack\Collections\Query_Helper::get_section_name
+	 */
+	public function test_get_section_name_empty() {
+		$section_name = Query_Helper::get_section_name( '' );
+
+		$this->assertIsString( $section_name, 'Section name should be a string.' );
+		$this->assertEquals( '', $section_name, 'Section name should be empty.' );
+	}
+
+	/**
+	 * Test get_section_name with non-existent section (fallback to slug).
+	 *
+	 * @covers \Newspack\Collections\Query_Helper::get_section_name
+	 */
+	public function test_get_section_name_nonexistent() {
+		$section_name = Query_Helper::get_section_name( 'nonexistent-section' );
+
+		$this->assertIsString( $section_name, 'Section name should be a string.' );
+		$this->assertEquals( 'nonexistent-section', $section_name, 'Section name should be "nonexistent-section".' );
+	}
+
+	/**
+	 * Test get_section_name with valid section term.
+	 *
+	 * @covers \Newspack\Collections\Query_Helper::get_section_name
+	 */
+	public function test_get_section_name_with_term() {
+		$this->set_current_user_role( 'administrator' );
+		$section_term = wp_insert_term(
+			'Test Section',
+			Collection_Section_Taxonomy::get_taxonomy(),
+			[
+				'slug' => 'test-section',
+			]
+		);
+		$this->assertNotWPError( $section_term, 'Section term should be created.' );
+
+		// Test that the method returns the term name, not the slug.
+		$section_name = Query_Helper::get_section_name( 'test-section' );
+
+		$this->assertIsString( $section_name, 'Section name should be a string.' );
+		$this->assertEquals( 'Test Section', $section_name, 'Section name should be "Test Section".' );
+	}
+
+	/**
+	 * Test get_recent with no collections.
+	 *
+	 * @covers \Newspack\Collections\Query_Helper::get_recent
+	 */
+	public function test_get_recent_empty() {
+		$recent = Query_Helper::get_recent();
+
+		$this->assertIsArray( $recent, 'Recent should be an array.' );
+		$this->assertEmpty( $recent, 'Recent should be empty.' );
+	}
+
+	/**
+	 * Test get_recent collections.
+	 *
+	 * @covers \Newspack\Collections\Query_Helper::get_recent
+	 */
+	public function test_get_recent() {
+		// Create multiple collections.
+		$this->create_test_collection( [ 'post_title' => 'Collection 1' ] );
+		$this->create_test_collection( [ 'post_title' => 'Collection 2' ] );
+		$this->create_test_collection( [ 'post_title' => 'Collection 3' ] );
+
+		$recent = Query_Helper::get_recent( [], 2 );
+
+		$this->assertIsArray( $recent, 'Recent should be an array.' );
+		$this->assertCount( 2, $recent, 'There should be two recent posts.' );
+		$this->assertInstanceOf( \WP_Post::class, $recent[0], 'The first recent post should be an instance of WP_Post.' );
+		$this->assertEquals( Post_Type::get_post_type(), $recent[0]->post_type, 'The first recent post should be a ' . Post_Type::get_post_type() . ' post.' );
+	}
+
+	/**
+	 * Test get_recent with exclusions.
+	 *
+	 * @covers \Newspack\Collections\Query_Helper::get_recent
+	 */
+	public function test_get_recent_with_exclusions() {
+		// Create multiple collections.
+		$collection_1 = $this->create_test_collection( [ 'post_title' => 'Collection 1' ] );
+		$this->create_test_collection( [ 'post_title' => 'Collection 2' ] );
+		$this->create_test_collection( [ 'post_title' => 'Collection 3' ] );
+
+		$recent = Query_Helper::get_recent( [ $collection_1 ], 2 );
+
+		$this->assertIsArray( $recent, 'Recent should be an array.' );
+		$this->assertCount( 2, $recent, 'There should be two recent posts.' );
+
+		// Should not contain the excluded collection.
+		$recent_ids = wp_list_pluck( $recent, 'ID' );
+		$this->assertNotContains( $collection_1, $recent_ids, 'The excluded collection should not be in the recent posts.' );
+	}
+}

--- a/tests/unit-tests/collections/class-test-sync.php
+++ b/tests/unit-tests/collections/class-test-sync.php
@@ -37,7 +37,7 @@ class Test_Sync extends \WP_UnitTestCase {
 	 */
 	public function test_create_collection_term_from_post() {
 		$post_id = $this->create_test_collection();
-		$term_id = get_post_meta( $post_id, Sync::LINKED_TERM_META_KEY, true );
+		$term_id = Sync::get_term_linked_to_collection( $post_id );
 
 		$term = get_term( $term_id, Collection_Taxonomy::get_taxonomy() );
 		$this->assertValidCollectionTerm( $term, 'Collection term should be created from post.' );
@@ -52,7 +52,7 @@ class Test_Sync extends \WP_UnitTestCase {
 	 */
 	public function test_term_marked_inactive_when_post_trashed() {
 		$post_id = $this->create_test_collection();
-		$term_id = get_post_meta( $post_id, Sync::LINKED_TERM_META_KEY, true );
+		$term_id = Sync::get_term_linked_to_collection( $post_id );
 
 		// Trash the post.
 		wp_trash_post( $post_id );
@@ -82,7 +82,7 @@ class Test_Sync extends \WP_UnitTestCase {
 	 */
 	public function test_term_reactivated_when_post_untrashed() {
 		$post_id = $this->create_test_collection();
-		$term_id = get_post_meta( $post_id, Sync::LINKED_TERM_META_KEY, true );
+		$term_id = Sync::get_term_linked_to_collection( $post_id );
 
 		// Trash the post.
 		wp_trash_post( $post_id );
@@ -111,7 +111,7 @@ class Test_Sync extends \WP_UnitTestCase {
 	 */
 	public function test_term_deleted_when_post_deleted() {
 		$post_id = $this->create_test_collection();
-		$term_id = get_post_meta( $post_id, Sync::LINKED_TERM_META_KEY, true );
+		$term_id = Sync::get_term_linked_to_collection( $post_id );
 
 		// Permanently delete the post.
 		wp_delete_post( $post_id, true );
@@ -129,7 +129,7 @@ class Test_Sync extends \WP_UnitTestCase {
 	 */
 	public function test_update_collection_term_from_post() {
 		$post_id = $this->create_test_collection();
-		$term_id = get_post_meta( $post_id, Sync::LINKED_TERM_META_KEY, true );
+		$term_id = Sync::get_term_linked_to_collection( $post_id );
 
 		wp_update_post(
 			[
@@ -151,7 +151,7 @@ class Test_Sync extends \WP_UnitTestCase {
 	 */
 	public function test_delete_collection_term_from_post() {
 		$post_id = $this->create_test_collection();
-		$term_id = get_post_meta( $post_id, Sync::LINKED_TERM_META_KEY, true );
+		$term_id = Sync::get_term_linked_to_collection( $post_id );
 
 		wp_delete_post( $post_id, true );
 
@@ -167,12 +167,12 @@ class Test_Sync extends \WP_UnitTestCase {
 	 */
 	public function test_restore_collection_term_from_post() {
 		$post_id = $this->create_test_collection();
-		$term_id = get_post_meta( $post_id, Sync::LINKED_TERM_META_KEY, true );
+		$term_id = Sync::get_term_linked_to_collection( $post_id );
 
 		wp_trash_post( $post_id );
 		wp_untrash_post( $post_id );
 
-		$term_id = get_post_meta( $post_id, Sync::LINKED_TERM_META_KEY, true );
+		$term_id = Sync::get_term_linked_to_collection( $post_id );
 		$term    = get_term( $term_id, Collection_Taxonomy::get_taxonomy() );
 
 		$this->assertValidCollectionTerm( $term, 'Term should be restored when post is untrashed.' );
@@ -187,7 +187,7 @@ class Test_Sync extends \WP_UnitTestCase {
 	 */
 	public function test_create_collection_post_from_term() {
 		$term    = $this->create_test_collection_term();
-		$post_id = get_term_meta( $term->term_id, Sync::LINKED_POST_META_KEY, true );
+		$post_id = Sync::get_collection_linked_to_term( $term->term_id );
 
 		$this->assertValidCollection( $post_id, 'Collection post should be created from term.' );
 		$this->assertCollectionAndTermLinked( $post_id, $term->term_id );
@@ -201,7 +201,7 @@ class Test_Sync extends \WP_UnitTestCase {
 	 */
 	public function test_update_collection_post_from_term() {
 		$term    = $this->create_test_collection_term();
-		$post_id = get_term_meta( $term->term_id, Sync::LINKED_POST_META_KEY, true );
+		$post_id = Sync::get_collection_linked_to_term( $term->term_id );
 
 		wp_update_term(
 			$term->term_id,
@@ -224,7 +224,7 @@ class Test_Sync extends \WP_UnitTestCase {
 	 */
 	public function test_trash_collection_post_from_term() {
 		$term    = $this->create_test_collection_term();
-		$post_id = get_term_meta( $term->term_id, Sync::LINKED_POST_META_KEY, true );
+		$post_id = Sync::get_collection_linked_to_term( $term->term_id );
 
 		wp_delete_term( $term->term_id, Collection_Taxonomy::get_taxonomy() );
 

--- a/tests/unit-tests/collections/class-test-template-helper.php
+++ b/tests/unit-tests/collections/class-test-template-helper.php
@@ -254,4 +254,32 @@ class Test_Template_Helper extends \WP_UnitTestCase {
 		$this->assertStringContainsString( '<a ', $html, 'See all link should be rendered.' );
 		$this->assertStringContainsString( get_post_type_archive_link( Post_Type::get_post_type() ), $html, 'See all link should point to the collection archive.' );
 	}
+
+	/**
+	 * Test load_template_part handles collections template parts correctly.
+	 *
+	 * @covers \Newspack\Collections\Template_Helper::load_template_part
+	 */
+	public function test_load_template_part() {
+		ob_start();
+		Template_Helper::load_template_part( Template_Helper::TEMPLATE_PARTS_DIR . 'newspack-collection-intro', null, [], [] );
+		$output = ob_get_clean();
+		$this->assertNotEmpty( $output, 'Collections template part should be processed.' );
+		$this->assertStringContainsString( 'collection-intro', $output, 'Collections template part should contain "collection-intro".' );
+
+		// Test collections template part with name parameter.
+		ob_start();
+		Template_Helper::load_template_part( Template_Helper::TEMPLATE_PARTS_DIR . 'newspack-collection-intro', 'variant', [], [] );
+		$this->assertEmpty( ob_get_clean(), 'Template with name should not output without existing file.' );
+
+		// Test collections template part with missing file should not output anything.
+		ob_start();
+		Template_Helper::load_template_part( Template_Helper::TEMPLATE_PARTS_DIR . 'non-existent', null, [], [] );
+		$this->assertEmpty( ob_get_clean(), 'Missing template should not output anything.' );
+
+		// Test non-collections template part.
+		ob_start();
+		Template_Helper::load_template_part( 'some/other/template', null, [], [] );
+		$this->assertEmpty( ob_get_clean(), 'Non-collections template should not be processed.' );
+	}
 }

--- a/tests/unit-tests/collections/class-test-template-helper.php
+++ b/tests/unit-tests/collections/class-test-template-helper.php
@@ -1,0 +1,257 @@
+<?php
+/**
+ * Tests for the Template_Helper class.
+ *
+ * @package Newspack\Tests\Unit\Collections
+ */
+
+namespace Newspack\Tests\Unit\Collections;
+
+use Newspack\Collections\Post_Type;
+use Newspack\Collections\Collection_Meta;
+use Newspack\Collections\Collection_Taxonomy;
+use Newspack\Collections\Collection_Category_Taxonomy;
+use Newspack\Collections\Template_Helper;
+use Newspack\Collections\Enqueuer;
+
+/**
+ * Tests for the Template_Helper class.
+ */
+class Test_Template_Helper extends \WP_UnitTestCase {
+	use Traits\Trait_Collections_Test;
+	use Traits\Trait_Enqueuer_Test;
+
+	/**
+	 * Set up the test environment.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		Post_Type::register_post_type();
+		Collection_Meta::register_meta();
+		Collection_Taxonomy::register_taxonomy();
+		Collection_Category_Taxonomy::register_taxonomy();
+	}
+
+	/**
+	 * Test template_include returns correct template names.
+	 *
+	 * @covers \Newspack\Collections\Template_Helper::template_include
+	 */
+	public function test_template_include() {
+		// Test archive template.
+		$this->go_to( get_post_type_archive_link( Post_Type::get_post_type() ) );
+
+		$template = Template_Helper::template_include( 'default-template.php' );
+		$this->assertStringEndsWith( 'archive-newspack-collection.php', $template, 'Template should match archive template.' );
+
+		// Test single template.
+		$collection_id = $this->create_test_collection();
+		$this->go_to( get_permalink( $collection_id ) );
+
+		$template = Template_Helper::template_include( 'default-template.php' );
+		$this->assertStringEndsWith( 'single-newspack-collection.php', $template, 'Template should match single template.' );
+	}
+
+	/**
+	 * Test enqueue_assets triggers on collection pages.
+	 *
+	 * @covers \Newspack\Collections\Template_Helper::enqueue_assets
+	 */
+	public function test_enqueue_assets() {
+		// Test archive page.
+		$this->go_to( get_post_type_archive_link( Post_Type::get_post_type() ) );
+		Template_Helper::enqueue_assets();
+		Enqueuer::maybe_enqueue_frontend_assets();
+
+		$this->assertFalse( wp_script_is( Enqueuer::SCRIPT_NAME_ADMIN, 'registered' ), 'Admin script should not be registered.' );
+		$this->assertFalse( wp_style_is( Enqueuer::SCRIPT_NAME_ADMIN, 'registered' ), 'Admin style should not be registered.' );
+		$this->assertTrue( wp_script_is( Enqueuer::SCRIPT_NAME_FRONTEND, 'registered' ), 'Frontend script should be registered.' );
+		$this->assertTrue( wp_style_is( Enqueuer::SCRIPT_NAME_FRONTEND, 'registered' ), 'Frontend style should be registered.' );
+
+		// Reset state.
+		$this->cleanup_enqueued_assets_for_script( Enqueuer::SCRIPT_NAME_FRONTEND );
+		$this->reset_enqueuer_data();
+
+		// Test regular post.
+		$this->go_to( get_permalink( $this->factory()->post->create() ) );
+		Template_Helper::enqueue_assets();
+		Enqueuer::maybe_enqueue_frontend_assets();
+
+		$this->assertFalse( wp_script_is( Enqueuer::SCRIPT_NAME_ADMIN, 'registered' ), 'Admin script should not be registered.' );
+		$this->assertFalse( wp_style_is( Enqueuer::SCRIPT_NAME_ADMIN, 'registered' ), 'Admin style should not be registered.' );
+		$this->assertFalse( wp_script_is( Enqueuer::SCRIPT_NAME_FRONTEND, 'registered' ), 'Frontend script should not be registered.' );
+		$this->assertFalse( wp_style_is( Enqueuer::SCRIPT_NAME_FRONTEND, 'registered' ), 'Frontend style should not be registered.' );
+
+		$this->cleanup_enqueued_assets_for_script( Enqueuer::SCRIPT_NAME_FRONTEND );
+	}
+
+	/**
+	 * Test archive_filters modifies query correctly.
+	 *
+	 * @covers \Newspack\Collections\Template_Helper::archive_filters
+	 */
+	public function test_archive_filters() {
+		// Create a test category.
+		$this->set_current_user_role( 'administrator' );
+		$term_data = wp_insert_term( 'Test Category', Collection_Category_Taxonomy::get_taxonomy() );
+
+		// Go to collection archive.
+		$this->go_to( get_post_type_archive_link( Post_Type::get_post_type() ) );
+
+		global $wp_query;
+
+		// Test category filtering.
+		$_GET['category'] = 'test-category';
+		Template_Helper::archive_filters( $wp_query );
+		$tax_query = $wp_query->get( 'tax_query' );
+		$this->assertIsArray( $tax_query, 'Tax query should be an array.' );
+		$this->assertEquals( Collection_Category_Taxonomy::get_taxonomy(), $tax_query[0]['taxonomy'], 'Taxonomy should match.' );
+		$this->assertEquals( 'test-category', $tax_query[0]['terms'], 'Terms should match.' );
+
+		// Test year filtering.
+		$_GET['year'] = '2023';
+		Template_Helper::archive_filters( $wp_query );
+		$date_query = $wp_query->get( 'date_query' );
+		$this->assertIsArray( $date_query, 'Date query should be an array.' );
+		$this->assertEquals( 2023, $date_query[0]['year'], 'Year should match.' );
+
+		// Test posts per page setting.
+		$posts_per_page = $wp_query->get( 'posts_per_page' );
+		$this->assertGreaterThan( 0, $posts_per_page, 'Posts per page should be greater than 0.' );
+
+		// Clean up.
+		unset( $_GET['category'], $_GET['year'] );
+	}
+
+	/**
+	 * Test prevent_year_redirect prevents redirects on collection archives.
+	 *
+	 * @covers \Newspack\Collections\Template_Helper::prevent_year_redirect
+	 */
+	public function test_prevent_year_redirect() {
+		$year_url = 'http://example.com/2023';
+		// Test on collection archive with year parameter.
+		$this->go_to( get_post_type_archive_link( Post_Type::get_post_type() ) );
+		$_GET['year'] = '2023';
+
+		$result = Template_Helper::prevent_year_redirect( $year_url );
+		$this->assertFalse( $result, 'Redirect should be prevented.' );
+
+		// Test on regular page.
+		$this->go_to( home_url() );
+		$result = Template_Helper::prevent_year_redirect( $year_url );
+		$this->assertEquals( $year_url, $result, 'Redirect should not be prevented.' );
+
+		// Clean up.
+		unset( $_GET['year'] );
+	}
+
+	/**
+	 * Test render_image generates correct HTML.
+	 *
+	 * @covers \Newspack\Collections\Template_Helper::render_image
+	 */
+	public function test_render_image() {
+		$collection_id = $this->create_test_collection();
+
+		// Test without thumbnail (placeholder).
+		$html = Template_Helper::render_image( $collection_id );
+		$this->assertStringContainsString( 'collection-placeholder', $html, 'Placeholder should be rendered.' );
+		$this->assertStringContainsString( get_permalink( $collection_id ), $html, 'Permalink should be rendered.' );
+
+		// Test with permalink disabled.
+		$html = Template_Helper::render_image( $collection_id, false );
+		$this->assertStringNotContainsString( '<a ', $html, 'Permalink should not be rendered.' );
+
+		// Test with custom permalink.
+		$custom_permalink = 'https://example.com';
+		$html             = Template_Helper::render_image( $collection_id, $custom_permalink );
+		$this->assertStringContainsString( $custom_permalink, $html, 'Custom permalink should be rendered.' );
+	}
+
+	/**
+	 * Test render_meta_text formats metadata correctly.
+	 *
+	 * @covers \Newspack\Collections\Template_Helper::render_meta_text
+	 */
+	public function test_render_meta_text() {
+		$collection_id = $this->create_test_collection();
+
+		// Test with no metadata.
+		$html = Template_Helper::render_meta_text( $collection_id );
+		$this->assertEmpty( $html, 'No metadata should be rendered.' );
+
+		// Test with metadata.
+		Collection_Meta::set( $collection_id, 'volume', '1' );
+		Collection_Meta::set( $collection_id, 'number', '2' );
+		Collection_Meta::set( $collection_id, 'period', 'Spring 2023' );
+
+		$html = Template_Helper::render_meta_text( $collection_id );
+		$this->assertStringContainsString( 'Spring 2023', $html, 'Period should be rendered.' );
+		$this->assertStringContainsString( 'Vol. 1', $html, 'Volume should be rendered.' );
+		$this->assertStringContainsString( 'No. 2', $html, 'Number should be rendered.' );
+		$this->assertStringContainsString( '<br>', $html, 'There should be 2 lines by default.' );
+
+		// Test with 1 line.
+		$html = Template_Helper::render_meta_text( $collection_id, 1 );
+		$this->assertStringNotContainsString( '<br>', $html, 'There should be 1 line.' );
+	}
+
+	/**
+	 * Test render_cta generates correct button HTML.
+	 *
+	 * @covers \Newspack\Collections\Template_Helper::render_cta
+	 */
+	public function test_render_cta() {
+		$url   = 'https://example.com';
+		$label = 'Subscribe';
+		$class = 'cta--subscribe_link';
+
+		$cta = compact( 'url', 'label', 'class' );
+
+		$html = Template_Helper::render_cta( $cta );
+		$this->assertStringContainsString( $url, $html, 'URL should be rendered.' );
+		$this->assertStringContainsString( $label, $html, 'Label should be rendered.' );
+		$this->assertStringContainsString( $class, $html, 'Class should be rendered.' );
+
+		// Test with missing data.
+		$empty_cta = [
+			'url'   => '',
+			'label' => '',
+		];
+		$html      = Template_Helper::render_cta( $empty_cta );
+		$this->assertEmpty( $html, 'Empty CTA should not be rendered.' );
+	}
+
+	/**
+	 * Test render_articles generates content loop block.
+	 *
+	 * @covers \Newspack\Collections\Template_Helper::render_articles
+	 */
+	public function test_render_articles() {
+		$post_ids = [
+			self::factory()->post->create(),
+			self::factory()->post->create(),
+		];
+
+		$html = Template_Helper::render_articles( $post_ids, 'Test Section' );
+		$this->assertIsString( $html, 'Articles HTML should be a string.' );
+
+		// Test with empty post IDs.
+		$html = Template_Helper::render_articles( [] );
+		$this->assertEmpty( $html, 'Empty post IDs should not render articles.' );
+	}
+
+	/**
+	 * Test render_see_all_link generates correct link.
+	 *
+	 * @covers \Newspack\Collections\Template_Helper::render_see_all_link
+	 */
+	public function test_render_see_all_link() {
+		$html = Template_Helper::render_see_all_link();
+
+		$this->assertStringContainsString( '<a ', $html, 'See all link should be rendered.' );
+		$this->assertStringContainsString( get_post_type_archive_link( Post_Type::get_post_type() ), $html, 'See all link should point to the collection archive.' );
+	}
+}

--- a/tests/unit-tests/collections/traits/trait-collections-test.php
+++ b/tests/unit-tests/collections/traits/trait-collections-test.php
@@ -82,7 +82,7 @@ trait Trait_Collections_Test {
 		$this->assertNotWPError( $post, 'Post should be valid.' );
 		$this->assertEquals( Post_Type::get_post_type(), $post->post_type, 'Post should be a collection.' );
 
-		$term_id = get_post_meta( $post_id, Sync::LINKED_TERM_META_KEY, true );
+		$term_id = Sync::get_term_linked_to_collection( $post_id );
 		$this->assertNotEmpty( $term_id, 'Linked term ID should be stored in post meta.' );
 
 		$term = get_term( $term_id, Collection_Taxonomy::get_taxonomy() );
@@ -113,12 +113,12 @@ trait Trait_Collections_Test {
 	protected function assertCollectionAndTermLinked( $post_id, $term_id, $message = '' ) {
 		$this->assertEquals(
 			$term_id,
-			get_post_meta( $post_id, Sync::LINKED_TERM_META_KEY, true ),
+			Sync::get_term_linked_to_collection( $post_id ),
 			$message ? $message : 'Post should be linked to term.'
 		);
 		$this->assertEquals(
 			$post_id,
-			get_term_meta( $term_id, Sync::LINKED_POST_META_KEY, true ),
+			Sync::get_collection_linked_to_term( $term_id ),
 			$message ? $message : 'Term should be linked to post.'
 		);
 	}

--- a/tests/unit-tests/collections/traits/trait-enqueuer-test.php
+++ b/tests/unit-tests/collections/traits/trait-enqueuer-test.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Trait with common test helper methods for enqueuer testing.
+ *
+ * @package Newspack\Tests\Unit\Collections
+ */
+
+namespace Newspack\Tests\Unit\Collections\Traits;
+
+use Newspack\Collections\Enqueuer;
+
+/**
+ * Trait providing common test helper methods for enqueuer testing.
+ *
+ * This trait provides reusable methods for cleaning up enqueued scripts and styles
+ * in unit tests.
+ */
+trait Trait_Enqueuer_Test {
+
+	/**
+	 * Clean up all enqueued scripts and styles for the Collections Enqueuer.
+	 * Deregisters and dequeues both admin and frontend scripts and styles.
+	 */
+	protected function cleanup_enqueued_assets() {
+		foreach ( [ Enqueuer::SCRIPT_NAME_ADMIN, Enqueuer::SCRIPT_NAME_FRONTEND ] as $script_name ) {
+			wp_deregister_script( $script_name );
+			wp_deregister_style( $script_name );
+			wp_dequeue_script( $script_name );
+			wp_dequeue_style( $script_name );
+		}
+	}
+
+	/**
+	 * Clean up enqueued assets for a specific script name.
+	 *
+	 * @param string $script_name The script name to clean up.
+	 */
+	protected function cleanup_enqueued_assets_for_script( $script_name ) {
+		wp_deregister_script( $script_name );
+		wp_deregister_style( $script_name );
+		wp_dequeue_script( $script_name );
+		wp_dequeue_style( $script_name );
+	}
+
+	/**
+	 * Reset the Enqueuer's internal data state via reflection.
+	 */
+	protected function reset_enqueuer_data() {
+		$reflection = new \ReflectionClass( Enqueuer::class );
+		$reflection->setStaticPropertyValue( 'data', [] );
+	}
+
+	/**
+	 * Clean up enqueued assets and reset enqueuer data. Convenience method.
+	 */
+	protected function cleanup_enqueuer_state() {
+		$this->cleanup_enqueued_assets();
+		$this->reset_enqueuer_data();
+	}
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -64,6 +64,7 @@ const entry = {
 	bylines: path.join( __dirname, 'src', 'bylines', 'index.js' ),
 	'nicename-change': path.join( __dirname, 'src', 'nicename-change', 'index.js' ),
 	'collections-admin': path.join( __dirname, 'src', 'collections', 'admin', 'index.js' ),
+	'collections-frontend': path.join( __dirname, 'src', 'collections', 'frontend', 'index.js' ),
 };
 
 // Get files for other scripts.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR implements the frontend functionality for the Collections feature, adding both PHP templates and frontend assets.

The changes include:
- PHP templates for archive and single Collections.
- New frontend styles and JS for Collections pages, separate from admin, but leveraging the existing enqueuer logic.
- A template helper class for the common rendering logic and required hooks.
- The database query logic is on the query helper class present in #4066, but also extended here.

The following hooks are introduced:
- **Template helper:**
  - Filters:
    - `newspack_collections_template_include`
    - `newspack_collections_render_image`
    - `newspack_collections_render_meta_text`
    - `newspack_collections_render_cta`
    - `newspack_collections_cta_html`
    - `newspack_collections_render_articles_attrs`
    - `newspack_collections_see_all_link_html`
- **Query helper:**
  - Filters:
    - `newspack_collections_available_years`
    - `newspack_collections_collection_categories`
    - `newspack_collections_ctas`
    - `newspack_collections_hierarchical_ctas`
    - `newspack_collections_posts_by_section`
    - `newspack_collections_post_collections`
    - `newspack_collections_section_name`
    - `newspack_collections_recent`
- **Collection archive template:**
  - Actions:
    - `newspack_collections_archive_start`
    - `newspack_collections_archive_after_filters`
    - `newspack_collections_archive_after_item`
    - `newspack_collections_archive_before_navigation`
    - `newspack_collections_archive_end`
- **Collection singular template:**
  - Filters:
    - `newspack_collections_single_section_posts`
  - Actions:
    - `newspack_collections_single_start`
    - `newspack_collections_single_after_meta`
    - `newspack_collections_single_after_intro`
    - `newspack_collections_single_end`

Closes NPPD-142, NPPD-143.

### How to test the changes in this Pull Request:

1. Enable the Collections module:
    - Navigate to Newspack > Settings > Collections
    - Enable the Collections module
    - Verify the module activates without errors and that fields can be edited without issues
2. Create the required objects:
    - Create multiple collection categories and fill their terms metas (subscribe and order links)
    - Create multiple collection sections and order them using the section order field of the taxonomy
    - Create multiple collections:
        - Assign them to categories
        - Use different years in the post date
    - Assign regular posts to collections and sections
3. Navigate to the collections archive page to verify:
    - Styling and layout matching designs
    - Filters behavior (year and category)
    - Pagination
4. Navigate to the collections' singular pages to verify:
    - Styling and layout
    - Collection description and metadata
    - Cover story (there could be more than one)
    - Post with no sections
    - Post with sections
    - Ordering of posts within sections
    - Recent collections section
5. Test that the plugin templates can be overridden by creating files at the theme or child theme level (`single-newspack-collection.php`, for example).
6. Test some of the new filters for the template and rendering functions.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?