### PR TITLE
feat(collections): add global setting for showing categories

### DIFF
--- a/includes/collections/class-settings.php
+++ b/includes/collections/class-settings.php
@@ -90,6 +90,12 @@ class Settings {
 				'default'           => false,
 				'sanitize_callback' => 'rest_sanitize_boolean',
 			],
+			// Collection Single section.
+			'articles_block_attrs'  => [
+				'required'          => false,
+				'default'           => [],
+				'sanitize_callback' => [ self::class, 'sanitize_articles_block_attrs' ],
+			],
 			// Collection Posts section.
 			'post_indicator_style'  => [
 				'required'          => false,
@@ -268,5 +274,39 @@ class Settings {
 		}
 
 		return self::get_settings();
+	}
+
+	/**
+	 * Sanitize articles block attributes, preserving unmanaged keys.
+	 *
+	 * @param mixed $value The input value to sanitize.
+	 * @return array Sanitized articles block attributes.
+	 */
+	public static function sanitize_articles_block_attrs( $value ) {
+		if ( ! is_array( $value ) ) {
+			return [];
+		}
+
+		// Get current value to preserve unmanaged keys.
+		$attrs = self::get_settings()['articles_block_attrs'] ?? null;
+		if ( ! is_array( $attrs ) ) {
+			return [];
+		}
+
+		// UI-managed keys with their sanitization.
+		$ui_managed = [
+			'showCategory' => 'rest_sanitize_boolean',
+		];
+
+		// Update only UI-managed keys.
+		foreach ( $ui_managed as $key => $sanitizer ) {
+			if ( isset( $value[ $key ] ) ) {
+				$attrs[ $key ] = $sanitizer( $value[ $key ] );
+			} elseif ( array_key_exists( $key, $value ) ) {
+				unset( $attrs[ $key ] );
+			}
+		}
+
+		return $attrs;
 	}
 }

--- a/includes/collections/class-template-helper.php
+++ b/includes/collections/class-template-helper.php
@@ -392,6 +392,12 @@ class Template_Helper {
 			'specificMode'  => true,
 		];
 
+		// Override with global settings if set.
+		$global_attrs = Settings::get_setting( 'articles_block_attrs', [] );
+		if ( is_array( $global_attrs ) && ! empty( $global_attrs ) ) {
+			$attrs = array_merge( $attrs, $global_attrs );
+		}
+
 		/**
 		 * Filters the attributes before rendering the content loop block for posts in a section.
 		 *

--- a/src/wizards/newspack/views/settings/collections/index.tsx
+++ b/src/wizards/newspack/views/settings/collections/index.tsx
@@ -16,19 +16,21 @@ const COLLECTIONS_PER_PAGE_OPTIONS = [ 12, 18, 24 ];
 
 // Default values for collections settings.
 const DEFAULT_COLLECTIONS_SETTINGS: CollectionsSettingsData = {
-	// Custom Naming section
+	// Custom Naming section.
 	custom_naming_enabled: false,
 	custom_name: '',
 	custom_singular_name: '',
 	custom_slug: '',
-	// Global CTAs section
+	// Global CTAs section.
 	subscribe_link: '',
 	order_link: '',
-	// Collections Archive section
+	// Collections Archive section.
 	posts_per_page: 12,
 	category_filter_label: '',
 	highlight_latest: false,
-	// Collection Posts section
+	// Collection Single section.
+	articles_block_attrs: {},
+	// Collection Posts section.
 	post_indicator_style: 'default',
 	card_message: __( "Keep reading. There's plenty more to discover.", 'newspack-plugin' ),
 };
@@ -78,6 +80,20 @@ function Collections() {
 
 	const updateSetting: FieldChangeHandler< CollectionsSettingsData > = ( key, value ) => {
 		setSettings( prev => ( { ...prev, [ key ]: value } ) );
+	};
+
+	const updateNestedSetting = < T extends keyof CollectionsSettingsData >(
+		parentKey: T,
+		childKey: keyof CollectionsSettingsData[ T ],
+		value: CollectionsSettingsData[ T ][ keyof CollectionsSettingsData[ T ] ]
+	) => {
+		setSettings( prev => {
+			const parentValue = prev[ parentKey ] || {};
+			return {
+				...prev,
+				[ parentKey ]: { ...( parentValue as object ), [ childKey ]: value },
+			};
+		} );
 	};
 
 	return (
@@ -163,6 +179,23 @@ function Collections() {
 								) }
 								checked={ settings.highlight_latest }
 								onChange={ ( value: boolean ) => updateSetting( 'highlight_latest', value ) }
+							/>
+						</Grid>
+					</WizardSection>
+
+					<WizardSection
+						title={ __( 'Collection Single', 'newspack-plugin' ) }
+						description={ __( 'Customize individual collection pages.', 'newspack-plugin' ) }
+					>
+						<Grid columns={ 2 } gutter={ 32 }>
+							<ToggleControl
+								label={ __( 'Show category', 'newspack-plugin' ) }
+								help={ __(
+									'Display the category information for posts when rendering them on collection pages.',
+									'newspack-plugin'
+								) }
+								checked={ settings.articles_block_attrs?.showCategory || false }
+								onChange={ ( value: boolean ) => updateNestedSetting( 'articles_block_attrs', 'showCategory', value ) }
 							/>
 						</Grid>
 					</WizardSection>

--- a/src/wizards/newspack/views/settings/collections/types.d.ts
+++ b/src/wizards/newspack/views/settings/collections/types.d.ts
@@ -13,6 +13,10 @@ type CollectionsSettingsData = {
 	posts_per_page: number;
 	category_filter_label: string;
 	highlight_latest: boolean;
+	// Collection Single section.
+	articles_block_attrs: {
+		showCategory?: boolean;
+	};
 	// Collection Posts section.
 	post_indicator_style: 'default' | 'card';
 	card_message: string;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The posts in the single pages template are rendered by reusing the `newspack-blocks/homepage-articles`. However, the arguments passed are fixed, and updating them requires adding code to the site. This PR adds a new "Show category" toggle to the global Collections settings that, when enabled, will append the `showCategory => true` attribute to the `render_block()` call.

Moreover, the way this change is structured allows future extensibility via the settings UI or by updating the option directly in the database, without modifying the `render_article()` logic.

The global Collections settings are stored in an array, and we're adding a nested `articles_block_attrs` array, whose values will get merged with the default block attributes:
```json
wp option get newspack_collections_settings --format=json
{
  "post_indicator_style": "card",
  "posts_per_page": 24,
  ...
  ...
  "articles_block_attrs": {
    "showCategory": true
  }
}
```

So, for example, if we want to modify the default behavior and add the `showDate` attribute, we can manipulate the option directly by overwriting the `articles_block_attrs` array:
```bash
wp option patch update newspack_collections_settings articles_block_attrs '{"showCategory":true,"showDate":true}' --format=json
```

Or extracting the values and modifying the specific nested key:
```bash
SETTINGS=$(wp option get newspack_collections_settings --format=json | jq -c '.articles_block_attrs.showDate = true') && wp option update newspack_collections_settings "$SETTINGS" --format=json
```

Closes NPPD-728.

### How to test the changes in this Pull Request:

1. Navigate to Newspack Settings > Collections and enable the module.
2. In the "Collection Single" section, enable the "Show category" toggle.
3. Go to a collection singular page and verify that the post category appears at the top of each article.
4. Turn off the toggle and verify that the categories disappear.
5. Test setting other [block attributes](https://github.com/Automattic/newspack-blocks/blob/4000d858b6931137d883e06b2b6c1200a420dfa7/src/blocks/homepage-articles/block.json#L5-L258) by directly modifying the `newspack_collections_settings` option via the methods described above and verify that the changes get reflected in the frontend.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?