### PR TITLE
fix(emails): handle magic link error

### DIFF
--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -2534,7 +2534,9 @@ final class Reader_Activation {
 	/**
 	 * Send a magic link with special messaging to verify the user.
 	 *
-	 * @param WP_User $user WP_User object to be verified.
+	 * @param \WP_User $user WP_User object to be verified.
+	 *
+	 * @return bool|\WP_Error
 	 */
 	public static function send_verification_email( $user ) {
 		// Send reminder to non-reader accounts to use standard WP login.
@@ -2550,13 +2552,18 @@ final class Reader_Activation {
 		$redirect_to = function_exists( '\wc_get_account_endpoint_url' ) ? \wc_get_account_endpoint_url( 'dashboard' ) : '';
 		\update_user_meta( $user->ID, self::LAST_EMAIL_DATE, time() );
 
+		$link = Magic_Link::generate_url( $user, $redirect_to );
+		if ( is_wp_error( $link ) ) {
+			return $link;
+		}
+
 		return Emails::send_email(
 			Reader_Activation_Emails::EMAIL_TYPES['VERIFICATION'],
 			$user->user_email,
 			[
 				[
 					'template' => '*VERIFICATION_URL*',
-					'value'    => Magic_Link::generate_url( $user, $redirect_to ),
+					'value'    => $link,
 				],
 			]
 		);

--- a/languages/newspack-plugin.pot
+++ b/languages/newspack-plugin.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GPL2.
 msgid ""
 msgstr ""
-"Project-Id-Version: Newspack 6.14.4\n"
+"Project-Id-Version: Newspack 6.15.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/project\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2025-08-11T15:27:34+00:00\n"
+"POT-Creation-Date: 2025-08-11T17:47:53+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: newspack-plugin\n"
@@ -3530,32 +3530,32 @@ msgstr ""
 msgid "Cannot register while logged in."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:2547
+#: includes/reader-activation/class-reader-activation.php:2549
 msgid "Please wait before requesting another verification email."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:2716
+#: includes/reader-activation/class-reader-activation.php:2723
 msgid "Your personal data will be used to process your order and create an account if one doesn't exist. This information will also support your experience throughout this website, and be used for other purposes described in our privacy policy."
 msgstr ""
 
 #. Translators: %s is the name of the site.
-#: includes/reader-activation/class-reader-activation.php:2733
+#: includes/reader-activation/class-reader-activation.php:2740
 #, php-format
 msgid "Thank you for supporting %s. Your transaction was completed successfully."
 msgstr ""
 
 #. Translators: %s is the name of the site.
-#: includes/reader-activation/class-reader-activation.php:2752
+#: includes/reader-activation/class-reader-activation.php:2759
 #, php-format
 msgid "Thank you for supporting %s. Your account has been created, and your transaction was completed successfully."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:2778
+#: includes/reader-activation/class-reader-activation.php:2785
 #: dist/audience-wizards.465ef24dd7707013533a.js:41
 msgid "I understand this is a recurring subscription and that I can cancel anytime through the My Account Page."
 msgstr ""
 
-#: includes/reader-activation/class-reader-activation.php:2802
+#: includes/reader-activation/class-reader-activation.php:2809
 #: dist/audience-wizards.465ef24dd7707013533a.js:41
 msgid "I have read and accept the {{Terms & Conditions}}."
 msgstr ""


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

`Magic_Link::generate_url()` may return `WP_Error`, which is currently unhandled in `Reader_Activation::send_verification_email()`.

This PR handles it by returning the magic link error before calling `Emails::send_email()` to avoid a fatal error:

```
PHP Fatal error:  Uncaught TypeError: str_replace(): Argument #2 ($replace) must be of type array|string, WP_Error given in /wordpress/plugins/newspack-plugin/6.14.4/includes/emails/class-emails.php:242
Stack trace:
#0 /wordpress/plugins/newspack-plugin/6.14.4/includes/emails/class-emails.php(242): str_replace('*VERIFICATION_U...', Object(WP_Error), '\n\t<!doctype htm...')
#1 /wordpress/plugins/newspack-plugin/6.14.4/includes/emails/class-emails.php(321): Newspack\Emails::get_email_payload('reader-activati...', Array)
#2 /wordpress/plugins/newspack-plugin/6.14.4/includes/reader-activation/class-reader-activation.php(2553): Newspack\Emails::send_email('reader-activati...', 'email@email.com', Array)
```

### How to test the changes in this Pull Request:

1. In the `release` branch, create a fresh reader account
2. Visit "My Account" and click "Send me a link"
3. Click "Send me a link" a second time (before the 1 minute mark to get rate-limited)
4. Confirm the fatal error
5. Checkout this branch, repeat steps and confirm the error message is presented

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->