### PR TITLE
feat: Collections feedback

### DIFF
--- a/includes/collections/README.md
+++ b/includes/collections/README.md
@@ -62,9 +62,15 @@ The following nested options are available as properties of the `newspack_collec
 | `custom_naming_enabled` | Boolean | Enable custom naming for collections | Boolean |
 | `custom_name` | String | Custom plural name for collections. Only affects the reader-facing nomenclature | Text (e.g., "Issues") |
 | `custom_singular_name` | String | Custom singular name for collections. Only affects the reader-facing nomenclature | Text (e.g., "Issue") |
+| `custom_archive_slug` | String | Custom URL slug for collections archive. | Text (e.g., "issues") |
 | `custom_slug` | String | Custom URL slug for collections. | Text (e.g., "issue") |
 | `subscribe_link` | String | Global subscription URL displayed on collection pages | Valid URL |
 | `order_link` | String | Global order URL for purchasing physical copies | Valid URL |
+| `posts_per_page` | Integer | Global posts per page | 12, 18, 24 |
+| `category_filter_label` | String | Custom label for the category filter dropdown | Text (e.g., "Publication:") |
+| `highlight_latest` | Boolean | Highlight the latest collection | Boolean |
+| `post_indicator_style` | String | Global post indicator style | "default" or "card" |
+| `card_message` | String | Global card message | Text |
 
 The `subscribe_link` and `order_link` settings provide defaults that can be overridden at the collection category level (via term meta) or collection level (via post meta).
 
@@ -181,12 +187,12 @@ The module provides a set of components for displaying collections-related eleme
 The frontend components are integrated into WordPress through:
 
 1. **Script Loading**
-   - Enqueued via `Enqueuer::enqueue_admin_scripts()` if the Collections module is enabled.
-   - Bundle: `dist/collections-admin.js`
+   - Enqueued via `Enqueuer::init()` if the Collections module is enabled.
+   - Bundles: `dist/collections-admin.js` and `dist/collections-frontend.js`
 
 2. **Style Loading**
-   - Enqueued via `Enqueuer::enqueue_admin_styles()` if the Collections module is enabled.
-   - Bundle: `dist/collections-admin.css`
+   - Enqueued via `Enqueuer::init()` if the Collections module is enabled.
+   - Bundles: `dist/collections-admin.css` and `dist/collections-frontend.css`
 
 3. **Data Localization**
    - Collection data is localized via `Enqueuer::localize_data()`.
@@ -199,6 +205,8 @@ The frontend components are integrated into WordPress through:
 
 - [`includes/collections/`](includes/collections/) - Core collection functionality (PHP).
 - [`includes/optional-modules/class-collections-optional-module.php`](includes/optional-modules/class-collections-optional-module.php) - Optional module setup.
+- [`includes/templates/collections/`](includes/templates/collections/) - Templates.
 - [`includes/wizards/newspack/class-collections-section.php`](includes/wizards/newspack/class-collections-section.php) - Newspack settings Collections tab.
 - [`src/collections/admin/`](src/collections/admin/) - Admin interface (JavaScript/styles).
+- [`src/wizards/newspack/views/settings/collections/`](src/wizards/newspack/views/settings/collections/) - Settings UI components.
 - [`tests/unit-tests/collections/`](tests/unit-tests/collections/) - Unit tests

--- a/includes/collections/README.md
+++ b/includes/collections/README.md
@@ -62,7 +62,6 @@ The following nested options are available as properties of the `newspack_collec
 | `custom_naming_enabled` | Boolean | Enable custom naming for collections | Boolean |
 | `custom_name` | String | Custom plural name for collections. Only affects the reader-facing nomenclature | Text (e.g., "Issues") |
 | `custom_singular_name` | String | Custom singular name for collections. Only affects the reader-facing nomenclature | Text (e.g., "Issue") |
-| `custom_archive_slug` | String | Custom URL slug for collections archive. | Text (e.g., "issues") |
 | `custom_slug` | String | Custom URL slug for collections. | Text (e.g., "issue") |
 | `subscribe_link` | String | Global subscription URL displayed on collection pages | Valid URL |
 | `order_link` | String | Global order URL for purchasing physical copies | Valid URL |

--- a/includes/collections/class-content-inserter.php
+++ b/includes/collections/class-content-inserter.php
@@ -165,7 +165,17 @@ class Content_Inserter {
 						<div class="wp-block-group">
 							<?php echo wp_kses_post( $image_html ); ?>
 							<p>
-								<strong>Browse <?php echo esc_html( $collection_title ); ?></strong>
+								<strong>
+									<?php
+									echo esc_html(
+										sprintf(
+											/* translators: %s is replaced with the collection title */
+											_x( 'Browse %s', 'browse collection', 'newspack-plugin' ),
+											$collection_title
+										)
+									);
+									?>
+								</strong>
 								<br>
 								<?php echo esc_html( $card_message ); ?>
 							</p>

--- a/includes/collections/class-post-type.php
+++ b/includes/collections/class-post-type.php
@@ -124,7 +124,7 @@ class Post_Type {
 			],
 			'menu_icon'     => $icon,
 			'supports'      => [ 'title', 'editor', 'thumbnail', 'custom-fields', 'page-attributes', 'newspack_blocks' ],
-			'has_archive'   => true,
+			'has_archive'   => Settings::get_collection_archive_slug(),
 			'menu_position' => 6,
 		];
 

--- a/includes/collections/class-post-type.php
+++ b/includes/collections/class-post-type.php
@@ -124,7 +124,7 @@ class Post_Type {
 			],
 			'menu_icon'     => $icon,
 			'supports'      => [ 'title', 'editor', 'thumbnail', 'custom-fields', 'page-attributes', 'newspack_blocks' ],
-			'has_archive'   => Settings::get_collection_archive_slug(),
+			'has_archive'   => true,
 			'menu_position' => 6,
 		];
 

--- a/includes/collections/class-settings.php
+++ b/includes/collections/class-settings.php
@@ -25,6 +25,11 @@ class Settings {
 	public const POSTS_PER_PAGE_OPTIONS = [ 12, 18, 24 ];
 
 	/**
+	 * Post indicator style options.
+	 */
+	public const POST_INDICATOR_STYLE_OPTIONS = [ 'default', 'card' ];
+
+	/**
 	 * Get fields definitions to be used in the REST API.
 	 *
 	 * @param string $return_type Whether to return only the default values, keys, or all. Returns all the configuration by default.
@@ -96,7 +101,9 @@ class Settings {
 			'post_indicator_style'  => [
 				'required'          => false,
 				'default'           => 'default',
-				'sanitize_callback' => 'sanitize_text_field',
+				'sanitize_callback' => function ( $value ) {
+					return in_array( $value, self::POST_INDICATOR_STYLE_OPTIONS, true ) ? $value : 'default';
+				},
 			],
 			'card_message'          => [
 				'required'          => false,

--- a/includes/collections/class-settings.php
+++ b/includes/collections/class-settings.php
@@ -54,6 +54,13 @@ class Settings {
 					return sanitize_title( is_string( $value ) ? $value : '' );
 				},
 			],
+			'custom_archive_slug'   => [
+				'required'          => false,
+				'default'           => '',
+				'sanitize_callback' => function ( $value ) {
+					return sanitize_title( is_string( $value ) ? $value : '' );
+				},
+			],
 			'subscribe_link'        => [
 				'required'          => false,
 				'default'           => '',
@@ -203,6 +210,15 @@ class Settings {
 	}
 
 	/**
+	 * Get the collection archive slug.
+	 *
+	 * @return string
+	 */
+	public static function get_collection_archive_slug() {
+		return self::get_custom_name( 'custom_archive_slug', 'collections' );
+	}
+
+	/**
 	 * Update collection settings from REST request.
 	 * Conditionally flushes rewrite rules when there are changes that will affect the post type or taxonomy slugs.
 	 *
@@ -240,7 +256,7 @@ class Settings {
 		self::update_settings( $updated_settings );
 
 		// Flush rewrite rules only if slug-related settings changed.
-		if ( ! empty( array_intersect( array_keys( $updated_settings ), [ 'custom_naming_enabled', 'custom_slug' ] ) ) ) {
+		if ( ! empty( array_intersect( array_keys( $updated_settings ), [ 'custom_naming_enabled', 'custom_slug', 'custom_archive_slug' ] ) ) ) {
 			/**
 			 * Fires before flushing rewrite rules after collection settings are updated.
 			 *

--- a/includes/collections/class-settings.php
+++ b/includes/collections/class-settings.php
@@ -53,13 +53,6 @@ class Settings {
 				'default'           => '',
 				'sanitize_callback' => 'sanitize_text_field',
 			],
-			'custom_archive_slug'   => [
-				'required'          => false,
-				'default'           => '',
-				'sanitize_callback' => function ( $value ) {
-					return sanitize_title( is_string( $value ) ? $value : '' );
-				},
-			],
 			'custom_slug'           => [
 				'required'          => false,
 				'default'           => '',
@@ -222,16 +215,7 @@ class Settings {
 	 * @return string
 	 */
 	public static function get_collection_slug() {
-		return self::get_custom_name( 'custom_slug', 'collection' );
-	}
-
-	/**
-	 * Get the collection archive slug.
-	 *
-	 * @return string
-	 */
-	public static function get_collection_archive_slug() {
-		return self::get_custom_name( 'custom_archive_slug', 'collections' );
+		return self::get_custom_name( 'custom_slug', 'collections' );
 	}
 
 	/**
@@ -272,7 +256,7 @@ class Settings {
 		self::update_settings( $updated_settings );
 
 		// Flush rewrite rules only if slug-related settings changed.
-		if ( ! empty( array_intersect( array_keys( $updated_settings ), [ 'custom_naming_enabled', 'custom_slug', 'custom_archive_slug' ] ) ) ) {
+		if ( ! empty( array_intersect( array_keys( $updated_settings ), [ 'custom_naming_enabled', 'custom_slug' ] ) ) ) {
 			/**
 			 * Fires before flushing rewrite rules after collection settings are updated.
 			 *

--- a/includes/collections/class-settings.php
+++ b/includes/collections/class-settings.php
@@ -32,6 +32,7 @@ class Settings {
 	 */
 	public static function get_rest_args( $return_type = 'all' ) {
 		$fields = [
+			// Custom Naming section.
 			'custom_naming_enabled' => [
 				'required'          => false,
 				'default'           => false,
@@ -47,13 +48,6 @@ class Settings {
 				'default'           => '',
 				'sanitize_callback' => 'sanitize_text_field',
 			],
-			'custom_slug'           => [
-				'required'          => false,
-				'default'           => '',
-				'sanitize_callback' => function ( $value ) {
-					return sanitize_title( is_string( $value ) ? $value : '' );
-				},
-			],
 			'custom_archive_slug'   => [
 				'required'          => false,
 				'default'           => '',
@@ -61,6 +55,14 @@ class Settings {
 					return sanitize_title( is_string( $value ) ? $value : '' );
 				},
 			],
+			'custom_slug'           => [
+				'required'          => false,
+				'default'           => '',
+				'sanitize_callback' => function ( $value ) {
+					return sanitize_title( is_string( $value ) ? $value : '' );
+				},
+			],
+			// Global CTAs section.
 			'subscribe_link'        => [
 				'required'          => false,
 				'default'           => '',
@@ -71,6 +73,26 @@ class Settings {
 				'default'           => '',
 				'sanitize_callback' => 'esc_url_raw',
 			],
+			// Collections Archive section.
+			'posts_per_page'        => [
+				'required'          => false,
+				'default'           => 12,
+				'sanitize_callback' => function ( $value ) {
+					$value = intval( $value );
+					return in_array( $value, self::POSTS_PER_PAGE_OPTIONS, true ) ? $value : 12;
+				},
+			],
+			'category_filter_label' => [
+				'required'          => false,
+				'default'           => '',
+				'sanitize_callback' => 'sanitize_text_field',
+			],
+			'highlight_latest'      => [
+				'required'          => false,
+				'default'           => false,
+				'sanitize_callback' => 'rest_sanitize_boolean',
+			],
+			// Collection Posts section.
 			'post_indicator_style'  => [
 				'required'          => false,
 				'default'           => 'default',
@@ -80,19 +102,6 @@ class Settings {
 				'required'          => false,
 				'default'           => '',
 				'sanitize_callback' => 'sanitize_text_field',
-			],
-			'posts_per_page'        => [
-				'required'          => false,
-				'default'           => 12,
-				'sanitize_callback' => function ( $value ) {
-					$value = intval( $value );
-					return in_array( $value, self::POSTS_PER_PAGE_OPTIONS, true ) ? $value : 12;
-				},
-			],
-			'highlight_latest'      => [
-				'required'          => false,
-				'default'           => false,
-				'sanitize_callback' => 'rest_sanitize_boolean',
 			],
 		];
 

--- a/includes/collections/class-template-helper.php
+++ b/includes/collections/class-template-helper.php
@@ -351,6 +351,8 @@ class Template_Helper {
 	 * Render articles block.
 	 * Reuses the Content Loop block.
 	 *
+	 * @uses newspack-blocks/homepage-articles Content Loop block from newspack-blocks plugin.
+	 *
 	 * @param array  $post_ids       Array of post IDs.
 	 * @param string $section_header The header of the section.
 	 * @param bool   $show_image     Whether to show the image.
@@ -361,6 +363,17 @@ class Template_Helper {
 	public static function render_articles( $post_ids, $section_header = '', $show_image = true, $columns = 2, $type_scale = 3 ) {
 		if ( empty( $post_ids ) ) {
 			return '';
+		}
+
+		$block_name = 'newspack-blocks/homepage-articles';
+
+		// Check if the required block is registered.
+		if ( ! \WP_Block_Type_Registry::get_instance()->is_registered( $block_name ) ) {
+			// Surface dependency for logged-in editors.
+			return ( current_user_can( 'edit_posts' ) )
+				/* translators: %s is the block name */
+				? sprintf( esc_html__( 'The %s block is required but not available. Please install and activate the Newspack Blocks plugin.', 'newspack-plugin' ), '<code>' . esc_html( $block_name ) . '</code>' )
+				: '';
 		}
 
 		$attrs = [
@@ -387,7 +400,7 @@ class Template_Helper {
 
 		return render_block(
 			[
-				'blockName' => 'newspack-blocks/homepage-articles',
+				'blockName' => $block_name,
 				'attrs'     => $attrs,
 			]
 		);

--- a/includes/collections/class-template-helper.php
+++ b/includes/collections/class-template-helper.php
@@ -264,11 +264,13 @@ class Template_Helper {
 		$vol_number = [];
 
 		if ( $volume ) {
-			$vol_number[] = sprintf( 'Vol. %s', esc_html( $volume ) );
+			/* translators: %s is the volume number of a collection */
+			$vol_number[] = sprintf( _x( 'Vol. %s', 'collection volume number', 'newspack-plugin' ), esc_html( $volume ) );
 		}
 
 		if ( $number ) {
-			$vol_number[] = sprintf( 'No. %s', esc_html( $number ) );
+			/* translators: %s is the issue number of a collection */
+			$vol_number[] = sprintf( _x( 'No. %s', 'collection issue number', 'newspack-plugin' ), esc_html( $number ) );
 		}
 
 		if ( $vol_number ) {
@@ -398,7 +400,7 @@ class Template_Helper {
 	 */
 	public static function render_see_all_link() {
 		$link  = get_post_type_archive_link( Post_Type::get_post_type() );
-		$label = __( 'See all', 'newspack-plugin' );
+		$label = _x( 'See all', 'see all collections link', 'newspack-plugin' );
 		$html  = sprintf( '<a href="%s">%s</a>', esc_url( $link ), esc_html( $label ) );
 
 		/**

--- a/includes/collections/class-template-helper.php
+++ b/includes/collections/class-template-helper.php
@@ -412,9 +412,20 @@ class Template_Helper {
 	 * @return string The rendered see all link.
 	 */
 	public static function render_see_all_link() {
-		$link  = get_post_type_archive_link( Post_Type::get_post_type() );
-		$label = _x( 'See all', 'see all collections link', 'newspack-plugin' );
-		$html  = sprintf( '<a href="%s">%s</a>', esc_url( $link ), esc_html( $label ) );
+		$link       = get_post_type_archive_link( Post_Type::get_post_type() );
+		$label      = _x( 'See all', 'see all collections link', 'newspack-plugin' );
+		$aria_label = sprintf(
+			/* translators: %s is the collection name (e.g., "Collections", "Issues") */
+			_x( 'See all %s', 'see all collections link aria-label', 'newspack-plugin' ),
+			strtolower( Settings::get_collection_label() )
+		);
+
+		$html = sprintf(
+			'<a href="%s" aria-label="%s">%s</a>',
+			esc_url( $link ),
+			esc_attr( $aria_label ),
+			esc_html( $label )
+		);
 
 		/**
 		 * Filters the see all link HTML.

--- a/includes/templates/collections/archive-newspack-collection.php
+++ b/includes/templates/collections/archive-newspack-collection.php
@@ -72,7 +72,7 @@ do_action( 'newspack_collections_archive_start' );
 				if ( count( $categories ) > 1 ) :
 					?>
 					<div class="collections-filter__select">
-						<label for="category"><?php esc_html_e( 'Publication:', 'newspack-plugin' ); ?></label>
+						<label for="category"><?php echo esc_html( Settings::get_setting( 'category_filter_label', _x( 'Publication:', 'collections category filter label', 'newspack-plugin' ) ) ); ?></label>
 						<select name="category" id="category">
 							<option value="" <?php selected( $selected_category, '' ); ?>><?php esc_html_e( 'All', 'newspack-plugin' ); ?></option>
 							<?php foreach ( $categories as $category ) : ?>

--- a/includes/templates/collections/archive-newspack-collection.php
+++ b/includes/templates/collections/archive-newspack-collection.php
@@ -30,8 +30,10 @@ do_action( 'newspack_collections_archive_start' );
 
 		<?php
 		if ( have_posts() ) :
-			// Render the intro section only if it's the first page of results and "Highlight Most Recent Collection" setting is enabled.
-			if ( ! is_paged() && Settings::get_setting( 'highlight_latest' ) ) :
+			$selected_year = isset( $_GET['year'] ) ? sanitize_text_field( $_GET['year'] ) : '';
+
+			// Render the intro section only if no year filter is applied, it's the first page of results and "Highlight Most Recent Collection" setting is enabled.
+			if ( empty( $selected_year ) && ! is_paged() && Settings::get_setting( 'highlight_latest' ) ) :
 				get_template_part(
 					Template_Helper::TEMPLATE_PARTS_DIR . 'newspack-collection-intro',
 					null,
@@ -50,7 +52,6 @@ do_action( 'newspack_collections_archive_start' );
 			<!-- Filter controls -->
 			<form class="collections-filter" method="get">
 				<?php
-				$selected_year     = isset( $_GET['year'] ) ? sanitize_text_field( $_GET['year'] ) : '';
 				$selected_category = isset( $_GET['category'] ) ? sanitize_text_field( $_GET['category'] ) : '';
 				$available_years   = Query_Helper::get_available_years( $selected_category );
 				?>

--- a/src/wizards/newspack/views/settings/collections/custom-naming-card.tsx
+++ b/src/wizards/newspack/views/settings/collections/custom-naming-card.tsx
@@ -36,24 +36,14 @@ const CustomNamingCard: React.FC< CustomNamingCardProps > = ( { settings, isSavi
 					placeholder="Collection"
 				/>
 				<TextControl
-					label={ __( 'Permalink archive slug', 'newspack-plugin' ) }
-					help={ __(
-						'Slug to be used for the collections archive page (e.g., "issues", "magazines"). Default: "collections".',
-						'newspack-plugin'
-					) }
-					value={ settings.custom_archive_slug }
-					onChange={ ( value: string ) => onChange( 'custom_archive_slug', value ) }
-					placeholder="collections"
-				/>
-				<TextControl
 					label={ __( 'Permalink base slug', 'newspack-plugin' ) }
 					help={ __(
-						'Base slug to be used in permalinks and the REST API (e.g., "issue", "magazine"). Default: "collection".',
+						'Base slug to be used in permalinks and the REST API (e.g., "issues", "magazine"). Default: "collections".',
 						'newspack-plugin'
 					) }
 					value={ settings.custom_slug }
 					onChange={ ( value: string ) => onChange( 'custom_slug', value ) }
-					placeholder="collection"
+					placeholder="collections"
 				/>
 			</Grid>
 		) }

--- a/src/wizards/newspack/views/settings/collections/custom-naming-card.tsx
+++ b/src/wizards/newspack/views/settings/collections/custom-naming-card.tsx
@@ -36,9 +36,19 @@ const CustomNamingCard: React.FC< CustomNamingCardProps > = ( { settings, isSavi
 					placeholder="Collection"
 				/>
 				<TextControl
+					label={ __( 'Permalink archive slug', 'newspack-plugin' ) }
+					help={ __(
+						'Slug to be used for the collections archive page (e.g., "issues", "magazines"). Default: "collections".',
+						'newspack-plugin'
+					) }
+					value={ settings.custom_archive_slug }
+					onChange={ ( value: string ) => onChange( 'custom_archive_slug', value ) }
+					placeholder="collections"
+				/>
+				<TextControl
 					label={ __( 'Permalink base slug', 'newspack-plugin' ) }
 					help={ __(
-						'Base slug to be used instead of "collection" in permalinks and the REST API (e.g., "issue", "magazine")',
+						'Base slug to be used in permalinks and the REST API (e.g., "issue", "magazine"). Default: "collection".',
 						'newspack-plugin'
 					) }
 					value={ settings.custom_slug }

--- a/src/wizards/newspack/views/settings/collections/index.tsx
+++ b/src/wizards/newspack/views/settings/collections/index.tsx
@@ -20,6 +20,7 @@ const DEFAULT_COLLECTIONS_SETTINGS: CollectionsSettingsData = {
 	custom_name: '',
 	custom_singular_name: '',
 	custom_slug: '',
+	custom_archive_slug: '',
 	subscribe_link: '',
 	order_link: '',
 	post_indicator_style: 'default',

--- a/src/wizards/newspack/views/settings/collections/index.tsx
+++ b/src/wizards/newspack/views/settings/collections/index.tsx
@@ -180,7 +180,7 @@ function Collections() {
 									'newspack-plugin'
 								) }
 								value={ settings.post_indicator_style }
-								onChange={ ( value: string ) => updateSetting( 'post_indicator_style', value ) }
+								onChange={ ( value: 'default' | 'card' ) => updateSetting( 'post_indicator_style', value ) }
 								buttonOptions={ [
 									{ label: __( 'Default', 'newspack-plugin' ), value: 'default' },
 									{ label: __( 'Card', 'newspack-plugin' ), value: 'card' },

--- a/src/wizards/newspack/views/settings/collections/index.tsx
+++ b/src/wizards/newspack/views/settings/collections/index.tsx
@@ -20,7 +20,6 @@ const DEFAULT_COLLECTIONS_SETTINGS: CollectionsSettingsData = {
 	custom_naming_enabled: false,
 	custom_name: '',
 	custom_singular_name: '',
-	custom_archive_slug: '',
 	custom_slug: '',
 	// Global CTAs section
 	subscribe_link: '',

--- a/src/wizards/newspack/views/settings/collections/index.tsx
+++ b/src/wizards/newspack/views/settings/collections/index.tsx
@@ -16,17 +16,22 @@ const COLLECTIONS_PER_PAGE_OPTIONS = [ 12, 18, 24 ];
 
 // Default values for collections settings.
 const DEFAULT_COLLECTIONS_SETTINGS: CollectionsSettingsData = {
+	// Custom Naming section
 	custom_naming_enabled: false,
 	custom_name: '',
 	custom_singular_name: '',
-	custom_slug: '',
 	custom_archive_slug: '',
+	custom_slug: '',
+	// Global CTAs section
 	subscribe_link: '',
 	order_link: '',
+	// Collections Archive section
+	posts_per_page: 12,
+	category_filter_label: '',
+	highlight_latest: false,
+	// Collection Posts section
 	post_indicator_style: 'default',
 	card_message: __( "Keep reading. There's plenty more to discover.", 'newspack-plugin' ),
-	posts_per_page: 12,
-	highlight_latest: false,
 };
 
 // Helper function to extract collection settings from API data with defaults.
@@ -140,6 +145,16 @@ function Collections() {
 									label: option.toString(),
 									value: option,
 								} ) ) }
+							/>
+							<TextControl
+								label={ __( 'Category Filter Label', 'newspack-plugin' ) }
+								help={ __(
+									'Custom label for the category filter dropdown (e.g., "Collection:", "Type:", "Series:"). Leave empty to use the default "Publication:".',
+									'newspack-plugin'
+								) }
+								value={ settings.category_filter_label }
+								onChange={ ( value: string ) => updateSetting( 'category_filter_label', value ) }
+								placeholder={ __( 'Publication:', 'newspack-plugin' ) }
 							/>
 							<ToggleControl
 								label={ __( 'Highlight Most Recent Collection', 'newspack-plugin' ) }

--- a/src/wizards/newspack/views/settings/collections/types.d.ts
+++ b/src/wizards/newspack/views/settings/collections/types.d.ts
@@ -5,6 +5,7 @@ type CollectionsSettingsData = {
 	custom_name: string;
 	custom_singular_name: string;
 	custom_slug: string;
+	custom_archive_slug: string;
 	subscribe_link: string;
 	order_link: string;
 	post_indicator_style: string;

--- a/src/wizards/newspack/views/settings/collections/types.d.ts
+++ b/src/wizards/newspack/views/settings/collections/types.d.ts
@@ -5,7 +5,6 @@ type CollectionsSettingsData = {
 	custom_naming_enabled: boolean;
 	custom_name: string;
 	custom_singular_name: string;
-	custom_archive_slug: string;
 	custom_slug: string;
 	// Global CTAs section.
 	subscribe_link: string;

--- a/src/wizards/newspack/views/settings/collections/types.d.ts
+++ b/src/wizards/newspack/views/settings/collections/types.d.ts
@@ -15,7 +15,7 @@ type CollectionsSettingsData = {
 	category_filter_label: string;
 	highlight_latest: boolean;
 	// Collection Posts section.
-	post_indicator_style: string;
+	post_indicator_style: 'default' | 'card';
 	card_message: string;
 };
 

--- a/src/wizards/newspack/views/settings/collections/types.d.ts
+++ b/src/wizards/newspack/views/settings/collections/types.d.ts
@@ -1,17 +1,22 @@
 // Types for the collections settings feature
 
 type CollectionsSettingsData = {
+	// Custom Naming section.
 	custom_naming_enabled: boolean;
 	custom_name: string;
 	custom_singular_name: string;
-	custom_slug: string;
 	custom_archive_slug: string;
+	custom_slug: string;
+	// Global CTAs section.
 	subscribe_link: string;
 	order_link: string;
+	// Collections Archive section.
+	posts_per_page: number;
+	category_filter_label: string;
+	highlight_latest: boolean;
+	// Collection Posts section.
 	post_indicator_style: string;
 	card_message: string;
-	posts_per_page: number;
-	highlight_latest: boolean;
 };
 
 type FieldChangeHandler< T > = < K extends keyof T >( key: K, value: T[ K ] ) => void;

--- a/tests/unit-tests/collections/class-test-post-type.php
+++ b/tests/unit-tests/collections/class-test-post-type.php
@@ -59,7 +59,7 @@ class Test_Post_Type extends WP_UnitTestCase {
 		$this->assertEquals( 'Collections', $post_type->labels->name, 'Post type label should be "Collections".' );
 		$this->assertTrue( $post_type->public, 'Post type should be public.' );
 		$this->assertTrue( $post_type->show_in_rest, 'Post type should be available in REST API.' );
-		$this->assertTrue( $post_type->has_archive, 'Post type should have archive.' );
+		$this->assertNotFalse( $post_type->has_archive, 'Post type should have archive.' );
 	}
 
 	/**

--- a/tests/unit-tests/collections/class-test-post-type.php
+++ b/tests/unit-tests/collections/class-test-post-type.php
@@ -255,7 +255,7 @@ class Test_Post_Type extends WP_UnitTestCase {
 	 */
 	public function test_post_type_slug_updates() {
 		Post_Type::init();
-		$this->assertEquals( 'collection', get_post_type_object( Post_Type::get_post_type() )->rewrite['slug'] );
+		$this->assertEquals( 'collections', get_post_type_object( Post_Type::get_post_type() )->rewrite['slug'] );
 
 		// Update settings via REST API.
 		$custom_slug = 'magazine';

--- a/tests/unit-tests/collections/class-test-settings.php
+++ b/tests/unit-tests/collections/class-test-settings.php
@@ -165,11 +165,6 @@ class Test_Settings extends WP_UnitTestCase {
 		$this->assertEquals( 'clean-slug', $slug_callback( 'Clean Slug' ) );
 		$this->assertEquals( 'clean-slug', $slug_callback( 'Clean Slug!' ) );
 
-		// Test archive slug sanitization.
-		$archive_slug_callback = $rest_args['custom_archive_slug']['sanitize_callback'];
-		$this->assertEquals( 'clean-archive-slug', $archive_slug_callback( 'Clean Archive Slug' ) );
-		$this->assertEquals( 'clean-archive-slug', $archive_slug_callback( '#$%Clean Archive Slug!' ) );
-
 		// Test post indicator style sanitization.
 		$style_callback = $rest_args['post_indicator_style']['sanitize_callback'];
 		$this->assertEquals( 'default', $style_callback( 'default' ) );

--- a/tests/unit-tests/collections/class-test-settings.php
+++ b/tests/unit-tests/collections/class-test-settings.php
@@ -173,7 +173,8 @@ class Test_Settings extends WP_UnitTestCase {
 		// Test post indicator style sanitization.
 		$style_callback = $rest_args['post_indicator_style']['sanitize_callback'];
 		$this->assertEquals( 'default', $style_callback( 'default' ) );
-		$this->assertEquals( 'custom', $style_callback( 'custom' ) );
+		$this->assertEquals( 'card', $style_callback( 'card' ) );
+		$this->assertEquals( 'default', $style_callback( 'custom' ) );
 
 		// Test card message sanitization.
 		$message_callback = $rest_args['card_message']['sanitize_callback'];

--- a/tests/unit-tests/collections/class-test-settings.php
+++ b/tests/unit-tests/collections/class-test-settings.php
@@ -164,7 +164,11 @@ class Test_Settings extends WP_UnitTestCase {
 		$slug_callback = $rest_args['custom_slug']['sanitize_callback'];
 		$this->assertEquals( 'clean-slug', $slug_callback( 'Clean Slug' ) );
 		$this->assertEquals( 'clean-slug', $slug_callback( 'Clean Slug!' ) );
-		$this->assertEquals( '', $slug_callback( 123 ) ); // Non-string should return empty string.
+
+		// Test archive slug sanitization.
+		$archive_slug_callback = $rest_args['custom_archive_slug']['sanitize_callback'];
+		$this->assertEquals( 'clean-archive-slug', $archive_slug_callback( 'Clean Archive Slug' ) );
+		$this->assertEquals( 'clean-archive-slug', $archive_slug_callback( '#$%Clean Archive Slug!' ) );
 
 		// Test post indicator style sanitization.
 		$style_callback = $rest_args['post_indicator_style']['sanitize_callback'];
@@ -187,6 +191,11 @@ class Test_Settings extends WP_UnitTestCase {
 		$highlight_latest_callback = $rest_args['highlight_latest']['sanitize_callback'];
 		$this->assertTrue( $highlight_latest_callback( 'true' ) );
 		$this->assertFalse( $highlight_latest_callback( 'false' ) );
+
+		// Test category filter label sanitization.
+		$category_filter_label_callback = $rest_args['category_filter_label']['sanitize_callback'];
+		$this->assertEquals( 'Custom label', $category_filter_label_callback( 'Custom label' ) );
+		$this->assertEquals( 'Clean label', $category_filter_label_callback( '<script>alert("xss")</script>Clean label' ) );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR addresses several feedback items to improve the Collections module's usability, accessibility, and customization options:

New features:
  - Changed the default slug: `collection` -> `collections`
  - Customizable category filter label: Added setting to customize the "Publication:" label in the archive filter dropdown (e.g., "Type:", "Series:").

Accessibility Improvements:
  - "See all" link: Added aria-label with full context for screen readers based on the custom name configured for collections (e.g., "See all collections", "See all issues").
  - Improved translations: Added context to translations using _x() for "Vol.", "No.", "Browse", and "See all" text

UX improvements:
  - "Highlight Most Recent Collection" now only displays when no year filter is applied.
  - Added user-friendly notices for editors when the required Newspack Blocks plugin is missing.

Other Improvements:
  - Improved backend sanitization and TypeScript validation for the indicator post style field.
  - Reorganized settings array everywhere to match visual interface order.
  - Updated README with missing settings and paths.

Closes NPPD-688.

### How to test the changes in this Pull Request:

1. Test archive slug customization:
    - Navigate to Newspack > Settings > Collections
    - Enable custom naming and set a different archive slug (e.g., "magazines")
    - Verify single collection URLs remain singular and archive uses plural slug
2. Test category filter label customization:
    - In Collections settings, set a custom category filter label (e.g., "Type:")
    - Visit the collections archive page and verify that the filter dropdown shows the custom label
3. Test accessibility improvements:
    - Use a screen reader or inspect the "See all" link aria-label
    - Verify translations include proper context for volume/number display
4. Test conditional highlighting:
    - Enable "Highlight Most Recent Collection" in settings
    - Verify that highlighting appears on the main archive page
    - Apply a year filter and confirm that no post is highlighted
5. Test dependency handling:
    - Deactivate Newspack Blocks plugin
    - View a collection page as an editor and verify dependency notice appears
    - View a collection page as a regular visitor or a subscriber and verify that it renders empty content
    - Reactivate the plugin and confirm normal functionality

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?