### PR TITLE
feat: add 'newspack_blocks' support to Collections to appear in Content Blocks

### DIFF
--- a/includes/collections/class-post-type.php
+++ b/includes/collections/class-post-type.php
@@ -118,7 +118,7 @@ class Post_Type {
 				'slug' => Settings::get_setting( 'custom_naming_enabled', false ) ? Settings::get_setting( 'custom_slug', 'collection' ) : 'collection',
 			],
 			'menu_icon'    => 'dashicons-portfolio',
-			'supports'     => [ 'title', 'editor', 'thumbnail', 'custom-fields', 'page-attributes', 'newspack-blocks' ],
+			'supports'     => [ 'title', 'editor', 'thumbnail', 'custom-fields', 'page-attributes', 'newspack_blocks' ],
 			'has_archive'  => true,
 		];
 

--- a/includes/collections/class-post-type.php
+++ b/includes/collections/class-post-type.php
@@ -118,7 +118,7 @@ class Post_Type {
 				'slug' => Settings::get_setting( 'custom_naming_enabled', false ) ? Settings::get_setting( 'custom_slug', 'collection' ) : 'collection',
 			],
 			'menu_icon'    => 'dashicons-portfolio',
-			'supports'     => [ 'title', 'editor', 'thumbnail', 'custom-fields', 'page-attributes' ],
+			'supports'     => [ 'title', 'editor', 'thumbnail', 'custom-fields', 'page-attributes', 'newspack-blocks' ],
 			'has_archive'  => true,
 		];
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds `newspack_blocks` support to the Collections post type, so it will appear as a queryable post type in the Content Loop and Content Carousel blocks.

### How to test the changes in this Pull Request:

1. Set up at least one collection; make sure to include a featured image and some text.
2. Apply this PR.
3. In a new page, add a Content Loop block and a Content Carousel block.
4. Confirm that you have 'Collections' available under 'Post Type', and that it will pull your collections into the block when enabled.

<img width="281" height="320" alt="CleanShot 2025-07-15 at 13 34 54" src="https://github.com/user-attachments/assets/a29b1472-03f2-40b1-8cd4-d1b8c8c0d7c3" />

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->