### PR TITLE
fix(rss): lax filter for script tag

### DIFF
--- a/includes/optional-modules/class-rss.php
+++ b/includes/optional-modules/class-rss.php
@@ -632,7 +632,7 @@ class RSS {
 		$settings['cdata_titles'] = (bool) $cdata_titles;
 
 		$custom_tracking_snippet = filter_input( INPUT_POST, 'custom_tracking_snippet', FILTER_DEFAULT ); // phpcs:ignore WordPressVIPMinimum.Security.PHPFilterFunctions.RestrictedFilter
-		$settings['custom_tracking_snippet'] = wp_kses_post( $custom_tracking_snippet );
+		$settings['custom_tracking_snippet'] = wp_unslash( $custom_tracking_snippet );
 
 		$category_settings = filter_input_array(
 			INPUT_POST,

--- a/includes/optional-modules/class-rss.php
+++ b/includes/optional-modules/class-rss.php
@@ -471,7 +471,29 @@ class RSS {
 		?>
 		<p><strong>Note:</strong> These settings are for modifying a feed to make it compatible with various integrations (SmartNews, Pugpig, etc.). They should only be used if a specific integration requires a non-standard RSS feed. Consult the integration's documentation or support for information about which elements are required.</p>
 
-		<table>
+		<style>
+			.newspack-rss-technical-settings {
+				width: 100%;
+				table-layout: auto;
+			}
+			.newspack-rss-technical-settings th {
+				vertical-align: top;
+				padding-right: 20px;
+				padding-bottom: 10px;
+				word-wrap: break-word;
+				max-width: 600px;
+			}
+			.newspack-rss-technical-settings td {
+				vertical-align: top;
+				padding-bottom: 10px;
+			}
+			.newspack-rss-technical-settings textarea {
+				width: 100%;
+				max-width: 400px;
+				box-sizing: border-box;
+			}
+		</style>
+		<table class="newspack-rss-technical-settings">
 			<tr>
 				<th><?php esc_html_e( 'Add post featured images in <image> tags', 'newspack-plugin' ); ?></th>
 				<td>

--- a/includes/optional-modules/class-rss.php
+++ b/includes/optional-modules/class-rss.php
@@ -631,7 +631,7 @@ class RSS {
 		$cdata_titles             = filter_input( INPUT_POST, 'cdata_titles', FILTER_SANITIZE_NUMBER_INT );
 		$settings['cdata_titles'] = (bool) $cdata_titles;
 
-		$custom_tracking_snippet = filter_input( INPUT_POST, 'custom_tracking_snippet', FILTER_DEFAULT ); // phpcs:ignore WordPressVIPMinimum.Security.PHPFilterFunctions.RestrictedFilter
+		$custom_tracking_snippet             = filter_input( INPUT_POST, 'custom_tracking_snippet', FILTER_DEFAULT ); // phpcs:ignore WordPressVIPMinimum.Security.PHPFilterFunctions.RestrictedFilter
 		$settings['custom_tracking_snippet'] = wp_unslash( $custom_tracking_snippet );
 
 		$category_settings = filter_input_array(

--- a/includes/optional-modules/class-rss.php
+++ b/includes/optional-modules/class-rss.php
@@ -524,7 +524,11 @@ class RSS {
 			<tr>
 				<th>
 					<?php esc_html_e( 'Custom tracking snippet', 'newspack-plugin' ); ?>
-					<p class="description"><?php echo esc_html_x( 'Tracking snippet that will be appended to the end of each post in the feed. You can use {{post-id}} and {{post-url}} as dynamic variables.', 'help text for custom tracking snippet', 'newspack-plugin' ); ?></p>
+					<p class="description">
+						<?php echo esc_html_x( 'Tracking snippet that will be appended to the end of each post in the feed. You can use {{post-id}} and {{post-url}} as dynamic variables.', 'help text for custom tracking snippet', 'newspack-plugin' ); ?>
+						<br>
+						<?php echo esc_html_x( 'Allowed HTML: script, img, iframe, noscript, div, span with safe attributes only.', 'help text for allowed HTML in tracking snippet', 'newspack-plugin' ); ?>
+					</p>
 				</th>
 				<td>
 					<textarea name="custom_tracking_snippet" rows="4" cols="50"><?php echo esc_textarea( $settings['custom_tracking_snippet'] ); ?></textarea>
@@ -632,7 +636,39 @@ class RSS {
 		$settings['cdata_titles'] = (bool) $cdata_titles;
 
 		$custom_tracking_snippet             = filter_input( INPUT_POST, 'custom_tracking_snippet', FILTER_DEFAULT ); // phpcs:ignore WordPressVIPMinimum.Security.PHPFilterFunctions.RestrictedFilter
-		$settings['custom_tracking_snippet'] = wp_unslash( $custom_tracking_snippet );
+		$settings['custom_tracking_snippet'] = wp_kses(
+			$custom_tracking_snippet,
+			[
+				'script'   => [
+					'id'    => true,
+					'src'   => true,
+					'type'  => true,
+					'async' => true,
+					'defer' => true,
+					'class' => true,
+				],
+				'img'      => [
+					'id'     => true,
+					'style'  => true,
+					'src'    => true,
+					'alt'    => true,
+					'class'  => true,
+					'width'  => true,
+					'height' => true,
+				],
+				'iframe'   => [
+					'id'     => true,
+					'style'  => true,
+					'src'    => true,
+					'class'  => true,
+					'width'  => true,
+					'height' => true,
+				],
+				'noscript' => true,
+				'div'      => true,
+				'span'     => true,
+			]
+		);
 
 		$category_settings = filter_input_array(
 			INPUT_POST,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This change will allow for rendering `script`, `img`, and `iframe` tags in the custom tracking snippet of an RSS Feed.

Closes https://app.asana.com/1/26890605006346/project/1210562189110460/task/1210847760541320?focus=true .

### How to test the changes in this Pull Request:

1. Add a new test feed.
2. Add `script` tag in custom tracking snippet.
3. Update the feed.
4. Check the tracking snipped being saved -> appearing in feed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->