### PR TITLE
feat(collections): add cover story image visibility settings

### DIFF
--- a/includes/collections/README.md
+++ b/includes/collections/README.md
@@ -68,6 +68,8 @@ The following nested options are available as properties of the `newspack_collec
 | `posts_per_page` | Integer | Global posts per page | 12, 18, 24 |
 | `category_filter_label` | String | Custom label for the category filter dropdown | Text (e.g., "Publication:") |
 | `highlight_latest` | Boolean | Highlight the latest collection | Boolean |
+| `articles_block_attrs` | Array | Override articles block attributes | Object with properties like `showCategory`. See possible [attributes](https://github.com/Automattic/newspack-blocks/blob/trunk/src/blocks/homepage-articles/block.json) |
+| `show_cover_story_img` | Boolean | Show featured images for cover stories by default | Boolean |
 | `post_indicator_style` | String | Global post indicator style | "default" or "card" |
 | `card_message` | String | Global card message | Text |
 
@@ -91,6 +93,7 @@ The following table details all available meta fields for collections:
 | `newspack_collection_subscribe_link` | String | Override global/category subscription link for this specific collection | Valid URL |
 | `newspack_collection_order_link` | String | Override global/category order link for this specific collection | Valid URL |
 | `newspack_collection_ctas` | Array | An array of CTAs (Call-to-Action buttons) | Array of objects with `label`, `type`, `id` and `url` properties |
+| `newspack_collection_cover_story_img_visibility` | String | Override global setting for cover story image visibility | "inherit", "show", or "hide" |
 
 Sample `newspack_collection_ctas` post meta structure:
 ```php

--- a/includes/collections/class-collection-meta.php
+++ b/includes/collections/class-collection-meta.php
@@ -23,21 +23,21 @@ class Collection_Meta {
 	 */
 	public static function get_meta_definitions() {
 		return [
-			'volume'         => [
+			'volume'                     => [
 				'type'              => 'string',
 				'label'             => __( 'Volume', 'newspack-plugin' ),
 				'single'            => true,
 				'sanitize_callback' => 'sanitize_text_field',
 				'show_in_rest'      => true,
 			],
-			'number'         => [
+			'number'                     => [
 				'type'              => 'string',
 				'label'             => __( 'Number', 'newspack-plugin' ),
 				'single'            => true,
 				'sanitize_callback' => 'sanitize_text_field',
 				'show_in_rest'      => true,
 			],
-			'period'         => [
+			'period'                     => [
 				'type'              => 'string',
 				'label'             => __( 'Period', 'newspack-plugin' ),
 				'description'       => __( 'Period as a string (e.g., "Spring 2025", "January 2025")', 'newspack-plugin' ),
@@ -45,7 +45,7 @@ class Collection_Meta {
 				'sanitize_callback' => 'sanitize_text_field',
 				'show_in_rest'      => true,
 			],
-			'subscribe_link' => [
+			'subscribe_link'             => [
 				'type'              => 'string',
 				'label'             => __( 'Subscription URL', 'newspack-plugin' ),
 				'single'            => true,
@@ -56,7 +56,7 @@ class Collection_Meta {
 					],
 				],
 			],
-			'order_link'     => [
+			'order_link'                 => [
 				'type'              => 'string',
 				'label'             => __( 'Order URL', 'newspack-plugin' ),
 				'single'            => true,
@@ -67,7 +67,7 @@ class Collection_Meta {
 					],
 				],
 			],
-			'ctas'           => [
+			'ctas'                       => [
 				'type'              => 'array',
 				'label'             => __( 'Call-to-Action', 'newspack-plugin' ),
 				'description'       => __( 'Add multiple CTAs linking to attachments or external URLs.', 'newspack-plugin' ),
@@ -95,6 +95,37 @@ class Collection_Meta {
 								],
 							],
 						],
+					],
+				],
+			],
+			'cover_story_img_visibility' => [
+				'type'              => 'string',
+				'field_type'        => 'select',
+				'label'             => __( 'Cover Story Image Visibility', 'newspack-plugin' ),
+				'description'       => __( 'Choose whether to display featured images for cover stories in this collection.', 'newspack-plugin' ),
+				'single'            => true,
+				'sanitize_callback' => function ( $value ) {
+					return in_array( $value, [ 'inherit', 'show', 'hide' ], true ) ? $value : 'inherit';
+				},
+				'show_in_rest'      => [
+					'schema' => [
+						'type' => 'string',
+						'enum' => [ 'inherit', 'show', 'hide' ],
+					],
+				],
+				'default'           => 'inherit',
+				'options'           => [
+					[
+						'label' => __( 'Use global setting', 'newspack-plugin' ),
+						'value' => 'inherit',
+					],
+					[
+						'label' => __( 'Show', 'newspack-plugin' ),
+						'value' => 'show',
+					],
+					[
+						'label' => __( 'Hide', 'newspack-plugin' ),
+						'value' => 'hide',
 					],
 				],
 			],

--- a/includes/collections/class-settings.php
+++ b/includes/collections/class-settings.php
@@ -96,6 +96,11 @@ class Settings {
 				'default'           => [],
 				'sanitize_callback' => [ self::class, 'sanitize_articles_block_attrs' ],
 			],
+			'show_cover_story_img'  => [
+				'required'          => false,
+				'default'           => false,
+				'sanitize_callback' => 'rest_sanitize_boolean',
+			],
 			// Collection Posts section.
 			'post_indicator_style'  => [
 				'required'          => false,

--- a/includes/collections/class-template-helper.php
+++ b/includes/collections/class-template-helper.php
@@ -465,4 +465,27 @@ class Template_Helper {
 
 		return $title_parts;
 	}
+
+	/**
+	 * Determine whether to show featured image for cover stories.
+	 * Can be overridden by collection-specific setting.
+	 *
+	 * @param int $collection_id The collection post ID.
+	 * @return bool Whether to show the featured image for cover stories.
+	 */
+	public static function should_show_cover_story_image( $collection_id ) {
+		$show_image = match ( Collection_Meta::get( $collection_id, 'cover_story_img_visibility' ) ) {
+			'show' => true,
+			'hide' => false,
+			default => (bool) Settings::get_setting( 'show_cover_story_img', false ), // Fallback to global setting.
+		};
+
+		/**
+		 * Filters whether to show the featured image for cover stories.
+		 *
+		 * @param bool $show_image    Whether to show the featured image for cover stories.
+		 * @param int  $collection_id The collection post ID.
+		 */
+		return apply_filters( 'newspack_should_show_cover_story_image', $show_image, $collection_id );
+	}
 }

--- a/includes/collections/traits/trait-meta-handler.php
+++ b/includes/collections/traits/trait-meta-handler.php
@@ -22,6 +22,13 @@ trait Meta_Handler {
 	public static $prefix = 'newspack_collection_';
 
 	/**
+	 * Frontend-only properties that should not be passed register_meta().
+	 *
+	 * @var array
+	 */
+	public static $fe_only_props = [ 'field_type', 'options' ];
+
+	/**
 	 * Object type.
 	 *
 	 * @var string
@@ -78,6 +85,9 @@ trait Meta_Handler {
 		}
 
 		foreach ( static::get_meta_definitions() as $key => $meta ) {
+			// Remove frontend-only properties before registering with WordPress.
+			$meta = array_diff_key( $meta, array_flip( static::$fe_only_props ) );
+
 			register_meta(
 				$object_type,
 				static::$prefix . $key,
@@ -105,11 +115,13 @@ trait Meta_Handler {
 			array_map(
 				fn( $key ) => array_filter(
 					[
-						'key'     => static::$prefix . $key,
-						'type'    => static::get_frontend_type( $metas[ $key ] ),
-						'label'   => $metas[ $key ]['label'] ?? null,
-						'help'    => $metas[ $key ]['description'] ?? null,
-						'default' => $metas[ $key ]['default'] ?? null,
+						'key'        => static::$prefix . $key,
+						'type'       => static::get_frontend_type( $metas[ $key ] ),
+						'label'      => $metas[ $key ]['label'] ?? null,
+						'help'       => $metas[ $key ]['description'] ?? null,
+						'default'    => $metas[ $key ]['default'] ?? null,
+						'field_type' => $metas[ $key ]['field_type'] ?? null,
+						'options'    => $metas[ $key ]['options'] ?? null,
 					],
 					fn( $value ) => null !== $value
 				),

--- a/includes/templates/collections/single-newspack-collection.php
+++ b/includes/templates/collections/single-newspack-collection.php
@@ -62,7 +62,7 @@ get_header();
 					$section_name = $is_cover
 						? ( count( $post_ids ) > 1 ? __( 'Cover Stories', 'newspack-plugin' ) : __( 'Cover Story', 'newspack-plugin' ) )
 						: Query_Helper::get_section_name( $section_slug );
-					$show_image   = ! $is_cover;
+					$show_image   = $is_cover ? Template_Helper::should_show_cover_story_image( $collection_id ) : true;
 					$columns      = $is_cover ? 1 : 2;
 					$type_scale   = $is_cover ? 5 : 3;
 					?>

--- a/languages/newspack-plugin.pot
+++ b/languages/newspack-plugin.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GPL2.
 msgid ""
 msgstr ""
-"Project-Id-Version: Newspack 6.14.2\n"
+"Project-Id-Version: Newspack 6.14.3\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/project\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2025-08-04T12:53:37+00:00\n"
+"POT-Creation-Date: 2025-08-04T23:34:29+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: newspack-plugin\n"
@@ -321,7 +321,7 @@ msgstr ""
 
 #: includes/class-plugin-manager.php:62
 #: dist/commons.js:13
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:5
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:5
 msgid "Google"
 msgstr ""
 
@@ -338,7 +338,7 @@ msgid "Rocketgenius"
 msgstr ""
 
 #: includes/class-plugin-manager.php:80
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:14
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:14
 msgid "Jetpack"
 msgstr ""
 
@@ -388,7 +388,7 @@ msgid "Distribute content across a network of Newspack sites."
 msgstr ""
 
 #: includes/class-plugin-manager.php:132
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:14
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:14
 msgid "Newspack Newsletters"
 msgstr ""
 
@@ -466,12 +466,12 @@ msgid "forgemedia"
 msgstr ""
 
 #: includes/class-plugin-manager.php:193
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Publish to Apple News"
 msgstr ""
 
 #: includes/class-plugin-manager.php:194
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Export and synchronize posts to Apple format."
 msgstr ""
 
@@ -600,12 +600,12 @@ msgid "Jake Goldman, 10up"
 msgstr ""
 
 #: includes/class-plugin-manager.php:296
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Distributor"
 msgstr ""
 
 #: includes/class-plugin-manager.php:297
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Distributor is a WordPress plugin that makes it easy to syndicate and reuse content across your websites — whether in a single multisite or across the web."
 msgstr ""
 
@@ -658,7 +658,7 @@ msgid "Integrate Broadstreet’s business directory and ad-serving features into
 msgstr ""
 
 #: includes/class-plugin-manager.php:337
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:14
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:14
 msgid "Everlit"
 msgstr ""
 
@@ -873,7 +873,7 @@ msgstr ""
 
 #: includes/collections/class-collection-category-taxonomy.php:40
 #: includes/collections/class-collection-meta.php:50
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 msgid "Subscription URL"
 msgstr ""
 
@@ -883,7 +883,7 @@ msgstr ""
 
 #: includes/collections/class-collection-category-taxonomy.php:52
 #: includes/collections/class-collection-meta.php:61
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 msgid "Order URL"
 msgstr ""
 
@@ -979,6 +979,30 @@ msgstr ""
 
 #: includes/collections/class-collection-meta.php:73
 msgid "Add multiple CTAs linking to attachments or external URLs."
+msgstr ""
+
+#: includes/collections/class-collection-meta.php:104
+msgid "Cover Story Image Visibility"
+msgstr ""
+
+#: includes/collections/class-collection-meta.php:105
+msgid "Choose whether to display featured images for cover stories in this collection."
+msgstr ""
+
+#: includes/collections/class-collection-meta.php:119
+msgid "Use global setting"
+msgstr ""
+
+#: includes/collections/class-collection-meta.php:123
+#: dist/audience-wizards.465ef24dd7707013533a.js:10
+#: src/wizards/audience/components/settings-modal/index.js:134
+msgid "Show"
+msgstr ""
+
+#: includes/collections/class-collection-meta.php:127
+#: dist/audience-wizards.465ef24dd7707013533a.js:10
+#: src/wizards/audience/components/settings-modal/index.js:134
+msgid "Hide"
 msgstr ""
 
 #: includes/collections/class-collection-section-taxonomy.php:54
@@ -1129,7 +1153,7 @@ msgid "Collections"
 msgstr ""
 
 #: includes/collections/class-content-inserter.php:140
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Keep reading. There's plenty more to discover."
 msgstr ""
 
@@ -1255,12 +1279,12 @@ msgid "See all %s"
 msgstr ""
 
 #. translators: %s: object type
-#: includes/collections/traits/trait-meta-handler.php:179
+#: includes/collections/traits/trait-meta-handler.php:191
 #, php-format
 msgid "You are not authorized to edit this %s."
 msgstr ""
 
-#: includes/collections/traits/trait-meta-handler.php:183
+#: includes/collections/traits/trait-meta-handler.php:195
 msgid "Unauthorized"
 msgstr ""
 
@@ -1578,7 +1602,7 @@ msgstr ""
 #: dist/commons.js:1
 #: dist/memberships-gate-editor.js:37
 #: dist/newsletters.js:4
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:5
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:5
 #: dist/other-scripts/emails.js:2
 #: dist/setup.js:7
 #: dist/wizards.js:1
@@ -1598,7 +1622,7 @@ msgid "Enable Lite Site"
 msgstr ""
 
 #: includes/lite-site/class-lite-site.php:105
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:5
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:5
 msgid "URL Base"
 msgstr ""
 
@@ -1861,10 +1885,10 @@ msgstr ""
 #: dist/audience-wizards.465ef24dd7707013533a.js:38
 #: dist/billboard.js:1
 #: dist/billboard.js:12
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:5
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:26
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:5
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:26
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 #: dist/setup.js:7
 #: src/wizards/advertising/views/ad-unit/index.js:167
 #: src/wizards/advertising/views/ad-units/index.js:120
@@ -2408,7 +2432,7 @@ msgid "One-time"
 msgstr ""
 
 #: includes/plugins/woocommerce/class-woocommerce-connection.php:434
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 msgid "Card"
 msgstr ""
 
@@ -2522,7 +2546,7 @@ msgstr ""
 #: dist/audience-wizards.465ef24dd7707013533a.js:38
 #: dist/newsletters.js:1
 #: dist/newsletters.js:4
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:14
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:14
 #: dist/setup.js:4
 #: dist/setup.js:7
 #: src/wizards/audience/components/active-campaign.js:31
@@ -2592,9 +2616,9 @@ msgstr ""
 #: dist/billboard.js:1
 #: dist/billboard.js:12
 #: dist/commons.js:13
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:5
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:26
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:5
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:26
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 #: dist/other-scripts/corrections-modal.js:7
 #: src/components/src/with-wizard/index.js:261
 #: src/other-scripts/corrections-modal/index.js:410
@@ -2996,9 +3020,9 @@ msgstr ""
 
 #: includes/plugins/woocommerce/my-account/templates/v1/payment-information.php:47
 #: dist/componentsDemo.js:1
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:5
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:5
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 #: dist/setup.js:7
 #: src/wizards/componentsDemo/index.js:556
 #: src/wizards/componentsDemo/index.js:562
@@ -3396,7 +3420,7 @@ msgid "This email will be used as \"Reply-To\" for transactional emails as well.
 msgstr ""
 
 #: includes/reader-activation/class-reader-activation.php:895
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "reCAPTCHA"
 msgstr ""
 
@@ -4699,12 +4723,12 @@ msgid "Google Ad Manager"
 msgstr ""
 
 #: includes/wizards/newspack/class-newspack-dashboard.php:277
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:1
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:1
 msgid "Disconnected"
 msgstr ""
 
 #: includes/wizards/newspack/class-newspack-dashboard.php:290
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:29
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:29
 msgid "Google Analytics"
 msgstr ""
 
@@ -4721,40 +4745,40 @@ msgid "Open data dashboard"
 msgstr ""
 
 #: includes/wizards/newspack/class-newspack-settings.php:48
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Connections"
 msgstr ""
 
 #: includes/wizards/newspack/class-newspack-settings.php:81
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Emails"
 msgstr ""
 
 #: includes/wizards/newspack/class-newspack-settings.php:93
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Social"
 msgstr ""
 
 #: includes/wizards/newspack/class-newspack-settings.php:96
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Syndication"
 msgstr ""
 
 #: includes/wizards/newspack/class-newspack-settings.php:99
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 msgid "SEO"
 msgstr ""
 
 #: includes/wizards/newspack/class-newspack-settings.php:102
 #: dist/componentsDemo.js:1
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 #: dist/setup.js:7
 #: src/wizards/componentsDemo/index.js:607
 msgid "Theme and Brand"
 msgstr ""
 
 #: includes/wizards/newspack/class-newspack-settings.php:105
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 msgid "Advanced Settings"
 msgstr ""
 
@@ -4763,7 +4787,7 @@ msgid "Print"
 msgstr ""
 
 #: includes/wizards/newspack/class-newspack-settings.php:121
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:5
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:5
 msgid "Additional Brands"
 msgstr ""
 
@@ -4798,7 +4822,7 @@ msgstr ""
 #: dist/audience-wizards.465ef24dd7707013533a.js:1
 #: dist/audience-wizards.465ef24dd7707013533a.js:16
 #: dist/billboard.js:12
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:5
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:5
 #: src/wizards/advertising/views/ad-units/options-popover.js:34
 #: src/wizards/audience/components/campaign-management-popover/index.js:32
 #: src/wizards/audience/components/prompt-popovers/primary.js:41
@@ -4849,7 +4873,7 @@ msgstr ""
 #: dist/audience-wizards.465ef24dd7707013533a.js:16
 #: dist/billboard.js:12
 #: dist/componentsDemo.js:1
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:5
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:5
 #: dist/other-scripts/corrections-modal.js:1
 #: src/other-scripts/corrections-modal/index.js:300
 #: src/wizards/advertising/views/ad-unit/index.js:155
@@ -4883,8 +4907,8 @@ msgstr ""
 #: dist/billboard.js:12
 #: dist/componentsDemo.js:1
 #: dist/newsletters.js:4
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:5
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:14
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:5
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:14
 #: dist/setup.js:7
 #: src/wizards/advertising/views/ad-units/options-popover.js:37
 #: src/wizards/audience/components/prompt-action-card/index.js:140
@@ -5247,16 +5271,6 @@ msgid "%s Advanced Settings"
 msgstr ""
 
 #: dist/audience-wizards.465ef24dd7707013533a.js:10
-#: src/wizards/audience/components/settings-modal/index.js:134
-msgid "Hide"
-msgstr ""
-
-#: dist/audience-wizards.465ef24dd7707013533a.js:10
-#: src/wizards/audience/components/settings-modal/index.js:134
-msgid "Show"
-msgstr ""
-
-#: dist/audience-wizards.465ef24dd7707013533a.js:10
 #: src/wizards/audience/components/settings-modal/index.js:141
 msgid "Category Exclusions"
 msgstr ""
@@ -5297,7 +5311,7 @@ msgstr ""
 #: dist/audience-wizards.465ef24dd7707013533a.js:10
 #: dist/audience-wizards.465ef24dd7707013533a.js:16
 #: dist/billboard.js:12
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:5
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:5
 #: src/wizards/advertising/views/ad-units/options-popover.js:28
 #: src/wizards/audience/components/prompt-action-card/index.js:78
 #: src/wizards/audience/views/campaigns/segments/segments-list.js:177
@@ -5479,7 +5493,7 @@ msgid "(archived)"
 msgstr ""
 
 #: dist/audience-wizards.465ef24dd7707013533a.js:16
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:26
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:26
 #: src/wizards/audience/views/campaigns/campaigns/index.js:222
 msgid "Actions"
 msgstr ""
@@ -5666,9 +5680,9 @@ msgstr ""
 #: dist/audience-wizards.465ef24dd7707013533a.js:41
 #: dist/billboard.js:12
 #: dist/newsletters.js:1
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:8
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:29
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:8
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:29
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 #: dist/setup.js:4
 #: src/wizards/advertising/components/suppression/index.js:69
 #: src/wizards/audience/components/cover-fees-settings/index.js:83
@@ -5759,7 +5773,7 @@ msgstr ""
 #. Translators: %s: Plugin status
 #: dist/audience-wizards.465ef24dd7707013533a.js:20
 #: dist/audience-wizards.465ef24dd7707013533a.js:35
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:14
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:14
 #, js-format
 msgid "Status: %s"
 msgstr ""
@@ -5768,7 +5782,7 @@ msgstr ""
 #: dist/audience-wizards.465ef24dd7707013533a.js:32
 #: dist/audience-wizards.465ef24dd7707013533a.js:38
 #: dist/audience-wizards.465ef24dd7707013533a.js:41
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:14
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:14
 #: src/wizards/audience/components/payment-methods/index.js:39
 #: src/wizards/audience/components/payment-methods/index.js:54
 #: src/wizards/audience/components/payment-methods/payment-gateway.js:70
@@ -5783,7 +5797,7 @@ msgstr ""
 #: dist/audience-wizards.465ef24dd7707013533a.js:20
 #: dist/audience-wizards.465ef24dd7707013533a.js:35
 #: dist/audience-wizards.465ef24dd7707013533a.js:41
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 #: dist/other-scripts/corrections-modal.js:7
 #: src/other-scripts/corrections-modal/index.js:391
 msgid "Saving…"
@@ -5927,7 +5941,7 @@ msgstr ""
 
 #: dist/audience-wizards.465ef24dd7707013533a.js:32
 #: dist/commons.js:13
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:14
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:14
 #: src/components/src/image-upload/index.js:98
 #: src/components/src/sortable-newsletter-list-control/index.js:59
 msgid "Remove"
@@ -6230,9 +6244,9 @@ msgstr ""
 #: dist/billboard.js:1
 #: dist/commons.js:13
 #: dist/componentsDemo.js:1
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:11
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:14
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:11
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:14
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 #: src/components/src/plugin-toggle/index.js:172
 #: src/wizards/advertising/views/providers/index.js:74
 #: src/wizards/advertising/views/providers/index.js:92
@@ -6281,12 +6295,12 @@ msgstr ""
 #: dist/audience-wizards.465ef24dd7707013533a.js:38
 #: dist/audience-wizards.465ef24dd7707013533a.js:41
 #: dist/commons.js:13
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:5
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:8
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:11
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:29
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:5
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:8
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:11
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:29
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 #: dist/setup.js:7
 #: src/components/src/autocomplete-with-suggestions/index.js:289
 #: src/components/src/plugin-toggle/index.js:163
@@ -6307,8 +6321,8 @@ msgstr ""
 
 #: dist/audience-wizards.465ef24dd7707013533a.js:38
 #: dist/audience-wizards.465ef24dd7707013533a.js:41
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:1
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:1
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 #: src/wizards/audience/components/payment-methods/payment-gateway.js:47
 #: src/wizards/audience/components/payment-methods/stripe.js:51
 #: src/wizards/audience/components/payment-methods/woopayments.js:47
@@ -6323,8 +6337,8 @@ msgstr ""
 #: dist/audience-wizards.465ef24dd7707013533a.js:38
 #: dist/audience-wizards.465ef24dd7707013533a.js:41
 #: dist/commons.js:16
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:8
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:8
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 #: src/wizards/audience/components/payment-methods/payment-gateway.js:42
 #: src/wizards/audience/components/payment-methods/stripe.js:43
 #: src/wizards/audience/components/payment-methods/woopayments.js:42
@@ -6334,8 +6348,8 @@ msgstr ""
 #: dist/audience-wizards.465ef24dd7707013533a.js:38
 #: dist/audience-wizards.465ef24dd7707013533a.js:41
 #: dist/commons.js:16
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:8
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:8
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 #: src/wizards/audience/components/payment-methods/payment-gateway.js:89
 #: src/wizards/audience/components/payment-methods/stripe.js:102
 #: src/wizards/audience/components/payment-methods/woopayments.js:89
@@ -6490,7 +6504,7 @@ msgstr ""
 
 #: dist/audience-wizards.465ef24dd7707013533a.js:41
 #: dist/collections-admin.js:1
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:26
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:26
 #: src/collections/admin/collection-meta-ctas-field.js:225
 msgid "URL"
 msgstr ""
@@ -6908,7 +6922,7 @@ msgid "Disconnected from GAM."
 msgstr ""
 
 #: dist/billboard.js:12
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 #: dist/setup.js:7
 #: src/wizards/advertising/components/ad-unit-size-control/index.js:73
 msgid "Custom"
@@ -6937,8 +6951,8 @@ msgid "Ad Unit Details"
 msgstr ""
 
 #: dist/billboard.js:12
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:5
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:5
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 #: src/wizards/advertising/views/ad-unit/index.js:79
 msgid "Name"
 msgstr ""
@@ -6974,7 +6988,7 @@ msgid "The ad unit must have at least one valid size or fluid size enabled."
 msgstr ""
 
 #: dist/billboard.js:12
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:17
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:17
 #: src/wizards/advertising/views/ad-unit/index.js:120
 msgid "Action"
 msgstr ""
@@ -7513,7 +7527,7 @@ msgstr ""
 
 #: dist/commons.js:13
 #: dist/componentsDemo.js:1
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:1
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:1
 #: src/components/src/plugin-toggle/index.js:149
 #: src/wizards/componentsDemo/index.js:287
 msgid "Installing…"
@@ -7550,7 +7564,7 @@ msgid "Selected"
 msgstr ""
 
 #: dist/commons.js:13
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 #: src/components/src/style-card/index.js:45
 #: src/components/src/style-card/index.js:48
 msgid "Select"
@@ -7659,38 +7673,38 @@ msgid "Unable to read file"
 msgstr ""
 
 #: dist/commons.js:13
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:1
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:1
 msgid "Invalid Mailchimp API Key."
 msgstr ""
 
 #: dist/commons.js:13
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:1
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:1
 msgid "Missing Google refresh token. Please re-authenticate site."
 msgstr ""
 
 #: dist/commons.js:13
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:1
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:1
 msgid "Popup blocked by browser. Disable any popup blocking settings and try again."
 msgstr ""
 
 #: dist/commons.js:13
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:1
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:1
 msgid "URL is invalid. Please try again or contact support if the issue persists."
 msgstr ""
 
 #. Translators: connected user's email address.
 #. translators: %s: username
 #: dist/commons.js:16
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:8
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:8
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 #, js-format
 msgid "Connected as %s"
 msgstr ""
 
 #: dist/commons.js:16
 #: dist/componentsDemo.js:1
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:8
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:8
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 #: src/wizards/componentsDemo/index.js:379
 msgid "Disconnect"
 msgstr ""
@@ -8168,7 +8182,7 @@ msgstr ""
 
 #: dist/componentsDemo.js:1
 #: dist/memberships-gate-editor.js:25
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 #: src/memberships-gate/editor.js:30
 #: src/wizards/componentsDemo/index.js:510
 #: src/wizards/componentsDemo/index.js:584
@@ -8216,7 +8230,7 @@ msgid "Buttons"
 msgstr ""
 
 #: dist/componentsDemo.js:1
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 #: dist/setup.js:7
 #: src/wizards/componentsDemo/index.js:559
 #: src/wizards/componentsDemo/index.js:570
@@ -8224,7 +8238,7 @@ msgid "Primary"
 msgstr ""
 
 #: dist/componentsDemo.js:1
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 #: dist/setup.js:7
 #: src/wizards/componentsDemo/index.js:560
 #: src/wizards/componentsDemo/index.js:573
@@ -8500,7 +8514,7 @@ msgid "Medium"
 msgstr ""
 
 #: dist/memberships-gate-editor.js:25
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 #: src/memberships-gate/editor.js:32
 msgid "Large"
 msgstr ""
@@ -8779,1252 +8793,1260 @@ msgstr ""
 msgid "Newsletters / Tracking"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:1
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:1
 msgid "Quick actions"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:1
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:1
 msgid "Add missing dependencies"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:1
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:1
 msgid "Fetching…"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:1
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:1
 msgid "Click to navigate to configuration"
 msgstr ""
 
 #. translators: %s is a comma separated list of needed dependencies.
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:4
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:4
 msgid "Missing dependency"
 msgid_plural "Missing dependencies"
 msgstr[0] ""
 msgstr[1] ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:4
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:4
 msgid "Install dependency"
 msgid_plural "Install dependencies"
 msgstr[0] ""
 msgstr[1] ""
 
 #. translators: %d is the HTTP status code
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:5
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:5
 #, js-format
 msgid "Request failed - %d"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:5
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:5
 msgid "Site status"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:5
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:5
 msgid "Site brands"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:5
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:5
 msgid "You have no saved brands."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:5
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:5
 msgid "Add New Brand"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:5
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:5
 msgid "Fetching brands…"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:5
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:5
 msgid "Create brands to enhance your readers experience."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:5
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:5
 msgid "Brand"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:5
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:5
 msgid "Set your brand identity"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:5
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:5
 msgid "Brand Name"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:5
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:5
 msgid "Fetching logo…"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:5
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:5
 msgid "Logo"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:5
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:5
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 #: dist/setup.js:7
 msgid "Colors"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:5
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:5
 msgid "These are the colors you can customize for this brand in the active theme"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:5
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:5
 msgid "Reset default color"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:5
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:5
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 #: dist/setup.js:7
 msgid "Homepage"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:5
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:5
 msgid "Slug"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:5
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:5
 msgid "Show on Front"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:5
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:5
 msgid "Latest posts"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:5
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:5
 msgid "A page"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:5
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:5
 msgid "Homepage URL"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:5
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:5
 msgid "Select a Page"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:5
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:5
 msgid "Menus"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:5
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:5
 msgid "Customize the menus for this brand"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:5
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:5
 msgid "Same as site"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:5
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:5
 msgid "Brands"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:5
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:5
 msgid "Configure brands settings"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:5
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:5
 msgid "Are you sure you want to delete this brand?"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:8
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:8
 msgid "X (formerly Twitter) Handle"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:8
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:8
 msgid "username"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:8
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:8
 msgid "X handle cannot exceed 15 characters!"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:8
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:8
 msgid "X handle may only contain letters, numbers, and underscores!"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:8
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:8
 msgid "Facebook"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:8
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:8
 msgid "Instagram"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:8
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:8
 msgid "YouTube"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:8
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:8
 msgid "LinkedIn"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:8
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:8
 msgid "Pinterest"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:8
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:8
 msgid "Field cannot be empty!"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:8
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:8
 msgid "Invalid URL!"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:8
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:8
 msgid "Value cannot be empty!"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:8
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:8
 msgid "Value cannot be zero!"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:8
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:8
 msgid "Value may only contain numbers!"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:8
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:8
 msgid "Value may only contain numbers and letters."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:8
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:8
 msgid "X Pixel"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:8
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:8
 msgid "Add the X pixel (formerly known as Twitter pixel) to your site."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:8
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:8
 msgid "Pixel ID"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:8
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:8
 msgid "The X Pixel ID. You only need to add the number, not the full code. Example: 123456789123456789. You can get this information <linkToFb>here</linkToFb>."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:8
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:8
 msgid "Meta Pixel"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:8
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:8
 msgid "Add the Meta pixel (formerly known as Facebook pixel) to your site."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:8
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:8
 msgid "The Meta Pixel ID. You only need to add the number, not the full code. Example: 123456789123456789. You can get this information <linkToFb>here</linkToFb>."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:8
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:8
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Page reloading…"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:8
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:8
 msgid "Page redirecting…"
 msgstr ""
 
 #. translators: %s: Plugin name
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:9
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:9
 #, js-format
 msgid "Install %s"
 msgstr ""
 
 #. translators: %s: Plugin name
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:10
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:10
 #, js-format
 msgid "Activate %s"
 msgstr ""
 
 #. translators: %s: Plugin name
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:11
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:11
 #, js-format
 msgid "Configure %s"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:11
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:11
 msgid "Complete Setup"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:11
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:11
 msgid "Status: Error!"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:11
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:11
 msgid "Connected."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:11
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:11
 msgid "Not connected."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:11
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:14
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:11
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:14
 msgid "Inactive."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:11
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:11
 msgid "Uninstalled."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:14
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:14
 msgid "Publicize"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:14
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:14
 msgid "Publicize makes it easy to share your site's posts on several social media networks automatically when you publish a new post."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:14
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:14
 msgid "Activate Jetpack"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:14
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:14
 msgid "Newspack uses Newspack Newsletters to handle editing email-type content. Please activate this plugin to proceed."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:14
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:14
 msgid "Until this feature is configured, default receipts will be used."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:14
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:14
 msgid "Newspack Newsletters is the plugin that powers Newspack email receipts."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:14
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:14
 msgid "This email is not active."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:14
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:14
 msgid "This email is not active. The default receipt will be used."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:14
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:14
 msgid "This email is not active. The receipt template will be used if active."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:14
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:14
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Reset"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:14
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:14
 msgid "Are you sure you want to reset the contents of this email?"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:14
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:14
 msgid "Site Kit by Google"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:14
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:14
 msgid "Not connected for this user"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:14
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:14
 msgid "AI-Generated Audio Stories"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:14
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:14
 msgid "Complete setup and licensing agreement to unlock 5 free audio stories per month."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:14
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:14
 msgid "Not installed."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:14
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:14
 msgid "Pending."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:14
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:14
 msgid "URL is required."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:14
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:14
 msgid "HTTPS protocol is required for the endpoint URL."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:14
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:14
 msgid "Invalid URL format."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:14
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:14
 msgid "Endpoint Actions"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:14
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:14
 msgid "Close Endpoint Actions"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:14
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:14
 msgid "View Requests"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:14
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:14
 msgid "Endpoint disabled due to error"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:14
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:14
 msgid "Actions:"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:14
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:14
 msgid "Latest Requests"
 msgstr ""
 
 #. translators: %s is the endpoint title (shortened URL).
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:17
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:17
 #, js-format
 msgid "Most recent requests for %s"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:17
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:17
 msgid "Error"
 msgstr ""
 
 #. translators: %s is a human-readable time difference.
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:20
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:20
 #, js-format
 msgid "sending in %s"
 msgstr ""
 
 #. translators: %s is a human-readable time difference.
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:23
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:23
 #, js-format
 msgid "processed %s"
 msgstr ""
 
 #. translators: %s is the number of errors.
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:26
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:26
 #, js-format
 msgid "Attempt #%s"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:26
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:26
 msgid "This endpoint hasn't received any requests yet."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:26
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:26
 msgid "Webhook Endpoint"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:26
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:26
 msgid "This webhook endpoint is currently disabled."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:26
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:26
 msgid "Request Error: "
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:26
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:26
 msgid "The URL to send requests to. It's required for the URL to be under a valid TLS/SSL certificate. You can use the test button below to verify the endpoint response."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:26
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:26
 msgid "Authentication token (optional)"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:26
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:26
 msgid "If your endpoint requires a token authentication, enter it here. It will be sent as a Bearer token in the Authorization header."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:26
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:26
 msgid "Send a test request"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:26
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:26
 msgid "Label (optional)"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:26
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:26
 msgid "A label to help you identify this endpoint. It will not be sent to the endpoint."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:26
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:26
 msgid "Select which actions should trigger this endpoint:"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:26
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:26
 msgid "At least one action is required."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:26
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:26
 msgid "Confirm"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:26
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:26
 msgid "Remove Endpoint"
 msgstr ""
 
 #. translators: %s: endpoint title
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:27
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:27
 #, js-format
 msgid "Are you sure you want to remove the endpoint %s?"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:27
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:27
 msgid "Enable Endpoint"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:27
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:27
 msgid "Disable Endpoint"
 msgstr ""
 
 #. translators: %s: endpoint title
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:28
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:28
 #, js-format
 msgid "Are you sure you want to enable the endpoint %s?"
 msgstr ""
 
 #. translators: %s: endpoint title
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:29
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:29
 #, js-format
 msgid "Are you sure you want to disable the endpoint %s?"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:29
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:29
 msgid "Webhook Endpoints"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:29
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:29
 msgid "Register webhook endpoints to integrate reader activity data to third-party services or private APIs"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:29
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:29
 msgid "Add New Endpoint"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:29
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:29
 msgid "No endpoints found"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:29
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:29
 msgid "View"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:29
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:29
 msgid "Site Key cannot be empty!"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:29
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:29
 msgid "Site Secret cannot be empty"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:29
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:29
 msgid "Threshold cannot be less than 0.1"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:29
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:29
 msgid "Threshold cannot be greater than 1"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:29
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:29
 msgid "Your site key and secret must match the selected reCAPTCHA version. Please enter new credentials."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:29
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:29
 msgid "You need a valid Measurement ID (e.g. \"G-ABCDE12345\") to activate Newspack Custom Events."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:29
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:29
 msgid "You need a valid Measurement API Secret to activate Newspack Custom Events."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:29
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:29
 msgid "Use reCAPTCHA"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:29
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:29
 msgid "Enabling reCAPTCHA can help protect your site against bot attacks and credit card testing."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:29
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:29
 msgid "Get started"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:29
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:29
 msgid "reCAPTCHA Version"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:29
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:29
 msgid "Learn more about reCAPTCHA versions"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:29
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:29
 msgid "Score based (v3)"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:29
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:29
 msgid "Challenge (v2) - invisible reCAPTCHA badge"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:29
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:29
 msgid "Site Key"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:29
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:29
 msgid "Site Secret"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:29
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:29
 msgid "Threshold"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:29
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:29
 msgid "Learn more about the threshold value"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:29
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:29
 msgid "Error fetching settings."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:29
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:29
 msgid "Error updating settings."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:29
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:29
 msgid "Force two-factor authentication"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:29
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:29
 msgid "Improve security by requiring two-factor authentication via WordPress.com for users with higher capabilities."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:29
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:29
 msgid "Two-factor authentication is currently enforced for all users via Jetpack configuration."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:29
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:29
 msgid "Customize which capabilties to enforce 2FA by untoggling the “Require accounts to use WordPress.com Two-Step Authentication” option in Jetpack settings."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:29
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:29
 msgid "Select the user capability to enforce two-factor authentication"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:29
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:29
 msgid "Capability"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:29
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:29
 msgid "Obfuscate restricted accounts by throwing WP’s “user not found” errors on login form attempts."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Add Mailchimp API Key"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Mailchimp API Key"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Find or generate your API key"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Connecting…"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Newspack already sends some custom event data to your GA account, but adding the credentials below enables enhanced events that are fired from your site's backend. For example, when a donation is confirmed or when a user successfully subscribes to a newsletter."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Measurement ID"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "You can find this in Site Kit Settings, or in Google Analytics > Admin > Data Streams and clickng the data stream. Example: G-ABCDE12345"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Measurement Protocol API Secret"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Generate an API secret from your GA dashboard in Admin > Data Streams and opening your data stream. Select \"Measurement Protocol API secrets\" under the Events section. Create a new secret."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Are you sure you want to reset the GA4 credentials?"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Create and manage customized RSS feeds for syndication partners"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Related Posts"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Automatically add related content at the bottom of each post."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "If set, posts will be shown as related content only if published within the past number of months. If 0, any published post can be shown, regardless of publish date."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Maximum age of related content, in months"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 msgid "Author Bio"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Display an author bio under individual posts."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Author Email"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Display the author email with bio on individual posts."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Length"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Truncates the author bio on single posts to this approximate character length, but without breaking a word. The full bio appears on the author archive page."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "You have more than 1000 posts. Applying these settings might take a moment."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Featured image position for all posts"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Set a featured image position for all posts."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Select to change all posts"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Behind article title"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Beside article title"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Hidden"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "After saving the settings with this option selected, all posts will be updated. This cannot be undone."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Template for all posts"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Set a template for all posts."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "With sidebar"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "One Column"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "One Column Wide"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Default featured image position for new posts"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Set a default featured image position for new posts."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Default template for new posts"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Set a default template for new posts."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Credit Class Name"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "A CSS class name to be applied to all image credit elements. Leave blank to display no class name."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Credit Label"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "A label to prefix all media credits. Leave blank to display no prefix."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Placeholder Image"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "A placeholder image to be displayed in place of images without credits. If none is chosen, the image will be displayed normally whether or not it has a credit."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Auto-populate image credits"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Automatically populate image credits from EXIF or IPTC metadata when uploading new images."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Create Page"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Edit Page"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Edit and Publish Page"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Your accessibility statement page has been moved to trash or deleted. Click \"Create Page\" to create a new one."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Your accessibility statement page is published."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Your accessibility statement page is not yet published. Please review and make edits before publishing."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Your accessibility statement page has been moved to trash. Click \"Create Page\" to create a new one."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Accessibility Statement Page"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Edit and publish an accessibility statement page. Once published, a link to this page will display in the footer of your site."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "An accessibility statement helps your readers understand how your site supports accessibility standards and what to do if they encounter accessibility issues. "
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "What makes a good accessibility statement."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "The page you create here will include a boilerplate accessibility statement. "
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Please review and make edits to ensure it meets the requirements before publishing. "
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "You can also use the W3C Accessibility Statement Generator to create a custom statement. "
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Try out the Accessibility Statement Generator."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Learn more about this feature in our documentation."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 #: dist/setup.js:7
 msgid "Activate Layout"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 #: dist/setup.js:7
 msgid "Serif"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 #: dist/setup.js:7
 msgid "Sans Serif"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 #: dist/setup.js:7
 msgid "Display"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 #: dist/setup.js:7
 msgid "Monospace"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 #: dist/setup.js:7
 msgid "XS"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 #: dist/setup.js:7
 msgid "S"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 #: dist/setup.js:7
 msgid "M"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 #: dist/setup.js:7
 msgid "L"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 #: dist/setup.js:7
 msgid "XL"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 #: dist/setup.js:7
 msgid "Headings"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 #: dist/setup.js:7
 msgid "Body"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 #: dist/setup.js:7
 msgid "Font provider import code or URL"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 #: dist/setup.js:7
 msgid "Font name"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 #: dist/setup.js:7
 msgid "Font fallback stack"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 #: dist/setup.js:7
 msgid "Typography Options"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 #: dist/setup.js:7
 msgid "Use all-caps for accent text"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Customize collections naming schema"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Override labels, messages and other reader-facing elements with custom naming."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Name to be used instead of \"Collections\" (e.g., \"Issues\", \"Magazines\")"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Singular name"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Singular name to be used instead of \"Collection\" (e.g., \"Issue\", \"Magazine\")"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Permalink base slug"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Base slug to be used in permalinks and the REST API (e.g., \"issues\", \"magazine\"). Default: \"collections\"."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Plugins"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "APIs"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Jetpack SSO"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Analytics"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Activate Newspack Custom Events"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Allows Newspack to send enhanced custom event data to your Google Analytics."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Invalid Google verification code!"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:30
 msgid "Invalid Bing verification code!"
 msgstr ""
 
 #. translators: %1$s: label, %2$s: placeholder
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 #, js-format
 msgid "Invalid URL for \"%1$s\", correct format is \"%2$s\""
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 msgid "Webmaster Tools"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 msgid "Add verification meta tags to your site"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 msgid "Social Accounts"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 msgid "Let search engines know which social profiles are associated to your site"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 #: dist/setup.js:7
 msgid "Theme"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 #: dist/setup.js:7
 msgid "Update your sites theme."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 #: dist/setup.js:7
 msgid "Select a homepage layout."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 #: dist/setup.js:7
 msgid "Pick your primary and secondary colors."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 #: dist/setup.js:7
 msgid "Typography"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 #: dist/setup.js:7
 msgid "Define the font pairing to use throughout your site"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 #: dist/setup.js:7
 msgid "Header"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 #: dist/setup.js:7
 msgid "Update the header and add your logo."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 #: dist/setup.js:7
 msgid "Footer"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 #: dist/setup.js:7
 msgid "Personalize the footer of your site."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 #: dist/setup.js:7
 msgid "Finish"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 msgid "Recirculation"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 msgid "Default Featured Image Position And Post Template"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 msgid "Modify how the featured image and post template settings are applied to new posts."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 msgid "Featured Image Position And Post Template For All Posts"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 msgid "Modify how the featured image and post template settings are applied to existing posts. Warning: saving these options will override all posts."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 msgid "Media Credits"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 msgid "Saving will overwrite existing posts, this cannot be undone. Are you sure you want to proceed?"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 msgid "Open Customizer"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 msgid "Manage print editions and other collections of content with custom ordering and organization."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 msgid "Collections Settings"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 msgid "Collections Module"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 msgid "Global CTAs"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 msgid "Renderd in Collections-related pages. Can be overridden on a per-category or per-collection basis."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 msgid "URL for the \"Subscribe\" button that will be displayed in the Collections archive page when no subscription URL is set for the Collection or its parent category."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 msgid "URL for the \"Order\" button that will be displayed in the Collections archive page when no order URL is set for the Collection or its parent category."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 msgid "Collections Archive"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 msgid "Customize the Collections archive page."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 msgid "Collections per page"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 msgid "Number of collections to display per page in the Collections archive page."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 msgid "Category Filter Label"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 msgid "Custom label for the category filter dropdown (e.g., \"Collection:\", \"Type:\", \"Series:\"). Leave empty to use the default \"Publication:\"."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 msgid "Publication:"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 msgid "Highlight Most Recent Collection"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 msgid "Feature the latest Collection prominently at the top of the archive page, showcasing its content and any associated CTAs."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 msgid "Collection Single"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 msgid "Customize individual collection pages."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
-msgid "Show category"
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
+msgid "Show Category"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 msgid "Display the category information for posts when rendering them on collection pages."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
+msgid "Show Cover Story Images"
+msgstr ""
+
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
+msgid "Display featured images for cover stories on collection pages. Individual collections can override this setting."
+msgstr ""
+
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 msgid "Collection Posts"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 msgid "Customize post single pages when they belong to a collection."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 msgid "Collection Indicator Style"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 msgid "How collection indicators should be displayed on posts. When choosing the default style, an indicator with a link will be displayed at the bottom of the post content."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 msgid "Card Message"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 msgid "Custom message displayed in the card style indicator, along with the featured image and a button to view the collection."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 msgid "Allows editors to export article content in Adobe InDesign Tagged Text format."
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 msgid "Adobe Indesign"
 msgstr ""
 
-#: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
+#: dist/newspack-wizards.6dc9df9cfab843ff2431.js:31
 msgid "Enable InDesign Export"
 msgstr ""
 

--- a/src/collections/admin/collection-meta-panel.js
+++ b/src/collections/admin/collection-meta-panel.js
@@ -5,7 +5,7 @@
 import { __ } from '@wordpress/i18n';
 import { registerPlugin } from '@wordpress/plugins';
 import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
-import { TextControl } from '@wordpress/components';
+import { TextControl, SelectControl } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useState, useCallback } from '@wordpress/element';
 import { store as editorStore } from '@wordpress/editor';
@@ -86,6 +86,19 @@ const CollectionMetaPanel = ( { postType, metaDefinitions, panelTitle } ) => {
 									help={ def.help }
 									meta={ meta }
 									updateMeta={ updateMeta }
+								/>
+							);
+						}
+
+						if ( def.field_type === 'select' && def.options ) {
+							return (
+								<SelectControl
+									key={ def.key }
+									label={ def.label }
+									help={ def.help }
+									value={ meta[ def.key ] || def.default || '' }
+									options={ def.options }
+									onChange={ value => updateMeta( def.key, value ) }
 								/>
 							);
 						}

--- a/src/wizards/newspack/views/settings/collections/index.tsx
+++ b/src/wizards/newspack/views/settings/collections/index.tsx
@@ -30,6 +30,7 @@ const DEFAULT_COLLECTIONS_SETTINGS: CollectionsSettingsData = {
 	highlight_latest: false,
 	// Collection Single section.
 	articles_block_attrs: {},
+	show_cover_story_img: false,
 	// Collection Posts section.
 	post_indicator_style: 'default',
 	card_message: __( "Keep reading. There's plenty more to discover.", 'newspack-plugin' ),
@@ -189,13 +190,22 @@ function Collections() {
 					>
 						<Grid columns={ 2 } gutter={ 32 }>
 							<ToggleControl
-								label={ __( 'Show category', 'newspack-plugin' ) }
+								label={ __( 'Show Category', 'newspack-plugin' ) }
 								help={ __(
 									'Display the category information for posts when rendering them on collection pages.',
 									'newspack-plugin'
 								) }
 								checked={ settings.articles_block_attrs?.showCategory || false }
 								onChange={ ( value: boolean ) => updateNestedSetting( 'articles_block_attrs', 'showCategory', value ) }
+							/>
+							<ToggleControl
+								label={ __( 'Show Cover Story Images', 'newspack-plugin' ) }
+								help={ __(
+									'Display featured images for cover stories on collection pages. Individual collections can override this setting.',
+									'newspack-plugin'
+								) }
+								checked={ settings.show_cover_story_img }
+								onChange={ ( value: boolean ) => updateSetting( 'show_cover_story_img', value ) }
 							/>
 						</Grid>
 					</WizardSection>

--- a/src/wizards/newspack/views/settings/collections/types.d.ts
+++ b/src/wizards/newspack/views/settings/collections/types.d.ts
@@ -17,6 +17,7 @@ type CollectionsSettingsData = {
 	articles_block_attrs: {
 		showCategory?: boolean;
 	};
+	show_cover_story_img: boolean;
 	// Collection Posts section.
 	post_indicator_style: 'default' | 'card';
 	card_message: string;

--- a/tests/unit-tests/collections/class-test-collection-meta.php
+++ b/tests/unit-tests/collections/class-test-collection-meta.php
@@ -31,6 +31,7 @@ class Test_Collection_Meta extends WP_UnitTestCase {
 		'subscribe_link',
 		'order_link',
 		'ctas',
+		'cover_story_img_visibility',
 	];
 
 	/**

--- a/tests/unit-tests/collections/class-test-settings.php
+++ b/tests/unit-tests/collections/class-test-settings.php
@@ -201,6 +201,11 @@ class Test_Settings extends WP_UnitTestCase {
 		Settings::update_setting( 'articles_block_attrs', [] );
 		$this->assertTrue( $articles_callback( [ 'showCategory' => true ] )['showCategory'] );
 		$this->assertFalse( $articles_callback( [ 'showCategory' => 'false' ] )['showCategory'] );
+
+		// Test show cover story image sanitization.
+		$show_cover_story_img_callback = $rest_args['show_cover_story_img']['sanitize_callback'];
+		$this->assertTrue( $show_cover_story_img_callback( 'true' ) );
+		$this->assertFalse( $show_cover_story_img_callback( 'false' ) );
 	}
 
 	/**

--- a/tests/unit-tests/collections/class-test-template-helper.php
+++ b/tests/unit-tests/collections/class-test-template-helper.php
@@ -306,6 +306,22 @@ class Test_Template_Helper extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test should_show_cover_story_image respects settings and meta.
+	 *
+	 * @covers \Newspack\Collections\Template_Helper::should_show_cover_story_image
+	 */
+	public function test_should_show_cover_story_image() {
+		$collection_id = $this->create_test_collection();
+
+		// Test default behavior (inherit from global setting).
+		$this->assertFalse( Template_Helper::should_show_cover_story_image( $collection_id ) );
+
+		// Test collection-specific override to show.
+		Collection_Meta::set( $collection_id, 'cover_story_img_visibility', 'show' );
+		$this->assertTrue( Template_Helper::should_show_cover_story_image( $collection_id ) );
+	}
+
+	/**
 	 * Test update_document_title modifies title for collections archive pages.
 	 *
 	 * @covers \Newspack\Collections\Template_Helper::update_document_title

--- a/tests/unit-tests/collections/traits/trait-meta-handler-test.php
+++ b/tests/unit-tests/collections/traits/trait-meta-handler-test.php
@@ -49,6 +49,9 @@ trait Trait_Meta_Handler_Test {
 
 			// Assert that each property of the meta definition matches the registered meta.
 			foreach ( $meta as $property => $value ) {
+				if ( in_array( $property, $class_name::$fe_only_props, true ) ) {
+					continue;
+				}
 				$this->assertEquals(
 					$value,
 					$registered_meta[ $meta_key ][ $property ],


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds the ability to control whether featured images are displayed for cover stories in Collections.
Currently, cover stories display without featured images (by design), while regular stories show featured images.

Changes:
- Collections settings page now includes a toggle to show cover story images by default.
- Individual collections can override the global setting with options to inherit, show, or hide cover story images.
- Default behavior remains unchanged (cover stories without images). Gives publishers flexibility to display cover story images when desired while preserving the original design intent as the default.

Closes NPPD-776.

### How to test the changes in this Pull Request:

#### Testing the global setting:
1. Navigate to Collections settings page.
2. Look for the new "Show Cover Story Images" toggle under Collection Single section.
3. Enable the toggle and verify cover stories now display featured images on collection pages.
4. Disable the toggle and confirm cover stories return to hiding featured images.

#### Testing per-collection overrides:
1. Edit any collection post.
2. In the Collection Meta panel, find the new "Cover Story Image Visibility" dropdown.
3. Test each option:
    - "Use global setting" - Should follow the global toggle setting.
    - "Show" - Should display cover story images regardless of global setting.
    - "Hide" - Should hide cover story images regardless of global setting.
5. View the collection page to confirm the setting takes effect.

#### Additional checks:
- Regular (non-cover) stories should always show featured images (unchanged behavior).
- Only cover stories should be affected by these new settings.
- Settings should persist after saving and page refresh.
- Collection pages should immediately reflect changes without cache issues.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?