### PR TITLE
fix(rss): use consistent featured image size

### DIFF
--- a/includes/class-rss-add-image.php
+++ b/includes/class-rss-add-image.php
@@ -26,6 +26,11 @@ class RSS_Add_Image {
 	 */
 	const OPTION_RSS_IMAGE_HEIGHT = 'newspack_rss_image_size_height';
 
+	/**
+	 * The featured image size used in the RSS feed.
+	 *
+	 * @var string
+	 */
 	const RSS_IMAGE_SIZE = 'rss-image-size';
 
 	/**

--- a/includes/class-rss-add-image.php
+++ b/includes/class-rss-add-image.php
@@ -26,6 +26,8 @@ class RSS_Add_Image {
 	 */
 	const OPTION_RSS_IMAGE_HEIGHT = 'newspack_rss_image_size_height';
 
+	const RSS_IMAGE_SIZE = 'rss-image-size';
+
 	/**
 	 * Hook actions and filters.
 	 */
@@ -40,7 +42,7 @@ class RSS_Add_Image {
 	 * Add RSS image size.
 	 */
 	public static function rss_image_size() {
-		add_image_size( 'rss-image-size', self::get_rss_image_width(), self::get_rss_image_height() );
+		add_image_size( self::RSS_IMAGE_SIZE, self::get_rss_image_width(), self::get_rss_image_height() );
 	}
 
 	/**
@@ -170,7 +172,7 @@ class RSS_Add_Image {
 	public static function thumbnails_in_rss( $content ) {
 		global $post;
 		if ( has_post_thumbnail( $post->ID ) ) {
-			$content = '<figure>' . get_the_post_thumbnail( $post->ID, 'rss-image-size' ) . '</figure>' . $content;
+			$content = '<figure>' . get_the_post_thumbnail( $post->ID, self::RSS_IMAGE_SIZE ) . '</figure>' . $content;
 		}
 		return $content;
 	}

--- a/includes/optional-modules/class-rss.php
+++ b/includes/optional-modules/class-rss.php
@@ -1130,7 +1130,7 @@ class RSS {
 		$post = get_post();
 
 		if ( $settings['use_image_tags'] ) {
-			$thumbnail_url = get_the_post_thumbnail_url( $post, 'full' );
+			$thumbnail_url = get_the_post_thumbnail_url( $post, RSS_Add_Image::RSS_IMAGE_SIZE );
 			if ( $thumbnail_url ) :
 				?>
 				<image><?php echo esc_url( $thumbnail_url ); ?></image>
@@ -1159,7 +1159,7 @@ class RSS {
 		if ( $settings['use_media_tags'] ) {
 			$thumbnail_id = get_post_thumbnail_id();
 			if ( $thumbnail_id ) {
-				$thumbnail_data = wp_get_attachment_image_src( $thumbnail_id, 'full' );
+				$thumbnail_data = wp_get_attachment_image_src( $thumbnail_id, RSS_Add_Image::RSS_IMAGE_SIZE );
 				if ( $thumbnail_data ) {
 					$caption = get_the_post_thumbnail_caption();
 					?>

--- a/languages/newspack-plugin.pot
+++ b/languages/newspack-plugin.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2025-08-07T09:36:59+00:00\n"
+"POT-Creation-Date: 2025-08-07T09:45:43+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: newspack-plugin\n"
@@ -733,15 +733,15 @@ msgstr ""
 msgid "Error: %s"
 msgstr ""
 
-#: includes/class-rss-add-image.php:124
+#: includes/class-rss-add-image.php:129
 msgid "Max Width"
 msgstr ""
 
-#: includes/class-rss-add-image.php:139
+#: includes/class-rss-add-image.php:144
 msgid "Max Height"
 msgstr ""
 
-#: includes/class-rss-add-image.php:150
+#: includes/class-rss-add-image.php:155
 msgid "Customize the featured image sizes used in the RSS feed"
 msgstr ""
 

--- a/languages/newspack-plugin.pot
+++ b/languages/newspack-plugin.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2025-08-06T14:38:05+00:00\n"
+"POT-Creation-Date: 2025-08-07T09:36:59+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: newspack-plugin\n"
@@ -733,15 +733,15 @@ msgstr ""
 msgid "Error: %s"
 msgstr ""
 
-#: includes/class-rss-add-image.php:122
+#: includes/class-rss-add-image.php:124
 msgid "Max Width"
 msgstr ""
 
-#: includes/class-rss-add-image.php:137
+#: includes/class-rss-add-image.php:139
 msgid "Max Height"
 msgstr ""
 
-#: includes/class-rss-add-image.php:148
+#: includes/class-rss-add-image.php:150
 msgid "Customize the featured image sizes used in the RSS feed"
 msgstr ""
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an issue where custom RSS featured image sizes configured in Media > Settings were not being consistently applied to all RSS feed image elements. Previously, the custom image size was only used for featured images added to content, but when RSS enhancement options like "use image tags" or "use media tags" were enabled, these would use the full-size image instead of respecting the configured RSS image size.

This extracts the RSS featured image size in a constant `RSS_IMAGE_SIZE` in the `RSS_Add_Image` class for single source of truth and ensures all RSS feed featured image (content, image tag, and media tag) consistently use the same configured dimensions.

Closes https://app.asana.com/1/26890605006346/project/1210562189110460/task/1210992220602512?focus=true .

### How to test the changes in this Pull Request:

1. Go to **Media > Settings** and configure custom RSS image dimensions (e.g., Max Width: 600px)
2. Create a post with a featured image larger than the configured dimensions
3. Create an RSS feed with "Use image tags" and/or "Use media tags" enabled
4. View the RSS feed XML and verify that all image elements use the configured dimensions instead of full-size images
5. Confirm that `<image>` tags and `<media:content>` tags show images with the correct dimensions

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->