### PR TITLE
hotfix(google-oauth): race conditions and cross-site issues

### DIFF
--- a/includes/oauth/class-google-login.php
+++ b/includes/oauth/class-google-login.php
@@ -182,9 +182,29 @@ class Google_Login {
 		/** Close window if it's a popup. */
 		?>
 		<script type="text/javascript" data-amp-plus-allowed>
+			// Debug logging function that uses the centralized logging from newspackReaderActivation.
+			const debugLog = function( level ) {
+				if ( window.opener && window.opener.newspackReaderActivation && window.opener.newspackReaderActivation.debugLog ) {
+					window.opener.newspackReaderActivation.debugLog.apply( null, [level].concat( Array.prototype.slice.call( arguments, 1 ) ) );
+				}
+			};
+
+			debugLog('log', '[Google OAuth Callback] Script running, window.opener:', window.opener);
 			if ( window.opener ) {
-				window.opener.dispatchEvent( new Event('google-oauth-success') );
+				// Use postMessage for cross-origin communication (handles COOP restrictions).
+				try {
+					debugLog('log', '[Google OAuth Callback] Sending postMessage to origin:', window.location.origin);
+					window.opener.postMessage( 'google-oauth-success', window.location.origin );
+					debugLog('log', '[Google OAuth Callback] postMessage sent successfully');
+				} catch ( e ) {
+					debugLog('error', '[Google OAuth Callback] postMessage failed:', e);
+					// Fallback: postMessage might fail in some edge cases.
+				}
+
+				debugLog('log', '[Google OAuth Callback] Closing window');
 				window.close();
+			} else {
+				debugLog('log', '[Google OAuth Callback] No window.opener found');
 			}
 		</script>
 		<?php

--- a/src/memberships-gate/gate.js
+++ b/src/memberships-gate/gate.js
@@ -3,20 +3,9 @@
  * Internal dependencies
  */
 import './gate.scss';
+import { debugLog } from '../reader-activation/utils';
 
 const EVENT_NAME = 'np_gate_interaction';
-
-/**
- * Debug logging function that uses the centralized logging from newspackReaderActivation.
- *
- * @param {string} level Log level ('log' or 'error')
- * @param {...any} args  Arguments to pass to console
- */
-const debugLog = ( level, ...args ) => {
-	if ( window.newspackReaderActivation?.debugLog ) {
-		window.newspackReaderActivation.debugLog( level, ...args );
-	}
-};
 
 /**
  * Specify a function to execute when the DOM is fully loaded.

--- a/src/memberships-gate/gate.js
+++ b/src/memberships-gate/gate.js
@@ -7,6 +7,18 @@ import './gate.scss';
 const EVENT_NAME = 'np_gate_interaction';
 
 /**
+ * Debug logging function that uses the centralized logging from newspackReaderActivation.
+ *
+ * @param {string} level Log level ('log' or 'error')
+ * @param {...any} args  Arguments to pass to console
+ */
+const debugLog = ( level, ...args ) => {
+	if ( window.newspackReaderActivation?.debugLog ) {
+		window.newspackReaderActivation.debugLog( level, ...args );
+	}
+};
+
+/**
  * Specify a function to execute when the DOM is fully loaded.
  *
  * @see https://github.com/WordPress/gutenberg/blob/trunk/packages/dom-ready/
@@ -39,22 +51,32 @@ const gateInfo = {
  * Reload the page when a newly registered reader is detected.
  */
 function initReloadHandler() {
+	debugLog( 'log', '[Gate] initReloadHandler called' );
 	window.newspackRAS = window.newspackRAS || [];
 	window.newspackRAS.push( function ( ras ) {
+		debugLog( 'log', '[Gate] RAS initialized' );
 		let reload = false;
 
 		const refreshPage = function ( ev ) {
+			debugLog( 'log', '[Gate] refreshPage called with event:', ev );
+			debugLog( 'log', '[Gate] Event detail:', ev?.detail );
+			debugLog( 'log', '[Gate] Event detail action:', ev?.detail?.action );
+			debugLog( 'log', '[Gate] Pending checkout:', window?.newspackReaderActivation?.getPendingCheckout() );
+
 			// When a new reader is registered, which may or may not happen inside an overlay.
 			if ( ev?.detail?.action && 'reader_registered' === ev.detail.action && ! window?.newspackReaderActivation?.getPendingCheckout() ) {
+				debugLog( 'log', '[Gate] reader_registered action detected' );
 				reload = true;
 			}
 
 			// When closing an overlay, check if the last activity was a checkout, registration, or login.
 			if ( ev?.detail?.overlays && ev.detail.removed ) {
 				const activities = window?.newspackReaderActivation?.getActivities();
+				debugLog( 'log', '[Gate] Overlay removed, activities:', activities );
 				const lastActivity = activities?.[ activities.length - 1 ] || {};
 				const validActions = [ 'checkout_completed', 'reader_registered', 'reader_logged_in', 'newsletter_signup' ];
 				if ( activities.length && validActions.includes( lastActivity.action ) ) {
+					debugLog( 'log', '[Gate] Valid action detected:', lastActivity.action );
 					reload = true;
 					// Add a CSS class to the body so we can keep the overlay content gate hidden while the page refreshes.
 					document.body.classList.add( 'newspack-memberships__gate-passed' );
@@ -64,11 +86,22 @@ function initReloadHandler() {
 				}
 			}
 
+			// Check for reader_logged_in action specifically for non-overlay contexts
+			if ( ev?.detail?.action && 'reader_logged_in' === ev.detail.action ) {
+				debugLog( 'log', '[Gate] reader_logged_in action detected' );
+				reload = true;
+			}
+
 			// If there are no overlays and a new reader, login, or checkout is detected,
 			// reload the window, but allow other JS – which might have
 			// triggered another overlay – to be executed (setTimeout hack).
 			setTimeout( () => {
-				if ( ! ras.overlays.get().length && reload ) {
+				const overlays = ras.overlays.get();
+				const activities = window?.newspackReaderActivation?.getActivities();
+				debugLog( 'log', '[Gate] Checking reload conditions - overlays:', overlays, 'reload:', reload );
+				debugLog( 'log', '[Gate] Current activities:', activities );
+				if ( ! overlays.length && reload ) {
+					debugLog( 'log', '[Gate] Reloading page!' );
 					window.location.reload();
 				}
 			}, 5 );

--- a/src/reader-activation-auth/google-oauth.js
+++ b/src/reader-activation-auth/google-oauth.js
@@ -5,6 +5,18 @@
  */
 import { domReady, convertFormDataToObject } from '../utils';
 
+/**
+ * Debug logging function that uses the centralized logging from newspackReaderActivation.
+ *
+ * @param {string} level Log level ('log' or 'error')
+ * @param {...any} args  Arguments to pass to console
+ */
+const debugLog = ( level, ...args ) => {
+	if ( window.newspackReaderActivation?.debugLog ) {
+		window.newspackReaderActivation.debugLog( level, ...args );
+	}
+};
+
 domReady( function () {
 	const loginsElements = document.querySelectorAll( '.newspack-reader__logins' );
 	[ ...loginsElements ].forEach( element => {
@@ -14,21 +26,26 @@ domReady( function () {
 	googleLoginElements.forEach( googleLoginElement => {
 		const googleLoginForm = googleLoginElement.closest( 'form' );
 		const checkLoginStatus = metadata => {
+			debugLog( 'log', '[Google OAuth] checkLoginStatus called with metadata:', metadata );
 			fetch( `/wp-json/newspack/v1/login/google/register?metadata=${ JSON.stringify( metadata ) }` )
 				.then( res => {
+					debugLog( 'log', '[Google OAuth] Register response status:', res.status );
 					res.json()
 						.then( ( { message, data } ) => {
+							debugLog( 'log', '[Google OAuth] Register response data:', { message, data } );
 							if ( googleLoginForm?.endLoginFlow ) {
 								googleLoginForm.endLoginFlow( message, res.status, data );
 							}
 						} )
 						.catch( error => {
+							debugLog( 'error', '[Google OAuth] Error parsing register response:', error );
 							if ( googleLoginForm?.endLoginFlow ) {
 								googleLoginForm.endLoginFlow( error?.message, res.status );
 							}
 						} );
 				} )
 				.catch( error => {
+					debugLog( 'error', '[Google OAuth] Error fetching register endpoint:', error );
 					if ( googleLoginForm?.endLoginFlow ) {
 						googleLoginForm.endLoginFlow( error?.message );
 					}
@@ -36,16 +53,46 @@ domReady( function () {
 		};
 
 		googleLoginElement.addEventListener( 'click', () => {
+			debugLog( 'log', '[Google OAuth] Login button clicked' );
 			if ( googleLoginForm?.startLoginFlow ) {
 				googleLoginForm.startLoginFlow();
 			}
 
 			const metadata = googleLoginForm ? convertFormDataToObject( new FormData( googleLoginForm ), [ 'lists[]' ] ) : {};
 			metadata.current_page_url = window.location.href;
+			debugLog( 'log', '[Google OAuth] Opening auth window with metadata:', metadata );
 			const authWindow = window.open( 'about:blank', 'newspack_google_login', 'width=500,height=600' );
-			let googleOAuthSuccess = false;
+			let messageListener = null;
+
+			// Clean up function to remove listeners.
+			const cleanup = () => {
+				debugLog( 'log', '[Google OAuth] Cleanup called' );
+				if ( messageListener ) {
+					window.removeEventListener( 'message', messageListener );
+					messageListener = null;
+				}
+			};
+
+			// Listen for postMessage from OAuth callback.
+			messageListener = event => {
+				debugLog( 'log', '[Google OAuth] Received postMessage:', {
+					origin: event.origin,
+					data: event.data,
+					expectedOrigin: window.location.origin,
+				} );
+				// Validate the message origin matches our domain.
+				if ( event.origin === window.location.origin && event.data === 'google-oauth-success' ) {
+					debugLog( 'log', '[Google OAuth] Valid success message received, calling checkLoginStatus' );
+					cleanup();
+					checkLoginStatus( metadata );
+				}
+			};
+			window.addEventListener( 'message', messageListener );
+
+			// Keep the legacy event listener for backwards compatibility.
 			window.addEventListener( 'google-oauth-success', () => {
-				googleOAuthSuccess = true;
+				debugLog( 'log', '[Google OAuth] Legacy google-oauth-success event received' );
+				cleanup();
 				checkLoginStatus( metadata );
 			} );
 
@@ -56,24 +103,19 @@ domReady( function () {
 						if ( authWindow ) {
 							authWindow.close();
 						}
+						cleanup();
 						if ( googleLoginForm?.endLoginFlow ) {
 							googleLoginForm.endLoginFlow( data.message, status );
 						}
 					} else if ( authWindow ) {
 						authWindow.location = data;
-						const interval = setInterval( () => {
-							if ( ! googleOAuthSuccess && authWindow.closed ) {
-								if ( googleLoginForm?.endLoginFlow ) {
-									googleLoginForm.endLoginFlow( newspack_reader_activation_labels.login_canceled, 401 );
-								}
-								clearInterval( interval );
-							}
-						}, 500 );
 					} else if ( googleLoginForm?.endLoginFlow ) {
+						cleanup();
 						googleLoginForm.endLoginFlow( newspack_reader_activation_labels.blocked_popup );
 					}
 				} )
 				.catch( error => {
+					cleanup();
 					if ( googleLoginForm?.endLoginFlow ) {
 						googleLoginForm.endLoginFlow( error?.message, 400 );
 					}

--- a/src/reader-activation-auth/google-oauth.js
+++ b/src/reader-activation-auth/google-oauth.js
@@ -4,18 +4,7 @@
  * Internal dependencies.
  */
 import { domReady, convertFormDataToObject } from '../utils';
-
-/**
- * Debug logging function that uses the centralized logging from newspackReaderActivation.
- *
- * @param {string} level Log level ('log' or 'error')
- * @param {...any} args  Arguments to pass to console
- */
-const debugLog = ( level, ...args ) => {
-	if ( window.newspackReaderActivation?.debugLog ) {
-		window.newspackReaderActivation.debugLog( level, ...args );
-	}
-};
+import { debugLog } from '../reader-activation/utils';
 
 domReady( function () {
 	const loginsElements = document.querySelectorAll( '.newspack-reader__logins' );
@@ -88,13 +77,6 @@ domReady( function () {
 				}
 			};
 			window.addEventListener( 'message', messageListener );
-
-			// Keep the legacy event listener for backwards compatibility.
-			window.addEventListener( 'google-oauth-success', () => {
-				debugLog( 'log', '[Google OAuth] Legacy google-oauth-success event received' );
-				cleanup();
-				checkLoginStatus( metadata );
-			} );
 
 			fetch( '/wp-json/newspack/v1/login/google?r=' + Math.random() )
 				.then( res => res.json().then( data => Promise.resolve( { data, status: res.status } ) ) )

--- a/src/reader-activation/index.js
+++ b/src/reader-activation/index.js
@@ -5,7 +5,7 @@ window.newspack_ras_config = window.newspack_ras_config || {};
 import Store from './store.js';
 import { getPendingCheckout, setPendingCheckout } from './checkout.js';
 import { EVENTS, on, off, emit } from './events.js';
-import { getCookie, setCookie, generateID } from './utils.js';
+import { getCookie, setCookie, generateID, debugLog } from './utils.js';
 import overlays from './overlays.js';
 import initAnalytics from './analytics.js';
 import setupArticleViewsAggregates from './article-view.js';
@@ -334,21 +334,6 @@ export function getAuthStrategy() {
 		return 'otp';
 	}
 	return getCookie( 'np_auth_strategy' );
-}
-
-/**
- * Debug logging function that only logs when localStorage flag is set.
- *
- * @param {string} level Log level ('log' or 'error').
- * @param {...any} args  Arguments to pass to console.
- */
-// eslint-disable-next-line no-console
-export function debugLog( level = 'log', ...args ) {
-	if ( localStorage.getItem( 'newspack-google-oauth-debug' ) === 'true' ) {
-		const method = level === 'error' ? 'error' : 'log';
-		// eslint-disable-next-line no-console
-		console[ method ]( ...args );
-	}
 }
 
 /**

--- a/src/reader-activation/index.js
+++ b/src/reader-activation/index.js
@@ -337,6 +337,21 @@ export function getAuthStrategy() {
 }
 
 /**
+ * Debug logging function that only logs when localStorage flag is set.
+ *
+ * @param {string} level Log level ('log' or 'error').
+ * @param {...any} args  Arguments to pass to console.
+ */
+// eslint-disable-next-line no-console
+export function debugLog( level = 'log', ...args ) {
+	if ( localStorage.getItem( 'newspack-google-oauth-debug' ) === 'true' ) {
+		const method = level === 'error' ? 'error' : 'log';
+		// eslint-disable-next-line no-console
+		console[ method ]( ...args );
+	}
+}
+
+/**
  * Ensure the client ID cookie is set.
  */
 function fixClientID() {
@@ -433,6 +448,7 @@ const readerActivation = {
 	getAuthStrategy,
 	setPendingCheckout,
 	getPendingCheckout,
+	debugLog,
 	...( newspack_ras_config.is_ras_enabled && { openAuthModal } ),
 };
 

--- a/src/reader-activation/utils.js
+++ b/src/reader-activation/utils.js
@@ -49,3 +49,18 @@ export function generateID( length = 9 ) {
 	}
 	return randomString;
 }
+
+/**
+ * Debug logging function that only logs when localStorage flag is set.
+ *
+ * @param {string} level Log level ('log' or 'error').
+ * @param {...any} args  Arguments to pass to console.
+ */
+// eslint-disable-next-line no-console
+export function debugLog( level = 'log', ...args ) {
+	if ( localStorage.getItem( 'newspack-reader-activation-debug' ) === 'true' ) {
+		const method = level === 'error' ? 'error' : 'log';
+		// eslint-disable-next-line no-console
+		console[ method ]( ...args );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Google OAuth login was failing to refresh the page after successful authentication on Chrome 138 with macOS Sonoma due to Cross-Origin-Opener-Policy (COOP) restrictions blocking access to `window.closed`.

#### Solution
Replaced the unreliable `window.closed` polling with a robust `postMessage` API for cross-origin communication between the OAuth popup and parent window.

#### Key Changes
- **Fixed COOP compatibility**: Replaced `window.closed` checks with `postMessage` communication
- **Improved reliability**: OAuth callback now uses `postMessage` to signal success to parent window
- **Enhanced debugging**: Added centralized debug logging system accessible via `window.newspackReaderActivation.debugLog`
- **Better error handling**: Graceful fallbacks for cross-origin communication failures

#### Files Modified
- `src/reader-activation-auth/google-oauth.js` - Updated to use postMessage listeners
- `includes/oauth/class-google-login.php` - OAuth callback sends postMessage to parent window
- `src/memberships-gate/gate.js` - Added support for `reader_logged_in` action detection
- `src/reader-activation/index.js` - Added centralized debug logging function

### How to test the changes in this Pull Request:

1. Ensure Google OAuth is configured in Newspack settings
1. Set up a membership gate on a test post/page
1. Navigate to a gated article while logged out
1. Run: `localStorage.setItem('newspack-google-oauth-debug', 'true')`
1. Click "Sign in with Google" button
1. Complete Google OAuth flow in popup window
1. **Expected**: Page should automatically refresh and show ungated content
1. **Expected**: No console errors related to `window.closed`
1. **Expected**: Console shows detailed logs of the OAuth process:
   - `[Google OAuth] Login button clicked`
   - `[Google OAuth] Received postMessage`
   - `[Gate] reader_logged_in action detected`
   - `[Gate] Reloading page!`


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->