### PR TITLE
fix: update the plugin's translations template (POT) file [NPPM-2112]

### DIFF
--- a/languages/newspack-plugin.pot
+++ b/languages/newspack-plugin.pot
@@ -1,20 +1,22 @@
-# Copyright (C) 2024 Automattic
+# Copyright (C) 2025 Automattic
 # This file is distributed under the GPL2.
 msgid ""
 msgstr ""
-"Project-Id-Version: Newspack 5.3.1\n"
+"Project-Id-Version: Newspack 6.12.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/newspack-plugin\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2024-08-30T15:23:48+00:00\n"
+"POT-Creation-Date: 2025-07-15T00:27:28+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.8.1\n"
 "X-Domain: newspack-plugin\n"
 
 #. Plugin Name of the plugin
+#: includes/class-plugin-manager.php:166
+#: release/newspack-plugin/includes/class-plugin-manager.php:166
 msgid "Newspack"
 msgstr ""
 
@@ -23,6 +25,28 @@ msgid "An advanced open-source publishing and revenue-generating platform for ne
 msgstr ""
 
 #. Author of the plugin
+#: includes/class-plugin-manager.php:46
+#: includes/class-plugin-manager.php:82
+#: includes/class-plugin-manager.php:91
+#: includes/class-plugin-manager.php:99
+#: includes/class-plugin-manager.php:107
+#: includes/class-plugin-manager.php:116
+#: includes/class-plugin-manager.php:125
+#: includes/class-plugin-manager.php:134
+#: includes/class-plugin-manager.php:142
+#: includes/class-plugin-manager.php:150
+#: includes/class-plugin-manager.php:158
+#: release/newspack-plugin/includes/class-plugin-manager.php:46
+#: release/newspack-plugin/includes/class-plugin-manager.php:82
+#: release/newspack-plugin/includes/class-plugin-manager.php:91
+#: release/newspack-plugin/includes/class-plugin-manager.php:99
+#: release/newspack-plugin/includes/class-plugin-manager.php:107
+#: release/newspack-plugin/includes/class-plugin-manager.php:116
+#: release/newspack-plugin/includes/class-plugin-manager.php:125
+#: release/newspack-plugin/includes/class-plugin-manager.php:134
+#: release/newspack-plugin/includes/class-plugin-manager.php:142
+#: release/newspack-plugin/includes/class-plugin-manager.php:150
+#: release/newspack-plugin/includes/class-plugin-manager.php:158
 msgid "Automattic"
 msgstr ""
 
@@ -30,240 +54,328 @@ msgstr ""
 msgid "https://newspack.com/"
 msgstr ""
 
-#: includes/class-donations.php:67
+#: includes/advanced-settings/class-accessibility-statement-page.php:56
+#: includes/advanced-settings/class-accessibility-statement-page.php:188
+#: release/newspack-plugin/includes/advanced-settings/class-accessibility-statement-page.php:56
+#: release/newspack-plugin/includes/advanced-settings/class-accessibility-statement-page.php:188
+msgid "Accessibility Statement"
+msgstr ""
+
+#: includes/advanced-settings/class-accessibility-statement-page.php:171
+#: includes/class-recaptcha.php:168
+#: includes/data-events/class-api.php:106
+#: includes/emails/class-emails.php:634
+#: includes/oauth/class-google-login.php:80
+#: release/newspack-plugin/includes/advanced-settings/class-accessibility-statement-page.php:171
+#: release/newspack-plugin/includes/class-recaptcha.php:168
+#: release/newspack-plugin/includes/data-events/class-api.php:106
+#: release/newspack-plugin/includes/emails/class-emails.php:634
+#: release/newspack-plugin/includes/oauth/class-google-login.php:80
+msgid "You cannot use this resource."
+msgstr ""
+
+#: includes/class-default-image.php:67
+#: release/newspack-plugin/includes/class-default-image.php:67
+msgid "Use this image as a default image, if the requested one is not found (404 status)."
+msgstr ""
+
+#: includes/class-donations.php:533
+#: release/newspack-plugin/includes/class-donations.php:533
 msgid "Donate"
 msgstr ""
 
-#: includes/class-donations.php:1109
-#: release/newspack-plugin/includes/class-donations.php:1109
+#: includes/class-donations.php:1158
+#: release/newspack-plugin/includes/class-donations.php:1158
 msgid "Donate now"
 msgstr ""
 
-#: includes/class-magic-link.php:347
-#: includes/class-magic-link.php:396
-#: includes/reader-activation/class-reader-activation.php:1041
-#: includes/reader-activation/class-reader-activation.php:1890
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:1011
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:1860
+#: includes/class-magic-link.php:343
+#: includes/class-magic-link.php:417
+#: includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:470
+#: includes/reader-activation/class-reader-activation.php:1244
+#: includes/reader-activation/class-reader-activation.php:2183
+#: release/newspack-plugin/includes/class-magic-link.php:343
+#: release/newspack-plugin/includes/class-magic-link.php:417
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:470
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:1244
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:2183
 msgid "Invalid user."
 msgstr ""
 
-#: includes/class-magic-link.php:367
+#: includes/class-magic-link.php:371
+#: release/newspack-plugin/includes/class-magic-link.php:371
 msgid "Please wait a minute before requesting another authorization code."
 msgstr ""
 
-#: includes/class-magic-link.php:520
-#: includes/class-magic-link.php:590
-#: includes/class-magic-link.php:673
-#: includes/class-magic-link.php:902
-#: includes/class-magic-link.php:1030
-#: includes/cli/class-ras.php:67
-#: release/newspack-plugin/includes/cli/class-ras.php:67
+#: includes/class-magic-link.php:550
+#: includes/class-magic-link.php:620
+#: includes/class-magic-link.php:703
+#: includes/class-magic-link.php:949
+#: includes/class-magic-link.php:1077
+#: includes/cli/class-ras.php:74
+#: includes/plugins/co-authors-plus/class-nicename-change-ui.php:127
+#: includes/reader-activation/sync/class-esp-sync-admin.php:169
+#: release/newspack-plugin/includes/class-magic-link.php:550
+#: release/newspack-plugin/includes/class-magic-link.php:620
+#: release/newspack-plugin/includes/class-magic-link.php:703
+#: release/newspack-plugin/includes/class-magic-link.php:949
+#: release/newspack-plugin/includes/class-magic-link.php:1077
+#: release/newspack-plugin/includes/cli/class-ras.php:74
+#: release/newspack-plugin/includes/plugins/co-authors-plus/class-nicename-change-ui.php:127
+#: release/newspack-plugin/includes/reader-activation/sync/class-esp-sync-admin.php:169
 msgid "User not found."
 msgstr ""
 
-#: includes/class-magic-link.php:522
-#: includes/class-magic-link.php:592
+#: includes/class-magic-link.php:552
+#: includes/class-magic-link.php:622
+#: release/newspack-plugin/includes/class-magic-link.php:552
+#: release/newspack-plugin/includes/class-magic-link.php:622
 msgid "Not allowed for this user"
 msgstr ""
 
-#: includes/class-magic-link.php:526
 #: includes/class-magic-link.php:556
+#: includes/class-magic-link.php:586
+#: includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:349
+#: release/newspack-plugin/includes/class-magic-link.php:556
+#: release/newspack-plugin/includes/class-magic-link.php:586
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:336
 msgid "Invalid token."
 msgstr ""
 
-#: includes/class-magic-link.php:547
+#: includes/class-magic-link.php:577
+#: release/newspack-plugin/includes/class-magic-link.php:577
 msgid "Invalid client."
 msgstr ""
 
-#: includes/class-magic-link.php:594
-#: includes/class-magic-link.php:678
+#: includes/class-magic-link.php:624
+#: includes/class-magic-link.php:708
+#: release/newspack-plugin/includes/class-magic-link.php:624
+#: release/newspack-plugin/includes/class-magic-link.php:708
 msgid "OTP is not enabled."
 msgstr ""
 
-#: includes/class-magic-link.php:598
-#: includes/class-magic-link.php:637
+#: includes/class-magic-link.php:628
+#: includes/class-magic-link.php:667
+#: release/newspack-plugin/includes/class-magic-link.php:628
+#: release/newspack-plugin/includes/class-magic-link.php:667
 msgid "Invalid hash."
 msgstr ""
 
-#: includes/class-magic-link.php:600
 #: includes/class-magic-link.php:630
+#: includes/class-magic-link.php:660
+#: release/newspack-plugin/includes/class-magic-link.php:630
+#: release/newspack-plugin/includes/class-magic-link.php:660
 msgid "Invalid OTP."
 msgstr ""
 
-#: includes/class-magic-link.php:626
+#: includes/class-magic-link.php:656
+#: release/newspack-plugin/includes/class-magic-link.php:656
 msgid "Maximum OTP attempts reached."
 msgstr ""
 
-#: includes/class-magic-link.php:730
+#: includes/class-magic-link.php:759
+#: release/newspack-plugin/includes/class-magic-link.php:759
 msgid "We were not able to authenticate your account. Please try logging in again."
 msgstr ""
 
-#: includes/class-magic-link.php:797
-#: includes/class-magic-link.php:830
+#: includes/class-magic-link.php:829
+#: includes/class-magic-link.php:862
+#: release/newspack-plugin/includes/class-magic-link.php:829
+#: release/newspack-plugin/includes/class-magic-link.php:862
 msgid "Unsupported request method"
 msgstr ""
 
-#: includes/class-magic-link.php:834
+#: includes/class-magic-link.php:866
+#: release/newspack-plugin/includes/class-magic-link.php:866
 msgid "Missing required parameters"
 msgstr ""
 
-#: includes/class-magic-link.php:839
+#: includes/class-magic-link.php:871
+#: release/newspack-plugin/includes/class-magic-link.php:871
 msgid "Invalid user"
 msgstr ""
 
-#: includes/class-magic-link.php:849
+#: includes/class-magic-link.php:881
+#: release/newspack-plugin/includes/class-magic-link.php:881
 msgid "You've reached the maximum attempts for this code, try again."
 msgstr ""
 
-#: includes/class-magic-link.php:852
+#: includes/class-magic-link.php:884
+#: release/newspack-plugin/includes/class-magic-link.php:884
 msgid "Code not recognized, try again."
 msgstr ""
 
-#: includes/class-magic-link.php:857
-msgid "Unable to authenticated, try again."
+#: includes/class-magic-link.php:889
+#: release/newspack-plugin/includes/class-magic-link.php:889
+msgid "Unable to authenticate, try again."
 msgstr ""
 
-#: includes/class-magic-link.php:860
-#: includes/reader-activation/class-reader-activation.php:235
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:235
+#: includes/class-magic-link.php:907
+#: includes/reader-activation/class-reader-activation.php:273
+#: release/newspack-plugin/includes/class-magic-link.php:907
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:273
 msgid "Login successful!"
 msgstr ""
 
 #. translators: %s is the email address of the user.
-#: includes/class-magic-link.php:912
+#: includes/class-magic-link.php:959
+#: release/newspack-plugin/includes/class-magic-link.php:959
 msgid "Email sent to %s."
 msgstr ""
 
-#: includes/class-magic-link.php:918
+#: includes/class-magic-link.php:965
+#: release/newspack-plugin/includes/class-magic-link.php:965
 msgid "Send a magic link to a reader."
 msgstr ""
 
-#: includes/class-magic-link.php:962
+#: includes/class-magic-link.php:1009
+#: release/newspack-plugin/includes/class-magic-link.php:1009
 msgid "Send authentication link"
 msgstr ""
 
-#: includes/class-magic-link.php:983
+#: includes/class-magic-link.php:1030
+#: release/newspack-plugin/includes/class-magic-link.php:1030
 msgid "Authentication link sent."
 msgstr ""
 
-#: includes/class-magic-link.php:986
+#: includes/class-magic-link.php:1033
+#: release/newspack-plugin/includes/class-magic-link.php:1033
 msgid "All authentication link tokens were removed."
 msgstr ""
 
-#: includes/class-magic-link.php:989
+#: includes/class-magic-link.php:1036
+#: release/newspack-plugin/includes/class-magic-link.php:1036
 msgid "Authentication links are now disabled."
 msgstr ""
 
-#: includes/class-magic-link.php:992
+#: includes/class-magic-link.php:1039
+#: release/newspack-plugin/includes/class-magic-link.php:1039
 msgid "Authentication links are now enabled."
 msgstr ""
 
-#: includes/class-magic-link.php:1014
-#: includes/class-magic-link.php:1018
-#: includes/reader-activation/class-reader-activation.php:1755
-#: includes/reader-revenue/my-account/class-woocommerce-my-account.php:264
-#: includes/reader-revenue/my-account/class-woocommerce-my-account.php:284
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:1725
-#: release/newspack-plugin/includes/reader-revenue/my-account/class-woocommerce-my-account.php:264
-#: release/newspack-plugin/includes/reader-revenue/my-account/class-woocommerce-my-account.php:284
+#: includes/class-magic-link.php:1061
+#: includes/class-magic-link.php:1065
+#: includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:537
+#: includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:557
+#: includes/reader-activation/class-reader-activation.php:2016
+#: includes/reader-activation/sync/class-esp-sync-admin.php:157
+#: release/newspack-plugin/includes/class-magic-link.php:1061
+#: release/newspack-plugin/includes/class-magic-link.php:1065
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:537
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:557
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:2016
+#: release/newspack-plugin/includes/reader-activation/sync/class-esp-sync-admin.php:157
 msgid "Invalid request."
 msgstr ""
 
-#: includes/class-magic-link.php:1024
+#: includes/class-magic-link.php:1071
+#: includes/reader-activation/sync/class-esp-sync-admin.php:125
+#: includes/reader-activation/sync/class-esp-sync-admin.php:163
+#: release/newspack-plugin/includes/class-magic-link.php:1071
+#: release/newspack-plugin/includes/reader-activation/sync/class-esp-sync-admin.php:125
+#: release/newspack-plugin/includes/reader-activation/sync/class-esp-sync-admin.php:163
 msgid "You do not have permission to do that."
 msgstr ""
 
-#: includes/class-magic-link.php:1074
+#: includes/class-magic-link.php:1121
+#: release/newspack-plugin/includes/class-magic-link.php:1121
 msgid "Passwordless Authentication Management"
 msgstr ""
 
-#: includes/class-magic-link.php:1077
+#: includes/class-magic-link.php:1124
+#: release/newspack-plugin/includes/class-magic-link.php:1124
 msgid "Authentication Link Support"
 msgstr ""
 
 #. translators: %1$s: Disabled or enabled. %2$s: User's display name.
-#: includes/class-magic-link.php:1088
+#: includes/class-magic-link.php:1135
+#: release/newspack-plugin/includes/class-magic-link.php:1135
 msgid "Authentication links support is currently %1$s for %2$s."
 msgstr ""
 
-#: includes/class-magic-link.php:1089
+#: includes/class-magic-link.php:1136
+#: release/newspack-plugin/includes/class-magic-link.php:1136
 #: dist/blocks.js:4
 #: release/newspack-plugin/dist/blocks.js:4
-#: src/blocks/reader-registration/edit.js:225
 msgid "disabled"
 msgstr ""
 
-#: includes/class-magic-link.php:1089
+#: includes/class-magic-link.php:1136
+#: release/newspack-plugin/includes/class-magic-link.php:1136
 #: dist/blocks.js:4
 #: release/newspack-plugin/dist/blocks.js:4
-#: src/blocks/reader-registration/edit.js:224
 msgid "enabled"
 msgstr ""
 
-#: includes/class-magic-link.php:1098
+#: includes/class-magic-link.php:1145
+#: release/newspack-plugin/includes/class-magic-link.php:1145
 msgid "Send Authentication Link"
 msgstr ""
 
 #. translators: %1$s: User's display name. %2$d is the expiration period in minutes.
-#: includes/class-magic-link.php:1105
+#: includes/class-magic-link.php:1152
+#: release/newspack-plugin/includes/class-magic-link.php:1152
 msgid "Generate and send a new link to %1$s, which will authenticate them instantly. The link will be valid for %2$d minutes after its creation."
 msgstr ""
 
-#: includes/class-magic-link.php:1114
+#: includes/class-magic-link.php:1161
+#: release/newspack-plugin/includes/class-magic-link.php:1161
 msgid "Clear All Tokens"
 msgstr ""
 
 #. translators: %s: User's display name.
-#: includes/class-magic-link.php:1121
+#: includes/class-magic-link.php:1168
+#: release/newspack-plugin/includes/class-magic-link.php:1168
 msgid "Clear all existing authentication link tokens for %s."
 msgstr ""
 
-#: includes/class-newspack-ui.php:524
-#: includes/class-newspack-ui.php:528
-#: includes/class-newspack-ui.php:532
-#: includes/class-newspack-ui.php:536
-#: includes/class-newspack-ui.php:540
-#: includes/class-newspack-ui.php:544
-#: includes/class-newspack-ui.php:548
-#: includes/class-newspack-ui.php:555
-#: includes/class-newspack-ui.php:560
-#: release/newspack-plugin/includes/class-newspack-ui.php:524
-#: release/newspack-plugin/includes/class-newspack-ui.php:528
-#: release/newspack-plugin/includes/class-newspack-ui.php:532
-#: release/newspack-plugin/includes/class-newspack-ui.php:536
-#: release/newspack-plugin/includes/class-newspack-ui.php:540
-#: release/newspack-plugin/includes/class-newspack-ui.php:544
-#: release/newspack-plugin/includes/class-newspack-ui.php:548
-#: release/newspack-plugin/includes/class-newspack-ui.php:555
-#: release/newspack-plugin/includes/class-newspack-ui.php:560
-msgid "Open Menu"
+#: includes/class-newspack-ui.php:116
+#: includes/class-newspack-ui.php:212
+#: includes/class-newspack-ui.php:848
+#: includes/class-newspack-ui.php:871
+#: includes/class-newspack-ui.php:910
+#: includes/class-newspack-ui.php:945
+#: includes/class-newspack-ui.php:977
+#: includes/class-newspack-ui.php:1025
+#: includes/class-newspack-ui.php:1062
+#: includes/class-newspack-ui.php:1116
+#: includes/reader-activation/class-reader-activation.php:1599
+#: includes/reader-activation/class-reader-activation.php:1714
+#: release/newspack-plugin/includes/class-newspack-ui.php:114
+#: release/newspack-plugin/includes/class-newspack-ui.php:750
+#: release/newspack-plugin/includes/class-newspack-ui.php:773
+#: release/newspack-plugin/includes/class-newspack-ui.php:812
+#: release/newspack-plugin/includes/class-newspack-ui.php:847
+#: release/newspack-plugin/includes/class-newspack-ui.php:879
+#: release/newspack-plugin/includes/class-newspack-ui.php:927
+#: release/newspack-plugin/includes/class-newspack-ui.php:964
+#: release/newspack-plugin/includes/class-newspack-ui.php:1018
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:1599
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:1714
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Close"
 msgstr ""
 
-#: includes/class-newspack-ui.php:573
-#: includes/class-newspack-ui.php:596
-#: includes/class-newspack-ui.php:635
-#: includes/class-newspack-ui.php:670
-#: includes/class-newspack-ui.php:702
-#: includes/class-newspack-ui.php:750
-#: includes/class-newspack-ui.php:787
-#: includes/class-newspack-ui.php:841
-#: includes/reader-activation/class-reader-activation.php:1373
-#: includes/reader-activation/class-reader-activation.php:1457
-#: release/newspack-plugin/includes/class-newspack-ui.php:573
-#: release/newspack-plugin/includes/class-newspack-ui.php:596
-#: release/newspack-plugin/includes/class-newspack-ui.php:635
-#: release/newspack-plugin/includes/class-newspack-ui.php:670
-#: release/newspack-plugin/includes/class-newspack-ui.php:702
-#: release/newspack-plugin/includes/class-newspack-ui.php:750
-#: release/newspack-plugin/includes/class-newspack-ui.php:787
-#: release/newspack-plugin/includes/class-newspack-ui.php:841
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:1346
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:1430
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/components/prompt-action-card/index.js:152
-msgid "Close"
+#: includes/class-newspack-ui.php:799
+#: includes/class-newspack-ui.php:803
+#: includes/class-newspack-ui.php:807
+#: includes/class-newspack-ui.php:811
+#: includes/class-newspack-ui.php:815
+#: includes/class-newspack-ui.php:819
+#: includes/class-newspack-ui.php:823
+#: includes/class-newspack-ui.php:830
+#: includes/class-newspack-ui.php:835
+#: release/newspack-plugin/includes/class-newspack-ui.php:701
+#: release/newspack-plugin/includes/class-newspack-ui.php:705
+#: release/newspack-plugin/includes/class-newspack-ui.php:709
+#: release/newspack-plugin/includes/class-newspack-ui.php:713
+#: release/newspack-plugin/includes/class-newspack-ui.php:717
+#: release/newspack-plugin/includes/class-newspack-ui.php:721
+#: release/newspack-plugin/includes/class-newspack-ui.php:725
+#: release/newspack-plugin/includes/class-newspack-ui.php:732
+#: release/newspack-plugin/includes/class-newspack-ui.php:737
+msgid "Open Menu"
 msgstr ""
 
 #: includes/class-patches.php:119
@@ -271,41 +383,569 @@ msgstr ""
 msgid "Pattern Categories"
 msgstr ""
 
-#: includes/class-patches.php:313
-#: release/newspack-plugin/includes/class-patches.php:313
+#: includes/class-patches.php:318
+#: release/newspack-plugin/includes/class-patches.php:318
 msgid "Please choose a new homepage before attempting to unpublish this page."
+msgstr ""
+
+#: includes/class-plugin-manager.php:44
+#: release/newspack-plugin/includes/class-plugin-manager.php:44
+msgid "Akismet Anti-Spam"
+msgstr ""
+
+#: includes/class-plugin-manager.php:45
+#: release/newspack-plugin/includes/class-plugin-manager.php:45
+msgid "Used by millions, Akismet is quite possibly the best way in the world to protect your blog from spam. It keeps your site protected even while you sleep."
+msgstr ""
+
+#: includes/class-plugin-manager.php:52
+#: release/newspack-plugin/includes/class-plugin-manager.php:52
+msgid "Co-Authors Plus"
+msgstr ""
+
+#: includes/class-plugin-manager.php:53
+#: release/newspack-plugin/includes/class-plugin-manager.php:53
+msgid "Allows multiple authors and guest authors to be assigned to a post."
+msgstr ""
+
+#: includes/class-plugin-manager.php:54
+#: release/newspack-plugin/includes/class-plugin-manager.php:54
+msgid "Mohammad Jangda, Daniel Bachhuber, Automattic, Weston Ruter"
+msgstr ""
+
+#: includes/class-plugin-manager.php:60
+#: includes/wizards/newspack/class-newspack-dashboard.php:295
+#: release/newspack-plugin/includes/class-plugin-manager.php:60
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:295
+msgid "Google Site Kit"
+msgstr ""
+
+#: includes/class-plugin-manager.php:61
+#: release/newspack-plugin/includes/class-plugin-manager.php:61
+msgid "Site Kit is is a one-stop solution for WordPress users to use everything Google has to offer to make them successful on the web."
+msgstr ""
+
+#: includes/class-plugin-manager.php:62
+#: release/newspack-plugin/includes/class-plugin-manager.php:62
+#: dist/commons.js:13
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:5
+#: release/newspack-plugin/dist/commons.js:13
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:5
+msgid "Google"
+msgstr ""
+
+#: includes/class-plugin-manager.php:73
+#: release/newspack-plugin/includes/class-plugin-manager.php:73
+msgid "Gravity Forms"
+msgstr ""
+
+#: includes/class-plugin-manager.php:74
+#: release/newspack-plugin/includes/class-plugin-manager.php:74
+msgid "Create custom web forms to capture leads, collect payments, automate your workflows, and build your business online."
+msgstr ""
+
+#: includes/class-plugin-manager.php:75
+#: release/newspack-plugin/includes/class-plugin-manager.php:75
+msgid "Rocketgenius"
+msgstr ""
+
+#: includes/class-plugin-manager.php:80
+#: release/newspack-plugin/includes/class-plugin-manager.php:80
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:14
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:14
+msgid "Jetpack"
+msgstr ""
+
+#: includes/class-plugin-manager.php:81
+#: release/newspack-plugin/includes/class-plugin-manager.php:81
+msgid "Bring the power of the WordPress.com cloud to your self-hosted WordPress. Jetpack enables you to connect your blog to a WordPress.com account to use the powerful features normally only available to WordPress.com users."
+msgstr ""
+
+#: includes/class-plugin-manager.php:89
+#: includes/wizards/newspack/class-newspack-dashboard.php:284
+#: release/newspack-plugin/includes/class-plugin-manager.php:89
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:284
+msgid "Newspack Ads"
+msgstr ""
+
+#: includes/class-plugin-manager.php:90
+#: release/newspack-plugin/includes/class-plugin-manager.php:90
+msgid "Ads integration."
+msgstr ""
+
+#: includes/class-plugin-manager.php:97
+#: release/newspack-plugin/includes/class-plugin-manager.php:97
+msgid "Newspack Blocks"
+msgstr ""
+
+#: includes/class-plugin-manager.php:98
+#: release/newspack-plugin/includes/class-plugin-manager.php:98
+msgid "A collection of blocks for news publishers."
+msgstr ""
+
+#: includes/class-plugin-manager.php:105
+#: release/newspack-plugin/includes/class-plugin-manager.php:105
+msgid "Newspack Content Converter"
+msgstr ""
+
+#: includes/class-plugin-manager.php:106
+#: release/newspack-plugin/includes/class-plugin-manager.php:106
+msgid "Batch conversion of Classic->Gutenberg post conversion."
+msgstr ""
+
+#: includes/class-plugin-manager.php:114
+#: release/newspack-plugin/includes/class-plugin-manager.php:114
+msgid "Newspack Multibranded Site"
+msgstr ""
+
+#: includes/class-plugin-manager.php:115
+#: release/newspack-plugin/includes/class-plugin-manager.php:115
+msgid "Brand different content and sections of your site with unique colors and navigation."
+msgstr ""
+
+#: includes/class-plugin-manager.php:123
+#: release/newspack-plugin/includes/class-plugin-manager.php:123
+msgid "Newspack Network"
+msgstr ""
+
+#: includes/class-plugin-manager.php:124
+#: release/newspack-plugin/includes/class-plugin-manager.php:124
+msgid "Distribute content across a network of Newspack sites."
+msgstr ""
+
+#: includes/class-plugin-manager.php:132
+#: release/newspack-plugin/includes/class-plugin-manager.php:132
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:14
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:14
+msgid "Newspack Newsletters"
+msgstr ""
+
+#: includes/class-plugin-manager.php:133
+#: release/newspack-plugin/includes/class-plugin-manager.php:133
+msgid "Newsletter authoring using the Gutenberg editor."
+msgstr ""
+
+#: includes/class-plugin-manager.php:140
+#: release/newspack-plugin/includes/class-plugin-manager.php:140
+msgid "Newspack Campaigns"
+msgstr ""
+
+#: includes/class-plugin-manager.php:141
+#: release/newspack-plugin/includes/class-plugin-manager.php:141
+msgid "Build persuasive call-to-action prompts from scratch and display them as overlays, inline with the story, or above the site header."
 msgstr ""
 
 #: includes/class-plugin-manager.php:148
 #: release/newspack-plugin/includes/class-plugin-manager.php:148
-msgid "Build persuasive call-to-action prompts from scratch and display them as overlays, inline with the story, or above the site header."
+msgid "Newspack Sponsors"
 msgstr ""
 
-#: includes/class-recaptcha.php:154
-#: includes/emails/class-emails.php:628
-#: includes/oauth/class-google-login.php:80
-#: release/newspack-plugin/includes/oauth/class-google-login.php:80
-msgid "You cannot use this resource."
+#: includes/class-plugin-manager.php:149
+#: release/newspack-plugin/includes/class-plugin-manager.php:149
+msgid "Sponsored and underwritten content for Newspack sites."
+msgstr ""
+
+#: includes/class-plugin-manager.php:156
+#: includes/wizards/class-listings-wizard.php:106
+#: release/newspack-plugin/includes/class-plugin-manager.php:156
+#: release/newspack-plugin/includes/wizards/class-listings-wizard.php:106
+msgid "Newspack Listings"
+msgstr ""
+
+#: includes/class-plugin-manager.php:157
+#: release/newspack-plugin/includes/class-plugin-manager.php:157
+msgid "Create reusable content in list form using the Gutenberg editor."
+msgstr ""
+
+#: includes/class-plugin-manager.php:164
+#: release/newspack-plugin/includes/class-plugin-manager.php:164
+msgid "Newspack Theme"
+msgstr ""
+
+#: includes/class-plugin-manager.php:165
+#: release/newspack-plugin/includes/class-plugin-manager.php:165
+msgid "The Newspack theme."
+msgstr ""
+
+#: includes/class-plugin-manager.php:169
+#: release/newspack-plugin/includes/class-plugin-manager.php:169
+msgid "Parse.ly"
+msgstr ""
+
+#: includes/class-plugin-manager.php:170
+#: release/newspack-plugin/includes/class-plugin-manager.php:170
+msgid "This plugin makes it a snap to add Parse.ly tracking code to your WordPress blog."
+msgstr ""
+
+#: includes/class-plugin-manager.php:171
+#: release/newspack-plugin/includes/class-plugin-manager.php:171
+msgid "Mike Sukmanowsky ( mike@parsely.com )"
+msgstr ""
+
+#: includes/class-plugin-manager.php:177
+#: release/newspack-plugin/includes/class-plugin-manager.php:177
+msgid "Password Protected"
+msgstr ""
+
+#: includes/class-plugin-manager.php:178
+#: release/newspack-plugin/includes/class-plugin-manager.php:178
+msgid "A very simple way to quickly password protect your WordPress site with a single password. Please note: This plugin does not restrict access to uploaded files and images and does not work with some caching setups."
+msgstr ""
+
+#: includes/class-plugin-manager.php:179
+#: release/newspack-plugin/includes/class-plugin-manager.php:179
+msgid "Ben Huson"
+msgstr ""
+
+#: includes/class-plugin-manager.php:186
+#: release/newspack-plugin/includes/class-plugin-manager.php:186
+msgid "Perfmatters"
+msgstr ""
+
+#: includes/class-plugin-manager.php:187
+#: release/newspack-plugin/includes/class-plugin-manager.php:187
+msgid "Perfmatters is a lightweight performance plugin developed to speed up your WordPress site."
+msgstr ""
+
+#: includes/class-plugin-manager.php:188
+#: release/newspack-plugin/includes/class-plugin-manager.php:188
+msgid "forgemedia"
+msgstr ""
+
+#: includes/class-plugin-manager.php:193
+#: release/newspack-plugin/includes/class-plugin-manager.php:193
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Publish to Apple News"
+msgstr ""
+
+#: includes/class-plugin-manager.php:194
+#: release/newspack-plugin/includes/class-plugin-manager.php:194
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Export and synchronize posts to Apple format."
+msgstr ""
+
+#: includes/class-plugin-manager.php:195
+#: release/newspack-plugin/includes/class-plugin-manager.php:195
+msgid "Alley Interactive"
+msgstr ""
+
+#: includes/class-plugin-manager.php:206
+#: release/newspack-plugin/includes/class-plugin-manager.php:206
+msgid "PWA"
+msgstr ""
+
+#: includes/class-plugin-manager.php:207
+#: release/newspack-plugin/includes/class-plugin-manager.php:207
+msgid "Feature plugin to bring Progressive Web App (PWA) capabilities to Core."
+msgstr ""
+
+#: includes/class-plugin-manager.php:208
+#: release/newspack-plugin/includes/class-plugin-manager.php:208
+msgid "PWA Plugin Contributors"
+msgstr ""
+
+#: includes/class-plugin-manager.php:214
+#: release/newspack-plugin/includes/class-plugin-manager.php:214
+msgid "Redirection"
+msgstr ""
+
+#: includes/class-plugin-manager.php:215
+#: release/newspack-plugin/includes/class-plugin-manager.php:215
+msgid "Manage all your 301 redirects and monitor 404 errors."
+msgstr ""
+
+#: includes/class-plugin-manager.php:216
+#: release/newspack-plugin/includes/class-plugin-manager.php:216
+msgid "John Godley"
+msgstr ""
+
+#: includes/class-plugin-manager.php:222
+#: includes/class-plugin-manager.php:233
+#: includes/class-plugin-manager.php:242
+#: includes/class-plugin-manager.php:251
+#: includes/class-plugin-manager.php:267
+#: release/newspack-plugin/includes/class-plugin-manager.php:222
+#: release/newspack-plugin/includes/class-plugin-manager.php:233
+#: release/newspack-plugin/includes/class-plugin-manager.php:242
+#: release/newspack-plugin/includes/class-plugin-manager.php:251
+#: release/newspack-plugin/includes/class-plugin-manager.php:267
+msgid "WooCommerce"
+msgstr ""
+
+#: includes/class-plugin-manager.php:223
+#: release/newspack-plugin/includes/class-plugin-manager.php:223
+msgid "An eCommerce toolkit that helps you sell anything. Beautifully."
+msgstr ""
+
+#: includes/class-plugin-manager.php:224
+#: release/newspack-plugin/includes/class-plugin-manager.php:224
+msgid "WordPress.com VIP, XWP, Google, and contributors"
+msgstr ""
+
+#: includes/class-plugin-manager.php:231
+#: release/newspack-plugin/includes/class-plugin-manager.php:231
+msgid "WooCommerce Stripe Gateway"
+msgstr ""
+
+#: includes/class-plugin-manager.php:232
+#: release/newspack-plugin/includes/class-plugin-manager.php:232
+msgid "Take credit card payments on your store using Stripe."
+msgstr ""
+
+#: includes/class-plugin-manager.php:240
+#: release/newspack-plugin/includes/class-plugin-manager.php:240
+msgid "WooPayments"
+msgstr ""
+
+#: includes/class-plugin-manager.php:241
+#: release/newspack-plugin/includes/class-plugin-manager.php:241
+msgid "Accept payments via credit card. Manage transactions within WordPress."
+msgstr ""
+
+#: includes/class-plugin-manager.php:249
+#: release/newspack-plugin/includes/class-plugin-manager.php:249
+msgid "WooCommerce PayPal Payments"
+msgstr ""
+
+#: includes/class-plugin-manager.php:250
+#: release/newspack-plugin/includes/class-plugin-manager.php:250
+msgid "PayPal's latest complete payments processing solution. Accept PayPal, Pay Later, credit/debit cards, alternative digital wallets local payment types and bank accounts. Turn on only PayPal options or process a full suite of payment methods. Enable global transaction with extensive currency and country coverage."
+msgstr ""
+
+#: includes/class-plugin-manager.php:258
+#: release/newspack-plugin/includes/class-plugin-manager.php:258
+msgid "WooCommerce Name Your Price"
+msgstr ""
+
+#: includes/class-plugin-manager.php:259
+#: release/newspack-plugin/includes/class-plugin-manager.php:259
+msgid "WooCommerce Name Your Price allows customers to set their own price for products or donations."
+msgstr ""
+
+#: includes/class-plugin-manager.php:260
+#: release/newspack-plugin/includes/class-plugin-manager.php:260
+msgid "Kathy Darling"
+msgstr ""
+
+#: includes/class-plugin-manager.php:265
+#: release/newspack-plugin/includes/class-plugin-manager.php:265
+msgid "WooCommerce Subscriptions"
+msgstr ""
+
+#: includes/class-plugin-manager.php:266
+#: release/newspack-plugin/includes/class-plugin-manager.php:266
+msgid "Sell products and services with recurring payments in your WooCommerce Store."
+msgstr ""
+
+#: includes/class-plugin-manager.php:272
+#: release/newspack-plugin/includes/class-plugin-manager.php:272
+msgid "Yoast SEO"
+msgstr ""
+
+#: includes/class-plugin-manager.php:273
+#: release/newspack-plugin/includes/class-plugin-manager.php:273
+msgid "The first true all-in-one SEO solution for WordPress, including on-page content analysis, XML sitemaps and much more."
+msgstr ""
+
+#: includes/class-plugin-manager.php:274
+#: release/newspack-plugin/includes/class-plugin-manager.php:274
+msgid "Team Yoast"
+msgstr ""
+
+#: includes/class-plugin-manager.php:280
+#: release/newspack-plugin/includes/class-plugin-manager.php:280
+msgid "Complianz - GDPR/CCPA Cookie Consent"
+msgstr ""
+
+#: includes/class-plugin-manager.php:281
+#: release/newspack-plugin/includes/class-plugin-manager.php:281
+msgid "Complianz is a GDPR/CCPA Cookie Consent plugin that supports GDPR, ePrivacy, DSGVO, TTDSG, LGPD, POPIA, APA, RGPD, CCPA/CPRA and PIPEDA with a conditional Cookie Notice and customized Cookie Policy based on the results of the built-in Cookie Scan."
+msgstr ""
+
+#: includes/class-plugin-manager.php:282
+#: release/newspack-plugin/includes/class-plugin-manager.php:282
+msgid "Really Simple Plugins"
+msgstr ""
+
+#: includes/class-plugin-manager.php:288
+#: release/newspack-plugin/includes/class-plugin-manager.php:288
+msgid "Simple Local Avatars"
+msgstr ""
+
+#: includes/class-plugin-manager.php:289
+#: release/newspack-plugin/includes/class-plugin-manager.php:289
+msgid "Adds an avatar upload field to user profiles if the current user has media permissions. Generates requested sizes on demand just like Gravatar! Simple and lightweight."
+msgstr ""
+
+#: includes/class-plugin-manager.php:290
+#: release/newspack-plugin/includes/class-plugin-manager.php:290
+msgid "Jake Goldman, 10up"
+msgstr ""
+
+#: includes/class-plugin-manager.php:296
+#: release/newspack-plugin/includes/class-plugin-manager.php:296
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Distributor"
+msgstr ""
+
+#: includes/class-plugin-manager.php:297
+#: release/newspack-plugin/includes/class-plugin-manager.php:297
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Distributor is a WordPress plugin that makes it easy to syndicate and reuse content across your websites — whether in a single multisite or across the web."
+msgstr ""
+
+#: includes/class-plugin-manager.php:304
+#: release/newspack-plugin/includes/class-plugin-manager.php:304
+msgid "Super Cool Ad Inserter Plugin"
+msgstr ""
+
+#: includes/class-plugin-manager.php:305
+#: release/newspack-plugin/includes/class-plugin-manager.php:305
+msgid "Display ads within your article content."
+msgstr ""
+
+#: includes/class-plugin-manager.php:306
+#: release/newspack-plugin/includes/class-plugin-manager.php:306
+msgid "INN Labs, Automattic"
+msgstr ""
+
+#: includes/class-plugin-manager.php:312
+#: release/newspack-plugin/includes/class-plugin-manager.php:312
+#: dist/billboard.js:12
+#: release/newspack-plugin/dist/billboard.js:12
+msgid "Ad Refresh Control"
+msgstr ""
+
+#: includes/class-plugin-manager.php:313
+#: release/newspack-plugin/includes/class-plugin-manager.php:313
+#: dist/billboard.js:12
+#: release/newspack-plugin/dist/billboard.js:12
+msgid "Enable Active View refresh for Google Ad Manager ads without needing to modify any code."
+msgstr ""
+
+#: includes/class-plugin-manager.php:314
+#: release/newspack-plugin/includes/class-plugin-manager.php:314
+msgid "Gary Thayer, David Green, 10up"
+msgstr ""
+
+#: includes/class-plugin-manager.php:320
+#: release/newspack-plugin/includes/class-plugin-manager.php:320
+msgid "Ads.txt Manager"
+msgstr ""
+
+#: includes/class-plugin-manager.php:321
+#: release/newspack-plugin/includes/class-plugin-manager.php:321
+msgid "Create, manage, and validate your ads.txt and app-ads.txt from within WordPress, just like any other content asset."
+msgstr ""
+
+#: includes/class-plugin-manager.php:322
+#: release/newspack-plugin/includes/class-plugin-manager.php:322
+msgid "10up"
+msgstr ""
+
+#: includes/class-plugin-manager.php:329
+#: release/newspack-plugin/includes/class-plugin-manager.php:329
+msgid "Broadstreet"
+msgstr ""
+
+#: includes/class-plugin-manager.php:330
+#: release/newspack-plugin/includes/class-plugin-manager.php:330
+msgid "Integrate Broadstreet’s business directory and ad-serving features into your site."
+msgstr ""
+
+#: includes/class-plugin-manager.php:337
+#: release/newspack-plugin/includes/class-plugin-manager.php:337
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:14
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:14
+msgid "Everlit"
+msgstr ""
+
+#: includes/class-plugin-manager.php:338
+#: release/newspack-plugin/includes/class-plugin-manager.php:338
+msgid "Using a new generation of ultra realistic, AI-driven speech synthesis, we are bringing a backlog of human interest stories, fiction, and knowledge to the present day."
+msgstr ""
+
+#: includes/class-plugin-manager.php:537
+#: release/newspack-plugin/includes/class-plugin-manager.php:537
+msgid "Invalid plugin."
+msgstr ""
+
+#: includes/class-plugin-manager.php:586
+#: includes/class-plugin-manager.php:710
+#: release/newspack-plugin/includes/class-plugin-manager.php:586
+#: release/newspack-plugin/includes/class-plugin-manager.php:710
+msgid "The plugin is not installed."
+msgstr ""
+
+#: includes/class-plugin-manager.php:596
+#: release/newspack-plugin/includes/class-plugin-manager.php:596
+msgid "The plugin is not active."
+msgstr ""
+
+#: includes/class-plugin-manager.php:601
+#: release/newspack-plugin/includes/class-plugin-manager.php:601
+msgid "Failed to deactivate plugin."
+msgstr ""
+
+#: includes/class-plugin-manager.php:680
+#: release/newspack-plugin/includes/class-plugin-manager.php:680
+msgid "Plugins cannot be installed."
+msgstr ""
+
+#: includes/class-plugin-manager.php:698
+#: release/newspack-plugin/includes/class-plugin-manager.php:698
+msgid "Plugins cannot be uninstalled."
+msgstr ""
+
+#: includes/class-plugin-manager.php:734
+#: release/newspack-plugin/includes/class-plugin-manager.php:734
+msgid "The plugin could not be uninstalled."
+msgstr ""
+
+#: includes/class-plugin-manager.php:747
+#: release/newspack-plugin/includes/class-plugin-manager.php:747
+msgid "The plugin directory already exists."
+msgstr ""
+
+#: includes/class-plugin-manager.php:754
+#: release/newspack-plugin/includes/class-plugin-manager.php:754
+msgid "Plugin not found."
+msgstr ""
+
+#: includes/class-plugin-manager.php:760
+#: release/newspack-plugin/includes/class-plugin-manager.php:760
+msgid "Newspack cannot install this plugin. You will need to get it from the plugin's site and install it manually."
+msgstr ""
+
+#. translators: %s: plugin URL
+#: includes/class-plugin-manager.php:763
+#: release/newspack-plugin/includes/class-plugin-manager.php:763
+msgid "Newspack cannot install this plugin. You will need to get it from <a href=\"%s\">the plugin's site</a> and install it manually."
 msgstr ""
 
 #. translators: 1: Privacy Policy URL, 2: Terms of Service URL.
-#: includes/class-recaptcha.php:353
+#: includes/class-recaptcha.php:380
+#: release/newspack-plugin/includes/class-recaptcha.php:380
 msgid "This site is protected by reCAPTCHA and the Google <a href=\"%1$s\" rel=\"noopener noreferrer\" target=\"_blank\">Privacy Policy</a> and <a href=\"%2$s\" rel=\"external\" target=\"_blank\">Terms of Service</a> apply."
 msgstr ""
 
-#: includes/class-recaptcha.php:371
-#: release/newspack-plugin/includes/class-recaptcha.php:360
+#: includes/class-recaptcha.php:398
+#: release/newspack-plugin/includes/class-recaptcha.php:398
 msgid "Could not complete this request. Please try again later."
 msgstr ""
 
-#: includes/class-recaptcha.php:371
-#: release/newspack-plugin/includes/class-recaptcha.php:360
+#: includes/class-recaptcha.php:398
+#: release/newspack-plugin/includes/class-recaptcha.php:398
 msgid "Please complete the challenge to continue."
 msgstr ""
 
 #. Translators: error message for reCaptcha.
-#: includes/class-recaptcha.php:403
-#: release/newspack-plugin/includes/class-recaptcha.php:392
+#: includes/class-recaptcha.php:430
+#: release/newspack-plugin/includes/class-recaptcha.php:430
 msgid "Error: %s"
 msgstr ""
 
@@ -324,139 +964,869 @@ msgstr ""
 msgid "Customize the featured image sizes used in the RSS feed"
 msgstr ""
 
-#: includes/cli/class-ras.php:24
-#: release/newspack-plugin/includes/cli/class-ras.php:24
+#: includes/cli/class-mailchimp.php:60
+#: includes/cli/class-mailchimp.php:147
+#: release/newspack-plugin/includes/cli/class-mailchimp.php:60
+#: release/newspack-plugin/includes/cli/class-mailchimp.php:147
+msgid "Mailchimp audience ID not set."
+msgstr ""
+
+#: includes/cli/class-mailchimp.php:65
+#: includes/cli/class-mailchimp.php:152
+#: release/newspack-plugin/includes/cli/class-mailchimp.php:65
+#: release/newspack-plugin/includes/cli/class-mailchimp.php:152
+msgid "Could not connect to Mailchimp API. Is the site connected to Mailchimp?"
+msgstr ""
+
+#: includes/cli/class-mailchimp.php:126
+#: release/newspack-plugin/includes/cli/class-mailchimp.php:126
+msgid "Please specify at least one field to delete."
+msgstr ""
+
+#: includes/cli/class-ras-esp-sync.php:92
+#: release/newspack-plugin/includes/cli/class-ras-esp-sync.php:92
+msgid "Running ESP contact sync..."
+msgstr ""
+
+#: includes/cli/class-ras-esp-sync.php:109
+#: release/newspack-plugin/includes/cli/class-ras-esp-sync.php:109
+msgid "Syncing by subscription ID..."
+msgstr ""
+
+#. Translators: %d is the subscription ID arg passed to the script.
+#: includes/cli/class-ras-esp-sync.php:119
+#: release/newspack-plugin/includes/cli/class-ras-esp-sync.php:119
+msgid "No subscription with ID %d. Skipping."
+msgstr ""
+
+#. Translators: %1$d is the subscription ID arg passed to the script. %2$s is the error message.
+#: includes/cli/class-ras-esp-sync.php:132
+#: release/newspack-plugin/includes/cli/class-ras-esp-sync.php:132
+msgid "Error syncing contact info for subscription ID %1$d. %2$s"
+msgstr ""
+
+#: includes/cli/class-ras-esp-sync.php:155
+#: release/newspack-plugin/includes/cli/class-ras-esp-sync.php:155
+msgid "Syncing by order ID..."
+msgstr ""
+
+#. Translators: %d is the order ID.
+#: includes/cli/class-ras-esp-sync.php:163
+#: release/newspack-plugin/includes/cli/class-ras-esp-sync.php:163
+msgid "No order with ID %d. Skipping."
+msgstr ""
+
+#. Translators: %1$d is the order ID arg passed to the script. %2$s is the error message.
+#: includes/cli/class-ras-esp-sync.php:176
+#: release/newspack-plugin/includes/cli/class-ras-esp-sync.php:176
+msgid "Error syncing contact info for order ID %1$d. %2$s"
+msgstr ""
+
+#: includes/cli/class-ras-esp-sync.php:189
+#: release/newspack-plugin/includes/cli/class-ras-esp-sync.php:189
+msgid "Syncing by customer user ID..."
+msgstr ""
+
+#. Translators: %1$d is the user ID arg passed to the script. %2$s is the error message.
+#: includes/cli/class-ras-esp-sync.php:197
+#: release/newspack-plugin/includes/cli/class-ras-esp-sync.php:197
+msgid "Error syncing contact info for user ID %1$d. %2$s"
+msgstr ""
+
+#: includes/cli/class-ras-esp-sync.php:215
+#: release/newspack-plugin/includes/cli/class-ras-esp-sync.php:215
+msgid "Syncing all readers with active subscriptions..."
+msgstr ""
+
+#: includes/cli/class-ras-esp-sync.php:217
+#: release/newspack-plugin/includes/cli/class-ras-esp-sync.php:217
+msgid "Syncing all readers..."
+msgstr ""
+
+#: includes/cli/class-ras-esp-sync.php:300
+#: release/newspack-plugin/includes/cli/class-ras-esp-sync.php:300
+msgid "The migrated-subscriptions flag requires the Newspack_Subscription_Migrations plugin to be installed and active."
+msgstr ""
+
+#. Translators: %s is the source of the subscriptions.
+#: includes/cli/class-ras-esp-sync.php:319
+#: release/newspack-plugin/includes/cli/class-ras-esp-sync.php:319
+msgid "Invalid subscription migration type: %s"
+msgstr ""
+
+#. Translators: total number of synced contacts.
+#: includes/cli/class-ras-esp-sync.php:409
+#: release/newspack-plugin/includes/cli/class-ras-esp-sync.php:409
+msgid "Synced %d contacts."
+msgstr ""
+
+#: includes/cli/class-ras.php:27
+#: release/newspack-plugin/includes/cli/class-ras.php:27
 msgid "RAS is already configured for this site."
 msgstr ""
 
-#: includes/cli/class-ras.php:28
-#: release/newspack-plugin/includes/cli/class-ras.php:28
+#: includes/cli/class-ras.php:31
+#: release/newspack-plugin/includes/cli/class-ras.php:31
 msgid "Newspack Campaigns plugin not found."
 msgstr ""
 
-#: includes/cli/class-ras.php:33
-#: release/newspack-plugin/includes/cli/class-ras.php:33
+#: includes/cli/class-ras.php:35
+#: release/newspack-plugin/includes/cli/class-ras.php:35
 msgid "Newspack Newsletters plugin not found."
 msgstr ""
 
-#: includes/cli/class-ras.php:37
-#: release/newspack-plugin/includes/cli/class-ras.php:37
+#: includes/cli/class-ras.php:39
+#: release/newspack-plugin/includes/cli/class-ras.php:39
 msgid "Newspack Newsletters provider not set."
 msgstr ""
 
-#: includes/cli/class-ras.php:43
-#: release/newspack-plugin/includes/cli/class-ras.php:43
+#: includes/cli/class-ras.php:45
+#: release/newspack-plugin/includes/cli/class-ras.php:45
 msgid "Something went wrong. Please check for required plugins and try again."
 msgstr ""
 
-#: includes/cli/class-ras.php:47
-#: release/newspack-plugin/includes/cli/class-ras.php:47
+#: includes/cli/class-ras.php:49
+#: release/newspack-plugin/includes/cli/class-ras.php:49
 msgid "RAS enabled with default prompts."
 msgstr ""
 
-#: includes/cli/class-ras.php:59
-#: release/newspack-plugin/includes/cli/class-ras.php:59
+#: includes/cli/class-ras.php:66
+#: release/newspack-plugin/includes/cli/class-ras.php:66
 msgid "Please provide a user ID or email address."
 msgstr ""
 
 #. Translators: email address of user that was verified.
-#: includes/cli/class-ras.php:76
-#: release/newspack-plugin/includes/cli/class-ras.php:76
+#: includes/cli/class-ras.php:83
+#: release/newspack-plugin/includes/cli/class-ras.php:83
 msgid "Verified user %s."
 msgstr ""
 
-#: includes/configuration_managers/class-woocommerce-configuration-manager.php:206
-#: release/newspack-plugin/includes/configuration_managers/class-woocommerce-configuration-manager.php:206
+#: includes/cli/class-woocommerce-subscriptions.php:161
+#: release/newspack-plugin/includes/cli/class-woocommerce-subscriptions.php:161
+msgid "Final payment retry scheduled by Newspack CLI command."
+msgstr ""
+
+#: includes/cli/class-woocommerce-subscriptions.php:213
+#: release/newspack-plugin/includes/cli/class-woocommerce-subscriptions.php:213
+msgid "Subscription status updated by Newspack CLI command."
+msgstr ""
+
+#: includes/collections/class-collection-category-taxonomy.php:53
+#: includes/collections/class-collection-meta.php:64
+#: release/newspack-plugin/includes/collections/class-collection-meta.php:83
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:31
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:31
+msgid "Subscription URL"
+msgstr ""
+
+#: includes/collections/class-collection-category-taxonomy.php:54
+msgid "Override the global subscription link for this category."
+msgstr ""
+
+#: includes/collections/class-collection-category-taxonomy.php:65
+#: includes/collections/class-collection-meta.php:75
+#: release/newspack-plugin/includes/collections/class-collection-meta.php:94
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:31
+msgid "Order URL"
+msgstr ""
+
+#: includes/collections/class-collection-category-taxonomy.php:66
+msgid "Override the global order link for this category."
+msgstr ""
+
+#: includes/collections/class-collection-category-taxonomy.php:99
+msgctxt "collection category taxonomy general name"
+msgid "Collection Categories"
+msgstr ""
+
+#: includes/collections/class-collection-category-taxonomy.php:100
+msgctxt "collection category taxonomy singular name"
+msgid "Collection Category"
+msgstr ""
+
+#: includes/collections/class-collection-category-taxonomy.php:101
+#: release/newspack-plugin/includes/collections/class-collection-category-taxonomy.php:50
+msgid "Search Collection Categories"
+msgstr ""
+
+#: includes/collections/class-collection-category-taxonomy.php:102
+msgid "Popular Collection Categories"
+msgstr ""
+
+#: includes/collections/class-collection-category-taxonomy.php:103
+#: release/newspack-plugin/includes/collections/class-collection-category-taxonomy.php:51
+msgid "All Collection Categories"
+msgstr ""
+
+#: includes/collections/class-collection-category-taxonomy.php:104
+#: release/newspack-plugin/includes/collections/class-collection-category-taxonomy.php:52
+msgid "Parent Collection Category"
+msgstr ""
+
+#: includes/collections/class-collection-category-taxonomy.php:105
+#: release/newspack-plugin/includes/collections/class-collection-category-taxonomy.php:53
+msgid "Parent Collection Category:"
+msgstr ""
+
+#: includes/collections/class-collection-category-taxonomy.php:106
+#: release/newspack-plugin/includes/collections/class-collection-category-taxonomy.php:54
+msgid "Edit Collection Category"
+msgstr ""
+
+#: includes/collections/class-collection-category-taxonomy.php:107
+msgid "View Collection Category"
+msgstr ""
+
+#: includes/collections/class-collection-category-taxonomy.php:108
+#: release/newspack-plugin/includes/collections/class-collection-category-taxonomy.php:55
+msgid "Update Collection Category"
+msgstr ""
+
+#: includes/collections/class-collection-category-taxonomy.php:109
+#: release/newspack-plugin/includes/collections/class-collection-category-taxonomy.php:56
+msgid "Add New Collection Category"
+msgstr ""
+
+#: includes/collections/class-collection-category-taxonomy.php:110
+#: release/newspack-plugin/includes/collections/class-collection-category-taxonomy.php:57
+msgid "New Collection Category Name"
+msgstr ""
+
+#: includes/collections/class-collection-category-taxonomy.php:111
+#: includes/lite-site/class-lite-site.php:121
+#: release/newspack-plugin/includes/collections/class-collection-category-taxonomy.php:58
+#: release/newspack-plugin/includes/collections/class-collection-category-taxonomy.php:81
+#: release/newspack-plugin/includes/lite-site/class-lite-site.php:121
+#: dist/billboard.js:12
+#: release/newspack-plugin/dist/billboard.js:12
+msgid "Categories"
+msgstr ""
+
+#: includes/collections/class-collection-category-taxonomy.php:116
+#: release/newspack-plugin/includes/collections/class-collection-category-taxonomy.php:63
+msgid "Taxonomy for categorizing collections."
+msgstr ""
+
+#: includes/collections/class-collection-category-taxonomy.php:137
+msgctxt "label for collection category column name"
+msgid "Categories"
+msgstr ""
+
+#: includes/collections/class-collection-meta.php:42
+#: release/newspack-plugin/includes/collections/class-collection-meta.php:61
+msgid "Volume"
+msgstr ""
+
+#: includes/collections/class-collection-meta.php:49
+#: release/newspack-plugin/includes/collections/class-collection-meta.php:68
+msgid "Number"
+msgstr ""
+
+#: includes/collections/class-collection-meta.php:56
+#: release/newspack-plugin/includes/collections/class-collection-meta.php:75
+msgid "Period"
+msgstr ""
+
+#: includes/collections/class-collection-meta.php:57
+#: release/newspack-plugin/includes/collections/class-collection-meta.php:76
+msgid "Period as a string (e.g., \"Spring 2025\", \"January 2025\")"
+msgstr ""
+
+#: includes/collections/class-collection-meta.php:86
+msgid "Call-to-Action"
+msgstr ""
+
+#: includes/collections/class-collection-meta.php:87
+msgid "Add multiple CTAs linking to attachments or external URLs."
+msgstr ""
+
+#: includes/collections/class-collection-section-taxonomy.php:54
+#: includes/collections/class-post-type.php:73
+#: release/newspack-plugin/includes/collections/class-collection-section-taxonomy.php:54
+#: release/newspack-plugin/includes/collections/class-post-type.php:73
+#: dist/collections-admin.js:1
+#: release/newspack-plugin/dist/collections-admin.js:1
+msgid "Order"
+msgstr ""
+
+#: includes/collections/class-collection-section-taxonomy.php:92
+msgctxt "collection section taxonomy general name"
+msgid "Collection Sections"
+msgstr ""
+
+#: includes/collections/class-collection-section-taxonomy.php:93
+msgctxt "collection section taxonomy singular name"
+msgid "Collection Section"
+msgstr ""
+
+#: includes/collections/class-collection-section-taxonomy.php:94
+#: release/newspack-plugin/includes/collections/class-collection-section-taxonomy.php:93
+msgid "Search Collection Sections"
+msgstr ""
+
+#: includes/collections/class-collection-section-taxonomy.php:95
+msgid "Popular Collection Sections"
+msgstr ""
+
+#: includes/collections/class-collection-section-taxonomy.php:96
+#: release/newspack-plugin/includes/collections/class-collection-section-taxonomy.php:94
+msgid "All Collection Sections"
+msgstr ""
+
+#: includes/collections/class-collection-section-taxonomy.php:97
+#: release/newspack-plugin/includes/collections/class-collection-section-taxonomy.php:95
+msgid "Parent Collection Section"
+msgstr ""
+
+#: includes/collections/class-collection-section-taxonomy.php:98
+#: release/newspack-plugin/includes/collections/class-collection-section-taxonomy.php:96
+msgid "Parent Collection Section:"
+msgstr ""
+
+#: includes/collections/class-collection-section-taxonomy.php:99
+#: release/newspack-plugin/includes/collections/class-collection-section-taxonomy.php:97
+msgid "Edit Collection Section"
+msgstr ""
+
+#: includes/collections/class-collection-section-taxonomy.php:100
+msgid "View Collection Section"
+msgstr ""
+
+#: includes/collections/class-collection-section-taxonomy.php:101
+#: release/newspack-plugin/includes/collections/class-collection-section-taxonomy.php:98
+msgid "Update Collection Section"
+msgstr ""
+
+#: includes/collections/class-collection-section-taxonomy.php:102
+#: release/newspack-plugin/includes/collections/class-collection-section-taxonomy.php:99
+msgid "Add New Collection Section"
+msgstr ""
+
+#: includes/collections/class-collection-section-taxonomy.php:103
+#: release/newspack-plugin/includes/collections/class-collection-section-taxonomy.php:100
+msgid "New Collection Section Name"
+msgstr ""
+
+#: includes/collections/class-collection-section-taxonomy.php:104
+msgctxt "label for collection section menu name"
+msgid "Sections"
+msgstr ""
+
+#: includes/collections/class-collection-section-taxonomy.php:109
+#: release/newspack-plugin/includes/collections/class-collection-section-taxonomy.php:106
+msgid "Taxonomy for organizing posts into sections within collections."
+msgstr ""
+
+#: includes/collections/class-collection-section-taxonomy.php:128
+msgctxt "collection section taxonomy page title"
+msgid "Sections"
+msgstr ""
+
+#: includes/collections/class-collection-section-taxonomy.php:129
+msgctxt "collection section taxonomy menu title"
+msgid "Sections"
+msgstr ""
+
+#: includes/collections/class-collection-section-taxonomy.php:160
+msgctxt "label for collection section column name"
+msgid "Sections"
+msgstr ""
+
+#: includes/collections/class-collection-section-taxonomy.php:242
+#: release/newspack-plugin/includes/collections/class-collection-section-taxonomy.php:235
+msgid "Enter a number to specify the order of this section (lower numbers appear first)."
+msgstr ""
+
+#: includes/collections/class-collection-taxonomy.php:77
+msgctxt "collection taxonomy general name"
+msgid "Collections"
+msgstr ""
+
+#: includes/collections/class-collection-taxonomy.php:78
+msgctxt "collection taxonomy singular name"
+msgid "Collection"
+msgstr ""
+
+#: includes/collections/class-collection-taxonomy.php:79
+#: includes/collections/class-post-type.php:103
+#: release/newspack-plugin/includes/collections/class-collection-taxonomy.php:79
+#: release/newspack-plugin/includes/collections/class-post-type.php:104
+msgid "Search Collections"
+msgstr ""
+
+#: includes/collections/class-collection-taxonomy.php:80
+msgid "Popular Collections"
+msgstr ""
+
+#: includes/collections/class-collection-taxonomy.php:81
+#: includes/collections/class-post-type.php:106
+#: release/newspack-plugin/includes/collections/class-collection-taxonomy.php:80
+#: release/newspack-plugin/includes/collections/class-post-type.php:103
+msgid "All Collections"
+msgstr ""
+
+#: includes/collections/class-collection-taxonomy.php:82
+#: includes/collections/class-post-type.php:101
+#: release/newspack-plugin/includes/collections/class-post-type.php:102
+msgid "View Collection"
+msgstr ""
+
+#: includes/collections/class-collection-taxonomy.php:83
+#: includes/collections/class-post-type.php:99
+#: release/newspack-plugin/includes/collections/class-collection-taxonomy.php:83
+#: release/newspack-plugin/includes/collections/class-post-type.php:101
+msgid "Edit Collection"
+msgstr ""
+
+#: includes/collections/class-collection-taxonomy.php:84
+#: release/newspack-plugin/includes/collections/class-collection-taxonomy.php:84
+msgid "Update Collection"
+msgstr ""
+
+#: includes/collections/class-collection-taxonomy.php:85
+#: includes/collections/class-post-type.php:98
+#: release/newspack-plugin/includes/collections/class-collection-taxonomy.php:85
+#: release/newspack-plugin/includes/collections/class-post-type.php:99
+msgid "Add New Collection"
+msgstr ""
+
+#: includes/collections/class-collection-taxonomy.php:86
+#: release/newspack-plugin/includes/collections/class-collection-taxonomy.php:86
+msgid "New Collection Name"
+msgstr ""
+
+#: includes/collections/class-collection-taxonomy.php:87
+msgctxt "label for collection menu name"
+msgid "Collections"
+msgstr ""
+
+#: includes/collections/class-collection-taxonomy.php:92
+#: release/newspack-plugin/includes/collections/class-collection-taxonomy.php:92
+msgid "Internal taxonomy for associating collections with posts."
+msgstr ""
+
+#: includes/collections/class-post-meta.php:41
+msgid "Order of the post within collections."
+msgstr ""
+
+#: includes/collections/class-post-meta.php:73
+msgctxt "title for collection settings panel"
+msgid "Collection Settings"
+msgstr ""
+
+#: includes/collections/class-post-meta.php:74
+msgctxt "help text for collection order field"
+msgid "Set the order of this post within collections."
+msgstr ""
+
+#: includes/collections/class-post-type.php:95
+msgctxt "collection post type general name"
+msgid "Collections"
+msgstr ""
+
+#: includes/collections/class-post-type.php:96
+msgctxt "collection post type singular name"
+msgid "Collection"
+msgstr ""
+
+#: includes/collections/class-post-type.php:97
+msgctxt "label for add new collection"
+msgid "Add New"
+msgstr ""
+
+#: includes/collections/class-post-type.php:100
+#: release/newspack-plugin/includes/collections/class-post-type.php:100
+msgid "New Collection"
+msgstr ""
+
+#: includes/collections/class-post-type.php:102
+msgid "View Collections"
+msgstr ""
+
+#: includes/collections/class-post-type.php:104
+#: release/newspack-plugin/includes/collections/class-post-type.php:106
+msgid "No collections found."
+msgstr ""
+
+#: includes/collections/class-post-type.php:105
+#: release/newspack-plugin/includes/collections/class-post-type.php:107
+msgid "No collections found in Trash."
+msgstr ""
+
+#: includes/collections/class-post-type.php:107
+#: release/newspack-plugin/includes/collections/class-post-type.php:108
+msgid "Collection published"
+msgstr ""
+
+#: includes/collections/class-post-type.php:108
+#: release/newspack-plugin/includes/collections/class-post-type.php:109
+msgid "Collection updated"
+msgstr ""
+
+#: includes/collections/class-post-type.php:112
+#: release/newspack-plugin/includes/collections/class-post-type.php:113
+msgid "Collection"
+msgstr ""
+
+#: includes/collections/class-post-type.php:114
+msgid "Grouped content for custom classification."
+msgstr ""
+
+#: includes/collections/class-post-type.php:177
+#: release/newspack-plugin/dist/collections-admin.js:1
+msgid "Collection Details"
+msgstr ""
+
+#: includes/configuration_managers/class-woocommerce-configuration-manager.php:306
+#: release/newspack-plugin/includes/configuration_managers/class-woocommerce-configuration-manager.php:306
 msgid "Error activating the Stripe payment gateway."
 msgstr ""
 
+#. Translators: %s is the slug of the payment gateway.
+#: includes/configuration_managers/class-woocommerce-configuration-manager.php:370
+#: release/newspack-plugin/includes/configuration_managers/class-woocommerce-configuration-manager.php:370
+msgid "Error activating %s gateway."
+msgstr ""
+
+#: includes/corrections/class-corrections.php:143
+#: release/newspack-plugin/includes/corrections/class-corrections.php:143
+msgctxt "post type general name"
+msgid "Corrections"
+msgstr ""
+
+#: includes/corrections/class-corrections.php:144
+#: release/newspack-plugin/includes/corrections/class-corrections.php:144
+msgctxt "post type singular name"
+msgid "Correction"
+msgstr ""
+
+#: includes/corrections/class-corrections.php:145
+#: release/newspack-plugin/includes/corrections/class-corrections.php:145
+msgctxt "admin menu"
+msgid "Corrections"
+msgstr ""
+
+#: includes/corrections/class-corrections.php:146
+#: release/newspack-plugin/includes/corrections/class-corrections.php:146
+msgctxt "add new on admin bar"
+msgid "Correction"
+msgstr ""
+
+#: includes/corrections/class-corrections.php:147
+#: release/newspack-plugin/includes/corrections/class-corrections.php:147
+msgctxt "correction"
+msgid "Add New"
+msgstr ""
+
+#: includes/corrections/class-corrections.php:148
+#: release/newspack-plugin/includes/corrections/class-corrections.php:148
+#: dist/other-scripts/corrections-modal.js:1
+#: release/newspack-plugin/dist/other-scripts/corrections-modal.js:1
+msgid "Add New Correction"
+msgstr ""
+
+#: includes/corrections/class-corrections.php:149
+#: release/newspack-plugin/includes/corrections/class-corrections.php:149
+msgid "New Correction"
+msgstr ""
+
+#: includes/corrections/class-corrections.php:150
+#: release/newspack-plugin/includes/corrections/class-corrections.php:150
+msgid "Edit Correction"
+msgstr ""
+
+#: includes/corrections/class-corrections.php:151
+#: includes/corrections/class-corrections.php:152
+#: release/newspack-plugin/includes/corrections/class-corrections.php:151
+#: release/newspack-plugin/includes/corrections/class-corrections.php:152
+msgid "View Correction"
+msgstr ""
+
+#: includes/corrections/class-corrections.php:153
+#: release/newspack-plugin/includes/corrections/class-corrections.php:153
+msgid "All Corrections"
+msgstr ""
+
+#: includes/corrections/class-corrections.php:154
+#: release/newspack-plugin/includes/corrections/class-corrections.php:154
+msgid "Search Corrections"
+msgstr ""
+
+#: includes/corrections/class-corrections.php:155
+#: release/newspack-plugin/includes/corrections/class-corrections.php:155
+msgid "Parent Correction:"
+msgstr ""
+
+#: includes/corrections/class-corrections.php:156
+#: release/newspack-plugin/includes/corrections/class-corrections.php:156
+msgid "No corrections found."
+msgstr ""
+
+#: includes/corrections/class-corrections.php:157
+#: release/newspack-plugin/includes/corrections/class-corrections.php:157
+msgid "No corrections found in Trash."
+msgstr ""
+
+#: includes/corrections/class-corrections.php:158
+#: release/newspack-plugin/includes/corrections/class-corrections.php:158
+msgid "Correction Archives"
+msgstr ""
+
+#: includes/corrections/class-corrections.php:159
+#: release/newspack-plugin/includes/corrections/class-corrections.php:159
+msgid "Correction Attributes"
+msgstr ""
+
+#: includes/corrections/class-corrections.php:160
+#: release/newspack-plugin/includes/corrections/class-corrections.php:160
+msgid "Insert into correction"
+msgstr ""
+
+#: includes/corrections/class-corrections.php:161
+#: release/newspack-plugin/includes/corrections/class-corrections.php:161
+msgid "Uploaded to this correction"
+msgstr ""
+
+#: includes/corrections/class-corrections.php:162
+#: release/newspack-plugin/includes/corrections/class-corrections.php:162
+msgid "Filter corrections list"
+msgstr ""
+
+#: includes/corrections/class-corrections.php:163
+#: release/newspack-plugin/includes/corrections/class-corrections.php:163
+msgid "Corrections list navigation"
+msgstr ""
+
+#: includes/corrections/class-corrections.php:164
+#: release/newspack-plugin/includes/corrections/class-corrections.php:164
+msgid "Corrections list"
+msgstr ""
+
+#: includes/corrections/class-corrections.php:165
+#: release/newspack-plugin/includes/corrections/class-corrections.php:165
+msgid "Correction published."
+msgstr ""
+
+#: includes/corrections/class-corrections.php:166
+#: release/newspack-plugin/includes/corrections/class-corrections.php:166
+msgid "Correction published privately."
+msgstr ""
+
+#: includes/corrections/class-corrections.php:167
+#: release/newspack-plugin/includes/corrections/class-corrections.php:167
+msgid "Correction reverted to draft."
+msgstr ""
+
+#: includes/corrections/class-corrections.php:168
+#: release/newspack-plugin/includes/corrections/class-corrections.php:168
+msgid "Correction scheduled."
+msgstr ""
+
+#: includes/corrections/class-corrections.php:169
+#: release/newspack-plugin/includes/corrections/class-corrections.php:169
+msgid "Correction updated."
+msgstr ""
+
+#: includes/corrections/class-corrections.php:170
+#: release/newspack-plugin/includes/corrections/class-corrections.php:170
+msgid "Correction Link"
+msgstr ""
+
+#: includes/corrections/class-corrections.php:171
+#: release/newspack-plugin/includes/corrections/class-corrections.php:171
+msgid "A link to a correction."
+msgstr ""
+
+#: includes/corrections/class-corrections.php:175
+#: release/newspack-plugin/includes/corrections/class-corrections.php:175
+msgid "Post type used to store corrections and clarifications."
+msgstr ""
+
+#: includes/corrections/class-corrections.php:265
+#: release/newspack-plugin/includes/corrections/class-corrections.php:265
+msgid "Corrections saved successfully."
+msgstr ""
+
+#: includes/corrections/class-corrections.php:412
+#: release/newspack-plugin/includes/corrections/class-corrections.php:412
+#: dist/other-scripts/corrections-modal.js:1
+#: release/newspack-plugin/dist/other-scripts/corrections-modal.js:1
+msgid "Clarification"
+msgstr ""
+
+#: includes/corrections/class-corrections.php:414
+#: release/newspack-plugin/includes/corrections/class-corrections.php:414
+#: dist/other-scripts/corrections-modal.js:1
+#: release/newspack-plugin/dist/other-scripts/corrections-modal.js:1
+msgid "Correction"
+msgstr ""
+
+#: includes/corrections/class-corrections.php:509
+#: release/newspack-plugin/includes/corrections/class-corrections.php:509
+msgid "Newspack Corrections"
+msgstr ""
+
+#: includes/corrections/class-corrections.php:517
+#: release/newspack-plugin/includes/corrections/class-corrections.php:517
+msgid "Corrections Loop"
+msgstr ""
+
+#: includes/corrections/class-corrections.php:518
+#: release/newspack-plugin/includes/corrections/class-corrections.php:518
+msgid "A block pattern for displaying an archive of corrections."
+msgstr ""
+
+#: includes/corrections/class-corrections.php:520
+#: release/newspack-plugin/includes/corrections/class-corrections.php:520
+msgid "corrections"
+msgstr ""
+
+#: includes/corrections/class-corrections.php:520
+#: release/newspack-plugin/includes/corrections/class-corrections.php:520
+msgid "archive"
+msgstr ""
+
+#: includes/corrections/class-corrections.php:520
+#: release/newspack-plugin/includes/corrections/class-corrections.php:520
+msgid "loop"
+msgstr ""
+
+#: includes/corrections/class-corrections.php:550
+#: release/newspack-plugin/includes/corrections/class-corrections.php:550
+msgid "Corrections Archive"
+msgstr ""
+
+#: includes/corrections/class-corrections.php:551
+#: release/newspack-plugin/includes/corrections/class-corrections.php:551
+msgid "A block template for displaying an archive of corrections."
+msgstr ""
+
+#: includes/data-events/class-api.php:169
+#: includes/data-events/class-api.php:251
+#: release/newspack-plugin/includes/data-events/class-api.php:169
+#: release/newspack-plugin/includes/data-events/class-api.php:251
+msgid "Invalid URL."
+msgstr ""
+
+#: includes/data-events/class-api.php:260
+#: release/newspack-plugin/includes/data-events/class-api.php:260
+msgid "You must select actions to trigger this endpoint."
+msgstr ""
+
+#. translators: %s: URL
+#: includes/data-events/class-api.php:285
+#: release/newspack-plugin/includes/data-events/class-api.php:285
+msgid "URL \"%s\" is already in use."
+msgstr ""
+
 #: includes/emails/class-emails.php:68
+#: release/newspack-plugin/includes/emails/class-emails.php:68
 msgctxt "post type general name"
 msgid "Newspack Emails"
 msgstr ""
 
 #: includes/emails/class-emails.php:69
+#: release/newspack-plugin/includes/emails/class-emails.php:69
 msgctxt "post type singular name"
 msgid "Newspack Email"
 msgstr ""
 
 #: includes/emails/class-emails.php:70
+#: release/newspack-plugin/includes/emails/class-emails.php:70
 msgctxt "admin menu"
 msgid "Newspack Emails"
 msgstr ""
 
 #: includes/emails/class-emails.php:71
+#: release/newspack-plugin/includes/emails/class-emails.php:71
 msgctxt "add new on admin bar"
 msgid "Newspack Email"
 msgstr ""
 
 #: includes/emails/class-emails.php:72
+#: release/newspack-plugin/includes/emails/class-emails.php:72
 msgctxt "popup"
 msgid "Add New"
 msgstr ""
 
 #: includes/emails/class-emails.php:73
+#: release/newspack-plugin/includes/emails/class-emails.php:73
 msgid "Add New Newspack Email"
 msgstr ""
 
 #: includes/emails/class-emails.php:74
+#: release/newspack-plugin/includes/emails/class-emails.php:74
 msgid "New Newspack Email"
 msgstr ""
 
 #: includes/emails/class-emails.php:75
+#: release/newspack-plugin/includes/emails/class-emails.php:75
 msgid "Edit Newspack Email"
 msgstr ""
 
 #: includes/emails/class-emails.php:76
+#: release/newspack-plugin/includes/emails/class-emails.php:76
 msgid "View Newspack Email"
 msgstr ""
 
 #: includes/emails/class-emails.php:77
+#: release/newspack-plugin/includes/emails/class-emails.php:77
 msgid "All Newspack Emails"
 msgstr ""
 
 #: includes/emails/class-emails.php:78
+#: release/newspack-plugin/includes/emails/class-emails.php:78
 msgid "Search Newspack Emails"
 msgstr ""
 
 #: includes/emails/class-emails.php:79
+#: release/newspack-plugin/includes/emails/class-emails.php:79
 msgid "Parent Newspack Emails:"
 msgstr ""
 
 #: includes/emails/class-emails.php:80
+#: release/newspack-plugin/includes/emails/class-emails.php:80
 msgid "No Newspack Emails found."
 msgstr ""
 
 #: includes/emails/class-emails.php:81
+#: release/newspack-plugin/includes/emails/class-emails.php:81
 msgid "No Newspack Emails found in Trash."
 msgstr ""
 
 #: includes/emails/class-emails.php:82
+#: release/newspack-plugin/includes/emails/class-emails.php:82
 msgid "Newspack Emails list"
 msgstr ""
 
 #: includes/emails/class-emails.php:83
+#: release/newspack-plugin/includes/emails/class-emails.php:83
 msgid "Newspack Email published"
 msgstr ""
 
 #: includes/emails/class-emails.php:84
+#: release/newspack-plugin/includes/emails/class-emails.php:84
 msgid "Newspack Email published privately"
 msgstr ""
 
 #: includes/emails/class-emails.php:85
+#: release/newspack-plugin/includes/emails/class-emails.php:85
 msgid "Newspack Email reverted to draft"
 msgstr ""
 
 #: includes/emails/class-emails.php:86
+#: release/newspack-plugin/includes/emails/class-emails.php:86
 msgid "Newspack Email scheduled"
 msgstr ""
 
 #: includes/emails/class-emails.php:87
+#: release/newspack-plugin/includes/emails/class-emails.php:87
 msgid "Newspack Email updated"
 msgstr ""
 
 #. translators: formatted store address where 1 is street address, 2 is city, and 3 is postcode.
 #: includes/emails/class-emails.php:193
+#: release/newspack-plugin/includes/emails/class-emails.php:193
 msgid "%1$s, %2$s %3$s"
 msgstr ""
 
@@ -466,11 +1836,136 @@ msgstr ""
 msgid "%1$s — %2$s"
 msgstr ""
 
-#: includes/emails/class-emails.php:587
+#: includes/emails/class-emails.php:593
+#: release/newspack-plugin/includes/emails/class-emails.php:593
 #: dist/other-scripts/emails.js:2
 #: release/newspack-plugin/dist/other-scripts/emails.js:2
-#: src/other-scripts/emails/index.js:84
 msgid "Test email was not sent."
+msgstr ""
+
+#: includes/lite-site/class-lite-site.php:90
+#: includes/wizards/advertising/class-advertising-sponsors.php:94
+#: includes/wizards/class-listings-wizard.php:119
+#: includes/wizards/class-network-wizard.php:325
+#: includes/wizards/class-newsletters-wizard.php:300
+#: includes/wizards/newspack/class-newspack-dashboard.php:101
+#: includes/wizards/newspack/class-newspack-dashboard.php:166
+#: includes/wizards/newspack/class-newspack-dashboard.php:202
+#: includes/wizards/newspack/class-newspack-settings.php:155
+#: release/newspack-plugin/includes/lite-site/class-lite-site.php:90
+#: release/newspack-plugin/includes/wizards/advertising/class-advertising-sponsors.php:90
+#: release/newspack-plugin/includes/wizards/class-listings-wizard.php:119
+#: release/newspack-plugin/includes/wizards/class-network-wizard.php:325
+#: release/newspack-plugin/includes/wizards/class-newsletters-wizard.php:300
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:101
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:166
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:202
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-settings.php:155
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:7
+#: dist/billboard.js:12
+#: dist/commons.js:1
+#: dist/memberships-gate-editor.js:37
+#: dist/newsletters.js:4
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:5
+#: dist/other-scripts/emails.js:2
+#: dist/setup.js:7
+#: dist/wizards.js:1
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:7
+#: release/newspack-plugin/dist/billboard.js:12
+#: release/newspack-plugin/dist/commons.js:1
+#: release/newspack-plugin/dist/memberships-gate-editor.js:37
+#: release/newspack-plugin/dist/newsletters.js:4
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:5
+#: release/newspack-plugin/dist/other-scripts/emails.js:2
+#: release/newspack-plugin/dist/setup.js:7
+#: release/newspack-plugin/dist/wizards.js:1
+msgid "Settings"
+msgstr ""
+
+#: includes/lite-site/class-lite-site.php:97
+#: release/newspack-plugin/includes/lite-site/class-lite-site.php:97
+msgid "Enable Lite Site"
+msgstr ""
+
+#: includes/lite-site/class-lite-site.php:105
+#: release/newspack-plugin/includes/lite-site/class-lite-site.php:105
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:5
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:5
+msgid "URL Base"
+msgstr ""
+
+#: includes/lite-site/class-lite-site.php:113
+#: release/newspack-plugin/includes/lite-site/class-lite-site.php:113
+msgid "Number of posts to display"
+msgstr ""
+
+#: includes/lite-site/class-lite-site.php:129
+#: release/newspack-plugin/includes/lite-site/class-lite-site.php:129
+msgid "Footer HTML"
+msgstr ""
+
+#: includes/lite-site/class-lite-site.php:141
+#: includes/lite-site/class-lite-site.php:142
+#: includes/lite-site/class-lite-site.php:155
+#: release/newspack-plugin/includes/lite-site/class-lite-site.php:141
+#: release/newspack-plugin/includes/lite-site/class-lite-site.php:142
+#: release/newspack-plugin/includes/lite-site/class-lite-site.php:155
+msgid "Lite Site"
+msgstr ""
+
+#: includes/lite-site/class-lite-site.php:156
+#: release/newspack-plugin/includes/lite-site/class-lite-site.php:156
+msgid "Lite Site is a text-only version of this website that loads faster and uses less data."
+msgstr ""
+
+#: includes/lite-site/class-lite-site.php:157
+#: release/newspack-plugin/includes/lite-site/class-lite-site.php:157
+msgid "It’s designed to allow your readers to still be able to access your content despite connectivity issues, poor network coverage, or in the event of natural disasters and emergencies."
+msgstr ""
+
+#: includes/lite-site/class-lite-site.php:182
+#: release/newspack-plugin/includes/lite-site/class-lite-site.php:182
+msgid "Enable lite site feature"
+msgstr ""
+
+#. translators: %s: is the site URL without a trailing slash, ex: https://example.com
+#: includes/lite-site/class-lite-site.php:204
+#: release/newspack-plugin/includes/lite-site/class-lite-site.php:204
+msgid "The URL base for the lite site (e.g. \"text\" for %s/text)"
+msgstr ""
+
+#: includes/lite-site/class-lite-site.php:257
+#: release/newspack-plugin/includes/lite-site/class-lite-site.php:257
+msgid "Select categories to include."
+msgstr ""
+
+#: includes/lite-site/class-lite-site.php:275
+#: release/newspack-plugin/includes/lite-site/class-lite-site.php:275
+msgid "HTML to be displayed in the footer of lite site pages."
+msgstr ""
+
+#. translators: %1$s: a comma separated list of authors names with links and, after the "and" %2$s: one last author link
+#: includes/lite-site/class-lite-site.php:409
+#: release/newspack-plugin/includes/lite-site/class-lite-site.php:409
+msgid "%1$s and %2$s"
+msgstr ""
+
+#. translators: %s: author name(s)
+#: includes/lite-site/class-lite-site.php:427
+#: release/newspack-plugin/includes/lite-site/class-lite-site.php:427
+msgid "By %s"
+msgstr ""
+
+#: includes/lite-site/templates/archive.php:21
+#: includes/lite-site/templates/single.php:30
+#: release/newspack-plugin/includes/lite-site/templates/archive.php:21
+#: release/newspack-plugin/includes/lite-site/templates/single.php:30
+msgid "View full site"
+msgstr ""
+
+#: includes/lite-site/templates/single.php:29
+#: release/newspack-plugin/includes/lite-site/templates/single.php:29
+msgid "Back to posts"
 msgstr ""
 
 #: includes/oauth/class-google-login.php:77
@@ -495,86 +1990,82 @@ msgstr ""
 msgid "Failed to get Google OAuth URL: %s"
 msgstr ""
 
-#: includes/oauth/class-google-login.php:125
-#: release/newspack-plugin/includes/oauth/class-google-login.php:125
-msgid "Nonce verification failed."
-msgstr ""
-
+#. translators: %s is a unique user id
 #: includes/oauth/class-google-login.php:126
-#: includes/reader-revenue/templates/myaccount-delete-account.php:20
 #: release/newspack-plugin/includes/oauth/class-google-login.php:126
-#: release/newspack-plugin/includes/reader-revenue/templates/myaccount-delete-account.php:20
-msgid "Invalid nonce."
+msgid "Nonce verification failed for id: %s"
 msgstr ""
 
-#: includes/oauth/class-google-login.php:131
-#: release/newspack-plugin/includes/oauth/class-google-login.php:131
-msgid "CSRF token or access token missing."
+#: includes/oauth/class-google-login.php:127
+#: includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:345
+#: includes/plugins/woocommerce/my-account/templates/delete-account.php:20
+#: release/newspack-plugin/includes/oauth/class-google-login.php:127
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:332
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/delete-account.php:20
+msgid "Invalid nonce."
 msgstr ""
 
 #: includes/oauth/class-google-login.php:132
 #: release/newspack-plugin/includes/oauth/class-google-login.php:132
+msgid "CSRF token or access token missing."
+msgstr ""
+
+#: includes/oauth/class-google-login.php:133
+#: release/newspack-plugin/includes/oauth/class-google-login.php:133
 msgid "Invalid request"
 msgstr ""
 
 #. translators: %s is a unique user id
-#: includes/oauth/class-google-login.php:140
-#: release/newspack-plugin/includes/oauth/class-google-login.php:140
+#: includes/oauth/class-google-login.php:142
+#: release/newspack-plugin/includes/oauth/class-google-login.php:142
 msgid "CSRF token verification failed for id: %s"
 msgstr ""
 
-#: includes/oauth/class-google-login.php:141
 #: includes/oauth/class-google-login.php:148
-#: includes/oauth/class-google-login.php:160
-#: release/newspack-plugin/includes/oauth/class-google-login.php:141
+#: includes/oauth/class-google-login.php:161
+#: includes/oauth/class-google-login.php:179
 #: release/newspack-plugin/includes/oauth/class-google-login.php:148
-#: release/newspack-plugin/includes/oauth/class-google-login.php:160
+#: release/newspack-plugin/includes/oauth/class-google-login.php:161
+#: release/newspack-plugin/includes/oauth/class-google-login.php:179
 msgid "Authentication failed."
 msgstr ""
 
 #. translators: %s is the error message
-#: includes/oauth/class-google-login.php:147
-#: release/newspack-plugin/includes/oauth/class-google-login.php:147
+#: includes/oauth/class-google-login.php:155
+#: release/newspack-plugin/includes/oauth/class-google-login.php:155
 msgid "Failed validating user: %s"
 msgstr ""
 
 #. translators: %s is a unique user id
-#: includes/oauth/class-google-login.php:159
-#: release/newspack-plugin/includes/oauth/class-google-login.php:159
+#: includes/oauth/class-google-login.php:173
+#: release/newspack-plugin/includes/oauth/class-google-login.php:173
 msgid "Failed setting email transient for id: %s"
 msgstr ""
 
 #. Translators: %1$s is the error message, %2$s is the user agent.
-#: includes/oauth/class-google-login.php:184
-#: release/newspack-plugin/includes/oauth/class-google-login.php:184
+#: includes/oauth/class-google-login.php:213
+#: release/newspack-plugin/includes/oauth/class-google-login.php:213
 msgid "%1$s | Details: %2$s"
 msgstr ""
 
-#: includes/oauth/class-google-login.php:220
-#: release/newspack-plugin/includes/oauth/class-google-login.php:220
-#: release/newspack-plugin/src/blocks/reader-registration/index.php:115
-#: release/newspack-plugin/src/blocks/reader-registration/index.php:357
-#: src/blocks/reader-registration/index.php:115
-#: src/blocks/reader-registration/index.php:354
-#: dist/blocks.js:1
-#: release/newspack-plugin/dist/blocks.js:1
-#: src/blocks/reader-registration/edit.js:85
+#: includes/oauth/class-google-login.php:273
+#: release/newspack-plugin/includes/oauth/class-google-login.php:273
 msgid "Thank you for registering!"
 msgstr ""
 
-#: includes/oauth/class-google-login.php:231
-#: release/newspack-plugin/includes/oauth/class-google-login.php:231
+#: includes/oauth/class-google-login.php:287
+#: release/newspack-plugin/includes/oauth/class-google-login.php:287
 msgid "Thank you for signing in!"
 msgstr ""
 
 #. translators: %s is a unique user id
-#: includes/oauth/class-google-login.php:248
-#: release/newspack-plugin/includes/oauth/class-google-login.php:248
+#: includes/oauth/class-google-login.php:304
+#: release/newspack-plugin/includes/oauth/class-google-login.php:304
 msgid "Missing email for unique id: %s"
 msgstr ""
 
-#: includes/oauth/class-google-login.php:249
-#: release/newspack-plugin/includes/oauth/class-google-login.php:249
+#: includes/oauth/class-google-login.php:305
+#: release/newspack-plugin/includes/oauth/class-google-login.php:305
 msgid "Failed to retrieve email address. Please try again."
 msgstr ""
 
@@ -707,925 +2198,2146 @@ msgid "If checked, the media partner markup will be skipped in RSS feeds and App
 msgstr ""
 
 #: includes/optional-modules/class-media-partners.php:477
+#: includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:248
 #: release/newspack-plugin/includes/optional-modules/class-media-partners.php:477
-#: dist/analytics.js:1
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:248
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:10
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:23
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:38
 #: dist/billboard.js:1
 #: dist/billboard.js:12
-#: dist/connections.js:18
-#: dist/engagement.js:8
-#: dist/engagement.js:20
-#: dist/popups.js:10
-#: dist/popups.js:16
-#: dist/site-design.js:1
-#: release/newspack-plugin/dist/analytics.js:1
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:5
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:26
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:31
+#: dist/setup.js:7
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:10
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:23
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:38
 #: release/newspack-plugin/dist/billboard.js:1
 #: release/newspack-plugin/dist/billboard.js:12
-#: release/newspack-plugin/dist/connections.js:18
-#: release/newspack-plugin/dist/engagement.js:8
-#: release/newspack-plugin/dist/engagement.js:20
-#: release/newspack-plugin/dist/popups.js:10
-#: release/newspack-plugin/dist/popups.js:16
-#: release/newspack-plugin/dist/site-design.js:1
-#: src/wizards/advertising/views/ad-unit/index.js:191
-#: src/wizards/advertising/views/ad-units/index.js:139
-#: src/wizards/advertising/views/placements/index.js:239
-#: src/wizards/advertising/views/providers/index.js:137
-#: src/wizards/advertising/views/suppression/index.js:161
-#: src/wizards/analytics/views/newspack-custom-events/index.js:112
-#: src/wizards/connections/views/main/webhooks.js:572
-#: src/wizards/popups/components/settings-modal/index.js:215
-#: src/wizards/popups/views/segments/single-segment.js:302
-#: src/wizards/site-design/index.js:129
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:5
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:26
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:31
+#: release/newspack-plugin/dist/setup.js:7
 msgid "Save"
 msgstr ""
 
-#: includes/optional-modules/class-rss.php:109
-#: release/newspack-plugin/includes/optional-modules/class-rss.php:109
+#: includes/optional-modules/class-rss.php:138
+#: release/newspack-plugin/includes/optional-modules/class-rss.php:118
 msgctxt "post type general name"
 msgid "RSS Feeds"
 msgstr ""
 
-#: includes/optional-modules/class-rss.php:110
-#: release/newspack-plugin/includes/optional-modules/class-rss.php:110
+#: includes/optional-modules/class-rss.php:139
+#: release/newspack-plugin/includes/optional-modules/class-rss.php:119
 msgctxt "post type singular name"
 msgid "RSS Feed"
 msgstr ""
 
-#: includes/optional-modules/class-rss.php:111
-#: release/newspack-plugin/includes/optional-modules/class-rss.php:111
+#: includes/optional-modules/class-rss.php:140
+#: release/newspack-plugin/includes/optional-modules/class-rss.php:120
 msgctxt "admin menu"
 msgid "RSS Feeds"
 msgstr ""
 
-#: includes/optional-modules/class-rss.php:112
-#: release/newspack-plugin/includes/optional-modules/class-rss.php:112
+#: includes/optional-modules/class-rss.php:141
+#: release/newspack-plugin/includes/optional-modules/class-rss.php:121
 msgctxt "add new on admin bar"
 msgid "RSS Feed"
 msgstr ""
 
-#: includes/optional-modules/class-rss.php:113
-#: release/newspack-plugin/includes/optional-modules/class-rss.php:113
+#: includes/optional-modules/class-rss.php:142
+#: release/newspack-plugin/includes/optional-modules/class-rss.php:122
 msgctxt "rss feed"
 msgid "Add New"
 msgstr ""
 
-#: includes/optional-modules/class-rss.php:114
-#: release/newspack-plugin/includes/optional-modules/class-rss.php:114
+#: includes/optional-modules/class-rss.php:143
+#: release/newspack-plugin/includes/optional-modules/class-rss.php:123
 msgid "Add New RSS Feed"
 msgstr ""
 
-#: includes/optional-modules/class-rss.php:115
-#: release/newspack-plugin/includes/optional-modules/class-rss.php:115
+#: includes/optional-modules/class-rss.php:144
+#: release/newspack-plugin/includes/optional-modules/class-rss.php:124
 msgid "New RSS Feed"
 msgstr ""
 
-#: includes/optional-modules/class-rss.php:116
-#: release/newspack-plugin/includes/optional-modules/class-rss.php:116
+#: includes/optional-modules/class-rss.php:145
+#: release/newspack-plugin/includes/optional-modules/class-rss.php:125
 msgid "Edit RSS Feed"
 msgstr ""
 
-#: includes/optional-modules/class-rss.php:117
-#: release/newspack-plugin/includes/optional-modules/class-rss.php:117
+#: includes/optional-modules/class-rss.php:146
+#: release/newspack-plugin/includes/optional-modules/class-rss.php:126
 msgid "View RSS Feed"
 msgstr ""
 
-#: includes/optional-modules/class-rss.php:118
-#: release/newspack-plugin/includes/optional-modules/class-rss.php:118
+#: includes/optional-modules/class-rss.php:147
+#: release/newspack-plugin/includes/optional-modules/class-rss.php:127
 msgid "All RSS Feeds"
 msgstr ""
 
-#: includes/optional-modules/class-rss.php:119
-#: release/newspack-plugin/includes/optional-modules/class-rss.php:119
+#: includes/optional-modules/class-rss.php:148
+#: release/newspack-plugin/includes/optional-modules/class-rss.php:128
 msgid "Search RSS Feeds"
 msgstr ""
 
-#: includes/optional-modules/class-rss.php:120
-#: release/newspack-plugin/includes/optional-modules/class-rss.php:120
+#: includes/optional-modules/class-rss.php:149
+#: release/newspack-plugin/includes/optional-modules/class-rss.php:129
 msgid "Parent RSS Feeds:"
 msgstr ""
 
-#: includes/optional-modules/class-rss.php:121
-#: release/newspack-plugin/includes/optional-modules/class-rss.php:121
+#: includes/optional-modules/class-rss.php:150
+#: release/newspack-plugin/includes/optional-modules/class-rss.php:130
 msgid "No RSS feeds found."
 msgstr ""
 
-#: includes/optional-modules/class-rss.php:122
-#: release/newspack-plugin/includes/optional-modules/class-rss.php:122
+#: includes/optional-modules/class-rss.php:151
+#: release/newspack-plugin/includes/optional-modules/class-rss.php:131
 msgid "No RSS seeds found in Trash."
 msgstr ""
 
-#: includes/optional-modules/class-rss.php:123
-#: release/newspack-plugin/includes/optional-modules/class-rss.php:123
+#: includes/optional-modules/class-rss.php:152
+#: release/newspack-plugin/includes/optional-modules/class-rss.php:132
 msgid "RSS Feed published"
 msgstr ""
 
-#: includes/optional-modules/class-rss.php:124
-#: release/newspack-plugin/includes/optional-modules/class-rss.php:124
+#: includes/optional-modules/class-rss.php:153
+#: release/newspack-plugin/includes/optional-modules/class-rss.php:133
 msgid "RSS Feed updated"
 msgstr ""
 
-#: includes/optional-modules/class-rss.php:129
-#: release/newspack-plugin/includes/optional-modules/class-rss.php:129
+#: includes/optional-modules/class-rss.php:158
+#: release/newspack-plugin/includes/optional-modules/class-rss.php:138
 msgid "RSS feeds customized for third-party services."
 msgstr ""
 
-#: includes/optional-modules/class-rss.php:157
-#: includes/optional-modules/class-rss.php:186
-#: release/newspack-plugin/includes/optional-modules/class-rss.php:157
-#: release/newspack-plugin/includes/optional-modules/class-rss.php:186
-msgid "Feed URL"
+#: includes/optional-modules/class-rss.php:187
+#: includes/optional-modules/class-rss.php:227
+#: release/newspack-plugin/includes/optional-modules/class-rss.php:167
+#: release/newspack-plugin/includes/optional-modules/class-rss.php:207
+msgid "Feed URLs"
 msgstr ""
 
-#: includes/optional-modules/class-rss.php:192
-#: release/newspack-plugin/includes/optional-modules/class-rss.php:192
+#: includes/optional-modules/class-rss.php:203
+#: release/newspack-plugin/includes/optional-modules/class-rss.php:183
+msgid "RSS:"
+msgstr ""
+
+#: includes/optional-modules/class-rss.php:210
+#: release/newspack-plugin/includes/optional-modules/class-rss.php:190
+msgid "Atom:"
+msgstr ""
+
+#: includes/optional-modules/class-rss.php:233
+#: release/newspack-plugin/includes/optional-modules/class-rss.php:213
 msgid "Content Settings"
 msgstr ""
 
-#: includes/optional-modules/class-rss.php:198
-#: release/newspack-plugin/includes/optional-modules/class-rss.php:198
+#: includes/optional-modules/class-rss.php:239
+#: release/newspack-plugin/includes/optional-modules/class-rss.php:219
 msgid "Technical Settings"
 msgstr ""
 
-#: includes/optional-modules/class-rss.php:241
-#: release/newspack-plugin/includes/optional-modules/class-rss.php:241
+#: includes/optional-modules/class-rss.php:282
+#: release/newspack-plugin/includes/optional-modules/class-rss.php:262
 msgid "A URL will be generated for this feed once published"
 msgstr ""
 
-#: includes/optional-modules/class-rss.php:278
-#: release/newspack-plugin/includes/optional-modules/class-rss.php:278
-msgid "Number of posts to display in feed:"
+#: includes/optional-modules/class-rss.php:293
+#: release/newspack-plugin/includes/optional-modules/class-rss.php:273
+msgid "RSS -"
 msgstr ""
 
-#: includes/optional-modules/class-rss.php:284
-#: release/newspack-plugin/includes/optional-modules/class-rss.php:284
-msgid "Offset posts by:"
-msgstr ""
-
-#: includes/optional-modules/class-rss.php:290
-#: release/newspack-plugin/includes/optional-modules/class-rss.php:290
-msgid "Limit timeframe to last # of hours:"
-msgstr ""
-
-#: includes/optional-modules/class-rss.php:296
-#: release/newspack-plugin/includes/optional-modules/class-rss.php:296
-msgid "Use post full content or excerpt:"
-msgstr ""
-
-#: includes/optional-modules/class-rss.php:299
-#: release/newspack-plugin/includes/optional-modules/class-rss.php:299
-msgid "Full content"
-msgstr ""
-
-#: includes/optional-modules/class-rss.php:300
-#: release/newspack-plugin/includes/optional-modules/class-rss.php:300
-msgid "Excerpt"
-msgstr ""
-
-#: includes/optional-modules/class-rss.php:305
-#: release/newspack-plugin/includes/optional-modules/class-rss.php:305
-msgid "Include only posts from these categories:"
-msgstr ""
-
-#: includes/optional-modules/class-rss.php:315
-#: release/newspack-plugin/includes/optional-modules/class-rss.php:315
-msgid "Exclude posts from these categories:"
-msgstr ""
-
-#: includes/optional-modules/class-rss.php:325
-#: release/newspack-plugin/includes/optional-modules/class-rss.php:325
-msgid "Update frequency:"
-msgstr ""
-
-#: includes/optional-modules/class-rss.php:328
-#: release/newspack-plugin/includes/optional-modules/class-rss.php:328
-msgid "Every hour"
-msgstr ""
-
-#: includes/optional-modules/class-rss.php:329
-#: release/newspack-plugin/includes/optional-modules/class-rss.php:329
-msgid "Every 5 minutes"
-msgstr ""
-
-#: includes/optional-modules/class-rss.php:330
-#: release/newspack-plugin/includes/optional-modules/class-rss.php:330
-msgid "Every 3 hours"
-msgstr ""
-
-#: includes/optional-modules/class-rss.php:331
-#: release/newspack-plugin/includes/optional-modules/class-rss.php:331
-msgid "Daily"
+#: includes/optional-modules/class-rss.php:303
+#: release/newspack-plugin/includes/optional-modules/class-rss.php:283
+msgid "Atom -"
 msgstr ""
 
 #: includes/optional-modules/class-rss.php:336
-#: release/newspack-plugin/includes/optional-modules/class-rss.php:336
-msgid "Use post ID as the guid instead of post URL:"
+#: release/newspack-plugin/includes/optional-modules/class-rss.php:316
+msgid "Number of posts to display in feed:"
 msgstr ""
 
-#: includes/optional-modules/class-rss.php:365
-#: release/newspack-plugin/includes/optional-modules/class-rss.php:365
-msgid "Add post featured images in <image> tags"
+#: includes/optional-modules/class-rss.php:342
+#: release/newspack-plugin/includes/optional-modules/class-rss.php:322
+msgid "Offset posts by:"
 msgstr ""
 
-#: includes/optional-modules/class-rss.php:372
-#: release/newspack-plugin/includes/optional-modules/class-rss.php:372
-msgid "Add post featured images in <media:> tags"
+#: includes/optional-modules/class-rss.php:348
+#: release/newspack-plugin/includes/optional-modules/class-rss.php:328
+msgid "Limit timeframe to last # of hours:"
 msgstr ""
 
-#: includes/optional-modules/class-rss.php:379
-#: release/newspack-plugin/includes/optional-modules/class-rss.php:379
-msgid "Add post updated time in <updated> tags"
+#: includes/optional-modules/class-rss.php:354
+#: release/newspack-plugin/includes/optional-modules/class-rss.php:334
+msgid "Use post full content or excerpt:"
+msgstr ""
+
+#: includes/optional-modules/class-rss.php:357
+#: release/newspack-plugin/includes/optional-modules/class-rss.php:337
+msgid "Full content"
+msgstr ""
+
+#: includes/optional-modules/class-rss.php:358
+#: release/newspack-plugin/includes/optional-modules/class-rss.php:338
+msgid "Excerpt"
+msgstr ""
+
+#: includes/optional-modules/class-rss.php:363
+#: release/newspack-plugin/includes/optional-modules/class-rss.php:343
+msgid "Include only posts from these categories:"
+msgstr ""
+
+#: includes/optional-modules/class-rss.php:373
+#: release/newspack-plugin/includes/optional-modules/class-rss.php:353
+msgid "Exclude posts from these categories:"
+msgstr ""
+
+#: includes/optional-modules/class-rss.php:383
+#: release/newspack-plugin/includes/optional-modules/class-rss.php:363
+msgid "Update frequency:"
 msgstr ""
 
 #: includes/optional-modules/class-rss.php:386
-#: release/newspack-plugin/includes/optional-modules/class-rss.php:386
+#: release/newspack-plugin/includes/optional-modules/class-rss.php:366
+msgid "Every hour"
+msgstr ""
+
+#: includes/optional-modules/class-rss.php:387
+msgid "Every 1 minute"
+msgstr ""
+
+#: includes/optional-modules/class-rss.php:388
+#: release/newspack-plugin/includes/optional-modules/class-rss.php:367
+msgid "Every 5 minutes"
+msgstr ""
+
+#: includes/optional-modules/class-rss.php:389
+#: release/newspack-plugin/includes/optional-modules/class-rss.php:368
+msgid "Every 3 hours"
+msgstr ""
+
+#: includes/optional-modules/class-rss.php:390
+#: release/newspack-plugin/includes/optional-modules/class-rss.php:369
+msgid "Daily"
+msgstr ""
+
+#: includes/optional-modules/class-rss.php:395
+#: release/newspack-plugin/includes/optional-modules/class-rss.php:374
+msgid "Use post ID as the guid instead of post URL:"
+msgstr ""
+
+#: includes/optional-modules/class-rss.php:417
+#: release/newspack-plugin/includes/optional-modules/class-rss.php:387
+msgid "Only include republishable posts"
+msgstr ""
+
+#: includes/optional-modules/class-rss.php:418
+#: release/newspack-plugin/includes/optional-modules/class-rss.php:388
+msgctxt "help text for only republishable setting"
+msgid "When toggled on, posts which have republication disabled will be excluded from the feed."
+msgstr ""
+
+#: includes/optional-modules/class-rss.php:427
+msgid "Include only distributable images"
+msgstr ""
+
+#: includes/optional-modules/class-rss.php:429
+msgctxt "help text for remove non-distributable images setting"
+msgid "When toggled on, images not marked as distributable will be excluded from feed content."
+msgstr ""
+
+#: includes/optional-modules/class-rss.php:431
+msgid "Note: this will respect the same settings for distributable images RTT uses for other distributiion purposes"
+msgstr ""
+
+#: includes/optional-modules/class-rss.php:463
+#: release/newspack-plugin/includes/optional-modules/class-rss.php:419
+msgid "Add post featured images in <image> tags"
+msgstr ""
+
+#: includes/optional-modules/class-rss.php:470
+#: release/newspack-plugin/includes/optional-modules/class-rss.php:426
+msgid "Add post featured images in <media:> tags"
+msgstr ""
+
+#: includes/optional-modules/class-rss.php:477
+#: release/newspack-plugin/includes/optional-modules/class-rss.php:433
+msgid "Add post updated time in <updated> tags"
+msgstr ""
+
+#: includes/optional-modules/class-rss.php:484
+#: release/newspack-plugin/includes/optional-modules/class-rss.php:440
 msgid "Add categories and tags in <tags> element"
 msgstr ""
 
-#: includes/optional-modules/class-rss.php:393
-#: release/newspack-plugin/includes/optional-modules/class-rss.php:393
+#: includes/optional-modules/class-rss.php:491
+#: release/newspack-plugin/includes/optional-modules/class-rss.php:447
 msgid "Add featured image at the top of feed content"
 msgstr ""
 
-#: includes/optional-modules/class-rss.php:400
-#: release/newspack-plugin/includes/optional-modules/class-rss.php:400
+#: includes/optional-modules/class-rss.php:498
+#: release/newspack-plugin/includes/optional-modules/class-rss.php:454
 msgid "Add Yahoo namespace to RSS namespace: xmlns:media=\"http://search.yahoo.com/mrss/\""
 msgstr ""
 
-#: includes/optional-modules/class-rss.php:407
-#: release/newspack-plugin/includes/optional-modules/class-rss.php:407
+#: includes/optional-modules/class-rss.php:505
+#: release/newspack-plugin/includes/optional-modules/class-rss.php:461
 msgid "Wrap the content of <title> elements in CDATA tags"
 msgstr ""
 
+#: includes/optional-modules/class-rss.php:513
+msgid "Custom tracking snippet"
+msgstr ""
+
+#: includes/optional-modules/class-rss.php:514
+msgctxt "help text for custom tracking snippet"
+msgid "Tracking snippet that will be appended to the end of each post in the feed. You can use {{post-id}} and {{post-url}} as dynamic variables."
+msgstr ""
+
+#: includes/optional-modules/class-rss.php:551
+#: release/newspack-plugin/includes/optional-modules/class-rss.php:489
+msgid "Add republication tracker snippet to posts"
+msgstr ""
+
+#: includes/optional-modules/class-woo-member-commenting.php:92
+#: release/newspack-plugin/includes/optional-modules/class-woo-member-commenting.php:92
+msgid "Only Members may post a comment."
+msgstr ""
+
+#. translators: %s: sign in URL
+#: includes/optional-modules/class-woo-member-commenting.php:96
+#: release/newspack-plugin/includes/optional-modules/class-woo-member-commenting.php:96
+msgid "If you already have a membership, then <a href=\"%s\">sign in</a>."
+msgstr ""
+
+#: includes/optional-modules/class-woo-member-commenting.php:178
+#: release/newspack-plugin/includes/optional-modules/class-woo-member-commenting.php:178
+msgid "Become a member now"
+msgstr ""
+
+#: includes/plugins/class-newspack-elections.php:31
+#: release/newspack-plugin/includes/plugins/class-newspack-elections.php:31
+msgid "Homepage Pre-Results Module — AP"
+msgstr ""
+
+#: includes/plugins/class-newspack-elections.php:32
+#: release/newspack-plugin/includes/plugins/class-newspack-elections.php:32
+msgid "Homepage Results Module — AP"
+msgstr ""
+
+#: includes/plugins/class-newspack-elections.php:33
+#: release/newspack-plugin/includes/plugins/class-newspack-elections.php:33
+msgid "Live Election Results Post — AP"
+msgstr ""
+
+#: includes/plugins/class-newspack-elections.php:34
+#: release/newspack-plugin/includes/plugins/class-newspack-elections.php:34
+msgid "Homepage Pre-Results Module — DDHQ"
+msgstr ""
+
+#: includes/plugins/class-newspack-elections.php:35
+#: release/newspack-plugin/includes/plugins/class-newspack-elections.php:35
+msgid "Homepage Results Module — DDHQ"
+msgstr ""
+
+#: includes/plugins/class-newspack-elections.php:36
+#: release/newspack-plugin/includes/plugins/class-newspack-elections.php:36
+msgid "Live Election Results Post — DDHQ"
+msgstr ""
+
+#: includes/plugins/class-newspack-elections.php:44
+#: release/newspack-plugin/includes/plugins/class-newspack-elections.php:44
+msgid "Newspack Elections"
+msgstr ""
+
+#: includes/plugins/class-newspack-elections.php:62
+#: release/newspack-plugin/includes/plugins/class-newspack-elections.php:62
+msgctxt "Block pattern description"
+msgid "Help format and provide context to AP and DDHQ elections embeds."
+msgstr ""
+
 #. translators: %s is the custom role name.
-#: includes/plugins/co-authors-plus/class-guest-contributor-role.php:126
-#: release/newspack-plugin/includes/plugins/class-co-authors-plus.php:120
+#: includes/plugins/co-authors-plus/class-guest-contributor-role.php:190
+#: release/newspack-plugin/includes/plugins/co-authors-plus/class-guest-contributor-role.php:190
 msgid "Can't update details of a \"%s\" user."
 msgstr ""
 
-#: includes/plugins/co-authors-plus/class-guest-contributor-role.php:143
-#: release/newspack-plugin/includes/plugins/class-co-authors-plus.php:137
+#: includes/plugins/co-authors-plus/class-guest-contributor-role.php:207
+#: release/newspack-plugin/includes/plugins/co-authors-plus/class-guest-contributor-role.php:207
 msgid "It looks like you are an author on this site. Please contact a site adminstrator to get your account deactivated."
 msgstr ""
 
-#: includes/plugins/co-authors-plus/class-guest-contributor-role.php:166
-#: release/newspack-plugin/includes/plugins/class-co-authors-plus.php:160
+#: includes/plugins/co-authors-plus/class-guest-contributor-role.php:230
+#: release/newspack-plugin/includes/plugins/co-authors-plus/class-guest-contributor-role.php:230
 msgid "Guest Contributor"
 msgstr ""
 
-#: includes/plugins/co-authors-plus/class-guest-contributor-role.php:297
-#: includes/reader-revenue/my-account/class-woocommerce-my-account.php:378
-#: includes/reader-revenue/templates/myaccount-edit-account.php:51
-#: release/newspack-plugin/includes/plugins/class-co-authors-plus.php:259
-#: release/newspack-plugin/includes/reader-revenue/my-account/class-woocommerce-my-account.php:378
-#: release/newspack-plugin/includes/reader-revenue/templates/myaccount-edit-account.php:51
+#: includes/plugins/co-authors-plus/class-guest-contributor-role.php:361
+#: includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:660
+#: includes/plugins/woocommerce/my-account/templates/v0/edit-account.php:54
+#: includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:86
+#: release/newspack-plugin/includes/plugins/co-authors-plus/class-guest-contributor-role.php:361
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:660
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v0/edit-account.php:54
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:86
 msgid "Display name"
 msgstr ""
 
-#: includes/plugins/co-authors-plus/class-guest-contributor-role.php:341
-#: release/newspack-plugin/includes/plugins/class-co-authors-plus.php:303
+#: includes/plugins/co-authors-plus/class-guest-contributor-role.php:405
+#: release/newspack-plugin/includes/plugins/co-authors-plus/class-guest-contributor-role.php:405
 msgid "Guest Contributors cannot login."
 msgstr ""
 
-#: includes/plugins/co-authors-plus/class-guest-contributor-role.php:353
-#: includes/plugins/co-authors-plus/class-guest-contributor-role.php:354
-#: includes/plugins/co-authors-plus/class-guest-contributor-role.php:367
-#: release/newspack-plugin/includes/plugins/class-co-authors-plus.php:315
-#: release/newspack-plugin/includes/plugins/class-co-authors-plus.php:316
-#: release/newspack-plugin/includes/plugins/class-co-authors-plus.php:329
+#: includes/plugins/co-authors-plus/class-guest-contributor-role.php:417
+#: includes/plugins/co-authors-plus/class-guest-contributor-role.php:418
+#: includes/plugins/co-authors-plus/class-guest-contributor-role.php:431
+#: release/newspack-plugin/includes/plugins/co-authors-plus/class-guest-contributor-role.php:417
+#: release/newspack-plugin/includes/plugins/co-authors-plus/class-guest-contributor-role.php:418
+#: release/newspack-plugin/includes/plugins/co-authors-plus/class-guest-contributor-role.php:431
 msgid "Guest Authors"
 msgstr ""
 
-#: includes/plugins/co-authors-plus/class-guest-contributor-role.php:369
-#: release/newspack-plugin/includes/plugins/class-co-authors-plus.php:331
+#: includes/plugins/co-authors-plus/class-guest-contributor-role.php:433
+#: release/newspack-plugin/includes/plugins/co-authors-plus/class-guest-contributor-role.php:433
 msgid "Co-Authors-Plus' Guest Authors are disabled in this site. Use the Guest Contributor user role instead."
 msgstr ""
 
-#: includes/plugins/co-authors-plus/class-guest-contributor-role.php:370
-#: release/newspack-plugin/includes/plugins/class-co-authors-plus.php:332
+#: includes/plugins/co-authors-plus/class-guest-contributor-role.php:434
+#: release/newspack-plugin/includes/plugins/co-authors-plus/class-guest-contributor-role.php:434
 msgid "You can use one of the shortcuts below:"
 msgstr ""
 
-#: includes/plugins/co-authors-plus/class-guest-contributor-role.php:372
-#: release/newspack-plugin/includes/plugins/class-co-authors-plus.php:334
+#: includes/plugins/co-authors-plus/class-guest-contributor-role.php:436
+#: release/newspack-plugin/includes/plugins/co-authors-plus/class-guest-contributor-role.php:436
 msgid "Create a new Guest Contributor"
 msgstr ""
 
-#: includes/plugins/co-authors-plus/class-guest-contributor-role.php:373
-#: release/newspack-plugin/includes/plugins/class-co-authors-plus.php:335
+#: includes/plugins/co-authors-plus/class-guest-contributor-role.php:437
+#: release/newspack-plugin/includes/plugins/co-authors-plus/class-guest-contributor-role.php:437
 msgid "View all Guest Contributors"
 msgstr ""
 
-#: includes/plugins/co-authors-plus/class-guest-contributor-role.php:419
-#: release/newspack-plugin/includes/plugins/class-co-authors-plus.php:381
+#: includes/plugins/co-authors-plus/class-guest-contributor-role.php:483
+#: release/newspack-plugin/includes/plugins/co-authors-plus/class-guest-contributor-role.php:483
 msgid "Co-Authors Plus Options"
 msgstr ""
 
-#: includes/plugins/co-authors-plus/class-guest-contributor-role.php:424
-#: release/newspack-plugin/includes/plugins/class-co-authors-plus.php:386
+#: includes/plugins/co-authors-plus/class-guest-contributor-role.php:488
+#: release/newspack-plugin/includes/plugins/co-authors-plus/class-guest-contributor-role.php:488
 msgid "Enable as coauthor"
 msgstr ""
 
-#: includes/plugins/co-authors-plus/class-guest-contributor-role.php:429
-#: release/newspack-plugin/includes/plugins/class-co-authors-plus.php:391
+#: includes/plugins/co-authors-plus/class-guest-contributor-role.php:493
+#: release/newspack-plugin/includes/plugins/co-authors-plus/class-guest-contributor-role.php:493
 msgid "Allow this user to be assigned as a co-author of a post."
 msgstr ""
 
-#: includes/plugins/co-authors-plus/class-guest-contributor-role.php:433
-#: release/newspack-plugin/includes/plugins/class-co-authors-plus.php:395
+#: includes/plugins/co-authors-plus/class-guest-contributor-role.php:497
+#: release/newspack-plugin/includes/plugins/co-authors-plus/class-guest-contributor-role.php:497
 msgid "If this option is checked, the \"Non Editing Contributor\" role will be added to the user and they will be able to be assigned as a co-author of a post even if they are not allowed to edit posts. For users with edit access, this option has no effect."
 msgstr ""
 
-#: includes/plugins/wc-memberships/class-memberships.php:1006
-#: release/newspack-plugin/includes/plugins/wc-memberships/class-memberships.php:1001
-msgid "Checking for expired memberships linked to active subscriptions..."
+#: includes/plugins/co-authors-plus/class-nicename-change-ui.php:64
+#: release/newspack-plugin/includes/plugins/co-authors-plus/class-nicename-change-ui.php:64
+msgid "Please provide a new slug."
 msgstr ""
 
-#. Translators: %1$d is the membership ID, %2$s is the subscription ID.
-#: includes/plugins/wc-memberships/class-memberships.php:1029
-#: release/newspack-plugin/includes/plugins/wc-memberships/class-memberships.php:1024
-msgid "Failed to reactivate membership %1$d linked to active subscription %2$s."
+#. translators: %s is the new nicename.
+#: includes/plugins/co-authors-plus/class-nicename-change-ui.php:90
+#: release/newspack-plugin/includes/plugins/co-authors-plus/class-nicename-change-ui.php:90
+msgid "Slug %s is available."
 msgstr ""
 
-#. Translators: %d is the number of reactivated memberships.
-#: includes/plugins/wc-memberships/class-memberships.php:1047
-#: release/newspack-plugin/includes/plugins/wc-memberships/class-memberships.php:1042
-msgid "Reactivated %d memberships linked to active subscriptions."
+#: includes/plugins/co-authors-plus/class-nicename-change-ui.php:94
+#: release/newspack-plugin/includes/plugins/co-authors-plus/class-nicename-change-ui.php:94
+msgid "Slug is not available."
 msgstr ""
 
-#: includes/plugins/wc-memberships/class-memberships.php:1114
-#: release/newspack-plugin/includes/plugins/wc-memberships/class-memberships.php:1109
+#. translators: %s is the new nicename.
+#: includes/plugins/co-authors-plus/class-nicename-change-ui.php:143
+#: release/newspack-plugin/includes/plugins/co-authors-plus/class-nicename-change-ui.php:143
+msgid "Slug updated to %s!"
+msgstr ""
+
+#: includes/plugins/co-authors-plus/class-nicename-change-ui.php:166
+#: release/newspack-plugin/includes/plugins/co-authors-plus/class-nicename-change-ui.php:166
+msgid "Change User archive URL"
+msgstr ""
+
+#: includes/plugins/co-authors-plus/class-nicename-change-ui.php:171
+#: release/newspack-plugin/includes/plugins/co-authors-plus/class-nicename-change-ui.php:171
+msgid "Current slug"
+msgstr ""
+
+#: includes/plugins/co-authors-plus/class-nicename-change-ui.php:179
+#: includes/plugins/co-authors-plus/class-nicename-change-ui.php:198
+#: release/newspack-plugin/includes/plugins/co-authors-plus/class-nicename-change-ui.php:179
+#: release/newspack-plugin/includes/plugins/co-authors-plus/class-nicename-change-ui.php:198
+msgid "Change slug"
+msgstr ""
+
+#: includes/plugins/co-authors-plus/class-nicename-change-ui.php:187
+#: release/newspack-plugin/includes/plugins/co-authors-plus/class-nicename-change-ui.php:187
+msgid "Changing the slug will change the URL of your author archive page. The old URL will redirect to the new one after the change."
+msgstr ""
+
+#: includes/plugins/co-authors-plus/class-nicename-change-ui.php:195
+#: release/newspack-plugin/includes/plugins/co-authors-plus/class-nicename-change-ui.php:195
+msgid "Check availability"
+msgstr ""
+
+#. translators: %s: Subscription ID
+#: includes/plugins/wc-memberships/class-membership-expiry.php:54
+msgid "Another active subscription for this product was found (Subscription ID: %s). Expiry prevented."
+msgstr ""
+
+#: includes/plugins/wc-memberships/class-memberships.php:974
+#: release/newspack-plugin/includes/plugins/wc-memberships/class-memberships.php:973
 msgid "Skip content restriction in RSS feeds"
 msgstr ""
 
-#: includes/plugins/wc-memberships/class-memberships.php:1116
-#: release/newspack-plugin/includes/plugins/wc-memberships/class-memberships.php:1111
+#: includes/plugins/wc-memberships/class-memberships.php:976
+#: release/newspack-plugin/includes/plugins/wc-memberships/class-memberships.php:975
 msgid "If enabled, full content will be available in RSS feeds."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation-emails.php:48
+#: includes/plugins/wc-memberships/class-memberships.php:1083
+#: release/newspack-plugin/includes/plugins/wc-memberships/class-memberships.php:1082
+msgid "Reevaluate status"
+msgstr ""
+
+#: includes/plugins/wc-memberships/class-memberships.php:1085
+#: release/newspack-plugin/includes/plugins/wc-memberships/class-memberships.php:1084
+msgid "Reevaluate status based on subscription status."
+msgstr ""
+
+#: includes/plugins/woocommerce-subscriptions/class-on-hold-duration.php:56
+#: release/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-on-hold-duration.php:56
+msgid "Newspack Subscriptions Settings"
+msgstr ""
+
+#: includes/plugins/woocommerce-subscriptions/class-on-hold-duration.php:58
+#: release/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-on-hold-duration.php:58
+msgid "Subscriptions settings added by Newspack."
+msgstr ""
+
+#: includes/plugins/woocommerce-subscriptions/class-on-hold-duration.php:62
+#: release/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-on-hold-duration.php:62
+msgid "On-hold Duration"
+msgstr ""
+
+#. Translators: %s is a line break.
+#: includes/plugins/woocommerce-subscriptions/class-on-hold-duration.php:73
+#: release/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-on-hold-duration.php:73
+msgid "Set the number of days a subscription remains in the On-Hold status after all automatic payment retries have failed.%sDuring this period, subscribers can update their payment details to restore the subscription at their current price. Once this time expires, the subscription will automatically transition to expired."
+msgstr ""
+
+#: includes/plugins/woocommerce-subscriptions/class-on-hold-duration.php:194
+#: release/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-on-hold-duration.php:194
+msgid "Subscription status updated by Newspack."
+msgstr ""
+
+#: includes/plugins/woocommerce-subscriptions/class-subscriptions-confirmation.php:56
+#: release/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-subscriptions-confirmation.php:56
+msgid "You must agree to the subscription terms before proceeding."
+msgstr ""
+
+#: includes/plugins/woocommerce-subscriptions/class-subscriptions-confirmation.php:62
+#: release/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-subscriptions-confirmation.php:62
+msgid "You must agree to the Terms & Conditions before proceeding."
+msgstr ""
+
+#. Translators: %s is the fee percentage.
+#: includes/plugins/woocommerce/class-woocommerce-cli.php:143
+#: includes/plugins/woocommerce/class-woocommerce-cover-fees.php:81
+#: release/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-cli.php:143
+#: release/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-cover-fees.php:81
+msgid "Transaction fee (%s)"
+msgstr ""
+
+#: includes/plugins/woocommerce/class-woocommerce-connection.php:205
+#: includes/reader-activation/class-reader-activation.php:2515
+#: release/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-connection.php:204
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:2507
+msgid "Please wait a moment before trying again."
+msgstr ""
+
+#: includes/plugins/woocommerce/class-woocommerce-connection.php:247
+#: release/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-connection.php:246
+msgid "Please wait a moment before trying to complete this transaction again."
+msgstr ""
+
+#: includes/plugins/woocommerce/class-woocommerce-connection.php:258
+#: includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:318
+#: release/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-connection.php:257
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:318
+msgid "Please wait a moment before trying to add a new payment method."
+msgstr ""
+
+#: includes/plugins/woocommerce/class-woocommerce-connection.php:388
+#: includes/plugins/woocommerce/class-woocommerce-connection.php:482
+#: release/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-connection.php:387
+#: release/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-connection.php:481
+msgid "Monthly"
+msgstr ""
+
+#: includes/plugins/woocommerce/class-woocommerce-connection.php:389
+#: includes/plugins/woocommerce/class-woocommerce-connection.php:483
+#: release/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-connection.php:388
+#: release/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-connection.php:482
+msgid "Yearly"
+msgstr ""
+
+#: includes/plugins/woocommerce/class-woocommerce-connection.php:418
+#: includes/plugins/woocommerce/class-woocommerce-connection.php:514
+#: release/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-connection.php:417
+#: release/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-connection.php:513
+msgid "One-time"
+msgstr ""
+
+#: includes/plugins/woocommerce/class-woocommerce-connection.php:434
+#: release/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-connection.php:433
+msgid "Card"
+msgstr ""
+
+#: includes/plugins/woocommerce/class-woocommerce-connection.php:438
+#: includes/reader-activation/class-reader-activation.php:293
+#: release/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-connection.php:437
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:293
+msgid "My Account"
+msgstr ""
+
+#: includes/plugins/woocommerce/class-woocommerce-connection.php:526
+#: release/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-connection.php:525
+msgid "Restart Donation"
+msgstr ""
+
+#: includes/plugins/woocommerce/class-woocommerce-connection.php:526
+#: release/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-connection.php:525
+msgid "Restart Subscription"
+msgstr ""
+
+#: includes/plugins/woocommerce/class-woocommerce-connection.php:534
+#: release/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-connection.php:533
+msgid "Donation Cancelled"
+msgstr ""
+
+#: includes/plugins/woocommerce/class-woocommerce-connection.php:534
+#: release/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-connection.php:533
+msgid "Subscription Cancelled"
+msgstr ""
+
+#: includes/plugins/woocommerce/class-woocommerce-connection.php:538
+#: release/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-connection.php:537
+msgid "recurring donation"
+msgstr ""
+
+#: includes/plugins/woocommerce/class-woocommerce-connection.php:538
+#: release/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-connection.php:537
+msgid "subscription"
+msgstr ""
+
+#. Translators: %s is the user's billing first and last name – or company name.
+#: includes/plugins/woocommerce/class-woocommerce-connection.php:779
+#: release/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-connection.php:778
+msgid "%s's Team"
+msgstr ""
+
+#: includes/plugins/woocommerce/class-woocommerce-cover-fees.php:97
+#: release/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-cover-fees.php:97
+msgid "The donor opted to cover transaction fees."
+msgstr ""
+
+#. Translators: %s is the possessive form of the site name.
+#: includes/plugins/woocommerce/class-woocommerce-cover-fees.php:177
+#: release/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-cover-fees.php:177
+msgid "I’d like to cover the %1$s transaction fee to ensure my full donation goes towards %2$s mission."
+msgstr ""
+
+#: includes/plugins/woocommerce/class-woocommerce-duplicate-orders.php:174
+#: release/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-duplicate-orders.php:174
+msgid "There are some potentially duplicate transactions to review. Some of these might be intentional. Click this message to display the list of possible duplicates."
+msgstr ""
+
+#. translators: 1: customer email, 2: order amount, 3: orders date, 4: order IDs
+#: includes/plugins/woocommerce/class-woocommerce-duplicate-orders.php:200
+#: release/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-duplicate-orders.php:200
+msgid "Customer %1$s made multiple orders of %2$s on %3$s. Orders: %4$s."
+msgstr ""
+
+#: includes/plugins/woocommerce/class-woocommerce-duplicate-orders.php:212
+#: release/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-duplicate-orders.php:212
+#: dist/commons.js:13
+#: dist/componentsDemo.js:1
+#: dist/handoff-banner.js:1
+#: release/newspack-plugin/dist/commons.js:13
+#: release/newspack-plugin/dist/componentsDemo.js:1
+#: release/newspack-plugin/dist/handoff-banner.js:1
+msgid "Dismiss"
+msgstr ""
+
+#: includes/plugins/woocommerce/class-woocommerce-order-utm.php:94
+#: release/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-order-utm.php:94
+msgid "UTM Parameters"
+msgstr ""
+
+#: includes/plugins/woocommerce/class-woocommerce-products.php:56
+#: release/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-products.php:56
+msgid "Auto-complete orders"
+msgstr ""
+
+#: includes/plugins/woocommerce/class-woocommerce-products.php:57
+#: release/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-products.php:57
+msgid "Allow orders containing this product to automatically complete upon successful payment."
+msgstr ""
+
+#. translators: %1$s: action URL, %2$s: link attributes
+#: includes/plugins/woocommerce/class-woocommerce-update-payment-notice.php:148
+msgid "Please <a href=\"%1$s\" %2$s>update your payment method</a>."
+msgstr ""
+
+#. translators: %s: donation formatted value
+#: includes/plugins/woocommerce/class-woocommerce-update-payment-notice.php:179
+msgid "Your recurring donation of %s has stopped."
+msgstr ""
+
+#. translators: %s: subscription product name
+#: includes/plugins/woocommerce/class-woocommerce-update-payment-notice.php:185
+msgid "Your “%s” subscription is not active."
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/class-my-account-ui-v0.php:90
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v0.php:90
+msgid "Please check your email inbox for instructions on how to delete your account."
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/class-my-account-ui-v0.php:90
+#: includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:434
+#: includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:585
+#: includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:1138
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v0.php:90
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:434
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:585
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:1138
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:26
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:32
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:35
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:38
+#: dist/newsletters.js:1
+#: dist/newsletters.js:4
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:14
+#: dist/setup.js:4
+#: dist/setup.js:7
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:26
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:32
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:35
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:38
+#: release/newspack-plugin/dist/newsletters.js:1
+#: release/newspack-plugin/dist/newsletters.js:4
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:14
+#: release/newspack-plugin/dist/setup.js:4
+#: release/newspack-plugin/dist/setup.js:7
+msgid "Something went wrong."
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/class-my-account-ui-v1-passwords.php:149
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1-passwords.php:149
+msgid "Please enter your current password."
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/class-my-account-ui-v1-passwords.php:154
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1-passwords.php:154
+msgid "Invalid current password."
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/class-my-account-ui-v1-passwords.php:166
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1-passwords.php:166
+msgid "Password updated."
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/class-my-account-ui-v1-passwords.php:188
+#: includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:216
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1-passwords.php:188
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:216
+msgid "New password"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/class-my-account-ui-v1-passwords.php:188
+#: includes/plugins/woocommerce/my-account/class-my-account-ui-v1-passwords.php:200
+#: includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:205
+#: includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:216
+#: includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:228
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1-passwords.php:188
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1-passwords.php:200
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:205
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:216
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:228
+msgid "Required"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/class-my-account-ui-v1-passwords.php:200
+#: includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:228
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1-passwords.php:200
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:228
+msgid "Re-enter new password"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/class-my-account-ui-v1-passwords.php:227
+#: includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:250
+#: includes/templates/reader-activation-emails/password-reset.php:42
+#: includes/templates/reader-activation-emails/password-reset.php:248
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1-passwords.php:227
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:250
+#: release/newspack-plugin/includes/templates/reader-activation-emails/password-reset.php:42
+#: release/newspack-plugin/includes/templates/reader-activation-emails/password-reset.php:248
+msgid "Set password"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/class-my-account-ui-v1-passwords.php:227
+#: includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:200
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1-passwords.php:227
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:200
+msgid "Reset password"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/class-my-account-ui-v1-passwords.php:235
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1-passwords.php:235
+msgid "Save password"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/class-my-account-ui-v1-passwords.php:239
+#: includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:296
+#: includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:382
+#: includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:520
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1-passwords.php:239
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:283
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:369
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:507
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:10
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: dist/billboard.js:1
+#: dist/billboard.js:12
+#: dist/commons.js:13
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:5
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:26
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: dist/other-scripts/corrections-modal.js:7
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:10
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+#: release/newspack-plugin/dist/billboard.js:1
+#: release/newspack-plugin/dist/billboard.js:12
+#: release/newspack-plugin/dist/commons.js:13
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:5
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:26
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+#: release/newspack-plugin/dist/other-scripts/corrections-modal.js:7
+msgid "Cancel"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:94
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:109
+msgid "Renew subscription"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:95
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:110
+msgid "Renew subscription early"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:96
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:111
+msgid "Change payment method"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:182
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:169
+msgid "Payment information"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:223
+#: includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:355
+#: includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:449
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:210
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:342
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:436
+msgid "Are you sure?"
+msgstr ""
+
+#. Translators: %s will be displayed only if the user has active subscriptions or newsletter subscriptions.
+#: includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:230
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:217
+msgid "Deleting your account is permanent and cannot be undone. All your data will be removed from our systems. %s"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:231
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:218
+msgid "Your newsletter subscriptions and all recurring payments will be cancelled."
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:239
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:226
+msgid "Instead of deleting your account, you may want to:"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:248
+#: includes/wizards/audience/class-audience-subscriptions.php:47
+#: includes/wizards/newspack/class-newspack-dashboard.php:70
+#: includes/wizards/newspack/class-newspack-dashboard.php:218
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:235
+#: release/newspack-plugin/includes/wizards/audience/class-audience-subscriptions.php:47
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:70
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:218
+msgid "Subscriptions"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:249
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:236
+msgid "Review and cancel active subscriptions."
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:253
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:240
+msgid "Manage subscriptions"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:261
+#: includes/wizards/newspack/class-newspack-dashboard.php:81
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:248
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:81
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Newsletters"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:262
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:249
+msgid "Update your newsletter preferences."
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:266
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:253
+msgid "Manage newsletters"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:278
+#: includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:283
+#: includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:322
+#: includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:371
+#: includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:378
+#: includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:265
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:265
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:270
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:309
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:358
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:365
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:265
+msgid "Delete account"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:311
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:298
+msgid "Your account deletion has been requested."
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:313
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:300
+msgid "We just sent instructions on how to delete your account to"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:327
+#: includes/reader-activation/class-reader-activation.php:274
+#: includes/reader-activation/class-reader-activation.php:302
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:314
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:274
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:302
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:38
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:38
+msgid "Continue"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:358
+#: includes/plugins/woocommerce/my-account/templates/delete-account.php:39
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:345
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/delete-account.php:39
+msgid "Confirm to delete your account permanently."
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:359
+#: includes/plugins/woocommerce/my-account/templates/delete-account.php:45
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:346
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/delete-account.php:45
+msgid "Caution, this action is irreversible!"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:414
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:401
+msgid "Your account has been successfully deleted."
+msgstr ""
+
+#. Translators: %s is either the next payment date, or a generic explanation of when the subscription will end if cancelled.
+#: includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:456
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:443
+msgid "If you cancel now, your subscription will remain active until %s."
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:457
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:444
+msgid "the end of your current billing period"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:463
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:450
+msgid "After this, your subscription access will end unless you choose to renew."
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:470
+#: includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:474
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:457
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:461
+msgid "Cancel subscription"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:479
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:466
+msgid "Keep subscription"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:512
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:499
+msgid "Add Payment Method"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:299
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:299
+msgid "Are you sure you want to cancel this subscription?"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:340
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:340
+msgid "Account settings"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:345
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:345
+msgid "Log out"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:427
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:427
+msgid "Please check your email inbox for instructions on how to set a new password."
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:514
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:514
+msgid "Invalid user ID."
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:578
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:578
+msgid "Please check your email inbox for a link to verify your account."
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:659
+#: includes/plugins/woocommerce/my-account/templates/v0/edit-account.php:68
+#: includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:100
+#: includes/reader-activation/class-reader-activation.php:979
+#: includes/reader-activation/class-reader-activation.php:1529
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:659
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v0/edit-account.php:68
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:100
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:979
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:1529
+msgid "Email address"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:899
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:899
+msgid "Active Memberships"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:900
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:900
+msgid "These memberships are active, but don't have an associated subscription. They will need to be manually renewed when they expire."
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:1024
+#: includes/reader-activation/class-reader-activation.php:263
+#: includes/reader-activation/class-reader-activation.php:2220
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:1024
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:263
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:2220
+msgid "Please enter a valid email address."
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:1026
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:1026
+msgid "This email address is already in use."
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:1030
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:1030
+msgid "Something went wrong. Please try again."
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:1070
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:1070
+msgid "Something went wrong. Please contact the site administrator."
+msgstr ""
+
+#. Translators: %s is the email address the verification email was sent to..
+#: includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:1075
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:1075
+msgid "A verification email has been sent to %s. Please verify to complete the change."
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:1117
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:1117
+msgid "Your email address has been successfully updated."
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:1142
+#: includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:1178
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:1142
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:1178
+msgid "This email change request has been cancelled or expired."
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:1173
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:1173
+msgid "Your email address change request has been cancelled."
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/templates/after-delete-account.php:15
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/after-delete-account.php:15
+msgid "Your account has been deleted."
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/templates/after-delete-account.php:18
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/after-delete-account.php:18
+msgid "We're sorry to see you go. But hope you'll continue to follow our coverage."
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/templates/after-delete-account.php:21
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/after-delete-account.php:21
+msgid "Return to home page"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/templates/delete-account.php:25
+#: includes/plugins/woocommerce/my-account/templates/delete-account.php:32
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/delete-account.php:25
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/delete-account.php:32
+msgid "Invalid token"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/templates/delete-account.php:42
+#: includes/plugins/woocommerce/my-account/templates/v0/edit-account.php:168
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/delete-account.php:42
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v0/edit-account.php:168
+msgid "Deleting your account will also cancel any newsletter subscriptions and recurring payments."
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/templates/delete-account.php:52
+#: includes/plugins/woocommerce/my-account/templates/v0/edit-account.php:160
+#: includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:271
+#: includes/reader-activation/class-reader-activation-emails.php:148
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/delete-account.php:52
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v0/edit-account.php:160
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:271
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation-emails.php:148
+msgid "Delete Account"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/templates/v0/edit-account.php:61
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v0/edit-account.php:61
+msgid "Your Name"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/templates/v0/edit-account.php:64
+#: includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:96
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v0/edit-account.php:64
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:96
+msgid "This is how your name is displayed publicly."
+msgstr ""
+
+#. Translators: %s is the account's current email address.
+#: includes/plugins/woocommerce/my-account/templates/v0/edit-account.php:81
+#: includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:136
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v0/edit-account.php:81
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:136
+msgid "This email address is pending verification. Please verify to complete the change request, or cancel the change to retain the current account email: %s"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/templates/v0/edit-account.php:116
+#: includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:182
+#: includes/templates/reader-activation-emails/change-email-cancel.php:44
+#: includes/templates/reader-activation-emails/change-email-cancel.php:245
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v0/edit-account.php:116
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:182
+#: release/newspack-plugin/includes/templates/reader-activation-emails/change-email-cancel.php:44
+#: release/newspack-plugin/includes/templates/reader-activation-emails/change-email-cancel.php:245
+msgid "Cancel email change"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/templates/v0/edit-account.php:118
+#: includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:185
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v0/edit-account.php:118
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:185
+msgid "Save changes"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/templates/v0/edit-account.php:133
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v0/edit-account.php:133
+msgid "Create a Password"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/templates/v0/edit-account.php:135
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v0/edit-account.php:135
+msgid "Reset Password"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/templates/v0/edit-account.php:142
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v0/edit-account.php:142
+msgid "Email me a link to set my password"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/templates/v0/edit-account.php:144
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v0/edit-account.php:144
+msgid "Email me a password reset link"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/templates/v0/edit-account.php:163
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v0/edit-account.php:163
+msgid "Request account deletion"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:52
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:52
+msgid "Profile"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:58
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:58
+msgid "First name"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:65
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:65
+msgid "Your First Name"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:71
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:71
+msgid "Last name"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:78
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:78
+msgid "Your Last Name"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:93
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:93
+msgid "Your Display Name"
+msgstr ""
+
+#. Translators: %s is the reply-to email address for the site.
+#: includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:151
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:151
+msgid "To update your email address, please <a href=\"mailto:%s\">contact us</a>."
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:185
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:185
+msgid "Update profile"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:194
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:194
+msgid "Password"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:197
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:197
+msgid "Create a password to secure your account."
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:197
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:197
+msgid "Reset your account password."
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:200
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:200
+msgid "Create a password"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:205
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:205
+msgid "Current password"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:250
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:250
+msgid "Update password"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:253
+#: includes/reader-activation/class-reader-activation.php:278
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:253
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:278
+msgid "Forgot password"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:267
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:267
+msgid "Please note, account deletion is final, and there will be no way to restore your account."
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/templates/v1/navigation.php:17
+#: includes/plugins/woocommerce/my-account/templates/v1/navigation.php:34
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/navigation.php:17
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/navigation.php:34
+msgid "Back to Homepage"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/templates/v1/navigation.php:19
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/navigation.php:19
+msgid "Open navigation"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/templates/v1/navigation.php:23
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/navigation.php:23
+msgid "Account pages"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/templates/v1/navigation.php:26
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/navigation.php:26
+msgid "Close navigation"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/templates/v1/navigation.php:29
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/navigation.php:29
+msgid "Back to homepage"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/templates/v1/navigation.php:55
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/navigation.php:55
+msgid "Sign out"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/templates/v1/payment-information.php:20
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/payment-information.php:20
+msgid "Payment methods"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/templates/v1/payment-information.php:41
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/payment-information.php:41
+msgid "Expired"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/templates/v1/payment-information.php:47
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/payment-information.php:47
+#: dist/componentsDemo.js:1
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:5
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: dist/setup.js:7
+#: release/newspack-plugin/dist/componentsDemo.js:1
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:5
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+#: release/newspack-plugin/dist/setup.js:7
+msgid "Default"
+msgstr ""
+
+#. translators: last 4 digits
+#: includes/plugins/woocommerce/my-account/templates/v1/payment-information.php:65
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/payment-information.php:65
+msgid "Ending in %s"
+msgstr ""
+
+#. translators: expiration date
+#: includes/plugins/woocommerce/my-account/templates/v1/payment-information.php:78
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/payment-information.php:78
+msgid "Exp. %s"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/templates/v1/payment-information.php:97
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/payment-information.php:97
+msgid "Delete payment method"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/templates/v1/payment-information.php:120
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/payment-information.php:120
+msgid "You don’t have any payment methods saved yet."
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/templates/v1/payment-information.php:128
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/payment-information.php:128
+msgid "Add payment method"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/templates/verify.php:56
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/verify.php:56
+msgid "You must verify your account before you can manage account settings. Verify with a link or by setting a password."
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/templates/verify.php:60
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/verify.php:60
+msgid "Send me a link"
+msgstr ""
+
+#: includes/plugins/woocommerce/my-account/templates/verify.php:63
+#: includes/templates/reader-activation-emails/password-reset.php:30
+#: includes/templates/reader-activation-emails/password-reset.php:73
+#: includes/templates/reader-activation-emails/password-reset.php:244
+#: includes/templates/reader-activation-emails/password-reset.php:261
+#: release/newspack-plugin/includes/plugins/woocommerce/my-account/templates/verify.php:63
+#: release/newspack-plugin/includes/templates/reader-activation-emails/password-reset.php:30
+#: release/newspack-plugin/includes/templates/reader-activation-emails/password-reset.php:73
+#: release/newspack-plugin/includes/templates/reader-activation-emails/password-reset.php:244
+#: release/newspack-plugin/includes/templates/reader-activation-emails/password-reset.php:261
+msgid "Set a new password"
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation-emails.php:53
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation-emails.php:53
 msgid "the site base address"
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation-emails.php:52
+#: includes/reader-activation/class-reader-activation-emails.php:57
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation-emails.php:57
 msgid "the site contact info, including site name and address"
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation-emails.php:56
+#: includes/reader-activation/class-reader-activation-emails.php:61
 #: includes/reader-revenue/class-reader-revenue-emails.php:87
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation-emails.php:61
 #: release/newspack-plugin/includes/reader-revenue/class-reader-revenue-emails.php:87
 msgid "the site title"
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation-emails.php:60
+#: includes/reader-activation/class-reader-activation-emails.php:65
 #: includes/reader-revenue/class-reader-revenue-emails.php:91
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation-emails.php:65
 #: release/newspack-plugin/includes/reader-revenue/class-reader-revenue-emails.php:91
 msgid "the site url"
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation-emails.php:66
+#: includes/reader-activation/class-reader-activation-emails.php:72
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation-emails.php:72
 msgid "Verification"
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation-emails.php:67
+#: includes/reader-activation/class-reader-activation-emails.php:73
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation-emails.php:73
 msgid "Email sent to the reader after they've registered."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation-emails.php:69
+#: includes/reader-activation/class-reader-activation-emails.php:75
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation-emails.php:75
 msgid "This email will be sent to a reader after they've registered."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation-emails.php:74
+#: includes/reader-activation/class-reader-activation-emails.php:80
+#: includes/reader-activation/class-reader-activation-emails.php:171
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation-emails.php:80
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation-emails.php:171
 msgid "the verification link"
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation-emails.php:82
+#: includes/reader-activation/class-reader-activation-emails.php:89
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation-emails.php:89
 msgid "Login link"
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation-emails.php:83
+#: includes/reader-activation/class-reader-activation-emails.php:90
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation-emails.php:90
 msgid "Email sent to users with a login link generated by Admin user or when one-time password is disabled."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation-emails.php:85
+#: includes/reader-activation/class-reader-activation-emails.php:92
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation-emails.php:92
 msgid "This email will be sent to a reader when they request a login link."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation-emails.php:90
-#: includes/reader-activation/class-reader-activation-emails.php:106
+#: includes/reader-activation/class-reader-activation-emails.php:97
+#: includes/reader-activation/class-reader-activation-emails.php:114
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation-emails.php:97
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation-emails.php:114
 msgid "the one-time password"
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation-emails.php:98
+#: includes/reader-activation/class-reader-activation-emails.php:106
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation-emails.php:106
 msgid "Login one-time password"
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation-emails.php:99
+#: includes/reader-activation/class-reader-activation-emails.php:107
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation-emails.php:107
 msgid "Email sent to users with a one-time password and login link."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation-emails.php:101
+#: includes/reader-activation/class-reader-activation-emails.php:109
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation-emails.php:109
 msgid "This email will be sent to a reader when they request a login link and a one-time password is available."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation-emails.php:110
+#: includes/reader-activation/class-reader-activation-emails.php:118
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation-emails.php:118
 msgid "the login link"
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation-emails.php:114
-#: includes/reader-activation/class-reader-activation-emails.php:130
+#: includes/reader-activation/class-reader-activation-emails.php:122
+#: includes/reader-activation/class-reader-activation-emails.php:139
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation-emails.php:122
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation-emails.php:139
 msgid "the password reset link"
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation-emails.php:122
+#: includes/reader-activation/class-reader-activation-emails.php:131
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation-emails.php:131
 msgid "Set a New Password"
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation-emails.php:123
+#: includes/reader-activation/class-reader-activation-emails.php:132
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation-emails.php:132
 msgid "Email with password reset link."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation-emails.php:125
+#: includes/reader-activation/class-reader-activation-emails.php:134
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation-emails.php:134
 msgid "This email will be sent to a reader when they request a password creation or reset."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation-emails.php:138
-#: includes/reader-revenue/templates/myaccount-delete-account.php:52
-#: includes/reader-revenue/templates/myaccount-edit-account.php:132
-#: release/newspack-plugin/includes/reader-revenue/templates/myaccount-delete-account.php:52
-#: release/newspack-plugin/includes/reader-revenue/templates/myaccount-edit-account.php:132
-msgid "Delete Account"
-msgstr ""
-
-#: includes/reader-activation/class-reader-activation-emails.php:139
+#: includes/reader-activation/class-reader-activation-emails.php:149
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation-emails.php:149
 msgid "Email with account deletion link."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation-emails.php:141
+#: includes/reader-activation/class-reader-activation-emails.php:151
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation-emails.php:151
 msgid "This email will be sent to a reader when they request an account deletion."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation-emails.php:144
+#: includes/reader-activation/class-reader-activation-emails.php:154
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation-emails.php:154
 msgid "the account deletion link"
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:224
-#: includes/reader-activation/class-reader-activation.php:233
+#: includes/reader-activation/class-reader-activation-emails.php:163
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation-emails.php:163
+msgid "Change Email Confirmation"
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation-emails.php:164
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation-emails.php:164
+msgid "Email sent to the reader to confirm or cancel a request to update their email address."
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation-emails.php:166
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation-emails.php:166
+msgid "This email will be sent to a reader's new email address after they update their email address."
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation-emails.php:175
+#: includes/reader-activation/class-reader-activation-emails.php:192
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation-emails.php:175
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation-emails.php:192
+msgid "the email change cancellation link"
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation-emails.php:184
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation-emails.php:184
+msgid "Change Email Notification"
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation-emails.php:185
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation-emails.php:185
+msgid "Email sent to notify the reader of a request to update their email addresses."
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation-emails.php:187
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation-emails.php:187
+msgid "This email will be sent to a reader's existing email address after they update their email address."
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation-emails.php:196
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation-emails.php:196
+msgid "the new account email address pending confirmation"
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation-emails.php:206
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation-emails.php:206
+msgid "Non-reader account"
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation-emails.php:207
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation-emails.php:207
+msgid "Email reminder sent to non-reader accounts instead of reader account-related emails."
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation-emails.php:209
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation-emails.php:209
+msgid "This email will be sent to non-reader WP user accounts as a reminder to use standard WP login flows."
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:262
+#: includes/reader-activation/class-reader-activation.php:271
 #: includes/templates/reader-activation-emails/magic-link.php:30
 #: includes/templates/reader-activation-emails/magic-link.php:103
 #: includes/templates/reader-activation-emails/magic-link.php:274
 #: includes/templates/reader-activation-emails/magic-link.php:299
+#: includes/templates/reader-activation-emails/non-reader.php:30
+#: includes/templates/reader-activation-emails/non-reader.php:50
+#: includes/templates/reader-activation-emails/non-reader.php:218
+#: includes/templates/reader-activation-emails/non-reader.php:223
 #: includes/templates/reader-activation-emails/otp.php:30
 #: includes/templates/reader-activation-emails/otp.php:111
 #: includes/templates/reader-activation-emails/otp.php:281
 #: includes/templates/reader-activation-emails/otp.php:311
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:224
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:233
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:262
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:271
 #: release/newspack-plugin/includes/templates/reader-activation-emails/magic-link.php:30
 #: release/newspack-plugin/includes/templates/reader-activation-emails/magic-link.php:103
 #: release/newspack-plugin/includes/templates/reader-activation-emails/magic-link.php:274
 #: release/newspack-plugin/includes/templates/reader-activation-emails/magic-link.php:299
+#: release/newspack-plugin/includes/templates/reader-activation-emails/non-reader.php:30
+#: release/newspack-plugin/includes/templates/reader-activation-emails/non-reader.php:50
+#: release/newspack-plugin/includes/templates/reader-activation-emails/non-reader.php:218
+#: release/newspack-plugin/includes/templates/reader-activation-emails/non-reader.php:223
 #: release/newspack-plugin/includes/templates/reader-activation-emails/otp.php:30
 #: release/newspack-plugin/includes/templates/reader-activation-emails/otp.php:111
 #: release/newspack-plugin/includes/templates/reader-activation-emails/otp.php:281
 #: release/newspack-plugin/includes/templates/reader-activation-emails/otp.php:311
-#: release/newspack-plugin/src/blocks/reader-registration/index.php:131
-#: src/blocks/reader-registration/index.php:131
 msgid "Sign in"
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:225
-#: includes/reader-activation/class-reader-activation.php:1929
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:225
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:1899
-msgid "Please enter a valid email address."
-msgstr ""
-
-#: includes/reader-activation/class-reader-activation.php:226
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:226
+#: includes/reader-activation/class-reader-activation.php:264
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:264
 msgid "Please enter a password."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:227
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:227
+#: includes/reader-activation/class-reader-activation.php:265
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:265
 msgid "Display name cannot match your email address. Please choose a different display name."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:228
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:228
+#: includes/reader-activation/class-reader-activation.php:266
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:266
 msgid "The popup has been blocked. Allow popups for the site and try again."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:229
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:229
+#: includes/reader-activation/class-reader-activation.php:267
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:267
 msgid "Code sent! Check your inbox."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:230
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:230
+#: includes/reader-activation/class-reader-activation.php:268
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:268
 msgid "Code resent! Check your inbox."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:231
-#: includes/reader-activation/class-reader-activation.php:241
-#: includes/reader-activation/class-reader-activation.php:247
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:231
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:241
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:247
+#: includes/reader-activation/class-reader-activation.php:269
+#: includes/reader-activation/class-reader-activation.php:279
+#: includes/reader-activation/class-reader-activation.php:285
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:269
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:279
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:285
 msgid "Create an account"
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:234
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:234
+#: includes/reader-activation/class-reader-activation.php:272
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:272
 msgid "Success! You’re signed in."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:236
-#: includes/reader-activation/class-reader-activation.php:264
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:236
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:264
-#: dist/engagement.js:20
-#: release/newspack-plugin/dist/engagement.js:20
-#: src/wizards/engagement/views/reader-activation/campaign.js:152
-msgid "Continue"
-msgstr ""
-
-#: includes/reader-activation/class-reader-activation.php:237
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:237
+#: includes/reader-activation/class-reader-activation.php:275
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:275
 msgid "Resend code"
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:238
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:238
+#: includes/reader-activation/class-reader-activation.php:276
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:276
 msgid "Email me a one-time code instead"
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:239
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:239
+#: includes/reader-activation/class-reader-activation.php:277
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:277
 msgid "Enter the code sent to your email."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:240
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:240
-msgid "Forgot password"
-msgstr ""
-
-#: includes/reader-activation/class-reader-activation.php:242
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:242
+#: includes/reader-activation/class-reader-activation.php:280
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:280
+#: dist/blocks.js:4
+#: release/newspack-plugin/dist/blocks.js:4
 msgid "Sign in to an existing account"
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:243
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:243
+#: includes/reader-activation/class-reader-activation.php:281
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:281
+#: dist/other-scripts/corrections-modal.js:7
+#: release/newspack-plugin/dist/other-scripts/corrections-modal.js:7
 msgid "Go back"
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:244
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:244
+#: includes/reader-activation/class-reader-activation.php:282
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:282
 msgid "Set a password (optional)"
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:248
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:248
+#: includes/reader-activation/class-reader-activation.php:286
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:286
+#: dist/blocks.js:1
+#: release/newspack-plugin/dist/blocks.js:1
 msgid "Success! Your account was created and you’re signed in."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:249
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:249
+#: includes/reader-activation/class-reader-activation.php:287
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:287
 msgid "In the future, you’ll sign in with a magic link, or a code sent to your email. If you’d rather use a password, you can set one below."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:251
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:251
+#: includes/reader-activation/class-reader-activation.php:289
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:289
 msgid "Thank you for verifying your account!"
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:252
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:252
+#: includes/reader-activation/class-reader-activation.php:290
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:290
 msgid "Please check your inbox for an authentication link."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:253
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:253
+#: includes/reader-activation/class-reader-activation.php:291
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:291
 msgid "Please wait a moment before requesting another password reset email."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:255
-#: includes/reader-revenue/woocommerce/class-woocommerce-connection.php:652
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:255
-#: release/newspack-plugin/includes/reader-revenue/woocommerce/class-woocommerce-connection.php:643
-#: release/newspack-plugin/src/blocks/reader-registration/index.php:121
-#: src/blocks/reader-registration/index.php:121
-msgid "My Account"
-msgstr ""
-
-#: includes/reader-activation/class-reader-activation.php:256
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:256
-#: dist/blocks.js:4
-#: release/newspack-plugin/dist/blocks.js:4
-#: src/blocks/reader-registration/edit.js:271
+#: includes/reader-activation/class-reader-activation.php:294
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:294
 msgid "Sign In"
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:258
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:258
-#: release/newspack-plugin/src/blocks/reader-registration/index.php:129
-#: src/blocks/reader-registration/index.php:129
+#: includes/reader-activation/class-reader-activation.php:296
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:296
 #: dist/blocks.js:4
 #: release/newspack-plugin/dist/blocks.js:4
-#: src/blocks/reader-registration/edit.js:324
 msgid "Subscribe to our newsletter"
 msgstr ""
 
 #. Translators: %s is the site name.
-#: includes/reader-activation/class-reader-activation.php:261
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:261
+#: includes/reader-activation/class-reader-activation.php:299
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:299
 msgid "Thanks for supporting %s."
 msgstr ""
 
 #. Translators: %s is the site name.
-#: includes/reader-activation/class-reader-activation.php:267
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:267
+#: includes/reader-activation/class-reader-activation.php:305
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:305
 msgid "Get the best of %s directly in your email inbox."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:270
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:270
+#: includes/reader-activation/class-reader-activation.php:308
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:308
 msgid "Signup successful!"
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:271
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:271
+#: includes/reader-activation/class-reader-activation.php:309
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:309
 msgid "Sign up for newsletters"
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:410
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:409
+#: includes/reader-activation/class-reader-activation.php:466
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:466
 msgid "Newspack Campaigns plugin is required to activate Reader Activation features."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:664
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:634
+#: includes/reader-activation/class-reader-activation.php:844
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:844
 msgid "Legal Pages"
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:665
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:635
+#: includes/reader-activation/class-reader-activation.php:845
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:845
 msgid "Displaying legal pages like Privacy Policy and Terms of Service on your site is recommended for allowing readers to register and access their account."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:667
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:637
+#: includes/reader-activation/class-reader-activation.php:847
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:847
 msgid "Privacy policies that tell users how you collect and use their data are essential for running a  trustworthy website. While rules and regulations can differ by country, certain legal pages might be required by law."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:670
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:640
+#: includes/reader-activation/class-reader-activation.php:850
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:850
 msgid "Legal Pages Disclaimer Text"
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:671
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:641
+#: includes/reader-activation/class-reader-activation.php:851
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:851
 msgid "Legal pages disclaimer text to display on registration."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:674
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:644
+#: includes/reader-activation/class-reader-activation.php:854
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:854
 msgid "Legal Pages URL"
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:675
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:645
+#: includes/reader-activation/class-reader-activation.php:855
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:855
 msgid "URL to the page containing the privacy policy or terms of service."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:684
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:654
+#: includes/reader-activation/class-reader-activation.php:866
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:866
 msgid "Email Service Provider (ESP)"
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:685
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:655
+#: includes/reader-activation/class-reader-activation.php:867
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:867
 msgid "Connect to your ESP to register readers with their email addresses and send newsletters."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:686
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:656
+#: includes/reader-activation/class-reader-activation.php:868
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:868
 msgid "Connect to your email service provider (ESP) and enable at least one subscription list."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:693
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:663
+#: includes/reader-activation/class-reader-activation.php:875
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:875
 msgid "Transactional Emails"
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:694
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:664
+#: includes/reader-activation/class-reader-activation.php:876
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:876
 msgid "Your sender name and email address determines how readers find emails related to their account in their inbox. To customize the content of these emails, visit Advanced Settings below."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:698
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:668
+#: includes/reader-activation/class-reader-activation.php:880
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:880
 msgid "Sender Name"
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:699
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:669
+#: includes/reader-activation/class-reader-activation.php:881
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:881
 msgid "Name to use as the sender of transactional emails."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:702
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:672
+#: includes/reader-activation/class-reader-activation.php:884
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:884
 msgid "Sender Email Address"
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:703
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:673
+#: includes/reader-activation/class-reader-activation.php:885
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:885
 msgid "Email address to use as the sender of transactional emails."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:706
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:676
+#: includes/reader-activation/class-reader-activation.php:888
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:888
 msgid "Contact Email Address"
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:707
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:677
+#: includes/reader-activation/class-reader-activation.php:889
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:889
 msgid "This email will be used as \"Reply-To\" for transactional emails as well."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:713
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:683
-#: dist/connections.js:3
-#: release/newspack-plugin/dist/connections.js:3
-#: src/wizards/connections/views/main/recaptcha.js:87
+#: includes/reader-activation/class-reader-activation.php:895
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:895
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
 msgid "reCAPTCHA"
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:714
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:684
+#: includes/reader-activation/class-reader-activation.php:896
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:896
 msgid "Connecting to a Google reCAPTCHA account enables enhanced anti-spam for all Newspack sign-up blocks."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:715
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:685
+#: includes/reader-activation/class-reader-activation.php:897
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:897
 msgid "Enable reCAPTCHA and enter your account credentials."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:727
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:697
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/views/segments/single-segment.js:254
+#: includes/reader-activation/class-reader-activation.php:907
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:907
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
 msgid "Reader Revenue"
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:728
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:698
+#: includes/reader-activation/class-reader-activation.php:908
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:908
 msgid "Setting suggested donation amounts is required for enabling a streamlined donation experience."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:729
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:699
+#: includes/reader-activation/class-reader-activation.php:909
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:909
 msgid "Set platform to \"Newspack\" or \"News Revenue Hub\" and configure your default donation settings. If using News Revenue Hub, set an Organization ID and a Donor Landing Page in News Revenue Hub Settings."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:740
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:710
-msgid "Reader Activation Campaign"
+#: includes/reader-activation/class-reader-activation.php:919
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:919
+msgid "Audience Management Campaign"
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:741
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:711
-msgid "Building a set of prompts with default segments and settings allows for an improved experience optimized for Reader Activation."
+#: includes/reader-activation/class-reader-activation.php:920
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:920
+msgid "Building a set of prompts with default segments and settings allows for an improved experience optimized for audience management."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:745
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:715
-msgid "Reader Activation campaign"
+#: includes/reader-activation/class-reader-activation.php:924
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:924
+msgid "Audience Management campaign"
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:746
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:716
+#: includes/reader-activation/class-reader-activation.php:925
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:925
 msgid "Waiting for all settings to be ready"
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:798
-#: includes/reader-activation/class-reader-activation.php:1303
-#: includes/reader-revenue/my-account/class-woocommerce-my-account.php:377
-#: includes/reader-revenue/templates/myaccount-edit-account.php:65
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:768
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:1273
-#: release/newspack-plugin/includes/reader-revenue/my-account/class-woocommerce-my-account.php:377
-#: release/newspack-plugin/includes/reader-revenue/templates/myaccount-edit-account.php:65
-msgid "Email address"
-msgstr ""
-
-#: includes/reader-activation/class-reader-activation.php:1234
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:1204
+#: includes/reader-activation/class-reader-activation.php:1444
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:1444
 msgid "Enter your email address"
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:1304
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:1274
+#: includes/reader-activation/class-reader-activation.php:1530
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:1530
 msgid "Your email address"
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:1309
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:1279
+#: includes/reader-activation/class-reader-activation.php:1535
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:1535
 msgid "6-digit code"
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:1312
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:1282
+#: includes/reader-activation/class-reader-activation.php:1538
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:1538
 msgid "Enter your password"
 msgstr ""
 
 #. Translators: %s is the email address.
-#: includes/reader-activation/class-reader-activation.php:1327
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:1300
+#: includes/reader-activation/class-reader-activation.php:1553
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:1553
 msgid "Sign in by entering the code we sent to %s, or clicking the magic link in the email."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:1468
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:1441
+#: includes/reader-activation/class-reader-activation.php:1680
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:1680
+msgid "See all"
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:1725
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:1725
 msgid "Sending to: "
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:1497
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:1470
+#: includes/reader-activation/class-reader-activation.php:1754
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:1754
 msgid "Invalid email address."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:1502
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:1475
+#: includes/reader-activation/class-reader-activation.php:1759
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:1759
 msgid "No lists selected."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:1680
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:1653
+#: includes/reader-activation/class-reader-activation.php:1935
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:1935
 #: dist/blocks.js:4
 #: release/newspack-plugin/dist/blocks.js:4
-#: src/blocks/reader-registration/edit.js:354
 msgid "Sign in with Google"
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:1683
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:1656
+#: includes/reader-activation/class-reader-activation.php:1938
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:1938
 #: dist/blocks.js:4
 #: release/newspack-plugin/dist/blocks.js:4
-#: src/blocks/reader-registration/edit.js:357
 msgid "Or"
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:1759
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:1729
-#: release/newspack-plugin/src/blocks/reader-registration/index.php:423
-#: src/blocks/reader-registration/index.php:420
+#: includes/reader-activation/class-reader-activation.php:2020
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:2020
 msgid "You must enter a valid email address."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:1766
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:1736
+#: includes/reader-activation/class-reader-activation.php:2027
+#: includes/reader-activation/class-reader-activation.php:2031
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:2027
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:2031
 msgid "Account not found. <a data-set-action=\"register\" href=\"#register_modal\">Create an account</a> instead?"
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:1785
-#: includes/reader-activation/class-reader-activation.php:1807
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:1755
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:1777
+#: includes/reader-activation/class-reader-activation.php:2031
+#: includes/reader-activation/class-reader-activation.php:2097
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:2031
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:2097
+msgid "An account was already registered with this email. Please check your inbox for an authentication link."
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:2054
+#: includes/reader-activation/class-reader-activation.php:2078
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:2054
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:2078
 msgid "We encountered an error sending an authentication link. Please try again."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:1795
-#: includes/reader-activation/class-reader-activation.php:1799
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:1765
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:1769
+#: includes/reader-activation/class-reader-activation.php:2064
+#: includes/reader-activation/class-reader-activation.php:2068
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:2064
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:2068
 msgid "Password not recognized, try again."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:1824
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:1794
-msgid "An account was already registered with this email."
+#: includes/reader-activation/class-reader-activation.php:2097
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:2097
+msgid "An account was already registered with this email. Please sign in to continue."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:1829
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:1799
+#: includes/reader-activation/class-reader-activation.php:2102
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:2102
 msgid "Unable to register your account. Try a different email."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:1919
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:1889
+#: includes/reader-activation/class-reader-activation.php:2210
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:2210
 msgid "Registration is disabled."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:1923
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:1893
+#: includes/reader-activation/class-reader-activation.php:2214
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:2214
 msgid "Cannot register while logged in."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:2202
-#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:2172
+#: includes/reader-activation/class-reader-activation.php:2547
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:2539
 msgid "Please wait before requesting another verification email."
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:2716
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:2708
+msgid "Your personal data will be used to process your order and create an account if one doesn't exist. This information will also support your experience throughout this website, and be used for other purposes described in our privacy policy."
+msgstr ""
+
+#. Translators: %s is the name of the site.
+#: includes/reader-activation/class-reader-activation.php:2733
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:2725
+msgid "Thank you for supporting %s. Your transaction was completed successfully."
+msgstr ""
+
+#. Translators: %s is the name of the site.
+#: includes/reader-activation/class-reader-activation.php:2752
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:2744
+msgid "Thank you for supporting %s. Your account has been created, and your transaction was completed successfully."
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:2778
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:2770
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:41
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:41
+msgid "I understand this is a recurring subscription and that I can cancel anytime through the My Account Page."
+msgstr ""
+
+#: includes/reader-activation/class-reader-activation.php:2802
+#: release/newspack-plugin/includes/reader-activation/class-reader-activation.php:2794
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:41
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:41
+msgid "I have read and accept the {{Terms & Conditions}}."
+msgstr ""
+
+#: includes/reader-activation/sync/class-esp-sync-admin.php:77
+#: release/newspack-plugin/includes/reader-activation/sync/class-esp-sync-admin.php:77
+msgid "Resync contact to ESP"
+msgstr ""
+
+#: includes/reader-activation/sync/class-esp-sync-admin.php:99
+#: release/newspack-plugin/includes/reader-activation/sync/class-esp-sync-admin.php:99
+msgid "Resync to the ESP"
+msgstr ""
+
+#: includes/reader-activation/sync/class-esp-sync-admin.php:118
+#: release/newspack-plugin/includes/reader-activation/sync/class-esp-sync-admin.php:118
+msgid "ActionScheduler is not available to perform the bulk action."
+msgstr ""
+
+#: includes/reader-activation/sync/class-esp-sync-admin.php:194
+#: release/newspack-plugin/includes/reader-activation/sync/class-esp-sync-admin.php:194
+msgid "Contact resynced to the ESP."
+msgstr ""
+
+#. translators: %d: number of contacts resynced.
+#: includes/reader-activation/sync/class-esp-sync-admin.php:199
+#: release/newspack-plugin/includes/reader-activation/sync/class-esp-sync-admin.php:199
+msgid "%d contacts scheculed for resync to the ESP and should complete in a couple of minutes."
+msgstr ""
+
+#: includes/reader-activation/sync/class-esp-sync-admin.php:209
+#: release/newspack-plugin/includes/reader-activation/sync/class-esp-sync-admin.php:209
+msgid "Click here to monitor progress."
+msgstr ""
+
+#: includes/reader-activation/sync/class-esp-sync.php:64
+#: release/newspack-plugin/includes/reader-activation/sync/class-esp-sync.php:64
+msgid "Newspack Newsletters is not available."
+msgstr ""
+
+#: includes/reader-activation/sync/class-esp-sync.php:71
+#: release/newspack-plugin/includes/reader-activation/sync/class-esp-sync.php:71
+msgid "ESP sync is not enabled."
+msgstr ""
+
+#: includes/reader-activation/sync/class-esp-sync.php:78
+#: release/newspack-plugin/includes/reader-activation/sync/class-esp-sync.php:78
+msgid "ESP master list ID is not set."
+msgstr ""
+
+#. Translators: %s is the email address of the contact to synced.
+#: includes/reader-activation/sync/class-esp-sync.php:164
+#: release/newspack-plugin/includes/reader-activation/sync/class-esp-sync.php:164
+msgid "Scheduling secondary sync for contact %s."
+msgstr ""
+
+#. Translators: %d is the user ID.
+#: includes/reader-activation/sync/class-esp-sync.php:206
+#: release/newspack-plugin/includes/reader-activation/sync/class-esp-sync.php:206
+msgid "Customer with ID %d does not exist."
+msgstr ""
+
+#. Translators: %1$s is the status and %2$s is the contact's email address.
+#: includes/reader-activation/sync/class-esp-sync.php:254
+#: release/newspack-plugin/includes/reader-activation/sync/class-esp-sync.php:254
+msgid "%1$s contact data for %2$s."
+msgstr ""
+
+#: includes/reader-activation/sync/class-esp-sync.php:255
+#: release/newspack-plugin/includes/reader-activation/sync/class-esp-sync.php:255
+msgid "Would sync"
+msgstr ""
+
+#: includes/reader-activation/sync/class-esp-sync.php:255
+#: release/newspack-plugin/includes/reader-activation/sync/class-esp-sync.php:255
+#: dist/other-scripts/salesforce.js:1
+#: release/newspack-plugin/dist/other-scripts/salesforce.js:1
+msgid "Synced"
+msgstr ""
+
+#: includes/reader-activation/sync/class-sync.php:51
+#: release/newspack-plugin/includes/reader-activation/sync/class-sync.php:51
+msgid "Audience Management is not enabled."
+msgstr ""
+
+#: includes/reader-activation/sync/class-sync.php:58
+#: release/newspack-plugin/includes/reader-activation/sync/class-sync.php:58
+msgid "Audience Management contact data syncing is disabled for cloned sites."
+msgstr ""
+
+#: includes/reader-activation/sync/class-sync.php:74
+#: release/newspack-plugin/includes/reader-activation/sync/class-sync.php:74
+msgid "Contact data syncing is disabled for staging sites. To bypass this check, set the NEWSPACK_ALLOW_READER_SYNC constant in your wp-config.php."
 msgstr ""
 
 #: includes/reader-revenue/class-reader-revenue-emails.php:60
@@ -1658,353 +4370,482 @@ msgstr ""
 msgid "the contact email to your site (same as the \"From\" email address)"
 msgstr ""
 
-#: includes/reader-revenue/class-reader-revenue-emails.php:97
-#: release/newspack-plugin/includes/reader-revenue/class-reader-revenue-emails.php:97
+#: includes/reader-revenue/class-reader-revenue-emails.php:98
+#: release/newspack-plugin/includes/reader-revenue/class-reader-revenue-emails.php:98
 msgid "Receipt"
 msgstr ""
 
-#: includes/reader-revenue/class-reader-revenue-emails.php:98
-#: release/newspack-plugin/includes/reader-revenue/class-reader-revenue-emails.php:98
+#: includes/reader-revenue/class-reader-revenue-emails.php:99
+#: release/newspack-plugin/includes/reader-revenue/class-reader-revenue-emails.php:99
 msgid "Email sent to the donor after they've donated."
 msgstr ""
 
-#: includes/reader-revenue/class-reader-revenue-emails.php:100
-#: release/newspack-plugin/includes/reader-revenue/class-reader-revenue-emails.php:100
+#: includes/reader-revenue/class-reader-revenue-emails.php:101
+#: release/newspack-plugin/includes/reader-revenue/class-reader-revenue-emails.php:101
 msgid "This email will be sent to a reader after they contribute to your site."
 msgstr ""
 
-#: includes/reader-revenue/class-reader-revenue-emails.php:106
-#: includes/reader-revenue/class-reader-revenue-emails.php:135
-#: release/newspack-plugin/includes/reader-revenue/class-reader-revenue-emails.php:106
-#: release/newspack-plugin/includes/reader-revenue/class-reader-revenue-emails.php:135
+#: includes/reader-revenue/class-reader-revenue-emails.php:107
+#: includes/reader-revenue/class-reader-revenue-emails.php:137
+#: release/newspack-plugin/includes/reader-revenue/class-reader-revenue-emails.php:107
+#: release/newspack-plugin/includes/reader-revenue/class-reader-revenue-emails.php:137
 msgid "automatically-generated receipt link"
 msgstr ""
 
-#: includes/reader-revenue/class-reader-revenue-emails.php:110
-#: includes/reader-revenue/class-reader-revenue-emails.php:139
-#: release/newspack-plugin/includes/reader-revenue/class-reader-revenue-emails.php:110
-#: release/newspack-plugin/includes/reader-revenue/class-reader-revenue-emails.php:139
+#: includes/reader-revenue/class-reader-revenue-emails.php:111
+#: includes/reader-revenue/class-reader-revenue-emails.php:141
+#: release/newspack-plugin/includes/reader-revenue/class-reader-revenue-emails.php:111
+#: release/newspack-plugin/includes/reader-revenue/class-reader-revenue-emails.php:141
 msgid "the payment amount"
 msgstr ""
 
-#: includes/reader-revenue/class-reader-revenue-emails.php:114
-#: includes/reader-revenue/class-reader-revenue-emails.php:143
-#: release/newspack-plugin/includes/reader-revenue/class-reader-revenue-emails.php:114
-#: release/newspack-plugin/includes/reader-revenue/class-reader-revenue-emails.php:143
+#: includes/reader-revenue/class-reader-revenue-emails.php:115
+#: includes/reader-revenue/class-reader-revenue-emails.php:145
+#: release/newspack-plugin/includes/reader-revenue/class-reader-revenue-emails.php:115
+#: release/newspack-plugin/includes/reader-revenue/class-reader-revenue-emails.php:145
 msgid "payment date"
 msgstr ""
 
-#: includes/reader-revenue/class-reader-revenue-emails.php:118
-#: includes/reader-revenue/class-reader-revenue-emails.php:147
-#: release/newspack-plugin/includes/reader-revenue/class-reader-revenue-emails.php:118
-#: release/newspack-plugin/includes/reader-revenue/class-reader-revenue-emails.php:147
+#: includes/reader-revenue/class-reader-revenue-emails.php:119
+#: includes/reader-revenue/class-reader-revenue-emails.php:149
+#: release/newspack-plugin/includes/reader-revenue/class-reader-revenue-emails.php:119
+#: release/newspack-plugin/includes/reader-revenue/class-reader-revenue-emails.php:149
 msgid "payment method (last four digits of the card used)"
 msgstr ""
 
-#: includes/reader-revenue/class-reader-revenue-emails.php:126
-#: release/newspack-plugin/includes/reader-revenue/class-reader-revenue-emails.php:126
+#: includes/reader-revenue/class-reader-revenue-emails.php:128
+#: release/newspack-plugin/includes/reader-revenue/class-reader-revenue-emails.php:128
 msgid "Welcome"
-msgstr ""
-
-#: includes/reader-revenue/class-reader-revenue-emails.php:127
-#: release/newspack-plugin/includes/reader-revenue/class-reader-revenue-emails.php:127
-msgid "Email sent to new reader accounts registered during a transaction."
 msgstr ""
 
 #: includes/reader-revenue/class-reader-revenue-emails.php:129
 #: release/newspack-plugin/includes/reader-revenue/class-reader-revenue-emails.php:129
+msgid "Email sent to new reader accounts registered during a transaction."
+msgstr ""
+
+#: includes/reader-revenue/class-reader-revenue-emails.php:131
+#: release/newspack-plugin/includes/reader-revenue/class-reader-revenue-emails.php:131
 msgid "This email will be sent to readers when they register an account during a transaction."
 msgstr ""
 
-#: includes/reader-revenue/class-reader-revenue-emails.php:151
+#: includes/reader-revenue/class-reader-revenue-emails.php:153
+#: release/newspack-plugin/includes/reader-revenue/class-reader-revenue-emails.php:153
 msgid "user account link"
-msgstr ""
-
-#: includes/reader-revenue/class-reader-revenue-emails.php:159
-#: release/newspack-plugin/includes/reader-revenue/class-reader-revenue-emails.php:159
-msgid "Cancellation"
-msgstr ""
-
-#: includes/reader-revenue/class-reader-revenue-emails.php:160
-#: release/newspack-plugin/includes/reader-revenue/class-reader-revenue-emails.php:160
-msgid "Email sent to the donor after they've cancelled a recurring donation."
 msgstr ""
 
 #: includes/reader-revenue/class-reader-revenue-emails.php:162
 #: release/newspack-plugin/includes/reader-revenue/class-reader-revenue-emails.php:162
+msgid "Cancellation"
+msgstr ""
+
+#: includes/reader-revenue/class-reader-revenue-emails.php:163
+#: release/newspack-plugin/includes/reader-revenue/class-reader-revenue-emails.php:163
+msgid "Email sent to the donor after they've cancelled a recurring donation."
+msgstr ""
+
+#: includes/reader-revenue/class-reader-revenue-emails.php:165
+#: release/newspack-plugin/includes/reader-revenue/class-reader-revenue-emails.php:165
 msgid "This email will be sent to a reader after they cancel a recurring donation."
 msgstr ""
 
-#: includes/reader-revenue/class-reader-revenue-emails.php:168
-#: release/newspack-plugin/includes/reader-revenue/class-reader-revenue-emails.php:168
+#: includes/reader-revenue/class-reader-revenue-emails.php:171
+#: release/newspack-plugin/includes/reader-revenue/class-reader-revenue-emails.php:171
 msgid "the email title containing the specific type of recurring subscription being cancelled"
 msgstr ""
 
-#: includes/reader-revenue/class-reader-revenue-emails.php:172
-#: release/newspack-plugin/includes/reader-revenue/class-reader-revenue-emails.php:172
+#: includes/reader-revenue/class-reader-revenue-emails.php:175
+#: release/newspack-plugin/includes/reader-revenue/class-reader-revenue-emails.php:175
 msgid "the type of recurring subscription being cancelled"
 msgstr ""
 
-#: includes/reader-revenue/class-reader-revenue-emails.php:176
-#: release/newspack-plugin/includes/reader-revenue/class-reader-revenue-emails.php:176
+#: includes/reader-revenue/class-reader-revenue-emails.php:179
+#: release/newspack-plugin/includes/reader-revenue/class-reader-revenue-emails.php:179
 msgid "the recurring donation management url"
 msgstr ""
 
-#: includes/reader-revenue/my-account/class-woocommerce-my-account.php:75
-#: release/newspack-plugin/includes/reader-revenue/my-account/class-woocommerce-my-account.php:75
-msgid "Are you sure you want to cancel this subscription?"
+#: includes/templates/block-patterns/corrections/corrections-loop.php:18
+#: includes/templates/corrections/corrections-archive.php:16
+#: release/newspack-plugin/includes/templates/block-patterns/corrections/corrections-loop.php:18
+#: release/newspack-plugin/includes/templates/corrections/corrections-archive.php:16
+#: dist/blocks.js:1
+#: dist/other-scripts/corrections-modal.js:1
+#: release/newspack-plugin/dist/blocks.js:1
+#: release/newspack-plugin/dist/other-scripts/corrections-modal.js:1
+msgid "Corrections & Clarifications"
 msgstr ""
 
-#: includes/reader-revenue/my-account/class-woocommerce-my-account.php:98
-#: release/newspack-plugin/includes/reader-revenue/my-account/class-woocommerce-my-account.php:98
-msgid "Log out"
+#: includes/templates/block-patterns/corrections/corrections-loop.php:22
+#: includes/templates/corrections/corrections-archive.php:20
+#: release/newspack-plugin/includes/templates/block-patterns/corrections/corrections-loop.php:22
+#: release/newspack-plugin/includes/templates/corrections/corrections-archive.php:20
+msgid "We are committed to truthful, transparent, and accurate reporting. When we make a mistake, we correct it promptly and note the change clearly. Clarifications, when needed, provide additional context."
 msgstr ""
 
-#: includes/reader-revenue/my-account/class-woocommerce-my-account.php:166
-#: release/newspack-plugin/includes/reader-revenue/my-account/class-woocommerce-my-account.php:166
-msgid "Please check your email inbox for instructions on how to set a new password."
+#: includes/templates/block-patterns/elections/home-pre-results-ap.php:11
+#: includes/templates/block-patterns/elections/home-pre-results-ddhq.php:11
+#: release/newspack-plugin/includes/templates/block-patterns/elections/home-pre-results-ap.php:11
+#: release/newspack-plugin/includes/templates/block-patterns/elections/home-pre-results-ddhq.php:11
+msgid "[Our Community] Heads to the Polls!"
 msgstr ""
 
-#: includes/reader-revenue/my-account/class-woocommerce-my-account.php:173
-#: includes/reader-revenue/my-account/class-woocommerce-my-account.php:241
-#: includes/reader-revenue/my-account/class-woocommerce-my-account.php:313
-#: release/newspack-plugin/includes/reader-revenue/my-account/class-woocommerce-my-account.php:173
-#: release/newspack-plugin/includes/reader-revenue/my-account/class-woocommerce-my-account.php:241
-#: release/newspack-plugin/includes/reader-revenue/my-account/class-woocommerce-my-account.php:313
-#: dist/commons.js:10
-#: dist/connections.js:3
-#: dist/engagement.js:1
-#: dist/engagement.js:4
-#: dist/engagement.js:11
-#: dist/engagement.js:17
-#: dist/engagement.js:20
-#: dist/setup.js:1
-#: dist/setup.js:4
-#: release/newspack-plugin/dist/commons.js:10
-#: release/newspack-plugin/dist/connections.js:3
-#: release/newspack-plugin/dist/engagement.js:1
-#: release/newspack-plugin/dist/engagement.js:4
-#: release/newspack-plugin/dist/engagement.js:11
-#: release/newspack-plugin/dist/engagement.js:17
-#: release/newspack-plugin/dist/engagement.js:20
-#: release/newspack-plugin/dist/setup.js:1
-#: release/newspack-plugin/dist/setup.js:4
-#: src/wizards/connections/views/main/fivetran.js:59
-#: src/wizards/connections/views/main/google.js:30
-#: src/wizards/connections/views/main/mailchimp.js:25
-#: src/wizards/engagement/components/active-campaign.js:33
-#: src/wizards/engagement/components/mailchimp.js:33
-#: src/wizards/engagement/views/newsletters/index.js:164
-#: src/wizards/engagement/views/newsletters/index.js:322
-#: src/wizards/engagement/views/reader-activation/campaign.js:114
-#: src/wizards/engagement/views/reader-activation/complete.js:179
-#: src/wizards/engagement/views/reader-activation/index.js:191
-#: src/wizards/readerRevenue/views/emails/index.js:140
-msgid "Something went wrong."
+#: includes/templates/block-patterns/elections/home-pre-results-ap.php:15
+#: includes/templates/block-patterns/elections/home-pre-results-ddhq.php:15
+#: includes/templates/block-patterns/elections/home-results-ap.php:15
+#: includes/templates/block-patterns/elections/home-results-ddhq.php:15
+#: release/newspack-plugin/includes/templates/block-patterns/elections/home-pre-results-ap.php:15
+#: release/newspack-plugin/includes/templates/block-patterns/elections/home-pre-results-ddhq.php:15
+#: release/newspack-plugin/includes/templates/block-patterns/elections/home-results-ap.php:15
+#: release/newspack-plugin/includes/templates/block-patterns/elections/home-results-ddhq.php:15
+msgid "Update the above headline throughout election night. Set it to link to your primary election results story. Delete these yellow paragraphs before publishing. To find out more about how to use these patterns, see the <a target=\"_blank\" href=\"https://help.newspack.com/newspack-election-results-patterns/\">Help Site documentation</a>."
 msgstr ""
 
-#: includes/reader-revenue/my-account/class-woocommerce-my-account.php:241
-#: release/newspack-plugin/includes/reader-revenue/my-account/class-woocommerce-my-account.php:241
-msgid "Please check your email inbox for instructions on how to delete your account."
+#: includes/templates/block-patterns/elections/home-pre-results-ap.php:23
+#: includes/templates/block-patterns/elections/home-pre-results-ddhq.php:23
+#: release/newspack-plugin/includes/templates/block-patterns/elections/home-pre-results-ap.php:23
+#: release/newspack-plugin/includes/templates/block-patterns/elections/home-pre-results-ddhq.php:23
+msgid "More space for election day  / voting stories."
 msgstr ""
 
-#: includes/reader-revenue/my-account/class-woocommerce-my-account.php:306
-#: release/newspack-plugin/includes/reader-revenue/my-account/class-woocommerce-my-account.php:306
-msgid "Please check your email inbox for a link to verify your account."
+#: includes/templates/block-patterns/elections/home-pre-results-ap.php:31
+#: includes/templates/block-patterns/elections/home-pre-results-ddhq.php:31
+#: release/newspack-plugin/includes/templates/block-patterns/elections/home-pre-results-ap.php:31
+#: release/newspack-plugin/includes/templates/block-patterns/elections/home-pre-results-ddhq.php:31
+msgid "Use this column for election-day stories and to let readers know when polls close."
 msgstr ""
 
-#: includes/reader-revenue/my-account/class-woocommerce-my-account.php:585
-#: release/newspack-plugin/includes/reader-revenue/my-account/class-woocommerce-my-account.php:585
-msgid "Active Memberships"
+#: includes/templates/block-patterns/elections/home-pre-results-ap.php:37
+#: release/newspack-plugin/includes/templates/block-patterns/elections/home-pre-results-ap.php:37
+msgid "AP RESULTS EMBED GOES HERE!"
 msgstr ""
 
-#: includes/reader-revenue/my-account/class-woocommerce-my-account.php:586
-#: release/newspack-plugin/includes/reader-revenue/my-account/class-woocommerce-my-account.php:586
-msgid "These memberships are active, but don't have an associated subscription. They will need to be manually renewed when they expire."
+#: includes/templates/block-patterns/elections/home-pre-results-ap.php:43
+#: includes/templates/block-patterns/elections/home-pre-results-ddhq.php:43
+#: release/newspack-plugin/includes/templates/block-patterns/elections/home-pre-results-ap.php:43
+#: release/newspack-plugin/includes/templates/block-patterns/elections/home-pre-results-ddhq.php:43
+msgid "Use this to point to your election-results pages. It's ok if they're not receiving data yet. It will be helpful for SEO if you link early in the day."
 msgstr ""
 
-#: includes/reader-revenue/templates/myaccount-after-delete-account.php:15
-#: release/newspack-plugin/includes/reader-revenue/templates/myaccount-after-delete-account.php:15
-msgid "Your account has been deleted."
+#: includes/templates/block-patterns/elections/home-pre-results-ap.php:49
+#: includes/templates/block-patterns/elections/home-pre-results-ddhq.php:53
+#: release/newspack-plugin/includes/templates/block-patterns/elections/home-pre-results-ap.php:49
+#: release/newspack-plugin/includes/templates/block-patterns/elections/home-pre-results-ddhq.php:53
+msgid "Update the copy on the below newsletter signup to tell people they'll find out when results start coming in, and when races are declared, if they sign up."
 msgstr ""
 
-#: includes/reader-revenue/templates/myaccount-after-delete-account.php:18
-#: release/newspack-plugin/includes/reader-revenue/templates/myaccount-after-delete-account.php:18
-msgid "We're sorry to see you go. But hope you'll continue to follow our coverage."
+#: includes/templates/block-patterns/elections/home-pre-results-ap.php:54
+#: includes/templates/block-patterns/elections/home-pre-results-ddhq.php:58
+#: includes/templates/block-patterns/elections/home-results-ap.php:62
+#: includes/templates/block-patterns/elections/home-results-ddhq.php:66
+#: release/newspack-plugin/includes/templates/block-patterns/elections/home-pre-results-ap.php:54
+#: release/newspack-plugin/includes/templates/block-patterns/elections/home-pre-results-ddhq.php:58
+#: release/newspack-plugin/includes/templates/block-patterns/elections/home-results-ap.php:62
+#: release/newspack-plugin/includes/templates/block-patterns/elections/home-results-ddhq.php:66
+msgid "Sign up to receive updates."
 msgstr ""
 
-#: includes/reader-revenue/templates/myaccount-after-delete-account.php:21
-#: release/newspack-plugin/includes/reader-revenue/templates/myaccount-after-delete-account.php:21
-msgid "Return to home page"
+#: includes/templates/block-patterns/elections/home-pre-results-ap.php:64
+#: includes/templates/block-patterns/elections/home-pre-results-ddhq.php:68
+#: includes/templates/block-patterns/elections/home-results-ap.php:72
+#: includes/templates/block-patterns/elections/home-results-ddhq.php:76
+#: release/newspack-plugin/includes/templates/block-patterns/elections/home-pre-results-ap.php:64
+#: release/newspack-plugin/includes/templates/block-patterns/elections/home-pre-results-ddhq.php:68
+#: release/newspack-plugin/includes/templates/block-patterns/elections/home-results-ap.php:72
+#: release/newspack-plugin/includes/templates/block-patterns/elections/home-results-ddhq.php:76
+msgid "We'll be monitoring [our community]'s key races until the results are in. Sign up for our mailing list to get the latest updates sent directly to your inbox."
 msgstr ""
 
-#: includes/reader-revenue/templates/myaccount-delete-account.php:25
-#: includes/reader-revenue/templates/myaccount-delete-account.php:32
-#: release/newspack-plugin/includes/reader-revenue/templates/myaccount-delete-account.php:25
-#: release/newspack-plugin/includes/reader-revenue/templates/myaccount-delete-account.php:32
-msgid "Invalid token"
+#: includes/templates/block-patterns/elections/home-pre-results-ddhq.php:37
+#: release/newspack-plugin/includes/templates/block-patterns/elections/home-pre-results-ddhq.php:37
+msgid "DDHQ RESULTS EMBED GOES HERE!"
 msgstr ""
 
-#: includes/reader-revenue/templates/myaccount-delete-account.php:39
-#: release/newspack-plugin/includes/reader-revenue/templates/myaccount-delete-account.php:39
-msgid "Confirm to delete your account permanently."
+#: includes/templates/block-patterns/elections/home-pre-results-ddhq.php:49
+#: includes/templates/block-patterns/elections/home-results-ddhq.php:61
+#: release/newspack-plugin/includes/templates/block-patterns/elections/home-pre-results-ddhq.php:49
+#: release/newspack-plugin/includes/templates/block-patterns/elections/home-results-ddhq.php:61
+msgid "DDHQ JS SNIPPET GOES HERE! (Should be provided to you by DDHQ)"
 msgstr ""
 
-#: includes/reader-revenue/templates/myaccount-delete-account.php:42
-#: includes/reader-revenue/templates/myaccount-edit-account.php:140
-#: release/newspack-plugin/includes/reader-revenue/templates/myaccount-delete-account.php:42
-#: release/newspack-plugin/includes/reader-revenue/templates/myaccount-edit-account.php:140
-msgid "Deleting your account will also cancel any newsletter subscriptions and recurring payments."
+#: includes/templates/block-patterns/elections/home-results-ap.php:11
+#: includes/templates/block-patterns/elections/home-results-ddhq.php:11
+#: release/newspack-plugin/includes/templates/block-patterns/elections/home-results-ap.php:11
+#: release/newspack-plugin/includes/templates/block-patterns/elections/home-results-ddhq.php:11
+msgid "Election Coverage Live Updated Heading"
 msgstr ""
 
-#: includes/reader-revenue/templates/myaccount-delete-account.php:45
-#: release/newspack-plugin/includes/reader-revenue/templates/myaccount-delete-account.php:45
-msgid "Caution, this action is irreversible!"
+#: includes/templates/block-patterns/elections/home-results-ap.php:23
+#: includes/templates/block-patterns/elections/home-results-ddhq.php:23
+#: release/newspack-plugin/includes/templates/block-patterns/elections/home-results-ap.php:23
+#: release/newspack-plugin/includes/templates/block-patterns/elections/home-results-ddhq.php:23
+msgid "Modify the above Posts block to contain election related stories (can use categories or tags for this)."
 msgstr ""
 
-#: includes/reader-revenue/templates/myaccount-edit-account.php:58
-#: release/newspack-plugin/includes/reader-revenue/templates/myaccount-edit-account.php:58
-msgid "Your Name"
+#: includes/templates/block-patterns/elections/home-results-ap.php:29
+#: includes/templates/block-patterns/elections/home-results-ddhq.php:29
+#: release/newspack-plugin/includes/templates/block-patterns/elections/home-results-ap.php:29
+#: release/newspack-plugin/includes/templates/block-patterns/elections/home-results-ddhq.php:29
+msgid "Decision 2024"
 msgstr ""
 
-#: includes/reader-revenue/templates/myaccount-edit-account.php:61
-#: release/newspack-plugin/includes/reader-revenue/templates/myaccount-edit-account.php:61
-msgid "This is how your name is displayed publicly."
+#: includes/templates/block-patterns/elections/home-results-ap.php:33
+#: includes/templates/block-patterns/elections/home-results-ap.php:47
+#: release/newspack-plugin/includes/templates/block-patterns/elections/home-results-ap.php:33
+#: release/newspack-plugin/includes/templates/block-patterns/elections/home-results-ap.php:47
+msgid "AP EMBED CODE GOES HERE!"
 msgstr ""
 
-#: includes/reader-revenue/templates/myaccount-edit-account.php:90
-#: release/newspack-plugin/includes/reader-revenue/templates/myaccount-edit-account.php:90
-msgid "Save changes"
+#: includes/templates/block-patterns/elections/home-results-ap.php:37
+#: release/newspack-plugin/includes/templates/block-patterns/elections/home-results-ap.php:37
+msgid "Results are coming in for the 2024 elections! <a href=\"#\">See all the results that matter to [our community]!</a>"
 msgstr ""
 
-#: includes/reader-revenue/templates/myaccount-edit-account.php:105
-#: release/newspack-plugin/includes/reader-revenue/templates/myaccount-edit-account.php:105
-msgid "Create a Password"
+#: includes/templates/block-patterns/elections/home-results-ap.php:41
+#: includes/templates/block-patterns/elections/home-results-ddhq.php:41
+#: release/newspack-plugin/includes/templates/block-patterns/elections/home-results-ap.php:41
+#: release/newspack-plugin/includes/templates/block-patterns/elections/home-results-ddhq.php:41
+msgid "Use this column for embedded live results of the most salient race for your audience."
 msgstr ""
 
-#: includes/reader-revenue/templates/myaccount-edit-account.php:107
-#: release/newspack-plugin/includes/reader-revenue/templates/myaccount-edit-account.php:107
-msgid "Reset Password"
+#: includes/templates/block-patterns/elections/home-results-ap.php:51
+#: includes/templates/block-patterns/elections/home-results-ddhq.php:51
+#: release/newspack-plugin/includes/templates/block-patterns/elections/home-results-ap.php:51
+#: release/newspack-plugin/includes/templates/block-patterns/elections/home-results-ddhq.php:51
+msgid "Use this column for embedded live results of a secondary key race for your audience."
 msgstr ""
 
-#: includes/reader-revenue/templates/myaccount-edit-account.php:114
-#: release/newspack-plugin/includes/reader-revenue/templates/myaccount-edit-account.php:114
-msgid "Email me a link to set my password"
+#: includes/templates/block-patterns/elections/home-results-ap.php:57
+#: includes/templates/block-patterns/elections/home-results-ddhq.php:57
+#: release/newspack-plugin/includes/templates/block-patterns/elections/home-results-ap.php:57
+#: release/newspack-plugin/includes/templates/block-patterns/elections/home-results-ddhq.php:57
+msgid "Update the copy on the below newsletter signup to highlight politics / election coverage, and tell people they'll find out when races are declared if they sign up."
 msgstr ""
 
-#: includes/reader-revenue/templates/myaccount-edit-account.php:116
-#: release/newspack-plugin/includes/reader-revenue/templates/myaccount-edit-account.php:116
-msgid "Email me a password reset link"
+#: includes/templates/block-patterns/elections/home-results-ddhq.php:33
+#: includes/templates/block-patterns/elections/home-results-ddhq.php:47
+#: release/newspack-plugin/includes/templates/block-patterns/elections/home-results-ddhq.php:33
+#: release/newspack-plugin/includes/templates/block-patterns/elections/home-results-ddhq.php:47
+msgid "DDHQ EMBED CODE GOES HERE!"
 msgstr ""
 
-#: includes/reader-revenue/templates/myaccount-edit-account.php:135
-#: release/newspack-plugin/includes/reader-revenue/templates/myaccount-edit-account.php:135
-msgid "Request account deletion"
+#: includes/templates/block-patterns/elections/live-results-post-ap.php:11
+#: release/newspack-plugin/includes/templates/block-patterns/elections/live-results-post-ap.php:11
+msgid "Welcome to Newspack's Election Results template. This article pattern is designed to work with AP results embeds. If you're not sure how to access those, contact AP. We've included guidance throughout the template to help you build an election results page that highlights your unique value to your audience and drives engagement. <strong>Make sure to delete these guide paragraphs with yellow backgrounds before publishing</strong>. To find out more about how to use these patterns, see the <a target=\"_blank\" href=\"https://help.newspack.com/newspack-election-results-patterns/\">Help Site documentation</a>."
 msgstr ""
 
-#: includes/reader-revenue/templates/myaccount-verify.php:56
-#: release/newspack-plugin/includes/reader-revenue/templates/myaccount-verify.php:56
-msgid "You must verify your account before you can manage account settings. Verify with a link or by setting a password."
+#: includes/templates/block-patterns/elections/live-results-post-ap.php:15
+#: includes/templates/block-patterns/elections/live-results-post-ddhq.php:15
+#: release/newspack-plugin/includes/templates/block-patterns/elections/live-results-post-ap.php:15
+#: release/newspack-plugin/includes/templates/block-patterns/elections/live-results-post-ddhq.php:15
+msgid "Replace this text with a tight intro explaining that this page contains live election results that will be updated automatically throughout the race."
 msgstr ""
 
-#: includes/reader-revenue/templates/myaccount-verify.php:60
-#: release/newspack-plugin/includes/reader-revenue/templates/myaccount-verify.php:60
-msgid "Send me a link"
+#: includes/templates/block-patterns/elections/live-results-post-ap.php:20
+#: includes/templates/block-patterns/elections/live-results-post-ddhq.php:20
+#: release/newspack-plugin/includes/templates/block-patterns/elections/live-results-post-ap.php:20
+#: release/newspack-plugin/includes/templates/block-patterns/elections/live-results-post-ddhq.php:20
+msgid "Key local races"
 msgstr ""
 
-#: includes/reader-revenue/templates/myaccount-verify.php:63
-#: release/newspack-plugin/includes/reader-revenue/templates/myaccount-verify.php:63
-msgid "Set a new password"
+#: includes/templates/block-patterns/elections/live-results-post-ap.php:24
+#: includes/templates/block-patterns/elections/live-results-post-ap.php:58
+#: includes/templates/block-patterns/elections/live-results-post-ap.php:68
+#: includes/templates/block-patterns/elections/live-results-post-ap.php:78
+#: includes/templates/block-patterns/elections/live-results-post-ap.php:118
+#: includes/templates/block-patterns/elections/live-results-post-ap.php:128
+#: includes/templates/block-patterns/elections/live-results-post-ap.php:138
+#: release/newspack-plugin/includes/templates/block-patterns/elections/live-results-post-ap.php:24
+#: release/newspack-plugin/includes/templates/block-patterns/elections/live-results-post-ap.php:58
+#: release/newspack-plugin/includes/templates/block-patterns/elections/live-results-post-ap.php:68
+#: release/newspack-plugin/includes/templates/block-patterns/elections/live-results-post-ap.php:78
+#: release/newspack-plugin/includes/templates/block-patterns/elections/live-results-post-ap.php:118
+#: release/newspack-plugin/includes/templates/block-patterns/elections/live-results-post-ap.php:128
+#: release/newspack-plugin/includes/templates/block-patterns/elections/live-results-post-ap.php:138
+msgid "PASTE EMBED CODE FROM AP HERE!"
 msgstr ""
 
-#. Translators: %s is the fee percentage.
-#: includes/reader-revenue/woocommerce/class-woocommerce-cli.php:143
-#: includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php:81
-#: release/newspack-plugin/includes/reader-revenue/woocommerce/class-woocommerce-cli.php:143
-#: release/newspack-plugin/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php:81
-msgid "Transaction fee (%s)"
+#: includes/templates/block-patterns/elections/live-results-post-ap.php:29
+#: includes/templates/block-patterns/elections/live-results-post-ddhq.php:29
+#: release/newspack-plugin/includes/templates/block-patterns/elections/live-results-post-ap.php:29
+#: release/newspack-plugin/includes/templates/block-patterns/elections/live-results-post-ddhq.php:29
+msgid "For the above embed block, we recommend embedding results that are specific to your audience and community — this might be a tight local race, a key ballot measure, or a collection of races of specific demographic interest. Include as many or as few as appropriate. Focus on the races where your proximity to your readers gives you a comparative advantage!"
 msgstr ""
 
-#: includes/reader-revenue/woocommerce/class-woocommerce-connection.php:602
-#: includes/reader-revenue/woocommerce/class-woocommerce-connection.php:689
-#: release/newspack-plugin/includes/reader-revenue/woocommerce/class-woocommerce-connection.php:593
-#: release/newspack-plugin/includes/reader-revenue/woocommerce/class-woocommerce-connection.php:680
-msgid "Monthly"
+#: includes/templates/block-patterns/elections/live-results-post-ap.php:34
+#: includes/templates/block-patterns/elections/live-results-post-ddhq.php:34
+#: release/newspack-plugin/includes/templates/block-patterns/elections/live-results-post-ap.php:34
+#: release/newspack-plugin/includes/templates/block-patterns/elections/live-results-post-ddhq.php:34
+msgid "Subscribe to our newsletter and we'll tell you the minute results start coming in and when a winner is declared."
 msgstr ""
 
-#: includes/reader-revenue/woocommerce/class-woocommerce-connection.php:603
-#: includes/reader-revenue/woocommerce/class-woocommerce-connection.php:690
-#: release/newspack-plugin/includes/reader-revenue/woocommerce/class-woocommerce-connection.php:594
-#: release/newspack-plugin/includes/reader-revenue/woocommerce/class-woocommerce-connection.php:681
-msgid "Yearly"
+#: includes/templates/block-patterns/elections/live-results-post-ap.php:41
+#: includes/templates/block-patterns/elections/live-results-post-ddhq.php:41
+#: release/newspack-plugin/includes/templates/block-patterns/elections/live-results-post-ap.php:41
+#: release/newspack-plugin/includes/templates/block-patterns/elections/live-results-post-ddhq.php:41
+msgid "Don't forget to modify the copy for the above newsletter subscription block to fit your editorial strategy and planning."
 msgstr ""
 
-#: includes/reader-revenue/woocommerce/class-woocommerce-connection.php:632
-#: includes/reader-revenue/woocommerce/class-woocommerce-connection.php:721
-#: release/newspack-plugin/includes/reader-revenue/woocommerce/class-woocommerce-connection.php:623
-#: release/newspack-plugin/includes/reader-revenue/woocommerce/class-woocommerce-connection.php:712
-msgid "One-time"
+#: includes/templates/block-patterns/elections/live-results-post-ap.php:45
+#: includes/templates/block-patterns/elections/live-results-post-ddhq.php:45
+#: release/newspack-plugin/includes/templates/block-patterns/elections/live-results-post-ap.php:45
+#: release/newspack-plugin/includes/templates/block-patterns/elections/live-results-post-ddhq.php:45
+msgid "More regional races"
 msgstr ""
 
-#: includes/reader-revenue/woocommerce/class-woocommerce-connection.php:648
-#: release/newspack-plugin/includes/reader-revenue/woocommerce/class-woocommerce-connection.php:639
-msgid "Card"
+#: includes/templates/block-patterns/elections/live-results-post-ap.php:49
+#: includes/templates/block-patterns/elections/live-results-post-ddhq.php:49
+#: release/newspack-plugin/includes/templates/block-patterns/elections/live-results-post-ap.php:49
+#: release/newspack-plugin/includes/templates/block-patterns/elections/live-results-post-ddhq.php:49
+msgid "For the following results blocks, we recommend repeating a simple visualization for secondary races that may be relevant for your audience, such as local house races in your area."
 msgstr ""
 
-#: includes/reader-revenue/woocommerce/class-woocommerce-connection.php:733
-#: release/newspack-plugin/includes/reader-revenue/woocommerce/class-woocommerce-connection.php:724
-msgid "Restart Donation"
+#: includes/templates/block-patterns/elections/live-results-post-ap.php:54
+#: includes/templates/block-patterns/elections/live-results-post-ddhq.php:54
+#: release/newspack-plugin/includes/templates/block-patterns/elections/live-results-post-ap.php:54
+#: release/newspack-plugin/includes/templates/block-patterns/elections/live-results-post-ddhq.php:54
+msgid "Race 1"
 msgstr ""
 
-#: includes/reader-revenue/woocommerce/class-woocommerce-connection.php:733
-#: release/newspack-plugin/includes/reader-revenue/woocommerce/class-woocommerce-connection.php:724
-msgid "Restart Subscription"
+#: includes/templates/block-patterns/elections/live-results-post-ap.php:64
+#: includes/templates/block-patterns/elections/live-results-post-ddhq.php:64
+#: release/newspack-plugin/includes/templates/block-patterns/elections/live-results-post-ap.php:64
+#: release/newspack-plugin/includes/templates/block-patterns/elections/live-results-post-ddhq.php:64
+msgid "Race 2"
 msgstr ""
 
-#: includes/reader-revenue/woocommerce/class-woocommerce-connection.php:741
-#: release/newspack-plugin/includes/reader-revenue/woocommerce/class-woocommerce-connection.php:732
-msgid "Donation Cancelled"
+#: includes/templates/block-patterns/elections/live-results-post-ap.php:74
+#: includes/templates/block-patterns/elections/live-results-post-ddhq.php:74
+#: release/newspack-plugin/includes/templates/block-patterns/elections/live-results-post-ap.php:74
+#: release/newspack-plugin/includes/templates/block-patterns/elections/live-results-post-ddhq.php:74
+msgid "Race 3"
 msgstr ""
 
-#: includes/reader-revenue/woocommerce/class-woocommerce-connection.php:741
-#: release/newspack-plugin/includes/reader-revenue/woocommerce/class-woocommerce-connection.php:732
-msgid "Subscription Cancelled"
+#: includes/templates/block-patterns/elections/live-results-post-ap.php:88
+#: release/newspack-plugin/includes/templates/block-patterns/elections/live-results-post-ap.php:88
+msgid "Support our coverage of key local issues"
 msgstr ""
 
-#: includes/reader-revenue/woocommerce/class-woocommerce-connection.php:745
-#: release/newspack-plugin/includes/reader-revenue/woocommerce/class-woocommerce-connection.php:736
-msgid "recurring donation"
+#: includes/templates/block-patterns/elections/live-results-post-ap.php:94
+#: includes/templates/block-patterns/elections/live-results-post-ddhq.php:94
+#: release/newspack-plugin/includes/templates/block-patterns/elections/live-results-post-ap.php:94
+#: release/newspack-plugin/includes/templates/block-patterns/elections/live-results-post-ddhq.php:94
+msgid "If your site offers a paid membership/subscription model, swap these Donation Blocks out for registration/subscription blocks."
 msgstr ""
 
-#: includes/reader-revenue/woocommerce/class-woocommerce-connection.php:745
-#: release/newspack-plugin/includes/reader-revenue/woocommerce/class-woocommerce-connection.php:736
-msgid "subscription"
+#: includes/templates/block-patterns/elections/live-results-post-ap.php:105
+#: includes/templates/block-patterns/elections/live-results-post-ddhq.php:105
+#: release/newspack-plugin/includes/templates/block-patterns/elections/live-results-post-ap.php:105
+#: release/newspack-plugin/includes/templates/block-patterns/elections/live-results-post-ddhq.php:105
+msgid "Only keep the above Homepage Posts Block if your site does not use Jetpack's Related Posts. If you use Related Posts, delete the above block. If you don't have a sidebar on this page with links to other coverage, consider moving this block higher up."
 msgstr ""
 
-#: includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php:97
-#: release/newspack-plugin/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php:97
-msgid "The donor opted to cover Stripe's transaction fee."
+#: includes/templates/block-patterns/elections/live-results-post-ap.php:114
+#: includes/templates/block-patterns/elections/live-results-post-ddhq.php:114
+#: release/newspack-plugin/includes/templates/block-patterns/elections/live-results-post-ap.php:114
+#: release/newspack-plugin/includes/templates/block-patterns/elections/live-results-post-ddhq.php:114
+msgid "Race 4"
 msgstr ""
 
-#. Translators: %s is the possessive form of the site name.
-#: includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php:173
-#: release/newspack-plugin/includes/reader-revenue/woocommerce/class-woocommerce-cover-fees.php:173
-msgid "I’d like to cover the %1$s transaction fee to ensure my full donation goes towards %2$s mission."
+#: includes/templates/block-patterns/elections/live-results-post-ap.php:124
+#: includes/templates/block-patterns/elections/live-results-post-ddhq.php:124
+#: release/newspack-plugin/includes/templates/block-patterns/elections/live-results-post-ap.php:124
+#: release/newspack-plugin/includes/templates/block-patterns/elections/live-results-post-ddhq.php:124
+msgid "Race 5"
 msgstr ""
 
-#: includes/reader-revenue/woocommerce/class-woocommerce-order-utm.php:94
-#: release/newspack-plugin/includes/reader-revenue/woocommerce/class-woocommerce-order-utm.php:94
-msgid "UTM Parameters"
+#: includes/templates/block-patterns/elections/live-results-post-ap.php:134
+#: includes/templates/block-patterns/elections/live-results-post-ddhq.php:134
+#: release/newspack-plugin/includes/templates/block-patterns/elections/live-results-post-ap.php:134
+#: release/newspack-plugin/includes/templates/block-patterns/elections/live-results-post-ddhq.php:134
+msgid "Race 6"
 msgstr ""
 
-#: includes/reader-revenue/woocommerce/class-woocommerce-products.php:56
-#: release/newspack-plugin/includes/reader-revenue/woocommerce/class-woocommerce-products.php:56
-msgid "Auto-complete orders"
+#: includes/templates/block-patterns/elections/live-results-post-ddhq.php:11
+#: release/newspack-plugin/includes/templates/block-patterns/elections/live-results-post-ddhq.php:11
+msgid "Welcome to Newspack's Election Results template. This article pattern is designed to work with DDHQ results embeds. If you're not sure how to access those, contact DDHQ. We've included guidance throughout the template to help you build an election results page that highlights your unique value to your audience and drives engagement. <strong>Make sure to delete these guide paragraphs with yellow backgrounds before publishing.</strong> To find out more about how to use these patterns, see the <a target=\"_blank\" href=\"https://help.newspack.com/newspack-election-results-patterns/\">Help Site documentation</a>."
 msgstr ""
 
-#: includes/reader-revenue/woocommerce/class-woocommerce-products.php:57
-#: release/newspack-plugin/includes/reader-revenue/woocommerce/class-woocommerce-products.php:57
-msgid "Allow orders containing this product to automatically complete upon successful payment."
+#: includes/templates/block-patterns/elections/live-results-post-ddhq.php:24
+#: includes/templates/block-patterns/elections/live-results-post-ddhq.php:58
+#: includes/templates/block-patterns/elections/live-results-post-ddhq.php:68
+#: includes/templates/block-patterns/elections/live-results-post-ddhq.php:78
+#: includes/templates/block-patterns/elections/live-results-post-ddhq.php:118
+#: includes/templates/block-patterns/elections/live-results-post-ddhq.php:128
+#: includes/templates/block-patterns/elections/live-results-post-ddhq.php:138
+#: release/newspack-plugin/includes/templates/block-patterns/elections/live-results-post-ddhq.php:24
+#: release/newspack-plugin/includes/templates/block-patterns/elections/live-results-post-ddhq.php:58
+#: release/newspack-plugin/includes/templates/block-patterns/elections/live-results-post-ddhq.php:68
+#: release/newspack-plugin/includes/templates/block-patterns/elections/live-results-post-ddhq.php:78
+#: release/newspack-plugin/includes/templates/block-patterns/elections/live-results-post-ddhq.php:118
+#: release/newspack-plugin/includes/templates/block-patterns/elections/live-results-post-ddhq.php:128
+#: release/newspack-plugin/includes/templates/block-patterns/elections/live-results-post-ddhq.php:138
+msgid "PASTE EMBED CODE FROM DDHQ HERE!"
+msgstr ""
+
+#: includes/templates/block-patterns/elections/live-results-post-ddhq.php:143
+#: release/newspack-plugin/includes/templates/block-patterns/elections/live-results-post-ddhq.php:143
+msgid "PASTE DDHQ JS SNIPPET HERE! (Should be provided to you by DDHQ)"
+msgstr ""
+
+#: includes/templates/reader-activation-emails/change-email-cancel.php:30
+#: includes/templates/reader-activation-emails/change-email-cancel.php:70
+#: includes/templates/reader-activation-emails/change-email-cancel.php:241
+#: includes/templates/reader-activation-emails/change-email-cancel.php:263
+#: release/newspack-plugin/includes/templates/reader-activation-emails/change-email-cancel.php:30
+#: release/newspack-plugin/includes/templates/reader-activation-emails/change-email-cancel.php:70
+#: release/newspack-plugin/includes/templates/reader-activation-emails/change-email-cancel.php:241
+#: release/newspack-plugin/includes/templates/reader-activation-emails/change-email-cancel.php:263
+msgid "Email change requested"
+msgstr ""
+
+#: includes/templates/reader-activation-emails/change-email-cancel.php:35
+#: includes/templates/reader-activation-emails/change-email-cancel.php:243
+#: release/newspack-plugin/includes/templates/reader-activation-emails/change-email-cancel.php:35
+#: release/newspack-plugin/includes/templates/reader-activation-emails/change-email-cancel.php:243
+msgid "We received a request to change your email address to *PENDING_EMAIL_ADDRESS*. If you didn't request or would like to cancel this change, please click the button below."
+msgstr ""
+
+#. Translators: 1: link to site url.
+#. Translators: s: link to site url.
+#: includes/templates/reader-activation-emails/change-email-cancel.php:61
+#: includes/templates/reader-activation-emails/change-email-cancel.php:251
+#: includes/templates/reader-activation-emails/change-email.php:65
+#: includes/templates/reader-activation-emails/change-email.php:257
+#: release/newspack-plugin/includes/templates/reader-activation-emails/change-email-cancel.php:61
+#: release/newspack-plugin/includes/templates/reader-activation-emails/change-email-cancel.php:251
+#: release/newspack-plugin/includes/templates/reader-activation-emails/change-email.php:65
+#: release/newspack-plugin/includes/templates/reader-activation-emails/change-email.php:257
+msgid "You received this email because you requested to update your email address for %s"
+msgstr ""
+
+#: includes/templates/reader-activation-emails/change-email.php:30
+#: includes/templates/reader-activation-emails/change-email.php:44
+#: includes/templates/reader-activation-emails/change-email.php:74
+#: includes/templates/reader-activation-emails/change-email.php:245
+#: includes/templates/reader-activation-emails/change-email.php:249
+#: includes/templates/reader-activation-emails/change-email.php:263
+#: release/newspack-plugin/includes/templates/reader-activation-emails/change-email.php:30
+#: release/newspack-plugin/includes/templates/reader-activation-emails/change-email.php:44
+#: release/newspack-plugin/includes/templates/reader-activation-emails/change-email.php:74
+#: release/newspack-plugin/includes/templates/reader-activation-emails/change-email.php:245
+#: release/newspack-plugin/includes/templates/reader-activation-emails/change-email.php:249
+#: release/newspack-plugin/includes/templates/reader-activation-emails/change-email.php:263
+msgid "Confirm email change"
+msgstr ""
+
+#: includes/templates/reader-activation-emails/change-email.php:35
+#: includes/templates/reader-activation-emails/change-email.php:247
+#: release/newspack-plugin/includes/templates/reader-activation-emails/change-email.php:35
+#: release/newspack-plugin/includes/templates/reader-activation-emails/change-email.php:247
+msgid "We received a request to change your email address. To complete this process and confirm your new email address, please click the button below."
+msgstr ""
+
+#. Translators: the email change cancellation url.
+#. Translators: the email change cancellation url
+#: includes/templates/reader-activation-emails/change-email.php:52
+#: includes/templates/reader-activation-emails/change-email.php:251
+#: release/newspack-plugin/includes/templates/reader-activation-emails/change-email.php:52
+#: release/newspack-plugin/includes/templates/reader-activation-emails/change-email.php:251
+msgid "If you didn't request or would like to cancel this change, please click the following link: %s"
 msgstr ""
 
 #: includes/templates/reader-activation-emails/delete-account.php:30
@@ -2100,6 +4941,23 @@ msgstr ""
 msgid "Click the magic link below to continue where you left off. You also have the option to %1$screate a password%2$s for your account."
 msgstr ""
 
+#: includes/templates/reader-activation-emails/non-reader.php:34
+#: includes/templates/reader-activation-emails/non-reader.php:218
+#: release/newspack-plugin/includes/templates/reader-activation-emails/non-reader.php:34
+#: release/newspack-plugin/includes/templates/reader-activation-emails/non-reader.php:218
+msgid "Someone attempted to sign into your account on *SITE_TITLE* using a login method reserved for reader accounts. Please use the following link to sign in via the WordPress admin dashboard:"
+msgstr ""
+
+#: includes/templates/reader-activation-emails/non-reader.php:39
+#: release/newspack-plugin/includes/templates/reader-activation-emails/non-reader.php:39
+msgid "Continue to *SITE_TITLE*"
+msgstr ""
+
+#: includes/templates/reader-activation-emails/non-reader.php:218
+#: release/newspack-plugin/includes/templates/reader-activation-emails/non-reader.php:218
+msgid "Sign In: Someone attempted to sign into your account on *SITE_TITLE* using a login method reserved for reader accounts. Please use the following link to sign in via the WordPress admin dashboard:"
+msgstr ""
+
 #. Translators: s: the site title.
 #: includes/templates/reader-activation-emails/otp.php:34
 #: includes/templates/reader-activation-emails/otp.php:283
@@ -2116,26 +4974,11 @@ msgstr ""
 msgid "Copy your one-time password, or click the magic link below to finish signing in. You also have the option to %1$screate a password%2$s for your account."
 msgstr ""
 
-#: includes/templates/reader-activation-emails/password-reset.php:30
-#: includes/templates/reader-activation-emails/password-reset.php:42
-#: includes/templates/reader-activation-emails/password-reset.php:73
-#: includes/templates/reader-activation-emails/password-reset.php:244
-#: includes/templates/reader-activation-emails/password-reset.php:248
-#: includes/templates/reader-activation-emails/password-reset.php:261
-#: release/newspack-plugin/includes/templates/reader-activation-emails/password-reset.php:30
-#: release/newspack-plugin/includes/templates/reader-activation-emails/password-reset.php:42
-#: release/newspack-plugin/includes/templates/reader-activation-emails/password-reset.php:73
-#: release/newspack-plugin/includes/templates/reader-activation-emails/password-reset.php:244
-#: release/newspack-plugin/includes/templates/reader-activation-emails/password-reset.php:248
-#: release/newspack-plugin/includes/templates/reader-activation-emails/password-reset.php:261
-msgid "Reset password"
-msgstr ""
-
 #: includes/templates/reader-activation-emails/password-reset.php:34
 #: includes/templates/reader-activation-emails/password-reset.php:246
 #: release/newspack-plugin/includes/templates/reader-activation-emails/password-reset.php:34
 #: release/newspack-plugin/includes/templates/reader-activation-emails/password-reset.php:246
-msgid "You have just requested a password reset for your account associated with this email address."
+msgid "You have just requested to set a password for your account associated with this email address."
 msgstr ""
 
 #. Translators: 1: Opening HTML anchor tag containing Newspack support link. 2: Closing HTML anchor tag.
@@ -2313,153 +5156,2544 @@ msgstr ""
 msgid "Here is a receipt for your recent transaction:"
 msgstr ""
 
-#: includes/wizards/class-engagement-wizard.php:310
-#: includes/wizards/class-reader-revenue-wizard.php:548
-#: release/newspack-plugin/includes/wizards/class-engagement-wizard.php:310
-#: release/newspack-plugin/includes/wizards/class-reader-revenue-wizard.php:548
+#: includes/wizards/advertising/class-advertising-display-ads.php:97
+#: includes/wizards/class-newsletters-wizard.php:292
+#: includes/wizards/newspack/class-newspack-dashboard.php:95
+#: includes/wizards/newspack/class-newspack-dashboard.php:110
+#: release/newspack-plugin/includes/wizards/advertising/class-advertising-display-ads.php:97
+#: release/newspack-plugin/includes/wizards/class-newsletters-wizard.php:292
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:95
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:110
+msgid "Advertising"
+msgstr ""
+
+#: includes/wizards/advertising/class-advertising-display-ads.php:503
+#: release/newspack-plugin/includes/wizards/advertising/class-advertising-display-ads.php:503
+msgid "Ad Units failed to fetch."
+msgstr ""
+
+#: includes/wizards/advertising/class-advertising-display-ads.php:644
+#: release/newspack-plugin/includes/wizards/advertising/class-advertising-display-ads.php:644
+#: dist/billboard.js:12
+#: release/newspack-plugin/dist/billboard.js:12
+msgid "Advertising / Display Ads"
+msgstr ""
+
+#: includes/wizards/advertising/class-advertising-display-ads.php:645
+#: includes/wizards/newspack/class-newspack-dashboard.php:118
+#: release/newspack-plugin/includes/wizards/advertising/class-advertising-display-ads.php:645
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:118
+msgid "Display Ads"
+msgstr ""
+
+#: includes/wizards/advertising/class-advertising-sponsors.php:90
+#: release/newspack-plugin/includes/wizards/advertising/class-advertising-sponsors.php:86
+msgid "All Sponsors"
+msgstr ""
+
+#: includes/wizards/advertising/class-advertising-sponsors.php:110
+#: release/newspack-plugin/includes/wizards/advertising/class-advertising-sponsors.php:106
+msgid "Advertising / Sponsors"
+msgstr ""
+
+#: includes/wizards/advertising/class-advertising-sponsors.php:151
+#: includes/wizards/newspack/class-newspack-dashboard.php:124
+#: release/newspack-plugin/includes/wizards/advertising/class-advertising-sponsors.php:147
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:124
+msgid "Sponsors"
+msgstr ""
+
+#: includes/wizards/audience/class-audience-campaigns.php:50
+#: release/newspack-plugin/includes/wizards/audience/class-audience-campaigns.php:50
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Audience Management / Campaigns"
+msgstr ""
+
+#: includes/wizards/audience/class-audience-campaigns.php:112
+#: includes/wizards/newspack/class-newspack-dashboard.php:58
+#: release/newspack-plugin/includes/wizards/audience/class-audience-campaigns.php:112
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:58
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:7
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:7
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Campaigns"
+msgstr ""
+
+#: includes/wizards/audience/class-audience-donations.php:46
+#: release/newspack-plugin/includes/wizards/audience/class-audience-donations.php:46
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:19
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:19
+msgid "Audience Management / Donations"
+msgstr ""
+
+#: includes/wizards/audience/class-audience-donations.php:56
+#: includes/wizards/newspack/class-newspack-dashboard.php:64
+#: release/newspack-plugin/includes/wizards/audience/class-audience-donations.php:56
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:64
+msgid "Donations"
+msgstr ""
+
+#: includes/wizards/audience/class-audience-donations.php:319
+#: includes/wizards/audience/class-audience-wizard.php:475
+#: release/newspack-plugin/includes/wizards/audience/class-audience-donations.php:319
+#: release/newspack-plugin/includes/wizards/audience/class-audience-wizard.php:475
 msgid "Invalid argument: no email template matches the provided id."
 msgstr ""
 
-#: includes/wizards/class-engagement-wizard.php:321
-#: includes/wizards/class-reader-revenue-wizard.php:559
-#: release/newspack-plugin/includes/wizards/class-engagement-wizard.php:321
-#: release/newspack-plugin/includes/wizards/class-reader-revenue-wizard.php:559
+#: includes/wizards/audience/class-audience-donations.php:330
+#: includes/wizards/audience/class-audience-wizard.php:486
+#: release/newspack-plugin/includes/wizards/audience/class-audience-donations.php:330
+#: release/newspack-plugin/includes/wizards/audience/class-audience-wizard.php:486
 msgid "Reset failed: unable to reset email template."
 msgstr ""
 
-#: release/newspack-plugin/src/blocks/reader-registration/index.php:39
-#: src/blocks/reader-registration/index.php:39
-msgid "Stacked"
+#: includes/wizards/audience/class-audience-subscriptions.php:37
+#: release/newspack-plugin/includes/wizards/audience/class-audience-subscriptions.php:37
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:41
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:41
+msgid "Audience Management / Subscriptions"
 msgstr ""
 
-#: release/newspack-plugin/src/blocks/reader-registration/index.php:47
-#: src/blocks/reader-registration/index.php:47
-msgid "Columns (newsletter subscription)"
+#: includes/wizards/audience/class-audience-subscriptions.php:71
+#: includes/wizards/audience/class-audience-wizard.php:142
+#: includes/wizards/newspack/class-newspack-dashboard.php:52
+#: release/newspack-plugin/includes/wizards/audience/class-audience-subscriptions.php:71
+#: release/newspack-plugin/includes/wizards/audience/class-audience-wizard.php:142
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:52
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:19
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:41
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:19
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:41
+msgid "Configuration"
 msgstr ""
 
-#. Translators: %s is a link to My Account.
-#: release/newspack-plugin/src/blocks/reader-registration/index.php:120
-#: src/blocks/reader-registration/index.php:120
-msgid "Please visit %s to verify and manage your account."
+#: includes/wizards/audience/class-audience-subscriptions.php:72
+#: release/newspack-plugin/includes/wizards/audience/class-audience-subscriptions.php:72
+msgid "Manage Subscriptions settings in Woo Memberships"
 msgstr ""
 
-#: release/newspack-plugin/src/blocks/reader-registration/index.php:128
-#: src/blocks/reader-registration/index.php:128
-#: dist/blocks.js:4
-#: release/newspack-plugin/dist/blocks.js:4
-#: src/blocks/reader-registration/edit.js:367
-msgid "Sign up"
+#: includes/wizards/audience/class-audience-subscriptions.php:73
+#: release/newspack-plugin/includes/wizards/audience/class-audience-subscriptions.php:73
+msgid "You can manage the details of your subscription offerings in the Woo Memberships plugin."
 msgstr ""
 
-#: release/newspack-plugin/src/blocks/reader-registration/index.php:130
-#: src/blocks/reader-registration/index.php:130
-#: dist/blocks.js:4
-#: release/newspack-plugin/dist/blocks.js:4
-#: src/blocks/reader-registration/edit.js:264
-msgid "Already have an account?"
+#: includes/wizards/audience/class-audience-subscriptions.php:75
+#: release/newspack-plugin/includes/wizards/audience/class-audience-subscriptions.php:75
+msgid "Manage Subscriptions"
 msgstr ""
 
-#: release/newspack-plugin/src/blocks/reader-registration/index.php:132
-#: src/blocks/reader-registration/index.php:132
-msgid "An account was already registered with this email. Please check your inbox for an authentication link."
+#: includes/wizards/audience/class-audience-wizard.php:71
+#: release/newspack-plugin/includes/wizards/audience/class-audience-wizard.php:71
+msgid "Audience Management / Configuration"
 msgstr ""
 
-#: dist/analytics.js:1
-#: release/newspack-plugin/dist/analytics.js:1
-#: src/wizards/analytics/views/plugins/index.js:29
+#: includes/wizards/audience/class-audience-wizard.php:72
+#: release/newspack-plugin/includes/wizards/audience/class-audience-wizard.php:72
+msgid "Audience Management / Setup"
+msgstr ""
+
+#: includes/wizards/audience/class-audience-wizard.php:132
+#: release/newspack-plugin/includes/wizards/audience/class-audience-wizard.php:132
+#: dist/wizards.js:1
+#: release/newspack-plugin/dist/wizards.js:1
+msgid "Audience"
+msgstr ""
+
+#: includes/wizards/audience/class-audience-wizard.php:143
+#: release/newspack-plugin/includes/wizards/audience/class-audience-wizard.php:143
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:41
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:41
+msgid "Setup"
+msgstr ""
+
+#: includes/wizards/audience/class-audience-wizard.php:531
+#: release/newspack-plugin/includes/wizards/audience/class-audience-wizard.php:531
+msgid "Error skipping prerequisite."
+msgstr ""
+
+#: includes/wizards/class-listings-wizard.php:70
+#: release/newspack-plugin/includes/wizards/class-listings-wizard.php:70
+msgid "Listings / Events"
+msgstr ""
+
+#: includes/wizards/class-listings-wizard.php:71
+#: release/newspack-plugin/includes/wizards/class-listings-wizard.php:71
+msgid "Listings / Generic Listings"
+msgstr ""
+
+#: includes/wizards/class-listings-wizard.php:72
+#: release/newspack-plugin/includes/wizards/class-listings-wizard.php:72
+msgid "Listings / Marketplace Listings"
+msgstr ""
+
+#: includes/wizards/class-listings-wizard.php:73
+#: release/newspack-plugin/includes/wizards/class-listings-wizard.php:73
+msgid "Listings / Places"
+msgstr ""
+
+#: includes/wizards/class-listings-wizard.php:75
+#: release/newspack-plugin/includes/wizards/class-listings-wizard.php:75
+msgid "Listings / Settings"
+msgstr ""
+
+#: includes/wizards/class-listings-wizard.php:107
+#: includes/wizards/newspack/class-newspack-dashboard.php:134
+#: release/newspack-plugin/includes/wizards/class-listings-wizard.php:107
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:134
+msgid "Listings"
+msgstr ""
+
+#: includes/wizards/class-listings-wizard.php:118
+#: release/newspack-plugin/includes/wizards/class-listings-wizard.php:118
+msgid "Newspack Listings: Site-Wide Settings"
+msgstr ""
+
+#: includes/wizards/class-network-wizard.php:65
+#: release/newspack-plugin/includes/wizards/class-network-wizard.php:65
+msgid "Network / Settings"
+msgstr ""
+
+#: includes/wizards/class-network-wizard.php:66
+#: release/newspack-plugin/includes/wizards/class-network-wizard.php:66
+msgid "Network / Event Log"
+msgstr ""
+
+#: includes/wizards/class-network-wizard.php:67
+#: release/newspack-plugin/includes/wizards/class-network-wizard.php:67
+msgid "Network / Membership Plans"
+msgstr ""
+
+#: includes/wizards/class-network-wizard.php:68
+#: release/newspack-plugin/includes/wizards/class-network-wizard.php:68
+msgid "Network / Content Distribution"
+msgstr ""
+
+#: includes/wizards/class-network-wizard.php:69
+#: release/newspack-plugin/includes/wizards/class-network-wizard.php:69
+msgid "Network / Distributor Settings"
+msgstr ""
+
+#: includes/wizards/class-network-wizard.php:70
+#: release/newspack-plugin/includes/wizards/class-network-wizard.php:70
+msgid "Network / Node Settings"
+msgstr ""
+
+#: includes/wizards/class-network-wizard.php:72
+#: release/newspack-plugin/includes/wizards/class-network-wizard.php:72
+msgid "Network / Nodes"
+msgstr ""
+
+#: includes/wizards/class-network-wizard.php:73
+#: release/newspack-plugin/includes/wizards/class-network-wizard.php:73
+msgid "Network / Orders"
+msgstr ""
+
+#: includes/wizards/class-network-wizard.php:74
+#: release/newspack-plugin/includes/wizards/class-network-wizard.php:74
+msgid "Network / Subscriptions"
+msgstr ""
+
+#: includes/wizards/class-network-wizard.php:191
+#: includes/wizards/class-network-wizard.php:324
+#: release/newspack-plugin/includes/wizards/class-network-wizard.php:191
+#: release/newspack-plugin/includes/wizards/class-network-wizard.php:324
+msgid "Site Role"
+msgstr ""
+
+#: includes/wizards/class-network-wizard.php:198
+#: includes/wizards/class-network-wizard.php:303
+#: includes/wizards/class-network-wizard.php:307
+#: release/newspack-plugin/includes/wizards/class-network-wizard.php:198
+#: release/newspack-plugin/includes/wizards/class-network-wizard.php:303
+#: release/newspack-plugin/includes/wizards/class-network-wizard.php:307
+msgid "Node Settings"
+msgstr ""
+
+#: includes/wizards/class-network-wizard.php:207
+#: includes/wizards/class-network-wizard.php:336
+#: includes/wizards/class-network-wizard.php:340
+#: release/newspack-plugin/includes/wizards/class-network-wizard.php:207
+#: release/newspack-plugin/includes/wizards/class-network-wizard.php:336
+#: release/newspack-plugin/includes/wizards/class-network-wizard.php:340
+msgid "Distributor Settings"
+msgstr ""
+
+#: includes/wizards/class-network-wizard.php:214
+#: includes/wizards/class-network-wizard.php:354
+#: includes/wizards/class-network-wizard.php:358
+#: release/newspack-plugin/includes/wizards/class-network-wizard.php:214
+#: release/newspack-plugin/includes/wizards/class-network-wizard.php:354
+#: release/newspack-plugin/includes/wizards/class-network-wizard.php:358
+msgid "Content Distribution"
+msgstr ""
+
+#: includes/wizards/class-network-wizard.php:292
+#: includes/wizards/newspack/class-newspack-dashboard.php:177
+#: release/newspack-plugin/includes/wizards/class-network-wizard.php:292
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:177
+msgid "Network"
+msgstr ""
+
+#: includes/wizards/class-newsletters-wizard.php:72
+#: release/newspack-plugin/includes/wizards/class-newsletters-wizard.php:72
+#: dist/newsletters.js:4
+#: release/newspack-plugin/dist/newsletters.js:4
+msgid "Newsletters / Settings"
+msgstr ""
+
+#: includes/wizards/class-newsletters-wizard.php:74
+#: release/newspack-plugin/includes/wizards/class-newsletters-wizard.php:74
+msgid "Newsletters / All Newsletters"
+msgstr ""
+
+#: includes/wizards/class-newsletters-wizard.php:75
+#: includes/wizards/class-newsletters-wizard.php:77
+#: release/newspack-plugin/includes/wizards/class-newsletters-wizard.php:75
+#: release/newspack-plugin/includes/wizards/class-newsletters-wizard.php:77
+msgid "Newsletters / Advertising"
+msgstr ""
+
+#: includes/wizards/class-newsletters-wizard.php:79
+#: release/newspack-plugin/includes/wizards/class-newsletters-wizard.php:79
+msgid "Newsletters / Lists"
+msgstr ""
+
+#: includes/wizards/class-newsletters-wizard.php:182
+#: release/newspack-plugin/includes/wizards/class-newsletters-wizard.php:182
+msgid "Whether click tracking is enabled."
+msgstr ""
+
+#: includes/wizards/class-newsletters-wizard.php:187
+#: release/newspack-plugin/includes/wizards/class-newsletters-wizard.php:187
+msgid "Whether the tracking pixel is enabled."
+msgstr ""
+
+#: includes/wizards/class-newsletters-wizard.php:291
+#: release/newspack-plugin/includes/wizards/class-newsletters-wizard.php:291
+msgid "Newsletters Advertising"
+msgstr ""
+
+#: includes/wizards/class-newsletters-wizard.php:299
+#: release/newspack-plugin/includes/wizards/class-newsletters-wizard.php:299
+msgid "Newsletters Settings"
+msgstr ""
+
+#: includes/wizards/class-newsletters-wizard.php:406
+#: release/newspack-plugin/includes/wizards/class-newsletters-wizard.php:406
+msgid "Ads"
+msgstr ""
+
+#: includes/wizards/class-newsletters-wizard.php:410
+#: release/newspack-plugin/includes/wizards/class-newsletters-wizard.php:410
+msgid "Advertisers"
+msgstr ""
+
+#: includes/wizards/newspack/class-newspack-dashboard.php:47
+#: includes/wizards/newspack/class-newspack-dashboard.php:260
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:47
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:260
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:32
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:41
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:32
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:41
+msgid "Audience Management"
+msgstr ""
+
+#: includes/wizards/newspack/class-newspack-dashboard.php:48
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:48
+msgid "Engage your readers more deeply with tools to build customer relationships that drive towards sustainable revenue."
+msgstr ""
+
+#: includes/wizards/newspack/class-newspack-dashboard.php:53
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:53
+msgid "Manage your Audience Management setup."
+msgstr ""
+
+#: includes/wizards/newspack/class-newspack-dashboard.php:59
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:59
+msgid "Coordinate prompts across your site to drive metrics."
+msgstr ""
+
+#: includes/wizards/newspack/class-newspack-dashboard.php:65
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:65
+msgid "Bring in revenue through voluntary gifts."
+msgstr ""
+
+#: includes/wizards/newspack/class-newspack-dashboard.php:71
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:71
+msgid "Gate your site's content behind a paywall."
+msgstr ""
+
+#: includes/wizards/newspack/class-newspack-dashboard.php:82
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:82
+msgid "Engage your readers directly in their email inbox."
+msgstr ""
+
+#: includes/wizards/newspack/class-newspack-dashboard.php:89
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:89
+msgid "All Newsletters"
+msgstr ""
+
+#: includes/wizards/newspack/class-newspack-dashboard.php:90
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:90
+msgid "See all newsletters you’ve sent out, and start new ones."
+msgstr ""
+
+#: includes/wizards/newspack/class-newspack-dashboard.php:96
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:96
+msgid "Get advertising revenue from your newsletters."
+msgstr ""
+
+#: includes/wizards/newspack/class-newspack-dashboard.php:102
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:102
+msgid "Configure tracking and other newsletter settings."
+msgstr ""
+
+#: includes/wizards/newspack/class-newspack-dashboard.php:111
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:111
+msgid "Sell space on your site to fund your operations."
+msgstr ""
+
+#: includes/wizards/newspack/class-newspack-dashboard.php:119
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:119
+msgid "Sell programmatic advertising on your site to drive revenue."
+msgstr ""
+
+#: includes/wizards/newspack/class-newspack-dashboard.php:125
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:125
+msgid "Sell sponsored content directly to purchasers."
+msgstr ""
+
+#: includes/wizards/newspack/class-newspack-dashboard.php:135
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:135
+msgid "Build databases of reusable or user-generated content to use on your site."
+msgstr ""
+
+#: includes/wizards/newspack/class-newspack-dashboard.php:142
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:142
+msgid "Events"
+msgstr ""
+
+#: includes/wizards/newspack/class-newspack-dashboard.php:143
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:143
+msgid "Easily use the same event information across multiple posts."
+msgstr ""
+
+#: includes/wizards/newspack/class-newspack-dashboard.php:148
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:148
+msgid "Marketplace Listings"
+msgstr ""
+
+#: includes/wizards/newspack/class-newspack-dashboard.php:149
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:149
+msgid "Allow users to list items and services for sale."
+msgstr ""
+
+#: includes/wizards/newspack/class-newspack-dashboard.php:154
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:154
+msgid "Generic Listing"
+msgstr ""
+
+#: includes/wizards/newspack/class-newspack-dashboard.php:155
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:155
+msgid "Manage any structured data for use in posts."
+msgstr ""
+
+#: includes/wizards/newspack/class-newspack-dashboard.php:160
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:160
+msgid "Places"
+msgstr ""
+
+#: includes/wizards/newspack/class-newspack-dashboard.php:161
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:161
+msgid "Create a database of places in your coverage area."
+msgstr ""
+
+#: includes/wizards/newspack/class-newspack-dashboard.php:167
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:167
+msgid "Configure the way that Listings work on your site."
+msgstr ""
+
+#: includes/wizards/newspack/class-newspack-dashboard.php:178
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:178
+msgid "Manage the way your site's content flows across your publishing network."
+msgstr ""
+
+#: includes/wizards/newspack/class-newspack-dashboard.php:203
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:203
+msgid "Configure how Newspack Network functions."
+msgstr ""
+
+#: includes/wizards/newspack/class-newspack-dashboard.php:212
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:212
+msgid "Nodes"
+msgstr ""
+
+#: includes/wizards/newspack/class-newspack-dashboard.php:213
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:213
+msgid "Manage which sites are part of your content network."
+msgstr ""
+
+#: includes/wizards/newspack/class-newspack-dashboard.php:219
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:219
+msgid "View all subscriptions across your network."
+msgstr ""
+
+#: includes/wizards/newspack/class-newspack-dashboard.php:224
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:224
+msgid "Orders"
+msgstr ""
+
+#: includes/wizards/newspack/class-newspack-dashboard.php:225
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:225
+msgid "View all payments across your network."
+msgstr ""
+
+#: includes/wizards/newspack/class-newspack-dashboard.php:230
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:230
+msgid "Event Log"
+msgstr ""
+
+#: includes/wizards/newspack/class-newspack-dashboard.php:231
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:231
+msgid "Troubleshoot issues by viewing all events across your network."
+msgstr ""
+
+#: includes/wizards/newspack/class-newspack-dashboard.php:262
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:262
+msgid "Enabled"
+msgstr ""
+
+#: includes/wizards/newspack/class-newspack-dashboard.php:263
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:263
+#: dist/componentsDemo.js:1
+#: release/newspack-plugin/dist/componentsDemo.js:1
+msgid "Disabled"
+msgstr ""
+
+#: includes/wizards/newspack/class-newspack-dashboard.php:269
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:269
+msgid "Woocommerce"
+msgstr ""
+
+#: includes/wizards/newspack/class-newspack-dashboard.php:275
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:275
+#: dist/billboard.js:1
+#: release/newspack-plugin/dist/billboard.js:1
+msgid "Google Ad Manager"
+msgstr ""
+
+#: includes/wizards/newspack/class-newspack-dashboard.php:277
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:277
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:1
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:1
+msgid "Disconnected"
+msgstr ""
+
+#: includes/wizards/newspack/class-newspack-dashboard.php:290
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:290
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:29
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:29
 msgid "Google Analytics"
 msgstr ""
 
-#: dist/analytics.js:1
-#: release/newspack-plugin/dist/analytics.js:1
-#: src/wizards/analytics/views/plugins/index.js:30
-msgid "Configure and view site analytics"
+#: includes/wizards/newspack/class-newspack-dashboard.php:306
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:306
+msgid "Start a new post"
 msgstr ""
 
-#: dist/analytics.js:1
-#: release/newspack-plugin/dist/analytics.js:1
-#: src/wizards/analytics/views/plugins/index.js:31
-msgid "View"
+#: includes/wizards/newspack/class-newspack-dashboard.php:313
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:313
+msgid "Draft a newsletter"
 msgstr ""
 
-#: dist/analytics.js:1
-#: release/newspack-plugin/dist/analytics.js:1
-#: src/wizards/analytics/views/newspack-custom-events/index.js:55
-msgid "Activate Newspack Custom Events"
+#: includes/wizards/newspack/class-newspack-dashboard.php:320
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-dashboard.php:320
+msgid "Open data dashboard"
 msgstr ""
 
-#: dist/analytics.js:1
-#: release/newspack-plugin/dist/analytics.js:1
-#: src/wizards/analytics/views/newspack-custom-events/index.js:56
-msgid "Allows Newspack to send enhanced custom event data to your Google Analytics."
+#: includes/wizards/newspack/class-newspack-settings.php:48
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-settings.php:48
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Connections"
 msgstr ""
 
-#: dist/analytics.js:1
-#: release/newspack-plugin/dist/analytics.js:1
-#: src/wizards/analytics/views/newspack-custom-events/index.js:63
-msgid "Newspack already sends some custom event data to your GA account, but adding the credentials below enables enhanced events that are fired from your site's backend. For example, when a donation is confirmed or when a user successfully subscribes to a newsletter."
+#: includes/wizards/newspack/class-newspack-settings.php:81
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-settings.php:81
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Emails"
 msgstr ""
 
-#: dist/analytics.js:1
-#: release/newspack-plugin/dist/analytics.js:1
-#: src/wizards/analytics/views/newspack-custom-events/index.js:74
-msgid "Measurement ID"
+#: includes/wizards/newspack/class-newspack-settings.php:93
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-settings.php:93
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Social"
 msgstr ""
 
-#: dist/analytics.js:1
-#: release/newspack-plugin/dist/analytics.js:1
-#: src/wizards/analytics/views/newspack-custom-events/index.js:75
-msgid "You can find this in Site Kit Settings, or in Google Analytics > Admin > Data Streams and clickng the data stream. Example: G-ABCD1234"
+#: includes/wizards/newspack/class-newspack-settings.php:96
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-settings.php:96
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Syndication"
 msgstr ""
 
-#: dist/analytics.js:1
-#: release/newspack-plugin/dist/analytics.js:1
-#: src/wizards/analytics/views/newspack-custom-events/index.js:91
-msgid "Measurement Protocol API Secret"
+#: includes/wizards/newspack/class-newspack-settings.php:99
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-settings.php:99
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:31
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:31
+msgid "SEO"
 msgstr ""
 
-#: dist/analytics.js:1
-#: release/newspack-plugin/dist/analytics.js:1
-#: src/wizards/analytics/views/newspack-custom-events/index.js:92
-msgid "Generate an API secret from your GA dashboard in Admin > Data Streams and opening your data stream. Select \"Measurement Protocol API secrets\" under the Events section. Create a new secret."
+#: includes/wizards/newspack/class-newspack-settings.php:102
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-settings.php:102
+#: dist/componentsDemo.js:1
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:31
+#: dist/setup.js:7
+#: release/newspack-plugin/dist/componentsDemo.js:1
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:31
+#: release/newspack-plugin/dist/setup.js:7
+msgid "Theme and Brand"
 msgstr ""
 
-#: dist/analytics.js:1
-#: dist/connections.js:18
-#: dist/health-check.js:1
-#: release/newspack-plugin/dist/analytics.js:1
-#: release/newspack-plugin/dist/connections.js:18
-#: release/newspack-plugin/dist/health-check.js:1
-#: src/wizards/analytics/index.js:25
-#: src/wizards/connections/views/main/index.js:27
-#: src/wizards/health-check/index.js:70
-msgid "Plugins"
+#: includes/wizards/newspack/class-newspack-settings.php:105
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-settings.php:105
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:31
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:31
+msgid "Advanced Settings"
 msgstr ""
 
-#: dist/analytics.js:1
-#: release/newspack-plugin/dist/analytics.js:1
-#: src/wizards/analytics/index.js:30
-msgid "Newspack Custom Events"
+#: includes/wizards/newspack/class-newspack-settings.php:110
+#: release/newspack-plugin/includes/collections/class-collection-taxonomy.php:87
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-settings.php:110
+msgid "Collections"
 msgstr ""
 
-#: dist/analytics.js:1
-#: release/newspack-plugin/dist/analytics.js:1
-#: src/wizards/analytics/index.js:42
-msgid "Analytics"
+#: includes/wizards/newspack/class-newspack-settings.php:115
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-settings.php:115
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:5
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:5
+msgid "Additional Brands"
 msgstr ""
 
-#: dist/analytics.js:1
-#: release/newspack-plugin/dist/analytics.js:1
-#: src/wizards/analytics/index.js:43
-msgid "Manage Google Analytics Configuration"
+#: includes/wizards/newspack/class-newspack-settings.php:154
+#: release/newspack-plugin/includes/wizards/newspack/class-newspack-settings.php:154
+msgid "Newspack / Settings"
+msgstr ""
+
+#: includes/wizards/traits/trait-wizards-admin-header.php:41
+#: release/newspack-plugin/includes/wizards/traits/trait-wizards-admin-header.php:41
+msgid "Newspack Settings"
+msgstr ""
+
+#: includes/wizards/traits/trait-wizards-admin-header.php:99
+#: release/newspack-plugin/includes/wizards/traits/trait-wizards-admin-header.php:99
+msgid "Loading..."
+msgstr ""
+
+#: release/newspack-plugin/includes/collections/class-collection-category-taxonomy.php:48
+msgctxt "taxonomy general name"
+msgid "Collection Categories"
+msgstr ""
+
+#: release/newspack-plugin/includes/collections/class-collection-category-taxonomy.php:49
+msgctxt "taxonomy singular name"
+msgid "Collection Category"
+msgstr ""
+
+#: release/newspack-plugin/includes/collections/class-collection-meta.php:42
+msgid "File upload"
+msgstr ""
+
+#: release/newspack-plugin/includes/collections/class-collection-meta.php:49
+msgid "External file URL"
+msgstr ""
+
+#: release/newspack-plugin/includes/collections/class-collection-meta.php:50
+msgid "Externally hosted PDF or file URL."
+msgstr ""
+
+#: release/newspack-plugin/includes/collections/class-collection-section-taxonomy.php:91
+msgctxt "taxonomy general name"
+msgid "Collection Sections"
+msgstr ""
+
+#: release/newspack-plugin/includes/collections/class-collection-section-taxonomy.php:92
+msgctxt "taxonomy singular name"
+msgid "Collection Section"
+msgstr ""
+
+#: release/newspack-plugin/includes/collections/class-collection-section-taxonomy.php:101
+#: release/newspack-plugin/includes/collections/class-collection-section-taxonomy.php:123
+#: release/newspack-plugin/includes/collections/class-collection-section-taxonomy.php:154
+msgid "Sections"
+msgstr ""
+
+#: release/newspack-plugin/includes/collections/class-collection-section-taxonomy.php:122
+msgid "Collection Sections"
+msgstr ""
+
+#: release/newspack-plugin/includes/collections/class-collection-taxonomy.php:77
+msgctxt "taxonomy general name"
+msgid "Collections"
+msgstr ""
+
+#: release/newspack-plugin/includes/collections/class-collection-taxonomy.php:78
+msgctxt "taxonomy singular name"
+msgid "Collection"
+msgstr ""
+
+#: release/newspack-plugin/includes/collections/class-collection-taxonomy.php:81
+msgid "Parent Collection"
+msgstr ""
+
+#: release/newspack-plugin/includes/collections/class-collection-taxonomy.php:82
+msgid "Parent Collection:"
+msgstr ""
+
+#: release/newspack-plugin/includes/collections/class-post-meta.php:41
+msgid "Order of the post within a collection."
+msgstr ""
+
+#: release/newspack-plugin/includes/collections/class-post-type.php:94
+msgctxt "post type general name"
+msgid "Collections"
+msgstr ""
+
+#: release/newspack-plugin/includes/collections/class-post-type.php:95
+msgctxt "post type singular name"
+msgid "Collection"
+msgstr ""
+
+#: release/newspack-plugin/includes/collections/class-post-type.php:96
+msgctxt "admin menu"
+msgid "Collections"
+msgstr ""
+
+#: release/newspack-plugin/includes/collections/class-post-type.php:97
+msgctxt "add new on admin bar"
+msgid "Collection"
+msgstr ""
+
+#: release/newspack-plugin/includes/collections/class-post-type.php:98
+msgctxt "collection"
+msgid "Add New"
+msgstr ""
+
+#: release/newspack-plugin/includes/collections/class-post-type.php:105
+msgid "Parent Collections:"
+msgstr ""
+
+#: release/newspack-plugin/includes/collections/class-post-type.php:115
+msgid "Collections of content for custom classification."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:1
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: dist/billboard.js:12
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:5
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:1
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+#: release/newspack-plugin/dist/billboard.js:12
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:5
+msgid "Close Popover"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:1
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:1
+msgid "Activate all prompts"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:1
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:1
+msgid "Deactivate all prompts"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:1
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:1
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Duplicate"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:1
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:1
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Rename"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:1
+#: dist/billboard.js:12
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:1
+#: release/newspack-plugin/dist/billboard.js:12
+msgid "Archive"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:1
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:1
+msgid "Unarchive"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:1
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: dist/billboard.js:12
+#: dist/componentsDemo.js:1
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:5
+#: dist/other-scripts/corrections-modal.js:1
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:1
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+#: release/newspack-plugin/dist/billboard.js:12
+#: release/newspack-plugin/dist/componentsDemo.js:1
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:5
+#: release/newspack-plugin/dist/other-scripts/corrections-modal.js:1
+msgid "Delete"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:1
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:1
+msgid "Restore"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:1
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:1
+msgid "Delete permanently"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:1
+#: dist/commons.js:13
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:1
+#: release/newspack-plugin/dist/commons.js:13
+msgid "Preview"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:1
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: dist/billboard.js:12
+#: dist/componentsDemo.js:1
+#: dist/newsletters.js:4
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:5
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:14
+#: dist/setup.js:7
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:1
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+#: release/newspack-plugin/dist/billboard.js:12
+#: release/newspack-plugin/dist/componentsDemo.js:1
+#: release/newspack-plugin/dist/newsletters.js:4
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:5
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:14
+#: release/newspack-plugin/dist/setup.js:7
+msgid "Edit"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:1
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:1
+msgid "Deactivate"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:1
+#: dist/commons.js:13
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:1
+#: release/newspack-plugin/dist/commons.js:13
+msgid "Activate"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:1
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:1
+msgid "ID:"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:1
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:1
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Top Overlay"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:1
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:1
+msgid "Top Left Overlay"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:1
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:1
+msgid "Top Right Overlay"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:1
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:1
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Center Overlay"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:1
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:1
+msgid "Center Left Overlay"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:1
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:1
+msgid "Center Right Overlay"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:1
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:1
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Bottom Overlay"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:1
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:1
+msgid "Bottom Left Overlay"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:1
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:1
+msgid "Bottom Right Overlay"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:1
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: dist/memberships-gate-editor.js:25
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:1
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+#: release/newspack-plugin/dist/memberships-gate-editor.js:25
+msgid "Inline"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:1
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:1
+msgid "In archive pages"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:1
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:1
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Above Header"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:1
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:1
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Manual Only"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:1
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:1
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Custom Placement"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:1
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:1
+msgid "Once a month"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:1
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:1
+msgid "Once a week"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:1
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:1
+msgid "Once a day"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:1
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:1
+msgid "Every pageview"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:1
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:1
+msgid "Custom frequency (edit prompt to manage)"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:1
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:1
+msgid "Campaign: "
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:1
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:1
+msgid "Campaigns: "
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:1
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:1
+msgid "Categories: "
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:1
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:1
+msgid "Tags: "
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:1
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:1
+msgid "Pending review"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:1
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:1
+msgid "Scheduled"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:1
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:1
+msgid "Frequency: "
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:1
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:1
+msgid "Segment disabled"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:1
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:1
+msgid "Favorite Categories:"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:1
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:1
+msgid "Subscribed to:"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:1
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:1
+msgid "Not subscribed to:"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:1
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+msgid "Deleted list"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:1
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:1
+msgid "Has active subscription(s):"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:1
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:1
+msgid "Does not have active subscription(s):"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:1
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+msgid "Deleted subscription"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:1
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:1
+msgid "Has active membership(s):"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:1
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:1
+msgid "Does not have active membership(s):"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:1
+msgid "Deleted membership"
+msgstr ""
+
+#. Translators: %s is prompt type (above-header or overlay).
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:4
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:4
+msgid "If multiple %s are rendered on the same pageview, only the most recent one will be displayed."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:4
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:4
+msgid "above-header prompts"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:4
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:4
+msgid "overlays"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:4
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:4
+msgid "If multiple prompts are rendered in the same custom placement, only the most recent one will be displayed."
+msgstr ""
+
+#. Translators: %s: 'Conflicts' or 'Conflict' depending on number of conflicts.
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:7
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:7
+msgid "%s detected:"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:7
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:7
+msgid "Conflicts"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:7
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:7
+msgid "Conflict"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:7
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:7
+msgid "Close Modal"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:7
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:7
+msgid "Assign a prompt to one or more campaigns for easier management"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:7
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:7
+msgid "When and how should the prompt be displayed"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:7
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:7
+msgid "Frequency"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:7
+#: dist/memberships-gate-editor.js:34
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:7
+#: release/newspack-plugin/dist/memberships-gate-editor.js:34
+msgid "Position"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:7
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:7
+msgid "Placement"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:7
+#: dist/billboard.js:12
+#: dist/memberships-gate-editor.js:34
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:7
+#: release/newspack-plugin/dist/billboard.js:12
+#: release/newspack-plugin/dist/memberships-gate-editor.js:34
+msgid "Size"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:7
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:7
+msgid "Targeting"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:7
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:7
+msgid "Under which conditions should the prompt be displayed"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:7
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:7
+msgid "If multiple conditions are set, all will have to be satisfied in order to display the prompt"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:7
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:7
+msgid "Segments"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:7
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:7
+msgid "Post categories"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:7
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:7
+msgid "Prompt will only appear on posts with the specified categories."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:7
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:7
+msgid "Post tags"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:7
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:7
+msgid "Prompt will only appear on posts with the specified tags."
+msgstr ""
+
+#. Translators: whether to show or hide advanced settings fields.
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:10
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:10
+msgid "%s Advanced Settings"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:10
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:10
+msgid "Hide"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:10
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:10
+msgid "Show"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:10
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:10
+msgid "Category Exclusions"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:10
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:10
+msgid "Prompt will not appear on posts with the specified categories."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:10
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:10
+msgid "Tag Exclusions"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:10
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:10
+msgid "Prompt will not appear on posts with the specified tags."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:10
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:10
+msgid " copy"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:10
+#: dist/commons.js:4
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:10
+#: release/newspack-plugin/dist/commons.js:4
+msgid "(no title)"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:10
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:10
+msgid "Prompt settings"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:10
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: dist/billboard.js:12
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:5
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:10
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+#: release/newspack-plugin/dist/billboard.js:12
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:5
+msgid "More options"
+msgstr ""
+
+#. Translators: %s: The title of the item.
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:13
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:13
+msgid "Duplicate “%s”"
+msgstr ""
+
+#. Translators: %s: The title of the item.
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Duplicate of “%s” created as a draft."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "This prompt is currently not assigned to any campaign."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "This prompt will not be assigned to any campaign."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Title"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "No unassigned prompts in this segment."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "No prompts in this segment for"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "No active prompts in this segment."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Edit Segment "
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Segment: "
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "All readers, regardless of segment"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Preview Segment"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Add New Prompt"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Fixed at the center of the screen"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Fixed at the top of the screen"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Fixed at the bottom of the screen"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Embedded in content"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "In Archive Pages"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Embedded once or many times in archive pages"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Embedded at the very top of the page"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Only appears when placed in content"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Only appears where Single Prompt block is inserted"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Rename Campaign"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Duplicate Campaign"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Add New Campaign"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: dist/other-scripts/corrections-modal.js:4
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+#: release/newspack-plugin/dist/other-scripts/corrections-modal.js:4
+msgid "Add"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Everyone"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Active Prompts"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "All Prompts"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Trash"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Unassigned Prompts"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Archived Campaigns"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "(archived)"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:26
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:26
+msgid "Actions"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Campaign Name"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Add New Segment"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Move segment position up"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Move segment position down"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "There was an error sorting segments. Please try again."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Audience segments"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "You have no saved audience segments."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Create audience segments to target visitors by engagement, activity, and more."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Start typing to search for lists…"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Start typing to search for products…"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Start typing to search for membership plans…"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+msgid "Deleted plan"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "There are unsaved changes to this segment. Discard changes?"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Untitled Segment"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Segment Status"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "If not enabled, the segment will be ignored for reader segmentation."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Segment enabled"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Reader Engagement"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Target readers based on their browsing behavior."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Registration"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Target readers based on their user account registration status."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Target readers based on their newsletter subscription status."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Target readers based on their revenue activity."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Referrer Sources"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Target readers based on where they’re coming from."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Segments using these options will apply only to the first page visited after coming from an external source."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Error duplicating prompt. Please try again later."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Collect transaction fees"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Allow donors to optionally cover transaction fees imposed by payment processors."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Fee multiplier"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Fee static portion"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Custom message"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "A message to explain the transaction fee option (optional)."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "Cover fees by default"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+msgid "If enabled, the option to cover the transaction fee will be checked by default."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:19
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:32
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:41
+#: dist/billboard.js:12
+#: dist/newsletters.js:1
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:8
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:29
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:31
+#: dist/setup.js:4
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:19
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:32
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:41
+#: release/newspack-plugin/dist/billboard.js:12
+#: release/newspack-plugin/dist/newsletters.js:1
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:8
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:29
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:31
+#: release/newspack-plugin/dist/setup.js:4
+msgid "Save Settings"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: dist/setup.js:1
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+#: release/newspack-plugin/dist/setup.js:1
+msgid "Suggested Donations"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: dist/setup.js:1
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+#: release/newspack-plugin/dist/setup.js:1
+msgid "Set suggested donation amounts. These will be the default settings for the Donate block."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: dist/setup.js:1
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+#: release/newspack-plugin/dist/setup.js:1
+msgid "Donation Type"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: dist/setup.js:1
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+#: release/newspack-plugin/dist/setup.js:1
+msgid "Tiered"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:16
+#: dist/setup.js:1
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:16
+#: release/newspack-plugin/dist/setup.js:1
+msgid "Untiered"
+msgstr ""
+
+#. Translators: %1$s is a link to the trashed products. %2$s is a comma-separated list of trashed product names.
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:19
+#: dist/setup.js:4
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:19
+#: release/newspack-plugin/dist/setup.js:4
+msgid "One or more donation products is in trash. Please <a href=\"%1$s\">restore the product(s)</a> to continue using donation features: %2$s"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:19
+#: dist/setup.js:4
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:19
+#: release/newspack-plugin/dist/setup.js:4
+msgid "Warning: suggested donations should be at least the minimum donation amount."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:19
+#: dist/setup.js:4
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:19
+#: release/newspack-plugin/dist/setup.js:4
+msgid "Minimum donation"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:19
+#: dist/setup.js:4
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:19
+#: release/newspack-plugin/dist/setup.js:4
+msgid "Set minimum donation amount. Setting a reasonable minimum donation amount can help protect your site from bot attacks."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:19
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:19
+msgid "Donations Landing Page"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:19
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:19
+msgid "Your donations landing page is published."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:19
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:19
+msgid "Your donations landing page is not yet published."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:19
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:35
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:19
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:35
+msgid "Pending"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:19
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:35
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:19
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:35
+msgid "Ready"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:19
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:19
+msgid "Skipped"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:19
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:19
+msgid "Unavailable"
+msgstr ""
+
+#. translators: %s: Prerequisite status
+#. Translators: Status of the prompt.
+#. Translators: %s: Plugin status
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:20
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:35
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:14
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:20
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:35
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:14
+msgid "Status: %s"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:20
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:32
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:38
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:41
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:14
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:20
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:32
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:38
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:41
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:14
+msgid "Learn more"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:20
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:35
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:41
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:31
+#: dist/other-scripts/corrections-modal.js:7
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:20
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:35
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:41
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:31
+#: release/newspack-plugin/dist/other-scripts/corrections-modal.js:7
+msgid "Saving…"
+msgstr ""
+
+#. Translators: Save or Update settings.
+#. Translators: %s is the email service provider title
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:23
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:26
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:23
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:26
+msgid "%s settings"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:23
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:38
+#: dist/bylines.js:1
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:23
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:38
+#: release/newspack-plugin/dist/bylines.js:1
+msgid "Update"
+msgstr ""
+
+#. Translators: %s is specific instructions for satisfying the prerequisite.
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:26
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:26
+msgid "%1$s%2$sReturn to the Audience Configuration page to complete the settings and activate%3$s."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:26
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:26
+msgid "Update "
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:26
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:26
+msgid "Save "
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:26
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:26
+msgid "Configure "
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:26
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:38
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:41
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:26
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:38
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:41
+msgid "Skip"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:26
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:26
+msgid "Audience ID"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:26
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:26
+msgid "Master List"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:26
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:26
+msgid "Choose an audience to receive reader activity data."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:26
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:26
+msgid "Choose a master list to which all registered readers will be added."
+msgstr ""
+
+#. Translators: %s is the email service provider title
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:26
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:26
+msgid "Settings for the %s integration."
+msgstr ""
+
+#. Translators: 1 is the term used to refer to lists for a given email service provider and 2 is the email service provider title
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:29
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:29
+msgid "No %1$s selected. You will not be able to send reader activity data to %2$s."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:29
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:29
+msgid "None"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:29
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:29
+msgid "Default reader status"
+msgstr ""
+
+#. Translators: %s is the email service provider title.
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:32
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:32
+msgid "Choose which %s status readers should have by default if they are not subscribed to any newsletters"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:32
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:32
+msgid "Transactional/Non-Subscribed"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:32
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:32
+msgid "Subscribed"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:32
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:32
+msgid "Metadata field settings"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:32
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:32
+msgid "Select which data to sync for each contact."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:32
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:32
+msgid "Metadata field prefix"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:32
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:32
+msgid "A string to prefix metadata fields attached to each contact synced to the ESP. Required to ensure that metadata field names are unique. Default: NP_"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:32
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:32
+msgid "Checked by default"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:32
+#: dist/commons.js:13
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:14
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:32
+#: release/newspack-plugin/dist/commons.js:13
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:14
+msgid "Remove"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:32
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:32
+msgid "Add more lists:"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:32
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:32
+msgid "Select lists:"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:32
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:32
+msgid "We couldn’t establish a connection to Salesforce. Please verify your Consumer Key and Secret and try connecting again."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:32
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:32
+msgid "Salesforce Settings"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:32
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:32
+msgid "Your site is connected to Salesforce."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:32
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:32
+msgid "Establish a connection to sync WooCommerce order data to Salesforce. To connect with Salesforce, create or choose a Connected App for this site in your Salesforce dashboard. Make sure to paste the full URL for this page ("
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:32
+msgid "copied to clipboard!"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:32
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:32
+msgid "copy to clipboard"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:32
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:32
+msgid ") into the “Callback URL” field in the Connected App’s settings. "
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:32
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:32
+msgid "Learn how to create a Connected App"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:32
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:32
+msgid "Newspack's Audience Management system is a set of features that aim to increase reader loyalty, promote engagement, and drive revenue. "
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:32
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:32
+msgid "The following plugins are required."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:32
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:32
+msgid "Complete these settings to enable Audience Management."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:32
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:32
+msgid "Audience Management is enabled."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:32
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:32
+msgid "Fetching status…"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:32
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:32
+msgid "Present newsletter signup after checkout and registration"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:32
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:32
+msgid "Ask readers to sign up for newsletters after creating an account or completing a purchase."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:32
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:32
+msgid "Initial list size"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:32
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:32
+msgid "Number of newsletters initially visible during signup. Additional newsletters will be hidden behind a \"See all\" button."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:32
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:32
+msgid "Email Service Provider (ESP) Advanced Settings"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:32
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:32
+msgid "Settings for Newspack Newsletters integration."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:32
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:32
+msgid "Newsletter subscription text on registration"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:32
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:32
+msgid "The text to display while subscribing to newsletters from the sign-in modal."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:32
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:32
+msgid "Configure options for syncing reader data to the connected ESP."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:32
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:32
+msgid "Sync contacts to ESP"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:32
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:32
+msgid "Sync user account deletion"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:32
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:32
+msgid "If enabled, the contact will be deleted from the ESP when a user account is deleted. If disabled, the contact will be unsubscribed from all lists, but not deleted."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:32
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:32
+msgid "Please select a Mailchimp Audience ID."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:32
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:32
+msgid "Please select an ActiveCampaign Master List."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:32
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:32
+msgid "Please select a Constant Contact Master List."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:32
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:32
+msgid "You have unsaved changes. Discard changes?"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:35
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:35
+msgid "Unsaved changes"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:35
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:35
+msgid "Select file"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:35
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:35
+msgid "Prompt saved."
+msgstr ""
+
+#. Translators: Save or Update settings.
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:38
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:38
+msgid "%s prompt settings"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:38
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:38
+msgid "Preview prompt"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:38
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:38
+msgid "We recommend"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:38
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:38
+msgid "Set Up Audience Management Campaign"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:38
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:38
+msgid "Preview and customize the prompts, or use our suggested defaults."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:38
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:38
+msgid "Retrieving prompts…"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:38
+#: dist/billboard.js:12
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:38
+#: release/newspack-plugin/dist/billboard.js:12
+msgid "Back"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:38
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:38
+msgid "Your <strong>current segments and prompts</strong> will be deactivated and archived."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:38
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:38
+msgid "<strong>Reader registration</strong> will be activated to enable better targeting for driving engagement and conversations."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:38
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:38
+msgid "The <strong>Audience Management campaign</strong> will be activated with default segments and settings."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:38
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:38
+msgid "Setting up new segments…"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:38
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:38
+msgid "Activating reader registration…"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:38
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:38
+msgid "Activating Audience Management Campaign…"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:38
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:38
+msgid "Done!"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:38
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:38
+msgid "Enable Audience Management"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:38
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:38
+msgid "An easy way to let your readers register for your site, sign up for newsletters, or become donors and paid members. "
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:38
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:38
+msgid "You're all set to enable Audience Management!"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:38
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:38
+msgid "This is what will happen next:"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:38
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:41
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:38
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:41
+msgid "Content Gating"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:38
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:38
+msgid "WooCommerce Memberships integration to improve the reader experience with content gating. "
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:38
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:38
+msgid "Content Gate"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:38
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:38
+msgid "Configure the gate rendered on content with restricted access."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:38
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:38
+msgid "The gate is currently published."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:38
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:38
+msgid "The gate is currently a draft."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:38
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:41
+#: dist/billboard.js:1
+#: dist/commons.js:13
+#: dist/componentsDemo.js:1
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:11
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:14
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:38
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:41
+#: release/newspack-plugin/dist/billboard.js:1
+#: release/newspack-plugin/dist/commons.js:13
+#: release/newspack-plugin/dist/componentsDemo.js:1
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:11
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:14
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Configure"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:38
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:38
+msgid "Require membership in all plans"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:38
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:38
+msgid "When enabled, readers must belong to all membership plans that apply to a restricted content item before they are granted access. Otherwise, they will be able to unlock access to that item with membership in any single plan that applies to it."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:38
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:38
+msgid "Display memberships on the subscriptions tab"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:38
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:38
+msgid "Display memberships that don't have active subscriptions on the My Account Subscriptions tab, so readers can see information like expiration dates."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:38
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:38
+msgid "Stripe"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:38
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:38
+msgid "Enable the Stripe payment gateway for WooCommerce. "
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:38
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:41
+#: dist/commons.js:13
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:5
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:8
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:11
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:29
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:31
+#: dist/setup.js:7
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:38
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:41
+#: release/newspack-plugin/dist/commons.js:13
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:5
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:8
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:11
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:29
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:31
+#: release/newspack-plugin/dist/setup.js:7
+msgid "Loading…"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:38
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:41
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:38
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:41
+msgid "Connected - test mode"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:38
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:41
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:1
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:38
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:41
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:1
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Connected"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:38
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:38
+msgid "Needs attention"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:38
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:41
+#: dist/commons.js:16
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:8
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:38
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:41
+#: release/newspack-plugin/dist/commons.js:16
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:8
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Not connected"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:38
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:41
+#: dist/commons.js:16
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:8
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:38
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:41
+#: release/newspack-plugin/dist/commons.js:16
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:8
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Connect"
+msgstr ""
+
+#. Translators: %s is the payment gateway name.
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:41
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:41
+msgid "Enable %s. "
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:41
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:41
+msgid "Payment Gateways"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:41
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:41
+msgid "Configure Newspack-supported payment gateways for WooCommerce. Payment gateways allow you to accept various payment methods from your readers. "
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:41
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:41
+msgid "Missing or invalid SSL configuration detected. To collect payments, the site must be secured with SSL. "
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:41
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:41
+msgid "News Revenue Hub Settings"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:41
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:41
+msgid "Configure your site’s connection to News Revenue Hub."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:41
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:41
+msgid "Organization ID"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:41
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:41
+msgid "Custom domain (optional)"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:41
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:41
+msgid "Salesforce Campaign ID (optional)"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:41
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:41
+msgid "Donor Landing Page"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:41
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:41
+msgid "Search for a New Donor Landing Page"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:41
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:41
+msgid "page"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:41
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:41
+msgid "pages"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:41
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:41
+msgid "Billing Fields"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:41
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:41
+msgid "Configure the billing fields shown in the modal checkout form. Fields marked with (*) are required if shown. Note that for shippable products, address fields will always be shown."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:41
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:41
+msgid "Checkout Configuration"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:41
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:41
+msgid "Require sign in or create account before checkout"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:41
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:41
+msgid "Prompt users who are not logged in to sign in or register a new account before proceeding to checkout. When disabled, an account will automatically be created with the email address used at checkout."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:41
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:41
+msgid "Post-checkout success message"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:41
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:41
+msgid "The success message to display to readers after completing checkout."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:41
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:41
+msgid "Post-checkout registration success message"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:41
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:41
+msgid "The success message to display to new readers that have an account automatically created after completing checkout."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:41
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:41
+msgid "Checkout privacy policy text"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:41
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:41
+msgid "The privacy policy text to display at time of checkout for existing users. This will not show up unless a privacy page is set."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:41
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:41
+msgid "Subscription"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:41
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:41
+msgid "Manage the settings for subscription transparency and compliance."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:41
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:41
+msgid "Enable subscription confirmation checkbox"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:41
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:41
+msgid "Display a separate checkbox at checkout to confirm the user understands this is a recurring subscription and they can cancel anytime."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:41
+#: dist/collections-admin.js:1
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:41
+msgid "Label"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:41
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:41
+msgid "Enable Terms & Conditions confirmation checkbox"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:41
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:41
+msgid "Display the 'I have read and accept the Terms & Conditions' checkbox at checkout. Ensure the Terms & Conditions include subscription details to comply with the FTC guidelines."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:41
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:41
+msgid "Text wrapped in {{ }} will be linked to the page set in the URL field."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:41
+#: dist/collections-admin.js:1
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:26
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:41
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:26
+msgid "URL"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:41
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:41
+msgid "Please provide a URL for the Terms & Conditions page."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:41
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:41
+msgid "Checkout & Payment"
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:41
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:41
+msgid "Reader revenue configuration for donations and subscriptions."
+msgstr ""
+
+#: dist/audience-wizards.0ecf4216f3b7f975ab17.js:41
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:41
+msgid "Are you sure you want to skip this step? You can always come back later."
+msgstr ""
+
+#: dist/avatar-block.js:1
+#: dist/blocks.js:1
+#: release/newspack-plugin/dist/avatar-block.js:1
+#: release/newspack-plugin/dist/blocks.js:1
+msgid "Avatar"
+msgstr ""
+
+#: dist/avatar-block.js:1
+#: dist/blocks.js:1
+#: release/newspack-plugin/dist/avatar-block.js:1
+#: release/newspack-plugin/dist/blocks.js:1
+msgid "author"
+msgstr ""
+
+#: dist/avatar-block.js:1
+#: dist/blocks.js:1
+#: release/newspack-plugin/dist/avatar-block.js:1
+#: release/newspack-plugin/dist/blocks.js:1
+msgid "user"
+msgstr ""
+
+#: dist/avatar-block.js:1
+#: dist/blocks.js:1
+#: release/newspack-plugin/dist/avatar-block.js:1
+#: release/newspack-plugin/dist/blocks.js:1
+msgid "profile"
+msgstr ""
+
+#: dist/avatar-block.js:1
+#: dist/blocks.js:1
+#: release/newspack-plugin/dist/avatar-block.js:1
+#: release/newspack-plugin/dist/blocks.js:1
+msgid "newspack"
+msgstr ""
+
+#: dist/avatar-block.js:1
+#: dist/blocks.js:1
+#: release/newspack-plugin/dist/avatar-block.js:1
+#: release/newspack-plugin/dist/blocks.js:1
+msgid "Display post author avatar."
 msgstr ""
 
 #: dist/billboard.js:1
 #: dist/billboard.js:12
 #: release/newspack-plugin/dist/billboard.js:1
 #: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/views/ad-units/index.js:112
-#: src/wizards/advertising/views/providers/index.js:55
 msgid "Created custom targeting keys:"
 msgstr ""
 
@@ -2467,88 +7701,33 @@ msgstr ""
 #: dist/billboard.js:12
 #: release/newspack-plugin/dist/billboard.js:1
 #: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/views/ad-units/index.js:118
-#: src/wizards/advertising/views/providers/index.js:62
 msgid "Visit your GAM dashboard"
 msgstr ""
 
 #: dist/billboard.js:1
 #: release/newspack-plugin/dist/billboard.js:1
-#: src/wizards/advertising/views/providers/index.js:74
 msgid "Click here to connect your account."
 msgstr ""
 
 #: dist/billboard.js:1
+#: dist/billboard.js:12
 #: release/newspack-plugin/dist/billboard.js:1
-#: src/wizards/advertising/views/providers/index.js:82
-msgid "Google Ad Manager"
+#: release/newspack-plugin/dist/billboard.js:12
+msgid "Providers"
 msgstr ""
 
 #: dist/billboard.js:1
 #: release/newspack-plugin/dist/billboard.js:1
-#: src/wizards/advertising/views/providers/index.js:83
 msgid "Manage Google Ad Manager ad units and placements directly from the Newspack dashboard."
 msgstr ""
 
 #: dist/billboard.js:1
-#: dist/billboard.js:12
-#: dist/commons.js:10
-#: dist/componentsDemo.js:1
-#: dist/engagement.js:14
-#: dist/engagement.js:20
 #: release/newspack-plugin/dist/billboard.js:1
-#: release/newspack-plugin/dist/billboard.js:12
-#: release/newspack-plugin/dist/commons.js:10
-#: release/newspack-plugin/dist/componentsDemo.js:1
-#: release/newspack-plugin/dist/engagement.js:14
-#: release/newspack-plugin/dist/engagement.js:20
-#: src/components/src/plugin-toggle/index.js:175
-#: src/wizards/advertising/components/add-ons/index.js:21
-#: src/wizards/advertising/components/add-ons/index.js:25
-#: src/wizards/advertising/views/providers/index.js:88
-#: src/wizards/advertising/views/providers/index.js:111
-#: src/wizards/componentsDemo/index.js:361
-#: src/wizards/componentsDemo/index.js:371
-#: src/wizards/componentsDemo/index.js:399
-#: src/wizards/componentsDemo/index.js:426
-#: src/wizards/componentsDemo/index.js:435
-#: src/wizards/engagement/views/reader-activation/index.js:267
-#: src/wizards/engagement/views/related-content/index.js:44
-#: src/wizards/engagement/views/social/index.js:35
-msgid "Configure"
-msgstr ""
-
-#: dist/billboard.js:1
-#: release/newspack-plugin/dist/billboard.js:1
-#: src/wizards/advertising/views/providers/index.js:118
 msgid "Google Ad Manager Setup"
 msgstr ""
 
 #: dist/billboard.js:1
-#: dist/billboard.js:12
-#: dist/connections.js:3
-#: dist/popups.js:10
-#: dist/popups.js:16
 #: release/newspack-plugin/dist/billboard.js:1
-#: release/newspack-plugin/dist/billboard.js:12
-#: release/newspack-plugin/dist/connections.js:3
-#: release/newspack-plugin/dist/popups.js:10
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/advertising/views/ad-unit/index.js:194
-#: src/wizards/advertising/views/placements/index.js:229
-#: src/wizards/advertising/views/providers/index.js:130
-#: src/wizards/connections/views/main/mailchimp.js:161
-#: src/wizards/connections/views/main/webhooks.js:123
-#: src/wizards/popups/components/prompt-action-card/index.js:186
-#: src/wizards/popups/components/settings-modal/index.js:212
-#: src/wizards/popups/views/campaigns/index.js:306
-#: src/wizards/popups/views/segments/single-segment.js:305
-msgid "Cancel"
-msgstr ""
-
-#: dist/billboard.js:1
-#: release/newspack-plugin/dist/billboard.js:1
-#: src/wizards/advertising/components/placement-control/index.js:25
 msgid "Select a provider"
 msgstr ""
 
@@ -2556,3527 +7735,1783 @@ msgstr ""
 #: dist/billboard.js:12
 #: release/newspack-plugin/dist/billboard.js:1
 #: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/components/placement-control/index.js:82
-#: src/wizards/advertising/views/placements/index.js:200
 msgid "Ad Unit"
 msgstr ""
 
 #. Translators: Ad bidder name.
 #: dist/billboard.js:4
 #: release/newspack-plugin/dist/billboard.js:4
-#: src/wizards/advertising/components/placement-control/index.js:107
 msgid "%s does not support the selected ad unit sizes."
 msgstr ""
 
 #: dist/billboard.js:4
 #: release/newspack-plugin/dist/billboard.js:4
-#: src/wizards/advertising/components/placement-control/index.js:125
 msgid "Provider"
 msgstr ""
 
 #: dist/billboard.js:4
 #: release/newspack-plugin/dist/billboard.js:4
-#: src/wizards/advertising/components/placement-control/index.js:49
 msgid "Select an Ad Unit"
 msgstr ""
 
 #. Translators: 1 is ad unit name and 2 is ad unit id.
 #: dist/billboard.js:7
 #: release/newspack-plugin/dist/billboard.js:7
-#: src/wizards/advertising/components/placement-control/index.js:56
 msgid "%1$s (%2$s)"
 msgstr ""
 
-#. Translators: Bidder name.
 #: dist/billboard.js:7
 #: release/newspack-plugin/dist/billboard.js:7
-#: src/wizards/advertising/components/placement-control/index.js:149
 msgid "%s Placement ID"
 msgstr ""
 
 #. Translators: Bidder name.
 #: dist/billboard.js:9
 #: release/newspack-plugin/dist/billboard.js:9
-#: src/wizards/advertising/components/placement-control/index.js:117
-#: src/wizards/advertising/views/placements/index.js:137
 msgid "There is no provider available."
 msgstr ""
 
 #: dist/billboard.js:9
+#: dist/billboard.js:12
 #: release/newspack-plugin/dist/billboard.js:9
-#: src/wizards/advertising/views/placements/index.js:162
+#: release/newspack-plugin/dist/billboard.js:12
+msgid "Placements"
+msgstr ""
+
+#: dist/billboard.js:9
+#: release/newspack-plugin/dist/billboard.js:9
 msgid "Placement settings"
 msgstr ""
 
 #. translators: %s is the name of the placement
 #: dist/billboard.js:12
 #: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/views/placements/index.js:175
 msgid "%s placement settings"
 msgstr ""
 
 #: dist/billboard.js:12
 #: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/views/placements/index.js:212
 msgid "Stick to Top"
 msgstr ""
 
 #: dist/billboard.js:12
 #: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/components/ad-refresh-control/index.js:21
-msgid "Viewability Threshold"
+msgid "Suppression settings"
 msgstr ""
 
 #: dist/billboard.js:12
 #: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/components/ad-refresh-control/index.js:22
-msgid "The percentage of the ad slot which must be visible in the viewport in order to be considered eligible for being refreshed. It's recommended you do not lower this below 50 or you risk third-party viewability tracking platforms flagging your ad impressions as not having been viewed before refreshing."
+msgid "Configure where ads are suppressed."
 msgstr ""
 
 #: dist/billboard.js:12
 #: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/components/ad-refresh-control/index.js:30
-msgid "Refresh Interval"
-msgstr ""
-
-#: dist/billboard.js:12
-#: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/components/ad-refresh-control/index.js:31
-msgid "The number of seconds that must pass between an ad crossing the viewability threshold and the the ad refreshing. The plugin enforces a minimum of 30 in order to avoid your site being flagged for abusing ad refreshes by advertisers. This value may however be overridden via the avc_refresh_interval_value filter hook."
-msgstr ""
-
-#: dist/billboard.js:12
-#: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/components/ad-refresh-control/index.js:39
-msgid "Maximum Refreshes"
-msgstr ""
-
-#: dist/billboard.js:12
-#: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/components/ad-refresh-control/index.js:40
-msgid "The number of times each ad slot is allowed to be refreshed. If this is set to 4 then an ad slot could have a total of 5 impressions by combining the initial loading of the ad with the 4 times it can refresh."
-msgstr ""
-
-#: dist/billboard.js:12
-#: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/components/ad-refresh-control/index.js:48
-msgid "Excluded Advertiser IDs"
-msgstr ""
-
-#: dist/billboard.js:12
-#: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/components/ad-refresh-control/index.js:49
-msgid "Prevent ad refreshes for specific advertiser IDs in the format of a comma separated list (e.g., 125,594,293). If an ad slot ever displays an ad creative from one of the listed advertiser IDs then that ad slot will stop refreshing for the remainder of the page view. AdSense does not allow their ads to be auto-refreshed. When Newspack detects that AdSense is the advertiser for any given impression, a refresh will not take place."
-msgstr ""
-
-#: dist/billboard.js:12
-#: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/components/ad-refresh-control/index.js:57
-msgid "Line Items IDs to Exclude"
-msgstr ""
-
-#: dist/billboard.js:12
-#: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/components/ad-refresh-control/index.js:58
-msgid "Prevent ad refreshs for specific line item IDs. (Comma Seperated List)"
-msgstr ""
-
-#: dist/billboard.js:12
-#: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/components/ad-refresh-control/index.js:66
-msgid "Sizes to Exclude"
-msgstr ""
-
-#: dist/billboard.js:12
-#: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/components/ad-refresh-control/index.js:67
-msgid "Prevent ad refreshs for specific sizes. Accepts string (fluid) or array (300x250). Example: fluid, 300x250."
-msgstr ""
-
-#: dist/billboard.js:12
-#: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/components/ad-refresh-control/index.js:75
-msgid "Slot IDs to Exclude"
-msgstr ""
-
-#: dist/billboard.js:12
-#: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/components/ad-refresh-control/index.js:76
-msgid "Prevent ad refreshs for specific slot IDs e.g. div-gpt-ad-grid-1. (Comma Seperated List)."
-msgstr ""
-
-#: dist/billboard.js:12
-#: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/components/ad-refresh-control/index.js:137
-msgid "Ad Refresh Control"
-msgstr ""
-
-#: dist/billboard.js:12
-#: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/components/ad-refresh-control/index.js:138
-msgid "Enable Active View refresh for Google Ad Manager ads without needing to modify any code."
-msgstr ""
-
-#: dist/billboard.js:12
-#: dist/popups.js:10
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/billboard.js:12
-#: release/newspack-plugin/dist/popups.js:10
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/advertising/views/ad-units/options-popover.js:28
-#: src/wizards/popups/components/prompt-action-card/index.js:87
-#: src/wizards/popups/views/segments/segments-list.js:184
-msgid "More options"
-msgstr ""
-
-#: dist/billboard.js:12
-#: dist/popups.js:1
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/billboard.js:12
-#: release/newspack-plugin/dist/popups.js:1
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/advertising/views/ad-units/options-popover.js:38
-#: src/wizards/popups/components/campaign-management-popover/index.js:36
-#: src/wizards/popups/components/prompt-popovers/primary.js:41
-#: src/wizards/popups/views/segments/segments-list.js:195
-msgid "Close Popover"
-msgstr ""
-
-#: dist/billboard.js:12
-#: dist/componentsDemo.js:1
-#: dist/connections.js:3
-#: dist/engagement.js:4
-#: dist/engagement.js:14
-#: dist/popups.js:1
-#: dist/popups.js:16
-#: dist/setup.js:4
-#: release/newspack-plugin/dist/billboard.js:12
-#: release/newspack-plugin/dist/componentsDemo.js:1
-#: release/newspack-plugin/dist/connections.js:3
-#: release/newspack-plugin/dist/engagement.js:4
-#: release/newspack-plugin/dist/engagement.js:14
-#: release/newspack-plugin/dist/popups.js:1
-#: release/newspack-plugin/dist/popups.js:16
-#: release/newspack-plugin/dist/setup.js:4
-#: src/wizards/advertising/views/ad-units/options-popover.js:41
-#: src/wizards/componentsDemo/index.js:302
-#: src/wizards/connections/views/main/webhooks.js:103
-#: src/wizards/engagement/views/newsletters/index.js:369
-#: src/wizards/engagement/views/reader-activation/index.js:313
-#: src/wizards/popups/components/prompt-action-card/index.js:155
-#: src/wizards/popups/components/prompt-popovers/primary.js:64
-#: src/wizards/popups/views/segments/segments-list.js:201
-#: src/wizards/readerRevenue/views/emails/index.js:114
-msgid "Edit"
-msgstr ""
-
-#: dist/billboard.js:12
-#: dist/popups.js:1
-#: release/newspack-plugin/dist/billboard.js:12
-#: release/newspack-plugin/dist/popups.js:1
-#: src/wizards/advertising/views/ad-units/options-popover.js:44
-#: src/wizards/popups/components/campaign-management-popover/index.js:87
-msgid "Archive"
-msgstr ""
-
-#: dist/billboard.js:12
-#: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/views/ad-units/index.js:43
-msgid "Google Ad Manager Error"
-msgstr ""
-
-#: dist/billboard.js:12
-#: dist/engagement.js:20
-#: release/newspack-plugin/dist/billboard.js:12
-#: release/newspack-plugin/dist/engagement.js:20
-#: src/wizards/advertising/views/ad-units/index.js:84
-#: src/wizards/engagement/views/reader-activation/campaign.js:155
-#: src/wizards/engagement/views/reader-activation/complete.js:193
-msgid "Back"
-msgstr ""
-
-#: dist/billboard.js:12
-#: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/views/ad-units/index.js:90
-msgid "Connected GAM network code"
-msgstr ""
-
-#: dist/billboard.js:12
-#: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/views/ad-units/index.js:101
-msgid "Your GAM network code is different than the network code the site was configured with. Legacy ad units are likely to not load."
-msgstr ""
-
-#: dist/billboard.js:12
-#: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/views/ad-units/index.js:127
-msgid "Currently operating in legacy mode."
-msgstr ""
-
-#: dist/billboard.js:12
-#: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/views/ad-units/index.js:132
-msgid "Network Code"
-msgstr ""
-
-#: dist/billboard.js:12
-#: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/views/ad-units/index.js:146
-msgid "Set up multiple ad units to use on your homepage, articles and other places throughout your site."
-msgstr ""
-
-#: dist/billboard.js:12
-#: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/views/ad-units/index.js:151
-msgid "You can place ads through our Newspack Ad Block in the Editor, Newspack Ad widget, and using the global placements."
-msgstr ""
-
-#: dist/billboard.js:12
-#: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/index.js:243
-#: src/wizards/advertising/views/ad-units/index.js:159
-msgid "Add New Ad Unit"
-msgstr ""
-
-#: dist/billboard.js:12
-#: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/views/ad-units/index.js:181
-msgid "Code:"
-msgstr ""
-
-#: dist/billboard.js:12
-#: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/views/ad-units/index.js:187
-msgid "Sizes:"
-msgstr ""
-
-#: dist/billboard.js:12
-#: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/views/ad-units/index.js:191
-msgid "Fluid"
-msgstr ""
-
-#: dist/billboard.js:12
-#: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/views/ad-units/index.js:197
-msgid "Legacy ad unit."
-msgstr ""
-
-#: dist/billboard.js:12
-#: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/views/ad-units/index.js:203
-msgid "Default ad unit."
-msgstr ""
-
-#: dist/billboard.js:12
-#: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/views/ad-units/index.js:209
-msgid "Disconnected from GAM."
-msgstr ""
-
-#: dist/billboard.js:12
-#: dist/memberships-gate-editor.js:34
-#: dist/popups.js:7
-#: release/newspack-plugin/dist/billboard.js:12
-#: release/newspack-plugin/dist/memberships-gate-editor.js:34
-#: release/newspack-plugin/dist/popups.js:7
-#: src/memberships-gate/editor.js:181
-#: src/wizards/advertising/components/ad-unit-size-control/index.js:73
-#: src/wizards/advertising/views/ad-unit/index.js:141
-#: src/wizards/popups/components/settings-modal/index.js:99
-msgid "Size"
-msgstr ""
-
-#: dist/billboard.js:12
-#: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/components/ad-unit-size-control/index.js:80
-msgid "Custom"
-msgstr ""
-
-#: dist/billboard.js:12
-#: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/components/ad-unit-size-control/index.js:99
-#: src/wizards/advertising/views/ad-unit/index.js:142
-msgid "Width"
-msgstr ""
-
-#: dist/billboard.js:12
-#: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/components/ad-unit-size-control/index.js:107
-#: src/wizards/advertising/views/ad-unit/index.js:143
-msgid "Height"
-msgstr ""
-
-#: dist/billboard.js:12
-#: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/components/ad-unit-size-control/index.js:91
-msgid "Fluid is a native ad size that allows more flexibility when styling your ad. It automatically sizes the ad by filling the width of the enclosing column and adjusting the height as appropriate."
-msgstr ""
-
-#: dist/billboard.js:12
-#: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/views/ad-unit/index.js:86
-msgid "Ad Unit Details"
-msgstr ""
-
-#: dist/billboard.js:12
-#: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/views/ad-unit/index.js:91
-msgid "Name"
-msgstr ""
-
-#: dist/billboard.js:12
-#: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/views/ad-unit/index.js:97
-msgid "Code"
-msgstr ""
-
-#: dist/billboard.js:12
-#: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/views/ad-unit/index.js:103
-msgid "Identifies the ad unit in the associated ad tag. Once you've created the ad unit, you can't change the code."
-msgstr ""
-
-#: dist/billboard.js:12
-#: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/views/ad-unit/index.js:117
-msgid "Ad Unit Sizes"
-msgstr ""
-
-#: dist/billboard.js:12
-#: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/views/ad-unit/index.js:118
-msgid "Ad Unit Size"
-msgstr ""
-
-#: dist/billboard.js:12
-#: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/views/ad-unit/index.js:126
-msgid "Add New Size"
-msgstr ""
-
-#: dist/billboard.js:12
-#: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/views/ad-unit/index.js:133
-msgid "The ad unit must have at least one valid size or fluid size enabled."
-msgstr ""
-
-#: dist/billboard.js:12
-#: dist/connections.js:9
-#: release/newspack-plugin/dist/billboard.js:12
-#: release/newspack-plugin/dist/connections.js:9
-#: src/wizards/advertising/views/ad-unit/index.js:144
-#: src/wizards/connections/views/main/webhooks.js:385
-msgid "Action"
-msgstr ""
-
-#: dist/billboard.js:12
-#: dist/componentsDemo.js:1
-#: dist/popups.js:1
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/billboard.js:12
-#: release/newspack-plugin/dist/componentsDemo.js:1
-#: release/newspack-plugin/dist/popups.js:1
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/advertising/views/ad-unit/index.js:179
-#: src/wizards/componentsDemo/index.js:303
-#: src/wizards/componentsDemo/index.js:352
-#: src/wizards/popups/components/campaign-management-popover/index.js:108
-#: src/wizards/popups/components/prompt-popovers/primary.js:84
-#: src/wizards/popups/views/segments/segments-list.js:207
-msgid "Delete"
-msgstr ""
-
-#: dist/billboard.js:12
-#: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/views/suppression/index.js:72
 msgid "Post Types"
 msgstr ""
 
 #: dist/billboard.js:12
 #: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/views/suppression/index.js:73
 msgid "Suppress ads on specific post types."
 msgstr ""
 
 #: dist/billboard.js:12
 #: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/views/suppression/index.js:94
 msgid "Tags"
 msgstr ""
 
 #: dist/billboard.js:12
 #: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/views/suppression/index.js:95
 msgid "Suppress ads on specific tags and their archive pages."
 msgstr ""
 
 #: dist/billboard.js:12
 #: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/views/suppression/index.js:108
 msgid "Tags to suppress ads on (archives and posts)"
 msgstr ""
 
 #: dist/billboard.js:12
 #: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/views/suppression/index.js:117
 msgid "All tag archive pages"
 msgstr ""
 
 #: dist/billboard.js:12
 #: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/views/suppression/index.js:120
-msgid "Categories"
-msgstr ""
-
-#: dist/billboard.js:12
-#: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/views/suppression/index.js:121
 msgid "Suppress ads on specific categories and their archive pages."
 msgstr ""
 
 #: dist/billboard.js:12
 #: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/views/suppression/index.js:134
 msgid "Categories to suppress ads on (archives and posts)"
 msgstr ""
 
 #: dist/billboard.js:12
 #: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/views/suppression/index.js:142
 msgid "All category archive pages"
 msgstr ""
 
 #: dist/billboard.js:12
 #: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/views/suppression/index.js:145
 msgid "Author Archive Pages"
 msgstr ""
 
 #: dist/billboard.js:12
 #: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/views/suppression/index.js:146
 msgid "Suppress ads on automatically generated pages displaying a list of posts by an author."
 msgstr ""
 
 #: dist/billboard.js:12
 #: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/views/suppression/index.js:157
 msgid "Suppress ads on author archive pages"
 msgstr ""
 
 #: dist/billboard.js:12
 #: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/components/add-ons/index.js:30
-msgid "Edit Media Kit"
+msgid "Viewability Threshold"
 msgstr ""
 
 #: dist/billboard.js:12
 #: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/index.js:121
+msgid "The percentage of the ad slot which must be visible in the viewport in order to be considered eligible for being refreshed. It's recommended you do not lower this below 50 or you risk third-party viewability tracking platforms flagging your ad impressions as not having been viewed before refreshing."
+msgstr ""
+
+#: dist/billboard.js:12
+#: release/newspack-plugin/dist/billboard.js:12
+msgid "Refresh Interval"
+msgstr ""
+
+#: dist/billboard.js:12
+#: release/newspack-plugin/dist/billboard.js:12
+msgid "The number of seconds that must pass between an ad crossing the viewability threshold and the the ad refreshing. The plugin enforces a minimum of 30 in order to avoid your site being flagged for abusing ad refreshes by advertisers. This value may however be overridden via the avc_refresh_interval_value filter hook."
+msgstr ""
+
+#: dist/billboard.js:12
+#: release/newspack-plugin/dist/billboard.js:12
+msgid "Maximum Refreshes"
+msgstr ""
+
+#: dist/billboard.js:12
+#: release/newspack-plugin/dist/billboard.js:12
+msgid "The number of times each ad slot is allowed to be refreshed. If this is set to 4 then an ad slot could have a total of 5 impressions by combining the initial loading of the ad with the 4 times it can refresh."
+msgstr ""
+
+#: dist/billboard.js:12
+#: release/newspack-plugin/dist/billboard.js:12
+msgid "Excluded Advertiser IDs"
+msgstr ""
+
+#: dist/billboard.js:12
+#: release/newspack-plugin/dist/billboard.js:12
+msgid "Prevent ad refreshes for specific advertiser IDs in the format of a comma separated list (e.g., 125,594,293). If an ad slot ever displays an ad creative from one of the listed advertiser IDs then that ad slot will stop refreshing for the remainder of the page view. AdSense does not allow their ads to be auto-refreshed. When Newspack detects that AdSense is the advertiser for any given impression, a refresh will not take place."
+msgstr ""
+
+#: dist/billboard.js:12
+#: release/newspack-plugin/dist/billboard.js:12
+msgid "Line Items IDs to Exclude"
+msgstr ""
+
+#: dist/billboard.js:12
+#: release/newspack-plugin/dist/billboard.js:12
+msgid "Prevent ad refreshs for specific line item IDs. (Comma Seperated List)"
+msgstr ""
+
+#: dist/billboard.js:12
+#: release/newspack-plugin/dist/billboard.js:12
+msgid "Sizes to Exclude"
+msgstr ""
+
+#: dist/billboard.js:12
+#: release/newspack-plugin/dist/billboard.js:12
+msgid "Prevent ad refreshs for specific sizes. Accepts string (fluid) or array (300x250). Example: fluid, 300x250."
+msgstr ""
+
+#: dist/billboard.js:12
+#: release/newspack-plugin/dist/billboard.js:12
+msgid "Slot IDs to Exclude"
+msgstr ""
+
+#: dist/billboard.js:12
+#: release/newspack-plugin/dist/billboard.js:12
+msgid "Prevent ad refreshs for specific slot IDs e.g. div-gpt-ad-grid-1. (Comma Seperated List)."
+msgstr ""
+
+#: dist/billboard.js:12
+#: release/newspack-plugin/dist/billboard.js:12
+msgid "Something went wrong, the Media Kit feature is unavailable."
+msgstr ""
+
+#: dist/billboard.js:12
+#: release/newspack-plugin/dist/billboard.js:12
+msgid "Media kit page is created but unpublished. Click the link to review and publish."
+msgstr ""
+
+#: dist/billboard.js:12
+#: release/newspack-plugin/dist/billboard.js:12
+msgid "Edit Media Kit page"
+msgstr ""
+
+#: dist/billboard.js:12
+#: release/newspack-plugin/dist/billboard.js:12
+msgid "Media Kit page is published. Click the link to edit it, or toggle this card to unpublish."
+msgstr ""
+
+#: dist/billboard.js:12
+#: release/newspack-plugin/dist/billboard.js:12
+msgid "Review draft page"
+msgstr ""
+
+#: dist/billboard.js:12
+#: release/newspack-plugin/dist/billboard.js:12
+msgid "Media Kit page has not been created. Toggle this card to create it."
+msgstr ""
+
+#: dist/billboard.js:12
+#: release/newspack-plugin/dist/billboard.js:12
+msgid "Media Kit"
+msgstr ""
+
+#: dist/billboard.js:12
+#: release/newspack-plugin/dist/billboard.js:12
+msgid "Google Ad Manager Error"
+msgstr ""
+
+#: dist/billboard.js:12
+#: release/newspack-plugin/dist/billboard.js:12
+msgid "Connected GAM network code"
+msgstr ""
+
+#: dist/billboard.js:12
+#: release/newspack-plugin/dist/billboard.js:12
+msgid "Your GAM network code is different than the network code the site was configured with. Legacy ad units are likely to not load."
+msgstr ""
+
+#: dist/billboard.js:12
+#: release/newspack-plugin/dist/billboard.js:12
+msgid "Currently operating in legacy mode."
+msgstr ""
+
+#: dist/billboard.js:12
+#: release/newspack-plugin/dist/billboard.js:12
+msgid "Network Code"
+msgstr ""
+
+#: dist/billboard.js:12
+#: release/newspack-plugin/dist/billboard.js:12
+msgid "Set up multiple ad units to use on your homepage, articles and other places throughout your site."
+msgstr ""
+
+#: dist/billboard.js:12
+#: release/newspack-plugin/dist/billboard.js:12
+msgid "You can place ads through our Newspack Ad Block in the Editor, Newspack Ad widget, and using the global placements."
+msgstr ""
+
+#: dist/billboard.js:12
+#: release/newspack-plugin/dist/billboard.js:12
+msgid "Add New Ad Unit"
+msgstr ""
+
+#: dist/billboard.js:12
+#: release/newspack-plugin/dist/billboard.js:12
+msgid "Code:"
+msgstr ""
+
+#: dist/billboard.js:12
+#: release/newspack-plugin/dist/billboard.js:12
+msgid "Sizes:"
+msgstr ""
+
+#: dist/billboard.js:12
+#: release/newspack-plugin/dist/billboard.js:12
+msgid "Fluid"
+msgstr ""
+
+#: dist/billboard.js:12
+#: release/newspack-plugin/dist/billboard.js:12
+msgid "Legacy ad unit."
+msgstr ""
+
+#: dist/billboard.js:12
+#: release/newspack-plugin/dist/billboard.js:12
+msgid "Default ad unit."
+msgstr ""
+
+#: dist/billboard.js:12
+#: release/newspack-plugin/dist/billboard.js:12
+msgid "Disconnected from GAM."
+msgstr ""
+
+#: dist/billboard.js:12
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: dist/setup.js:7
+#: release/newspack-plugin/dist/billboard.js:12
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+#: release/newspack-plugin/dist/setup.js:7
+msgid "Custom"
+msgstr ""
+
+#: dist/billboard.js:12
+#: release/newspack-plugin/dist/billboard.js:12
+msgid "Width"
+msgstr ""
+
+#: dist/billboard.js:12
+#: release/newspack-plugin/dist/billboard.js:12
+msgid "Height"
+msgstr ""
+
+#: dist/billboard.js:12
+#: release/newspack-plugin/dist/billboard.js:12
+msgid "Fluid is a native ad size that allows more flexibility when styling your ad. It automatically sizes the ad by filling the width of the enclosing column and adjusting the height as appropriate."
+msgstr ""
+
+#: dist/billboard.js:12
+#: release/newspack-plugin/dist/billboard.js:12
+msgid "Ad Unit Details"
+msgstr ""
+
+#: dist/billboard.js:12
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:5
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/billboard.js:12
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:5
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Name"
+msgstr ""
+
+#: dist/billboard.js:12
+#: release/newspack-plugin/dist/billboard.js:12
+msgid "Code"
+msgstr ""
+
+#: dist/billboard.js:12
+#: release/newspack-plugin/dist/billboard.js:12
+msgid "Identifies the ad unit in the associated ad tag. Once you've created the ad unit, you can't change the code."
+msgstr ""
+
+#: dist/billboard.js:12
+#: release/newspack-plugin/dist/billboard.js:12
+msgid "Ad Unit Sizes"
+msgstr ""
+
+#: dist/billboard.js:12
+#: release/newspack-plugin/dist/billboard.js:12
+msgid "Ad Unit Size"
+msgstr ""
+
+#: dist/billboard.js:12
+#: release/newspack-plugin/dist/billboard.js:12
+msgid "Add New Size"
+msgstr ""
+
+#: dist/billboard.js:12
+#: release/newspack-plugin/dist/billboard.js:12
+msgid "The ad unit must have at least one valid size or fluid size enabled."
+msgstr ""
+
+#: dist/billboard.js:12
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:17
+#: release/newspack-plugin/dist/billboard.js:12
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:17
+msgid "Action"
+msgstr ""
+
+#: dist/billboard.js:12
+#: release/newspack-plugin/dist/billboard.js:12
 msgid "Are you sure you want to archive this ad unit?"
 msgstr ""
 
 #: dist/billboard.js:12
 #: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/index.js:149
-msgid "Providers"
-msgstr ""
-
-#: dist/billboard.js:12
-#: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/index.js:154
-msgid "Placements"
-msgstr ""
-
-#: dist/billboard.js:12
-#: dist/memberships-gate-editor.js:37
-#: dist/other-scripts/emails.js:2
-#: dist/popups.js:7
-#: release/newspack-plugin/dist/billboard.js:12
-#: release/newspack-plugin/dist/memberships-gate-editor.js:37
-#: release/newspack-plugin/dist/other-scripts/emails.js:2
-#: release/newspack-plugin/dist/popups.js:7
-#: src/memberships-gate/editor.js:203
-#: src/other-scripts/emails/index.js:112
-#: src/wizards/advertising/index.js:158
-#: src/wizards/popups/components/settings-modal/index.js:68
-msgid "Settings"
-msgstr ""
-
-#: dist/billboard.js:12
-#: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/index.js:162
-msgid "Suppression"
-msgstr ""
-
-#: dist/billboard.js:12
-#: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/index.js:166
-msgid "Add-Ons"
-msgstr ""
-
-#: dist/billboard.js:12
-#: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/index.js:181
-msgid "Manage ad providers and their settings."
-msgstr ""
-
-#: dist/billboard.js:12
-#: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/index.js:196
-#: src/wizards/advertising/index.js:209
-#: src/wizards/advertising/index.js:299
-#: src/wizards/advertising/index.js:314
-msgid "Advertising"
-msgstr ""
-
-#: dist/billboard.js:12
-#: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/index.js:197
-msgid "Define global advertising placements to serve ad units on your site"
-msgstr ""
-
-#: dist/billboard.js:12
-#: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/index.js:210
-msgid "Configure display and advanced settings for your ads"
-msgstr ""
-
-#: dist/billboard.js:12
-#: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/index.js:224
 msgid "Monetize your content through Google Ad Manager"
 msgstr ""
 
 #: dist/billboard.js:12
 #: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/index.js:244
-#: src/wizards/advertising/index.js:277
 msgid "Allows you to place ads on your site"
 msgstr ""
 
 #: dist/billboard.js:12
 #: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/index.js:276
 msgid "Edit Ad Unit"
 msgstr ""
 
-#: dist/billboard.js:12
-#: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/index.js:300
-msgid "Allows you to manage site-wide ad suppression"
+#: dist/blocks.js:1
+#: dist/correction-box-block.js:1
+#: release/newspack-plugin/dist/blocks.js:1
+#: release/newspack-plugin/dist/correction-box-block.js:1
+msgid "Corrections"
 msgstr ""
 
-#: dist/billboard.js:12
-#: release/newspack-plugin/dist/billboard.js:12
-#: src/wizards/advertising/index.js:315
-msgid "Add-ons for enhanced advertising"
+#: dist/blocks.js:1
+#: dist/correction-box-block.js:1
+#: release/newspack-plugin/dist/blocks.js:1
+#: release/newspack-plugin/dist/correction-box-block.js:1
+msgid "clarifications"
+msgstr ""
+
+#: dist/blocks.js:1
+#: dist/correction-box-block.js:1
+#: release/newspack-plugin/dist/blocks.js:1
+#: release/newspack-plugin/dist/correction-box-block.js:1
+msgid "updates"
+msgstr ""
+
+#: dist/blocks.js:1
+#: dist/correction-box-block.js:1
+#: release/newspack-plugin/dist/blocks.js:1
+#: release/newspack-plugin/dist/correction-box-block.js:1
+msgid "Display all corrections and clarifications made to a post."
+msgstr ""
+
+#: dist/blocks.js:1
+#: dist/correction-item-block.js:1
+#: release/newspack-plugin/dist/blocks.js:1
+#: release/newspack-plugin/dist/correction-item-block.js:1
+msgid "Correction Item"
+msgstr ""
+
+#: dist/blocks.js:1
+#: dist/correction-item-block.js:1
+#: release/newspack-plugin/dist/blocks.js:1
+#: release/newspack-plugin/dist/correction-item-block.js:1
+msgid "Display an archive of all the corrections and clarifications."
 msgstr ""
 
 #: dist/blocks.js:1
 #: release/newspack-plugin/dist/blocks.js:1
-#: src/blocks/reader-registration/edit.js:40
+msgid "Please select \"Corrections\" as the post type in the Query Loop to use this block."
+msgstr ""
+
+#: dist/blocks.js:1
+#: release/newspack-plugin/dist/blocks.js:1
+msgid "Correction Type, Date, and Time: "
+msgstr ""
+
+#: dist/blocks.js:1
+#: release/newspack-plugin/dist/blocks.js:1
+msgid "This is where the content will appear, providing details about the update, whether correcting an error or offering additional context."
+msgstr ""
+
+#: dist/blocks.js:1
+#: release/newspack-plugin/dist/blocks.js:1
+msgid "Post Title"
+msgstr ""
+
+#: dist/blocks.js:1
+#: release/newspack-plugin/dist/blocks.js:1
 msgid "Initial"
 msgstr ""
 
 #: dist/blocks.js:1
 #: release/newspack-plugin/dist/blocks.js:1
-#: src/blocks/reader-registration/edit.js:41
 msgid "Registration Success"
 msgstr ""
 
 #: dist/blocks.js:1
 #: release/newspack-plugin/dist/blocks.js:1
-#: src/blocks/reader-registration/edit.js:42
 msgid "Login Success"
 msgstr ""
 
 #: dist/blocks.js:1
 #: release/newspack-plugin/dist/blocks.js:1
-#: src/blocks/reader-registration/edit.js:131
 msgid "Form settings"
 msgstr ""
 
 #: dist/blocks.js:1
 #: release/newspack-plugin/dist/blocks.js:1
-#: src/blocks/reader-registration/edit.js:133
 msgid "Input placeholder"
 msgstr ""
 
 #: dist/blocks.js:1
 #: release/newspack-plugin/dist/blocks.js:1
-#: src/blocks/reader-registration/edit.js:140
 msgid "Newsletter Subscription"
 msgstr ""
 
 #: dist/blocks.js:1
 #: release/newspack-plugin/dist/blocks.js:1
-#: src/blocks/reader-registration/edit.js:142
 msgid "Enable newsletter subscription"
 msgstr ""
 
 #: dist/blocks.js:1
 #: release/newspack-plugin/dist/blocks.js:1
-#: src/blocks/reader-registration/edit.js:154
 msgid "To enable newsletter subscription, you must configure subscription lists on Newspack Newsletters."
 msgstr ""
 
 #: dist/blocks.js:1
 #: release/newspack-plugin/dist/blocks.js:1
-#: src/blocks/reader-registration/edit.js:163
 msgid "Display list description"
 msgstr ""
 
 #: dist/blocks.js:1
 #: release/newspack-plugin/dist/blocks.js:1
-#: src/blocks/reader-registration/edit.js:171
 msgid "Hide newsletter selection and always subscribe"
 msgstr ""
 
 #: dist/blocks.js:1
 #: release/newspack-plugin/dist/blocks.js:1
-#: src/blocks/reader-registration/edit.js:184
 msgid "You must select at least one list."
 msgstr ""
 
 #: dist/blocks.js:1
 #: release/newspack-plugin/dist/blocks.js:1
-#: src/blocks/reader-registration/edit.js:189
 msgid "Lists"
 msgstr ""
 
 #: dist/blocks.js:1
 #: release/newspack-plugin/dist/blocks.js:1
-#: src/blocks/reader-registration/edit.js:210
 msgid "Configure your subscription lists"
 msgstr ""
 
 #: dist/blocks.js:1
 #: release/newspack-plugin/dist/blocks.js:1
-#: src/blocks/reader-registration/edit.js:218
 msgid "Spam protection"
 msgstr ""
 
 #. translators: %s is either 'enabled' or 'disabled'.
 #: dist/blocks.js:4
 #: release/newspack-plugin/dist/blocks.js:4
-#: src/blocks/reader-registration/edit.js:222
 msgid "reCAPTCHA is currently %s."
 msgstr ""
 
 #: dist/blocks.js:4
 #: release/newspack-plugin/dist/blocks.js:4
-#: src/blocks/reader-registration/edit.js:230
 msgid "It's highly recommended that you enable reCAPTCHA protection to prevent spambots from using this form!"
 msgstr ""
 
 #: dist/blocks.js:4
 #: release/newspack-plugin/dist/blocks.js:4
-#: src/blocks/reader-registration/edit.js:238
 msgid "Configure your reCAPTCHA settings."
 msgstr ""
 
 #: dist/blocks.js:4
 #: release/newspack-plugin/dist/blocks.js:4
-#: src/blocks/reader-registration/edit.js:245
 msgid "Edited State"
 msgstr ""
 
 #: dist/blocks.js:4
 #: release/newspack-plugin/dist/blocks.js:4
-#: src/blocks/reader-registration/edit.js:280
 msgid "Add title"
 msgstr ""
 
 #: dist/blocks.js:4
 #: release/newspack-plugin/dist/blocks.js:4
-#: src/blocks/reader-registration/edit.js:287
 msgid "Add description"
 msgstr ""
 
 #: dist/blocks.js:4
 #: release/newspack-plugin/dist/blocks.js:4
-#: src/blocks/reader-registration/edit.js:297
-msgid "Newsletters title…"
+msgid "Sign up"
 msgstr ""
 
 #: dist/blocks.js:4
 #: release/newspack-plugin/dist/blocks.js:4
-#: src/blocks/reader-registration/edit.js:379
 msgid "Terms & Conditions statement…"
 msgstr ""
 
 #: dist/blocks.js:4
 #: release/newspack-plugin/dist/blocks.js:4
-#: src/blocks/reader-registration/edit.js:401
 msgid "Logged in message…"
 msgstr ""
 
+#: dist/bylines.js:1
+#: release/newspack-plugin/dist/bylines.js:1
+msgid "Add author"
+msgstr ""
+
+#: dist/bylines.js:1
+#: release/newspack-plugin/dist/bylines.js:1
+msgid "Byline"
+msgstr ""
+
+#: dist/bylines.js:1
+#: release/newspack-plugin/dist/bylines.js:1
+msgid "Provides flexibility in defining how the byline appears."
+msgstr ""
+
+#: dist/bylines.js:1
+#: release/newspack-plugin/dist/bylines.js:1
+msgid "Enable custom byline"
+msgstr ""
+
+#: dist/bylines.js:1
+#: release/newspack-plugin/dist/bylines.js:1
+msgid "Edit byline"
+msgstr ""
+
+#: dist/collections-admin.js:1
+msgid "Remove attachment"
+msgstr ""
+
+#: dist/collections-admin.js:1
+#: release/newspack-plugin/dist/collections-admin.js:1
+msgid "Please enter a valid URL."
+msgstr ""
+
+#: dist/collections-admin.js:1
+#: release/newspack-plugin/dist/collections-admin.js:1
+msgid "Please upload a PDF file."
+msgstr ""
+
+#: dist/collections-admin.js:1
+msgid "Drag to reorder"
+msgstr ""
+
+#: dist/collections-admin.js:1
+msgid "Enter a label…"
+msgstr ""
+
+#: dist/collections-admin.js:1
+msgid "External Link"
+msgstr ""
+
+#: dist/collections-admin.js:1
+msgid "File Upload"
+msgstr ""
+
+#: dist/collections-admin.js:1
+#: dist/other-scripts/corrections-modal.js:1
+#: dist/other-scripts/corrections-modal.js:4
+#: release/newspack-plugin/dist/other-scripts/corrections-modal.js:1
+#: release/newspack-plugin/dist/other-scripts/corrections-modal.js:4
+msgid "Type"
+msgstr ""
+
+#: dist/collections-admin.js:1
+msgid "Enter the URL…"
+msgstr ""
+
+#: dist/collections-admin.js:1
+msgid "File"
+msgstr ""
+
+#: dist/collections-admin.js:1
+msgid "Upload PDF"
+msgstr ""
+
+#: dist/collections-admin.js:1
+msgid "Remove CTA"
+msgstr ""
+
+#: dist/collections-admin.js:1
+msgid "Add CTA"
+msgstr ""
+
 #: dist/commons.js:1
 #: release/newspack-plugin/dist/commons.js:1
-#: src/components/src/autocomplete-with-suggestions/index.js:20
+msgid "Image size"
+msgstr ""
+
+#: dist/commons.js:1
+#: release/newspack-plugin/dist/commons.js:1
+msgid "Link to author archive"
+msgstr ""
+
+#. translators: %s: Author name.
+#: dist/commons.js:4
+#: release/newspack-plugin/dist/commons.js:4
+msgid "%s Avatar"
+msgstr ""
+
+#: dist/commons.js:4
+#: release/newspack-plugin/dist/commons.js:4
+msgid "Default Avatar"
+msgstr ""
+
+#: dist/commons.js:4
+#: release/newspack-plugin/dist/commons.js:4
+msgid "Loading avatar…"
+msgstr ""
+
+#: dist/commons.js:4
+#: release/newspack-plugin/dist/commons.js:4
+msgid "This is the Corrections block, it will display all the corrections and clarifications."
+msgstr ""
+
+#: dist/commons.js:4
+#: release/newspack-plugin/dist/commons.js:4
+msgid "If there are no corrections or clarifications, this block will not be displayed."
+msgstr ""
+
+#: dist/commons.js:4
+#: release/newspack-plugin/dist/commons.js:4
+msgid "Correction Box Settings"
+msgstr ""
+
+#: dist/commons.js:4
+#: release/newspack-plugin/dist/commons.js:4
+msgid "Corrections by Priority"
+msgstr ""
+
+#: dist/commons.js:4
+#: release/newspack-plugin/dist/commons.js:4
+msgid "Filter corrections by their priority."
+msgstr ""
+
+#: dist/commons.js:4
+#: dist/other-scripts/corrections-modal.js:1
+#: release/newspack-plugin/dist/commons.js:4
+#: release/newspack-plugin/dist/other-scripts/corrections-modal.js:1
+msgid "High"
+msgstr ""
+
+#: dist/commons.js:4
+#: dist/other-scripts/corrections-modal.js:1
+#: release/newspack-plugin/dist/commons.js:4
+#: release/newspack-plugin/dist/other-scripts/corrections-modal.js:1
+msgid "Low"
+msgstr ""
+
+#: dist/commons.js:4
+#: release/newspack-plugin/dist/commons.js:4
+msgid "All"
+msgstr ""
+
+#: dist/commons.js:4
+#: release/newspack-plugin/dist/commons.js:4
+msgid "Refresh"
+msgstr ""
+
+#: dist/commons.js:4
+#: release/newspack-plugin/dist/commons.js:4
 msgid "Begin typing search term, click autocomplete result to select."
 msgstr ""
 
-#: dist/commons.js:1
-#: release/newspack-plugin/dist/commons.js:1
-#: src/components/src/autocomplete-with-suggestions/index.js:22
+#: dist/commons.js:4
+#: release/newspack-plugin/dist/commons.js:4
 msgid "Search"
 msgstr ""
 
-#: dist/commons.js:1
-#: release/newspack-plugin/dist/commons.js:1
-#: src/components/src/autocomplete-with-suggestions/index.js:28
+#: dist/commons.js:4
+#: release/newspack-plugin/dist/commons.js:4
 msgid "item"
 msgstr ""
 
-#: dist/commons.js:1
-#: release/newspack-plugin/dist/commons.js:1
-#: src/components/src/autocomplete-with-suggestions/index.js:29
+#: dist/commons.js:4
+#: release/newspack-plugin/dist/commons.js:4
 msgid "items"
 msgstr ""
 
-#: dist/commons.js:1
-#: dist/popups.js:10
-#: release/newspack-plugin/dist/commons.js:1
-#: release/newspack-plugin/dist/popups.js:10
-#: src/components/src/autocomplete-with-suggestions/index.js:99
-#: src/components/src/autocomplete-with-suggestions/index.js:133
-#: src/wizards/popups/components/prompt-action-card/index.js:67
-msgid "(no title)"
-msgstr ""
-
 #. Translators: %1: the length of selections. %2: the selection leabel.
-#: dist/commons.js:4
-#: release/newspack-plugin/dist/commons.js:4
-#: src/components/src/autocomplete-with-suggestions/index.js:180
+#: dist/commons.js:7
+#: release/newspack-plugin/dist/commons.js:7
 msgid "%1$s %2$s selected"
 msgstr ""
 
 #. Translators: %s: The label for the selection.
-#: dist/commons.js:7
-#: release/newspack-plugin/dist/commons.js:7
-#: src/components/src/autocomplete-with-suggestions/index.js:185
+#: dist/commons.js:10
+#: release/newspack-plugin/dist/commons.js:10
 msgid "Selected %s"
 msgstr ""
 
-#: dist/commons.js:7
-#: release/newspack-plugin/dist/commons.js:7
-#: src/components/src/autocomplete-with-suggestions/index.js:193
+#: dist/commons.js:10
+#: release/newspack-plugin/dist/commons.js:10
 msgctxt "separator character"
 msgid " – "
 msgstr ""
 
-#: dist/commons.js:7
-#: release/newspack-plugin/dist/commons.js:7
-#: src/components/src/autocomplete-with-suggestions/index.js:196
+#: dist/commons.js:10
+#: release/newspack-plugin/dist/commons.js:10
 msgid "Clear all"
 msgstr ""
 
 #. Translators: %s: The name of the type.
-#: dist/commons.js:10
-#: release/newspack-plugin/dist/commons.js:10
-#: src/components/src/autocomplete-with-suggestions/index.js:224
+#: dist/commons.js:13
+#: release/newspack-plugin/dist/commons.js:13
 msgid "%s type"
 msgstr ""
 
 #. Translators: %s: the name of a post type.
-#: dist/commons.js:10
-#: release/newspack-plugin/dist/commons.js:10
-#: src/components/src/autocomplete-with-suggestions/index.js:284
+#: dist/commons.js:13
+#: release/newspack-plugin/dist/commons.js:13
 msgid "Or, select a recent %s:"
 msgstr ""
 
-#: dist/commons.js:10
-#: dist/connections.js:3
-#: release/newspack-plugin/dist/commons.js:10
-#: release/newspack-plugin/dist/connections.js:3
-#: src/components/src/autocomplete-with-suggestions/index.js:299
-#: src/components/src/plugin-toggle/index.js:166
-#: src/components/src/web-preview/index.js:115
-#: src/wizards/connections/views/main/google.js:144
-#: src/wizards/connections/views/main/mailchimp.js:93
-#: src/wizards/connections/views/main/plugins.js:131
-msgid "Loading…"
-msgstr ""
-
-#: dist/commons.js:10
-#: release/newspack-plugin/dist/commons.js:10
-#: src/components/src/autocomplete-with-suggestions/index.js:300
+#: dist/commons.js:13
+#: release/newspack-plugin/dist/commons.js:13
 msgid "Load more"
 msgstr ""
 
-#: dist/commons.js:10
-#: release/newspack-plugin/dist/commons.js:10
-#: src/components/src/footer/index.js:35
+#: dist/commons.js:13
+#: release/newspack-plugin/dist/commons.js:13
 msgid "About"
 msgstr ""
 
-#: dist/commons.js:10
-#: release/newspack-plugin/dist/commons.js:10
-#: src/components/src/footer/index.js:40
+#: dist/commons.js:13
+#: release/newspack-plugin/dist/commons.js:13
 msgid "Documentation"
 msgstr ""
 
-#: dist/commons.js:10
+#: dist/commons.js:13
 #: dist/componentsDemo.js:1
-#: release/newspack-plugin/dist/commons.js:10
+#: release/newspack-plugin/dist/commons.js:13
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/components/src/footer/index.js:47
-#: src/wizards/componentsDemo/index.js:93
 msgid "Components Demo"
 msgstr ""
 
-#: dist/commons.js:10
-#: release/newspack-plugin/dist/commons.js:10
-#: src/components/src/footer/index.js:53
+#: dist/commons.js:13
+#: release/newspack-plugin/dist/commons.js:13
 msgid "Setup Wizard"
 msgstr ""
 
-#: dist/commons.js:10
-#: release/newspack-plugin/dist/commons.js:10
-#: src/components/src/footer/index.js:59
+#: dist/commons.js:13
+#: release/newspack-plugin/dist/commons.js:13
 msgid "Reset Newspack"
 msgstr ""
 
-#: dist/commons.js:10
-#: release/newspack-plugin/dist/commons.js:10
-#: src/components/src/footer/index.js:65
+#: dist/commons.js:13
+#: release/newspack-plugin/dist/commons.js:13
 msgid "Remove Starter Content"
 msgstr ""
 
-#: dist/commons.js:10
-#: release/newspack-plugin/dist/commons.js:10
-#: src/components/src/footer/index.js:71
+#: dist/commons.js:13
+#: release/newspack-plugin/dist/commons.js:13
 msgid "Contact Support"
 msgstr ""
 
-#: dist/commons.js:10
-#: release/newspack-plugin/dist/commons.js:10
-#: src/components/src/handoff/index.js:55
-#: src/components/src/handoff/index.js:57
-#: src/components/src/handoff/index.js:58
+#: dist/commons.js:13
+#: release/newspack-plugin/dist/commons.js:13
 msgid "Manage"
 msgstr ""
 
-#: dist/commons.js:10
-#: dist/componentsDemo.js:1
-#: dist/handoff-banner.js:1
-#: release/newspack-plugin/dist/commons.js:10
-#: release/newspack-plugin/dist/componentsDemo.js:1
-#: release/newspack-plugin/dist/handoff-banner.js:1
-#: src/components/src/handoff/index.js:59
-#: src/wizards/componentsDemo/index.js:243
-#: src/wizards/handoff-banner/index.js:22
-msgid "Dismiss"
-msgstr ""
-
-#: dist/commons.js:10
-#: release/newspack-plugin/dist/commons.js:10
-#: src/components/src/handoff/index.js:119
+#: dist/commons.js:13
+#: release/newspack-plugin/dist/commons.js:13
 msgid " not installed"
 msgstr ""
 
-#: dist/commons.js:10
-#: release/newspack-plugin/dist/commons.js:10
-#: src/components/src/handoff/index.js:130
+#: dist/commons.js:13
+#: release/newspack-plugin/dist/commons.js:13
 msgid "Retrieving Plugin Info"
 msgstr ""
 
-#: dist/commons.js:10
-#: release/newspack-plugin/dist/commons.js:10
-#: src/components/src/image-upload/index.js:105
+#: dist/commons.js:13
+#: release/newspack-plugin/dist/commons.js:13
 msgid "Image preview"
 msgstr ""
 
-#: dist/commons.js:10
-#: release/newspack-plugin/dist/commons.js:10
-#: src/components/src/image-upload/index.js:109
+#: dist/commons.js:13
+#: release/newspack-plugin/dist/commons.js:13
 msgid "Replace"
 msgstr ""
 
-#: dist/commons.js:10
-#: dist/connections.js:3
-#: dist/engagement.js:11
-#: release/newspack-plugin/dist/commons.js:10
-#: release/newspack-plugin/dist/connections.js:3
-#: release/newspack-plugin/dist/engagement.js:11
-#: src/components/src/image-upload/index.js:118
-#: src/components/src/sortable-newsletter-list-control/index.js:65
-#: src/wizards/connections/views/main/webhooks.js:108
-msgid "Remove"
-msgstr ""
-
-#: dist/commons.js:10
-#: release/newspack-plugin/dist/commons.js:10
-#: src/components/src/image-upload/index.js:124
+#: dist/commons.js:13
+#: release/newspack-plugin/dist/commons.js:13
 msgid "Upload"
 msgstr ""
 
-#: dist/commons.js:10
-#: release/newspack-plugin/dist/commons.js:10
-#: src/components/src/notice/index.js:65
-msgid "Debug Mode"
-msgstr ""
-
-#: dist/commons.js:10
-#: release/newspack-plugin/dist/commons.js:10
-#: src/components/src/patrons-logo/index.js:24
-msgid "A project of WordPress.com and the Google News Initiative"
-msgstr ""
-
-#: dist/commons.js:10
-#: dist/popups.js:1
-#: release/newspack-plugin/dist/commons.js:10
-#: release/newspack-plugin/dist/popups.js:1
-#: src/components/src/plugin-installer/index.js:173
-#: src/components/src/plugin-installer/index.js:220
-#: src/wizards/popups/components/prompt-popovers/primary.js:81
-msgid "Activate"
-msgstr ""
-
-#: dist/commons.js:10
+#: dist/commons.js:13
 #: dist/componentsDemo.js:1
-#: release/newspack-plugin/dist/commons.js:10
+#: release/newspack-plugin/dist/commons.js:13
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/components/src/plugin-installer/index.js:174
-#: src/wizards/componentsDemo/index.js:294
-#: src/wizards/componentsDemo/index.js:321
-#: src/wizards/componentsDemo/index.js:382
-#: src/wizards/componentsDemo/index.js:418
 msgid "Install"
 msgstr ""
 
-#: dist/commons.js:10
-#: release/newspack-plugin/dist/commons.js:10
-#: src/components/src/plugin-installer/index.js:186
+#: dist/commons.js:13
+#: release/newspack-plugin/dist/commons.js:13
 msgid "Retrieving plugin information…"
 msgstr ""
 
-#: dist/commons.js:10
-#: release/newspack-plugin/dist/commons.js:10
-#: src/components/src/plugin-installer/index.js:227
+#: dist/commons.js:13
+#: release/newspack-plugin/dist/commons.js:13
 msgid "Installed"
 msgstr ""
 
-#: dist/commons.js:10
-#: release/newspack-plugin/dist/commons.js:10
-#: src/components/src/plugin-installer/index.js:205
+#: dist/commons.js:13
+#: release/newspack-plugin/dist/commons.js:13
 msgid "Contact Newspack support to install"
 msgstr ""
 
-#: dist/commons.js:10
-#: release/newspack-plugin/dist/commons.js:10
-#: src/components/src/plugin-installer/index.js:206
+#: dist/commons.js:13
+#: release/newspack-plugin/dist/commons.js:13
 msgid "Plugin must be installed manually"
 msgstr ""
 
-#: dist/commons.js:10
-#: release/newspack-plugin/dist/commons.js:10
-#: src/components/src/plugin-settings/index.js:208
+#: dist/commons.js:13
+#: release/newspack-plugin/dist/commons.js:13
 msgid "General Settings"
 msgstr ""
 
-#: dist/commons.js:10
-#: release/newspack-plugin/dist/commons.js:10
-#: src/components/src/plugin-toggle/index.js:72
+#: dist/commons.js:13
+#: release/newspack-plugin/dist/commons.js:13
 msgid "There was an error managing this plugin."
 msgstr ""
 
-#: dist/commons.js:10
+#: dist/commons.js:13
 #: dist/componentsDemo.js:1
-#: release/newspack-plugin/dist/commons.js:10
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:1
+#: release/newspack-plugin/dist/commons.js:13
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/components/src/plugin-toggle/index.js:152
-#: src/wizards/componentsDemo/index.js:315
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:1
 msgid "Installing…"
 msgstr ""
 
-#: dist/commons.js:10
-#: release/newspack-plugin/dist/commons.js:10
-#: src/components/src/plugin-toggle/index.js:159
+#: dist/commons.js:13
+#: release/newspack-plugin/dist/commons.js:13
 msgid "Deactivating…"
 msgstr ""
 
-#: dist/commons.js:10
-#: release/newspack-plugin/dist/commons.js:10
-#: src/components/src/select-control/GroupedSelectControl.js:55
+#: dist/commons.js:13
+#: release/newspack-plugin/dist/commons.js:13
 msgid "-- Select --"
 msgstr ""
 
-#: dist/commons.js:10
-#: release/newspack-plugin/dist/commons.js:10
-#: src/components/src/settings/MinMaxSetting.js:27
+#: dist/commons.js:13
+#: release/newspack-plugin/dist/commons.js:13
 msgid "Min"
 msgstr ""
 
-#: dist/commons.js:10
-#: release/newspack-plugin/dist/commons.js:10
-#: src/components/src/settings/MinMaxSetting.js:41
+#: dist/commons.js:13
+#: release/newspack-plugin/dist/commons.js:13
 msgid "Max"
 msgstr ""
 
-#: dist/commons.js:10
-#: release/newspack-plugin/dist/commons.js:10
-#: src/components/src/style-card/index.js:41
+#: dist/commons.js:13
+#: release/newspack-plugin/dist/commons.js:13
 msgid "Thumbnail"
 msgstr ""
 
-#: dist/commons.js:10
-#: release/newspack-plugin/dist/commons.js:10
-#: src/components/src/style-card/index.js:46
+#: dist/commons.js:13
+#: release/newspack-plugin/dist/commons.js:13
 msgid "Selected"
 msgstr ""
 
-#: dist/commons.js:10
-#: dist/site-design.js:1
-#: release/newspack-plugin/dist/commons.js:10
-#: release/newspack-plugin/dist/site-design.js:1
-#: src/components/src/style-card/index.js:53
-#: src/components/src/style-card/index.js:57
-#: src/wizards/site-design/views/theme-settings/index.js:219
+#: dist/commons.js:13
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/commons.js:13
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
 msgid "Select"
 msgstr ""
 
-#: dist/commons.js:10
-#: release/newspack-plugin/dist/commons.js:10
-#: src/components/src/style-card/index.js:63
+#: dist/commons.js:13
+#: release/newspack-plugin/dist/commons.js:13
 msgid "View Demo"
 msgstr ""
 
-#: dist/commons.js:10
-#: release/newspack-plugin/dist/commons.js:10
+#: dist/commons.js:13
+#: release/newspack-plugin/dist/commons.js:13
 msgid "(required)"
 msgstr ""
 
-#: dist/commons.js:10
-#: release/newspack-plugin/dist/commons.js:10
-#: src/components/src/web-preview/index.js:84
+#: dist/commons.js:13
+#: release/newspack-plugin/dist/commons.js:13
 msgid "Preview Desktop Size"
 msgstr ""
 
-#: dist/commons.js:10
-#: release/newspack-plugin/dist/commons.js:10
-#: src/components/src/web-preview/index.js:90
+#: dist/commons.js:13
+#: release/newspack-plugin/dist/commons.js:13
 msgid "Preview Tablet Size"
 msgstr ""
 
-#: dist/commons.js:10
-#: release/newspack-plugin/dist/commons.js:10
-#: src/components/src/web-preview/index.js:96
+#: dist/commons.js:13
+#: release/newspack-plugin/dist/commons.js:13
 msgid "Preview Phone Size"
 msgstr ""
 
-#: dist/commons.js:10
-#: release/newspack-plugin/dist/commons.js:10
-#: src/components/src/web-preview/index.js:107
+#: dist/commons.js:13
+#: release/newspack-plugin/dist/commons.js:13
 msgid "Close Preview"
 msgstr ""
 
-#: dist/commons.js:10
-#: dist/popups.js:1
-#: release/newspack-plugin/dist/commons.js:10
-#: release/newspack-plugin/dist/popups.js:1
-#: src/components/src/web-preview/index.js:169
-#: src/wizards/popups/components/prompt-popovers/primary.js:61
-msgid "Preview"
-msgstr ""
-
-#: dist/commons.js:10
+#: dist/commons.js:13
 #: dist/componentsDemo.js:1
-#: release/newspack-plugin/dist/commons.js:10
+#: release/newspack-plugin/dist/commons.js:13
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/components/src/with-wizard-screen/index.js:69
-#: src/components/src/with-wizard/index.js:108
-#: src/components/src/with-wizard/index.js:222
-#: src/components/src/wizard/components/WizardError.js:44
-#: src/components/src/wizard/index.js:93
-#: src/wizards/componentsDemo/index.js:85
 msgid "Return to Dashboard"
 msgstr ""
 
-#: dist/commons.js:10
-#: release/newspack-plugin/dist/commons.js:10
-#: src/components/src/with-wizard/index.js:232
-#: src/components/src/wizard/index.js:60
+#: dist/commons.js:13
+#: release/newspack-plugin/dist/commons.js:13
 msgid "Required plugins"
 msgstr ""
 
-#: dist/commons.js:10
-#: release/newspack-plugin/dist/commons.js:10
-#: src/components/src/with-wizard/index.js:233
-#: src/components/src/wizard/index.js:61
+#: dist/commons.js:13
+#: release/newspack-plugin/dist/commons.js:13
 msgid "Required plugin"
 msgstr ""
 
-#: dist/commons.js:10
-#: release/newspack-plugin/dist/commons.js:10
-#: src/wizards/advertising/components/onboarding/index.js:64
+#: dist/commons.js:13
+#: release/newspack-plugin/dist/commons.js:13
+msgid "OK"
+msgstr ""
+
+#: dist/commons.js:13
+#: release/newspack-plugin/dist/commons.js:13
 msgid "Authenticate with Google in order to connect your Google Ad Manager account:"
 msgstr ""
 
-#: dist/commons.js:10
-#: release/newspack-plugin/dist/commons.js:10
-#: src/wizards/advertising/components/onboarding/index.js:80
+#: dist/commons.js:13
+#: release/newspack-plugin/dist/commons.js:13
 msgid "We're all set here!"
 msgstr ""
 
-#: dist/commons.js:10
-#: release/newspack-plugin/dist/commons.js:10
-#: src/wizards/advertising/components/onboarding/index.js:84
+#: dist/commons.js:13
+#: release/newspack-plugin/dist/commons.js:13
 msgid "Enter your Google Ad Manager network code and service account credentials for a full integration:"
 msgstr ""
 
-#: dist/commons.js:10
-#: release/newspack-plugin/dist/commons.js:10
-#: src/wizards/advertising/components/onboarding/index.js:93
+#: dist/commons.js:13
+#: release/newspack-plugin/dist/commons.js:13
 msgid "Network code"
 msgstr ""
 
-#: dist/commons.js:10
-#: release/newspack-plugin/dist/commons.js:10
-#: src/wizards/advertising/components/onboarding/index.js:100
+#: dist/commons.js:13
+#: release/newspack-plugin/dist/commons.js:13
 msgid "Upload credentials"
 msgstr ""
 
-#: dist/commons.js:10
-#: release/newspack-plugin/dist/commons.js:10
-#: src/wizards/advertising/components/onboarding/index.js:102
+#: dist/commons.js:13
+#: release/newspack-plugin/dist/commons.js:13
 msgid "Upload your Service Account credentials file to connect your GAM account."
 msgstr ""
 
-#: dist/commons.js:10
-#: release/newspack-plugin/dist/commons.js:10
-#: src/wizards/advertising/components/onboarding/index.js:116
+#: dist/commons.js:13
+#: release/newspack-plugin/dist/commons.js:13
 msgid "How to get a service account user for API access"
 msgstr ""
 
-#: dist/commons.js:10
-#: release/newspack-plugin/dist/commons.js:10
-#: src/wizards/advertising/components/utils/index.js:21
+#: dist/commons.js:13
+#: release/newspack-plugin/dist/commons.js:13
 msgid "Invalid JSON file"
 msgstr ""
 
-#: dist/commons.js:10
-#: release/newspack-plugin/dist/commons.js:10
-#: src/wizards/advertising/components/utils/index.js:26
+#: dist/commons.js:13
+#: release/newspack-plugin/dist/commons.js:13
 msgid "Unable to read file"
 msgstr ""
 
-#: dist/commons.js:10
-#: release/newspack-plugin/dist/commons.js:10
-#: src/wizards/connections/views/main/google.js:42
-msgid "Missing Google refresh token. Please"
+#: dist/commons.js:13
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:1
+#: release/newspack-plugin/dist/commons.js:13
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:1
+msgid "Invalid Mailchimp API Key."
 msgstr ""
 
-#: dist/commons.js:10
-#: release/newspack-plugin/dist/commons.js:10
-#: src/wizards/connections/views/main/google.js:50
-msgid "revoke credentials"
+#: dist/commons.js:13
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:1
+#: release/newspack-plugin/dist/commons.js:13
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:1
+msgid "Missing Google refresh token. Please re-authenticate site."
 msgstr ""
 
-#: dist/commons.js:10
-#: release/newspack-plugin/dist/commons.js:10
-#: src/wizards/connections/views/main/google.js:53
-msgid "and authorize the site again."
+#: dist/commons.js:13
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:1
+#: release/newspack-plugin/dist/commons.js:13
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:1
+msgid "Popup blocked by browser. Disable any popup blocking settings and try again."
 msgstr ""
 
-#: dist/commons.js:10
-#: release/newspack-plugin/dist/commons.js:10
-#: src/wizards/connections/views/main/google.js:158
-msgid "Google"
-msgstr ""
-
-#: dist/commons.js:10
-#: dist/connections.js:3
-#: release/newspack-plugin/dist/commons.js:10
-#: release/newspack-plugin/dist/connections.js:3
-#: src/wizards/connections/views/main/fivetran.js:119
-#: src/wizards/connections/views/main/google.js:159
-#: src/wizards/connections/views/main/mailchimp.js:116
-#: src/wizards/connections/views/main/plugins.js:148
-msgid "Status:"
+#: dist/commons.js:13
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:1
+#: release/newspack-plugin/dist/commons.js:13
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:1
+msgid "URL is invalid. Please try again or contact support if the issue persists."
 msgstr ""
 
 #. Translators: connected user's email address.
-#. Translators: user connection status message.
-#: dist/commons.js:13
-#: dist/connections.js:3
-#: release/newspack-plugin/dist/commons.js:13
-#: release/newspack-plugin/dist/connections.js:3
-#: src/wizards/connections/views/main/google.js:149
-#: src/wizards/connections/views/main/mailchimp.js:97
+#. translators: %s: username
+#: dist/commons.js:16
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:8
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/commons.js:16
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:8
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
 msgid "Connected as %s"
 msgstr ""
 
-#: dist/commons.js:13
-#: dist/connections.js:3
-#: release/newspack-plugin/dist/commons.js:13
-#: release/newspack-plugin/dist/connections.js:3
-#: src/wizards/connections/views/main/fivetran.js:44
-#: src/wizards/connections/views/main/google.js:153
-#: src/wizards/connections/views/main/mailchimp.js:99
-msgid "Not connected"
-msgstr ""
-
-#: dist/commons.js:13
+#: dist/commons.js:16
 #: dist/componentsDemo.js:1
-#: dist/connections.js:3
-#: release/newspack-plugin/dist/commons.js:13
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:8
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/commons.js:16
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: release/newspack-plugin/dist/connections.js:3
-#: src/wizards/componentsDemo/index.js:408
-#: src/wizards/connections/views/main/google.js:169
-#: src/wizards/connections/views/main/mailchimp.js:126
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:8
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
 msgid "Disconnect"
 msgstr ""
 
-#: dist/commons.js:13
-#: dist/connections.js:3
-#: dist/health-check.js:1
-#: release/newspack-plugin/dist/commons.js:13
-#: release/newspack-plugin/dist/connections.js:3
-#: release/newspack-plugin/dist/health-check.js:1
-#: src/wizards/connections/views/main/fivetran.js:125
-#: src/wizards/connections/views/main/google.js:170
-#: src/wizards/connections/views/main/mailchimp.js:109
-#: src/wizards/connections/views/main/mailchimp.js:127
-#: src/wizards/health-check/views/configuration/index.js:37
-#: src/wizards/health-check/views/configuration/index.js:48
-msgid "Connect"
-msgstr ""
-
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:95
 msgid "Simple components used for composing the UI of Newspack"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:106
 msgid "Autocomplete with Suggestions (single-select)"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:108
 msgid "Search for a post"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:109
-#: src/wizards/componentsDemo/index.js:126
 msgid "Begin typing post title, click autocomplete result to select."
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:121
 msgid "Autocomplete with Suggestions (multi-select)"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:125
 msgid "Search widgets"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:143
 msgid "Plugin toggles"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:150
 msgid "Configure Instant Articles"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:157
 msgid "Web Previews"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:161
-#: src/wizards/componentsDemo/index.js:168
 msgid "Preview Newspack Blog"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:175
 msgid "Waiting"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:181
 msgid "Spinner on the left"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:185
 msgid "Spinner on the right"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:192
 msgid "Color picker"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:194
 msgid "Color Picker"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:200
 msgid "Handoff Buttons"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:203
 msgid "Manage AMP"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:204
 msgid "Click to go to the AMP dashboard. There will be a notification bar at the top with a link to return to Newspack."
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:219
 msgid "Specific Yoast Page"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:224
 msgid "Modal"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:227
 msgid "Open modal"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:232
 msgid "This is the modal title"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:236
 msgid "Based on industry research, we advise to test the modal component, and continuing this sentence so we can see how the text wraps is one good way of doing that."
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:246
 msgid "Also dismiss"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:253
 msgid "Notice"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:254
 msgid "This is an info notice."
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:255
 msgid "This is an error notice."
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:256
 msgid "This is a help notice."
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:257
 msgid "This is a success notice."
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:258
 msgid "This is a warning notice."
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:261
 msgid "Plugin installer"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:276
 msgid "Plugin installer (small)"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:292
 msgid "Example One"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:293
 msgid "Has an action button."
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:300
 msgid "Example Two"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:301
 msgid "Has action button and secondary button."
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:313
 msgid "Example Three"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:314
 msgid "Waiting/in-progress state, no action button."
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:319
 msgid "Example Four"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:320
 msgid "Error notification"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:333
 msgid "Example Five"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:334
 msgid "Warning notification, action button"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:344
 msgid "Example Six"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:345
 msgid "Static text, no button"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:346
-#: src/wizards/componentsDemo/index.js:351
 msgid "Active"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:349
 msgid "Example Seven"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:350
 msgid "Static text, secondary action button."
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:359
 msgid "Example Eight"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:360
 msgid "Image with link and action button."
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:369
 msgid "Example Nine"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:370
 msgid "Action Card with Toggle Control."
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:379
-#: src/wizards/componentsDemo/index.js:415
 msgid "Premium"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:380
 msgid "Example Ten"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:381
 msgid "An example of an action card with a badge."
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:389
 msgid "Example Eleven"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:390
 msgid "An example of a small action card."
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:391
 msgid "Installing"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:397
 msgid "Example Twelve"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:398
 msgid "Action card with an unchecked checkbox."
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:406
 msgid "Example Thirteen"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:407
 msgid "Action card with a checked checkbox."
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:415
 msgid "Archived"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:416
 msgid "Example Fourteen"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:417
 msgid "An example of an action card with two badges."
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:424
-#: src/wizards/componentsDemo/index.js:430
+msgid "It works"
+msgstr ""
+
+#: dist/componentsDemo.js:1
+#: release/newspack-plugin/dist/componentsDemo.js:1
+msgid "Example Fifteen"
+msgstr ""
+
+#: dist/componentsDemo.js:1
+#: release/newspack-plugin/dist/componentsDemo.js:1
+msgid "An example of an action card with a success badge."
+msgstr ""
+
+#: dist/componentsDemo.js:1
+#: release/newspack-plugin/dist/componentsDemo.js:1
+msgid "Uh oh"
+msgstr ""
+
+#: dist/componentsDemo.js:1
+#: release/newspack-plugin/dist/componentsDemo.js:1
+msgid "Example Sixteen"
+msgstr ""
+
+#: dist/componentsDemo.js:1
+#: release/newspack-plugin/dist/componentsDemo.js:1
+msgid "An example of an action card with a warning badge."
+msgstr ""
+
+#: dist/componentsDemo.js:1
+#: release/newspack-plugin/dist/componentsDemo.js:1
+msgid "Oh no"
+msgstr ""
+
+#: dist/componentsDemo.js:1
+#: release/newspack-plugin/dist/componentsDemo.js:1
+msgid "Example Seventeen"
+msgstr ""
+
+#: dist/componentsDemo.js:1
+#: release/newspack-plugin/dist/componentsDemo.js:1
+msgid "An example of an action card with an error badge."
+msgstr ""
+
+#: dist/componentsDemo.js:1
+#: release/newspack-plugin/dist/componentsDemo.js:1
 msgid "Handoff"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:425
 msgid "An example of an action card with Handoff."
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:431
 msgid " An example of an action card with Handoff and EditLink."
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:441
 msgid "Expandable"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:442
 msgid " An example of an action card with expandable inner content."
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:448
 msgid "Some inner content to display when the card is expanded."
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:455
 msgid "Image Uploader"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:466
 msgid "Progress bar"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:471
-#: src/wizards/componentsDemo/index.js:477
 msgid "Progress made"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:482
 msgid "Select dropdowns"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:485
 msgid "Label for Select with a preselection"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:488
-#: src/wizards/componentsDemo/index.js:499
-#: src/wizards/componentsDemo/index.js:510
-#: src/wizards/componentsDemo/index.js:521
 msgid "- Select -"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:489
-#: src/wizards/componentsDemo/index.js:500
-#: src/wizards/componentsDemo/index.js:511
-#: src/wizards/componentsDemo/index.js:522
-#: src/wizards/componentsDemo/index.js:533
 msgid "First"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:490
-#: src/wizards/componentsDemo/index.js:501
-#: src/wizards/componentsDemo/index.js:512
-#: src/wizards/componentsDemo/index.js:523
-#: src/wizards/componentsDemo/index.js:534
 msgid "Second"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:491
-#: src/wizards/componentsDemo/index.js:502
-#: src/wizards/componentsDemo/index.js:513
-#: src/wizards/componentsDemo/index.js:524
-#: src/wizards/componentsDemo/index.js:535
 msgid "Third"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:496
 msgid "Label for Select with no preselection"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:507
 msgid "Label for disabled Select"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: dist/memberships-gate-editor.js:25
-#: dist/site-design.js:1
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
 #: release/newspack-plugin/dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/memberships-gate-editor.js:25
-#: release/newspack-plugin/dist/site-design.js:1
-#: src/memberships-gate/editor.js:30
-#: src/wizards/componentsDemo/index.js:517
-#: src/wizards/componentsDemo/index.js:587
-#: src/wizards/site-design/views/theme-settings/index.js:103
-#: src/wizards/site-design/views/theme-settings/index.js:146
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
 msgid "Small"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:530
 msgid "Multi-select"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:536
 msgid "Fourth"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:537
 msgid "Fifth"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:538
 msgid "Sixth"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:539
 msgid "Seventh"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:546
 msgid "Selected:"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:549
 msgid "none"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:556
 msgid "Buttons"
 msgstr ""
 
 #: dist/componentsDemo.js:1
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: dist/setup.js:7
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:559
-#: src/wizards/componentsDemo/index.js:565
-#: src/wizards/componentsDemo/index.js:581
-#: src/wizards/componentsDemo/index.js:599
-msgid "Default"
-msgstr ""
-
-#: dist/componentsDemo.js:1
-#: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:562
-#: src/wizards/componentsDemo/index.js:573
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+#: release/newspack-plugin/dist/setup.js:7
 msgid "Primary"
 msgstr ""
 
 #: dist/componentsDemo.js:1
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: dist/setup.js:7
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:563
-#: src/wizards/componentsDemo/index.js:576
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+#: release/newspack-plugin/dist/setup.js:7
 msgid "Secondary"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:564
-#: src/wizards/componentsDemo/index.js:579
 msgid "Tertiary"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:566
-#: src/wizards/componentsDemo/index.js:583
-#: src/wizards/componentsDemo/index.js:601
 msgid "isLink"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:569
-msgid "Disabled"
-msgstr ""
-
-#: dist/componentsDemo.js:1
-#: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:591
 msgid "isPrimary"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:594
 msgid "isSecondary"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:597
 msgid "isTertiary"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:607
 msgid "ButtonCard"
 msgstr ""
 
 #: dist/componentsDemo.js:1
-#: dist/site-design.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: release/newspack-plugin/dist/site-design.js:1
-#: src/wizards/componentsDemo/index.js:610
-#: src/wizards/site-design/index.js:104
-#: src/wizards/site-design/index.js:124
-msgid "Site Design"
-msgstr ""
-
-#: dist/componentsDemo.js:1
-#: dist/site-design.js:1
-#: release/newspack-plugin/dist/componentsDemo.js:1
-#: release/newspack-plugin/dist/site-design.js:1
-#: src/wizards/componentsDemo/index.js:611
-#: src/wizards/site-design/index.js:105
 msgid "Customize the look and feel of your site"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:617
 msgid "Start a new site"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:618
 msgid "You don't have content to import"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:625
 msgid "Migrate an existing site"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:626
 msgid "You have content to import"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:633
 msgid "Add a new Podcast"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:642
 msgid "Add a new Font"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:652
 msgid "Plugin Settings Section"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:655
 msgid "Example plugin settings"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:656
 msgid "Example plugin settings description"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:662
 msgid "Example Text Field"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:663
 msgid "Example text field help text"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:664
 msgid "Example Value"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:669
 msgid "Example checkbox Field"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:670
 msgid "Example checkbox field help text"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:676
 msgid "Example options field"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:677
 msgid "Example options field help text"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:681
-#: src/wizards/componentsDemo/index.js:698
 msgid "Example Value 1"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:685
-#: src/wizards/componentsDemo/index.js:702
 msgid "Example Value 2"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:692
 msgid "Example multiple options field"
 msgstr ""
 
 #: dist/componentsDemo.js:1
 #: release/newspack-plugin/dist/componentsDemo.js:1
-#: src/wizards/componentsDemo/index.js:693
 msgid "Example multiple options field help text"
 msgstr ""
 
-#: dist/connections.js:1
-#: release/newspack-plugin/dist/connections.js:1
-#: src/wizards/connections/views/main/plugins.js:37
-msgid "Site Kit by Google"
+#: dist/componentsDemo.js:1
+#: release/newspack-plugin/dist/componentsDemo.js:1
+msgid "Box Contrast"
 msgstr ""
 
-#: dist/connections.js:1
-#: release/newspack-plugin/dist/connections.js:1
-#: src/wizards/connections/views/main/plugins.js:39
-msgid "Not connected for this user"
+#: dist/componentsDemo.js:1
+#: release/newspack-plugin/dist/componentsDemo.js:1
+msgid "Demo 1:"
 msgstr ""
 
-#: dist/connections.js:1
-#: release/newspack-plugin/dist/connections.js:1
-#: src/wizards/connections/views/main/plugins.js:48
-msgid "Everlit"
+#: dist/componentsDemo.js:1
+#: release/newspack-plugin/dist/componentsDemo.js:1
+msgid "Demo 2:"
 msgstr ""
 
-#: dist/connections.js:1
-#: release/newspack-plugin/dist/connections.js:1
-#: src/wizards/connections/views/main/plugins.js:49
-msgid "AI-Generated Audio Stories"
-msgstr ""
-
-#: dist/connections.js:1
-#: release/newspack-plugin/dist/connections.js:1
-#: src/wizards/connections/views/main/plugins.js:53
-msgid "Complete setup and licensing agreement to unlock 5 free audio stories per month."
-msgstr ""
-
-#: dist/connections.js:1
-#: dist/engagement.js:5
-#: dist/engagement.js:11
-#: dist/engagement.js:20
-#: release/newspack-plugin/dist/connections.js:1
-#: release/newspack-plugin/dist/engagement.js:5
-#: release/newspack-plugin/dist/engagement.js:11
-#: release/newspack-plugin/dist/engagement.js:20
-#: src/wizards/connections/views/main/plugins.js:58
-#: src/wizards/engagement/views/reader-activation/complete.js:153
-#: src/wizards/engagement/views/reader-activation/index.js:184
-msgid "Learn more"
-msgstr ""
-
-#: dist/connections.js:1
-#: release/newspack-plugin/dist/connections.js:1
-#: src/wizards/connections/views/main/plugins.js:63
-msgid "Not installed."
-msgstr ""
-
-#: dist/connections.js:1
-#: dist/connections.js:3
-#: release/newspack-plugin/dist/connections.js:1
-#: release/newspack-plugin/dist/connections.js:3
-#: src/wizards/connections/views/main/plugins.js:64
-#: src/wizards/connections/views/main/plugins.js:139
-msgid "Inactive."
-msgstr ""
-
-#: dist/connections.js:1
-#: release/newspack-plugin/dist/connections.js:1
-#: src/wizards/connections/views/main/plugins.js:65
-msgid "Pending."
-msgstr ""
-
-#: dist/connections.js:1
-#: release/newspack-plugin/dist/connections.js:1
-#: src/wizards/connections/views/main/plugins.js:83
-msgid "Page reloading…"
-msgstr ""
-
-#: dist/connections.js:1
-#: release/newspack-plugin/dist/connections.js:1
-#: src/wizards/connections/views/main/plugins.js:109
-msgid "Complete Setup"
-msgstr ""
-
-#. translators: %s: Plugin name
-#: dist/connections.js:2
-#: release/newspack-plugin/dist/connections.js:2
-#: src/wizards/connections/views/main/plugins.js:103
-msgid "Activate %s"
-msgstr ""
-
-#. translators: %s: Plugin name
-#: dist/connections.js:3
-#: release/newspack-plugin/dist/connections.js:3
-#: src/wizards/connections/views/main/plugins.js:93
-msgid "Install %s"
-msgstr ""
-
-#: dist/connections.js:3
-#: release/newspack-plugin/dist/connections.js:3
-#: src/wizards/connections/views/main/mailchimp.js:107
-#: src/wizards/connections/views/main/plugins.js:144
-msgid "Connected"
-msgstr ""
-
-#: dist/connections.js:3
-#: release/newspack-plugin/dist/connections.js:3
-#: src/wizards/connections/views/main/plugins.js:142
-msgid "Not connected."
-msgstr ""
-
-#: dist/connections.js:3
-#: release/newspack-plugin/dist/connections.js:3
-#: src/wizards/connections/views/main/plugins.js:137
-msgid "Uninstalled."
-msgstr ""
-
-#: dist/connections.js:3
-#: release/newspack-plugin/dist/connections.js:3
-#: src/wizards/connections/views/main/mailchimp.js:66
-msgid "Something went wrong during verification of your Mailchimp API key."
-msgstr ""
-
-#: dist/connections.js:3
-#: release/newspack-plugin/dist/connections.js:3
-#: src/wizards/connections/views/main/mailchimp.js:134
-msgid "Add Mailchimp API Key"
-msgstr ""
-
-#: dist/connections.js:3
-#: release/newspack-plugin/dist/connections.js:3
-#: src/wizards/connections/views/main/mailchimp.js:141
-msgid "Mailchimp API Key"
-msgstr ""
-
-#: dist/connections.js:3
-#: release/newspack-plugin/dist/connections.js:3
-#: src/wizards/connections/views/main/mailchimp.js:154
-msgid "Find or generate your API key"
-msgstr ""
-
-#: dist/connections.js:3
-#: release/newspack-plugin/dist/connections.js:3
-#: src/wizards/connections/views/main/mailchimp.js:104
-msgid "Connecting…"
-msgstr ""
-
-#: dist/connections.js:3
-#: release/newspack-plugin/dist/connections.js:3
-#: src/wizards/connections/views/main/fivetran.js:23
-msgid "Stripe"
-msgstr ""
-
-#: dist/connections.js:3
-#: release/newspack-plugin/dist/connections.js:3
-#: src/wizards/connections/views/main/fivetran.js:91
-msgid "In order to use the this features, you must read and accept"
-msgstr ""
-
-#: dist/connections.js:3
-#: release/newspack-plugin/dist/connections.js:3
-#: src/wizards/connections/views/main/fivetran.js:93
-msgid "Newspack Terms of Service"
-msgstr ""
-
-#: dist/connections.js:3
-#: release/newspack-plugin/dist/connections.js:3
-#: src/wizards/connections/views/main/fivetran.js:111
-msgid "I've read and accept Newspack Terms of Service"
-msgstr ""
-
-#: dist/connections.js:3
-#: release/newspack-plugin/dist/connections.js:3
-#: src/wizards/connections/views/main/fivetran.js:38
-msgid "Sync is in progress – please check back in a while."
-msgstr ""
-
-#: dist/connections.js:3
-#: release/newspack-plugin/dist/connections.js:3
-#: src/wizards/connections/views/main/fivetran.js:124
-msgid "Re-connect"
-msgstr ""
-
-#: dist/connections.js:3
-#: release/newspack-plugin/dist/connections.js:3
-#: src/wizards/connections/views/main/recaptcha.js:39
-msgid "Error fetching settings."
-msgstr ""
-
-#: dist/connections.js:3
-#: release/newspack-plugin/dist/connections.js:3
-#: src/wizards/connections/views/main/recaptcha.js:53
-msgid "Your site key and secret must match the selected reCAPTCHA version. Please enter new credentials."
-msgstr ""
-
-#: dist/connections.js:3
-#: release/newspack-plugin/dist/connections.js:3
-#: src/wizards/connections/views/main/recaptcha.js:74
-msgid "Error updating settings."
-msgstr ""
-
-#: dist/connections.js:3
-#: release/newspack-plugin/dist/connections.js:3
-#: src/wizards/connections/views/main/recaptcha.js:90
-msgid "Use reCAPTCHA"
-msgstr ""
-
-#: dist/connections.js:3
-#: release/newspack-plugin/dist/connections.js:3
-#: src/wizards/connections/views/main/recaptcha.js:93
-msgid "Enabling reCAPTCHA can help protect your site against bot attacks and credit card testing."
-msgstr ""
-
-#: dist/connections.js:3
-#: release/newspack-plugin/dist/connections.js:3
-#: src/wizards/connections/views/main/recaptcha.js:98
-msgid "Get started"
-msgstr ""
-
-#: dist/connections.js:3
-#: dist/engagement.js:1
-#: dist/engagement.js:20
-#: dist/readerRevenue.js:1
-#: dist/setup.js:1
-#: release/newspack-plugin/dist/connections.js:3
-#: release/newspack-plugin/dist/engagement.js:1
-#: release/newspack-plugin/dist/engagement.js:20
-#: release/newspack-plugin/dist/readerRevenue.js:1
-#: release/newspack-plugin/dist/setup.js:1
-#: src/wizards/connections/views/main/recaptcha.js:112
-#: src/wizards/engagement/index.js:186
-#: src/wizards/engagement/views/newsletters/index.js:170
-#: src/wizards/readerRevenue/views/stripe-setup/index.js:249
-msgid "Save Settings"
-msgstr ""
-
-#: dist/connections.js:3
-#: release/newspack-plugin/dist/connections.js:3
-#: src/wizards/connections/views/main/recaptcha.js:123
-msgid "You must enter a valid site key and secret to use reCAPTCHA."
-msgstr ""
-
-#: dist/connections.js:3
-#: release/newspack-plugin/dist/connections.js:3
-#: src/wizards/connections/views/main/recaptcha.js:132
-#: src/wizards/connections/views/main/recaptcha.js:140
-msgid "reCAPTCHA Version"
-msgstr ""
-
-#: dist/connections.js:3
-#: release/newspack-plugin/dist/connections.js:3
-#: src/wizards/connections/views/main/recaptcha.js:135
-msgid "Learn more about reCAPTCHA versions"
-msgstr ""
-
-#: dist/connections.js:3
-#: release/newspack-plugin/dist/connections.js:3
-#: src/wizards/connections/views/main/recaptcha.js:148
-msgid "Score based (v3)"
-msgstr ""
-
-#: dist/connections.js:3
-#: release/newspack-plugin/dist/connections.js:3
-#: src/wizards/connections/views/main/recaptcha.js:151
-msgid "Challenge (v2) - invisible reCAPTCHA badge"
-msgstr ""
-
-#: dist/connections.js:3
-#: release/newspack-plugin/dist/connections.js:3
-#: src/wizards/connections/views/main/recaptcha.js:160
-msgid "Site Key"
-msgstr ""
-
-#: dist/connections.js:3
-#: release/newspack-plugin/dist/connections.js:3
-#: src/wizards/connections/views/main/recaptcha.js:177
-msgid "Site Secret"
-msgstr ""
-
-#: dist/connections.js:3
-#: release/newspack-plugin/dist/connections.js:3
-#: src/wizards/connections/views/main/recaptcha.js:198
-msgid "Threshold"
-msgstr ""
-
-#: dist/connections.js:3
-#: release/newspack-plugin/dist/connections.js:3
-#: src/wizards/connections/views/main/recaptcha.js:205
-msgid "Learn more about the threshold value"
-msgstr ""
-
-#: dist/connections.js:3
-#: release/newspack-plugin/dist/connections.js:3
-#: src/wizards/connections/views/main/webhooks.js:86
-msgid "Endpoint Actions"
-msgstr ""
-
-#: dist/connections.js:3
-#: release/newspack-plugin/dist/connections.js:3
-#: src/wizards/connections/views/main/webhooks.js:96
-msgid "Close Endpoint Actions"
-msgstr ""
-
-#: dist/connections.js:3
-#: release/newspack-plugin/dist/connections.js:3
-#: src/wizards/connections/views/main/webhooks.js:99
-msgid "View Requests"
-msgstr ""
-
-#: dist/connections.js:3
-#: release/newspack-plugin/dist/connections.js:3
-#: src/wizards/connections/views/main/webhooks.js:126
-msgid "Confirm"
-msgstr ""
-
-#: dist/connections.js:3
-#: release/newspack-plugin/dist/connections.js:3
-#: src/wizards/connections/views/main/webhooks.js:260
-msgid "Webhook Endpoints"
-msgstr ""
-
-#: dist/connections.js:3
-#: release/newspack-plugin/dist/connections.js:3
-#: src/wizards/connections/views/main/webhooks.js:261
-msgid "Register webhook endpoints to integrate reader activity data to third-party services or private APIs"
-msgstr ""
-
-#: dist/connections.js:3
-#: release/newspack-plugin/dist/connections.js:3
-#: src/wizards/connections/views/main/webhooks.js:272
-msgid "Add New Endpoint"
-msgstr ""
-
-#: dist/connections.js:3
-#: release/newspack-plugin/dist/connections.js:3
-#: src/wizards/connections/views/main/webhooks.js:290
-msgid "This endpoint is disabled due to excessive request errors"
-msgstr ""
-
-#: dist/connections.js:3
-#: release/newspack-plugin/dist/connections.js:3
-#: src/wizards/connections/views/main/webhooks.js:300
-msgid "Actions:"
-msgstr ""
-
-#: dist/connections.js:3
-#: release/newspack-plugin/dist/connections.js:3
-#: src/wizards/connections/views/main/webhooks.js:303
-msgid "global"
-msgstr ""
-
-#: dist/connections.js:3
-#: release/newspack-plugin/dist/connections.js:3
-#: src/wizards/connections/views/main/webhooks.js:329
-msgid "Remove Endpoint"
-msgstr ""
-
-#. translators: %s: endpoint title
-#: dist/connections.js:4
-#: release/newspack-plugin/dist/connections.js:4
-#: src/wizards/connections/views/main/webhooks.js:332
-msgid "Are you sure you want to remove the endpoint %s?"
-msgstr ""
-
-#: dist/connections.js:4
-#: release/newspack-plugin/dist/connections.js:4
-#: src/wizards/connections/views/main/webhooks.js:344
-msgid "Enable Endpoint"
-msgstr ""
-
-#: dist/connections.js:4
-#: release/newspack-plugin/dist/connections.js:4
-#: src/wizards/connections/views/main/webhooks.js:345
-msgid "Disable Endpoint"
-msgstr ""
-
-#. translators: %s: endpoint title
-#: dist/connections.js:5
-#: release/newspack-plugin/dist/connections.js:5
-#: src/wizards/connections/views/main/webhooks.js:351
-msgid "Are you sure you want to enable the endpoint %s?"
-msgstr ""
-
-#. translators: %s: endpoint title
-#: dist/connections.js:6
-#: release/newspack-plugin/dist/connections.js:6
-#: src/wizards/connections/views/main/webhooks.js:355
-msgid "Are you sure you want to disable the endpoint %s?"
-msgstr ""
-
-#: dist/connections.js:6
-#: release/newspack-plugin/dist/connections.js:6
-#: src/wizards/connections/views/main/webhooks.js:367
-msgid "Latest Requests"
-msgstr ""
-
-#. translators: %s is the endpoint title (shortened URL).
-#: dist/connections.js:9
-#: release/newspack-plugin/dist/connections.js:9
-#: src/wizards/connections/views/main/webhooks.js:373
-msgid "Most recent requests for %s"
-msgstr ""
-
-#: dist/connections.js:9
-#: release/newspack-plugin/dist/connections.js:9
-#: src/wizards/connections/views/main/webhooks.js:387
-msgid "Error"
-msgstr ""
-
-#. translators: %s is a human-readable time difference.
-#: dist/connections.js:12
-#: release/newspack-plugin/dist/connections.js:12
-#: src/wizards/connections/views/main/webhooks.js:400
-msgid "sending in %s"
-msgstr ""
-
-#. translators: %s is a human-readable time difference.
-#: dist/connections.js:15
-#: release/newspack-plugin/dist/connections.js:15
-#: src/wizards/connections/views/main/webhooks.js:405
-msgid "processed %s"
-msgstr ""
-
-#. translators: %s is the number of errors.
-#: dist/connections.js:18
-#: release/newspack-plugin/dist/connections.js:18
-#: src/wizards/connections/views/main/webhooks.js:420
-msgid "Attempt #%s"
-msgstr ""
-
-#: dist/connections.js:18
-#: release/newspack-plugin/dist/connections.js:18
-#: src/wizards/connections/views/main/webhooks.js:432
-msgid "This endpoint hasn't received any requests yet."
-msgstr ""
-
-#: dist/connections.js:18
-#: release/newspack-plugin/dist/connections.js:18
-#: src/wizards/connections/views/main/webhooks.js:442
-msgid "Webhook Endpoint"
-msgstr ""
-
-#: dist/connections.js:18
-#: release/newspack-plugin/dist/connections.js:18
-#: src/wizards/connections/views/main/webhooks.js:451
-msgid "This webhook endpoint is currently disabled."
-msgstr ""
-
-#: dist/connections.js:18
-#: release/newspack-plugin/dist/connections.js:18
-#: src/wizards/connections/views/main/webhooks.js:458
-msgid "Request Error: "
-msgstr ""
-
-#: dist/connections.js:18
-#: release/newspack-plugin/dist/connections.js:18
-#: src/wizards/connections/views/main/webhooks.js:465
-msgid "Test Error: "
-msgstr ""
-
-#: dist/connections.js:18
-#: release/newspack-plugin/dist/connections.js:18
-#: src/wizards/connections/views/main/webhooks.js:471
-msgid "URL"
-msgstr ""
-
-#: dist/connections.js:18
-#: release/newspack-plugin/dist/connections.js:18
-#: src/wizards/connections/views/main/webhooks.js:472
-msgid "The URL to send requests to. It's required for the URL to be under a valid TLS/SSL certificate. You can use the test button below to verify the endpoint response."
-msgstr ""
-
-#: dist/connections.js:18
-#: release/newspack-plugin/dist/connections.js:18
-#: src/wizards/connections/views/main/webhooks.js:482
-msgid "Authentication token (optional)"
-msgstr ""
-
-#: dist/connections.js:18
-#: release/newspack-plugin/dist/connections.js:18
-#: src/wizards/connections/views/main/webhooks.js:483
-msgid "If your endpoint requires a token authentication, enter it here. It will be sent as a Bearer token in the Authorization header."
-msgstr ""
-
-#: dist/connections.js:18
-#: release/newspack-plugin/dist/connections.js:18
-#: src/wizards/connections/views/main/webhooks.js:507
-msgid "Send a test request"
-msgstr ""
-
-#: dist/connections.js:18
-#: release/newspack-plugin/dist/connections.js:18
-#: src/wizards/connections/views/main/webhooks.js:513
-msgid "Label (optional)"
-msgstr ""
-
-#: dist/connections.js:18
-#: release/newspack-plugin/dist/connections.js:18
-#: src/wizards/connections/views/main/webhooks.js:514
-msgid "A label to help you identify this endpoint. It will not be sent to the endpoint."
-msgstr ""
-
-#: dist/connections.js:18
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/connections.js:18
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/connections/views/main/webhooks.js:523
-#: src/wizards/popups/views/campaigns/index.js:237
-msgid "Actions"
-msgstr ""
-
-#: dist/connections.js:18
-#: release/newspack-plugin/dist/connections.js:18
-#: src/wizards/connections/views/main/webhooks.js:527
-msgid "Global"
-msgstr ""
-
-#: dist/connections.js:18
-#: release/newspack-plugin/dist/connections.js:18
-#: src/wizards/connections/views/main/webhooks.js:528
-msgid "Leave this checked if you want this endpoint to receive data from all actions."
-msgstr ""
-
-#: dist/connections.js:18
-#: release/newspack-plugin/dist/connections.js:18
-#: src/wizards/connections/views/main/webhooks.js:537
-msgid "If this endpoint is not global, select which actions should trigger this endpoint:"
-msgstr ""
-
-#: dist/connections.js:18
-#: release/newspack-plugin/dist/connections.js:18
-#: src/wizards/connections/views/main/index.js:29
-msgid "APIs"
-msgstr ""
-
-#: dist/connections.js:18
-#: release/newspack-plugin/dist/connections.js:18
-#: src/wizards/connections/views/main/index.js:31
-msgid "Google: "
-msgstr ""
-
-#: dist/connections.js:18
-#: release/newspack-plugin/dist/connections.js:18
-#: src/wizards/connections/views/main/index.js:33
-msgid "Mailchimp: "
-msgstr ""
-
-#: dist/connections.js:18
-#: release/newspack-plugin/dist/connections.js:18
-#: src/wizards/connections/views/main/index.js:38
-msgid "Fivetran: "
-msgstr ""
-
-#: dist/connections.js:18
-#: release/newspack-plugin/dist/connections.js:18
-#: src/wizards/connections/views/main/index.js:42
-msgid "reCAPTCHA: "
-msgstr ""
-
-#: dist/connections.js:18
-#: release/newspack-plugin/dist/connections.js:18
-#: src/wizards/connections/index.js:24
-msgid "Connections"
-msgstr ""
-
-#: dist/connections.js:18
-#: release/newspack-plugin/dist/connections.js:18
-#: src/wizards/connections/index.js:25
-msgid "Connections to third-party services"
-msgstr ""
-
-#: dist/engagement.js:1
-#: dist/setup.js:1
-#: release/newspack-plugin/dist/engagement.js:1
-#: release/newspack-plugin/dist/setup.js:1
-#: src/wizards/engagement/views/newsletters/index.js:158
-msgid "Email Service Provider"
-msgstr ""
-
-#: dist/engagement.js:1
-#: dist/setup.js:1
-#: release/newspack-plugin/dist/engagement.js:1
-#: release/newspack-plugin/dist/setup.js:1
-#: src/wizards/engagement/views/newsletters/index.js:159
-msgid "Connect an email service provider (ESP) to author and send newsletters."
-msgstr ""
-
-#: dist/engagement.js:1
-#: dist/setup.js:1
-#: release/newspack-plugin/dist/engagement.js:1
-#: release/newspack-plugin/dist/setup.js:1
-#: src/wizards/engagement/views/newsletters/index.js:178
-msgid "Authorize Application"
-msgstr ""
-
-#. translators: %s is the name of the ESP.
-#: dist/engagement.js:4
-#: dist/setup.js:4
-#: release/newspack-plugin/dist/engagement.js:4
-#: release/newspack-plugin/dist/setup.js:4
-#: src/wizards/engagement/views/newsletters/index.js:182
-msgid "Authorize %s to connect to Newspack."
-msgstr ""
-
-#: dist/engagement.js:4
-#: dist/setup.js:4
-#: release/newspack-plugin/dist/engagement.js:4
-#: release/newspack-plugin/dist/setup.js:4
-#: src/wizards/engagement/views/newsletters/index.js:187
-msgid "Authorize"
-msgstr ""
-
-#: dist/engagement.js:4
-#: dist/setup.js:4
-#: release/newspack-plugin/dist/engagement.js:4
-#: release/newspack-plugin/dist/setup.js:4
-#: src/wizards/engagement/views/newsletters/index.js:194
-msgid "Campaign Monitor support will be deprecated"
-msgstr ""
-
-#: dist/engagement.js:4
-#: dist/setup.js:4
-#: release/newspack-plugin/dist/engagement.js:4
-#: release/newspack-plugin/dist/setup.js:4
-#: src/wizards/engagement/views/newsletters/index.js:314
-msgid "Subscription Lists"
-msgstr ""
-
-#: dist/engagement.js:4
-#: dist/setup.js:4
-#: release/newspack-plugin/dist/engagement.js:4
-#: release/newspack-plugin/dist/setup.js:4
-#: src/wizards/engagement/views/newsletters/index.js:315
-msgid "Manage the lists available to readers for subscription."
-msgstr ""
-
-#: dist/engagement.js:4
-#: dist/setup.js:4
-#: release/newspack-plugin/dist/engagement.js:4
-#: release/newspack-plugin/dist/setup.js:4
-#: src/wizards/engagement/views/newsletters/index.js:324
-msgid "Please save your ESP settings before changing your subscription lists."
-msgstr ""
-
-#: dist/engagement.js:4
-#: dist/setup.js:4
-#: release/newspack-plugin/dist/engagement.js:4
-#: release/newspack-plugin/dist/setup.js:4
-#: src/wizards/engagement/views/newsletters/index.js:339
-msgid "Add New"
-msgstr ""
-
-#: dist/engagement.js:4
-#: dist/setup.js:4
-#: release/newspack-plugin/dist/engagement.js:4
-#: release/newspack-plugin/dist/setup.js:4
-#: src/wizards/engagement/views/newsletters/index.js:343
-msgid "Save Subscription Lists"
-msgstr ""
-
-#: dist/engagement.js:4
-#: dist/setup.js:4
-#: release/newspack-plugin/dist/engagement.js:4
-#: release/newspack-plugin/dist/setup.js:4
-#: src/wizards/engagement/views/newsletters/index.js:377
-msgid "List title"
-msgstr ""
-
-#: dist/engagement.js:4
-#: dist/setup.js:4
-#: release/newspack-plugin/dist/engagement.js:4
-#: release/newspack-plugin/dist/setup.js:4
-#: src/wizards/engagement/views/newsletters/index.js:383
-msgid "List description"
-msgstr ""
-
-#: dist/engagement.js:4
-#: dist/setup.js:4
-#: release/newspack-plugin/dist/engagement.js:4
-#: release/newspack-plugin/dist/setup.js:4
-#: src/wizards/engagement/views/newsletters/index.js:419
-msgid "WooCommerce integration"
-msgstr ""
-
-#: dist/engagement.js:4
-#: dist/engagement.js:17
-#: release/newspack-plugin/dist/engagement.js:4
-#: release/newspack-plugin/dist/engagement.js:17
-msgid "Pending"
-msgstr ""
-
-#: dist/engagement.js:4
-#: dist/engagement.js:17
-#: release/newspack-plugin/dist/engagement.js:4
-#: release/newspack-plugin/dist/engagement.js:17
-msgid "Ready"
-msgstr ""
-
-#: dist/engagement.js:4
-#: dist/engagement.js:20
-#: release/newspack-plugin/dist/engagement.js:4
-#: release/newspack-plugin/dist/engagement.js:20
-#: src/wizards/engagement/views/reader-activation/campaign.js:144
-msgid "Skipped"
-msgstr ""
-
-#: dist/engagement.js:4
-#: release/newspack-plugin/dist/engagement.js:4
-msgid "Unavailable"
-msgstr ""
-
-#. translators: %s: Prerequisite status
-#. Translators: Status of the prompt.
-#: dist/engagement.js:5
-#: dist/engagement.js:17
-#: release/newspack-plugin/dist/engagement.js:5
-#: release/newspack-plugin/dist/engagement.js:17
-msgid "Status: %s"
-msgstr ""
-
-#: dist/engagement.js:5
-#: dist/engagement.js:17
-#: release/newspack-plugin/dist/engagement.js:5
-#: release/newspack-plugin/dist/engagement.js:17
-msgid "Saving…"
-msgstr ""
-
-#. Translators: Save or Update settings.
-#: dist/engagement.js:8
-#: release/newspack-plugin/dist/engagement.js:8
-msgid "%s settings"
-msgstr ""
-
-#: dist/engagement.js:8
-#: dist/engagement.js:20
-#: release/newspack-plugin/dist/engagement.js:8
-#: release/newspack-plugin/dist/engagement.js:20
-msgid "Update"
-msgstr ""
-
-#. Translators: %s is specific instructions for satisfying the prerequisite.
-#: dist/engagement.js:11
-#: release/newspack-plugin/dist/engagement.js:11
-msgid "%1$s%2$sReturn to the Reader Activation page to complete the settings and activate%3$s."
-msgstr ""
-
-#: dist/engagement.js:11
-#: release/newspack-plugin/dist/engagement.js:11
-msgid "Update "
-msgstr ""
-
-#: dist/engagement.js:11
-#: release/newspack-plugin/dist/engagement.js:11
-msgid "Save "
-msgstr ""
-
-#: dist/engagement.js:11
-#: release/newspack-plugin/dist/engagement.js:11
-msgid "Configure "
-msgstr ""
-
-#: dist/engagement.js:11
-#: release/newspack-plugin/dist/engagement.js:11
-#: src/wizards/engagement/components/active-campaign.js:38
-msgid "ActiveCampaign settings"
-msgstr ""
-
-#: dist/engagement.js:11
-#: release/newspack-plugin/dist/engagement.js:11
-#: src/wizards/engagement/components/active-campaign.js:39
-msgid "Settings for the ActiveCampaign integration."
-msgstr ""
-
-#: dist/engagement.js:11
-#: release/newspack-plugin/dist/engagement.js:11
-#: src/wizards/engagement/components/active-campaign.js:42
-msgid "Master List"
-msgstr ""
-
-#: dist/engagement.js:11
-#: release/newspack-plugin/dist/engagement.js:11
-#: src/wizards/engagement/components/active-campaign.js:43
-msgid "Choose a list to which all registered readers will be added."
-msgstr ""
-
-#: dist/engagement.js:11
-#: release/newspack-plugin/dist/engagement.js:11
-#: src/wizards/engagement/components/active-campaign.js:51
-#: src/wizards/engagement/components/mailchimp.js:48
-msgid "None"
-msgstr ""
-
-#: dist/engagement.js:11
-#: release/newspack-plugin/dist/engagement.js:11
-#: src/wizards/engagement/components/metadata-fields.js:16
-msgid "Metadata field settings"
-msgstr ""
-
-#: dist/engagement.js:11
-#: release/newspack-plugin/dist/engagement.js:11
-#: src/wizards/engagement/components/metadata-fields.js:17
-msgid "Select which data to sync for each contact."
-msgstr ""
-
-#: dist/engagement.js:11
-#: release/newspack-plugin/dist/engagement.js:11
-#: src/wizards/engagement/components/metadata-fields.js:20
-msgid "Metadata field prefix"
-msgstr ""
-
-#: dist/engagement.js:11
-#: release/newspack-plugin/dist/engagement.js:11
-#: src/wizards/engagement/components/metadata-fields.js:21
-msgid "A string to prefix metadata fields attached to each contact synced to the ESP. Required to ensure that metadata field names are unique. Default: NP_"
-msgstr ""
-
-#: dist/engagement.js:11
-#: release/newspack-plugin/dist/engagement.js:11
-#: src/wizards/engagement/components/mailchimp.js:38
-msgid "Mailchimp settings"
-msgstr ""
-
-#: dist/engagement.js:11
-#: release/newspack-plugin/dist/engagement.js:11
-#: src/wizards/engagement/components/mailchimp.js:39
-msgid "Settings for the Mailchimp integration."
-msgstr ""
-
-#: dist/engagement.js:11
-#: release/newspack-plugin/dist/engagement.js:11
-#: src/wizards/engagement/components/mailchimp.js:42
-msgid "Audience ID"
-msgstr ""
-
-#: dist/engagement.js:11
-#: release/newspack-plugin/dist/engagement.js:11
-#: src/wizards/engagement/components/mailchimp.js:43
-msgid "Choose an audience to receive reader activity data."
-msgstr ""
-
-#: dist/engagement.js:11
-#: release/newspack-plugin/dist/engagement.js:11
-#: src/components/src/sortable-newsletter-list-control/index.js:55
-msgid "Checked by default"
-msgstr ""
-
-#: dist/engagement.js:11
-#: release/newspack-plugin/dist/engagement.js:11
-#: src/components/src/sortable-newsletter-list-control/index.js:118
-msgid "Add more lists:"
-msgstr ""
-
-#: dist/engagement.js:11
-#: release/newspack-plugin/dist/engagement.js:11
-#: src/components/src/sortable-newsletter-list-control/index.js:120
-msgid "Select lists:"
-msgstr ""
-
-#: dist/engagement.js:11
-#: dist/engagement.js:20
-#: release/newspack-plugin/dist/engagement.js:11
-#: release/newspack-plugin/dist/engagement.js:20
-#: src/wizards/engagement/index.js:86
-#: src/wizards/engagement/views/reader-activation/index.js:176
-msgid "Reader Activation"
-msgstr ""
-
-#: dist/engagement.js:11
-#: release/newspack-plugin/dist/engagement.js:11
-#: src/wizards/engagement/views/reader-activation/index.js:179
-msgid "Newspack’s Reader Activation system is a set of features that aim to increase reader loyalty, promote engagement, and drive revenue. "
-msgstr ""
-
-#: dist/engagement.js:11
-#: release/newspack-plugin/dist/engagement.js:11
-#: src/wizards/engagement/views/reader-activation/index.js:197
-msgid "The following plugins are required."
-msgstr ""
-
-#: dist/engagement.js:11
-#: release/newspack-plugin/dist/engagement.js:11
-#: src/wizards/engagement/views/reader-activation/index.js:203
-msgid "Complete these settings to enable Reader Activation."
-msgstr ""
-
-#: dist/engagement.js:11
-#: release/newspack-plugin/dist/engagement.js:11
-#: src/wizards/engagement/views/reader-activation/index.js:211
-msgid "Reader Activation is enabled."
-msgstr ""
-
-#: dist/engagement.js:11
-#: release/newspack-plugin/dist/engagement.js:11
-#: src/wizards/engagement/views/reader-activation/index.js:216
-msgid "Retrieving status…"
-msgstr ""
-
-#. Translators: Show or Hide advanced settings.
-#. Translators: whether to show or hide advanced settings fields.
-#: dist/engagement.js:14
-#: dist/popups.js:10
-#: release/newspack-plugin/dist/engagement.js:14
-#: release/newspack-plugin/dist/popups.js:10
-#: src/wizards/engagement/views/reader-activation/index.js:245
-#: src/wizards/popups/components/settings-modal/index.js:163
-msgid "%s Advanced Settings"
-msgstr ""
-
-#: dist/engagement.js:14
-#: dist/popups.js:10
-#: release/newspack-plugin/dist/engagement.js:14
-#: release/newspack-plugin/dist/popups.js:10
-#: src/wizards/engagement/views/reader-activation/index.js:246
-#: src/wizards/popups/components/settings-modal/index.js:164
-msgid "Hide"
-msgstr ""
-
-#: dist/engagement.js:14
-#: dist/popups.js:10
-#: release/newspack-plugin/dist/engagement.js:14
-#: release/newspack-plugin/dist/popups.js:10
-#: src/wizards/engagement/views/reader-activation/index.js:246
-#: src/wizards/popups/components/settings-modal/index.js:164
-msgid "Show"
-msgstr ""
-
-#: dist/engagement.js:14
-#: release/newspack-plugin/dist/engagement.js:14
-#: src/wizards/engagement/views/reader-activation/index.js:256
-msgid "Memberships Integration"
-msgstr ""
-
-#: dist/engagement.js:14
-#: release/newspack-plugin/dist/engagement.js:14
-#: src/wizards/engagement/views/reader-activation/index.js:257
-msgid "Improve the reader experience on content gating."
-msgstr ""
-
-#: dist/engagement.js:14
-#: release/newspack-plugin/dist/engagement.js:14
-#: src/wizards/engagement/views/reader-activation/index.js:263
-msgid "Content Gate"
-msgstr ""
-
-#: dist/engagement.js:14
-#: release/newspack-plugin/dist/engagement.js:14
-#: src/wizards/engagement/views/reader-activation/index.js:158
-msgid "Configure the gate rendered on content with restricted access."
-msgstr ""
-
-#: dist/engagement.js:14
-#: release/newspack-plugin/dist/engagement.js:14
-#: src/wizards/engagement/views/reader-activation/index.js:163
-msgid "The gate is currently published."
-msgstr ""
-
-#: dist/engagement.js:14
-#: release/newspack-plugin/dist/engagement.js:14
-#: src/wizards/engagement/views/reader-activation/index.js:168
-msgid "The gate is currently a draft."
-msgstr ""
-
-#: dist/engagement.js:14
-#: release/newspack-plugin/dist/engagement.js:14
-#: src/wizards/engagement/views/reader-activation/index.js:271
-msgid "Require membership in all plans"
-msgstr ""
-
-#: dist/engagement.js:14
-#: release/newspack-plugin/dist/engagement.js:14
-#: src/wizards/engagement/views/reader-activation/index.js:272
-msgid "When enabled, readers must belong to all membership plans that apply to a restricted content item before they are granted access. Otherwise, they will be able to unlock access to that item with membership in any single plan that applies to it."
-msgstr ""
-
-#: dist/engagement.js:14
-#: release/newspack-plugin/dist/engagement.js:14
-#: src/wizards/engagement/views/reader-activation/index.js:283
-msgid "Display memberships on the subscriptions tab"
-msgstr ""
-
-#: dist/engagement.js:14
-#: release/newspack-plugin/dist/engagement.js:14
-#: src/wizards/engagement/views/reader-activation/index.js:284
-msgid "Display memberships that don't have active subscriptions on the My Account Subscriptions tab, so readers can see information like expiration dates."
-msgstr ""
-
-#: dist/engagement.js:14
-#: release/newspack-plugin/dist/engagement.js:14
-#: src/wizards/engagement/views/reader-activation/index.js:300
-msgid "Transactional Email Content"
-msgstr ""
-
-#: dist/engagement.js:14
-#: release/newspack-plugin/dist/engagement.js:14
-#: src/wizards/engagement/views/reader-activation/index.js:301
-msgid "Customize the content of transactional emails."
-msgstr ""
-
-#: dist/engagement.js:14
-#: dist/readerRevenue.js:1
-#: release/newspack-plugin/dist/engagement.js:14
-#: release/newspack-plugin/dist/readerRevenue.js:1
-#: src/wizards/engagement/views/reader-activation/index.js:317
-#: src/wizards/readerRevenue/views/emails/index.js:119
-msgid "Are you sure you want to reset the contents of this email?"
-msgstr ""
-
-#: dist/engagement.js:14
-#: release/newspack-plugin/dist/engagement.js:14
-#: src/wizards/engagement/views/reader-activation/index.js:326
-#: src/wizards/readerRevenue/views/emails/index.js:115
-msgid "Reset"
-msgstr ""
-
-#: dist/engagement.js:14
-#: release/newspack-plugin/dist/engagement.js:14
-#: src/wizards/engagement/views/reader-activation/index.js:335
-msgid "Newsletter Subscription Lists"
-msgstr ""
-
-#: dist/engagement.js:14
-#: release/newspack-plugin/dist/engagement.js:14
-#: src/wizards/engagement/views/reader-activation/index.js:337
-msgid "Present newsletter signup after checkout and registration"
-msgstr ""
-
-#: dist/engagement.js:14
-#: release/newspack-plugin/dist/engagement.js:14
-#: src/wizards/engagement/views/reader-activation/index.js:341
-msgid "Ask readers to sign up for newsletters after creating an account or completing a purchase."
-msgstr ""
-
-#: dist/engagement.js:14
-#: release/newspack-plugin/dist/engagement.js:14
-#: src/wizards/engagement/views/reader-activation/index.js:359
-msgid "Email Service Provider (ESP) Advanced Settings"
-msgstr ""
-
-#: dist/engagement.js:14
-#: release/newspack-plugin/dist/engagement.js:14
-#: src/wizards/engagement/views/reader-activation/index.js:360
-msgid "Settings for Newspack Newsletters integration."
-msgstr ""
-
-#: dist/engagement.js:14
-#: release/newspack-plugin/dist/engagement.js:14
-#: src/wizards/engagement/views/reader-activation/index.js:366
-msgid "Newsletter subscription text on registration"
-msgstr ""
-
-#: dist/engagement.js:14
-#: release/newspack-plugin/dist/engagement.js:14
-#: src/wizards/engagement/views/reader-activation/index.js:367
-msgid "The text to display while subscribing to newsletters from the sign-in modal."
-msgstr ""
-
-#: dist/engagement.js:14
-#: release/newspack-plugin/dist/engagement.js:14
-#: src/wizards/engagement/views/reader-activation/index.js:374
-msgid "Configure options for syncing reader data to the connected ESP."
-msgstr ""
-
-#: dist/engagement.js:14
-#: release/newspack-plugin/dist/engagement.js:14
-#: src/wizards/engagement/views/reader-activation/index.js:380
-msgid "Sync contacts to ESP"
-msgstr ""
-
-#: dist/engagement.js:14
-#: release/newspack-plugin/dist/engagement.js:14
-#: src/wizards/engagement/views/reader-activation/index.js:441
-msgid "Save advanced settings"
-msgstr ""
-
-#: dist/engagement.js:14
-#: release/newspack-plugin/dist/engagement.js:14
-msgid "You have unsaved changes. Discard changes?"
-msgstr ""
-
-#: dist/engagement.js:17
-#: release/newspack-plugin/dist/engagement.js:17
-msgid "Unsaved changes"
-msgstr ""
-
-#: dist/engagement.js:17
-#: release/newspack-plugin/dist/engagement.js:17
-msgid "Select file"
-msgstr ""
-
-#: dist/engagement.js:17
-#: release/newspack-plugin/dist/engagement.js:17
-msgid "Prompt saved."
-msgstr ""
-
-#. Translators: Save or Update settings.
-#: dist/engagement.js:20
-#: release/newspack-plugin/dist/engagement.js:20
-msgid "%s prompt settings"
-msgstr ""
-
-#: dist/engagement.js:20
-#: release/newspack-plugin/dist/engagement.js:20
-msgid "Preview prompt"
-msgstr ""
-
-#: dist/engagement.js:20
-#: release/newspack-plugin/dist/engagement.js:20
-msgid "We recommend"
-msgstr ""
-
-#: dist/engagement.js:20
-#: release/newspack-plugin/dist/engagement.js:20
-#: src/wizards/engagement/views/reader-activation/campaign.js:106
-msgid "Set Up Reader Activation Campaign"
-msgstr ""
-
-#: dist/engagement.js:20
-#: release/newspack-plugin/dist/engagement.js:20
-#: src/wizards/engagement/views/reader-activation/campaign.js:107
-msgid "Preview and customize the prompts, or use our suggested defaults."
-msgstr ""
-
-#: dist/engagement.js:20
-#: release/newspack-plugin/dist/engagement.js:20
-#: src/wizards/engagement/views/reader-activation/campaign.js:121
-msgid "Retrieving prompts…"
-msgstr ""
-
-#: dist/engagement.js:20
-#: release/newspack-plugin/dist/engagement.js:20
-#: src/wizards/engagement/views/reader-activation/campaign.js:62
-msgid "Are you sure you want to skip setting up a reader activation campaign?"
-msgstr ""
-
-#: dist/engagement.js:20
-#: release/newspack-plugin/dist/engagement.js:20
-#: src/wizards/engagement/views/reader-activation/campaign.js:79
-msgid "Server not updated"
-msgstr ""
-
-#: dist/engagement.js:20
-#: release/newspack-plugin/dist/engagement.js:20
-#: src/wizards/engagement/views/reader-activation/campaign.js:142
-msgid "Skipping…"
-msgstr ""
-
-#: dist/engagement.js:20
-#: release/newspack-plugin/dist/engagement.js:20
-#: src/wizards/engagement/views/reader-activation/campaign.js:145
-msgid "Skip"
-msgstr ""
-
-#: dist/engagement.js:20
-#: release/newspack-plugin/dist/engagement.js:20
-#: src/wizards/engagement/views/reader-activation/complete.js:26
-msgid "Your <strong>current segments and prompts</strong> will be deactivated and archived."
-msgstr ""
-
-#: dist/engagement.js:20
-#: release/newspack-plugin/dist/engagement.js:20
-#: src/wizards/engagement/views/reader-activation/complete.js:33
-msgid "<strong>Reader registration</strong> will be activated to enable better targeting for driving engagement and conversations."
-msgstr ""
-
-#: dist/engagement.js:20
-#: release/newspack-plugin/dist/engagement.js:20
-#: src/wizards/engagement/views/reader-activation/complete.js:39
-msgid "The <strong>Reader Activation campaign</strong> will be activated with default segments and settings."
-msgstr ""
-
-#: dist/engagement.js:20
-#: release/newspack-plugin/dist/engagement.js:20
-#: src/wizards/engagement/views/reader-activation/complete.js:48
-msgid "Setting up new segments…"
-msgstr ""
-
-#: dist/engagement.js:20
-#: release/newspack-plugin/dist/engagement.js:20
-#: src/wizards/engagement/views/reader-activation/complete.js:49
-msgid "Activating reader registration…"
-msgstr ""
-
-#: dist/engagement.js:20
-#: release/newspack-plugin/dist/engagement.js:20
-#: src/wizards/engagement/views/reader-activation/complete.js:50
-msgid "Activating Reader Activation Campaign…"
-msgstr ""
-
-#: dist/engagement.js:20
-#: release/newspack-plugin/dist/engagement.js:20
-#: src/wizards/engagement/views/reader-activation/complete.js:112
-msgid "Done!"
-msgstr ""
-
-#: dist/engagement.js:20
-#: release/newspack-plugin/dist/engagement.js:20
-#: src/wizards/engagement/views/reader-activation/complete.js:143
-#: src/wizards/engagement/views/reader-activation/complete.js:186
-msgid "Enable Reader Activation"
-msgstr ""
-
-#: dist/engagement.js:20
-#: release/newspack-plugin/dist/engagement.js:20
-#: src/wizards/engagement/views/reader-activation/complete.js:146
-msgid "An easy way to let your readers register for your site, sign up for newsletters, or become donors and paid members. "
-msgstr ""
-
-#: dist/engagement.js:20
-#: release/newspack-plugin/dist/engagement.js:20
-#: src/wizards/engagement/views/reader-activation/complete.js:170
-msgid "You're all set to enable Reader Activation!"
-msgstr ""
-
-#: dist/engagement.js:20
-#: release/newspack-plugin/dist/engagement.js:20
-#: src/wizards/engagement/views/reader-activation/complete.js:171
-msgid "This is what will happen next:"
-msgstr ""
-
-#: dist/engagement.js:20
-#: release/newspack-plugin/dist/engagement.js:20
-#: src/wizards/engagement/views/social/meta-pixel.js:14
-msgid "Meta Pixel"
-msgstr ""
-
-#: dist/engagement.js:20
-#: release/newspack-plugin/dist/engagement.js:20
-#: src/wizards/engagement/views/social/meta-pixel.js:17
-msgid "Add the Meta pixel (formely known as Facebook pixel) to your site."
-msgstr ""
-
-#: dist/engagement.js:20
-#: release/newspack-plugin/dist/engagement.js:20
-#: src/wizards/engagement/views/social/meta-pixel.js:21
-#: src/wizards/engagement/views/social/twitter-pixel.js:18
-msgid "Pixel ID"
-msgstr ""
-
-#: dist/engagement.js:20
-#: release/newspack-plugin/dist/engagement.js:20
-#: src/wizards/engagement/views/social/meta-pixel.js:23
-msgid "The Meta Pixel ID. You only need to add the number, not the full code. Example: 123456789123456789. You can get this information <linkToFb>here</linkToFb>."
-msgstr ""
-
-#: dist/engagement.js:20
-#: release/newspack-plugin/dist/engagement.js:20
-#: src/wizards/engagement/views/social/twitter-pixel.js:14
-msgid "Twitter Pixel"
-msgstr ""
-
-#: dist/engagement.js:20
-#: release/newspack-plugin/dist/engagement.js:20
-#: src/wizards/engagement/views/social/twitter-pixel.js:16
-msgid "Add the Twitter pixel to your site."
-msgstr ""
-
-#: dist/engagement.js:20
-#: release/newspack-plugin/dist/engagement.js:20
-#: src/wizards/engagement/views/social/twitter-pixel.js:20
-msgid "The Twitter Pixel ID. You only need to add the ID, not the full code. Example: ny3ad. You can read more about it <link>here</link>."
-msgstr ""
-
-#: dist/engagement.js:20
-#: release/newspack-plugin/dist/engagement.js:20
-#: src/wizards/engagement/views/social/index.js:29
-msgid "Publicize"
-msgstr ""
-
-#: dist/engagement.js:20
-#: release/newspack-plugin/dist/engagement.js:20
-#: src/wizards/engagement/views/social/index.js:31
-msgid "Publicize makes it easy to share your site’s posts on several social media networks automatically when you publish a new post."
-msgstr ""
-
-#: dist/engagement.js:20
-#: release/newspack-plugin/dist/engagement.js:20
-#: src/wizards/engagement/views/related-content/index.js:38
-msgid "Related Posts"
-msgstr ""
-
-#: dist/engagement.js:20
-#: release/newspack-plugin/dist/engagement.js:20
-#: src/wizards/engagement/views/related-content/index.js:40
-msgid "Automatically add related content at the bottom of each post."
-msgstr ""
-
-#: dist/engagement.js:20
-#: release/newspack-plugin/dist/engagement.js:20
-#: src/wizards/engagement/views/related-content/index.js:53
-msgid "If set, posts will be shown as related content only if published within the past number of months. If 0, any published post can be shown, regardless of publish date."
-msgstr ""
-
-#: dist/engagement.js:20
-#: release/newspack-plugin/dist/engagement.js:20
-#: src/wizards/engagement/views/related-content/index.js:57
-#: src/wizards/engagement/views/related-content/index.js:59
-msgid "Maximum age of related content, in months"
-msgstr ""
-
-#: dist/engagement.js:20
-#: release/newspack-plugin/dist/engagement.js:20
-#: src/wizards/engagement/index.js:70
-msgid "There was an error saving settings. Please try again."
-msgstr ""
-
-#: dist/engagement.js:20
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/engagement.js:20
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/engagement/index.js:96
-#: src/wizards/popups/views/segments/single-segment.js:233
-msgid "Newsletters"
-msgstr ""
-
-#: dist/engagement.js:20
-#: release/newspack-plugin/dist/engagement.js:20
-#: src/wizards/engagement/index.js:101
-msgid "Social"
-msgstr ""
-
-#: dist/engagement.js:20
-#: release/newspack-plugin/dist/engagement.js:20
-#: src/wizards/engagement/index.js:106
-msgid "Recirculation"
-msgstr ""
-
-#: dist/engagement.js:20
-#: release/newspack-plugin/dist/engagement.js:20
-#: src/wizards/engagement/index.js:111
-msgid "Engagement"
-msgstr ""
-
-#: dist/engagement.js:20
-#: release/newspack-plugin/dist/engagement.js:20
-#: src/wizards/engagement/index.js:125
-msgid "Configure your reader activation settings"
-msgstr ""
-
-#: dist/engagement.js:20
-#: release/newspack-plugin/dist/engagement.js:20
-#: src/wizards/engagement/index.js:137
-#: src/wizards/engagement/index.js:149
-msgid "Preview and customize the reader activation prompts"
-msgstr ""
-
-#: dist/engagement.js:20
-#: release/newspack-plugin/dist/engagement.js:20
-#: src/wizards/engagement/index.js:161
-msgid "Configure your newsletter settings"
-msgstr ""
-
-#: dist/engagement.js:20
-#: release/newspack-plugin/dist/engagement.js:20
-#: src/wizards/engagement/index.js:171
-msgid "Share your content to social media"
-msgstr ""
-
-#: dist/engagement.js:20
-#: release/newspack-plugin/dist/engagement.js:20
-#: src/wizards/engagement/index.js:182
-msgid "Engage visitors with related content"
+#: dist/componentsDemo.js:1
+#: release/newspack-plugin/dist/componentsDemo.js:1
+msgid "Demo 3:"
 msgstr ""
 
 #: dist/handoff-banner.js:1
 #: release/newspack-plugin/dist/handoff-banner.js:1
-#: src/wizards/handoff-banner/index.js:20
 msgid "Return to Newspack after completing configuration"
 msgstr ""
 
 #: dist/handoff-banner.js:1
 #: release/newspack-plugin/dist/handoff-banner.js:1
-#: src/wizards/handoff-banner/index.js:21
 msgid "Back to Newspack"
-msgstr ""
-
-#: dist/health-check.js:1
-#: release/newspack-plugin/dist/health-check.js:1
-#: src/wizards/health-check/views/plugins/index.js:37
-msgid "These plugins shoud be active:"
-msgstr ""
-
-#: dist/health-check.js:1
-#: release/newspack-plugin/dist/health-check.js:1
-#: src/wizards/health-check/views/plugins/index.js:46
-msgid "Newspack does not support these plugins:"
-msgstr ""
-
-#: dist/health-check.js:1
-#: release/newspack-plugin/dist/health-check.js:1
-#: src/wizards/health-check/views/plugins/index.js:59
-msgid "Deactivate All"
-msgstr ""
-
-#: dist/health-check.js:1
-#: release/newspack-plugin/dist/health-check.js:1
-#: src/wizards/health-check/views/plugins/index.js:65
-msgid "No unsupported plugins found."
-msgstr ""
-
-#: dist/health-check.js:1
-#: release/newspack-plugin/dist/health-check.js:1
-#: src/wizards/health-check/views/configuration/index.js:31
-msgid "Jetpack"
-msgstr ""
-
-#: dist/health-check.js:1
-#: release/newspack-plugin/dist/health-check.js:1
-#: src/wizards/health-check/views/configuration/index.js:34
-msgid "Jetpack is connected."
-msgstr ""
-
-#: dist/health-check.js:1
-#: release/newspack-plugin/dist/health-check.js:1
-#: src/wizards/health-check/views/configuration/index.js:35
-msgid "Jetpack is not connected. "
-msgstr ""
-
-#: dist/health-check.js:1
-#: release/newspack-plugin/dist/health-check.js:1
-#: src/wizards/health-check/views/configuration/index.js:42
-msgid "Google Site Kit"
-msgstr ""
-
-#: dist/health-check.js:1
-#: release/newspack-plugin/dist/health-check.js:1
-#: src/wizards/health-check/views/configuration/index.js:45
-msgid "Site Kit is connected."
-msgstr ""
-
-#: dist/health-check.js:1
-#: release/newspack-plugin/dist/health-check.js:1
-#: src/wizards/health-check/views/configuration/index.js:46
-msgid "Site Kit is not connected. "
-msgstr ""
-
-#: dist/health-check.js:1
-#: release/newspack-plugin/dist/health-check.js:1
-#: src/wizards/health-check/index.js:75
-msgid "Configuration"
-msgstr ""
-
-#: dist/health-check.js:1
-#: release/newspack-plugin/dist/health-check.js:1
-#: src/wizards/health-check/index.js:88
-#: src/wizards/health-check/index.js:106
-msgid "Health Check"
-msgstr ""
-
-#: dist/health-check.js:1
-#: release/newspack-plugin/dist/health-check.js:1
-#: src/wizards/health-check/index.js:89
-#: src/wizards/health-check/index.js:107
-msgid "Verify and correct site health issues"
 msgstr ""
 
 #. translators: Overlay Position
 #: dist/memberships-gate-editor.js:3
 #: release/newspack-plugin/dist/memberships-gate-editor.js:3
-#: src/components/src/position-control/index.js:35
 msgid "Top"
 msgstr ""
 
@@ -6085,1830 +9520,2058 @@ msgstr ""
 #: dist/memberships-gate-editor.js:17
 #: release/newspack-plugin/dist/memberships-gate-editor.js:5
 #: release/newspack-plugin/dist/memberships-gate-editor.js:17
-#: src/components/src/position-control/index.js:40
-#: src/components/src/position-control/index.js:71
 msgid "Center"
 msgstr ""
 
 #. translators: Overlay Position
 #: dist/memberships-gate-editor.js:7
 #: release/newspack-plugin/dist/memberships-gate-editor.js:7
-#: src/components/src/position-control/index.js:45
 msgid "Bottom"
 msgstr ""
 
 #. translators: Overlay Position
 #: dist/memberships-gate-editor.js:9
 #: release/newspack-plugin/dist/memberships-gate-editor.js:9
-#: src/components/src/position-control/index.js:51
 msgid "Top Left"
 msgstr ""
 
 #. translators: Overlay Position
 #: dist/memberships-gate-editor.js:11
 #: release/newspack-plugin/dist/memberships-gate-editor.js:11
-#: src/components/src/position-control/index.js:56
 msgid "Top Center"
 msgstr ""
 
 #. translators: Overlay Position
 #: dist/memberships-gate-editor.js:13
 #: release/newspack-plugin/dist/memberships-gate-editor.js:13
-#: src/components/src/position-control/index.js:61
 msgid "Top Right"
 msgstr ""
 
 #. translators: Overlay Position
 #: dist/memberships-gate-editor.js:15
 #: release/newspack-plugin/dist/memberships-gate-editor.js:15
-#: src/components/src/position-control/index.js:66
 msgid "Center Left"
 msgstr ""
 
 #. translators: Overlay Position
 #: dist/memberships-gate-editor.js:19
 #: release/newspack-plugin/dist/memberships-gate-editor.js:19
-#: src/components/src/position-control/index.js:76
 msgid "Center Right"
 msgstr ""
 
 #. translators: Overlay Position
 #: dist/memberships-gate-editor.js:21
 #: release/newspack-plugin/dist/memberships-gate-editor.js:21
-#: src/components/src/position-control/index.js:81
 msgid "Bottom Left"
 msgstr ""
 
 #. translators: Overlay Position
 #: dist/memberships-gate-editor.js:23
 #: release/newspack-plugin/dist/memberships-gate-editor.js:23
-#: src/components/src/position-control/index.js:86
 msgid "Bottom Center"
 msgstr ""
 
 #. translators: Overlay Position
 #: dist/memberships-gate-editor.js:25
 #: release/newspack-plugin/dist/memberships-gate-editor.js:25
-#: src/components/src/position-control/index.js:91
 msgid "Bottom Right"
 msgstr ""
 
 #: dist/memberships-gate-editor.js:25
 #: release/newspack-plugin/dist/memberships-gate-editor.js:25
-#: src/components/src/position-control/index.js:97
 msgid "Select Position"
 msgstr ""
 
 #: dist/memberships-gate-editor.js:25
-#: dist/popups.js:1
-#: dist/popups.js:16
 #: release/newspack-plugin/dist/memberships-gate-editor.js:25
-#: release/newspack-plugin/dist/popups.js:1
-#: release/newspack-plugin/dist/popups.js:16
-#: src/memberships-gate/editor.js:19
-#: src/wizards/popups/components/segment-group/index.js:139
-#: src/wizards/popups/utils.js:61
-msgid "Inline"
-msgstr ""
-
-#: dist/memberships-gate-editor.js:25
-#: release/newspack-plugin/dist/memberships-gate-editor.js:25
-#: src/memberships-gate/editor.js:20
 msgid "Overlay"
 msgstr ""
 
 #: dist/memberships-gate-editor.js:25
 #: release/newspack-plugin/dist/memberships-gate-editor.js:25
-#: src/memberships-gate/editor.js:24
 msgid "center"
 msgstr ""
 
 #: dist/memberships-gate-editor.js:25
 #: release/newspack-plugin/dist/memberships-gate-editor.js:25
-#: src/memberships-gate/editor.js:25
 msgid "bottom"
 msgstr ""
 
 #: dist/memberships-gate-editor.js:25
 #: release/newspack-plugin/dist/memberships-gate-editor.js:25
-#: src/memberships-gate/editor.js:29
 msgid "Extra Small"
 msgstr ""
 
 #: dist/memberships-gate-editor.js:25
 #: release/newspack-plugin/dist/memberships-gate-editor.js:25
-#: src/memberships-gate/editor.js:31
 msgid "Medium"
 msgstr ""
 
 #: dist/memberships-gate-editor.js:25
-#: dist/site-design.js:1
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
 #: release/newspack-plugin/dist/memberships-gate-editor.js:25
-#: release/newspack-plugin/dist/site-design.js:1
-#: src/memberships-gate/editor.js:32
-#: src/wizards/site-design/views/theme-settings/index.js:102
-#: src/wizards/site-design/views/theme-settings/index.js:145
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
 msgid "Large"
 msgstr ""
 
 #: dist/memberships-gate-editor.js:25
 #: release/newspack-plugin/dist/memberships-gate-editor.js:25
-#: src/memberships-gate/editor.js:33
 msgid "Full Width"
 msgstr ""
 
 #. translators: %s is the list of plans.
 #: dist/memberships-gate-editor.js:28
 #: release/newspack-plugin/dist/memberships-gate-editor.js:28
-#: src/memberships-gate/editor.js:62
 msgid "You're currently editing a gate for content restricted by: %s"
 msgstr ""
 
 #: dist/memberships-gate-editor.js:28
 #: release/newspack-plugin/dist/memberships-gate-editor.js:28
-#: src/memberships-gate/editor.js:80
 msgid "Newspack Campaign prompts won't be displayed when rendering gated content."
 msgstr ""
 
 #: dist/memberships-gate-editor.js:28
 #: release/newspack-plugin/dist/memberships-gate-editor.js:28
-#: src/memberships-gate/editor.js:90
 msgid "WooCommerce Memberships"
 msgstr ""
 
 #. translators: %s is the list of plans.
 #: dist/memberships-gate-editor.js:31
 #: release/newspack-plugin/dist/memberships-gate-editor.js:31
-#: src/memberships-gate/editor.js:106
 msgid "This gate will be rendered for the following membership plans: %s"
 msgstr ""
 
 #. translators: %s is the link to the primary gate.
 #: dist/memberships-gate-editor.js:34
 #: release/newspack-plugin/dist/memberships-gate-editor.js:34
-#: src/memberships-gate/editor.js:118
 msgid "Edit the <a href=\"%s\">primary gate</a>, or:"
 msgstr ""
 
 #: dist/memberships-gate-editor.js:34
 #: release/newspack-plugin/dist/memberships-gate-editor.js:34
-#: src/memberships-gate/editor.js:95
 msgid "This gate will be rendered for all membership plans. Manage custom gates for when the content is locked behind a specific plan:"
 msgstr ""
 
 #: dist/memberships-gate-editor.js:34
 #: release/newspack-plugin/dist/memberships-gate-editor.js:34
-#: src/memberships-gate/editor.js:133
 msgid "published"
 msgstr ""
 
 #: dist/memberships-gate-editor.js:34
 #: release/newspack-plugin/dist/memberships-gate-editor.js:34
-#: src/memberships-gate/editor.js:134
 msgid "draft"
 msgstr ""
 
 #: dist/memberships-gate-editor.js:34
 #: release/newspack-plugin/dist/memberships-gate-editor.js:34
-#: src/memberships-gate/editor.js:141
 msgid "edit gate"
 msgstr ""
 
 #: dist/memberships-gate-editor.js:34
 #: release/newspack-plugin/dist/memberships-gate-editor.js:34
-#: src/memberships-gate/editor.js:142
 msgid "create gate"
 msgstr ""
 
 #: dist/memberships-gate-editor.js:34
 #: release/newspack-plugin/dist/memberships-gate-editor.js:34
-#: src/memberships-gate/editor.js:152
 msgid "Styles"
 msgstr ""
 
 #: dist/memberships-gate-editor.js:34
 #: release/newspack-plugin/dist/memberships-gate-editor.js:34
-#: src/memberships-gate/editor.js:169
 msgid "Apply fade to last paragraph"
 msgstr ""
 
 #: dist/memberships-gate-editor.js:34
 #: release/newspack-plugin/dist/memberships-gate-editor.js:34
-#: src/memberships-gate/editor.js:172
 msgid "Whether to apply a gradient fade effect before rendering the gate."
-msgstr ""
-
-#: dist/memberships-gate-editor.js:34
-#: dist/popups.js:7
-#: release/newspack-plugin/dist/memberships-gate-editor.js:34
-#: release/newspack-plugin/dist/popups.js:7
-#: src/memberships-gate/editor.js:187
-#: src/wizards/popups/components/settings-modal/index.js:87
-msgid "Position"
 msgstr ""
 
 #. translators: %s is the placement of the gate.
 #: dist/memberships-gate-editor.js:37
 #: release/newspack-plugin/dist/memberships-gate-editor.js:37
-#: src/memberships-gate/editor.js:194
 msgid "The gate will be displayed at the %s of the screen."
 msgstr ""
 
 #: dist/memberships-gate-editor.js:37
 #: release/newspack-plugin/dist/memberships-gate-editor.js:37
-#: src/memberships-gate/editor.js:209
 msgid "Default paragraph count"
 msgstr ""
 
 #: dist/memberships-gate-editor.js:37
 #: release/newspack-plugin/dist/memberships-gate-editor.js:37
-#: src/memberships-gate/editor.js:211
 msgid "Number of paragraphs that readers can see above the content gate."
 msgstr ""
 
 #: dist/memberships-gate-editor.js:37
 #: release/newspack-plugin/dist/memberships-gate-editor.js:37
-#: src/memberships-gate/editor.js:218
 msgid "Use “More” tag to manually place content gate"
 msgstr ""
 
 #: dist/memberships-gate-editor.js:37
 #: release/newspack-plugin/dist/memberships-gate-editor.js:37
-#: src/memberships-gate/editor.js:221
 msgid "Override the default paragraph count on pages where a “More” block has been placed."
 msgstr ""
 
 #: dist/memberships-gate-editor.js:37
 #: release/newspack-plugin/dist/memberships-gate-editor.js:37
-#: src/memberships-gate/editor.js:229
 msgid "Metering"
 msgstr ""
 
 #: dist/memberships-gate-editor.js:37
 #: release/newspack-plugin/dist/memberships-gate-editor.js:37
-#: src/memberships-gate/editor.js:232
 msgid "Enable metering"
 msgstr ""
 
 #: dist/memberships-gate-editor.js:37
 #: release/newspack-plugin/dist/memberships-gate-editor.js:37
-#: src/memberships-gate/editor.js:235
 msgid "Implement metering to configure access to restricted content before showing the gate."
 msgstr ""
 
 #: dist/memberships-gate-editor.js:37
 #: release/newspack-plugin/dist/memberships-gate-editor.js:37
-#: src/memberships-gate/editor.js:246
 msgid "Available views for anonymous readers"
 msgstr ""
 
 #: dist/memberships-gate-editor.js:37
 #: release/newspack-plugin/dist/memberships-gate-editor.js:37
-#: src/memberships-gate/editor.js:248
 msgid "Number of times an anonymous reader can view gated content. If set to 0, anonymous readers will always render the gate."
 msgstr ""
 
 #: dist/memberships-gate-editor.js:37
 #: release/newspack-plugin/dist/memberships-gate-editor.js:37
-#: src/memberships-gate/editor.js:257
 msgid "Available views for registered readers"
 msgstr ""
 
 #: dist/memberships-gate-editor.js:37
 #: release/newspack-plugin/dist/memberships-gate-editor.js:37
-#: src/memberships-gate/editor.js:259
 msgid "Number of times a registered reader can view gated content. If set to 0, registered readers without membership plan will always render the gate."
 msgstr ""
 
 #: dist/memberships-gate-editor.js:37
 #: release/newspack-plugin/dist/memberships-gate-editor.js:37
-#: src/memberships-gate/editor.js:265
 msgid "Time period"
 msgstr ""
 
 #: dist/memberships-gate-editor.js:37
 #: release/newspack-plugin/dist/memberships-gate-editor.js:37
-#: src/memberships-gate/editor.js:268
 msgid "Day"
 msgstr ""
 
 #: dist/memberships-gate-editor.js:37
 #: release/newspack-plugin/dist/memberships-gate-editor.js:37
-#: src/memberships-gate/editor.js:269
 msgid "Week"
 msgstr ""
 
 #: dist/memberships-gate-editor.js:37
 #: release/newspack-plugin/dist/memberships-gate-editor.js:37
-#: src/memberships-gate/editor.js:270
 msgid "Month"
 msgstr ""
 
 #: dist/memberships-gate-editor.js:37
 #: release/newspack-plugin/dist/memberships-gate-editor.js:37
-#: src/memberships-gate/editor.js:273
 msgid "The time period during which the metering views will be counted. For example, if the metering period is set to a week, the metering views will be reset every week."
+msgstr ""
+
+#: dist/newsletters.js:1
+#: dist/setup.js:4
+#: release/newspack-plugin/dist/newsletters.js:1
+#: release/newspack-plugin/dist/setup.js:4
+msgid "Email Service Provider"
+msgstr ""
+
+#: dist/newsletters.js:1
+#: dist/setup.js:4
+#: release/newspack-plugin/dist/newsletters.js:1
+#: release/newspack-plugin/dist/setup.js:4
+msgid "Connect an email service provider (ESP) to author and send newsletters."
+msgstr ""
+
+#: dist/newsletters.js:1
+#: dist/setup.js:4
+#: release/newspack-plugin/dist/newsletters.js:1
+#: release/newspack-plugin/dist/setup.js:4
+msgid "Authorize Application"
+msgstr ""
+
+#. translators: %s is the name of the ESP.
+#: dist/newsletters.js:4
+#: dist/setup.js:7
+#: release/newspack-plugin/dist/newsletters.js:4
+#: release/newspack-plugin/dist/setup.js:7
+msgid "Authorize %s to connect to Newspack."
+msgstr ""
+
+#: dist/newsletters.js:4
+#: dist/setup.js:7
+#: release/newspack-plugin/dist/newsletters.js:4
+#: release/newspack-plugin/dist/setup.js:7
+msgid "Authorize"
+msgstr ""
+
+#: dist/newsletters.js:4
+#: dist/setup.js:7
+#: release/newspack-plugin/dist/newsletters.js:4
+#: release/newspack-plugin/dist/setup.js:7
+msgid "Campaign Monitor support will be deprecated"
+msgstr ""
+
+#: dist/newsletters.js:4
+#: dist/setup.js:7
+#: release/newspack-plugin/dist/newsletters.js:4
+#: release/newspack-plugin/dist/setup.js:7
+msgid "Please save your ESP settings before changing your subscription lists."
+msgstr ""
+
+#: dist/newsletters.js:4
+#: dist/setup.js:7
+#: release/newspack-plugin/dist/newsletters.js:4
+#: release/newspack-plugin/dist/setup.js:7
+msgid "Subscription Lists"
+msgstr ""
+
+#: dist/newsletters.js:4
+#: dist/setup.js:7
+#: release/newspack-plugin/dist/newsletters.js:4
+#: release/newspack-plugin/dist/setup.js:7
+msgid "Manage the lists available to readers for subscription."
+msgstr ""
+
+#: dist/newsletters.js:4
+#: dist/setup.js:7
+#: release/newspack-plugin/dist/newsletters.js:4
+#: release/newspack-plugin/dist/setup.js:7
+msgid "Add New"
+msgstr ""
+
+#: dist/newsletters.js:4
+#: dist/setup.js:7
+#: release/newspack-plugin/dist/newsletters.js:4
+#: release/newspack-plugin/dist/setup.js:7
+msgid "Save Subscription Lists"
+msgstr ""
+
+#: dist/newsletters.js:4
+#: dist/setup.js:7
+#: release/newspack-plugin/dist/newsletters.js:4
+#: release/newspack-plugin/dist/setup.js:7
+msgid "List title"
+msgstr ""
+
+#: dist/newsletters.js:4
+#: dist/setup.js:7
+#: release/newspack-plugin/dist/newsletters.js:4
+#: release/newspack-plugin/dist/setup.js:7
+msgid "List description"
+msgstr ""
+
+#: dist/newsletters.js:4
+#: release/newspack-plugin/dist/newsletters.js:4
+msgid "Tracking"
+msgstr ""
+
+#: dist/newsletters.js:4
+#: release/newspack-plugin/dist/newsletters.js:4
+msgid "Click-tracking"
+msgstr ""
+
+#: dist/newsletters.js:4
+#: release/newspack-plugin/dist/newsletters.js:4
+msgid "Track the clicks on the links in your newsletter."
+msgstr ""
+
+#: dist/newsletters.js:4
+#: release/newspack-plugin/dist/newsletters.js:4
+msgid "Tracking pixel"
+msgstr ""
+
+#: dist/newsletters.js:4
+#: release/newspack-plugin/dist/newsletters.js:4
+msgid "Track the opens of your newsletter."
+msgstr ""
+
+#: dist/newsletters.js:4
+#: release/newspack-plugin/dist/newsletters.js:4
+msgid "Newsletters / Tracking"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:1
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:1
+msgid "Quick actions"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:1
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:1
+msgid "Add missing dependencies"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:1
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:1
+msgid "Fetching…"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:1
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:1
+msgid "Click to navigate to configuration"
+msgstr ""
+
+#. translators: %s is a comma separated list of needed dependencies.
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:4
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:4
+msgid "Missing dependency"
+msgid_plural "Missing dependencies"
+msgstr[0] ""
+msgstr[1] ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:4
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:4
+msgid "Install dependency"
+msgid_plural "Install dependencies"
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %d is the HTTP status code
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:5
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:5
+msgid "Request failed - %d"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:5
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:5
+msgid "Site status"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:5
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:5
+msgid "Site brands"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:5
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:5
+msgid "You have no saved brands."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:5
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:5
+msgid "Add New Brand"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:5
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:5
+msgid "Fetching brands…"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:5
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:5
+msgid "Create brands to enhance your readers experience."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:5
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:5
+msgid "Brand"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:5
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:5
+msgid "Set your brand identity"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:5
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:5
+msgid "Brand Name"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:5
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:5
+msgid "Fetching logo…"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:5
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:5
+msgid "Logo"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:5
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:31
+#: dist/setup.js:7
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:5
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:31
+#: release/newspack-plugin/dist/setup.js:7
+msgid "Colors"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:5
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:5
+msgid "These are the colors you can customize for this brand in the active theme"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:5
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:5
+msgid "Reset default color"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:5
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:31
+#: dist/setup.js:7
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:5
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:31
+#: release/newspack-plugin/dist/setup.js:7
+msgid "Homepage"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:5
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:5
+msgid "Slug"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:5
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:5
+msgid "Show on Front"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:5
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:5
+msgid "Latest posts"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:5
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:5
+msgid "A page"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:5
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:5
+msgid "Homepage URL"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:5
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:5
+msgid "Select a Page"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:5
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:5
+msgid "Menus"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:5
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:5
+msgid "Customize the menus for this brand"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:5
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:5
+msgid "Same as site"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:5
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:5
+msgid "Brands"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:5
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:5
+msgid "Configure brands settings"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:5
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:5
+msgid "Are you sure you want to delete this brand?"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:8
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:8
+msgid "X (formerly Twitter) Handle"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:8
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:8
+msgid "username"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:8
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:8
+msgid "X handle cannot exceed 15 characters!"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:8
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:8
+msgid "X handle may only contain letters, numbers, and underscores!"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:8
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:8
+msgid "Facebook"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:8
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:8
+msgid "Instagram"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:8
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:8
+msgid "YouTube"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:8
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:8
+msgid "LinkedIn"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:8
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:8
+msgid "Pinterest"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:8
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:8
+msgid "Field cannot be empty!"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:8
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:8
+msgid "Invalid URL!"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:8
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:8
+msgid "Value cannot be empty!"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:8
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:8
+msgid "Value cannot be zero!"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:8
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:8
+msgid "Value may only contain numbers!"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:8
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:8
+msgid "Value may only contain numbers and letters."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:8
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:8
+msgid "X Pixel"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:8
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:8
+msgid "Add the X pixel (formerly known as Twitter pixel) to your site."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:8
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:8
+msgid "Pixel ID"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:8
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:8
+msgid "The X Pixel ID. You only need to add the number, not the full code. Example: 123456789123456789. You can get this information <linkToFb>here</linkToFb>."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:8
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:8
+msgid "Meta Pixel"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:8
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:8
+msgid "Add the Meta pixel (formerly known as Facebook pixel) to your site."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:8
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:8
+msgid "The Meta Pixel ID. You only need to add the number, not the full code. Example: 123456789123456789. You can get this information <linkToFb>here</linkToFb>."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:8
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:8
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Page reloading…"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:8
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:8
+msgid "Page redirecting…"
+msgstr ""
+
+#. translators: %s: Plugin name
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:9
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:9
+msgid "Install %s"
+msgstr ""
+
+#. translators: %s: Plugin name
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:10
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:10
+msgid "Activate %s"
+msgstr ""
+
+#. translators: %s: Plugin name
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:11
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:11
+msgid "Configure %s"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:11
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:11
+msgid "Complete Setup"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:11
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:11
+msgid "Status: Error!"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:11
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:11
+msgid "Connected."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:11
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:11
+msgid "Not connected."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:11
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:14
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:11
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:14
+msgid "Inactive."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:11
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:11
+msgid "Uninstalled."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:14
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:14
+msgid "Publicize"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:14
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:14
+msgid "Publicize makes it easy to share your site's posts on several social media networks automatically when you publish a new post."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:14
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:14
+msgid "Activate Jetpack"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:14
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:14
+msgid "Newspack uses Newspack Newsletters to handle editing email-type content. Please activate this plugin to proceed."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:14
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:14
+msgid "Until this feature is configured, default receipts will be used."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:14
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:14
+msgid "Newspack Newsletters is the plugin that powers Newspack email receipts."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:14
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:14
+msgid "This email is not active."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:14
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:14
+msgid "This email is not active. The default receipt will be used."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:14
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:14
+msgid "This email is not active. The receipt template will be used if active."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:14
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:14
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Reset"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:14
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:14
+msgid "Are you sure you want to reset the contents of this email?"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:14
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:14
+msgid "Site Kit by Google"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:14
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:14
+msgid "Not connected for this user"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:14
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:14
+msgid "AI-Generated Audio Stories"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:14
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:14
+msgid "Complete setup and licensing agreement to unlock 5 free audio stories per month."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:14
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:14
+msgid "Not installed."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:14
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:14
+msgid "Pending."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:14
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:14
+msgid "URL is required."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:14
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:14
+msgid "HTTPS protocol is required for the endpoint URL."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:14
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:14
+msgid "Invalid URL format."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:14
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:14
+msgid "Endpoint Actions"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:14
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:14
+msgid "Close Endpoint Actions"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:14
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:14
+msgid "View Requests"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:14
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:14
+msgid "Endpoint disabled due to error"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:14
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:14
+msgid "Actions:"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:14
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:14
+msgid "Latest Requests"
+msgstr ""
+
+#. translators: %s is the endpoint title (shortened URL).
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:17
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:17
+msgid "Most recent requests for %s"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:17
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:17
+msgid "Error"
+msgstr ""
+
+#. translators: %s is a human-readable time difference.
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:20
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:20
+msgid "sending in %s"
+msgstr ""
+
+#. translators: %s is a human-readable time difference.
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:23
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:23
+msgid "processed %s"
+msgstr ""
+
+#. translators: %s is the number of errors.
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:26
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:26
+msgid "Attempt #%s"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:26
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:26
+msgid "This endpoint hasn't received any requests yet."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:26
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:26
+msgid "Webhook Endpoint"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:26
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:26
+msgid "This webhook endpoint is currently disabled."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:26
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:26
+msgid "Request Error: "
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:26
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:26
+msgid "The URL to send requests to. It's required for the URL to be under a valid TLS/SSL certificate. You can use the test button below to verify the endpoint response."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:26
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:26
+msgid "Authentication token (optional)"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:26
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:26
+msgid "If your endpoint requires a token authentication, enter it here. It will be sent as a Bearer token in the Authorization header."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:26
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:26
+msgid "Send a test request"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:26
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:26
+msgid "Label (optional)"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:26
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:26
+msgid "A label to help you identify this endpoint. It will not be sent to the endpoint."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:26
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:26
+msgid "Select which actions should trigger this endpoint:"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:26
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:26
+msgid "At least one action is required."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:26
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:26
+msgid "Confirm"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:26
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:26
+msgid "Remove Endpoint"
+msgstr ""
+
+#. translators: %s: endpoint title
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:27
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:27
+msgid "Are you sure you want to remove the endpoint %s?"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:27
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:27
+msgid "Enable Endpoint"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:27
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:27
+msgid "Disable Endpoint"
+msgstr ""
+
+#. translators: %s: endpoint title
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:28
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:28
+msgid "Are you sure you want to enable the endpoint %s?"
+msgstr ""
+
+#. translators: %s: endpoint title
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:29
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:29
+msgid "Are you sure you want to disable the endpoint %s?"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:29
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:29
+msgid "Webhook Endpoints"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:29
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:29
+msgid "Register webhook endpoints to integrate reader activity data to third-party services or private APIs"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:29
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:29
+msgid "Add New Endpoint"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:29
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:29
+msgid "No endpoints found"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:29
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:29
+msgid "View"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:29
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:29
+msgid "Site Key cannot be empty!"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:29
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:29
+msgid "Site Secret cannot be empty"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:29
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:29
+msgid "Threshold cannot be less than 0.1"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:29
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:29
+msgid "Threshold cannot be greater than 1"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:29
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:29
+msgid "Your site key and secret must match the selected reCAPTCHA version. Please enter new credentials."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:29
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:29
+msgid "You need a valid Measurement ID (e.g. \"G-ABCDE12345\") to activate Newspack Custom Events."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:29
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:29
+msgid "You need a valid Measurement API Secret to activate Newspack Custom Events."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:29
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:29
+msgid "Use reCAPTCHA"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:29
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:29
+msgid "Enabling reCAPTCHA can help protect your site against bot attacks and credit card testing."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:29
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:29
+msgid "Get started"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:29
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:29
+msgid "reCAPTCHA Version"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:29
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:29
+msgid "Learn more about reCAPTCHA versions"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:29
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:29
+msgid "Score based (v3)"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:29
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:29
+msgid "Challenge (v2) - invisible reCAPTCHA badge"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:29
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:29
+msgid "Site Key"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:29
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:29
+msgid "Site Secret"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:29
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:29
+msgid "Threshold"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:29
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:29
+msgid "Learn more about the threshold value"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:29
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:29
+msgid "Error fetching settings."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:29
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:29
+msgid "Error updating settings."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:29
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:29
+msgid "Force two-factor authentication"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:29
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:29
+msgid "Improve security by requiring two-factor authentication via WordPress.com for users with higher capabilities."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:29
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:29
+msgid "Two-factor authentication is currently enforced for all users via Jetpack configuration."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:29
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:29
+msgid "Customize which capabilties to enforce 2FA by untoggling the “Require accounts to use WordPress.com Two-Step Authentication” option in Jetpack settings."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:29
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:29
+msgid "Select the user capability to enforce two-factor authentication"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:29
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:29
+msgid "Capability"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:29
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:29
+msgid "Obfuscate restricted accounts by throwing WP’s “user not found” errors on login form attempts."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Add Mailchimp API Key"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Mailchimp API Key"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Find or generate your API key"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Connecting…"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Newspack already sends some custom event data to your GA account, but adding the credentials below enables enhanced events that are fired from your site's backend. For example, when a donation is confirmed or when a user successfully subscribes to a newsletter."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Measurement ID"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "You can find this in Site Kit Settings, or in Google Analytics > Admin > Data Streams and clickng the data stream. Example: G-ABCDE12345"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Measurement Protocol API Secret"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Generate an API secret from your GA dashboard in Admin > Data Streams and opening your data stream. Select \"Measurement Protocol API secrets\" under the Events section. Create a new secret."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Are you sure you want to reset the GA4 credentials?"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Create and manage customized RSS feeds for syndication partners"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Related Posts"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Automatically add related content at the bottom of each post."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "If set, posts will be shown as related content only if published within the past number of months. If 0, any published post can be shown, regardless of publish date."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Maximum age of related content, in months"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:31
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:31
+msgid "Author Bio"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Display an author bio under individual posts."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Author Email"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Display the author email with bio on individual posts."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Length"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Truncates the author bio on single posts to this approximate character length, but without breaking a word. The full bio appears on the author archive page."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "You have more than 1000 posts. Applying these settings might take a moment."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Featured image position for all posts"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Set a featured image position for all posts."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Select to change all posts"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Behind article title"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Beside article title"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Hidden"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "After saving the settings with this option selected, all posts will be updated. This cannot be undone."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Template for all posts"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Set a template for all posts."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "With sidebar"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "One Column"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "One Column Wide"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Default featured image position for new posts"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Set a default featured image position for new posts."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Default template for new posts"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Set a default template for new posts."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Credit Class Name"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "A CSS class name to be applied to all image credit elements. Leave blank to display no class name."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Credit Label"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "A label to prefix all media credits. Leave blank to display no prefix."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Placeholder Image"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "A placeholder image to be displayed in place of images without credits. If none is chosen, the image will be displayed normally whether or not it has a credit."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Auto-populate image credits"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Automatically populate image credits from EXIF or IPTC metadata when uploading new images."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Create Page"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Edit Page"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Edit and Publish Page"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Your accessibility statement page has been moved to trash or deleted. Click \"Create Page\" to create a new one."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Your accessibility statement page is published."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Your accessibility statement page is not yet published. Please review and make edits before publishing."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Your accessibility statement page has been moved to trash. Click \"Create Page\" to create a new one."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Accessibility Statement Page"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Edit and publish an accessibility statement page. Once published, a link to this page will display in the footer of your site."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "An accessibility statement helps your readers understand how your site supports accessibility standards and what to do if they encounter accessibility issues. "
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "What makes a good accessibility statement."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "The page you create here will include a boilerplate accessibility statement. "
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Please review and make edits to ensure it meets the requirements before publishing. "
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "You can also use the W3C Accessibility Statement Generator to create a custom statement. "
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Try out the Accessibility Statement Generator."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Learn more about this feature in our documentation."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: dist/setup.js:7
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+#: release/newspack-plugin/dist/setup.js:7
+msgid "Activate Layout"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: dist/setup.js:7
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+#: release/newspack-plugin/dist/setup.js:7
+msgid "Serif"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: dist/setup.js:7
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+#: release/newspack-plugin/dist/setup.js:7
+msgid "Sans Serif"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: dist/setup.js:7
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+#: release/newspack-plugin/dist/setup.js:7
+msgid "Display"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: dist/setup.js:7
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+#: release/newspack-plugin/dist/setup.js:7
+msgid "Monospace"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: dist/setup.js:7
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+#: release/newspack-plugin/dist/setup.js:7
+msgid "XS"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: dist/setup.js:7
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+#: release/newspack-plugin/dist/setup.js:7
+msgid "S"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: dist/setup.js:7
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+#: release/newspack-plugin/dist/setup.js:7
+msgid "M"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: dist/setup.js:7
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+#: release/newspack-plugin/dist/setup.js:7
+msgid "L"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: dist/setup.js:7
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+#: release/newspack-plugin/dist/setup.js:7
+msgid "XL"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: dist/setup.js:7
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+#: release/newspack-plugin/dist/setup.js:7
+msgid "Headings"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: dist/setup.js:7
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+#: release/newspack-plugin/dist/setup.js:7
+msgid "Body"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: dist/setup.js:7
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+#: release/newspack-plugin/dist/setup.js:7
+msgid "Font provider import code or URL"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: dist/setup.js:7
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+#: release/newspack-plugin/dist/setup.js:7
+msgid "Font name"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: dist/setup.js:7
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+#: release/newspack-plugin/dist/setup.js:7
+msgid "Font fallback stack"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: dist/setup.js:7
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+#: release/newspack-plugin/dist/setup.js:7
+msgid "Typography Options"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: dist/setup.js:7
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+#: release/newspack-plugin/dist/setup.js:7
+msgid "Use all-caps for accent text"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Customize collections naming schema"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+msgid "Override labels, messages and other reader-facing elements with custom naming."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Name to be used instead of \"Collections\" (e.g., \"Issues\", \"Magazines\")"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Singular name"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Singular name to be used instead of \"Collection\" (e.g., \"Issue\", \"Magazine\")"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Permalink base slug"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Base slug to be used instead of \"collection\" in permalinks and the REST API (e.g., \"issue\", \"magazine\")"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Plugins"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "APIs"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Jetpack SSO"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Analytics"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Activate Newspack Custom Events"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Allows Newspack to send enhanced custom event data to your Google Analytics."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Invalid Google verification code!"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:30
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Invalid Bing verification code!"
+msgstr ""
+
+#. translators: %1$s: label, %2$s: placeholder
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:31
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:31
+msgid "Invalid URL for \"%1$s\", correct format is \"%2$s\""
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:31
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:31
+msgid "Webmaster Tools"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:31
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:31
+msgid "Add verification meta tags to your site"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:31
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:31
+msgid "Social Accounts"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:31
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:31
+msgid "Let search engines know which social profiles are associated to your site"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:31
+#: dist/setup.js:7
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:31
+#: release/newspack-plugin/dist/setup.js:7
+msgid "Theme"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:31
+#: dist/setup.js:7
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:31
+#: release/newspack-plugin/dist/setup.js:7
+msgid "Update your sites theme."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:31
+#: dist/setup.js:7
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:31
+#: release/newspack-plugin/dist/setup.js:7
+msgid "Select a homepage layout."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:31
+#: dist/setup.js:7
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:31
+#: release/newspack-plugin/dist/setup.js:7
+msgid "Pick your primary and secondary colors."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:31
+#: dist/setup.js:7
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:31
+#: release/newspack-plugin/dist/setup.js:7
+msgid "Typography"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:31
+#: dist/setup.js:7
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:31
+#: release/newspack-plugin/dist/setup.js:7
+msgid "Define the font pairing to use throughout your site"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:31
+#: dist/setup.js:7
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:31
+#: release/newspack-plugin/dist/setup.js:7
+msgid "Header"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:31
+#: dist/setup.js:7
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:31
+#: release/newspack-plugin/dist/setup.js:7
+msgid "Update the header and add your logo."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:31
+#: dist/setup.js:7
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:31
+#: release/newspack-plugin/dist/setup.js:7
+msgid "Footer"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:31
+#: dist/setup.js:7
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:31
+#: release/newspack-plugin/dist/setup.js:7
+msgid "Personalize the footer of your site."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:31
+#: dist/setup.js:7
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:31
+#: release/newspack-plugin/dist/setup.js:7
+msgid "Finish"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:31
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:31
+msgid "Recirculation"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:31
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:31
+msgid "Default Featured Image Position And Post Template"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:31
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:31
+msgid "Modify how the featured image and post template settings are applied to new posts."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:31
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:31
+msgid "Featured Image Position And Post Template For All Posts"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:31
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:31
+msgid "Modify how the featured image and post template settings are applied to existing posts. Warning: saving these options will override all posts."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:31
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:31
+msgid "Media Credits"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:31
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:31
+msgid "Saving will overwrite existing posts, this cannot be undone. Are you sure you want to proceed?"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:31
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:31
+msgid "Open Customizer"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:31
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:31
+msgid "Manage print editions and other collections of content with custom ordering and organization."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:31
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:31
+msgid "Collections Settings"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:31
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:31
+msgid "Collections Module"
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:31
+msgid "URL for the \"Subscribe\" button that will be displayed in the Collections archive pages when no subscription URL is set for the Collection or its parent category."
+msgstr ""
+
+#: dist/newspack-wizards.a3acb51617fec0947c93.js:31
+msgid "URL for the \"Order\" button that will be displayed in the Collections archive pages when no order URL is set for the Collection or its parent category."
+msgstr ""
+
+#: dist/other-scripts/corrections-modal.js:1
+#: release/newspack-plugin/dist/other-scripts/corrections-modal.js:1
+msgid "Changes have been saved successfully."
+msgstr ""
+
+#: dist/other-scripts/corrections-modal.js:1
+#: release/newspack-plugin/dist/other-scripts/corrections-modal.js:1
+msgid "Manage corrections and clarifications"
+msgstr ""
+
+#: dist/other-scripts/corrections-modal.js:1
+#: release/newspack-plugin/dist/other-scripts/corrections-modal.js:1
+msgid "Manage corrections"
+msgstr ""
+
+#: dist/other-scripts/corrections-modal.js:1
+#: release/newspack-plugin/dist/other-scripts/corrections-modal.js:1
+msgid "No corrections or clarifications have been added."
+msgstr ""
+
+#: dist/other-scripts/corrections-modal.js:1
+#: dist/other-scripts/corrections-modal.js:4
+#: release/newspack-plugin/dist/other-scripts/corrections-modal.js:1
+#: release/newspack-plugin/dist/other-scripts/corrections-modal.js:4
+msgid "Priority"
+msgstr ""
+
+#: dist/other-scripts/corrections-modal.js:1
+#: release/newspack-plugin/dist/other-scripts/corrections-modal.js:1
+msgid "Date"
+msgstr ""
+
+#: dist/other-scripts/corrections-modal.js:1
+#: dist/other-scripts/corrections-modal.js:4
+#: release/newspack-plugin/dist/other-scripts/corrections-modal.js:1
+#: release/newspack-plugin/dist/other-scripts/corrections-modal.js:4
+msgid "Description"
+msgstr ""
+
+#. Translators: Type of correction.
+#: dist/other-scripts/corrections-modal.js:4
+#: release/newspack-plugin/dist/other-scripts/corrections-modal.js:4
+msgid "%s deleted successfully."
+msgstr ""
+
+#. Translators: Type of correction.
+#: dist/other-scripts/corrections-modal.js:7
+#: release/newspack-plugin/dist/other-scripts/corrections-modal.js:7
+msgid "%s added successfully."
+msgstr ""
+
+#: dist/other-scripts/corrections-modal.js:7
+#: release/newspack-plugin/dist/other-scripts/corrections-modal.js:7
+msgid "Save & close"
+msgstr ""
+
+#: dist/other-scripts/corrections-modal.js:7
+#: release/newspack-plugin/dist/other-scripts/corrections-modal.js:7
+msgid "Add new correction"
 msgstr ""
 
 #. translators: 1: "From" email address 2: "From" email name
 #: dist/other-scripts/emails.js:2
 #: release/newspack-plugin/dist/other-scripts/emails.js:2
-#: src/other-scripts/emails/index.js:59
 msgid "This email will be sent from %1$s <%2$s>."
 msgstr ""
 
 #: dist/other-scripts/emails.js:2
 #: release/newspack-plugin/dist/other-scripts/emails.js:2
-#: src/other-scripts/emails/index.js:95
 msgid "Instructions"
 msgstr ""
 
 #: dist/other-scripts/emails.js:2
 #: release/newspack-plugin/dist/other-scripts/emails.js:2
-#: src/other-scripts/emails/index.js:97
 msgid "Use the following placeholders to insert dynamic content in the email:"
 msgstr ""
 
 #: dist/other-scripts/emails.js:2
 #: release/newspack-plugin/dist/other-scripts/emails.js:2
-#: src/other-scripts/emails/index.js:115
 msgid "Subject"
 msgstr ""
 
 #: dist/other-scripts/emails.js:2
 #: release/newspack-plugin/dist/other-scripts/emails.js:2
-#: src/other-scripts/emails/index.js:122
 msgid "Testing"
 msgstr ""
 
 #: dist/other-scripts/emails.js:2
 #: release/newspack-plugin/dist/other-scripts/emails.js:2
-#: src/other-scripts/emails/index.js:125
 msgid "Send to"
 msgstr ""
 
 #: dist/other-scripts/emails.js:2
 #: release/newspack-plugin/dist/other-scripts/emails.js:2
-#: src/other-scripts/emails/index.js:81
 msgid "Test email sent!"
 msgstr ""
 
 #: dist/other-scripts/emails.js:2
 #: release/newspack-plugin/dist/other-scripts/emails.js:2
-#: src/other-scripts/emails/index.js:132
 msgid "Sending…"
 msgstr ""
 
 #: dist/other-scripts/emails.js:2
 #: release/newspack-plugin/dist/other-scripts/emails.js:2
-#: src/other-scripts/emails/index.js:132
 msgid "Send"
+msgstr ""
+
+#: dist/other-scripts/recaptcha.js:1
+#: release/newspack-plugin/dist/other-scripts/recaptcha.js:1
+msgid "There was an error connecting with reCAPTCHA. Please reload the page and try again."
 msgstr ""
 
 #: dist/other-scripts/salesforce.js:1
 #: release/newspack-plugin/dist/other-scripts/salesforce.js:1
-#: src/other-scripts/salesforce/index.js:28
 msgid "Not synced"
 msgstr ""
 
 #: dist/other-scripts/salesforce.js:1
 #: release/newspack-plugin/dist/other-scripts/salesforce.js:1
-#: src/other-scripts/salesforce/index.js:39
-#: src/other-scripts/salesforce/index.js:44
 msgid "Error fetching status"
-msgstr ""
-
-#: dist/other-scripts/salesforce.js:1
-#: release/newspack-plugin/dist/other-scripts/salesforce.js:1
-#: src/other-scripts/salesforce/index.js:35
-msgid "Synced"
 msgstr ""
 
 #: dist/plugins-screen.js:1
 #: release/newspack-plugin/dist/plugins-screen.js:1
-#: src/plugins-screen/plugins-screen.js:50
 msgid "Plugin review required"
 msgstr ""
 
 #: dist/plugins-screen.js:1
 #: release/newspack-plugin/dist/plugins-screen.js:1
-#: src/plugins-screen/plugins-screen.js:51
 msgid "Please submit a plugin for review by the Newspack Team before installing it on your website. If you plan to install an approved plugin, feel free to close this message."
 msgstr ""
 
 #: dist/plugins-screen.js:1
 #: release/newspack-plugin/dist/plugins-screen.js:1
-#: src/plugins-screen/plugins-screen.js:60
 msgid "Plugin Review Form"
 msgstr ""
 
 #: dist/plugins-screen.js:1
 #: release/newspack-plugin/dist/plugins-screen.js:1
-#: src/plugins-screen/plugins-screen.js:65
 msgid "Approved Plugins List"
 msgstr ""
 
 #: dist/plugins-screen.js:1
 #: release/newspack-plugin/dist/plugins-screen.js:1
-#: src/plugins-screen/plugins-screen.js:68
 msgid "Close this message"
 msgstr ""
 
-#: dist/popups.js:1
-#: release/newspack-plugin/dist/popups.js:1
-#: src/wizards/popups/components/campaign-management-popover/index.js:47
-msgid "Activate all prompts"
+#: dist/setup.js:7
+#: release/newspack-plugin/dist/setup.js:7
+msgid "To edit settings for News Revenue Hub, visit the Reader Revenue section from the Newspack dashboard."
 msgstr ""
 
-#: dist/popups.js:1
-#: release/newspack-plugin/dist/popups.js:1
-#: src/wizards/popups/components/campaign-management-popover/index.js:58
-msgid "Deactivate all prompts"
+#: dist/setup.js:7
+#: release/newspack-plugin/dist/setup.js:7
+msgid "Use a third-party reader revenue platform."
 msgstr ""
 
-#: dist/popups.js:1
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:1
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/components/campaign-management-popover/index.js:68
-#: src/wizards/popups/components/prompt-action-card/index.js:196
-#: src/wizards/popups/components/prompt-popovers/primary.js:70
-#: src/wizards/popups/views/campaigns/index.js:57
-#: src/wizards/popups/views/segments/segments-list.js:178
-msgid "Duplicate"
+#: dist/setup.js:7
+#: release/newspack-plugin/dist/setup.js:7
+msgid "Use Newspack’s advanced integration with WooCommerce. For more configuration options, visit the Reader Revenue section from the Newspack dashboard."
 msgstr ""
 
-#: dist/popups.js:1
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:1
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/components/campaign-management-popover/index.js:77
-#: src/wizards/popups/views/campaigns/index.js:55
-msgid "Rename"
+#: dist/wizards.js:1
+#: release/newspack-plugin/dist/wizards.js:1
+msgid "Dashboard"
 msgstr ""
 
-#: dist/popups.js:1
-#: release/newspack-plugin/dist/popups.js:1
-#: src/wizards/popups/components/campaign-management-popover/index.js:98
-msgid "Unarchive"
+#: dist/wizards.js:1
+#: release/newspack-plugin/dist/wizards.js:1
+msgid "Audience Campaigns"
 msgstr ""
 
-#: dist/popups.js:1
-#: release/newspack-plugin/dist/popups.js:1
-#: src/wizards/popups/components/prompt-popovers/primary.js:46
-msgid "Restore"
+#: dist/wizards.js:1
+#: release/newspack-plugin/dist/wizards.js:1
+msgid "Audience Donations"
 msgstr ""
 
-#: dist/popups.js:1
-#: release/newspack-plugin/dist/popups.js:1
-#: src/wizards/popups/components/prompt-popovers/primary.js:49
-msgid "Delete permanently"
+#: dist/wizards.js:1
+#: release/newspack-plugin/dist/wizards.js:1
+msgid "Audience Subscriptions"
 msgstr ""
 
-#: dist/popups.js:1
-#: release/newspack-plugin/dist/popups.js:1
-#: src/wizards/popups/components/prompt-popovers/primary.js:80
-msgid "Deactivate"
+#: dist/wizards.js:1
+#: release/newspack-plugin/dist/wizards.js:1
+msgid "loading"
 msgstr ""
 
-#: dist/popups.js:1
-#: release/newspack-plugin/dist/popups.js:1
-#: src/wizards/popups/components/prompt-popovers/primary.js:89
-msgid "ID:"
+#: release/newspack-plugin/dist/audience-wizards.5326beeae3612c42cc78.js:32
+msgid "Redirect URL copied to clipboard."
 msgstr ""
 
-#: dist/popups.js:1
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:1
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/components/segment-group/index.js:127
-#: src/wizards/popups/utils.js:52
-msgid "Top Overlay"
+#: release/newspack-plugin/dist/collections-admin.js:1
+msgid "Error loading file. Please try uploading again."
 msgstr ""
 
-#: dist/popups.js:1
-#: release/newspack-plugin/dist/popups.js:1
-#: src/wizards/popups/utils.js:53
-msgid "Top Left Overlay"
+#: release/newspack-plugin/dist/collections-admin.js:1
+msgid "Replace file"
 msgstr ""
 
-#: dist/popups.js:1
-#: release/newspack-plugin/dist/popups.js:1
-#: src/wizards/popups/utils.js:54
-msgid "Top Right Overlay"
+#: release/newspack-plugin/dist/collections-admin.js:1
+msgid "Upload file"
 msgstr ""
 
-#: dist/popups.js:1
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:1
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/components/segment-group/index.js:121
-#: src/wizards/popups/utils.js:55
-msgid "Center Overlay"
+#: release/newspack-plugin/dist/collections-admin.js:1
+msgid "Remove file"
 msgstr ""
 
-#: dist/popups.js:1
-#: release/newspack-plugin/dist/popups.js:1
-#: src/wizards/popups/utils.js:56
-msgid "Center Left Overlay"
+#: release/newspack-plugin/dist/collections-admin.js:1
+msgid "Collection Settings"
 msgstr ""
 
-#: dist/popups.js:1
-#: release/newspack-plugin/dist/popups.js:1
-#: src/wizards/popups/utils.js:57
-msgid "Center Right Overlay"
+#: release/newspack-plugin/dist/collections-admin.js:1
+msgid "Set the order of this post within a collection."
 msgstr ""
 
-#: dist/popups.js:1
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:1
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/components/segment-group/index.js:133
-#: src/wizards/popups/utils.js:58
-msgid "Bottom Overlay"
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:30
+msgid "Override post type labels, menus and other parts with custom naming."
 msgstr ""
 
-#: dist/popups.js:1
-#: release/newspack-plugin/dist/popups.js:1
-#: src/wizards/popups/utils.js:59
-msgid "Bottom Left Overlay"
-msgstr ""
-
-#: dist/popups.js:1
-#: release/newspack-plugin/dist/popups.js:1
-#: src/wizards/popups/utils.js:60
-msgid "Bottom Right Overlay"
-msgstr ""
-
-#: dist/popups.js:1
-#: release/newspack-plugin/dist/popups.js:1
-#: src/wizards/popups/utils.js:62
-msgid "In archive pages"
-msgstr ""
-
-#: dist/popups.js:1
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:1
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/components/segment-group/index.js:154
-#: src/wizards/popups/utils.js:63
-msgid "Above Header"
-msgstr ""
-
-#: dist/popups.js:1
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:1
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/components/segment-group/index.js:166
-#: src/wizards/popups/utils.js:64
-msgid "Manual Only"
-msgstr ""
-
-#: dist/popups.js:1
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:1
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/components/segment-group/index.js:160
-#: src/wizards/popups/utils.js:70
-msgid "Custom Placement"
-msgstr ""
-
-#: dist/popups.js:1
-#: release/newspack-plugin/dist/popups.js:1
-#: src/wizards/popups/utils.js:99
-msgid "Once a month"
-msgstr ""
-
-#: dist/popups.js:1
-#: release/newspack-plugin/dist/popups.js:1
-#: src/wizards/popups/utils.js:100
-msgid "Once a week"
-msgstr ""
-
-#: dist/popups.js:1
-#: release/newspack-plugin/dist/popups.js:1
-#: src/wizards/popups/utils.js:101
-msgid "Once a day"
-msgstr ""
-
-#: dist/popups.js:1
-#: release/newspack-plugin/dist/popups.js:1
-#: src/wizards/popups/utils.js:102
-msgid "Every pageview"
-msgstr ""
-
-#: dist/popups.js:1
-#: release/newspack-plugin/dist/popups.js:1
-#: src/wizards/popups/utils.js:103
-msgid "Custom frequency (edit prompt to manage)"
-msgstr ""
-
-#: dist/popups.js:1
-#: release/newspack-plugin/dist/popups.js:1
-#: src/wizards/popups/utils.js:128
-msgid "Campaign: "
-msgstr ""
-
-#: dist/popups.js:1
-#: release/newspack-plugin/dist/popups.js:1
-#: src/wizards/popups/utils.js:129
-msgid "Campaigns: "
-msgstr ""
-
-#: dist/popups.js:1
-#: release/newspack-plugin/dist/popups.js:1
-#: src/wizards/popups/utils.js:134
-msgid "Categories: "
-msgstr ""
-
-#: dist/popups.js:1
-#: release/newspack-plugin/dist/popups.js:1
-#: src/wizards/popups/utils.js:140
-msgid "Tags: "
-msgstr ""
-
-#: dist/popups.js:1
-#: release/newspack-plugin/dist/popups.js:1
-#: src/wizards/popups/utils.js:144
-msgid "Pending review"
-msgstr ""
-
-#: dist/popups.js:1
-#: release/newspack-plugin/dist/popups.js:1
-#: src/wizards/popups/utils.js:147
-msgid "Scheduled"
-msgstr ""
-
-#: dist/popups.js:1
-#: release/newspack-plugin/dist/popups.js:1
-#: src/wizards/popups/utils.js:149
-msgid "Frequency: "
-msgstr ""
-
-#: dist/popups.js:1
-#: release/newspack-plugin/dist/popups.js:1
-#: src/wizards/popups/utils.js:158
-msgid "Segment disabled"
-msgstr ""
-
-#: dist/popups.js:1
-#: release/newspack-plugin/dist/popups.js:1
-#: src/wizards/popups/utils.js:240
-msgid "Favorite Categories:"
-msgstr ""
-
-#: dist/popups.js:1
-#: release/newspack-plugin/dist/popups.js:1
-#: src/wizards/popups/utils.js:308
-msgid "Subscribed to:"
-msgstr ""
-
-#: dist/popups.js:1
-#: release/newspack-plugin/dist/popups.js:1
-#: src/wizards/popups/utils.js:309
-msgid "Not subscribed to:"
-msgstr ""
-
-#: dist/popups.js:1
-#: release/newspack-plugin/dist/popups.js:1
-#: src/wizards/popups/utils.js:332
-msgid "Has active subscription(s):"
-msgstr ""
-
-#: dist/popups.js:1
-#: release/newspack-plugin/dist/popups.js:1
-#: src/wizards/popups/utils.js:333
-msgid "Does not have active subscription(s):"
-msgstr ""
-
-#: dist/popups.js:1
-#: release/newspack-plugin/dist/popups.js:1
-#: src/wizards/popups/utils.js:356
-msgid "Has active membership(s):"
-msgstr ""
-
-#: dist/popups.js:1
-#: release/newspack-plugin/dist/popups.js:1
-#: src/wizards/popups/utils.js:357
-msgid "Does not have active membership(s):"
-msgstr ""
-
-#. Translators: %s is prompt type (above-header or overlay).
-#: dist/popups.js:4
-#: release/newspack-plugin/dist/popups.js:4
-#: src/wizards/popups/utils.js:385
-msgid "If multiple %s are rendered on the same pageview, only the most recent one will be displayed."
-msgstr ""
-
-#: dist/popups.js:4
-#: release/newspack-plugin/dist/popups.js:4
-#: src/wizards/popups/utils.js:390
-msgid "above-header prompts"
-msgstr ""
-
-#: dist/popups.js:4
-#: release/newspack-plugin/dist/popups.js:4
-#: src/wizards/popups/utils.js:391
-msgid "overlays"
-msgstr ""
-
-#: dist/popups.js:4
-#: release/newspack-plugin/dist/popups.js:4
-#: src/wizards/popups/utils.js:396
-msgid "If multiple prompts are rendered in the same custom placement, only the most recent one will be displayed."
-msgstr ""
-
-#. Translators: %s: 'Conflicts' or 'Conflict' depending on number of conflicts.
-#: dist/popups.js:7
-#: release/newspack-plugin/dist/popups.js:7
-#: src/wizards/popups/utils.js:447
-msgid "%s detected:"
-msgstr ""
-
-#: dist/popups.js:7
-#: release/newspack-plugin/dist/popups.js:7
-#: src/wizards/popups/utils.js:449
-msgid "Conflicts"
-msgstr ""
-
-#: dist/popups.js:7
-#: release/newspack-plugin/dist/popups.js:7
-#: src/wizards/popups/utils.js:450
-msgid "Conflict"
-msgstr ""
-
-#: dist/popups.js:7
-#: release/newspack-plugin/dist/popups.js:7
-#: src/wizards/popups/components/settings-modal/index.js:44
-msgid "Close Modal"
-msgstr ""
-
-#: dist/popups.js:7
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:7
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/components/settings-modal/index.js:48
-#: src/wizards/popups/components/settings-modal/index.js:61
-#: src/wizards/popups/index.js:29
-#: src/wizards/popups/views/campaigns/index.js:184
-#: src/wizards/popups/views/campaigns/index.js:213
-msgid "Campaigns"
-msgstr ""
-
-#: dist/popups.js:7
-#: release/newspack-plugin/dist/popups.js:7
-#: src/wizards/popups/components/settings-modal/index.js:49
-msgid "Assign a prompt to one or more campaigns for easier management"
-msgstr ""
-
-#: dist/popups.js:7
-#: release/newspack-plugin/dist/popups.js:7
-#: src/wizards/popups/components/settings-modal/index.js:69
-msgid "When and how should the prompt be displayed"
-msgstr ""
-
-#: dist/popups.js:7
-#: release/newspack-plugin/dist/popups.js:7
-#: src/wizards/popups/components/settings-modal/index.js:76
-msgid "Frequency"
-msgstr ""
-
-#: dist/popups.js:7
-#: release/newspack-plugin/dist/popups.js:7
-#: src/wizards/popups/components/settings-modal/index.js:88
-msgid "Placement"
-msgstr ""
-
-#: dist/popups.js:7
-#: release/newspack-plugin/dist/popups.js:7
-#: src/wizards/popups/components/settings-modal/index.js:111
-msgid "Targeting"
-msgstr ""
-
-#: dist/popups.js:7
-#: release/newspack-plugin/dist/popups.js:7
-#: src/wizards/popups/components/settings-modal/index.js:114
-msgid "Under which conditions should the prompt be displayed"
-msgstr ""
-
-#: dist/popups.js:7
-#: release/newspack-plugin/dist/popups.js:7
-#: src/wizards/popups/components/settings-modal/index.js:116
-msgid "If multiple conditions are set, all will have to be satisfied in order to display the prompt"
-msgstr ""
-
-#: dist/popups.js:7
-#: release/newspack-plugin/dist/popups.js:7
-#: src/wizards/popups/components/settings-modal/index.js:132
-msgid "Segments"
-msgstr ""
-
-#: dist/popups.js:7
-#: release/newspack-plugin/dist/popups.js:7
-#: src/wizards/popups/components/settings-modal/index.js:136
-msgid "Post categories"
-msgstr ""
-
-#: dist/popups.js:7
-#: release/newspack-plugin/dist/popups.js:7
-#: src/wizards/popups/components/settings-modal/index.js:141
-msgid "Prompt will only appear on posts with the specified categories."
-msgstr ""
-
-#: dist/popups.js:7
-#: release/newspack-plugin/dist/popups.js:7
-#: src/wizards/popups/components/settings-modal/index.js:147
-msgid "Post tags"
-msgstr ""
-
-#: dist/popups.js:7
-#: release/newspack-plugin/dist/popups.js:7
-#: src/wizards/popups/components/settings-modal/index.js:153
-msgid "Prompt will only appear on posts with the specified tags."
-msgstr ""
-
-#: dist/popups.js:10
-#: release/newspack-plugin/dist/popups.js:10
-#: src/wizards/popups/components/settings-modal/index.js:171
-msgid "Category Exclusions"
-msgstr ""
-
-#: dist/popups.js:10
-#: release/newspack-plugin/dist/popups.js:10
-#: src/wizards/popups/components/settings-modal/index.js:182
-msgid "Prompt will not appear on posts with the specified categories."
-msgstr ""
-
-#: dist/popups.js:10
-#: release/newspack-plugin/dist/popups.js:10
-#: src/wizards/popups/components/settings-modal/index.js:188
-msgid "Tag Exclusions"
-msgstr ""
-
-#: dist/popups.js:10
-#: release/newspack-plugin/dist/popups.js:10
-#: src/wizards/popups/components/settings-modal/index.js:200
-msgid "Prompt will not appear on posts with the specified tags."
-msgstr ""
-
-#: dist/popups.js:10
-#: release/newspack-plugin/dist/popups.js:10
-#: src/wizards/popups/components/prompt-action-card/index.js:57
-msgid " copy"
-msgstr ""
-
-#: dist/popups.js:10
-#: release/newspack-plugin/dist/popups.js:10
-#: src/wizards/popups/components/prompt-action-card/index.js:80
-msgid "Prompt settings"
-msgstr ""
-
-#. Translators: %s: The title of the item.
-#: dist/popups.js:13
-#: release/newspack-plugin/dist/popups.js:13
-#: src/wizards/popups/components/prompt-action-card/index.js:116
-msgid "Duplicate “%s”"
-msgstr ""
-
-#. Translators: %s: The title of the item.
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/components/prompt-action-card/index.js:130
-msgid "Duplicate of “%s” created as a draft."
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/components/prompt-action-card/index.js:137
-msgid "This prompt is currently not assigned to any campaign."
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/components/prompt-action-card/index.js:164
-msgid "This prompt will not be assigned to any campaign."
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/components/prompt-action-card/index.js:172
-#: src/wizards/popups/views/segments/single-segment.js:175
-msgid "Title"
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/components/segment-group/index.js:57
-msgid "No unassigned prompts in this segment."
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/components/segment-group/index.js:60
-msgid "No prompts in this segment for"
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/components/segment-group/index.js:62
-msgid "No active prompts in this segment."
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/components/segment-group/index.js:74
-msgid "Edit Segment "
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/components/segment-group/index.js:79
-msgid "Segment: "
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/components/segment-group/index.js:87
-msgid "All readers, regardless of segment"
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/components/segment-group/index.js:97
-msgid "Preview Segment"
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/components/segment-group/index.js:108
-#: src/wizards/popups/components/segment-group/index.js:112
-msgid "Add New Prompt"
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/components/segment-group/index.js:122
-msgid "Fixed at the center of the screen"
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/components/segment-group/index.js:128
-msgid "Fixed at the top of the screen"
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/components/segment-group/index.js:134
-msgid "Fixed at the bottom of the screen"
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/components/segment-group/index.js:140
-msgid "Embedded in content"
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/components/segment-group/index.js:145
-msgid "In Archive Pages"
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/components/segment-group/index.js:146
-msgid "Embedded once or many times in archive pages"
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/components/segment-group/index.js:155
-msgid "Embedded at the very top of the page"
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/components/segment-group/index.js:161
-msgid "Only appears when placed in content"
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/components/segment-group/index.js:167
-msgid "Only appears where Single Prompt block is inserted"
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/views/campaigns/index.js:46
-msgid "Rename Campaign"
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/views/campaigns/index.js:48
-msgid "Duplicate Campaign"
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/views/campaigns/index.js:50
-#: src/wizards/popups/views/campaigns/index.js:275
-msgid "Add New Campaign"
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/views/campaigns/index.js:59
-msgid "Add"
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/views/campaigns/index.js:102
-msgid "Everyone"
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/views/campaigns/index.js:163
-msgid "Active Prompts"
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/views/campaigns/index.js:167
-msgid "All Prompts"
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/views/campaigns/index.js:171
-msgid "Trash"
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/views/campaigns/index.js:177
-msgid "Unassigned Prompts"
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/views/campaigns/index.js:197
-msgid "Archived Campaigns"
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/views/campaigns/index.js:203
-msgid "(archived)"
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/views/campaigns/index.js:286
-#: src/wizards/popups/views/campaigns/index.js:288
-msgid "Campaign Name"
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/views/analytics/index.js:18
-msgid "Coming soon"
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/views/analytics/index.js:21
-msgid "We’re currently redesigning this dashboard to accommodate GA4 and give you deeper insights into Campaign performance. In the meantime, you can find Campaign event data within your GA account. Review this "
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/views/analytics/index.js:26
-msgid "help page"
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/views/analytics/index.js:28
-msgid " to see how Campaign data is being recorded in GA."
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/views/analytics/index.js:38
-msgid "View the help page"
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/views/segments/segments-list.js:20
-msgid "Add New Segment"
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/views/segments/segments-list.js:228
-msgid "Move segment position up"
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/views/segments/segments-list.js:234
-msgid "Move segment position down"
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/views/segments/segments-list.js:310
-msgid "There was an error sorting segments. Please try again."
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/views/segments/segments-list.js:327
-msgid "Audience segments"
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/views/segments/segments-list.js:355
-msgid "You have no saved audience segments."
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/views/segments/segments-list.js:359
-msgid "Create audience segments to target visitors by engagement, activity, and more."
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/views/segments/single-segment.js:345
-msgid "Start typing to search for lists…"
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/views/segments/single-segment.js:366
-msgid "Start typing to search for products…"
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/views/segments/single-segment.js:387
-msgid "Start typing to search for membership plans…"
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/views/segments/single-segment.js:58
-msgid "There are unsaved changes to this segment. Discard changes?"
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/views/segments/single-segment.js:172
-msgid "Untitled Segment"
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/views/segments/single-segment.js:180
-msgid "Segment Status"
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/views/segments/single-segment.js:181
-msgid "If not enabled, the segment will be ignored for reader segmentation."
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/views/segments/single-segment.js:188
-msgid "Segment enabled"
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/views/segments/single-segment.js:195
-msgid "Reader Engagement"
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/views/segments/single-segment.js:196
-msgid "Target readers based on their browsing behavior."
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/views/segments/single-segment.js:212
-msgid "Registration"
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/views/segments/single-segment.js:213
-msgid "Target readers based on their user account registration status."
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/views/segments/single-segment.js:234
-msgid "Target readers based on their newsletter subscription status."
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/views/segments/single-segment.js:255
-msgid "Target readers based on their revenue activity."
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/views/segments/single-segment.js:272
-msgid "Referrer Sources"
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/views/segments/single-segment.js:273
-msgid "Target readers based on where they’re coming from."
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/views/segments/single-segment.js:277
-msgid "Segments using these options will apply only to the first page visited after coming from an external source."
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/index.js:30
-msgid "Reach your readers with configurable campaigns"
-msgstr ""
-
-#: dist/popups.js:16
-#: release/newspack-plugin/dist/popups.js:16
-#: src/wizards/popups/index.js:178
-msgid "Error duplicating prompt. Please try again later."
-msgstr ""
-
-#: dist/readerRevenue.js:1
-#: dist/setup.js:1
-#: release/newspack-plugin/dist/readerRevenue.js:1
-#: release/newspack-plugin/dist/setup.js:1
-msgid "Suggested Donations"
-msgstr ""
-
-#: dist/readerRevenue.js:1
-#: dist/setup.js:1
-#: release/newspack-plugin/dist/readerRevenue.js:1
-#: release/newspack-plugin/dist/setup.js:1
-msgid "Set suggested donation amounts. These will be the default settings for the Donate block."
-msgstr ""
-
-#: dist/readerRevenue.js:1
-#: dist/setup.js:1
-#: release/newspack-plugin/dist/readerRevenue.js:1
-#: release/newspack-plugin/dist/setup.js:1
-msgid "Donation Type"
-msgstr ""
-
-#: dist/readerRevenue.js:1
-#: dist/setup.js:1
-#: release/newspack-plugin/dist/readerRevenue.js:1
-#: release/newspack-plugin/dist/setup.js:1
-msgid "Tiered"
-msgstr ""
-
-#: dist/readerRevenue.js:1
-#: dist/setup.js:1
-#: release/newspack-plugin/dist/readerRevenue.js:1
-#: release/newspack-plugin/dist/setup.js:1
-msgid "Untiered"
-msgstr ""
-
-#: dist/readerRevenue.js:1
-#: dist/setup.js:1
-#: release/newspack-plugin/dist/readerRevenue.js:1
-#: release/newspack-plugin/dist/setup.js:1
-msgid "Warning: suggested donations should be at least the minimum donation amount."
-msgstr ""
-
-#: dist/readerRevenue.js:1
-#: dist/setup.js:1
-#: release/newspack-plugin/dist/readerRevenue.js:1
-#: release/newspack-plugin/dist/setup.js:1
-msgid "Minimum donation"
-msgstr ""
-
-#: dist/readerRevenue.js:1
-#: dist/setup.js:1
-#: release/newspack-plugin/dist/readerRevenue.js:1
-#: release/newspack-plugin/dist/setup.js:1
-msgid "Set minimum donation amount. Setting a reasonable minimum donation amount can help protect your site from bot attacks."
-msgstr ""
-
-#: dist/readerRevenue.js:1
-#: release/newspack-plugin/dist/readerRevenue.js:1
-msgid "Billing Fields"
-msgstr ""
-
-#: dist/readerRevenue.js:1
-#: release/newspack-plugin/dist/readerRevenue.js:1
-msgid "Configure the billing fields shown in the modal checkout form. Fields marked with (*) are required if shown. Note that for shippable products, address fields will always be shown."
-msgstr ""
-
-#: dist/readerRevenue.js:1
-#: release/newspack-plugin/dist/readerRevenue.js:1
-msgid "Configure options for donations."
-msgstr ""
-
-#: dist/readerRevenue.js:1
-#: release/newspack-plugin/dist/readerRevenue.js:1
-msgid "Donation Settings"
-msgstr ""
-
-#: dist/readerRevenue.js:1
-#: release/newspack-plugin/dist/readerRevenue.js:1
-msgid "Save Donation Settings"
-msgstr ""
-
-#: dist/readerRevenue.js:1
-#: release/newspack-plugin/dist/readerRevenue.js:1
-msgid "Donations Landing Page"
-msgstr ""
-
-#: dist/readerRevenue.js:1
-#: release/newspack-plugin/dist/readerRevenue.js:1
-msgid "Your donations landing page is published."
-msgstr ""
-
-#: dist/readerRevenue.js:1
-#: release/newspack-plugin/dist/readerRevenue.js:1
-msgid "Your donations landing page is not yet published."
-msgstr ""
-
-#: dist/readerRevenue.js:1
-#: release/newspack-plugin/dist/readerRevenue.js:1
-msgid "Configure options for modal checkouts."
-msgstr ""
-
-#: dist/readerRevenue.js:1
-#: release/newspack-plugin/dist/readerRevenue.js:1
-msgid "Modal Checkout Settings"
-msgstr ""
-
-#: dist/readerRevenue.js:1
-#: release/newspack-plugin/dist/readerRevenue.js:1
-msgid "Save Modal Checkout Settings"
-msgstr ""
-
-#: dist/readerRevenue.js:1
-#: release/newspack-plugin/dist/readerRevenue.js:1
-#: src/wizards/readerRevenue/views/stripe-setup/index.js:27
-msgid "Transaction Fees"
-msgstr ""
-
-#: dist/readerRevenue.js:1
-#: release/newspack-plugin/dist/readerRevenue.js:1
-#: src/wizards/readerRevenue/views/stripe-setup/index.js:28
-msgid "If you have a non-default or negotiated fee with Stripe, update its parameters here."
-msgstr ""
-
-#: dist/readerRevenue.js:1
-#: release/newspack-plugin/dist/readerRevenue.js:1
-#: src/wizards/readerRevenue/views/stripe-setup/index.js:40
-msgid "Fee multiplier"
-msgstr ""
-
-#: dist/readerRevenue.js:1
-#: release/newspack-plugin/dist/readerRevenue.js:1
-#: src/wizards/readerRevenue/views/stripe-setup/index.js:47
-msgid "Fee static portion"
-msgstr ""
-
-#: dist/readerRevenue.js:1
-#: dist/setup.js:1
-#: release/newspack-plugin/dist/readerRevenue.js:1
-#: release/newspack-plugin/dist/setup.js:1
-#: src/wizards/readerRevenue/views/stripe-setup/index.js:76
-msgid "Configure Stripe and enter your API keys"
-msgstr ""
-
-#: dist/readerRevenue.js:1
-#: dist/setup.js:1
-#: release/newspack-plugin/dist/readerRevenue.js:1
-#: release/newspack-plugin/dist/setup.js:1
-#: src/wizards/readerRevenue/views/stripe-setup/index.js:83
-msgid "Use Stripe in test mode"
-msgstr ""
-
-#: dist/readerRevenue.js:1
-#: dist/setup.js:1
-#: release/newspack-plugin/dist/readerRevenue.js:1
-#: release/newspack-plugin/dist/setup.js:1
-#: src/wizards/readerRevenue/views/stripe-setup/index.js:86
-msgid "Test mode will not capture real payments. Use it for testing your purchase flow."
-msgstr ""
-
-#: dist/readerRevenue.js:1
-#: dist/setup.js:1
-#: release/newspack-plugin/dist/readerRevenue.js:1
-#: release/newspack-plugin/dist/setup.js:1
-#: src/wizards/readerRevenue/views/stripe-setup/index.js:98
-msgid "Test Publishable Key"
-msgstr ""
-
-#: dist/readerRevenue.js:1
-#: dist/setup.js:1
-#: release/newspack-plugin/dist/readerRevenue.js:1
-#: release/newspack-plugin/dist/setup.js:1
-#: src/wizards/readerRevenue/views/stripe-setup/index.js:104
-msgid "Test Secret Key"
-msgstr ""
-
-#: dist/readerRevenue.js:1
-#: dist/setup.js:1
-#: release/newspack-plugin/dist/readerRevenue.js:1
-#: release/newspack-plugin/dist/setup.js:1
-#: src/wizards/readerRevenue/views/stripe-setup/index.js:113
-msgid "Publishable Key"
-msgstr ""
-
-#: dist/readerRevenue.js:1
-#: dist/setup.js:1
-#: release/newspack-plugin/dist/readerRevenue.js:1
-#: release/newspack-plugin/dist/setup.js:1
-#: src/wizards/readerRevenue/views/stripe-setup/index.js:119
-msgid "Secret Key"
-msgstr ""
-
-#: dist/readerRevenue.js:1
-#: release/newspack-plugin/dist/readerRevenue.js:1
-#: src/wizards/readerRevenue/views/stripe-setup/index.js:186
-msgid "This site does not use SSL. The page hosting the Stipe integration should be secured with SSL."
-msgstr ""
-
-#: dist/readerRevenue.js:1
-#: release/newspack-plugin/dist/readerRevenue.js:1
-#: src/wizards/readerRevenue/views/stripe-setup/index.js:197
-msgid "Enable Stripe"
-msgstr ""
-
-#: dist/readerRevenue.js:1
-#: release/newspack-plugin/dist/readerRevenue.js:1
-#: src/wizards/readerRevenue/views/stripe-setup/index.js:208
-msgid "Allow donors to cover transaction fees"
-msgstr ""
-
-#: dist/readerRevenue.js:1
-#: release/newspack-plugin/dist/readerRevenue.js:1
-#: src/wizards/readerRevenue/views/stripe-setup/index.js:211
-msgid "If checked, the donors will be able to cover Stripe's transaction fees."
-msgstr ""
-
-#: dist/readerRevenue.js:1
-#: release/newspack-plugin/dist/readerRevenue.js:1
-#: src/wizards/readerRevenue/views/stripe-setup/index.js:217
-msgid "Enable covering fees by default"
-msgstr ""
-
-#: dist/readerRevenue.js:1
-#: release/newspack-plugin/dist/readerRevenue.js:1
-#: src/wizards/readerRevenue/views/stripe-setup/index.js:220
-msgid "If checked, the option to cover transaction fees will be checked by default."
-msgstr ""
-
-#: dist/readerRevenue.js:1
-#: release/newspack-plugin/dist/readerRevenue.js:1
-#: src/wizards/readerRevenue/views/stripe-setup/index.js:228
-msgid "Custom message"
-msgstr ""
-
-#: dist/readerRevenue.js:1
-#: release/newspack-plugin/dist/readerRevenue.js:1
-#: src/wizards/readerRevenue/views/stripe-setup/index.js:229
-msgid "A message to explain the transaction fee option (optional)."
-msgstr ""
-
-#: dist/readerRevenue.js:1
-#: release/newspack-plugin/dist/readerRevenue.js:1
-#: src/wizards/readerRevenue/views/stripe-setup/index.js:239
-msgid "Other gateways can be enabled and set up in the "
-msgstr ""
-
-#: dist/readerRevenue.js:1
-#: release/newspack-plugin/dist/readerRevenue.js:1
-#: src/wizards/readerRevenue/views/stripe-setup/index.js:241
-msgid "WooCommerce payment gateway settings"
-msgstr ""
-
-#: dist/readerRevenue.js:1
-#: release/newspack-plugin/dist/readerRevenue.js:1
-#: src/wizards/readerRevenue/views/stripe-setup/index.js:152
-msgid "To configure Stripe, install the WooCommerce Stripe Gateway plugin."
-msgstr ""
-
-#: dist/readerRevenue.js:1
-#: release/newspack-plugin/dist/readerRevenue.js:1
-#: src/wizards/readerRevenue/views/emails/index.js:91
-msgid "This email is not active."
-msgstr ""
-
-#: dist/readerRevenue.js:1
-#: release/newspack-plugin/dist/readerRevenue.js:1
-#: src/wizards/readerRevenue/views/emails/index.js:93
-msgid "This email is not active. The default receipt will be used."
-msgstr ""
-
-#: dist/readerRevenue.js:1
-#: release/newspack-plugin/dist/readerRevenue.js:1
-#: src/wizards/readerRevenue/views/emails/index.js:100
-msgid "This email is not active. The receipt template will be used if active."
-msgstr ""
-
-#: dist/site-design.js:1
-#: release/newspack-plugin/dist/site-design.js:1
-#: src/wizards/site-design/views/theme-settings/index.js:50
-#: src/wizards/site-design/views/theme-settings/index.js:56
-msgid "Author Bio"
-msgstr ""
-
-#: dist/site-design.js:1
-#: release/newspack-plugin/dist/site-design.js:1
-#: src/wizards/site-design/views/theme-settings/index.js:51
-msgid "Control how author bios are displayed on posts."
-msgstr ""
-
-#: dist/site-design.js:1
-#: release/newspack-plugin/dist/site-design.js:1
-#: src/wizards/site-design/views/theme-settings/index.js:57
-msgid "Display an author bio under individual posts."
-msgstr ""
-
-#: dist/site-design.js:1
-#: release/newspack-plugin/dist/site-design.js:1
-#: src/wizards/site-design/views/theme-settings/index.js:63
-msgid "Author Email"
-msgstr ""
-
-#: dist/site-design.js:1
-#: release/newspack-plugin/dist/site-design.js:1
-#: src/wizards/site-design/views/theme-settings/index.js:64
-msgid "Display the author email with bio on individual posts."
-msgstr ""
-
-#: dist/site-design.js:1
-#: release/newspack-plugin/dist/site-design.js:1
-#: src/wizards/site-design/views/theme-settings/index.js:76
-msgid "Length"
-msgstr ""
-
-#: dist/site-design.js:1
-#: release/newspack-plugin/dist/site-design.js:1
-#: src/wizards/site-design/views/theme-settings/index.js:77
-msgid "Truncates the author bio on single posts to this approximate character length, but without breaking a word. The full bio appears on the author archive page."
-msgstr ""
-
-#: dist/site-design.js:1
-#: release/newspack-plugin/dist/site-design.js:1
-#: src/wizards/site-design/views/theme-settings/index.js:90
-msgid "Default Featured Image Position And Post Template"
-msgstr ""
-
-#: dist/site-design.js:1
-#: release/newspack-plugin/dist/site-design.js:1
-#: src/wizards/site-design/views/theme-settings/index.js:91
-msgid "Modify how the featured image and post template settings are applied to new posts."
-msgstr ""
-
-#: dist/site-design.js:1
-#: release/newspack-plugin/dist/site-design.js:1
-#: src/wizards/site-design/views/theme-settings/index.js:98
-msgid "Default featured image position for new posts"
-msgstr ""
-
-#: dist/site-design.js:1
-#: release/newspack-plugin/dist/site-design.js:1
-#: src/wizards/site-design/views/theme-settings/index.js:99
-msgid "Set a default featured image position for new posts."
-msgstr ""
-
-#: dist/site-design.js:1
-#: release/newspack-plugin/dist/site-design.js:1
-#: src/wizards/site-design/views/theme-settings/index.js:104
-#: src/wizards/site-design/views/theme-settings/index.js:147
-msgid "Behind article title"
-msgstr ""
-
-#: dist/site-design.js:1
-#: release/newspack-plugin/dist/site-design.js:1
-#: src/wizards/site-design/views/theme-settings/index.js:105
-#: src/wizards/site-design/views/theme-settings/index.js:148
-msgid "Beside article title"
-msgstr ""
-
-#: dist/site-design.js:1
-#: release/newspack-plugin/dist/site-design.js:1
-#: src/wizards/site-design/views/theme-settings/index.js:106
-#: src/wizards/site-design/views/theme-settings/index.js:149
-msgid "Hidden"
-msgstr ""
-
-#: dist/site-design.js:1
-#: release/newspack-plugin/dist/site-design.js:1
-#: src/wizards/site-design/views/theme-settings/index.js:111
-msgid "Default template for new posts"
-msgstr ""
-
-#: dist/site-design.js:1
-#: release/newspack-plugin/dist/site-design.js:1
-#: src/wizards/site-design/views/theme-settings/index.js:112
-msgid "Set a default template for new posts."
-msgstr ""
-
-#: dist/site-design.js:1
-#: release/newspack-plugin/dist/site-design.js:1
-#: src/wizards/site-design/views/theme-settings/index.js:115
-#: src/wizards/site-design/views/theme-settings/index.js:170
-msgid "With sidebar"
-msgstr ""
-
-#: dist/site-design.js:1
-#: release/newspack-plugin/dist/site-design.js:1
-#: src/wizards/site-design/views/theme-settings/index.js:116
-#: src/wizards/site-design/views/theme-settings/index.js:171
-msgid "One Column"
-msgstr ""
-
-#: dist/site-design.js:1
-#: release/newspack-plugin/dist/site-design.js:1
-#: src/wizards/site-design/views/theme-settings/index.js:117
-#: src/wizards/site-design/views/theme-settings/index.js:172
-msgid "One Column Wide"
-msgstr ""
-
-#: dist/site-design.js:1
-#: release/newspack-plugin/dist/site-design.js:1
-#: src/wizards/site-design/views/theme-settings/index.js:123
-msgid "Featured Image Position And Post Template For All Posts"
-msgstr ""
-
-#: dist/site-design.js:1
-#: release/newspack-plugin/dist/site-design.js:1
-#: src/wizards/site-design/views/theme-settings/index.js:124
-msgid "Modify how the featured image and post template settings are applied to existing posts. Warning: saving these options will override all posts."
-msgstr ""
-
-#: dist/site-design.js:1
-#: release/newspack-plugin/dist/site-design.js:1
-#: src/wizards/site-design/views/theme-settings/index.js:131
-msgid "You have more than 1000 posts. Applying these settings might take a moment."
-msgstr ""
-
-#: dist/site-design.js:1
-#: release/newspack-plugin/dist/site-design.js:1
-#: src/wizards/site-design/views/theme-settings/index.js:140
-msgid "Featured image position for all posts"
-msgstr ""
-
-#: dist/site-design.js:1
-#: release/newspack-plugin/dist/site-design.js:1
-#: src/wizards/site-design/views/theme-settings/index.js:141
-msgid "Set a featured image position for all posts."
-msgstr ""
-
-#: dist/site-design.js:1
-#: release/newspack-plugin/dist/site-design.js:1
-#: src/wizards/site-design/views/theme-settings/index.js:144
-#: src/wizards/site-design/views/theme-settings/index.js:169
-msgid "Select to change all posts"
-msgstr ""
-
-#: dist/site-design.js:1
-#: release/newspack-plugin/dist/site-design.js:1
-#: src/wizards/site-design/views/theme-settings/index.js:155
-#: src/wizards/site-design/views/theme-settings/index.js:178
-msgid "After saving the settings with this option selected, all posts will be updated. This cannot be undone."
-msgstr ""
-
-#: dist/site-design.js:1
-#: release/newspack-plugin/dist/site-design.js:1
-#: src/wizards/site-design/views/theme-settings/index.js:165
-msgid "Template for all posts"
-msgstr ""
-
-#: dist/site-design.js:1
-#: release/newspack-plugin/dist/site-design.js:1
-#: src/wizards/site-design/views/theme-settings/index.js:166
-msgid "Set a template for all posts."
-msgstr ""
-
-#: dist/site-design.js:1
-#: release/newspack-plugin/dist/site-design.js:1
-#: src/wizards/site-design/views/theme-settings/index.js:188
-msgid "Media Credits"
-msgstr ""
-
-#: dist/site-design.js:1
-#: release/newspack-plugin/dist/site-design.js:1
-#: src/wizards/site-design/views/theme-settings/index.js:189
-msgid "Control how credits are displayed alongside media attachments."
-msgstr ""
-
-#: dist/site-design.js:1
-#: release/newspack-plugin/dist/site-design.js:1
-#: src/wizards/site-design/views/theme-settings/index.js:197
-msgid "Credit Class Name"
-msgstr ""
-
-#: dist/site-design.js:1
-#: release/newspack-plugin/dist/site-design.js:1
-#: src/wizards/site-design/views/theme-settings/index.js:198
-msgid "A CSS class name to be applied to all image credit elements. Leave blank to display no class name."
-msgstr ""
-
-#: dist/site-design.js:1
-#: release/newspack-plugin/dist/site-design.js:1
-#: src/wizards/site-design/views/theme-settings/index.js:206
-msgid "Credit Label"
-msgstr ""
-
-#: dist/site-design.js:1
-#: release/newspack-plugin/dist/site-design.js:1
-#: src/wizards/site-design/views/theme-settings/index.js:207
-msgid "A label to prefix all media credits. Leave blank to display no prefix."
-msgstr ""
-
-#: dist/site-design.js:1
-#: release/newspack-plugin/dist/site-design.js:1
-#: src/wizards/site-design/views/theme-settings/index.js:218
-msgid "Placeholder Image"
-msgstr ""
-
-#: dist/site-design.js:1
-#: release/newspack-plugin/dist/site-design.js:1
-#: src/wizards/site-design/views/theme-settings/index.js:224
-msgid "A placeholder image to be displayed in place of images without credits. If none is chosen, the image will be displayed normally whether or not it has a credit."
-msgstr ""
-
-#: dist/site-design.js:1
-#: release/newspack-plugin/dist/site-design.js:1
-#: src/wizards/site-design/views/theme-settings/index.js:230
-msgid "Auto-populate image credits"
-msgstr ""
-
-#: dist/site-design.js:1
-#: release/newspack-plugin/dist/site-design.js:1
-#: src/wizards/site-design/views/theme-settings/index.js:231
-msgid "Automatically populate image credits from EXIF or IPTC metadata when uploading new images."
-msgstr ""
-
-#: dist/site-design.js:1
-#: release/newspack-plugin/dist/site-design.js:1
-#: src/wizards/site-design/index.js:50
-msgid "Saving will overwrite existing posts, this cannot be undone. Are you sure you want to proceed?"
-msgstr ""
-
-#: dist/site-design.js:1
-#: release/newspack-plugin/dist/site-design.js:1
-#: src/wizards/site-design/index.js:125
-msgid "Configure your Newspack theme"
-msgstr ""
-
-#: dist/site-design.js:1
-#: release/newspack-plugin/dist/site-design.js:1
-#: src/wizards/site-design/index.js:131
-msgid "Advanced Settings"
-msgstr ""
-
-#: src/wizards/readerRevenue/views/emails/index.js:67
-msgid "Newspack uses Newspack Newsletters to handle editing email-type content. Please activate this plugin to proceed."
-msgstr ""
-
-#: src/wizards/readerRevenue/views/emails/index.js:73
-msgid "Until this feature is configured, default receipts will be used."
+#: release/newspack-plugin/dist/newspack-wizards.25b9f9f8bf1e806413a8.js:31
+msgid "Global URL where readers can subscribe to collections."
 msgstr ""
 
 #: dist/blocks/reader-registration/block.json
 #: release/newspack-plugin/dist/blocks/reader-registration/block.json
-#: release/newspack-plugin/src/blocks/reader-registration/block.json
-#: src/blocks/reader-registration/block.json
 msgctxt "block title"
 msgid "Reader Registration"
 msgstr ""
 
 #: dist/blocks/reader-registration/block.json
 #: release/newspack-plugin/dist/blocks/reader-registration/block.json
-#: release/newspack-plugin/src/blocks/reader-registration/block.json
-#: src/blocks/reader-registration/block.json
 msgctxt "block description"
 msgid "Register a reader with their email."
 msgstr ""


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This hotfix includes an updated POT file so publications can translate the latest strings in the plugin.

### How to test the changes in this Pull Request:

1. This is a pretty easy one, since we don't bundle translations with this plugin! One way to test is confirm that the POT file contains updated strings like "Account Settings".

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->