### PR TITLE
feat(collections): update cpt icon

### DIFF
--- a/includes/collections/class-post-type.php
+++ b/includes/collections/class-post-type.php
@@ -108,18 +108,26 @@ class Post_Type {
 			'item_updated'       => __( 'Collection updated', 'newspack-plugin' ),
 		];
 
+		$svg = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"><path d="M5.5 17.0009V18.5009H7.5V17.0009H5.5ZM5.5 20.0009C4.67188 20.0009 4 19.329 4 18.5009V17.0009V16.2509V15.5009V8.50092V7.75092V7.00092V5.50092C4 4.6728 4.67188 4.00092 5.5 4.00092C7.33333 4.00092 9.16667 4.00092 11 4.00092C11.6438 4.00092 12.1906 4.40405 12.4062 4.9728C12.5813 4.78217 12.8094 4.63842 13.075 4.56655L14.9344 4.05092C15.7063 3.83842 16.5 4.3103 16.7063 5.10717L17.2688 7.26967L17.4563 7.99467L19.3875 15.4415L19.575 16.1665L19.9469 17.604C20.1531 18.4009 19.6969 19.2197 18.925 19.4322L17.0625 19.9478C16.2906 20.1603 15.4969 19.6884 15.2906 18.8915L14.7281 16.729L14.5406 16.004L12.6125 8.5603L12.5 8.13217V8.50092V15.5009V16.2509V17.0009V18.5009C12.5 19.329 11.8281 20.0009 11 20.0009C9.08318 20.0009 7.41682 20.0009 5.5 20.0009ZM9 18.5009H11V17.0009H9V18.5009ZM7.5 5.50092H5.5V7.00092H7.5V5.50092ZM7.5 8.50092H5.5V15.5009H7.5V8.50092ZM9 7.00092H11V5.50092H9V7.00092ZM11 15.5009V8.50092H9V15.5009H11ZM17.7531 15.1165L16.0094 8.3978L14.2437 8.8853L15.9875 15.604L17.7531 15.1165ZM16.3656 17.0572L16.7375 18.4853L18.5 17.9978C18.5 17.9947 18.5 17.9915 18.5 17.9884V17.9853L18.1344 16.5728L16.3687 17.0603L16.3656 17.0572ZM13.8687 7.43217L15.6344 6.94467L15.2625 5.51655L13.5 6.00405C13.5 6.00717 13.5 6.0103 13.5 6.01655L13.8656 7.42905L13.8687 7.43217Z" /></svg>';
+
+		$icon = sprintf(
+			'data:image/svg+xml;base64,%s',
+			base64_encode( $svg )
+		);
+
 		$args = [
-			'label'        => __( 'Collection', 'newspack-plugin' ),
-			'labels'       => $labels,
-			'description'  => __( 'Grouped content for custom classification.', 'newspack-plugin' ),
-			'public'       => true,
-			'show_in_rest' => true,
-			'rewrite'      => [
+			'label'         => __( 'Collection', 'newspack-plugin' ),
+			'labels'        => $labels,
+			'description'   => __( 'Grouped content for custom classification.', 'newspack-plugin' ),
+			'public'        => true,
+			'show_in_rest'  => true,
+			'rewrite'       => [
 				'slug' => Settings::get_setting( 'custom_naming_enabled', false ) ? Settings::get_setting( 'custom_slug', 'collection' ) : 'collection',
 			],
-			'menu_icon'    => 'dashicons-portfolio',
-			'supports'     => [ 'title', 'editor', 'thumbnail', 'custom-fields', 'page-attributes' ],
-			'has_archive'  => true,
+			'menu_icon'     => $icon,
+			'supports'      => [ 'title', 'editor', 'thumbnail', 'custom-fields', 'page-attributes' ],
+			'has_archive'   => true,
+			'menu_position' => 6,
 		];
 
 		register_post_type( self::get_post_type(), $args );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR updates the CPT's icon. It also makes sure the menu item is just underneath the Posts rather than being place randomly at the bottom.

<img width="318" height="602" alt="image" src="https://github.com/user-attachments/assets/354cf308-1b1c-48a0-9fc2-2868398ceaf5" />

### How to test the changes in this Pull Request:

1. Switch to this branch
2. Check if you see the menu item just underneath Posts
3. Check if you see the new icon

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->