### PR TITLE
Fix/scripts add hooks in Lite Site

### DIFF
--- a/includes/lite-site/class-lite-site.php
+++ b/includes/lite-site/class-lite-site.php
@@ -440,10 +440,10 @@ class Lite_Site {
 		$content = preg_replace( '/<!--(.|\s)*?-->/', '', $content );
 
 		// First remove figures and their contents (including images and captions).
-		$content = preg_replace( '/<figure.*?>.*?<\/figure>/s', '', $content );
+		$content = preg_replace( '/<figure.*?>.*?<\/figure>/is', '', $content );
 
 		// Remove script tags.
-		$content = preg_replace( '/<script.*?>.*?<\/script>/s', '', $content );
+		$content = preg_replace( '/<script.*?>.*?<\/script>/is', '', $content );
 
 		// Define allowed HTML elements for text-only content.
 		$allowed_html = [

--- a/includes/lite-site/class-lite-site.php
+++ b/includes/lite-site/class-lite-site.php
@@ -442,6 +442,9 @@ class Lite_Site {
 		// First remove figures and their contents (including images and captions).
 		$content = preg_replace( '/<figure.*?>.*?<\/figure>/s', '', $content );
 
+		// Remove script tags.
+		$content = preg_replace( '/<script.*?>.*?<\/script>/s', '', $content );
+
 		// Define allowed HTML elements for text-only content.
 		$allowed_html = [
 			'p'          => [],

--- a/includes/lite-site/templates/archive.php
+++ b/includes/lite-site/templates/archive.php
@@ -76,5 +76,13 @@ namespace Newspack;
 			<?php echo wp_kses_post( $footer_html ); ?>
 		</footer>
 	<?php endif; ?>
+
+	<?php
+	/**
+	 * Fires after the footer of the lite site archive page.
+	 */
+	do_action( 'newspack_lite_site_archive_after_footer' );
+	?>
+
 </body>
 </html>

--- a/includes/lite-site/templates/single.php
+++ b/includes/lite-site/templates/single.php
@@ -52,5 +52,15 @@ if ( ! $current_post ) {
 			<?php echo wp_kses_post( $footer_html ); ?>
 		</footer>
 	<?php endif; ?>
+
+
+	<?php
+	/**
+	 * Fires after the footer of the lite site single post page.
+	 *
+	 * @param WP_Post $current_post The current post.
+	 */
+	do_action( 'newspack_lite_site_single_after_footer', $current_post );
+	?>
 </body>
 </html>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Lite site: Fixes handling of script tags and add two new hooks

### How to test the changes in this Pull Request:

1. Add a custom HTML block to a post and some simple JS to it like `<script>alert(1)</script>`
2. Visit the post on the Lite site version of it
3. on `trunk` you'll see that `alert(1)` shows up as plain text
4. on this branch the script is gone
5. Check the new hooks in the code and confirm they look good


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->