### PR TITLE
fix(sitekit-logger): also check GA from Tag Manager

### DIFF
--- a/includes/plugins/google-site-kit/class-googlesitekit-logger.php
+++ b/includes/plugins/google-site-kit/class-googlesitekit-logger.php
@@ -93,9 +93,16 @@ class GoogleSiteKit_Logger {
 		}
 
 		try {
-			$settings = get_option( 'googlesitekit_analytics-4_settings', [] );
-			$will_output_snippet = ! empty( $settings['useSnippet'] ) && ! empty( $settings['measurementID'] );
-			if ( ! $will_output_snippet ) {
+			// Check Analytics 4 settings.
+			$analytics_settings      = get_option( 'googlesitekit_analytics-4_settings', [] );
+			$analytics_will_output   = ! empty( $analytics_settings['useSnippet'] ) && ! empty( $analytics_settings['measurementID'] );
+
+			// Check Tag Manager settings (which can also output Google Analytics).
+			$tagmanager_settings     = get_option( 'googlesitekit_tagmanager_settings', [] );
+			$tagmanager_will_output  = ! empty( $tagmanager_settings['useSnippet'] ) && ! empty( $tagmanager_settings['containerID'] );
+
+			// If neither Analytics 4 nor Tag Manager will output snippets, consider it disconnected.
+			if ( ! $analytics_will_output && ! $tagmanager_will_output ) {
 				return [
 					'status' => 'disconnected',
 					'reason' => 'will_not_output_snippet',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Hopefully the final adjustment after the last one in https://github.com/Automattic/newspack-plugin/pull/4119.
On top of Google Analytics connection, GA tracking may also be added by Tag Manager. This PR adds a check for TM. 

### How to test the changes in this Pull Request:


1. With Site Kit disconnected, run `wp eval "echo json_encode(\Newspack\GoogleSiteKit_Logger::get_connection_status());" | jq '.'` - observe 

```json
{
  "status": "disconnected",
  "reason": "will_not_output_snippet"
}
```

logged.

2. Connect Site Kit, configure Tag Manager with GA tracking, but not GA module, observe it's fully connected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->