### PR TITLE
fix: sanitize newspack_reader_data_item fields on save

### DIFF
--- a/includes/reader-activation/class-reader-data.php
+++ b/includes/reader-activation/class-reader-data.php
@@ -191,6 +191,11 @@ final class Reader_Data {
 			$value = wp_json_encode( $value );
 		}
 
+		$value = sanitize_text_field( $value );
+		if ( ! $value ) {
+			return new \WP_Error( 'invalid_value', __( 'Invalid value.', 'newspack' ), [ 'status' => 400 ] );
+		}
+
 		/**
 		 * Filter the maximum number of items per user.
 		 *


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://linear.app/a8c/issue/NPPM-2160/htmlscript-code-being-inserted-in-woo-custom-fields

This PR just adds a sanitize on reader data item update to ensure no HTML entities are stored.

### How to test the changes in this Pull Request:

1. Run the following curl command:
```
curl --location 'https://YOURSITE/wp-json/newspack/v1/reader-data' \
--header 'Cookie: COPYFROMANYSESSION' \
--header 'X-WP-Nonce: COPYFROMANYSESSION' \
--header 'Content-Type: application/x-www-form-urlencoded' \
--data-urlencode 'key=test' \
--data-urlencode 'value={"test": "<script>alert('\''hello world'\'')</script>"}'
```
2. Check the database for the relevant reader data item (`wp user meta get USEREMAIL newspack_reader_data_item_test`)
3. Verify script tags have been sanitized

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->