### PR TITLE
fix(woocommerce): hide duplicated tab headings

### DIFF
--- a/includes/plugins/woocommerce/class-woocommerce-products.php
+++ b/includes/plugins/woocommerce/class-woocommerce-products.php
@@ -27,6 +27,8 @@ class WooCommerce_Products {
 		\add_action( 'woocommerce_process_product_meta', [ __CLASS__, 'save_custom_product_options' ] );
 		\add_action( 'woocommerce_admin_process_variation_object', [ __CLASS__, 'save_custom_variation_options' ], 30, 2 );
 		\add_filter( 'woocommerce_order_item_needs_processing', [ __CLASS__, 'require_order_processing' ], 10, 2 );
+		\add_filter( 'woocommerce_product_description_heading', '__return_false', 10, 2 );
+		\add_filter( 'woocommerce_product_additional_information_heading', '__return_false', 10, 2 );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Removes duplication of WooCommerce tab title in the tab content:

| Before | After | 
|--------------|-----------|
| <img width="363" height="190" alt="image" src="https://github.com/user-attachments/assets/14f0e7df-5bb9-418a-aa9a-54b73d0af0bd" /> | <img width="373" height="132" alt="image" src="https://github.com/user-attachments/assets/374c4cd6-5f50-4998-8ac2-dd02f2938e7c" /> |

### How to test the changes in this Pull Request:

1. On `trunk`, create a product with description and at least one attribute
2. Visit the product page, observe the tab titles are repeated in tab content
3. Switch to this branch, observe no repetition

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->