### PR TITLE
feat(collections): highlight latest collection feature

### DIFF
--- a/includes/collections/class-query-helper.php
+++ b/includes/collections/class-query-helper.php
@@ -133,13 +133,14 @@ class Query_Helper {
 	/**
 	 * Get processed CTAs from a collection post.
 	 *
-	 * @param int      $post_id     The post ID.
-	 * @param int|null $limit       Optional limit on the number of CTAs.
-	 * @param bool     $hierarchical Whether to include hierarchical CTAs. Default is true.
+	 * @param int|WP_Post $post         The post ID or post object.
+	 * @param int|null    $limit        Optional limit on the number of CTAs.
+	 * @param bool        $hierarchical Whether to include hierarchical CTAs. Default is true.
 	 * @return array Array of processed CTAs with 'url' and 'label' keys.
 	 */
-	public static function get_ctas( $post_id, $limit = null, $hierarchical = true ) {
-		$ctas = Collection_Meta::get( $post_id, 'ctas' );
+	public static function get_ctas( $post, $limit = null, $hierarchical = true ) {
+		$post_id = $post instanceof \WP_Post ? $post->ID : $post;
+		$ctas    = Collection_Meta::get( $post_id, 'ctas' );
 
 		if ( ! is_array( $ctas ) ) {
 			$ctas = [];
@@ -199,8 +200,8 @@ class Query_Helper {
 	 */
 	public static function get_hierarchical_ctas( $post_id ) {
 		$cta_keys = [
-			'subscribe_link' => __( 'Subscribe', 'newspack' ),
-			'order_link'     => __( 'Order', 'newspack' ),
+			'subscribe_link' => __( 'Subscribe', 'newspack-plugin' ),
+			'order_link'     => __( 'Order', 'newspack-plugin' ),
 		];
 
 		$ctas = array_values(

--- a/includes/collections/class-settings.php
+++ b/includes/collections/class-settings.php
@@ -82,6 +82,11 @@ class Settings {
 					return in_array( $value, self::POSTS_PER_PAGE_OPTIONS, true ) ? $value : 12;
 				},
 			],
+			'highlight_latest'      => [
+				'required'          => false,
+				'default'           => false,
+				'sanitize_callback' => 'rest_sanitize_boolean',
+			],
 		];
 
 		switch ( $return_type ) {

--- a/includes/collections/class-template-helper.php
+++ b/includes/collections/class-template-helper.php
@@ -83,10 +83,10 @@ class Template_Helper {
 	 * Override template part loading for Collections pages to use plugin templates as fallback.
 	 * Follows WordPress template hierarchy - theme template parts take precedence.
 	 *
-	 * @param string   $slug      The template slug.
-	 * @param string   $name      The template name.
+	 * @param string   $slug      The slug name for the generic template.
+	 * @param string   $name      The name of the specialized template or an empty string if there is none.
 	 * @param string[] $templates Array of template names.
-	 * @param array    $args      Additional arguments.
+	 * @param array    $args      Additional arguments passed to the template.
 	 */
 	public static function load_template_part( $slug, $name, $templates, $args ) {
 		if ( ! str_starts_with( $slug, self::TEMPLATE_PARTS_DIR ) ) {
@@ -102,8 +102,24 @@ class Template_Helper {
 			return;
 		}
 
-		// Fallback to plugin template.
-		$plugin_template = plugin_dir_path( __DIR__ ) . "templates/{$template_file}";
+		/**
+		 * Filters the fallback plugin template path before attempting to load it.
+		 *
+		 * @param string $plugin_template Path to the plugin template.
+		 * @param string $template_file   Relative template file name.
+		 * @param string $slug            The slug name for the generic template.
+		 * @param string $name            The name of the specialized template or an empty string if there is none.
+		 * @param array  $args            Additional arguments passed to the template.
+		 */
+		$plugin_template = apply_filters(
+			'newspack_collections_plugin_template_part',
+			plugin_dir_path( __DIR__ ) . "templates/{$template_file}",
+			$template_file,
+			$slug,
+			$name,
+			$args
+		);
+
 		if ( file_exists( $plugin_template ) ) {
 			load_template( $plugin_template, false, $args );
 		}

--- a/includes/collections/class-template-helper.php
+++ b/includes/collections/class-template-helper.php
@@ -15,10 +15,18 @@ defined( 'ABSPATH' ) || exit;
 class Template_Helper {
 
 	/**
+	 * The directory where the collection template parts are located.
+	 *
+	 * @var string
+	 */
+	public const TEMPLATE_PARTS_DIR = 'collections/parts/';
+
+	/**
 	 * Initialize hooks.
 	 */
 	public static function init() {
 		add_filter( 'template_include', [ __CLASS__, 'template_include' ] );
+		add_action( 'get_template_part', [ __CLASS__, 'load_template_part' ], 10, 4 );
 		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'enqueue_assets' ], 5 );
 		add_action( 'pre_get_posts', [ __CLASS__, 'archive_filters' ] );
 		add_filter( 'redirect_canonical', [ __CLASS__, 'prevent_year_redirect' ] );
@@ -69,6 +77,36 @@ class Template_Helper {
 		$plugin_template = plugin_dir_path( __DIR__ ) . 'templates/collections/' . $template_name;
 
 		return file_exists( $plugin_template ) ? $plugin_template : '';
+	}
+
+	/**
+	 * Override template part loading for Collections pages to use plugin templates as fallback.
+	 * Follows WordPress template hierarchy - theme template parts take precedence.
+	 *
+	 * @param string   $slug      The template slug.
+	 * @param string   $name      The template name.
+	 * @param string[] $templates Array of template names.
+	 * @param array    $args      Additional arguments.
+	 */
+	public static function load_template_part( $slug, $name, $templates, $args ) {
+		if ( ! str_starts_with( $slug, self::TEMPLATE_PARTS_DIR ) ) {
+			return;
+		}
+
+		// Build the template file path.
+		$template_file = ( $name ? "{$slug}-{$name}" : $slug ) . '.php';
+
+		// Look in theme first.
+		$theme_template = locate_template( $template_file );
+		if ( $theme_template ) {
+			return;
+		}
+
+		// Fallback to plugin template.
+		$plugin_template = plugin_dir_path( __DIR__ ) . "templates/{$template_file}";
+		if ( file_exists( $plugin_template ) ) {
+			load_template( $plugin_template, false, $args );
+		}
 	}
 
 	/**
@@ -192,11 +230,12 @@ class Template_Helper {
 	/**
 	 * Get formatted collection metadata text.
 	 *
-	 * @param int $post_id Post ID.
-	 * @param int $lines   Number of lines to output (1 = inline, 2 = stacked). Default 2.
+	 * @param int|WP_Post $post  Post ID or post object.
+	 * @param int         $lines Number of lines to output (1 = inline, 2 = stacked). Default 2.
 	 * @return string Formatted metadata text.
 	 */
-	public static function render_meta_text( $post_id, $lines = 2 ) {
+	public static function render_meta_text( $post, $lines = 2 ) {
+		$post_id    = $post instanceof \WP_Post ? $post->ID : $post;
 		$meta_parts = [];
 		$volume     = Collection_Meta::get( $post_id, 'volume' );
 		$number     = Collection_Meta::get( $post_id, 'number' );
@@ -343,7 +382,7 @@ class Template_Helper {
 	 */
 	public static function render_see_all_link() {
 		$link  = get_post_type_archive_link( Post_Type::get_post_type() );
-		$label = __( 'See all', 'newspack' );
+		$label = __( 'See all', 'newspack-plugin' );
 		$html  = sprintf( '<a href="%s">%s</a>', esc_url( $link ), esc_html( $label ) );
 
 		/**

--- a/includes/collections/class-template-helper.php
+++ b/includes/collections/class-template-helper.php
@@ -392,4 +392,14 @@ class Template_Helper {
 		 */
 		return apply_filters( 'newspack_collections_see_all_link_html', $html );
 	}
+
+	/**
+	 * Render a separator.
+	 *
+	 * @param string $class_name Optional class for the separator.
+	 * @return string The separator HTML.
+	 */
+	public static function render_separator( $class_name = '' ) {
+		return '<hr class="has-light-gray-background-color has-background is-style-wide ' . esc_attr( $class_name ) . '"/>';
+	}
 }

--- a/includes/templates/collections/archive-newspack-collection.php
+++ b/includes/templates/collections/archive-newspack-collection.php
@@ -43,9 +43,9 @@ do_action( 'newspack_collections_archive_start' );
 
 				// Advance the loop to the next post so it doesn't render twice.
 				the_post();
-				?>
-				<hr class="has-light-gray-background-color has-background is-style-wide"/>
-			<?php endif; ?>
+				echo wp_kses_post( Template_Helper::render_separator( 'is-latest-collection' ) );
+			endif;
+			?>
 
 			<!-- Filter controls -->
 			<form class="collections-filter" method="get">
@@ -84,9 +84,9 @@ do_action( 'newspack_collections_archive_start' );
 
 			</form> <!-- .collections-filter -->
 
-			<hr class="has-light-gray-background-color has-background is-style-wide"/>
-
 			<?php
+			echo wp_kses_post( Template_Helper::render_separator() );
+
 			/**
 			 * Fires after the filter controls in the archive template.
 			 *

--- a/includes/templates/collections/archive-newspack-collection.php
+++ b/includes/templates/collections/archive-newspack-collection.php
@@ -28,7 +28,24 @@ do_action( 'newspack_collections_archive_start' );
 
 	<main id="main" class="site-main">
 
-		<?php if ( have_posts() ) : ?>
+		<?php
+		if ( have_posts() ) :
+			// Render the intro section only if it's the first page of results and "Highlight Most Recent Collection" setting is enabled.
+			if ( ! is_paged() && Settings::get_setting( 'highlight_latest' ) ) :
+				get_template_part(
+					Template_Helper::TEMPLATE_PARTS_DIR . 'newspack-collection-intro',
+					null,
+					[
+						'is_latest' => true,
+						'permalink' => true,
+					]
+				);
+
+				// Advance the loop to the next post so it doesn't render twice.
+				the_post();
+				?>
+				<hr class="has-light-gray-background-color has-background is-style-wide"/>
+			<?php endif; ?>
 
 			<!-- Filter controls -->
 			<form class="collections-filter" method="get">
@@ -39,9 +56,9 @@ do_action( 'newspack_collections_archive_start' );
 				?>
 
 				<div class="collections-filter__select">
-					<label for="year"><?php esc_html_e( 'Year:', 'newspack' ); ?></label>
+					<label for="year"><?php esc_html_e( 'Year:', 'newspack-plugin' ); ?></label>
 					<select name="year" id="year">
-						<option value="" <?php selected( $selected_year, '' ); ?>><?php esc_html_e( 'All', 'newspack' ); ?></option>
+						<option value="" <?php selected( $selected_year, '' ); ?>><?php esc_html_e( 'All', 'newspack-plugin' ); ?></option>
 						<?php foreach ( $available_years as $available_year ) : ?>
 							<option value="<?php echo esc_attr( $available_year ); ?>" <?php selected( $selected_year, $available_year ); ?>><?php echo esc_html( $available_year ); ?></option>
 						<?php endforeach; ?>
@@ -54,9 +71,9 @@ do_action( 'newspack_collections_archive_start' );
 				if ( count( $categories ) > 1 ) :
 					?>
 					<div class="collections-filter__select">
-						<label for="category"><?php esc_html_e( 'Publication:', 'newspack' ); ?></label>
+						<label for="category"><?php esc_html_e( 'Publication:', 'newspack-plugin' ); ?></label>
 						<select name="category" id="category">
-							<option value="" <?php selected( $selected_category, '' ); ?>><?php esc_html_e( 'All', 'newspack' ); ?></option>
+							<option value="" <?php selected( $selected_category, '' ); ?>><?php esc_html_e( 'All', 'newspack-plugin' ); ?></option>
 							<?php foreach ( $categories as $category ) : ?>
 								<option value="<?php echo esc_attr( $category->slug ); ?>" <?php selected( $selected_category, $category->slug ); ?>><?php echo esc_html( $category->name ); ?></option>
 							<?php endforeach; ?>
@@ -66,6 +83,8 @@ do_action( 'newspack_collections_archive_start' );
 				<?php endif; ?>
 
 			</form> <!-- .collections-filter -->
+
+			<hr class="has-light-gray-background-color has-background is-style-wide"/>
 
 			<?php
 			/**

--- a/includes/templates/collections/parts/newspack-collection-intro.php
+++ b/includes/templates/collections/parts/newspack-collection-intro.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Template part for the Collection intro section.
+ *
+ * @package Newspack\Collections
+ */
+
+use Newspack\Collections\Query_Helper;
+use Newspack\Collections\Template_Helper;
+
+$collection       = ( $args['collection'] ?? null ); // Allow overriding the collection post object by passing it as an argument.
+$collection       = $collection instanceof WP_Post ? $collection : get_post( $collection ); // The collection argument could be either post object or post ID.
+$is_latest        = ( $args['is_latest'] ?? false );
+$collection_title = get_the_title( $collection );
+$permalink        = match ( true ) { // Allow overriding the permalink by passing it as a string or a boolean argument.
+	is_string( $args['permalink'] ?? null )  => $args['permalink'],               // If the argument is a string, use it as the permalink.
+	( $args['permalink'] ?? false ) === true => get_the_permalink( $collection ), // If a `true` boolean, use the collection permalink.
+	default                                  => false,                            // If not provided (or if a falsey value), don't use a permalink.
+};
+
+/**
+ * Fires before the collection intro section.
+ *
+ * @param WP_Post $collection The collection post.
+ */
+do_action( 'newspack_collections_intro_before', $collection );
+?>
+
+<!-- Intro Section -->
+<div class="collection-intro">
+
+	<!-- Cover Card -->
+	<div class="collection-intro__card">
+		<?php
+		/**
+		 * Fires before the collection image card in the intro section.
+		 *
+		 * @param WP_Post $collection The collection post.
+		 */
+		do_action( 'newspack_collections_intro_image_card', $collection );
+
+		echo wp_kses_post( Template_Helper::render_image( $collection, $permalink ) );
+		?>
+	</div>
+
+	<!-- Content -->
+	<div class="collection-intro__content">
+		<?php
+		/**
+		 * Fires before the collection meta in the intro content section.
+		 *
+		 * @param WP_Post $collection The collection post.
+		 */
+		do_action( 'newspack_collections_intro_before_meta', $collection );
+		?>
+
+		<div class="collection-intro__content__meta">
+			<?php if ( $is_latest ) : ?>
+				<h6 class="wp-block-heading latest-collection-heading has-primary-color has-text-color has-link-color has-normal-font-size"><?php echo esc_html_e( 'Latest', 'newspack-plugin' ); ?></h6>
+			<?php endif; ?>
+			<h1>
+				<?php if ( $permalink ) : ?>
+					<a href="<?php echo esc_url( $permalink ); ?>">
+						<?php echo wp_kses_post( $collection_title ); ?>
+					</a>
+				<?php else : ?>
+					<?php echo wp_kses_post( $collection_title ); ?>
+				<?php endif; ?>
+			</h1>
+			<?php echo wp_kses_post( Template_Helper::render_meta_text( $collection, 1 ) ); ?>
+		</div>
+
+		<div class="collection-intro__content__description">
+			<?php
+			/**
+			 * Fires before the collection description in the intro section.
+			 *
+			 * @param WP_Post $collection The collection post.
+			 */
+			do_action( 'newspack_collections_intro_before_description', $collection );
+
+			echo wp_kses_post( get_the_content( null, false, $collection ) );
+			?>
+		</div>
+
+		<?php
+		$ctas = Query_Helper::get_ctas( $collection );
+		if ( $ctas ) :
+			?>
+			<div class="collection-buttons">
+				<?php foreach ( $ctas as $cta ) : ?>
+					<?php echo wp_kses_post( Template_Helper::render_cta( $cta ) ); ?>
+				<?php endforeach; ?>
+			</div>
+		<?php endif; ?>
+	</div>
+</div>
+
+<?php
+/**
+ * Fires after the collection intro section.
+ *
+ * @param WP_Post $collection The collection post.
+ */
+do_action( 'newspack_collections_intro_after', $collection );
+?>

--- a/includes/templates/collections/single-newspack-collection.php
+++ b/includes/templates/collections/single-newspack-collection.php
@@ -37,11 +37,9 @@ get_header();
 			 * @param int $collection_id The collection post ID.
 			 */
 			do_action( 'newspack_collections_single_after_intro', $collection_id );
-			?>
 
-			<hr class="has-light-gray-background-color has-background is-style-wide"/>
+			echo wp_kses_post( Template_Helper::render_separator( 'is-latest-collection' ) );
 
-			<?php
 			// Get posts in this collection organized by sections.
 			$collection_posts = Query_Helper::get_collection_posts( $collection_id );
 
@@ -79,8 +77,8 @@ get_header();
 			$recent_collections = Query_Helper::get_recent( [ $collection_id ], 6 );
 
 			if ( $recent_collections ) :
+				echo wp_kses_post( Template_Helper::render_separator( 'is-latest-collection' ) );
 				?>
-				<hr class="has-light-gray-background-color has-background is-style-wide"/>
 
 				<!-- Recent Collections Section -->
 				<div class="collections-recent">

--- a/includes/templates/collections/single-newspack-collection.php
+++ b/includes/templates/collections/single-newspack-collection.php
@@ -28,50 +28,9 @@ get_header();
 			 * @param WP_Post $post The collection post.
 			 */
 			do_action( 'newspack_collections_single_start', $post );
-			?>
 
-			<!-- Intro Section -->
-			<div class="collection-intro">
+			get_template_part( Template_Helper::TEMPLATE_PARTS_DIR . 'newspack-collection-intro' );
 
-				<!-- Cover Card -->
-				<div class="collection-intro__card">
-					<?php echo wp_kses_post( Template_Helper::render_image( $post, false ) ); ?>
-				</div>
-
-				<!-- Content -->
-				<div class="collection-intro__content">
-					<div class="collection-intro__content__meta">
-						<h1><?php the_title(); ?></h1>
-						<?php echo wp_kses_post( Template_Helper::render_meta_text( $collection_id, 1 ) ); ?>
-					</div>
-
-					<?php
-					/**
-					 * Fires after the collection meta in the intro section.
-					 *
-					 * @param int $collection_id The collection post ID.
-					 */
-					do_action( 'newspack_collections_single_after_meta', $collection_id );
-					?>
-
-					<div class="collection-intro__content__description">
-						<?php the_content(); ?>
-					</div>
-
-					<?php
-					$ctas = Query_Helper::get_ctas( $collection_id );
-					if ( $ctas ) :
-						?>
-						<div class="collection-buttons">
-							<?php foreach ( $ctas as $cta ) : ?>
-								<?php echo wp_kses_post( Template_Helper::render_cta( $cta ) ); ?>
-							<?php endforeach; ?>
-						</div>
-					<?php endif; ?>
-				</div>
-			</div>
-
-			<?php
 			/**
 			 * Fires after the collection intro section.
 			 *
@@ -103,7 +62,7 @@ get_header();
 
 					$is_cover     = Query_Helper::COVER_SECTION === $section_slug;
 					$section_name = $is_cover
-						? ( count( $post_ids ) > 1 ? __( 'Cover Stories', 'newspack' ) : __( 'Cover Story', 'newspack' ) )
+						? ( count( $post_ids ) > 1 ? __( 'Cover Stories', 'newspack-plugin' ) : __( 'Cover Story', 'newspack-plugin' ) )
 						: Query_Helper::get_section_name( $section_slug );
 					$show_image   = ! $is_cover;
 					$columns      = $is_cover ? 1 : 2;
@@ -126,7 +85,7 @@ get_header();
 				<!-- Recent Collections Section -->
 				<div class="collections-recent">
 					<div class="collections-recent__header">
-						<h2><?php esc_html_e( 'Recent', 'newspack' ); ?></h2>
+						<h2><?php esc_html_e( 'Recent', 'newspack-plugin' ); ?></h2>
 						<p class="has-medium-gray-color has-text-color has-link-color has-small-font-size">
 							<?php echo wp_kses_post( Template_Helper::render_see_all_link() ); ?>
 						</p>

--- a/src/collections/frontend/_archive.scss
+++ b/src/collections/frontend/_archive.scss
@@ -7,6 +7,10 @@
 		width: 100%;
 	}
 
+	hr {
+		margin: 16px 0;
+	}
+
 	.collections-filter {
 		font-size: var(--newspack-theme-font-size-base-sm);
 		gap: 16px;

--- a/src/collections/frontend/_archive.scss
+++ b/src/collections/frontend/_archive.scss
@@ -1,4 +1,5 @@
 @use "breakpoints" as bp;
+@use "intro";
 
 /* Collections archive template styles */
 .post-type-archive-newspack_collection {

--- a/src/collections/frontend/_intro.scss
+++ b/src/collections/frontend/_intro.scss
@@ -1,0 +1,66 @@
+@use "breakpoints" as bp;
+
+/* Collection intro styles */
+.collection-intro {
+	display: grid;
+	grid-template-columns: 1fr;
+	padding-bottom: 16px;
+	gap: 16px;
+
+	h1 {
+		margin: 0;
+		font-size: var(--newspack-theme-font-size-lg);
+
+		@media #{bp.$media-md-up} {
+			font-size: var(--newspack-theme-font-size-xl);
+		}
+	}
+
+	&__card {
+		grid-column: span 1;
+	}
+
+	&__content {
+		grid-column: auto;
+
+		&__meta {
+			display: flex;
+			flex-direction: column;
+			gap: 0.5em;
+
+			.latest-collection-heading {
+				margin: 0;
+				text-transform: uppercase;
+			}
+
+			a {
+				color: var(--newspack-theme-color-text-main);
+			}
+
+			p {
+				margin: 0;
+			}
+		}
+
+		&__description {
+			margin: 32px 0;
+		}
+	}
+
+	@media #{bp.$media-sm-up} {
+		grid-template-columns: repeat(3, minmax(0, 1fr));
+
+		&__content {
+			grid-column: span 2;
+		}
+	}
+
+	@media #{bp.$media-lg-up} {
+		grid-template-columns: repeat(6, minmax(0, 1fr));
+		gap: 32px;
+
+		&__content {
+			grid-column: span 5;
+		}
+	}
+}

--- a/src/collections/frontend/_single.scss
+++ b/src/collections/frontend/_single.scss
@@ -1,65 +1,11 @@
 @use "breakpoints" as bp;
+@use "intro";
 
 /* Single collection template styles */
 .single-newspack_collection {
-	h1 {
-		margin: 0;
-		font-size: var(--newspack-theme-font-size-lg);
-
-		@media #{bp.$media-md-up} {
-			font-size: var(--newspack-theme-font-size-xl);
-		}
-	}
-
 	hr {
 		flex: 0 0 100%;
 		margin: 32px 0 62px;
-	}
-
-	.collection-intro {
-		display: grid;
-		grid-template-columns: 1fr;
-		padding-bottom: 16px;
-		gap: 16px;
-
-		&__card {
-			grid-column: span 1;
-		}
-
-		&__content {
-			grid-column: auto;
-
-			&__meta {
-				display: flex;
-				flex-direction: column;
-				gap: 0.5em;
-
-				p {
-					margin: 0;
-				}
-			}
-
-			&__description {
-				margin: 32px 0;
-			}
-		}
-
-		@media #{bp.$media-sm-up} {
-			grid-template-columns: repeat(3, minmax(0, 1fr));
-
-			&__content {
-				grid-column: span 2;
-			}
-		}
-
-		@media #{bp.$media-lg-up} {
-			grid-template-columns: repeat(6, minmax(0, 1fr));
-			gap: 32px;
-
-			&__content {
-				grid-column: span 5;
-			}
-		}
 	}
 
 	.collection-section {

--- a/src/wizards/newspack/views/settings/collections/index.tsx
+++ b/src/wizards/newspack/views/settings/collections/index.tsx
@@ -4,6 +4,7 @@
 
 import { __ } from '@wordpress/i18n';
 import { useState, useEffect } from '@wordpress/element';
+import { ToggleControl } from '@wordpress/components';
 import WizardSection from '../../../../wizards-section';
 import WizardsActionCard from '../../../../wizards-action-card';
 import useWizardApiFetchToggle from '../../../../hooks/use-wizard-api-fetch-toggle';
@@ -24,6 +25,7 @@ const DEFAULT_COLLECTIONS_SETTINGS: CollectionsSettingsData = {
 	post_indicator_style: 'default',
 	card_message: __( "Keep reading. There's plenty more to discover.", 'newspack-plugin' ),
 	posts_per_page: 12,
+	highlight_latest: false,
 };
 
 // Helper function to extract collection settings from API data with defaults.
@@ -137,6 +139,15 @@ function Collections() {
 									label: option.toString(),
 									value: option,
 								} ) ) }
+							/>
+							<ToggleControl
+								label={ __( 'Highlight Most Recent Collection', 'newspack-plugin' ) }
+								help={ __(
+									'Feature the latest Collection prominently at the top of the archive page, showcasing its content and any associated CTAs.',
+									'newspack-plugin'
+								) }
+								checked={ settings.highlight_latest }
+								onChange={ ( value: boolean ) => updateSetting( 'highlight_latest', value ) }
 							/>
 						</Grid>
 					</WizardSection>

--- a/src/wizards/newspack/views/settings/collections/types.d.ts
+++ b/src/wizards/newspack/views/settings/collections/types.d.ts
@@ -10,6 +10,7 @@ type CollectionsSettingsData = {
 	post_indicator_style: string;
 	card_message: string;
 	posts_per_page: number;
+	highlight_latest: boolean;
 };
 
 type FieldChangeHandler< T > = < K extends keyof T >( key: K, value: T[ K ] ) => void;

--- a/tests/unit-tests/collections/class-test-settings.php
+++ b/tests/unit-tests/collections/class-test-settings.php
@@ -182,6 +182,11 @@ class Test_Settings extends WP_UnitTestCase {
 			$this->assertEquals( $option, $posts_per_page_callback( $option ) );
 		}
 		$this->assertEquals( 12, $posts_per_page_callback( 42 ) ); // Invalid values default to 12.
+
+		// Test highlight latest sanitization.
+		$highlight_latest_callback = $rest_args['highlight_latest']['sanitize_callback'];
+		$this->assertTrue( $highlight_latest_callback( 'true' ) );
+		$this->assertFalse( $highlight_latest_callback( 'false' ) );
 	}
 
 	/**

--- a/tests/unit-tests/collections/class-test-template-helper.php
+++ b/tests/unit-tests/collections/class-test-template-helper.php
@@ -254,4 +254,32 @@ class Test_Template_Helper extends \WP_UnitTestCase {
 		$this->assertStringContainsString( '<a ', $html, 'See all link should be rendered.' );
 		$this->assertStringContainsString( get_post_type_archive_link( Post_Type::get_post_type() ), $html, 'See all link should point to the collection archive.' );
 	}
+
+	/**
+	 * Test load_template_part handles collections template parts correctly.
+	 *
+	 * @covers \Newspack\Collections\Template_Helper::load_template_part
+	 */
+	public function test_load_template_part() {
+		ob_start();
+		Template_Helper::load_template_part( Template_Helper::TEMPLATE_PARTS_DIR . 'newspack-collection-intro', null, [], [] );
+		$output = ob_get_clean();
+		$this->assertNotEmpty( $output, 'Collections template part should be processed.' );
+		$this->assertStringContainsString( 'collection-intro', $output, 'Collections template part should contain "collection-intro".' );
+
+		// Test collections template part with name parameter.
+		ob_start();
+		Template_Helper::load_template_part( Template_Helper::TEMPLATE_PARTS_DIR . 'newspack-collection-intro', 'variant', [], [] );
+		$this->assertEmpty( ob_get_clean(), 'Template with name should not output without existing file.' );
+
+		// Test collections template part with missing file should not output anything.
+		ob_start();
+		Template_Helper::load_template_part( Template_Helper::TEMPLATE_PARTS_DIR . 'non-existent', null, [], [] );
+		$this->assertEmpty( ob_get_clean(), 'Missing template should not output anything.' );
+
+		// Test non-collections template part.
+		ob_start();
+		Template_Helper::load_template_part( 'some/other/template', null, [], [] );
+		$this->assertEmpty( ob_get_clean(), 'Non-collections template should not be processed.' );
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR introduces a "Highlight Most Recent Collection" feature that allows publishers to showcase their most recent collection prominently in the Collection archive pages.

<img width="489" height="97" alt="image" src="https://github.com/user-attachments/assets/748dc126-bfb9-49cd-af17-18d399001e75" />

The implementation includes:
- New global setting to enable/disable this feature.
- Reusable collection intro template part that displays collection information and styling. Basically, a generalization of the code previously existing only in the single collection template.
- Custom template part loading logic to support plugin-specific templates.
- Refactored code to eliminate duplication between archive and single collection templates. Intro section styles were moved to their own file.

Closes NPPD-677.

### How to test the changes in this Pull Request:

1. Test the highlight latest collection setting:
    - Go to Newspack > Settings > Collections
    - Enable the Collections module if not already enabled
    - In the "Collections Archive" section, toggle "Highlight Most Recent Collection"
    - Save the settings and verify that the setting persists
    - Check the collections archive page to see if the latest collection is visually highlighted
    - Validate that the highlighted collection doesn't appear in the grid
    - Verify that the next pages don't show the highlighted collection.
  2. Test the custom template part loading logic:
    - Create a custom template in your active theme: `collections/parts/newspack-collection-intro.php`
    - Add custom content to verify theme override works
    - Visit a collection single page and archive page (if the highlight latest setting is on) to see the custom template
    - Remove the theme template to verify plugin fallback works
    - Test with template variants by creating `newspack-collection-intro-variant.php`
  4. Test template consistency:
    - Compare collection intro sections on archive vs single pages
    - Verify metadata, images, and CTAs display consistently
    - Test responsive behavior on different screen sizes
    - Check that separator styling is consistent across templates

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
