### PR TITLE
Fix CLI module activation logic

### DIFF
--- a/includes/cli/class-optional-modules.php
+++ b/includes/cli/class-optional-modules.php
@@ -78,12 +78,15 @@ class Optional_Modules {
 			\WP_CLI::error( sprintf( 'Module is not available. These are the available modules: %s', implode( ', ', $available_modules ) ) );
 		}
 
-		$settings = \Newspack\Optional_Modules::activate_optional_module( $module_name );
+		if ( \Newspack\Optional_Modules::is_optional_module_active( $module_name ) ) {
+			\WP_CLI::error( "Cannot activate module – it's already active." );
+		}
 
-		if ( empty( $settings[ \Newspack\Optional_Modules::MODULE_ENABLED_PREFIX . $module_name ] ) ) {
+		$settings = \Newspack\Optional_Modules::activate_optional_module( $module_name );
+		if ( ! empty( $settings[ \Newspack\Optional_Modules::MODULE_ENABLED_PREFIX . $module_name ] ) ) {
 			\WP_CLI::success( 'Module activated.' );
 		} else {
-			\WP_CLI::error( "Cannot activate module – it's already active" );
+			\WP_CLI::error( 'Failed to activate module.' );
 		}
 	}
 
@@ -98,13 +101,11 @@ class Optional_Modules {
 	public static function cmd_deactivate_module( array $pos_args, array $assoc_args ) {
 		$module_name = $pos_args[0];
 
-		$enabled_modules = array_filter( \Newspack\Optional_Modules::get_settings() );
-
-		if ( empty( $enabled_modules[ \Newspack\Optional_Modules::MODULE_ENABLED_PREFIX . $module_name ] ) ) {
+		if ( ! \Newspack\Optional_Modules::is_optional_module_active( $module_name ) ) {
 			\WP_CLI::error( 'Module is not active. Cannot deactivate it' );
 		}
-		$settings = \Newspack\Optional_Modules::deactivate_optional_module( $module_name );
 
+		$settings = \Newspack\Optional_Modules::deactivate_optional_module( $module_name );
 		if ( empty( $settings[ \Newspack\Optional_Modules::MODULE_ENABLED_PREFIX . $module_name ] ) ) {
 			\WP_CLI::success( 'Module deactivated.' );
 		} else {

--- a/includes/cli/class-optional-modules.php
+++ b/includes/cli/class-optional-modules.php
@@ -79,7 +79,8 @@ class Optional_Modules {
 		}
 
 		if ( \Newspack\Optional_Modules::is_optional_module_active( $module_name ) ) {
-			\WP_CLI::error( "Cannot activate module – it's already active." );
+			\WP_CLI::warning( "Cannot activate module – it's already active." );
+			return;
 		}
 
 		$settings = \Newspack\Optional_Modules::activate_optional_module( $module_name );
@@ -102,7 +103,8 @@ class Optional_Modules {
 		$module_name = $pos_args[0];
 
 		if ( ! \Newspack\Optional_Modules::is_optional_module_active( $module_name ) ) {
-			\WP_CLI::error( 'Module is not active. Cannot deactivate it' );
+			\WP_CLI::warning( 'Module is not active. Cannot deactivate it' );
+			return;
 		}
 
 		$settings = \Newspack\Optional_Modules::deactivate_optional_module( $module_name );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a tiny bug that I ran into today. The logic of the success/error message when activating an optional module via the CLI is not correct. It will throw an "Error: Cannot activate module – it's already active." error after successfully activating a module. This PR fixes that issue and makes a small readability improvement to the deactivate command. 

This does NOT need to go out as a hotfix since the command actually works fine and only we ever see its output.

### How to test the changes in this Pull Request:

1. Before applying this PR, have the InDesign module deactivated and run `wp newspack optional-module activate indesign-export`. Observe it will activate the module **and** say "Error: Cannot activate module – it's already active.".
2. Apply this PR. 
3. Via CLI, activate an inactive module and observe it says that it did so successfully. 
4. Try and activate it again and observe it won't let you. 
5. Deactivate the module. Observe it does so successfully. 
6. Deactivate it again, and observe it won't let you.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->