### PR TITLE
feat: package action scheduler into the plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
 	"require": {
 		"composer/installers": "~2.0",
 		"joshtronic/php-loremipsum": "^2.1",
-		"google/auth": "^1.15"
+		"google/auth": "^1.15",
+		"woocommerce/action-scheduler": "^3.9"
 	},
 	"require-dev": {
 		"brainmaestro/composer-git-hooks": "^3.0",
@@ -40,6 +41,11 @@
 			"pre-push": "./.hooks/pre-push",
 			"commit-msg": [
 				"cat $1 | ./node_modules/.bin/newspack-scripts commitlint"
+			]
+		},
+		"installer-paths": {
+			"vendor/{$vendor}/{$name}": [
+				"woocommerce/action-scheduler"
 			]
 		}
 	},

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9cff618b1f3116dbf3434351cf490b20",
+    "content-hash": "3ce2226e2b9d1eae3259a32cb22c4769",
     "packages": [
         {
             "name": "composer/installers",
@@ -969,6 +969,49 @@
                 }
             ],
             "time": "2023-01-24T14:02:46+00:00"
+        },
+        {
+            "name": "woocommerce/action-scheduler",
+            "version": "3.9.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/woocommerce/action-scheduler.git",
+                "reference": "c58cdbab17651303d406cd3b22cf9d75c71c986c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/woocommerce/action-scheduler/zipball/c58cdbab17651303d406cd3b22cf9d75c71c986c",
+                "reference": "c58cdbab17651303d406cd3b22cf9d75c71c986c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5",
+                "woocommerce/woocommerce-sniffs": "0.1.0",
+                "wp-cli/wp-cli": "~2.5.0",
+                "yoast/phpunit-polyfills": "^2.0"
+            },
+            "type": "wordpress-plugin",
+            "extra": {
+                "scripts-description": {
+                    "test": "Run unit tests",
+                    "phpcs": "Analyze code against the WordPress coding standards with PHP_CodeSniffer",
+                    "phpcbf": "Fix coding standards warnings/errors automatically with PHP Code Beautifier"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-3.0-or-later"
+            ],
+            "description": "Action Scheduler for WordPress and WooCommerce",
+            "homepage": "https://actionscheduler.org/",
+            "support": {
+                "issues": "https://github.com/woocommerce/action-scheduler/issues",
+                "source": "https://github.com/woocommerce/action-scheduler/tree/3.9.3"
+            },
+            "time": "2025-07-15T09:32:30+00:00"
         }
     ],
     "packages-dev": [

--- a/newspack.php
+++ b/newspack.php
@@ -28,6 +28,9 @@ if ( ! defined( 'NEWSPACK_PLUGIN_BASEDIR' ) ) {
 
 require_once __DIR__ . '/vendor/autoload.php';
 
+// Action Scheduler.
+require_once __DIR__ . '/vendor/woocommerce/action-scheduler/action-scheduler.php';
+
 // Include the main Newspack class.
 if ( ! class_exists( 'Newspack' ) ) {
 	include_once __DIR__ . '/includes/class-newspack.php';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

We have some features in our plugin, namely the Data Events API, that use the action scheduler when available.

We want it always to be available, even when Woo is not installed.

The PR adds the action scheduler as a composer dependency for the plugin

Refs NPPM-2127

### How to test the changes in this Pull Request:

1. Checkout this branch and build or run `composer install`
2. Confirm there are no errors in the admin and action scheduler is available
3. Check this with both Woo plugin active and inactive


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->