### PR TITLE
fix: coerce number strings on segment criteria save

### DIFF
--- a/src/wizards/audience/components/lists-control/index.js
+++ b/src/wizards/audience/components/lists-control/index.js
@@ -34,7 +34,7 @@ export default function ListsControl( { label, help, placeholder, value, onChang
 				const values = Array.isArray( lists ) ? lists : Object.values( lists );
 				return ids
 					.map( id => {
-						const item = values.find( it => it.id === id );
+						const item = values.find( it => ( isNaN( it.id ) ? it.id : parseInt( it.id ) === id ) );
 						if ( item ) {
 							return getSuggestions( item );
 						}


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://linear.app/a8c/issue/NPPM-2166/segments-targeting-active-campaign-newsletter-lists-are-showing-as

This PR fixes an issue where saving a newsletter list segment criteria while ActiveCampaign is the ESP caused the saved list to revert to "Deleted list".

This happens because active campaign returns the id in string format despite being a number, and we are doing a strict comparison. This PR fixes this by checking if the ID is a number, and if it is, calling `parseInt` before comparing.

![Screenshot 2025-08-13 at 16 01 35](https://github.com/user-attachments/assets/4163b95f-ca65-4405-9419-65a3c8b5d56d)

### How to test the changes in this Pull Request:

1. Ensure Active Campaign is the active ESP
2. Go to Audience > Campaigns > Segments.
3. Start a new segment or edit an existing segment, and type a list name into the Subscribed to newsletter lists or Not subscribed to newsletter lists field.
4. Select the list name.
5. On `trunk` the name of the saved list will change to `Deleted list`. On this branch it should not.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->