### PR TITLE
Adjust feed media URL encoding to avoid html entities

### DIFF
--- a/includes/optional-modules/class-rss.php
+++ b/includes/optional-modules/class-rss.php
@@ -880,7 +880,7 @@ class RSS {
 			$thumbnail_url = get_the_post_thumbnail_url( $post, 'full' );
 			if ( $thumbnail_url ) :
 				?>
-				<image><?php echo esc_url( $thumbnail_url ); ?></image>
+				<image><?php echo esc_url( $thumbnail_url, null, 'db' ); ?></image>
 				<?php
 			endif;
 		}
@@ -910,11 +910,11 @@ class RSS {
 				if ( $thumbnail_data ) {
 					$caption = get_the_post_thumbnail_caption();
 					?>
-					<media:content type="<?php echo esc_attr( get_post_mime_type( $thumbnail_id ) ); ?>" url="<?php echo esc_url( $thumbnail_data[0] ); ?>">
+					<media:content type="<?php echo esc_attr( get_post_mime_type( $thumbnail_id ) ); ?>" url="<?php echo esc_url( $thumbnail_data[0], null, 'db' ); ?>">
 						<?php if ( ! empty( $caption ) ) : ?>
 						<media:description><?php echo esc_html( $caption ); ?></media:description>
 						<?php endif; ?>
-						<media:thumbnail url="<?php echo esc_url( $thumbnail_data[0] ); ?>" width="<?php echo esc_attr( $thumbnail_data[1] ); ?>" height="<?php echo esc_attr( $thumbnail_data[2] ); ?>" />
+						<media:thumbnail url="<?php echo esc_url( $thumbnail_data[0], null, 'db' ); ?>" width="<?php echo esc_attr( $thumbnail_data[1] ); ?>" height="<?php echo esc_attr( $thumbnail_data[2] ); ?>" />
 					</media:content>
 					<?php
 				}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes an issue @supersusie inadvertently reported. :)

MailChimp and other things that do RSS ingestion can fail to ingest `media:content` elements from live sites. This is because the Jetpack CDN URLs have their query parameters converted into HTML entities by the sanitization. For example `https://i0.wp.com/example.com/wp-content/uploads/2025/07/image.png?fit=1200%2C630&ssl=1` becomes `https://i0.wp.com/example.com/wp-content/uploads/2025/07/image.png?fit=1200%2C630&#038;ssl=1`. 

This PR adjusts the handling so that we're still running sanitizing on image URLs, but not converting parts of the URL to HTML entities. 

### How to test the changes in this Pull Request:

1. You'll need a site with Jetpack CDN active and Newspack RSS Enhancements active.
2. Create a partner feed and check the "Add post featured images in <media:> tags" setting.
3. Before applying this patch, visit the RSS feed. Observe (on posts with featured images), the media: tag looks something like this:
```
<media:content type="image/png" url="https://i0.wp.com/example.com/wp-content/uploads/2025/07/image.png?fit=1200%2C630&#038;ssl=1">
	<media:thumbnail url="https://i0.wp.com/example.com/wp-content/uploads/2025/07/image.png?fit=1200%2C630&#038;ssl=1" width="1200" height="630" />
</media:content>
```
5. Apply this patch, visit the RSS feed. Observe the media: tag looks something like this:
```
<media:content type="image/png" url="https://i0.wp.com/example.com/wp-content/uploads/2025/07/image.png?fit=1200%2C630&ssl=1">
	<media:thumbnail url="https://i0.wp.com/example.com/wp-content/uploads/2025/07/image.png?fit=1200%2C630&ssl=1" width="1200" height="630" />
</media:content>
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->