### PR TITLE
fix: user deletion w/out WC

### DIFF
--- a/includes/data-events/connectors/class-esp-connector.php
+++ b/includes/data-events/connectors/class-esp-connector.php
@@ -56,6 +56,9 @@ class ESP_Connector extends Reader_Activation\ESP_Sync {
 	 * @param int $user_id User ID being deleted.
 	 */
 	public static function store_user_data_before_deletion( $user_id ) {
+		if ( ! class_exists( 'WC_Customer' ) ) {
+			return;
+		}
 		$user = get_userdata( $user_id );
 		if ( ! $user ) {
 			return;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Similar to #4065, fixes an issue with the code assuming WooCommerce is active.

### How to test the changes in this Pull Request:

1. On `release`,
2. Deactivate `woocommerce` and delete a user with WP CLI
3. Observe a fatal error
4. Switch to this branch, observe a user can be deleted

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->