### PR TITLE
Fix small typo in RSS Enhancements

### DIFF
--- a/includes/optional-modules/class-rss.php
+++ b/includes/optional-modules/class-rss.php
@@ -162,7 +162,7 @@ class RSS {
 			'search_items'       => __( 'Search RSS Feeds', 'newspack-plugin' ),
 			'parent_item_colon'  => __( 'Parent RSS Feeds:', 'newspack-plugin' ),
 			'not_found'          => __( 'No RSS feeds found.', 'newspack-plugin' ),
-			'not_found_in_trash' => __( 'No RSS seeds found in Trash.', 'newspack-plugin' ),
+			'not_found_in_trash' => __( 'No RSS feeds found in Trash.', 'newspack-plugin' ),
 			'item_published'     => __( 'RSS Feed published', 'newspack-plugin' ),
 			'item_updated'       => __( 'RSS Feed updated', 'newspack-plugin' ),
 		);

--- a/languages/newspack-plugin.pot
+++ b/languages/newspack-plugin.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2025-08-06T14:38:05+00:00\n"
+"POT-Creation-Date: 2025-08-06T22:46:34+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: newspack-plugin\n"
@@ -1957,7 +1957,7 @@ msgid "No RSS feeds found."
 msgstr ""
 
 #: includes/optional-modules/class-rss.php:165
-msgid "No RSS seeds found in Trash."
+msgid "No RSS feeds found in Trash."
 msgstr ""
 
 #: includes/optional-modules/class-rss.php:166


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

I apologize for taking attention from whoever reviews this PR. Fixes a small typo I ran across.

### How to test the changes in this Pull Request:

1. Visit `/wp-admin/edit.php?post_status=trash&post_type=partner_rss_feed`. Confirm it's not telling you something about RSS seeds.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->