### PR TITLE
Put InDesign Exporter behind feature flag

### DIFF
--- a/includes/optional-modules/class-indesign-exporter.php
+++ b/includes/optional-modules/class-indesign-exporter.php
@@ -27,6 +27,10 @@ class InDesign_Exporter {
 	 * Initialize the module.
 	 */
 	public static function init() {
+		if ( ! self::is_feature_enabled() ) {
+			return;
+		}
+
 		if ( ! Optional_Modules::is_optional_module_active( self::MODULE_NAME ) ) {
 			return;
 		}
@@ -42,6 +46,22 @@ class InDesign_Exporter {
 		add_filter( 'post_row_actions', [ __CLASS__, 'add_row_action' ], 10, 2 );
 		add_action( 'admin_post_export_indesign_single', [ __CLASS__, 'handle_single_export' ] );
 		add_action( 'admin_notices', [ __CLASS__, 'admin_notices' ] );
+	}
+
+	/**
+	 * Whether the InDesign module is enabled.
+	 *
+	 * @return bool True if InDesign Exporter is enabled.
+	 */
+	public static function is_feature_enabled() {
+		$is_enabled = defined( 'NEWSPACK_INDESIGN_EXPORT_ENABLED' ) ? constant( 'NEWSPACK_INDESIGN_EXPORT_ENABLED' ) : false;
+
+		/**
+		 * Filters whether the InDesign Export feature is enabled.
+		 *
+		 * @param bool $is_enabled Whether the InDesign Export module is enabled.
+		 */
+		return apply_filters( 'newspack_indesign_export_enabled', $is_enabled );
 	}
 
 	/**

--- a/includes/wizards/newspack/class-newspack-settings.php
+++ b/includes/wizards/newspack/class-newspack-settings.php
@@ -101,9 +101,6 @@ class Newspack_Settings extends Wizard {
 			'theme-and-brand'   => [
 				'label' => __( 'Theme and Brand', 'newspack-plugin' ),
 			],
-			'print'             => [
-				'label' => __( 'Print', 'newspack-plugin' ),
-			],
 			'advanced-settings' => [
 				'label' => __( 'Advanced Settings', 'newspack-plugin' ),
 			],
@@ -112,6 +109,12 @@ class Newspack_Settings extends Wizard {
 			$newspack_settings['collections'] = [
 				'label' => __( 'Collections', 'newspack-plugin' ),
 			];
+		}
+		if ( \Newspack\Optional_Modules\InDesign_Exporter::is_feature_enabled() ) {
+			$newspack_settings['print'] = [
+				'label' => __( 'Print', 'newspack-plugin' ),
+			];
+
 		}
 		if ( defined( 'NEWSPACK_MULTIBRANDED_SITE_PLUGIN_FILE' ) ) {
 			$newspack_settings['additional-brands'] = [


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Puts the InDesign Export feature behind a feature flag so we can do a phased rollout and make sure it nicely meets publisher needs before releasing everywhere. Implementation of the feature flag and code is basically the exact same as the Collections feature flag.

**Note: This PR will have to be cherry picked to alpha once merged, so that it gets included in the next release.**

### How to test the changes in this Pull Request:

1. Visit Newspack > Settings. Observe no Print section:

<img width="857" height="165" alt="Screenshot 2025-07-24 at 5 58 26 PM" src="https://github.com/user-attachments/assets/7bafbc54-ecaf-4be6-9142-5b20dac85c18" />

2. Add this to your wp-config.php: `define( 'NEWSPACK_INDESIGN_EXPORT_ENABLED', true );`
3. Visit Newspack > Settings. Observe the Print section. Visit it and toggle on the InDesign feature. Observe the "Export as Adobe InDesign" feature available on the admin Posts screen.

<img width="1374" height="419" alt="Screenshot 2025-07-24 at 5 59 17 PM" src="https://github.com/user-attachments/assets/96e1bf7a-3156-4035-99c5-4b4ecbdf75c6" />

<img width="321" height="104" alt="Screenshot 2025-07-24 at 6 05 02 PM" src="https://github.com/user-attachments/assets/8c6c6c6c-086c-487a-a32e-d4add00a36a9" />

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->