### PR TITLE
fix: pattern categories count and add filter

### DIFF
--- a/includes/class-patches.php
+++ b/includes/class-patches.php
@@ -191,7 +191,7 @@ class Patches {
 			]
 		);
 
-		if ( empty( $terms ) ) {
+		if ( empty( $terms ) || is_wp_error( $terms ) ) {
 			return;
 		}
 

--- a/includes/class-patches.php
+++ b/includes/class-patches.php
@@ -24,6 +24,10 @@ class Patches {
 		add_action( 'manage_edit-wp_block_columns', [ __CLASS__, 'add_custom_columns' ] );
 		add_action( 'manage_edit-wp_block_sortable_columns', [ __CLASS__, 'add_sortable_columns' ] );
 		add_action( 'manage_wp_block_posts_custom_column', [ __CLASS__, 'custom_column_content' ], 10, 2 );
+		add_action( 'restrict_manage_posts', [ __CLASS__, 'add_pattern_category_filter' ] );
+		add_action( 'pre_get_posts', [ __CLASS__, 'filter_patterns_by_category' ] );
+		add_filter( 'manage_edit-wp_pattern_category_columns', [ __CLASS__, 'remove_pattern_category_count' ] );
+		add_action( 'manage_wp_pattern_category_custom_column', [ __CLASS__, 'render_pattern_category_posts_count' ], 10, 3 );
 		add_filter( 'map_meta_cap', [ __CLASS__, 'prevent_accidental_page_deletion' ], 10, 4 );
 		add_action( 'pre_post_update', [ __CLASS__, 'prevent_unpublish_front_page' ], 10, 2 );
 		add_action( 'pre_get_posts', [ __CLASS__, 'maybe_display_author_page' ] );
@@ -165,6 +169,73 @@ class Patches {
 					empty( $sync_status ) ? esc_html( __( 'synced', 'newspack' ) ) : esc_html( $sync_status )
 				);
 				break;
+		}
+	}
+
+	/**
+	 * Add pattern category filter dropdown to the patterns list page.
+	 */
+	public static function add_pattern_category_filter() {
+		global $typenow;
+
+		// Only show on wp_block post type.
+		if ( 'wp_block' !== $typenow ) {
+			return;
+		}
+
+		$taxonomy = 'wp_pattern_category';
+		$terms    = get_terms(
+			[
+				'taxonomy'   => $taxonomy,
+				'hide_empty' => true,
+			]
+		);
+
+		if ( empty( $terms ) ) {
+			return;
+		}
+
+		$current_term = isset( $_GET[ $taxonomy ] ) ? sanitize_text_field( wp_unslash( $_GET[ $taxonomy ] ) ) : '';
+
+		?>
+		<select name="<?php echo esc_attr( $taxonomy ); ?>">
+			<option value=""><?php esc_html_e( 'All Pattern Categories', 'newspack-plugin' ); ?></option>
+			<?php foreach ( $terms as $term ) : ?>
+				<option value="<?php echo esc_attr( $term->slug ); ?>" <?php selected( $current_term, $term->slug ); ?>>
+					<?php echo esc_html( $term->name ); ?>
+				</option>
+			<?php endforeach; ?>
+		</select>
+		<?php
+	}
+
+	/**
+	 * Filter patterns by category when the filter is applied.
+	 *
+	 * @param WP_Query $query The query object.
+	 */
+	public static function filter_patterns_by_category( $query ) {
+		global $pagenow, $typenow;
+
+		// Only apply on the patterns list page.
+		if ( ! is_admin() || 'edit.php' !== $pagenow || 'wp_block' !== $typenow ) {
+			return;
+		}
+
+		$taxonomy = 'wp_pattern_category';
+		$term_slug = isset( $_GET[ $taxonomy ] ) ? sanitize_text_field( wp_unslash( $_GET[ $taxonomy ] ) ) : '';
+
+		if ( ! empty( $term_slug ) ) {
+			$query->set(
+				'tax_query',
+				[
+					[
+						'taxonomy' => $taxonomy,
+						'field'    => 'slug',
+						'terms'    => $term_slug,
+					],
+				]
+			);
 		}
 	}
 
@@ -447,6 +518,45 @@ class Patches {
 	 */
 	public static function remove_tec_extra_excerpt_filtering() {
 		remove_all_actions( 'tribe_events_views_v2_after_make_view' );
+	}
+
+	/**
+	 * Remove the pattern category count from the edit screen and add custom posts count column.
+	 *
+	 * @param array $columns The columns array.
+	 * @return array Modified columns array.
+	 */
+	public static function remove_pattern_category_count( $columns ) {
+		unset( $columns['posts'] );
+		$columns['posts_count'] = __( 'Patterns Count', 'newspack-plugin' );
+		return $columns;
+	}
+
+	/**
+	 * Render the custom posts count column for pattern categories.
+	 *
+	 * @param string $content The column content.
+	 * @param string $column_name The column name.
+	 * @param int    $term_id The term ID.
+	 */
+	public static function render_pattern_category_posts_count( $content, $column_name, $term_id ) {
+		if ( 'posts_count' !== $column_name ) {
+			return $content;
+		}
+
+		$term = get_term( $term_id, 'wp_pattern_category' );
+		if ( ! $term || is_wp_error( $term ) ) {
+			return $content;
+		}
+
+		$count = $term->count;
+		$url   = admin_url( 'edit.php?post_type=wp_block&wp_pattern_category=' . $term->slug );
+
+		printf(
+			'<a href="%s">%d</a>',
+			esc_url( $url ),
+			esc_html( $count )
+		);
 	}
 }
 Patches::init();

--- a/includes/class-patches.php
+++ b/includes/class-patches.php
@@ -198,7 +198,8 @@ class Patches {
 		$current_term = isset( $_GET[ $taxonomy ] ) ? sanitize_text_field( wp_unslash( $_GET[ $taxonomy ] ) ) : '';
 
 		?>
-		<select name="<?php echo esc_attr( $taxonomy ); ?>">
+		<label class="screen-reader-text" for="filter-by-pattern-category"><?php esc_html_e( 'Filter by Pattern Category', 'newspack-plugin' ); ?></label>
+		<select name="<?php echo esc_attr( $taxonomy ); ?>" id="filter-by-pattern-category">
 			<option value=""><?php esc_html_e( 'All Pattern Categories', 'newspack-plugin' ); ?></option>
 			<?php foreach ( $terms as $term ) : ?>
 				<option value="<?php echo esc_attr( $term->slug ); ?>" <?php selected( $current_term, $term->slug ); ?>>

--- a/languages/newspack-plugin.pot
+++ b/languages/newspack-plugin.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2025-08-07T09:45:43+00:00\n"
+"POT-Creation-Date: 2025-08-08T13:49:20+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: newspack-plugin\n"
@@ -282,12 +282,20 @@ msgstr ""
 msgid "Open Menu"
 msgstr ""
 
-#: includes/class-patches.php:118
+#: includes/class-patches.php:122
 msgid "Pattern Categories"
 msgstr ""
 
-#: includes/class-patches.php:303
+#: includes/class-patches.php:202
+msgid "All Pattern Categories"
+msgstr ""
+
+#: includes/class-patches.php:374
 msgid "Please choose a new homepage before attempting to unpublish this page."
+msgstr ""
+
+#: includes/class-patches.php:531
+msgid "Patterns Count"
 msgstr ""
 
 #: includes/class-plugin-manager.php:44


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The "count" column in the Pattern Categories screen was incorrectly linking to the the `post` Post type list, making it impossible to list patterns of a certain category. This PR

* Replaces the Count column with one with the right link
* Add a filter by category in the Patterns list

Refs NPPM-2159

### How to test the changes in this Pull Request:

1. Visit the Pattern categories page and check that the link in the counts are correct
2. Test the new filter in the Patterns screen

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->