### PR TITLE
feat: add the collections category to the Content Loop filters (NPPD-729)

### DIFF
--- a/includes/collections/class-collection-category-taxonomy.php
+++ b/includes/collections/class-collection-category-taxonomy.php
@@ -223,7 +223,7 @@ class Collection_Category_Taxonomy {
 		];
 
 		$point_of_insertion = null;
-		// Loop through the taxonomies; confirm Collections doesn't already exist, and grab the index of Collection Sections if it's there.
+		// Loop through the taxonomies; confirm Collection Categories doesn't already exist, and grab the index of Collection Sections if it's there.
 		foreach ( $custom_taxonomies as $index => $tax ) {
 			if ( isset( $tax['slug'] ) ) {
 				if ( $tax['slug'] === $collections_category_taxonomy['slug'] ) {

--- a/includes/collections/class-collection-category-taxonomy.php
+++ b/includes/collections/class-collection-category-taxonomy.php
@@ -230,7 +230,7 @@ class Collection_Category_Taxonomy {
 					return $custom_taxonomies;
 				}
 				if ( $tax['slug'] === Collection_Section_Taxonomy::get_taxonomy() ) {
-					$point_of_insertion = $index;
+					$point_of_insertion = $index + 1;
 				}
 			}
 		}

--- a/includes/collections/class-collection-category-taxonomy.php
+++ b/includes/collections/class-collection-category-taxonomy.php
@@ -235,7 +235,7 @@ class Collection_Category_Taxonomy {
 			}
 		}
 
-		// If Collection Sections exists in the taxonomy filters, insert Collections before it. If not, use the default insertion point.
+		// If Collection Sections exists in the taxonomy filters, insert Collection Categories before it. If not, use the default insertion point.
 		if ( null !== $point_of_insertion ) {
 			array_splice( $custom_taxonomies, $point_of_insertion, 0, [ $collections_category_taxonomy ] );
 		} else {

--- a/includes/collections/class-collection-category-taxonomy.php
+++ b/includes/collections/class-collection-category-taxonomy.php
@@ -70,6 +70,7 @@ class Collection_Category_Taxonomy {
 		add_action( 'init', [ __CLASS__, 'register_meta' ] );
 		add_action( 'newspack_collections_before_flush_rewrites', [ __CLASS__, 'update_registration' ] );
 		add_action( 'manage_' . Post_Type::get_post_type() . '_posts_columns', [ __CLASS__, 'set_taxonomy_column_name' ] );
+		add_filter( 'newspack_blocks_home_page_block_custom_taxonomies', [ __CLASS__, 'add_collections_category_taxonomy_to_blocks' ] );
 
 		// Term meta field handling.
 		add_action( self::get_taxonomy() . '_add_form_fields', [ __CLASS__, 'add_term_meta_fields' ] );
@@ -207,5 +208,40 @@ class Collection_Category_Taxonomy {
 			}
 		}
 		// phpcs:enable WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+	}
+
+	/**
+	 * Add the Collection Categories taxonomy to the custom taxonomies array.
+	 *
+	 * @param array $custom_taxonomies Array of custom taxonomies.
+	 * @return array Modified array of custom taxonomies.
+	 */
+	public static function add_collections_category_taxonomy_to_blocks( $custom_taxonomies ) {
+		$collections_category_taxonomy = [
+			'slug'  => self::get_taxonomy(),
+			'label' => __( 'Collection Categories', 'newspack-plugin' ),
+		];
+
+		$point_of_insertion = null;
+		// Loop through the taxonomies; confirm Collections doesn't already exist, and grab the index of Collection Sections if it's there.
+		foreach ( $custom_taxonomies as $index => $tax ) {
+			if ( isset( $tax['slug'] ) ) {
+				if ( $tax['slug'] === $collections_category_taxonomy['slug'] ) {
+					return $custom_taxonomies;
+				}
+				if ( $tax['slug'] === Collection_Section_Taxonomy::get_taxonomy() ) {
+					$point_of_insertion = $index;
+				}
+			}
+		}
+
+		// If Collection Sections exists in the taxonomy filters, insert Collections before it. If not, use the default insertion point.
+		if ( null !== $point_of_insertion ) {
+			array_splice( $custom_taxonomies, $point_of_insertion, 0, [ $collections_category_taxonomy ] );
+		} else {
+			$custom_taxonomies[] = $collections_category_taxonomy;
+		}
+
+		return $custom_taxonomies;
 	}
 }

--- a/languages/newspack-plugin.pot
+++ b/languages/newspack-plugin.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GPL2.
 msgid ""
 msgstr ""
-"Project-Id-Version: Newspack 6.14.2\n"
+"Project-Id-Version: Newspack 6.14.3\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/project\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2025-08-04T12:53:37+00:00\n"
+"POT-Creation-Date: 2025-08-06T00:35:05+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: newspack-plugin\n"
@@ -891,70 +891,74 @@ msgstr ""
 msgid "Override the global order link for this category."
 msgstr ""
 
-#: includes/collections/class-collection-category-taxonomy.php:86
+#: includes/collections/class-collection-category-taxonomy.php:87
 msgctxt "collection category taxonomy general name"
 msgid "Collection Categories"
 msgstr ""
 
-#: includes/collections/class-collection-category-taxonomy.php:87
+#: includes/collections/class-collection-category-taxonomy.php:88
 msgctxt "collection category taxonomy singular name"
 msgid "Collection Category"
 msgstr ""
 
-#: includes/collections/class-collection-category-taxonomy.php:88
+#: includes/collections/class-collection-category-taxonomy.php:89
 msgid "Search Collection Categories"
 msgstr ""
 
-#: includes/collections/class-collection-category-taxonomy.php:89
+#: includes/collections/class-collection-category-taxonomy.php:90
 msgid "Popular Collection Categories"
 msgstr ""
 
-#: includes/collections/class-collection-category-taxonomy.php:90
+#: includes/collections/class-collection-category-taxonomy.php:91
 msgid "All Collection Categories"
 msgstr ""
 
-#: includes/collections/class-collection-category-taxonomy.php:91
+#: includes/collections/class-collection-category-taxonomy.php:92
 msgid "Parent Collection Category"
 msgstr ""
 
-#: includes/collections/class-collection-category-taxonomy.php:92
+#: includes/collections/class-collection-category-taxonomy.php:93
 msgid "Parent Collection Category:"
 msgstr ""
 
-#: includes/collections/class-collection-category-taxonomy.php:93
+#: includes/collections/class-collection-category-taxonomy.php:94
 msgid "Edit Collection Category"
 msgstr ""
 
-#: includes/collections/class-collection-category-taxonomy.php:94
+#: includes/collections/class-collection-category-taxonomy.php:95
 msgid "View Collection Category"
 msgstr ""
 
-#: includes/collections/class-collection-category-taxonomy.php:95
+#: includes/collections/class-collection-category-taxonomy.php:96
 msgid "Update Collection Category"
 msgstr ""
 
-#: includes/collections/class-collection-category-taxonomy.php:96
+#: includes/collections/class-collection-category-taxonomy.php:97
 msgid "Add New Collection Category"
 msgstr ""
 
-#: includes/collections/class-collection-category-taxonomy.php:97
+#: includes/collections/class-collection-category-taxonomy.php:98
 msgid "New Collection Category Name"
 msgstr ""
 
-#: includes/collections/class-collection-category-taxonomy.php:98
+#: includes/collections/class-collection-category-taxonomy.php:99
 #: includes/lite-site/class-lite-site.php:121
 #: dist/billboard.js:12
 #: src/wizards/advertising/components/suppression/index.js:126
 msgid "Categories"
 msgstr ""
 
-#: includes/collections/class-collection-category-taxonomy.php:103
+#: includes/collections/class-collection-category-taxonomy.php:104
 msgid "Taxonomy for categorizing collections."
 msgstr ""
 
-#: includes/collections/class-collection-category-taxonomy.php:131
+#: includes/collections/class-collection-category-taxonomy.php:132
 msgctxt "label for collection category column name"
 msgid "Categories"
+msgstr ""
+
+#: includes/collections/class-collection-category-taxonomy.php:222
+msgid "Collection Categories"
 msgstr ""
 
 #: includes/collections/class-collection-meta.php:28


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Similar to https://github.com/Automattic/newspack-plugin/pull/4100, this PR adds the Collection Categories taxonomy as an option to filter Collections by. 

### How to test the changes in this Pull Request:

1. If not already, enable Collections under WP Admin > Newspack > Settings on your test site.
2. Make sure you have some Collections set up on your test site, and posts populating each of them.
3. Assign a couple different Collection Categories to your Collections.
4. Create a page and add a Content Loop block. In the Content panel of the right sidebar, confirm you have a Collection Categories filter along with other options. Collection Categories and Exclude Collection Categories should appear below Collection Sections and Exclude Collection Sections, respectively:

<img width="252" height="734" alt="CleanShot 2025-08-05 at 17 38 53" src="https://github.com/user-attachments/assets/e56b849a-b416-43b0-a1a4-d1d58b92dcca" />

5. Under Post Types, select Collections and deselect other post types. Confirm that the block is pulling in your Collections.
6. Under Collection Categories, try filtering the Collections in the block by one or two of your categories. Confirm the blocks are correct in the editor and on the front-end.
7. Repeat the above for the Exclude Collection Categories field, and confirm it removes Collections that are associated with the excluded category.
8. Repeat steps 4-7 with the Content Carousel block.
9. Disable the Collections module under WP Admin > Newspack > Settings.
10. Confirm that the Collection Categories query option is no longer available under the Content Loop and Carousel block settings. Any blocks set to return posts based on Collection should be empty.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->