### PR TITLE
fix: make hr styles more specific and account for < 6 issues

### DIFF
--- a/src/collections/frontend/_archive.scss
+++ b/src/collections/frontend/_archive.scss
@@ -5,10 +5,11 @@
 .post-type-archive-newspack_collection {
 	main#main {
 		width: 100%;
-	}
 
-	hr {
-		margin: 16px 0;
+		hr {
+			margin: 16px 0;
+			width: 100%;
+		}
 	}
 
 	.collections-filter {
@@ -18,6 +19,7 @@
 		flex-wrap: wrap;
 		justify-content: right;
 		margin-bottom: 16px;
+		width: 100%;
 
 		&__select {
 			align-items: center;

--- a/src/collections/frontend/_single.scss
+++ b/src/collections/frontend/_single.scss
@@ -3,7 +3,7 @@
 
 /* Single collection template styles */
 .single-newspack_collection {
-	hr {
+	#main hr {
 		flex: 0 0 100%;
 		margin: 32px 0 62px;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR tweaks a couple small things in the Collections styles:
* It makes the `hr` selectors on single Collections and the Collections archive pages more specific, so they don't "bleed" into other areas (like widgets or campaigns)
* It adds a couple 100% widths to the archive page filter area to make it full width, even when there are less than 6 issues to show -- otherwise it matches the width of the issues.

### How to test the changes in this Pull Request:

1. Set up your staging site so it has a full-width separator block in the above-footer widget area, and less than 6 collections (preferably 1-2). To make it stand out, gave my separator block a unique background.
2. View the main Collections landing page and note the filter is flush left, and you can't see the border underneath it:

<img width="1268" height="639" alt="CleanShot 2025-07-18 at 08 23 55" src="https://github.com/user-attachments/assets/734cb7ef-f774-44d6-bad2-de0527a49d13" />

3. Inspect the `hr` in the footer and note it's picking up the `hr` styles specific to the archives (16px margins):

<img width="1772" height="511" alt="CleanShot 2025-07-18 at 08 24 32" src="https://github.com/user-attachments/assets/006085a4-0847-4003-aead-e956c18cb09e" />

5. View the single issue and inspect the `hr` in the footer; note it's picking up the spacing from the single post verison (32px top and 64px bottom margins).

<img width="1779" height="542" alt="CleanShot 2025-07-18 at 08 25 08" src="https://github.com/user-attachments/assets/ee978456-0b33-428d-a580-b9401f2237ed" />

4. Apply this PR and run `npm run build`.
5. Confirm the above issues are fixed.

<img width="1240" height="221" alt="CleanShot 2025-07-18 at 08 12 14" src="https://github.com/user-attachments/assets/ec0ef672-0899-407d-8f7f-43d88dcbd19c" />

<img width="1241" height="487" alt="CleanShot 2025-07-18 at 08 13 06" src="https://github.com/user-attachments/assets/88fc3a41-84eb-426a-891d-02681810da8f" />

6. Confirm that the `hr`s in the Collections markup (below the filter on the main Collection archive page, and below the cover on a single collection) are picking up the margin styles from the Collections CSS, and look right.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->