### PR TITLE
feat(collections): collection indicators for single posts

### DIFF
--- a/includes/collections/class-content-inserter.php
+++ b/includes/collections/class-content-inserter.php
@@ -69,6 +69,14 @@ class Content_Inserter {
 			return;
 		}
 
+		// Sort by post date descending.
+		usort(
+			$collections,
+			function ( $a, $b ) {
+				return get_the_date( 'U', $b ) - get_the_date( 'U', $a );
+			}
+		);
+
 		self::$post_collections = $collections;
 		Enqueuer::add_data( 'post_is_in_collections', true );
 		add_filter( 'the_content', [ __CLASS__, 'maybe_insert_collection_indicators' ], 1 );

--- a/includes/collections/class-content-inserter.php
+++ b/includes/collections/class-content-inserter.php
@@ -121,7 +121,7 @@ class Content_Inserter {
 	 * @param int             $limit       The number of collections to render. Default is self::MAX_COLLECTIONS_TO_RENDER.
 	 * @return string The card HTML.
 	 */
-	private static function build_card_html( $collections, $limit = self::MAX_COLLECTIONS_TO_RENDER ) {
+	public static function build_card_html( $collections, $limit = self::MAX_COLLECTIONS_TO_RENDER ) {
 		if ( empty( $collections ) ) {
 			return '';
 		}
@@ -207,7 +207,7 @@ class Content_Inserter {
 	 * @param int    $nth_block   The block number (1-based). Default is self::INSERT_AFTER_BLOCK_NUMBER.
 	 * @return string The modified content.
 	 */
-	private static function insert_after_nth_block( $content, $insert_html, $nth_block = self::INSERT_AFTER_BLOCK_NUMBER ) {
+	public static function insert_after_nth_block( $content, $insert_html, $nth_block = self::INSERT_AFTER_BLOCK_NUMBER ) {
 		$parsed_blocks = parse_blocks( $content );
 
 		// Filter out empty blocks.
@@ -258,7 +258,7 @@ class Content_Inserter {
 	 * @param int|null        $limit       The number of collections to render. Default is self::MAX_COLLECTIONS_TO_RENDER.
 	 * @return string The indicator HTML.
 	 */
-	private static function build_default_indicator_html( $collections, $limit = self::MAX_COLLECTIONS_TO_RENDER ) {
+	public static function build_default_indicator_html( $collections, $limit = self::MAX_COLLECTIONS_TO_RENDER ) {
 		if ( empty( $collections ) ) {
 			return '';
 		}

--- a/includes/collections/class-content-inserter.php
+++ b/includes/collections/class-content-inserter.php
@@ -166,15 +166,15 @@ class Content_Inserter {
 					</div>
 
 					<div class="wp-block-column collection-card__buttons-column is-vertically-aligned-center">
-						<?php 
+						<?php
 						echo wp_kses_post(
 							Template_Helper::render_cta(
 								[
 									'url'   => $collection_link,
 									'label' => __( 'See more', 'newspack-plugin' ),
-								] 
-							) 
-						); 
+								]
+							)
+						);
 						?>
 					</div>
 				</div>
@@ -255,26 +255,41 @@ class Content_Inserter {
 	 * Build the default indicator HTML.
 	 *
 	 * @param int[]|WP_Post[] $collections The collections.
-	 * @param int|null        $limit       The number of collections to render. Default is self::MAX_COLLECTIONS_TO_RENDER.
+	 * @param int|null        $limit       The number of collections to render. Default is null (show all).
 	 * @return string The indicator HTML.
 	 */
-	public static function build_default_indicator_html( $collections, $limit = self::MAX_COLLECTIONS_TO_RENDER ) {
+	public static function build_default_indicator_html( $collections, $limit = null ) {
+		if ( ! is_array( $collections ) ) {
+			return '';
+		}
+
+		if ( $limit ) {
+			$collections = array_slice( $collections, 0, $limit );
+		}
+
 		if ( empty( $collections ) ) {
 			return '';
 		}
 
-		$collections    = is_array( $collections ) ? array_slice( $collections, 0, $limit ) : [];
-		$indicator_html = '';
-		$intro_text     = __( 'This article appears in', 'newspack-plugin' );
+		$collection_links = array_map(
+			function ( $collection ) {
+				return sprintf(
+					'<a href="%s">%s</a>',
+					esc_url( get_permalink( $collection ) ),
+					esc_html( get_the_title( $collection ) )
+				);
+			},
+			$collections
+		);
 
-		foreach ( $collections as $collection ) {
-			$indicator_html .= sprintf(
-				'<p class="collection-link has-small-font-size">%s <a href="%s">%s</a>.</p>',
-				esc_html( $intro_text ),
-				esc_url( get_permalink( $collection ) ),
-				esc_html( get_the_title( $collection ) )
-			);
-		}
+		$indicator_html = sprintf(
+			'<p class="collection-link has-small-font-size">%s</p>',
+			wp_sprintf(
+				/* translators: %l is replaced with the collection name(s) */
+				__( 'This article appears in %l.', 'newspack-plugin' ),
+				$collection_links
+			)
+		);
 
 		/**
 		 * Filters the collection default indicator HTML.

--- a/includes/collections/class-content-inserter.php
+++ b/includes/collections/class-content-inserter.php
@@ -1,0 +1,288 @@
+<?php
+/**
+ * Collections Content Inserter.
+ *
+ * @package Newspack\Collections
+ */
+
+namespace Newspack\Collections;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Content inserter class for Collections indicators.
+ */
+class Content_Inserter {
+
+	/**
+	 * The maximum number of collections to render by default in the post content indicator.
+	 *
+	 * @var int
+	 */
+	public const MAX_COLLECTIONS_TO_RENDER = 1;
+
+	/**
+	 * The block number to insert the indicator after.
+	 *
+	 * @var int
+	 */
+	public const INSERT_AFTER_BLOCK_NUMBER = 2;
+
+	/**
+	 * Whether we've already inserted indicators into the content.
+	 * Prevents duplicate execution.
+	 *
+	 * @var boolean
+	 */
+	public static $the_content_has_rendered = false;
+
+	/**
+	 * The collections the current post is in.
+	 *
+	 * @var WP_Post[]
+	 */
+	public static $post_collections = [];
+
+	/**
+	 * Initialize hooks.
+	 */
+	public static function init() {
+		// Use template_redirect as it runs on the frontend before wp_enqueue_scripts.
+		add_action( 'template_redirect', [ __CLASS__, 'check_if_post_is_in_collection' ] );
+	}
+
+	/**
+	 * Check if the post is in a collection and add a filter for the post content.
+	 */
+	public static function check_if_post_is_in_collection() {
+		if ( ! is_singular( 'post' ) ) {
+			return;
+		}
+
+		$post = get_post();
+		if ( ! $post ) {
+			return;
+		}
+
+		$collections = Query_Helper::get_post_collections( $post );
+		if ( empty( $collections ) ) {
+			return;
+		}
+
+		self::$post_collections = $collections;
+		Enqueuer::add_data( 'post_is_in_collections', true );
+		add_filter( 'the_content', [ __CLASS__, 'maybe_insert_collection_indicators' ], 1 );
+	}
+
+	/**
+	 * Maybe insert collection indicators into post content.
+	 *
+	 * @param string $content The post content.
+	 * @return string The modified content.
+	 */
+	public static function maybe_insert_collection_indicators( $content ) {
+		if ( self::$the_content_has_rendered || ! in_the_loop() || empty( trim( $content ) ) ) {
+			return $content;
+		}
+		$post_style = Settings::get_setting( 'post_indicator_style', 'default' );
+
+		switch ( $post_style ) {
+			case 'card':
+				// Insert indicator at the specified position.
+				$content_with_indicators = self::insert_after_nth_block(
+					$content,
+					self::build_card_html( self::$post_collections )
+				);
+				break;
+			case 'default':
+			default:
+				// Insert indicator at the end of the content.
+				$content_with_indicators = $content . self::build_default_indicator_html( self::$post_collections );
+				break;
+		}
+
+		self::$the_content_has_rendered = true;
+
+		/**
+		 * Filters the content with collection indicators inserted.
+		 *
+		 * @param string          $content_with_indicators The content with indicators.
+		 * @param string          $content                 The original content.
+		 * @param string          $post_style              The post style.
+		 * @param int[]|WP_Post[] $collections             The collections.
+		 */
+		return apply_filters( 'newspack_collections_content_with_indicators', $content_with_indicators, $content, $post_style, self::$post_collections );
+	}
+
+	/**
+	 * Build the card HTML using output buffering.
+	 *
+	 * @param int[]|WP_Post[] $collections The collection objects.
+	 * @param int             $limit       The number of collections to render. Default is self::MAX_COLLECTIONS_TO_RENDER.
+	 * @return string The card HTML.
+	 */
+	private static function build_card_html( $collections, $limit = self::MAX_COLLECTIONS_TO_RENDER ) {
+		if ( empty( $collections ) ) {
+			return '';
+		}
+
+		$collections  = is_array( $collections ) ? array_slice( $collections, 0, $limit ) : [];
+		$card_message = Settings::get_setting(
+			'card_message',
+			__( "Keep reading. There's plenty more to discover.", 'newspack-plugin' )
+		);
+		ob_start();
+
+		foreach ( $collections as $collection ) {
+			$collection_link  = get_permalink( $collection );
+			$collection_title = get_the_title( $collection );
+
+			// Get collection image.
+			$image_html = Template_Helper::render_image(
+				$collection,
+				false,
+				[ 144, 192 ] // 2x of a 72px width.
+			);
+			?>
+			<!-- wp:group {"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
+			<div class="collection-card wp-block-group">
+				<!-- wp:separator -->
+				<hr class="wp-block-separator has-light-gray-background-color has-background is-style-wide"/>
+				<!-- /wp:separator -->
+
+				<!-- wp:columns -->
+				<div class="collection-card__columns wp-block-columns">
+					<div class="collection-card__content-column wp-block-column is-vertically-aligned-center">
+						<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+						<div class="wp-block-group">
+							<?php echo wp_kses_post( $image_html ); ?>
+							<p>
+								<strong>Browse <?php echo esc_html( $collection_title ); ?></strong>
+								<br>
+								<?php echo esc_html( $card_message ); ?>
+							</p>
+						</div>
+						<!-- /wp:group -->
+					</div>
+
+					<div class="wp-block-column collection-card__buttons-column is-vertically-aligned-center">
+						<?php 
+						echo wp_kses_post(
+							Template_Helper::render_cta(
+								[
+									'url'   => $collection_link,
+									'label' => __( 'See more', 'newspack-plugin' ),
+								] 
+							) 
+						); 
+						?>
+					</div>
+				</div>
+				<!-- /wp:columns -->
+
+				<!-- wp:separator -->
+				<hr class="wp-block-separator has-light-gray-background-color has-background is-style-wide"/>
+				<!-- /wp:separator -->
+			</div>
+			<!-- /wp:group -->
+			<?php
+		}
+
+		$card_html = do_blocks( ob_get_clean() );
+
+		/**
+		 * Filters the collection card HTML.
+		 *
+		 * @param string          $card_html   The card HTML.
+		 * @param int[]|WP_Post[] $collections The collections.
+		 */
+		return apply_filters( 'newspack_collections_card_html', $card_html, $collections );
+	}
+
+	/**
+	 * Insert content after the nth block using block parsing.
+	 *
+	 * @param string $content     The content.
+	 * @param string $insert_html The HTML to insert.
+	 * @param int    $nth_block   The block number (1-based). Default is self::INSERT_AFTER_BLOCK_NUMBER.
+	 * @return string The modified content.
+	 */
+	private static function insert_after_nth_block( $content, $insert_html, $nth_block = self::INSERT_AFTER_BLOCK_NUMBER ) {
+		$parsed_blocks = parse_blocks( $content );
+
+		// Filter out empty blocks.
+		$blocks_to_skip_empty = [
+			'core/paragraph',
+			'core/heading',
+			'core/list',
+			'core/quote',
+			'core/html',
+			'core/freeform',
+		];
+
+		$parsed_blocks = array_values(
+			array_filter(
+				$parsed_blocks,
+				function ( $block ) use ( $blocks_to_skip_empty ) {
+					$null_block_name     = null === $block['blockName'];
+					$is_skip_empty_block = in_array( $block['blockName'], $blocks_to_skip_empty, true );
+					$is_empty            = empty( trim( $block['innerHTML'] ) );
+					return ! ( $is_empty && ( $null_block_name || $is_skip_empty_block ) );
+				}
+			)
+		);
+
+		// If we don't have enough blocks, append at the end.
+		if ( count( $parsed_blocks ) < $nth_block ) {
+			return $content . $insert_html;
+		}
+
+		// Insert after the nth block.
+		$rendered_content = '';
+		foreach ( $parsed_blocks as $index => $block ) {
+			$rendered_content .= $block['innerHTML'];
+
+			// Insert after the nth block (index is 0-based).
+			if ( $index === $nth_block - 1 ) {
+				$rendered_content .= $insert_html;
+			}
+		}
+
+		return $rendered_content;
+	}
+
+	/**
+	 * Build the default indicator HTML.
+	 *
+	 * @param int[]|WP_Post[] $collections The collections.
+	 * @param int|null        $limit       The number of collections to render. Default is self::MAX_COLLECTIONS_TO_RENDER.
+	 * @return string The indicator HTML.
+	 */
+	private static function build_default_indicator_html( $collections, $limit = self::MAX_COLLECTIONS_TO_RENDER ) {
+		if ( empty( $collections ) ) {
+			return '';
+		}
+
+		$collections    = is_array( $collections ) ? array_slice( $collections, 0, $limit ) : [];
+		$indicator_html = '';
+		$intro_text     = __( 'This article appears in', 'newspack-plugin' );
+
+		foreach ( $collections as $collection ) {
+			$indicator_html .= sprintf(
+				'<p class="collection-link has-small-font-size">%s <a href="%s">%s</a>.</p>',
+				esc_html( $intro_text ),
+				esc_url( get_permalink( $collection ) ),
+				esc_html( get_the_title( $collection ) )
+			);
+		}
+
+		/**
+		 * Filters the collection default indicator HTML.
+		 *
+		 * @param string          $indicator_html The indicator HTML.
+		 * @param int[]|WP_Post[] $collections    The collections.
+		 * @param int             $limit          The number of collections rendered. If a falsey value, all collections were rendered.
+		 */
+		return apply_filters( 'newspack_collections_default_indicator_html', $indicator_html, $collections, $limit );
+	}
+}

--- a/includes/collections/class-query-helper.php
+++ b/includes/collections/class-query-helper.php
@@ -133,13 +133,14 @@ class Query_Helper {
 	/**
 	 * Get processed CTAs from a collection post.
 	 *
-	 * @param int      $post_id     The post ID.
-	 * @param int|null $limit       Optional limit on the number of CTAs.
-	 * @param bool     $hierarchical Whether to include hierarchical CTAs. Default is true.
+	 * @param int|WP_Post $post         The post ID or post object.
+	 * @param int|null    $limit        Optional limit on the number of CTAs.
+	 * @param bool        $hierarchical Whether to include hierarchical CTAs. Default is true.
 	 * @return array Array of processed CTAs with 'url' and 'label' keys.
 	 */
-	public static function get_ctas( $post_id, $limit = null, $hierarchical = true ) {
-		$ctas = Collection_Meta::get( $post_id, 'ctas' );
+	public static function get_ctas( $post, $limit = null, $hierarchical = true ) {
+		$post_id = $post instanceof \WP_Post ? $post->ID : $post;
+		$ctas    = Collection_Meta::get( $post_id, 'ctas' );
 
 		if ( ! is_array( $ctas ) ) {
 			$ctas = [];
@@ -199,8 +200,8 @@ class Query_Helper {
 	 */
 	public static function get_hierarchical_ctas( $post_id ) {
 		$cta_keys = [
-			'subscribe_link' => __( 'Subscribe', 'newspack' ),
-			'order_link'     => __( 'Order', 'newspack' ),
+			'subscribe_link' => __( 'Subscribe', 'newspack-plugin' ),
+			'order_link'     => __( 'Order', 'newspack-plugin' ),
 		];
 
 		$ctas = array_values(

--- a/includes/collections/class-settings.php
+++ b/includes/collections/class-settings.php
@@ -20,16 +20,73 @@ class Settings {
 	const OPTION_NAME = 'newspack_collections_settings';
 
 	/**
-	 * Settings fields and their defaults.
+	 * Get fields definitions to be used in the REST API.
+	 *
+	 * @param string $return_type Whether to return only the default values, keys, or all. Returns all the configuration by default.
+	 * @return array Fields definitions.
 	 */
-	const FIELDS = [
-		'custom_naming_enabled' => false,
-		'custom_name'           => '',
-		'custom_singular_name'  => '',
-		'custom_slug'           => '',
-		'subscribe_link'        => '',
-		'order_link'            => '',
-	];
+	public static function get_rest_args( $return_type = 'all' ) {
+		$fields = [
+			'custom_naming_enabled' => [
+				'required'          => false,
+				'default'           => false,
+				'sanitize_callback' => 'rest_sanitize_boolean',
+			],
+			'custom_name'           => [
+				'required'          => false,
+				'default'           => '',
+				'sanitize_callback' => 'sanitize_text_field',
+			],
+			'custom_singular_name'  => [
+				'required'          => false,
+				'default'           => '',
+				'sanitize_callback' => 'sanitize_text_field',
+			],
+			'custom_slug'           => [
+				'required'          => false,
+				'default'           => '',
+				'sanitize_callback' => function ( $value ) {
+					return sanitize_title( is_string( $value ) ? $value : '' );
+				},
+			],
+			'subscribe_link'        => [
+				'required'          => false,
+				'default'           => '',
+				'sanitize_callback' => 'esc_url_raw',
+			],
+			'order_link'            => [
+				'required'          => false,
+				'default'           => '',
+				'sanitize_callback' => 'esc_url_raw',
+			],
+			'post_indicator_style'  => [
+				'required'          => false,
+				'default'           => 'default',
+				'sanitize_callback' => 'sanitize_text_field',
+			],
+			'card_message'          => [
+				'required'          => false,
+				'default'           => '',
+				'sanitize_callback' => 'sanitize_text_field',
+			],
+		];
+
+		switch ( $return_type ) {
+			case 'defaults':
+				$fields = array_map(
+					function ( $field ) {
+						return $field['default'];
+					},
+					$fields
+				);
+				break;
+			case 'keys':
+				$fields = array_keys( $fields );
+				break;
+		}
+
+		return $fields;
+	}
 
 	/**
 	 * Get all collection settings with defaults applied.
@@ -38,8 +95,9 @@ class Settings {
 	 */
 	public static function get_settings() {
 		$collection_settings = get_option( self::OPTION_NAME, [] );
+		$defaults            = self::get_rest_args( 'defaults' );
 
-		return wp_parse_args( $collection_settings, self::FIELDS );
+		return wp_parse_args( $collection_settings, $defaults );
 	}
 
 	/**
@@ -127,42 +185,6 @@ class Settings {
 	}
 
 	/**
-	 * Get REST API args for collection fields.
-	 *
-	 * @return array REST API arguments.
-	 */
-	public static function get_rest_args() {
-		return [
-			'custom_naming_enabled' => [
-				'required'          => false,
-				'sanitize_callback' => 'rest_sanitize_boolean',
-			],
-			'custom_name'           => [
-				'required'          => false,
-				'sanitize_callback' => 'sanitize_text_field',
-			],
-			'custom_singular_name'  => [
-				'required'          => false,
-				'sanitize_callback' => 'sanitize_text_field',
-			],
-			'custom_slug'           => [
-				'required'          => false,
-				'sanitize_callback' => function ( $value ) {
-					return sanitize_title( is_string( $value ) ? $value : '' );
-				},
-			],
-			'subscribe_link'        => [
-				'required'          => false,
-				'sanitize_callback' => 'esc_url_raw',
-			],
-			'order_link'            => [
-				'required'          => false,
-				'sanitize_callback' => 'esc_url_raw',
-			],
-		];
-	}
-
-	/**
 	 * Update collection settings from REST request.
 	 * Conditionally flushes rewrite rules when there are changes that will affect the post type or taxonomy slugs.
 	 *
@@ -173,7 +195,7 @@ class Settings {
 		$settings         = self::get_settings();
 		$updated_settings = [];
 
-		foreach ( array_keys( self::FIELDS ) as $key ) {
+		foreach ( self::get_rest_args( 'keys' ) as $key ) {
 			if ( ! $request->has_param( $key ) ) {
 				continue;
 			}

--- a/includes/collections/class-settings.php
+++ b/includes/collections/class-settings.php
@@ -17,7 +17,12 @@ class Settings {
 	/**
 	 * Option name for all collection settings.
 	 */
-	const OPTION_NAME = 'newspack_collections_settings';
+	public const OPTION_NAME = 'newspack_collections_settings';
+
+	/**
+	 * Posts per page options.
+	 */
+	public const POSTS_PER_PAGE_OPTIONS = [ 12, 18, 24 ];
 
 	/**
 	 * Get fields definitions to be used in the REST API.
@@ -68,6 +73,19 @@ class Settings {
 				'required'          => false,
 				'default'           => '',
 				'sanitize_callback' => 'sanitize_text_field',
+			],
+			'posts_per_page'        => [
+				'required'          => false,
+				'default'           => 12,
+				'sanitize_callback' => function ( $value ) {
+					$value = intval( $value );
+					return in_array( $value, self::POSTS_PER_PAGE_OPTIONS, true ) ? $value : 12;
+				},
+			],
+			'highlight_latest'      => [
+				'required'          => false,
+				'default'           => false,
+				'sanitize_callback' => 'rest_sanitize_boolean',
 			],
 		];
 

--- a/includes/collections/class-template-helper.php
+++ b/includes/collections/class-template-helper.php
@@ -15,10 +15,18 @@ defined( 'ABSPATH' ) || exit;
 class Template_Helper {
 
 	/**
+	 * The directory where the collection template parts are located.
+	 *
+	 * @var string
+	 */
+	public const TEMPLATE_PARTS_DIR = 'collections/parts/';
+
+	/**
 	 * Initialize hooks.
 	 */
 	public static function init() {
 		add_filter( 'template_include', [ __CLASS__, 'template_include' ] );
+		add_action( 'get_template_part', [ __CLASS__, 'load_template_part' ], 10, 4 );
 		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'enqueue_assets' ], 5 );
 		add_action( 'pre_get_posts', [ __CLASS__, 'archive_filters' ] );
 		add_filter( 'redirect_canonical', [ __CLASS__, 'prevent_year_redirect' ] );
@@ -72,6 +80,52 @@ class Template_Helper {
 	}
 
 	/**
+	 * Override template part loading for Collections pages to use plugin templates as fallback.
+	 * Follows WordPress template hierarchy - theme template parts take precedence.
+	 *
+	 * @param string   $slug      The slug name for the generic template.
+	 * @param string   $name      The name of the specialized template or an empty string if there is none.
+	 * @param string[] $templates Array of template names.
+	 * @param array    $args      Additional arguments passed to the template.
+	 */
+	public static function load_template_part( $slug, $name, $templates, $args ) {
+		if ( ! str_starts_with( $slug, self::TEMPLATE_PARTS_DIR ) ) {
+			return;
+		}
+
+		// Build the template file path.
+		$template_file = ( $name ? "{$slug}-{$name}" : $slug ) . '.php';
+
+		// Look in theme first.
+		$theme_template = locate_template( $template_file );
+		if ( $theme_template ) {
+			return;
+		}
+
+		/**
+		 * Filters the fallback plugin template path before attempting to load it.
+		 *
+		 * @param string $plugin_template Path to the plugin template.
+		 * @param string $template_file   Relative template file name.
+		 * @param string $slug            The slug name for the generic template.
+		 * @param string $name            The name of the specialized template or an empty string if there is none.
+		 * @param array  $args            Additional arguments passed to the template.
+		 */
+		$plugin_template = apply_filters(
+			'newspack_collections_plugin_template_part',
+			plugin_dir_path( __DIR__ ) . "templates/{$template_file}",
+			$template_file,
+			$slug,
+			$name,
+			$args
+		);
+
+		if ( file_exists( $plugin_template ) ) {
+			load_template( $plugin_template, false, $args );
+		}
+	}
+
+	/**
 	 * Trigger frontend asset loading for Collections pages.
 	 */
 	public static function enqueue_assets() {
@@ -94,7 +148,8 @@ class Template_Helper {
 		}
 
 		// Set posts per page.
-		$query->set( 'posts_per_page', 24 ); // TODO: Make this a global setting.
+		$posts_per_page = Settings::get_setting( 'posts_per_page' );
+		$query->set( 'posts_per_page', $posts_per_page );
 
 		// Handle category filtering.
 		$category = isset( $_GET['category'] ) ? sanitize_text_field( $_GET['category'] ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
@@ -191,11 +246,12 @@ class Template_Helper {
 	/**
 	 * Get formatted collection metadata text.
 	 *
-	 * @param int $post_id Post ID.
-	 * @param int $lines   Number of lines to output (1 = inline, 2 = stacked). Default 2.
+	 * @param int|WP_Post $post  Post ID or post object.
+	 * @param int         $lines Number of lines to output (1 = inline, 2 = stacked). Default 2.
 	 * @return string Formatted metadata text.
 	 */
-	public static function render_meta_text( $post_id, $lines = 2 ) {
+	public static function render_meta_text( $post, $lines = 2 ) {
+		$post_id    = $post instanceof \WP_Post ? $post->ID : $post;
 		$meta_parts = [];
 		$volume     = Collection_Meta::get( $post_id, 'volume' );
 		$number     = Collection_Meta::get( $post_id, 'number' );
@@ -342,7 +398,7 @@ class Template_Helper {
 	 */
 	public static function render_see_all_link() {
 		$link  = get_post_type_archive_link( Post_Type::get_post_type() );
-		$label = __( 'See all', 'newspack' );
+		$label = __( 'See all', 'newspack-plugin' );
 		$html  = sprintf( '<a href="%s">%s</a>', esc_url( $link ), esc_html( $label ) );
 
 		/**
@@ -351,5 +407,15 @@ class Template_Helper {
 		 * @param string $html The see all link HTML.
 		 */
 		return apply_filters( 'newspack_collections_see_all_link_html', $html );
+	}
+
+	/**
+	 * Render a separator.
+	 *
+	 * @param string $class_name Optional class for the separator.
+	 * @return string The separator HTML.
+	 */
+	public static function render_separator( $class_name = '' ) {
+		return '<hr class="has-light-gray-background-color has-background is-style-wide ' . esc_attr( $class_name ) . '"/>';
 	}
 }

--- a/includes/optional-modules/class-collections.php
+++ b/includes/optional-modules/class-collections.php
@@ -18,6 +18,7 @@ use Newspack\Collections\Collection_Section_Taxonomy;
 use Newspack\Collections\Post_Meta;
 use Newspack\Collections\Cache;
 use Newspack\Collections\Template_Helper;
+use Newspack\Collections\Content_Inserter;
 
 /**
  * Collections module for managing print editions and other collections.
@@ -47,6 +48,7 @@ class Collections {
 		Post_Meta::init();
 		Cache::init();
 		Template_Helper::init();
+		Content_Inserter::init();
 	}
 
 	/**

--- a/includes/templates/collections/archive-newspack-collection.php
+++ b/includes/templates/collections/archive-newspack-collection.php
@@ -28,7 +28,24 @@ do_action( 'newspack_collections_archive_start' );
 
 	<main id="main" class="site-main">
 
-		<?php if ( have_posts() ) : ?>
+		<?php
+		if ( have_posts() ) :
+			// Render the intro section only if it's the first page of results and "Highlight Most Recent Collection" setting is enabled.
+			if ( ! is_paged() && Settings::get_setting( 'highlight_latest' ) ) :
+				get_template_part(
+					Template_Helper::TEMPLATE_PARTS_DIR . 'newspack-collection-intro',
+					null,
+					[
+						'is_latest' => true,
+						'permalink' => true,
+					]
+				);
+
+				// Advance the loop to the next post so it doesn't render twice.
+				the_post();
+				echo wp_kses_post( Template_Helper::render_separator( 'is-latest-collection' ) );
+			endif;
+			?>
 
 			<!-- Filter controls -->
 			<form class="collections-filter" method="get">
@@ -39,9 +56,9 @@ do_action( 'newspack_collections_archive_start' );
 				?>
 
 				<div class="collections-filter__select">
-					<label for="year"><?php esc_html_e( 'Year:', 'newspack' ); ?></label>
+					<label for="year"><?php esc_html_e( 'Year:', 'newspack-plugin' ); ?></label>
 					<select name="year" id="year">
-						<option value="" <?php selected( $selected_year, '' ); ?>><?php esc_html_e( 'All', 'newspack' ); ?></option>
+						<option value="" <?php selected( $selected_year, '' ); ?>><?php esc_html_e( 'All', 'newspack-plugin' ); ?></option>
 						<?php foreach ( $available_years as $available_year ) : ?>
 							<option value="<?php echo esc_attr( $available_year ); ?>" <?php selected( $selected_year, $available_year ); ?>><?php echo esc_html( $available_year ); ?></option>
 						<?php endforeach; ?>
@@ -54,9 +71,9 @@ do_action( 'newspack_collections_archive_start' );
 				if ( count( $categories ) > 1 ) :
 					?>
 					<div class="collections-filter__select">
-						<label for="category"><?php esc_html_e( 'Publication:', 'newspack' ); ?></label>
+						<label for="category"><?php esc_html_e( 'Publication:', 'newspack-plugin' ); ?></label>
 						<select name="category" id="category">
-							<option value="" <?php selected( $selected_category, '' ); ?>><?php esc_html_e( 'All', 'newspack' ); ?></option>
+							<option value="" <?php selected( $selected_category, '' ); ?>><?php esc_html_e( 'All', 'newspack-plugin' ); ?></option>
 							<?php foreach ( $categories as $category ) : ?>
 								<option value="<?php echo esc_attr( $category->slug ); ?>" <?php selected( $selected_category, $category->slug ); ?>><?php echo esc_html( $category->name ); ?></option>
 							<?php endforeach; ?>
@@ -68,6 +85,8 @@ do_action( 'newspack_collections_archive_start' );
 			</form> <!-- .collections-filter -->
 
 			<?php
+			echo wp_kses_post( Template_Helper::render_separator() );
+
 			/**
 			 * Fires after the filter controls in the archive template.
 			 *

--- a/includes/templates/collections/parts/newspack-collection-intro.php
+++ b/includes/templates/collections/parts/newspack-collection-intro.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Template part for the Collection intro section.
+ *
+ * @package Newspack\Collections
+ */
+
+use Newspack\Collections\Query_Helper;
+use Newspack\Collections\Template_Helper;
+
+$collection       = ( $args['collection'] ?? null ); // Allow overriding the collection post object by passing it as an argument.
+$collection       = $collection instanceof WP_Post ? $collection : get_post( $collection ); // The collection argument could be either post object or post ID.
+$is_latest        = ( $args['is_latest'] ?? false );
+$collection_title = get_the_title( $collection );
+$permalink        = match ( true ) { // Allow overriding the permalink by passing it as a string or a boolean argument.
+	is_string( $args['permalink'] ?? null )  => $args['permalink'],               // If the argument is a string, use it as the permalink.
+	( $args['permalink'] ?? false ) === true => get_the_permalink( $collection ), // If a `true` boolean, use the collection permalink.
+	default                                  => false,                            // If not provided (or if a falsey value), don't use a permalink.
+};
+
+/**
+ * Fires before the collection intro section.
+ *
+ * @param WP_Post $collection The collection post.
+ */
+do_action( 'newspack_collections_intro_before', $collection );
+?>
+
+<!-- Intro Section -->
+<div class="collection-intro">
+
+	<!-- Cover Card -->
+	<div class="collection-intro__card">
+		<?php
+		/**
+		 * Fires before the collection image card in the intro section.
+		 *
+		 * @param WP_Post $collection The collection post.
+		 */
+		do_action( 'newspack_collections_intro_image_card', $collection );
+
+		echo wp_kses_post( Template_Helper::render_image( $collection, $permalink ) );
+		?>
+	</div>
+
+	<!-- Content -->
+	<div class="collection-intro__content">
+		<?php
+		/**
+		 * Fires before the collection meta in the intro content section.
+		 *
+		 * @param WP_Post $collection The collection post.
+		 */
+		do_action( 'newspack_collections_intro_before_meta', $collection );
+		?>
+
+		<div class="collection-intro__content__meta">
+			<?php if ( $is_latest ) : ?>
+				<h6 class="wp-block-heading latest-collection-heading has-primary-color has-text-color has-link-color has-normal-font-size"><?php echo esc_html_e( 'Latest', 'newspack-plugin' ); ?></h6>
+			<?php endif; ?>
+			<h1>
+				<?php if ( $permalink ) : ?>
+					<a href="<?php echo esc_url( $permalink ); ?>">
+						<?php echo wp_kses_post( $collection_title ); ?>
+					</a>
+				<?php else : ?>
+					<?php echo wp_kses_post( $collection_title ); ?>
+				<?php endif; ?>
+			</h1>
+			<?php echo wp_kses_post( Template_Helper::render_meta_text( $collection, 1 ) ); ?>
+		</div>
+
+		<div class="collection-intro__content__description">
+			<?php
+			/**
+			 * Fires before the collection description in the intro section.
+			 *
+			 * @param WP_Post $collection The collection post.
+			 */
+			do_action( 'newspack_collections_intro_before_description', $collection );
+
+			echo wp_kses_post( get_the_content( null, false, $collection ) );
+			?>
+		</div>
+
+		<?php
+		$ctas = Query_Helper::get_ctas( $collection );
+		if ( $ctas ) :
+			?>
+			<div class="collection-buttons">
+				<?php foreach ( $ctas as $cta ) : ?>
+					<?php echo wp_kses_post( Template_Helper::render_cta( $cta ) ); ?>
+				<?php endforeach; ?>
+			</div>
+		<?php endif; ?>
+	</div>
+</div>
+
+<?php
+/**
+ * Fires after the collection intro section.
+ *
+ * @param WP_Post $collection The collection post.
+ */
+do_action( 'newspack_collections_intro_after', $collection );
+?>

--- a/includes/templates/collections/single-newspack-collection.php
+++ b/includes/templates/collections/single-newspack-collection.php
@@ -28,61 +28,18 @@ get_header();
 			 * @param WP_Post $post The collection post.
 			 */
 			do_action( 'newspack_collections_single_start', $post );
-			?>
 
-			<!-- Intro Section -->
-			<div class="collection-intro">
+			get_template_part( Template_Helper::TEMPLATE_PARTS_DIR . 'newspack-collection-intro' );
 
-				<!-- Cover Card -->
-				<div class="collection-intro__card">
-					<?php echo wp_kses_post( Template_Helper::render_image( $post, false ) ); ?>
-				</div>
-
-				<!-- Content -->
-				<div class="collection-intro__content">
-					<div class="collection-intro__content__meta">
-						<h1><?php the_title(); ?></h1>
-						<?php echo wp_kses_post( Template_Helper::render_meta_text( $collection_id, 1 ) ); ?>
-					</div>
-
-					<?php
-					/**
-					 * Fires after the collection meta in the intro section.
-					 *
-					 * @param int $collection_id The collection post ID.
-					 */
-					do_action( 'newspack_collections_single_after_meta', $collection_id );
-					?>
-
-					<div class="collection-intro__content__description">
-						<?php the_content(); ?>
-					</div>
-
-					<?php
-					$ctas = Query_Helper::get_ctas( $collection_id );
-					if ( $ctas ) :
-						?>
-						<div class="collection-buttons">
-							<?php foreach ( $ctas as $cta ) : ?>
-								<?php echo wp_kses_post( Template_Helper::render_cta( $cta ) ); ?>
-							<?php endforeach; ?>
-						</div>
-					<?php endif; ?>
-				</div>
-			</div>
-
-			<?php
 			/**
 			 * Fires after the collection intro section.
 			 *
 			 * @param int $collection_id The collection post ID.
 			 */
 			do_action( 'newspack_collections_single_after_intro', $collection_id );
-			?>
 
-			<hr class="has-light-gray-background-color has-background is-style-wide"/>
+			echo wp_kses_post( Template_Helper::render_separator( 'is-latest-collection' ) );
 
-			<?php
 			// Get posts in this collection organized by sections.
 			$collection_posts = Query_Helper::get_collection_posts( $collection_id );
 
@@ -103,7 +60,7 @@ get_header();
 
 					$is_cover     = Query_Helper::COVER_SECTION === $section_slug;
 					$section_name = $is_cover
-						? ( count( $post_ids ) > 1 ? __( 'Cover Stories', 'newspack' ) : __( 'Cover Story', 'newspack' ) )
+						? ( count( $post_ids ) > 1 ? __( 'Cover Stories', 'newspack-plugin' ) : __( 'Cover Story', 'newspack-plugin' ) )
 						: Query_Helper::get_section_name( $section_slug );
 					$show_image   = ! $is_cover;
 					$columns      = $is_cover ? 1 : 2;
@@ -120,13 +77,13 @@ get_header();
 			$recent_collections = Query_Helper::get_recent( [ $collection_id ], 6 );
 
 			if ( $recent_collections ) :
+				echo wp_kses_post( Template_Helper::render_separator( 'is-latest-collection' ) );
 				?>
-				<hr class="has-light-gray-background-color has-background is-style-wide"/>
 
 				<!-- Recent Collections Section -->
 				<div class="collections-recent">
 					<div class="collections-recent__header">
-						<h2><?php esc_html_e( 'Recent', 'newspack' ); ?></h2>
+						<h2><?php esc_html_e( 'Recent', 'newspack-plugin' ); ?></h2>
 						<p class="has-medium-gray-color has-text-color has-link-color has-small-font-size">
 							<?php echo wp_kses_post( Template_Helper::render_see_all_link() ); ?>
 						</p>

--- a/src/collections/frontend/_archive.scss
+++ b/src/collections/frontend/_archive.scss
@@ -1,9 +1,14 @@
 @use "breakpoints" as bp;
+@use "intro";
 
 /* Collections archive template styles */
 .post-type-archive-newspack_collection {
 	main#main {
 		width: 100%;
+	}
+
+	hr {
+		margin: 16px 0;
 	}
 
 	.collections-filter {

--- a/src/collections/frontend/_intro.scss
+++ b/src/collections/frontend/_intro.scss
@@ -1,0 +1,66 @@
+@use "breakpoints" as bp;
+
+/* Collection intro styles */
+.collection-intro {
+	display: grid;
+	grid-template-columns: 1fr;
+	padding-bottom: 16px;
+	gap: 16px;
+
+	h1 {
+		margin: 0;
+		font-size: var(--newspack-theme-font-size-lg);
+
+		@media #{bp.$media-md-up} {
+			font-size: var(--newspack-theme-font-size-xl);
+		}
+	}
+
+	&__card {
+		grid-column: span 1;
+	}
+
+	&__content {
+		grid-column: auto;
+
+		&__meta {
+			display: flex;
+			flex-direction: column;
+			gap: 0.5em;
+
+			.latest-collection-heading {
+				margin: 0;
+				text-transform: uppercase;
+			}
+
+			a {
+				color: var(--newspack-theme-color-text-main);
+			}
+
+			p {
+				margin: 0;
+			}
+		}
+
+		&__description {
+			margin: 32px 0;
+		}
+	}
+
+	@media #{bp.$media-sm-up} {
+		grid-template-columns: repeat(3, minmax(0, 1fr));
+
+		&__content {
+			grid-column: span 2;
+		}
+	}
+
+	@media #{bp.$media-lg-up} {
+		grid-template-columns: repeat(6, minmax(0, 1fr));
+		gap: 32px;
+
+		&__content {
+			grid-column: span 5;
+		}
+	}
+}

--- a/src/collections/frontend/_post-indicator.scss
+++ b/src/collections/frontend/_post-indicator.scss
@@ -1,0 +1,38 @@
+@use "breakpoints" as bp;
+
+/* Collection post indicators styles */
+.entry-content {
+	> p.collection-link {
+		color: var(--newspack-theme-color-text-light, var(--wp--preset--color--contrast-3));
+		margin-bottom: -24px;
+
+		a {
+			color: inherit;
+		}
+	}
+}
+
+.collection-card {
+	&__columns,
+	&__content-column .wp-block-group {
+		gap: calc(var(--wp--preset--spacing--20) + 0.5em) !important;
+	}
+
+	&__columns {
+		padding: var(--wp--preset--spacing--20) 0;
+	}
+
+	.collection-image {
+		width: 72px;
+	}
+
+	@media #{bp.$media-md-up} {
+		&__content-column {
+			flex-basis: 75% !important;
+		}
+
+		&__buttons-column {
+			flex-basis: 25% !important;
+		}
+	}
+}

--- a/src/collections/frontend/_single.scss
+++ b/src/collections/frontend/_single.scss
@@ -1,65 +1,11 @@
 @use "breakpoints" as bp;
+@use "intro";
 
 /* Single collection template styles */
 .single-newspack_collection {
-	h1 {
-		margin: 0;
-		font-size: var(--newspack-theme-font-size-lg);
-
-		@media #{bp.$media-md-up} {
-			font-size: var(--newspack-theme-font-size-xl);
-		}
-	}
-
 	hr {
 		flex: 0 0 100%;
 		margin: 32px 0 62px;
-	}
-
-	.collection-intro {
-		display: grid;
-		grid-template-columns: 1fr;
-		padding-bottom: 16px;
-		gap: 16px;
-
-		&__card {
-			grid-column: span 1;
-		}
-
-		&__content {
-			grid-column: auto;
-
-			&__meta {
-				display: flex;
-				flex-direction: column;
-				gap: 0.5em;
-
-				p {
-					margin: 0;
-				}
-			}
-
-			&__description {
-				margin: 32px 0;
-			}
-		}
-
-		@media #{bp.$media-sm-up} {
-			grid-template-columns: repeat(3, minmax(0, 1fr));
-
-			&__content {
-				grid-column: span 2;
-			}
-		}
-
-		@media #{bp.$media-lg-up} {
-			grid-template-columns: repeat(6, minmax(0, 1fr));
-			gap: 32px;
-
-			&__content {
-				grid-column: span 5;
-			}
-		}
 	}
 
 	.collection-section {

--- a/src/collections/frontend/style.scss
+++ b/src/collections/frontend/style.scss
@@ -6,3 +6,4 @@
 @use "common";
 @use "archive";
 @use "single";
+@use "post-indicator";

--- a/src/components/src/select-control/ButtonGroupControl.js
+++ b/src/components/src/select-control/ButtonGroupControl.js
@@ -14,11 +14,12 @@ import { BaseControl, Button, ButtonGroup } from '@wordpress/components';
  */
 import { hooks } from '..';
 
-const ButtonGroupControl = ( { buttonOptions, buttonSmall, className, hideLabelFromVision, label, onChange, value } ) => {
+const ButtonGroupControl = ( { buttonOptions, buttonSmall, className, help, hideLabelFromVision, label, onChange, value } ) => {
 	const id = hooks.useUniqueId( 'button-group' );
 	return (
 		<BaseControl
 			label={ label }
+			help={ help }
 			hideLabelFromVision={ hideLabelFromVision }
 			id={ id.current }
 			className={ classnames( className, 'components-select-control' ) }

--- a/src/wizards/newspack/views/settings/collections/index.tsx
+++ b/src/wizards/newspack/views/settings/collections/index.tsx
@@ -13,7 +13,7 @@ import { useState, useEffect } from '@wordpress/element';
  */
 import WizardsActionCard from '../../../../wizards-action-card';
 import useWizardApiFetchToggle from '../../../../hooks/use-wizard-api-fetch-toggle';
-import { TextControl, Button, Grid } from '../../../../../components/src';
+import { TextControl, SelectControl, Button, Grid } from '../../../../../components/src';
 import CustomNamingCard from './custom-naming-card';
 
 // Default values for collections settings
@@ -24,6 +24,8 @@ const DEFAULT_COLLECTIONS_SETTINGS: CollectionsSettingsData = {
 	custom_slug: '',
 	subscribe_link: '',
 	order_link: '',
+	post_indicator_style: 'default',
+	card_message: __( "Keep reading. There's plenty more to discover.", 'newspack-plugin' ),
 };
 
 // Helper function to extract collection settings from API data with defaults.
@@ -113,6 +115,25 @@ function Collections() {
 							onChange={ ( value: string ) => updateSetting( 'order_link', value ) }
 							placeholder={ `e.g., https://${ window.location.hostname }/order` }
 						/>
+						<SelectControl
+							label={ __( 'Collection Indicator Style', 'newspack-plugin' ) }
+							help={ __( 'Choose how collection indicators should be displayed on posts.', 'newspack-plugin' ) }
+							value={ settings.post_indicator_style }
+							onChange={ ( value: string ) => updateSetting( 'post_indicator_style', value ) }
+							buttonOptions={ [
+								{ label: __( 'Default', 'newspack-plugin' ), value: 'default' },
+								{ label: __( 'Card', 'newspack-plugin' ), value: 'card' },
+							] }
+						/>
+						{ settings.post_indicator_style === 'card' && (
+							<TextControl
+								label={ __( 'Card Message', 'newspack-plugin' ) }
+								help={ __( 'Custom message displayed in the card style indicator.', 'newspack-plugin' ) }
+								value={ settings.card_message }
+								onChange={ ( value: string ) => updateSetting( 'card_message', value ) }
+								placeholder={ DEFAULT_COLLECTIONS_SETTINGS.card_message }
+							/>
+						) }
 					</Grid>
 
 					<div className="newspack-buttons-card">

--- a/src/wizards/newspack/views/settings/collections/index.tsx
+++ b/src/wizards/newspack/views/settings/collections/index.tsx
@@ -2,21 +2,19 @@
  * Settings Collections: Global settings for Collections module.
  */
 
-/**
- * WordPress dependencies
- */
 import { __ } from '@wordpress/i18n';
 import { useState, useEffect } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
+import { ToggleControl } from '@wordpress/components';
+import WizardSection from '../../../../wizards-section';
 import WizardsActionCard from '../../../../wizards-action-card';
 import useWizardApiFetchToggle from '../../../../hooks/use-wizard-api-fetch-toggle';
 import { TextControl, SelectControl, Button, Grid } from '../../../../../components/src';
 import CustomNamingCard from './custom-naming-card';
 
-// Default values for collections settings
+// Collections per page options.
+const COLLECTIONS_PER_PAGE_OPTIONS = [ 12, 18, 24 ];
+
+// Default values for collections settings.
 const DEFAULT_COLLECTIONS_SETTINGS: CollectionsSettingsData = {
 	custom_naming_enabled: false,
 	custom_name: '',
@@ -26,6 +24,8 @@ const DEFAULT_COLLECTIONS_SETTINGS: CollectionsSettingsData = {
 	order_link: '',
 	post_indicator_style: 'default',
 	card_message: __( "Keep reading. There's plenty more to discover.", 'newspack-plugin' ),
+	posts_per_page: 12,
+	highlight_latest: false,
 };
 
 // Helper function to extract collection settings from API data with defaults.
@@ -94,53 +94,96 @@ function Collections() {
 				<>
 					<CustomNamingCard settings={ settings } isSaving={ isSavingSettings } onChange={ updateSetting } />
 
-					<Grid columns={ 2 } gutter={ 32 }>
-						<TextControl
-							label={ __( 'Subscription URL', 'newspack-plugin' ) }
-							help={ __(
-								'URL for the "Subscribe" button that will be displayed in the Collections archive pages when no subscription URL is set for the Collection or its parent category.',
-								'newspack-plugin'
-							) }
-							value={ settings.subscribe_link }
-							onChange={ ( value: string ) => updateSetting( 'subscribe_link', value ) }
-							placeholder={ `e.g., https://${ window.location.hostname }/subscribe` }
-						/>
-						<TextControl
-							label={ __( 'Order URL', 'newspack-plugin' ) }
-							help={ __(
-								'URL for the "Order" button that will be displayed in the Collections archive pages when no order URL is set for the Collection or its parent category.',
-								'newspack-plugin'
-							) }
-							value={ settings.order_link }
-							onChange={ ( value: string ) => updateSetting( 'order_link', value ) }
-							placeholder={ `e.g., https://${ window.location.hostname }/order` }
-						/>
-						<SelectControl
-							label={ __( 'Collection Indicator Style', 'newspack-plugin' ) }
-							help={ __(
-								'How collection indicators should be displayed on posts. When choosing the default style, an indicator with a link will be displayed at the bottom of the post content.',
-								'newspack-plugin'
-							) }
-							value={ settings.post_indicator_style }
-							onChange={ ( value: string ) => updateSetting( 'post_indicator_style', value ) }
-							buttonOptions={ [
-								{ label: __( 'Default', 'newspack-plugin' ), value: 'default' },
-								{ label: __( 'Card', 'newspack-plugin' ), value: 'card' },
-							] }
-						/>
-						{ settings.post_indicator_style === 'card' && (
+					<WizardSection
+						title={ __( 'Global CTAs', 'newspack-plugin' ) }
+						description={ __(
+							'Renderd in Collections-related pages. Can be overridden on a per-category or per-collection basis.',
+							'newspack-plugin'
+						) }
+					>
+						<Grid columns={ 2 } gutter={ 32 }>
 							<TextControl
-								label={ __( 'Card Message', 'newspack-plugin' ) }
+								label={ __( 'Subscription URL', 'newspack-plugin' ) }
 								help={ __(
-									'Custom message displayed in the card style indicator, along with the featured image and a button to view the collection.',
+									'URL for the "Subscribe" button that will be displayed in the Collections archive page when no subscription URL is set for the Collection or its parent category.',
 									'newspack-plugin'
 								) }
-								value={ settings.card_message }
-								onChange={ ( value: string ) => updateSetting( 'card_message', value ) }
-								placeholder={ DEFAULT_COLLECTIONS_SETTINGS.card_message }
+								value={ settings.subscribe_link }
+								onChange={ ( value: string ) => updateSetting( 'subscribe_link', value ) }
+								placeholder={ `e.g., https://${ window.location.hostname }/subscribe` }
 							/>
-						) }
-					</Grid>
+							<TextControl
+								label={ __( 'Order URL', 'newspack-plugin' ) }
+								help={ __(
+									'URL for the "Order" button that will be displayed in the Collections archive page when no order URL is set for the Collection or its parent category.',
+									'newspack-plugin'
+								) }
+								value={ settings.order_link }
+								onChange={ ( value: string ) => updateSetting( 'order_link', value ) }
+								placeholder={ `e.g., https://${ window.location.hostname }/order` }
+							/>
+						</Grid>
+					</WizardSection>
+
+					<WizardSection
+						title={ __( 'Collections Archive', 'newspack-plugin' ) }
+						description={ __( 'Customize the Collections archive page.', 'newspack-plugin' ) }
+					>
+						<Grid columns={ 2 } gutter={ 32 }>
+							<SelectControl
+								label={ __( 'Collections per page', 'newspack-plugin' ) }
+								help={ __( 'Number of collections to display per page in the Collections archive page.', 'newspack-plugin' ) }
+								value={ settings.posts_per_page }
+								onChange={ ( value: number ) => updateSetting( 'posts_per_page', value ) }
+								buttonOptions={ COLLECTIONS_PER_PAGE_OPTIONS.map( option => ( {
+									label: option.toString(),
+									value: option,
+								} ) ) }
+							/>
+							<ToggleControl
+								label={ __( 'Highlight Most Recent Collection', 'newspack-plugin' ) }
+								help={ __(
+									'Feature the latest Collection prominently at the top of the archive page, showcasing its content and any associated CTAs.',
+									'newspack-plugin'
+								) }
+								checked={ settings.highlight_latest }
+								onChange={ ( value: boolean ) => updateSetting( 'highlight_latest', value ) }
+							/>
+						</Grid>
+					</WizardSection>
+
+					<WizardSection
+						title={ __( 'Collection Posts', 'newspack-plugin' ) }
+						description={ __( 'Customize post single pages when they belong to a collection.', 'newspack-plugin' ) }
+					>
+						<Grid columns={ 2 } gutter={ 32 }>
+							<SelectControl
+								label={ __( 'Collection Indicator Style', 'newspack-plugin' ) }
+								help={ __(
+									'How collection indicators should be displayed on posts. When choosing the default style, an indicator with a link will be displayed at the bottom of the post content.',
+									'newspack-plugin'
+								) }
+								value={ settings.post_indicator_style }
+								onChange={ ( value: string ) => updateSetting( 'post_indicator_style', value ) }
+								buttonOptions={ [
+									{ label: __( 'Default', 'newspack-plugin' ), value: 'default' },
+									{ label: __( 'Card', 'newspack-plugin' ), value: 'card' },
+								] }
+							/>
+							{ settings.post_indicator_style === 'card' && (
+								<TextControl
+									label={ __( 'Card Message', 'newspack-plugin' ) }
+									help={ __(
+										'Custom message displayed in the card style indicator, along with the featured image and a button to view the collection.',
+										'newspack-plugin'
+									) }
+									value={ settings.card_message }
+									onChange={ ( value: string ) => updateSetting( 'card_message', value ) }
+									placeholder={ DEFAULT_COLLECTIONS_SETTINGS.card_message }
+								/>
+							) }
+						</Grid>
+					</WizardSection>
 
 					<div className="newspack-buttons-card">
 						<Button variant="primary" onClick={ handleSaveSettings } disabled={ isSavingSettings }>

--- a/src/wizards/newspack/views/settings/collections/index.tsx
+++ b/src/wizards/newspack/views/settings/collections/index.tsx
@@ -117,7 +117,10 @@ function Collections() {
 						/>
 						<SelectControl
 							label={ __( 'Collection Indicator Style', 'newspack-plugin' ) }
-							help={ __( 'Choose how collection indicators should be displayed on posts.', 'newspack-plugin' ) }
+							help={ __(
+								'How collection indicators should be displayed on posts. When choosing the default style, an indicator with a link will be displayed at the bottom of the post content.',
+								'newspack-plugin'
+							) }
 							value={ settings.post_indicator_style }
 							onChange={ ( value: string ) => updateSetting( 'post_indicator_style', value ) }
 							buttonOptions={ [
@@ -128,7 +131,10 @@ function Collections() {
 						{ settings.post_indicator_style === 'card' && (
 							<TextControl
 								label={ __( 'Card Message', 'newspack-plugin' ) }
-								help={ __( 'Custom message displayed in the card style indicator.', 'newspack-plugin' ) }
+								help={ __(
+									'Custom message displayed in the card style indicator, along with the featured image and a button to view the collection.',
+									'newspack-plugin'
+								) }
 								value={ settings.card_message }
 								onChange={ ( value: string ) => updateSetting( 'card_message', value ) }
 								placeholder={ DEFAULT_COLLECTIONS_SETTINGS.card_message }

--- a/src/wizards/newspack/views/settings/collections/types.d.ts
+++ b/src/wizards/newspack/views/settings/collections/types.d.ts
@@ -7,6 +7,8 @@ type CollectionsSettingsData = {
 	custom_slug: string;
 	subscribe_link: string;
 	order_link: string;
+	post_indicator_style: string;
+	card_message: string;
 };
 
 type FieldChangeHandler< T > = < K extends keyof T >( key: K, value: T[ K ] ) => void;

--- a/src/wizards/newspack/views/settings/collections/types.d.ts
+++ b/src/wizards/newspack/views/settings/collections/types.d.ts
@@ -9,6 +9,8 @@ type CollectionsSettingsData = {
 	order_link: string;
 	post_indicator_style: string;
 	card_message: string;
+	posts_per_page: number;
+	highlight_latest: boolean;
 };
 
 type FieldChangeHandler< T > = < K extends keyof T >( key: K, value: T[ K ] ) => void;

--- a/tests/unit-tests/collections/class-test-content-inserter.php
+++ b/tests/unit-tests/collections/class-test-content-inserter.php
@@ -1,0 +1,321 @@
+<?php
+/**
+ * Tests for the Content_Inserter class.
+ *
+ * @package Newspack\Tests\Unit\Collections
+ */
+
+namespace Newspack\Tests\Unit\Collections;
+
+use Newspack\Collections\Content_Inserter;
+use Newspack\Collections\Post_Type;
+use Newspack\Collections\Collection_Taxonomy;
+use Newspack\Collections\Sync;
+use Newspack\Collections\Enqueuer;
+
+/**
+ * Tests for the Content_Inserter class.
+ */
+class Test_Content_Inserter extends \WP_UnitTestCase {
+	use Traits\Trait_Collections_Test;
+	use Traits\Trait_Enqueuer_Test;
+
+	/**
+	 * Set up the test environment.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		Post_Type::init();
+		Collection_Taxonomy::register_taxonomy();
+	}
+
+	/**
+	 * Tear down the test environment.
+	 */
+	public function tear_down() {
+		parent::tear_down();
+
+		$this->reset_content_inserter_state();
+		remove_all_filters( 'the_content' );
+	}
+
+	/**
+	 * Reset Content_Inserter static state using reflection.
+	 */
+	private function reset_content_inserter_state() {
+		$reflection = new \ReflectionClass( Content_Inserter::class );
+		$reflection->setStaticPropertyValue( 'the_content_has_rendered', false );
+		$reflection->setStaticPropertyValue( 'post_collections', [] );
+	}
+
+	/**
+	 * Test check_if_post_is_in_collection behavior.
+	 *
+	 * @covers \Newspack\Collections\Content_Inserter::check_if_post_is_in_collection
+	 */
+	public function test_check_if_post_is_in_collection() {
+		$filter_name     = 'the_content';
+		$filter_function = [ Content_Inserter::class, 'maybe_insert_collection_indicators' ];
+
+		// Non-singular page should not add filter.
+		$this->go_to( home_url() );
+		Content_Inserter::check_if_post_is_in_collection();
+		$this->assertFalse( has_filter( $filter_name, $filter_function ), 'Filter should not be added on non-singular pages.' );
+
+		// Reset state.
+		$this->reset_content_inserter_state();
+
+		// Singular post with no collections should not add filter.
+		$post_id = self::factory()->post->create();
+		$this->go_to( get_permalink( $post_id ) );
+		Content_Inserter::check_if_post_is_in_collection();
+		$this->assertFalse( has_filter( $filter_name, $filter_function ), 'Filter should not be added when post is not in collections.' );
+
+		// Reset state.
+		$this->reset_content_inserter_state();
+
+		// Singular post with collections should add filter and enqueuer data.
+		$collection_id = $this->create_test_collection();
+
+		// Get the linked term and assign post to collection.
+		$term_id = Sync::get_term_linked_to_collection( $collection_id );
+		wp_set_object_terms( $post_id, $term_id, Collection_Taxonomy::get_taxonomy() );
+
+		$this->go_to( get_permalink( $post_id ) );
+		Content_Inserter::check_if_post_is_in_collection();
+
+		// Should add filter since post is in a collection.
+		$this->assertNotFalse( has_filter( $filter_name, $filter_function ), 'Filter should be added when post is in collections.' );
+
+		// Should add enqueuer data.
+		$enqueuer_data = Enqueuer::get_data();
+		$this->assertArrayHasKey( 'post_is_in_collections', $enqueuer_data, 'Enqueuer data should indicate post is in collections.' );
+		$this->assertTrue( $enqueuer_data['post_is_in_collections'], 'Post should be marked as being in collections.' );
+
+		// Clean up.
+		$this->reset_enqueuer_data();
+	}
+
+	/**
+	 * Test maybe_insert_collection_indicators early returns.
+	 *
+	 * @covers \Newspack\Collections\Content_Inserter::maybe_insert_collection_indicators
+	 */
+	public function test_maybe_insert_collection_indicators_early_returns() {
+		$content = '<p>Test content</p>';
+
+		// Test when already rendered.
+		$reflection = new \ReflectionClass( Content_Inserter::class );
+		$reflection->setStaticPropertyValue( 'the_content_has_rendered', true );
+
+		$result = Content_Inserter::maybe_insert_collection_indicators( $content );
+		$this->assertEquals( $content, $result, 'Content should be unchanged when already rendered.' );
+
+		// Reset state.
+		$this->reset_content_inserter_state();
+
+		// Test with empty content.
+		$result = Content_Inserter::maybe_insert_collection_indicators( '' );
+		$this->assertEquals( '', $result, 'Empty content should remain unchanged.' );
+	}
+
+	/**
+	 * Test maybe_insert_collection_indicators with default style.
+	 *
+	 * @covers \Newspack\Collections\Content_Inserter::maybe_insert_collection_indicators
+	 * @covers \Newspack\Collections\Content_Inserter::build_default_indicator_html
+	 */
+	public function test_maybe_insert_collection_indicators_default_style() {
+		$collection_title = 'Test Collection';
+		$collection_id    = $this->create_test_collection( [ 'post_title' => $collection_title ] );
+
+		// Set up collections for the inserter.
+		$reflection = new \ReflectionClass( Content_Inserter::class );
+		$reflection->setStaticPropertyValue( 'post_collections', [ $collection_id ] );
+
+		// Mock in_the_loop() to return true.
+		global $wp_query;
+		$wp_query->in_the_loop = true;
+
+		$content = '<p>Test content paragraph.</p>';
+		$result  = Content_Inserter::maybe_insert_collection_indicators( $content );
+
+		$this->assertStringContainsString( $content, $result, 'Original content should be preserved.' );
+		$this->assertStringContainsString( 'This article appears in', $result, 'Default indicator text should be present.' );
+		$this->assertStringContainsString( $collection_title, $result, 'Collection title should be present.' );
+		$this->assertStringContainsString( get_permalink( $collection_id ), $result, 'Collection link should be present.' );
+	}
+
+	/**
+	 * Test maybe_insert_collection_indicators with card style.
+	 *
+	 * @covers \Newspack\Collections\Content_Inserter::maybe_insert_collection_indicators
+	 * @covers \Newspack\Collections\Content_Inserter::build_card_html
+	 */
+	public function test_maybe_insert_collection_indicators_card_style() {
+		$collection_title = 'Test Collection';
+		$collection_id    = $this->create_test_collection( [ 'post_title' => $collection_title ] );
+
+		// Set up collections for the inserter.
+		$reflection = new \ReflectionClass( Content_Inserter::class );
+		$reflection->setStaticPropertyValue( 'post_collections', [ $collection_id ] );
+
+		// Mock settings to use card style.
+		$card_message = 'Custom card message';
+		add_filter(
+			'pre_option_newspack_collections_settings',
+			function () use ( $card_message ) {
+				return [
+					'post_indicator_style' => 'card',
+					'card_message'         => $card_message,
+				];
+			}
+		);
+
+		// Mock in_the_loop() to return true.
+		global $wp_query;
+		$wp_query->in_the_loop = true;
+
+		$content = '<p>First paragraph.</p><p>Second paragraph.</p><p>Third paragraph.</p>';
+		$result  = Content_Inserter::maybe_insert_collection_indicators( $content );
+
+		$this->assertStringContainsString( 'First paragraph', $result, 'First paragraph should be preserved.' );
+		$this->assertStringContainsString( 'Second paragraph', $result, 'Second paragraph should be preserved.' );
+		$this->assertStringContainsString( 'Browse ' . $collection_title, $result, 'Collection title should be present in card.' );
+		$this->assertStringContainsString( $card_message, $result, 'Custom card message should be present.' );
+		$this->assertStringContainsString( 'See more', $result, 'See more button should be present.' );
+
+		// Clean up.
+		remove_all_filters( 'pre_option_newspack_collections_settings' );
+	}
+
+	/**
+	 * Test maybe_insert_collection_indicators prevents double execution.
+	 *
+	 * @covers \Newspack\Collections\Content_Inserter::maybe_insert_collection_indicators
+	 */
+	public function test_maybe_insert_collection_indicators_prevents_double_execution() {
+		$collection_id = $this->create_test_collection( [ 'post_title' => 'Test Collection' ] );
+
+		// Set up collections for the inserter.
+		$reflection = new \ReflectionClass( Content_Inserter::class );
+		$reflection->setStaticPropertyValue( 'post_collections', [ $collection_id ] );
+
+		// Mock in_the_loop() to return true.
+		global $wp_query;
+		$wp_query->in_the_loop = true;
+
+		$content = '<p>Test content.</p>';
+
+		// First call should add indicators.
+		$result1 = Content_Inserter::maybe_insert_collection_indicators( $content );
+		$this->assertStringContainsString( 'This article appears in', $result1, 'First call should add indicators.' );
+
+		// Second call should not add indicators again.
+		$result2 = Content_Inserter::maybe_insert_collection_indicators( $content );
+		$this->assertEquals( $content, $result2, 'Second call should not modify content.' );
+	}
+
+	/**
+	 * Test build_card_html respects limit parameter.
+	 *
+	 * @covers \Newspack\Collections\Content_Inserter::build_card_html
+	 */
+	public function test_build_card_html_respects_limit() {
+		$collection_id_1 = $this->create_test_collection( [ 'post_title' => 'Collection 1' ] );
+		$collection_id_2 = $this->create_test_collection( [ 'post_title' => 'Collection 2' ] );
+
+		$result = Content_Inserter::build_card_html( [ $collection_id_1, $collection_id_2 ], 1 );
+
+		$this->assertStringContainsString( 'Collection 1', $result, 'First collection should be present.' );
+		$this->assertStringNotContainsString( 'Collection 2', $result, 'Second collection should not be present due to limit.' );
+	}
+
+	/**
+	 * Test insert_after_nth_block with insufficient blocks.
+	 *
+	 * @covers \Newspack\Collections\Content_Inserter::insert_after_nth_block
+	 */
+	public function test_insert_after_nth_block_insufficient_blocks() {
+		$content     = '<p>Only one paragraph.</p>';
+		$insert_html = '<div>Inserted content</div>';
+		$result      = Content_Inserter::insert_after_nth_block( $content, $insert_html, 3 );
+
+		// Should append at the end since there aren't 3 blocks.
+		$this->assertStringContainsString( $content, $result, 'Original content should be preserved.' );
+		$this->assertStringEndsWith( $insert_html, $result, 'Insert HTML should be appended at the end.' );
+	}
+
+	/**
+	 * Test insert_after_nth_block behavior with different content types.
+	 *
+	 * @covers \Newspack\Collections\Content_Inserter::insert_after_nth_block
+	 */
+	public function test_insert_after_nth_block() {
+		$insert_html = '<div>Inserted content</div>';
+
+		// Test HTML content.
+		$html_content = '<p>First paragraph.</p><p>Second paragraph.</p>';
+		$html_result  = Content_Inserter::insert_after_nth_block( $html_content, $insert_html, 2 );
+		$this->assertEquals( $html_content . $insert_html, $html_result, 'HTML content should append at end when insufficient blocks detected.' );
+
+		// Test Gutenberg blocks.
+		$block_content = "<!-- wp:paragraph -->\n<p>First paragraph.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Second paragraph.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Third paragraph.</p>\n<!-- /wp:paragraph -->";
+		$block_result  = Content_Inserter::insert_after_nth_block( $block_content, $insert_html, 2 );
+
+		$this->assertStringContainsString( '<p>First paragraph.</p>', $block_result, 'First paragraph should be present.' );
+		$this->assertStringContainsString( '<p>Second paragraph.</p>', $block_result, 'Second paragraph should be present.' );
+		$this->assertStringContainsString( $insert_html, $block_result, 'Inserted content should be present.' );
+		$this->assertStringContainsString( '<p>Third paragraph.</p>', $block_result, 'Third paragraph should be present.' );
+
+		// Verify proper insertion order for Gutenberg blocks.
+		$second_pos = strpos( $block_result, '<p>Second paragraph.</p>' );
+		$insert_pos = strpos( $block_result, $insert_html );
+		$third_pos  = strpos( $block_result, '<p>Third paragraph.</p>' );
+
+		$this->assertGreaterThan( $second_pos, $insert_pos, 'Inserted content should come after second paragraph.' );
+		$this->assertLessThan( $third_pos, $insert_pos, 'Inserted content should come before third paragraph.' );
+	}
+
+	/**
+	 * Test build_default_indicator_html with empty collections.
+	 *
+	 * @covers \Newspack\Collections\Content_Inserter::build_default_indicator_html
+	 */
+	public function test_build_default_indicator_html_empty() {
+		$result = Content_Inserter::build_default_indicator_html( [] );
+		$this->assertEmpty( $result, 'Empty collections should return empty string.' );
+	}
+
+	/**
+	 * Test build_default_indicator_html with valid collections.
+	 *
+	 * @covers \Newspack\Collections\Content_Inserter::build_default_indicator_html
+	 */
+	public function test_build_default_indicator_html_with_collections() {
+		$collection_title = 'Test Collection';
+		$collection_id    = $this->create_test_collection( [ 'post_title' => $collection_title ] );
+
+		$result = Content_Inserter::build_default_indicator_html( [ $collection_id ] );
+
+		$this->assertStringContainsString( 'This article appears in', $result, 'Default indicator text should be present.' );
+		$this->assertStringContainsString( $collection_title, $result, 'Collection title should be present.' );
+		$this->assertStringContainsString( get_permalink( $collection_id ), $result, 'Collection permalink should be present.' );
+	}
+
+	/**
+	 * Test build_default_indicator_html respects limit parameter.
+	 *
+	 * @covers \Newspack\Collections\Content_Inserter::build_default_indicator_html
+	 */
+	public function test_build_default_indicator_html_respects_limit() {
+		$collection_id_1 = $this->create_test_collection( [ 'post_title' => 'Collection 1' ] );
+		$collection_id_2 = $this->create_test_collection( [ 'post_title' => 'Collection 2' ] );
+
+		$result = Content_Inserter::build_default_indicator_html( [ $collection_id_1, $collection_id_2 ], 1 );
+
+		$this->assertStringContainsString( 'Collection 1', $result, 'First collection should be present.' );
+		$this->assertStringNotContainsString( 'Collection 2', $result, 'Second collection should not be present due to limit.' );
+	}
+}

--- a/tests/unit-tests/collections/class-test-content-inserter.php
+++ b/tests/unit-tests/collections/class-test-content-inserter.php
@@ -127,12 +127,12 @@ class Test_Content_Inserter extends \WP_UnitTestCase {
 	 * @covers \Newspack\Collections\Content_Inserter::build_default_indicator_html
 	 */
 	public function test_maybe_insert_collection_indicators_default_style() {
-		$collection_title = 'Test Collection';
-		$collection_id    = $this->create_test_collection( [ 'post_title' => $collection_title ] );
+		$collection_id_1 = $this->create_test_collection( [ 'post_title' => 'Test Collection 1' ] );
+		$collection_id_2 = $this->create_test_collection( [ 'post_title' => 'Test Collection 2' ] );
 
 		// Set up collections for the inserter.
 		$reflection = new \ReflectionClass( Content_Inserter::class );
-		$reflection->setStaticPropertyValue( 'post_collections', [ $collection_id ] );
+		$reflection->setStaticPropertyValue( 'post_collections', [ $collection_id_1, $collection_id_2 ] );
 
 		// Mock in_the_loop() to return true.
 		global $wp_query;
@@ -143,8 +143,8 @@ class Test_Content_Inserter extends \WP_UnitTestCase {
 
 		$this->assertStringContainsString( $content, $result, 'Original content should be preserved.' );
 		$this->assertStringContainsString( 'This article appears in', $result, 'Default indicator text should be present.' );
-		$this->assertStringContainsString( $collection_title, $result, 'Collection title should be present.' );
-		$this->assertStringContainsString( get_permalink( $collection_id ), $result, 'Collection link should be present.' );
+		$this->assertStringContainsString( get_the_title( $collection_id_1 ), $result, 'Collection title should be present.' );
+		$this->assertStringContainsString( get_permalink( $collection_id_2 ), $result, 'Collection link should be present.' );
 	}
 
 	/**

--- a/tests/unit-tests/collections/class-test-settings.php
+++ b/tests/unit-tests/collections/class-test-settings.php
@@ -32,7 +32,8 @@ class Test_Settings extends WP_UnitTestCase {
 	 */
 	public function test_get_settings_returns_defaults_when_empty() {
 		$settings = Settings::get_settings();
-		$this->assertEquals( Settings::FIELDS, $settings );
+		$defaults = Settings::get_rest_args( 'defaults' );
+		$this->assertEquals( $defaults, $settings );
 	}
 
 	/**
@@ -50,7 +51,8 @@ class Test_Settings extends WP_UnitTestCase {
 		update_option( Settings::OPTION_NAME, $existing_settings );
 
 		$settings = Settings::get_settings();
-		$expected = array_merge( Settings::FIELDS, $existing_settings );
+		$defaults = Settings::get_rest_args( 'defaults' );
+		$expected = array_merge( $defaults, $existing_settings );
 
 		$this->assertEquals( $expected, $settings );
 	}
@@ -118,10 +120,11 @@ class Test_Settings extends WP_UnitTestCase {
 		$this->assertIsArray( $rest_args );
 
 		// Test all expected fields exist.
-		$expected_fields = array_keys( Settings::FIELDS );
+		$expected_fields = Settings::get_rest_args( 'keys' );
 		foreach ( $expected_fields as $field ) {
 			$this->assertArrayHasKey( $field, $rest_args );
 			$this->assertArrayHasKey( 'required', $rest_args[ $field ] );
+			$this->assertArrayHasKey( 'default', $rest_args[ $field ] );
 			$this->assertArrayHasKey( 'sanitize_callback', $rest_args[ $field ] );
 			$this->assertFalse( $rest_args[ $field ]['required'] );
 			$this->assertIsCallable( $rest_args[ $field ]['sanitize_callback'] );
@@ -162,6 +165,16 @@ class Test_Settings extends WP_UnitTestCase {
 		$this->assertEquals( 'clean-slug', $slug_callback( 'Clean Slug' ) );
 		$this->assertEquals( 'clean-slug', $slug_callback( 'Clean Slug!' ) );
 		$this->assertEquals( '', $slug_callback( 123 ) ); // Non-string should return empty string.
+
+		// Test post indicator style sanitization.
+		$style_callback = $rest_args['post_indicator_style']['sanitize_callback'];
+		$this->assertEquals( 'default', $style_callback( 'default' ) );
+		$this->assertEquals( 'custom', $style_callback( 'custom' ) );
+
+		// Test card message sanitization.
+		$message_callback = $rest_args['card_message']['sanitize_callback'];
+		$this->assertEquals( 'Custom message', $message_callback( 'Custom message' ) );
+		$this->assertEquals( 'Clean message', $message_callback( '<script>alert("xss")</script>Clean message' ) );
 	}
 
 	/**
@@ -171,9 +184,10 @@ class Test_Settings extends WP_UnitTestCase {
 	 */
 	public function test_update_from_request_handles_non_field_parameters_and_empty_requests() {
 		// Test with empty request.
-		$request = new WP_REST_Request();
-		$result  = Settings::update_from_request( $request );
-		$this->assertEquals( Settings::FIELDS, $result );
+		$request  = new WP_REST_Request();
+		$result   = Settings::update_from_request( $request );
+		$defaults = Settings::get_rest_args( 'defaults' );
+		$this->assertEquals( $defaults, $result );
 
 		// Test ignores non-field parameters.
 		$request = new WP_REST_Request();

--- a/tests/unit-tests/collections/class-test-settings.php
+++ b/tests/unit-tests/collections/class-test-settings.php
@@ -175,6 +175,18 @@ class Test_Settings extends WP_UnitTestCase {
 		$message_callback = $rest_args['card_message']['sanitize_callback'];
 		$this->assertEquals( 'Custom message', $message_callback( 'Custom message' ) );
 		$this->assertEquals( 'Clean message', $message_callback( '<script>alert("xss")</script>Clean message' ) );
+
+		// Test posts per page archive sanitization.
+		$posts_per_page_callback = $rest_args['posts_per_page']['sanitize_callback'];
+		foreach ( Settings::POSTS_PER_PAGE_OPTIONS as $option ) {
+			$this->assertEquals( $option, $posts_per_page_callback( $option ) );
+		}
+		$this->assertEquals( 12, $posts_per_page_callback( 42 ) ); // Invalid values default to 12.
+
+		// Test highlight latest sanitization.
+		$highlight_latest_callback = $rest_args['highlight_latest']['sanitize_callback'];
+		$this->assertTrue( $highlight_latest_callback( 'true' ) );
+		$this->assertFalse( $highlight_latest_callback( 'false' ) );
 	}
 
 	/**

--- a/tests/unit-tests/collections/class-test-template-helper.php
+++ b/tests/unit-tests/collections/class-test-template-helper.php
@@ -254,4 +254,32 @@ class Test_Template_Helper extends \WP_UnitTestCase {
 		$this->assertStringContainsString( '<a ', $html, 'See all link should be rendered.' );
 		$this->assertStringContainsString( get_post_type_archive_link( Post_Type::get_post_type() ), $html, 'See all link should point to the collection archive.' );
 	}
+
+	/**
+	 * Test load_template_part handles collections template parts correctly.
+	 *
+	 * @covers \Newspack\Collections\Template_Helper::load_template_part
+	 */
+	public function test_load_template_part() {
+		ob_start();
+		Template_Helper::load_template_part( Template_Helper::TEMPLATE_PARTS_DIR . 'newspack-collection-intro', null, [], [] );
+		$output = ob_get_clean();
+		$this->assertNotEmpty( $output, 'Collections template part should be processed.' );
+		$this->assertStringContainsString( 'collection-intro', $output, 'Collections template part should contain "collection-intro".' );
+
+		// Test collections template part with name parameter.
+		ob_start();
+		Template_Helper::load_template_part( Template_Helper::TEMPLATE_PARTS_DIR . 'newspack-collection-intro', 'variant', [], [] );
+		$this->assertEmpty( ob_get_clean(), 'Template with name should not output without existing file.' );
+
+		// Test collections template part with missing file should not output anything.
+		ob_start();
+		Template_Helper::load_template_part( Template_Helper::TEMPLATE_PARTS_DIR . 'non-existent', null, [], [] );
+		$this->assertEmpty( ob_get_clean(), 'Missing template should not output anything.' );
+
+		// Test non-collections template part.
+		ob_start();
+		Template_Helper::load_template_part( 'some/other/template', null, [], [] );
+		$this->assertEmpty( ob_get_clean(), 'Non-collections template should not be processed.' );
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR introduces a new feature that allows publishers to display visual indicators when posts are part of a collection. The implementation includes:
- New collection indicator global settings that allow publishers to configure the style and message for collection indicators, including options for two different visual styles:
    - Default
      - Display a short sentence near the bottom of the post.
      - Place it just above any corrections or clarifications section.
      - Include a link back to the relevant Collection.
    - Card:
      - Automatically insert a visually distinct card after the 2nd paragraph of the post (with a logic similar to what the `newspack-popups` plugin does for [inserting popups in the content](https://github.com/Automattic/newspack-popups/blob/34af5f6173f04f109180392d0c011a2e64159879/includes/class-newspack-popups-inserter.php#L273)).
      - If there are fewer than 2 paragraphs, it will be inserted at the end of the content.
      - Allow publishers to customize the card message.
- New content inserter class that automatically adds collection indicators to posts when they belong to a collection.
- Improved the `ButtonGroupControl` component interface to render the help property when passed from a `SelectControl`.

Closes NPPD-664.

### How to test the changes in this Pull Request:
1. Enable the Collections module:
    - Navigate to Newspack > Settings > Collections
    - Enable the Collections module
2. Configure Collection settings:
    - Verify that new options for collection indicator style and message are available and can be configured properly
3. Test Content Insertion:
    - Create or assign posts to collections
    - Verify that collection indicators appear on the frontend with the configured style and message
    - Check that the collection indicators display correctly across different breakpoints and post content layouts
    - Validate that the indicators don't interfere with existing content
    - Validate that the links point to the current collection

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?