### PR TITLE
feat(collections): use custom label in document title for archives

### DIFF
--- a/includes/collections/class-settings.php
+++ b/includes/collections/class-settings.php
@@ -197,7 +197,7 @@ class Settings {
 	 * @return string The plural collection label.
 	 */
 	public static function get_collection_label() {
-		return self::get_custom_name( 'custom_name', 'Collections' );
+		return self::get_custom_name( 'custom_name', _x( 'Collections', 'collections general label', 'newspack' ) );
 	}
 
 	/**
@@ -206,7 +206,7 @@ class Settings {
 	 * @return string The singular collection label.
 	 */
 	public static function get_collection_singular_label() {
-		return self::get_custom_name( 'custom_singular_name', 'Collection' );
+		return self::get_custom_name( 'custom_singular_name', _x( 'Collection', 'collections singular label', 'newspack' ) );
 	}
 
 	/**

--- a/includes/collections/class-template-helper.php
+++ b/includes/collections/class-template-helper.php
@@ -31,6 +31,7 @@ class Template_Helper {
 		add_action( 'pre_get_posts', [ __CLASS__, 'archive_filters' ] );
 		add_filter( 'redirect_canonical', [ __CLASS__, 'prevent_year_redirect' ] );
 		add_filter( 'jetpack_relatedposts_filter_enabled_for_request', [ __CLASS__, 'disable_jetpack_related_posts' ] );
+		add_filter( 'document_title_parts', [ __CLASS__, 'update_document_title' ] );
 	}
 
 	/**
@@ -443,5 +444,19 @@ class Template_Helper {
 	 */
 	public static function render_separator( $class_name = '' ) {
 		return '<hr class="has-light-gray-background-color has-background is-style-wide ' . esc_attr( $class_name ) . '"/>';
+	}
+
+	/**
+	 * Filter document title for collections pages to use custom label.
+	 *
+	 * @param array $title_parts The document title parts.
+	 * @return array Modified title parts.
+	 */
+	public static function update_document_title( $title_parts ) {
+		if ( is_post_type_archive( Post_Type::get_post_type() ) ) {
+			$title_parts['title'] = Settings::get_collection_label();
+		}
+
+		return $title_parts;
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The changes in this PR update the `<title>` tag on archive pages to make it match the Collections label if a custom name is set. Currently, it's always using the "Collections" default string.

Closes NPPD-727.

### How to test the changes in this Pull Request:

1. Navigate to Newspack Settings > Collections.
2. Enable the "Customize collections naming schema" toggle, set a custom name to use instead of the "Collections" default, and save the changes.
3. Navigate to the Collections archive pages and verify that the page title in the template and the tab title in the browser (or `<title>` tag in the HTML head) all match the custom name configured in the settings.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?