### PR TITLE
feat(collections): improve rewrite rules flushing logic

### DIFF
--- a/includes/collections/class-collection-category-taxonomy.php
+++ b/includes/collections/class-collection-category-taxonomy.php
@@ -17,6 +17,7 @@ defined( 'ABSPATH' ) || exit;
 class Collection_Category_Taxonomy {
 
 	use Traits\Meta_Handler;
+	use Traits\Registration_Manager;
 
 	/**
 	 * Get the taxonomy for Collection Categories.
@@ -67,7 +68,7 @@ class Collection_Category_Taxonomy {
 	public static function init() {
 		add_action( 'init', [ __CLASS__, 'register_taxonomy' ] );
 		add_action( 'init', [ __CLASS__, 'register_meta' ] );
-		add_action( 'newspack_collections_before_flush_rewrites', [ __CLASS__, 'register_taxonomy' ] );
+		add_action( 'newspack_collections_before_flush_rewrites', [ __CLASS__, 'update_registration' ] );
 		add_action( 'manage_' . Post_Type::get_post_type() . '_posts_columns', [ __CLASS__, 'set_taxonomy_column_name' ] );
 
 		// Term meta field handling.

--- a/includes/collections/class-collection-section-taxonomy.php
+++ b/includes/collections/class-collection-section-taxonomy.php
@@ -17,6 +17,7 @@ defined( 'ABSPATH' ) || exit;
 class Collection_Section_Taxonomy {
 
 	use Traits\Meta_Handler;
+	use Traits\Registration_Manager;
 
 	/**
 	 * Taxonomy for Collection Sections.
@@ -76,7 +77,7 @@ class Collection_Section_Taxonomy {
 		// Register taxonomy and menu relationships.
 		add_action( 'init', [ __CLASS__, 'register_taxonomy' ] );
 		add_action( 'init', [ __CLASS__, 'register_meta' ] );
-		add_action( 'newspack_collections_before_flush_rewrites', [ __CLASS__, 'register_taxonomy' ] );
+		add_action( 'newspack_collections_before_flush_rewrites', [ __CLASS__, 'update_registration' ] );
 		add_action( 'admin_menu', [ __CLASS__, 'add_to_collections_menu' ] );
 		add_filter( 'parent_file', [ __CLASS__, 'set_parent_menu' ] );
 

--- a/includes/collections/class-post-type.php
+++ b/includes/collections/class-post-type.php
@@ -16,6 +16,7 @@ require_once __DIR__ . '/class-collection-meta.php';
  */
 class Post_Type {
 	use Traits\Hook_Manager;
+	use Traits\Registration_Manager;
 
 	/**
 	 * Post type for Collections.
@@ -76,7 +77,7 @@ class Post_Type {
 	 */
 	public static function init() {
 		add_action( 'init', [ __CLASS__, 'register_post_type' ] );
-		add_action( 'newspack_collections_before_flush_rewrites', [ __CLASS__, 'register_post_type' ] );
+		add_action( 'newspack_collections_before_flush_rewrites', [ __CLASS__, 'update_registration' ] );
 		add_action( 'current_screen', [ __CLASS__, 'output_collection_meta_data_for_admin_scripts' ] );
 		add_action( 'manage_' . self::get_post_type() . '_posts_columns', [ __CLASS__, 'add_order_column' ] );
 		add_action( 'manage_' . self::get_post_type() . '_posts_custom_column', [ __CLASS__, 'display_order_column' ], 10, 2 );

--- a/includes/collections/traits/trait-registration-manager.php
+++ b/includes/collections/traits/trait-registration-manager.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Trait for handling WordPress registration management.
+ *
+ * @package Newspack\Collections
+ */
+
+namespace Newspack\Collections\Traits;
+
+use Newspack\Optional_Modules;
+use Newspack\Optional_Modules\Collections;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Trait for handling post type and taxonomy registration management.
+ *
+ * This trait provides a common pattern for unregistering and re-registering
+ * WordPress objects when settings change or modules are toggled.
+ */
+trait Registration_Manager {
+
+	/**
+	 * Update the object registration.
+	 *
+	 * @param array $settings Collection module settings.
+	 */
+	public static function update_registration( $settings ) {
+		// Check if the Collections module was enabled.
+		$should_register = $settings[ Optional_Modules::MODULE_ENABLED_PREFIX . Collections::MODULE_NAME ] ?? true;
+
+		if ( method_exists( static::class, 'get_post_type' ) ) { // For post types.
+			if ( post_type_exists( static::get_post_type() ) ) {
+				unregister_post_type( static::get_post_type() );
+			}
+			if ( $should_register ) {
+				static::register_post_type();
+			}
+		} elseif ( method_exists( static::class, 'get_taxonomy' ) ) { // For taxonomies.
+			if ( taxonomy_exists( static::get_taxonomy() ) ) {
+				unregister_taxonomy( static::get_taxonomy() );
+			}
+			if ( $should_register ) {
+				static::register_taxonomy();
+			}
+		}
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR essentially tackles these two issues:
1. Right now, rewrite rules are only flushed when there are changes on the custom slug, but not when initially activating the Collections optional module.
2. When a custom slug is set and then modified, the new slug is registered, but the previous rules are not flushed, so both paths are reachable (until rewrite rules are flushed again).

Closes NPPD-726.

### How to test the changes in this Pull Request:

1. Enable and disable the Collections module toggle in the Newspack settings.
2. Verify that the `/collections` path immediately responds with an HTTP status of 404 or 200 depending on the toggle state.
3. In the same settings page, enable the "Customize collections naming schema" toggle, set a custom slug in the "Permalink base slug" field, and save the changes.
4. Verify that the `/collections` path is immediately unreachable and the page now loads under the new slug.
5. Deactivate the custom naming toggle or use a different slug, and save the changes.
6. Verify that the new slug is reachable, and the previous one is no longer reachable.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?