### PR TITLE
feat: add collections to block filters (NPPD-717) 

### DIFF
--- a/includes/collections/class-collection-taxonomy.php
+++ b/includes/collections/class-collection-taxonomy.php
@@ -228,19 +228,16 @@ class Collection_Taxonomy {
 			'label' => __( 'Collections', 'newspack-plugin' ),
 		];
 
-		// Don't add a duplicate if this taxonomy is already in the list.
-		foreach ( $custom_taxonomies as $tax ) {
-			if ( $tax['slug'] === $collections_taxonomy['slug'] ) {
-				return $custom_taxonomies;
-			}
-		}
-
-		// Capture where Collection Sections is in the sidebar.
 		$point_of_insertion = null;
+		// Loop through the taxonomies; confirm Collections doesn't already exist, and grab the index of Collection Sections if it's there.
 		foreach ( $custom_taxonomies as $index => $tax ) {
-			if ( isset( $tax['slug'] ) && $tax['slug'] === 'newspack_collection_section' ) {
-				$point_of_insertion = $index;
-				break;
+			if ( isset( $tax['slug'] ) ) {
+				if ( $tax['slug'] === $collections_taxonomy['slug'] ) {
+					return $custom_taxonomies;
+				}
+				if ( $tax['slug'] === Collection_Section_Taxonomy::get_taxonomy() ) {
+					$point_of_insertion = $index;
+				}
 			}
 		}
 

--- a/includes/collections/class-collection-taxonomy.php
+++ b/includes/collections/class-collection-taxonomy.php
@@ -64,6 +64,7 @@ class Collection_Taxonomy {
 	 */
 	public static function init() {
 		add_action( 'init', [ __CLASS__, 'register_taxonomy' ] );
+		add_filter( 'newspack_blocks_home_page_block_custom_taxonomies', [ __CLASS__, 'add_collections_taxonomy_to_blocks' ] );
 		self::register_hooks();
 	}
 
@@ -154,6 +155,7 @@ class Collection_Taxonomy {
 		// Remove the filter to check if term is in the database.
 		self::unregister_hooks();
 		$result = term_exists( $term_id, self::get_taxonomy() );
+
 		self::register_hooks();
 
 		return $result;
@@ -213,5 +215,43 @@ class Collection_Taxonomy {
 		}
 
 		return get_terms( $args );
+	}
+
+	/**
+	 * Add the Collections taxonomy to the custom taxonomies array.
+	 *
+	 * @param array $custom_taxonomies Array of custom taxonomies.
+	 * @return array Modified array of custom taxonomies.
+	 */
+	public static function add_collections_taxonomy_to_blocks( $custom_taxonomies ) {
+		$collections_taxonomy = [
+			'slug'  => self::TAXONOMY,
+			'label' => __( 'Collections', 'newspack-plugin' ),
+		];
+
+		// Don't add a duplicate if this taxonomy is already in the list.
+		foreach ( $custom_taxonomies as $tax ) {
+			if ( $tax['slug'] === $collections_taxonomy['slug'] ) {
+				return $custom_taxonomies;
+			}
+		}
+
+		// Capture where Collection Sections is in the sidebar.
+		$point_of_insertion = null;
+		foreach ( $custom_taxonomies as $index => $tax ) {
+			if ( isset( $tax['slug'] ) && $tax['slug'] === 'newspack_collection_section' ) {
+				$point_of_insertion = $index;
+				break;
+			}
+		}
+
+		// If Collection Sections exists in the taxonomy filters, insert Collections before it. If not, use the default insertion point.
+		if ( null !== $point_of_insertion ) {
+			array_splice( $custom_taxonomies, $insert_index, 0, [ $collections_taxonomy ] );
+		} else {
+			$custom_taxonomies[] = $collections_taxonomy;
+		}
+
+		return $custom_taxonomies;
 	}
 }

--- a/includes/collections/class-collection-taxonomy.php
+++ b/includes/collections/class-collection-taxonomy.php
@@ -155,7 +155,6 @@ class Collection_Taxonomy {
 		// Remove the filter to check if term is in the database.
 		self::unregister_hooks();
 		$result = term_exists( $term_id, self::get_taxonomy() );
-
 		self::register_hooks();
 
 		return $result;

--- a/includes/collections/class-collection-taxonomy.php
+++ b/includes/collections/class-collection-taxonomy.php
@@ -246,7 +246,7 @@ class Collection_Taxonomy {
 
 		// If Collection Sections exists in the taxonomy filters, insert Collections before it. If not, use the default insertion point.
 		if ( null !== $point_of_insertion ) {
-			array_splice( $custom_taxonomies, $insert_index, 0, [ $collections_taxonomy ] );
+			array_splice( $custom_taxonomies, $point_of_insertion, 0, [ $collections_taxonomy ] );
 		} else {
 			$custom_taxonomies[] = $collections_taxonomy;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds an option to filter posts by Collection in the Content Loop & Content Carousel blocks. It's a more reasonable version of https://github.com/Automattic/newspack-blocks/pull/2168 😅 

### How to test the changes in this Pull Request:

1. If not already, enable Collections under WP Admin > Newspack > Settings on your test site.
2. Make sure you have some Collections set up on your test site, and posts populating each of them.
3. Create a page and add a Content Loop block. In the Content panel of the right sidebar, confirm you have a Collections filter along with other options. Collections and Exclude Collections should appear above Collection Sections and Exclude Collection Sections, respectively. (I had to do something a little hacky with the taxonomies order to get this to work, otherwise Collections was showing up after Collection Sections, and after Sponsors on my test site).

<img width="263" height="440" alt="image" src="https://github.com/user-attachments/assets/6e418ac5-8276-4bef-a14f-dbe5f12b13af" />

4. Type in one of your collection names; confirm you get some autocomplete behaviour.
5. Pick the Collection; confirm your block now only shows that collection.
6. Publish your page and confirm the correct stories appear on the front-end.
7. Set up a post that's assigned to a Collection, and a Collection Section within that Collection.
8. In a Content Loop block, assign both the Collection and Collection Section; confirm you get the correct post.
9. Publish your page and confirm the correct stories appear on the front-end.
10. Repeat steps 3-9 with the Content Carousel block.
11. Disable the Collections module under WP Admin > Newspack > Settings.
12. Confirm that the Collections query option is no longer available under the Content Loop and Carousel block settings (ditto Collection Section, but that should happen automagically). Any blocks set to return posts based on Collection should be empty.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->