### PR TITLE
feat(newspack-ui): update buttons accent color and border-radius

### DIFF
--- a/includes/class-newspack-ui.php
+++ b/includes/class-newspack-ui.php
@@ -652,11 +652,11 @@ class Newspack_UI {
 			<hr>
 
 			<h2 id="buttons">Buttons</h2>
-			<p><code>newspack-ui__button--primary</code>, <code>--branded</code>, <code>--secondary</code>, <code>--ghost</code>, and <code>--destructive</code> classes for colours/borders, and <code>newspack-ui__button--wide</code> for being 100% wide</p>
+			<p><code>newspack-ui__button--primary</code>, <code>--accent</code>, <code>--secondary</code>, <code>--ghost</code>, and <code>--destructive</code> classes for colours/borders, and <code>newspack-ui__button--wide</code> for being 100% wide</p>
 			<button class="newspack-ui__button newspack-ui__button--primary">Primary Button</button><br>
 			<button class="newspack-ui__button newspack-ui__button--primary" disabled>Primary Button Disabled</button><br>
-			<button class="newspack-ui__button newspack-ui__button--branded">Branded Button</button><br>
-			<button class="newspack-ui__button newspack-ui__button--branded" disabled>Branded Button Disabled</button><br>
+			<button class="newspack-ui__button newspack-ui__button--accent">Accent Button</button><br>
+			<button class="newspack-ui__button newspack-ui__button--accent" disabled>Accent Button Disabled</button><br>
 			<button class="newspack-ui__button newspack-ui__button--secondary">Secondary Button</button><br>
 			<button class="newspack-ui__button newspack-ui__button--secondary" disabled>Secondary Button Disabled</button><br>
 			<button class="newspack-ui__button newspack-ui__button--ghost">Ghost Button</button><br>
@@ -674,7 +674,7 @@ class Newspack_UI {
 
 			<h3>Wide buttons</h3>
 			<button class="newspack-ui__button newspack-ui__button--primary newspack-ui__button--wide">Primary Button</button>
-			<button class="newspack-ui__button newspack-ui__button--branded newspack-ui__button--wide">Branded Button</button>
+			<button class="newspack-ui__button newspack-ui__button--accent newspack-ui__button--wide">Accent Button</button>
 			<button class="newspack-ui__button newspack-ui__button--secondary newspack-ui__button--wide">Secondary Button</button>
 			<button class="newspack-ui__button newspack-ui__button--ghost newspack-ui__button--wide">Ghost Button</button>
 			<button class="newspack-ui__button newspack-ui__button--secondary newspack-ui__button--wide">
@@ -802,7 +802,7 @@ class Newspack_UI {
 				<?php \Newspack\Newspack_UI_Icons::print_svg( 'menu' ); ?>
 				<span class="screen-reader-text"><?php esc_html_e( 'Open Menu', 'newspack-plugin' ); ?></span>
 			</button>
-			<button class="newspack-ui__button newspack-ui__button--branded newspack-ui__button--icon">
+			<button class="newspack-ui__button newspack-ui__button--accent newspack-ui__button--icon">
 				<?php \Newspack\Newspack_UI_Icons::print_svg( 'menu' ); ?>
 				<span class="screen-reader-text"><?php esc_html_e( 'Open Menu', 'newspack-plugin' ); ?></span>
 			</button>

--- a/src/newspack-ui/scss/elements/_segmented-control.scss
+++ b/src/newspack-ui/scss/elements/_segmented-control.scss
@@ -17,7 +17,7 @@
 			.newspack-ui__button {
 				background: transparent;
 				border: 1px solid transparent;
-				border-radius: var(--newspack-ui-border-radius-xs);
+				border-radius: var(--newspack-ui-border-radius-s);
 				color: var(--newspack-ui-color-neutral-60);
 				cursor: pointer;
 

--- a/src/newspack-ui/scss/elements/forms/_buttons.scss
+++ b/src/newspack-ui/scss/elements/forms/_buttons.scss
@@ -67,7 +67,7 @@
 
 		// Sizes
 		&--x-small {
-			border-radius: var(--newspack-ui-border-radius-s);
+			border-radius: var(--newspack-ui-border-radius-xs);
 			font-size: var(--newspack-ui-font-size-xs);
 			line-height: var(--newspack-ui-line-height-xs);
 			min-height: var(--newspack-ui-spacer-6);
@@ -75,6 +75,7 @@
 		}
 
 		&--small {
+			border-radius: var(--newspack-ui-border-radius-s);
 			font-size: var(--newspack-ui-font-size-xs);
 			line-height: var(--newspack-ui-line-height-xs);
 			min-height: var(--newspack-ui-spacer-8);
@@ -101,6 +102,7 @@
 			}
 		}
 
+		&--accent,
 		&--branded {
 			background: var(--newspack-ui-color-primary);
 			color: var(--newspack-ui-color-against-primary);

--- a/src/newspack-ui/scss/variables/_colors.scss
+++ b/src/newspack-ui/scss/variables/_colors.scss
@@ -47,12 +47,9 @@
 	--newspack-ui-color-warning-30: #{colors.$warning-300};
 	--newspack-ui-color-warning-40: #{colors.$warning-400};
 
-	// Theme variables - from the classic theme; overridden in class-newspack-ui.php for block theme.
-	// TODO: commented out for now with the assumption all should be blue when used.
-	// --newspack-ui-color-primary: var(--newspack-theme-color-primary, var(--newspack-ui-color-neutral-90));
-	// --newspack-ui-color-against-primary: var(--newspack-theme-color-against-primary, var(--newspack-ui-color-neutral-0));
-	--newspack-ui-color-primary: var(--newspack-ui-color-primary-60);
-	--newspack-ui-color-against-primary: var(--newspack-ui-color-neutral-0);
+	// Theme variables - from the classic and block themes; overridden in class-newspack-ui.php for block theme.
+	--newspack-ui-color-primary: var(--newspack-theme-color-primary, var(--newspack-ui-color-primary-60));
+	--newspack-ui-color-against-primary: var(--newspack-theme-color-against-primary, var(--newspack-ui-color-neutral-0));
 
 	// Specific assignments - general:
 	--newspack-ui-color-border: var(--newspack-ui-color-neutral-30);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Small update to the Newspack UI button component:

* If size is XS, then border-radius should be XS
* If size is S, then border-radius should be S
* Renamed `--branded` to `--accent` to match Figma and Block Theme naming convention (kept `--branded` for backward support)
* Accent buttons should use the theme's primary colour

### How to test the changes in this Pull Request:

1. Check front-end and add `/?ui-demo`
2. Switch to this branch
3. Refresh page and notice difference on buttons

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->