### PR TITLE
fix: coerce number strings on segment criteria save

### DIFF
--- a/languages/newspack-plugin.pot
+++ b/languages/newspack-plugin.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GPL2.
 msgid ""
 msgstr ""
-"Project-Id-Version: Newspack 6.15.0\n"
+"Project-Id-Version: Newspack 6.15.1\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/project\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2025-08-11T17:47:53+00:00\n"
+"POT-Creation-Date: 2025-08-14T15:55:31+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: newspack-plugin\n"
@@ -265,7 +265,7 @@ msgstr ""
 #: includes/class-newspack-ui.php:1116
 #: includes/reader-activation/class-reader-activation.php:1599
 #: includes/reader-activation/class-reader-activation.php:1714
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/components/prompt-action-card/index.js:137
 msgid "Close"
 msgstr ""
@@ -1573,7 +1573,7 @@ msgstr ""
 #: includes/wizards/newspack/class-newspack-dashboard.php:166
 #: includes/wizards/newspack/class-newspack-dashboard.php:202
 #: includes/wizards/newspack/class-newspack-settings.php:161
-#: dist/audience-wizards.465ef24dd7707013533a.js:7
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:7
 #: dist/billboard.js:12
 #: dist/commons.js:1
 #: dist/memberships-gate-editor.js:37
@@ -1855,10 +1855,10 @@ msgstr ""
 
 #: includes/optional-modules/class-media-partners.php:477
 #: includes/plugins/woocommerce/my-account/templates/v1/account-settings.php:248
-#: dist/audience-wizards.465ef24dd7707013533a.js:10
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
-#: dist/audience-wizards.465ef24dd7707013533a.js:23
-#: dist/audience-wizards.465ef24dd7707013533a.js:38
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:10
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:23
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:38
 #: dist/billboard.js:1
 #: dist/billboard.js:12
 #: dist/newspack-wizards.3d38b7c2696efc78d038.js:5
@@ -2516,10 +2516,10 @@ msgstr ""
 #: includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:434
 #: includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:585
 #: includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php:1138
-#: dist/audience-wizards.465ef24dd7707013533a.js:26
-#: dist/audience-wizards.465ef24dd7707013533a.js:32
-#: dist/audience-wizards.465ef24dd7707013533a.js:35
-#: dist/audience-wizards.465ef24dd7707013533a.js:38
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:26
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:32
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:35
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:38
 #: dist/newsletters.js:1
 #: dist/newsletters.js:4
 #: dist/newspack-wizards.3d38b7c2696efc78d038.js:14
@@ -2587,8 +2587,8 @@ msgstr ""
 #: includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:299
 #: includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:385
 #: includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:523
-#: dist/audience-wizards.465ef24dd7707013533a.js:10
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:10
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: dist/billboard.js:1
 #: dist/billboard.js:12
 #: dist/commons.js:13
@@ -2661,7 +2661,7 @@ msgstr ""
 
 #: includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:264
 #: includes/wizards/newspack/class-newspack-dashboard.php:81
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/views/campaigns/segments/single-segment.js:208
 msgid "Newsletters"
 msgstr ""
@@ -2694,7 +2694,7 @@ msgstr ""
 #: includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:330
 #: includes/reader-activation/class-reader-activation.php:274
 #: includes/reader-activation/class-reader-activation.php:302
-#: dist/audience-wizards.465ef24dd7707013533a.js:38
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:38
 #: src/wizards/audience/views/setup/campaign.js:86
 msgid "Continue"
 msgstr ""
@@ -3409,7 +3409,7 @@ msgid "Enable reCAPTCHA and enter your account credentials."
 msgstr ""
 
 #: includes/reader-activation/class-reader-activation.php:907
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/views/campaigns/segments/single-segment.js:222
 msgid "Reader Revenue"
 msgstr ""
@@ -3551,12 +3551,12 @@ msgid "Thank you for supporting %s. Your account has been created, and your tran
 msgstr ""
 
 #: includes/reader-activation/class-reader-activation.php:2785
-#: dist/audience-wizards.465ef24dd7707013533a.js:41
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:41
 msgid "I understand this is a recurring subscription and that I can cancel anytime through the My Account Page."
 msgstr ""
 
 #: includes/reader-activation/class-reader-activation.php:2809
-#: dist/audience-wizards.465ef24dd7707013533a.js:41
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:41
 msgid "I have read and accept the {{Terms & Conditions}}."
 msgstr ""
 
@@ -4318,15 +4318,15 @@ msgid "Sponsors"
 msgstr ""
 
 #: includes/wizards/audience/class-audience-campaigns.php:50
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/views/campaigns/index.js:30
 msgid "Audience Management / Campaigns"
 msgstr ""
 
 #: includes/wizards/audience/class-audience-campaigns.php:112
 #: includes/wizards/newspack/class-newspack-dashboard.php:58
-#: dist/audience-wizards.465ef24dd7707013533a.js:7
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:7
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/components/settings-modal/index.js:31
 #: src/wizards/audience/components/settings-modal/index.js:41
 #: src/wizards/audience/views/campaigns/campaigns/index.js:172
@@ -4335,7 +4335,7 @@ msgid "Campaigns"
 msgstr ""
 
 #: includes/wizards/audience/class-audience-donations.php:46
-#: dist/audience-wizards.465ef24dd7707013533a.js:19
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:19
 #: src/wizards/audience/views/donations/index.js:34
 msgid "Audience Management / Donations"
 msgstr ""
@@ -4356,15 +4356,15 @@ msgid "Reset failed: unable to reset email template."
 msgstr ""
 
 #: includes/wizards/audience/class-audience-subscriptions.php:37
-#: dist/audience-wizards.465ef24dd7707013533a.js:41
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:41
 msgid "Audience Management / Subscriptions"
 msgstr ""
 
 #: includes/wizards/audience/class-audience-subscriptions.php:71
 #: includes/wizards/audience/class-audience-wizard.php:142
 #: includes/wizards/newspack/class-newspack-dashboard.php:52
-#: dist/audience-wizards.465ef24dd7707013533a.js:19
-#: dist/audience-wizards.465ef24dd7707013533a.js:41
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:19
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:41
 #: src/wizards/audience/views/donations/index.js:26
 #: src/wizards/audience/views/setup/index.js:100
 msgid "Configuration"
@@ -4396,7 +4396,7 @@ msgid "Audience"
 msgstr ""
 
 #: includes/wizards/audience/class-audience-wizard.php:143
-#: dist/audience-wizards.465ef24dd7707013533a.js:41
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:41
 #: src/wizards/audience/views/setup/index.js:100
 msgid "Setup"
 msgstr ""
@@ -4543,8 +4543,8 @@ msgstr ""
 
 #: includes/wizards/newspack/class-newspack-dashboard.php:47
 #: includes/wizards/newspack/class-newspack-dashboard.php:260
-#: dist/audience-wizards.465ef24dd7707013533a.js:32
-#: dist/audience-wizards.465ef24dd7707013533a.js:41
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:32
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:41
 #: src/wizards/audience/views/setup/index.js:135
 #: src/wizards/audience/views/setup/setup.js:80
 msgid "Audience Management"
@@ -4795,8 +4795,8 @@ msgstr ""
 msgid "Sign up"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:1
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:1
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: dist/billboard.js:12
 #: dist/newspack-wizards.3d38b7c2696efc78d038.js:5
 #: src/wizards/advertising/views/ad-units/options-popover.js:34
@@ -4806,18 +4806,18 @@ msgstr ""
 msgid "Close Popover"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:1
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:1
 #: src/wizards/audience/components/campaign-management-popover/index.js:43
 msgid "Activate all prompts"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:1
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:1
 #: src/wizards/audience/components/campaign-management-popover/index.js:54
 msgid "Deactivate all prompts"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:1
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:1
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/components/campaign-management-popover/index.js:64
 #: src/wizards/audience/components/prompt-action-card/index.js:175
 #: src/wizards/audience/components/prompt-popovers/primary.js:67
@@ -4826,27 +4826,27 @@ msgstr ""
 msgid "Duplicate"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:1
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:1
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/components/campaign-management-popover/index.js:73
 #: src/wizards/audience/views/campaigns/campaigns/index.js:47
 msgid "Rename"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:1
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:1
 #: dist/billboard.js:12
 #: src/wizards/advertising/views/ad-units/options-popover.js:40
 #: src/wizards/audience/components/campaign-management-popover/index.js:83
 msgid "Archive"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:1
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:1
 #: src/wizards/audience/components/campaign-management-popover/index.js:94
 msgid "Unarchive"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:1
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:1
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: dist/billboard.js:12
 #: dist/componentsDemo.js:1
 #: dist/newspack-wizards.3d38b7c2696efc78d038.js:5
@@ -4861,25 +4861,25 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:1
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:1
 #: src/wizards/audience/components/prompt-popovers/primary.js:46
 msgid "Restore"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:1
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:1
 #: src/wizards/audience/components/prompt-popovers/primary.js:49
 msgid "Delete permanently"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:1
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:1
 #: dist/commons.js:13
 #: src/components/src/web-preview/index.js:169
 #: src/wizards/audience/components/prompt-popovers/primary.js:61
 msgid "Preview"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:1
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:1
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: dist/billboard.js:12
 #: dist/componentsDemo.js:1
 #: dist/newsletters.js:4
@@ -4895,12 +4895,12 @@ msgstr ""
 msgid "Edit"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:1
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:1
 #: src/wizards/audience/components/prompt-popovers/primary.js:76
 msgid "Deactivate"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:1
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:1
 #: dist/commons.js:13
 #: src/components/src/plugin-installer/index.js:169
 #: src/components/src/plugin-installer/index.js:214
@@ -4908,64 +4908,64 @@ msgstr ""
 msgid "Activate"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:1
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:1
 #: src/wizards/audience/components/prompt-popovers/primary.js:84
 msgid "ID:"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:1
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:1
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/components/segment-group/index.js:110
 #: src/wizards/audience/views/campaigns/utils.js:53
 msgid "Top Overlay"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:1
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:1
 #: src/wizards/audience/views/campaigns/utils.js:54
 msgid "Top Left Overlay"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:1
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:1
 #: src/wizards/audience/views/campaigns/utils.js:55
 msgid "Top Right Overlay"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:1
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:1
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/components/segment-group/index.js:104
 #: src/wizards/audience/views/campaigns/utils.js:56
 msgid "Center Overlay"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:1
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:1
 #: src/wizards/audience/views/campaigns/utils.js:57
 msgid "Center Left Overlay"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:1
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:1
 #: src/wizards/audience/views/campaigns/utils.js:58
 msgid "Center Right Overlay"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:1
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:1
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/components/segment-group/index.js:116
 #: src/wizards/audience/views/campaigns/utils.js:59
 msgid "Bottom Overlay"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:1
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:1
 #: src/wizards/audience/views/campaigns/utils.js:60
 msgid "Bottom Left Overlay"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:1
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:1
 #: src/wizards/audience/views/campaigns/utils.js:61
 msgid "Bottom Right Overlay"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:1
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:1
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: dist/memberships-gate-editor.js:25
 #: src/memberships-gate/editor.js:19
 #: src/wizards/audience/components/segment-group/index.js:122
@@ -4973,223 +4973,223 @@ msgstr ""
 msgid "Inline"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:1
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:1
 #: src/wizards/audience/views/campaigns/utils.js:63
 msgid "In archive pages"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:1
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:1
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/components/segment-group/index.js:134
 #: src/wizards/audience/views/campaigns/utils.js:64
 msgid "Above Header"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:1
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:1
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/components/segment-group/index.js:146
 #: src/wizards/audience/views/campaigns/utils.js:65
 msgid "Manual Only"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:1
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:1
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/components/segment-group/index.js:140
 #: src/wizards/audience/views/campaigns/utils.js:71
 msgid "Custom Placement"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:1
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:1
 #: src/wizards/audience/views/campaigns/utils.js:96
 msgid "Once a month"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:1
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:1
 #: src/wizards/audience/views/campaigns/utils.js:97
 msgid "Once a week"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:1
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:1
 #: src/wizards/audience/views/campaigns/utils.js:98
 msgid "Once a day"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:1
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:1
 #: src/wizards/audience/views/campaigns/utils.js:99
 msgid "Every pageview"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:1
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:1
 #: src/wizards/audience/views/campaigns/utils.js:100
 msgid "Custom frequency (edit prompt to manage)"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:1
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:1
 #: src/wizards/audience/views/campaigns/utils.js:124
 msgid "Campaign: "
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:1
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:1
 #: src/wizards/audience/views/campaigns/utils.js:124
 msgid "Campaigns: "
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:1
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:1
 #: src/wizards/audience/views/campaigns/utils.js:128
 msgid "Categories: "
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:1
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:1
 #: src/wizards/audience/views/campaigns/utils.js:131
 msgid "Tags: "
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:1
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:1
 #: src/wizards/audience/views/campaigns/utils.js:134
 msgid "Pending review"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:1
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:1
 #: src/wizards/audience/views/campaigns/utils.js:137
 msgid "Scheduled"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:1
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:1
 #: src/wizards/audience/views/campaigns/utils.js:139
 msgid "Frequency: "
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:1
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:1
 #: src/wizards/audience/views/campaigns/utils.js:148
 msgid "Segment disabled"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:1
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:1
 #: src/wizards/audience/views/campaigns/utils.js:228
 msgid "Favorite Categories:"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:1
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:1
 #: src/wizards/audience/views/campaigns/utils.js:288
 msgid "Subscribed to:"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:1
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:1
 #: src/wizards/audience/views/campaigns/utils.js:288
 msgid "Not subscribed to:"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:1
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:1
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/views/campaigns/segments/single-segment.js:295
 #: src/wizards/audience/views/campaigns/utils.js:292
 msgid "Deleted list"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:1
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:1
 #: src/wizards/audience/views/campaigns/utils.js:309
 msgid "Has active subscription(s):"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:1
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:1
 #: src/wizards/audience/views/campaigns/utils.js:310
 msgid "Does not have active subscription(s):"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:1
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:1
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/views/campaigns/segments/single-segment.js:313
 #: src/wizards/audience/views/campaigns/utils.js:314
 msgid "Deleted subscription"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:1
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:1
 #: src/wizards/audience/views/campaigns/utils.js:330
 msgid "Has active membership(s):"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:1
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:1
 #: src/wizards/audience/views/campaigns/utils.js:331
 msgid "Does not have active membership(s):"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:1
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:1
 #: src/wizards/audience/views/campaigns/utils.js:335
 msgid "Deleted membership"
 msgstr ""
 
 #. Translators: %s is prompt type (above-header or overlay).
-#: dist/audience-wizards.465ef24dd7707013533a.js:4
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:4
 #: src/wizards/audience/views/campaigns/utils.js:356
 #, js-format
 msgid "If multiple %s are rendered on the same pageview, only the most recent one will be displayed."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:4
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:4
 #: src/wizards/audience/views/campaigns/utils.js:357
 msgid "above-header prompts"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:4
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:4
 #: src/wizards/audience/views/campaigns/utils.js:357
 msgid "overlays"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:4
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:4
 #: src/wizards/audience/views/campaigns/utils.js:362
 msgid "If multiple prompts are rendered in the same custom placement, only the most recent one will be displayed."
 msgstr ""
 
 #. Translators: %s: 'Conflicts' or 'Conflict' depending on number of conflicts.
-#: dist/audience-wizards.465ef24dd7707013533a.js:7
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:7
 #: src/wizards/audience/views/campaigns/utils.js:398
 #, js-format
 msgid "%s detected:"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:7
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:7
 #: src/wizards/audience/views/campaigns/utils.js:399
 msgid "Conflicts"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:7
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:7
 #: src/wizards/audience/views/campaigns/utils.js:399
 msgid "Conflict"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:7
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:7
 #: src/wizards/audience/components/settings-modal/index.js:27
 msgid "Close Modal"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:7
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:7
 #: src/wizards/audience/components/settings-modal/index.js:32
 msgid "Assign a prompt to one or more campaigns for easier management"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:7
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:7
 #: src/wizards/audience/components/settings-modal/index.js:49
 msgid "When and how should the prompt be displayed"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:7
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:7
 #: src/wizards/audience/components/settings-modal/index.js:56
 msgid "Frequency"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:7
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:7
 #: dist/memberships-gate-editor.js:34
 #: src/memberships-gate/editor.js:168
 #: src/wizards/audience/components/settings-modal/index.js:65
 msgid "Position"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:7
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:7
 #: src/wizards/audience/components/settings-modal/index.js:65
 msgid "Placement"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:7
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:7
 #: dist/billboard.js:12
 #: dist/memberships-gate-editor.js:34
 #: src/memberships-gate/editor.js:162
@@ -5199,89 +5199,89 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:7
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:7
 #: src/wizards/audience/components/settings-modal/index.js:87
 msgid "Targeting"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:7
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:7
 #: src/wizards/audience/components/settings-modal/index.js:90
 msgid "Under which conditions should the prompt be displayed"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:7
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:7
 #: src/wizards/audience/components/settings-modal/index.js:92
 msgid "If multiple conditions are set, all will have to be satisfied in order to display the prompt"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:7
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:7
 #: src/wizards/audience/components/settings-modal/index.js:108
 msgid "Segments"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:7
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:7
 #: src/wizards/audience/components/settings-modal/index.js:112
 msgid "Post categories"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:7
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:7
 #: src/wizards/audience/components/settings-modal/index.js:117
 msgid "Prompt will only appear on posts with the specified categories."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:7
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:7
 #: src/wizards/audience/components/settings-modal/index.js:120
 msgid "Post tags"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:7
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:7
 #: src/wizards/audience/components/settings-modal/index.js:126
 msgid "Prompt will only appear on posts with the specified tags."
 msgstr ""
 
 #. Translators: whether to show or hide advanced settings fields.
-#: dist/audience-wizards.465ef24dd7707013533a.js:10
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:10
 #: src/wizards/audience/components/settings-modal/index.js:133
 #, js-format
 msgid "%s Advanced Settings"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:10
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:10
 #: src/wizards/audience/components/settings-modal/index.js:134
 msgid "Hide"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:10
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:10
 #: src/wizards/audience/components/settings-modal/index.js:134
 msgid "Show"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:10
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:10
 #: src/wizards/audience/components/settings-modal/index.js:141
 msgid "Category Exclusions"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:10
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:10
 #: src/wizards/audience/components/settings-modal/index.js:152
 msgid "Prompt will not appear on posts with the specified categories."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:10
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:10
 #: src/wizards/audience/components/settings-modal/index.js:155
 msgid "Tag Exclusions"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:10
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:10
 #: src/wizards/audience/components/settings-modal/index.js:167
 msgid "Prompt will not appear on posts with the specified tags."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:10
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:10
 #: src/wizards/audience/components/prompt-action-card/index.js:48
 msgid " copy"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:10
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:10
 #: dist/commons.js:4
 #: src/components/src/autocomplete-with-suggestions/index.js:99
 #: src/components/src/autocomplete-with-suggestions/index.js:133
@@ -5289,13 +5289,13 @@ msgstr ""
 msgid "(no title)"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:10
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:10
 #: src/wizards/audience/components/prompt-action-card/index.js:71
 msgid "Prompt settings"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:10
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:10
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: dist/billboard.js:12
 #: dist/newspack-wizards.3d38b7c2696efc78d038.js:5
 #: src/wizards/advertising/views/ad-units/options-popover.js:28
@@ -5305,365 +5305,365 @@ msgid "More options"
 msgstr ""
 
 #. Translators: %s: The title of the item.
-#: dist/audience-wizards.465ef24dd7707013533a.js:13
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:13
 #: src/wizards/audience/components/prompt-action-card/index.js:107
 #, js-format
 msgid "Duplicate “%s”"
 msgstr ""
 
 #. Translators: %s: The title of the item.
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/components/prompt-action-card/index.js:121
 #, js-format
 msgid "Duplicate of “%s” created as a draft."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/components/prompt-action-card/index.js:126
 msgid "This prompt is currently not assigned to any campaign."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/components/prompt-action-card/index.js:147
 msgid "This prompt will not be assigned to any campaign."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/components/prompt-action-card/index.js:151
 #: src/wizards/audience/views/campaigns/segments/single-segment.js:164
 msgid "Title"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/components/segment-group/index.js:45
 msgid "No unassigned prompts in this segment."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/components/segment-group/index.js:47
 msgid "No prompts in this segment for"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/components/segment-group/index.js:49
 msgid "No active prompts in this segment."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/components/segment-group/index.js:61
 msgid "Edit Segment "
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/components/segment-group/index.js:66
 msgid "Segment: "
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/components/segment-group/index.js:74
 msgid "All readers, regardless of segment"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/components/segment-group/index.js:84
 msgid "Preview Segment"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/components/segment-group/index.js:91
 #: src/wizards/audience/components/segment-group/index.js:95
 msgid "Add New Prompt"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/components/segment-group/index.js:105
 msgid "Fixed at the center of the screen"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/components/segment-group/index.js:111
 msgid "Fixed at the top of the screen"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/components/segment-group/index.js:117
 msgid "Fixed at the bottom of the screen"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/components/segment-group/index.js:123
 msgid "Embedded in content"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/components/segment-group/index.js:128
 msgid "In Archive Pages"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/components/segment-group/index.js:129
 msgid "Embedded once or many times in archive pages"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/components/segment-group/index.js:135
 msgid "Embedded at the very top of the page"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/components/segment-group/index.js:141
 msgid "Only appears when placed in content"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/components/segment-group/index.js:147
 msgid "Only appears where Single Prompt block is inserted"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/views/campaigns/campaigns/index.js:38
 msgid "Rename Campaign"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/views/campaigns/campaigns/index.js:40
 msgid "Duplicate Campaign"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/views/campaigns/campaigns/index.js:42
 #: src/wizards/audience/views/campaigns/campaigns/index.js:260
 msgid "Add New Campaign"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: dist/other-scripts/corrections-modal.js:4
 #: src/other-scripts/corrections-modal/index.js:353
 #: src/wizards/audience/views/campaigns/campaigns/index.js:51
 msgid "Add"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/views/campaigns/campaigns/index.js:89
 msgid "Everyone"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/views/campaigns/campaigns/index.js:150
 msgid "Active Prompts"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/views/campaigns/campaigns/index.js:154
 msgid "All Prompts"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/views/campaigns/campaigns/index.js:158
 msgid "Trash"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/views/campaigns/campaigns/index.js:164
 msgid "Unassigned Prompts"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/views/campaigns/campaigns/index.js:186
 msgid "Archived Campaigns"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/views/campaigns/campaigns/index.js:193
 msgid "(archived)"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: dist/newspack-wizards.3d38b7c2696efc78d038.js:26
 #: src/wizards/audience/views/campaigns/campaigns/index.js:222
 msgid "Actions"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/views/campaigns/campaigns/index.js:271
 #: src/wizards/audience/views/campaigns/campaigns/index.js:273
 msgid "Campaign Name"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/views/campaigns/segments/segments-list.js:21
 msgid "Add New Segment"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/views/campaigns/segments/segments-list.js:210
 msgid "Move segment position up"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/views/campaigns/segments/segments-list.js:216
 msgid "Move segment position down"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/views/campaigns/segments/segments-list.js:293
 msgid "There was an error sorting segments. Please try again."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/views/campaigns/segments/segments-list.js:309
 msgid "Audience segments"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/views/campaigns/segments/segments-list.js:334
 msgid "You have no saved audience segments."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/views/campaigns/segments/segments-list.js:337
 msgid "Create audience segments to target visitors by engagement, activity, and more."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/views/campaigns/segments/single-segment.js:291
 msgid "Start typing to search for lists…"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/views/campaigns/segments/single-segment.js:309
 msgid "Start typing to search for products…"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/views/campaigns/segments/single-segment.js:327
 msgid "Start typing to search for membership plans…"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/views/campaigns/segments/single-segment.js:331
 msgid "Deleted plan"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/views/campaigns/segments/single-segment.js:50
 msgid "There are unsaved changes to this segment. Discard changes?"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/views/campaigns/segments/single-segment.js:161
 msgid "Untitled Segment"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/views/campaigns/segments/single-segment.js:169
 msgid "Segment Status"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/views/campaigns/segments/single-segment.js:170
 msgid "If not enabled, the segment will be ignored for reader segmentation."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/views/campaigns/segments/single-segment.js:174
 msgid "Segment enabled"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/views/campaigns/segments/single-segment.js:181
 msgid "Reader Engagement"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/views/campaigns/segments/single-segment.js:182
 msgid "Target readers based on their browsing behavior."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/views/campaigns/segments/single-segment.js:194
 msgid "Registration"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/views/campaigns/segments/single-segment.js:195
 msgid "Target readers based on their user account registration status."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/views/campaigns/segments/single-segment.js:209
 msgid "Target readers based on their newsletter subscription status."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/views/campaigns/segments/single-segment.js:223
 msgid "Target readers based on their revenue activity."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/views/campaigns/segments/single-segment.js:236
 msgid "Referrer Sources"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/views/campaigns/segments/single-segment.js:237
 msgid "Target readers based on where they’re coming from."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/views/campaigns/segments/single-segment.js:238
 msgid "Segments using these options will apply only to the first page visited after coming from an external source."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/views/campaigns/index.js:173
 msgid "Error duplicating prompt. Please try again later."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/components/cover-fees-settings/index.js:38
 msgid "Collect transaction fees"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/components/cover-fees-settings/index.js:39
 msgid "Allow donors to optionally cover transaction fees imposed by payment processors."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/components/cover-fees-settings/index.js:55
 msgid "Fee multiplier"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/components/cover-fees-settings/index.js:62
 msgid "Fee static portion"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/components/cover-fees-settings/index.js:67
 msgid "Custom message"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/components/cover-fees-settings/index.js:68
 msgid "A message to explain the transaction fee option (optional)."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/components/cover-fees-settings/index.js:72
 msgid "Cover fees by default"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: src/wizards/audience/components/cover-fees-settings/index.js:75
 msgid "If enabled, the option to cover the transaction fee will be checked by default."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
-#: dist/audience-wizards.465ef24dd7707013533a.js:19
-#: dist/audience-wizards.465ef24dd7707013533a.js:32
-#: dist/audience-wizards.465ef24dd7707013533a.js:41
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:19
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:32
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:41
 #: dist/billboard.js:12
 #: dist/newsletters.js:1
 #: dist/newspack-wizards.3d38b7c2696efc78d038.js:8
@@ -5677,97 +5677,97 @@ msgstr ""
 msgid "Save Settings"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: dist/setup.js:1
 msgid "Suggested Donations"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: dist/setup.js:1
 msgid "Set suggested donation amounts. These will be the default settings for the Donate block."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: dist/setup.js:1
 msgid "Donation Type"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: dist/setup.js:1
 msgid "Tiered"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:16
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:16
 #: dist/setup.js:1
 msgid "Untiered"
 msgstr ""
 
 #. Translators: %1$s is a link to the trashed products. %2$s is a comma-separated list of trashed product names.
-#: dist/audience-wizards.465ef24dd7707013533a.js:19
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:19
 #: dist/setup.js:4
 #, js-format
 msgid "One or more donation products is in trash. Please <a href=\"%1$s\">restore the product(s)</a> to continue using donation features: %2$s"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:19
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:19
 #: dist/setup.js:4
 msgid "Warning: suggested donations should be at least the minimum donation amount."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:19
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:19
 #: dist/setup.js:4
 msgid "Minimum donation"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:19
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:19
 #: dist/setup.js:4
 msgid "Set minimum donation amount. Setting a reasonable minimum donation amount can help protect your site from bot attacks."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:19
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:19
 msgid "Donations Landing Page"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:19
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:19
 msgid "Your donations landing page is published."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:19
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:19
 msgid "Your donations landing page is not yet published."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:19
-#: dist/audience-wizards.465ef24dd7707013533a.js:35
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:19
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:35
 msgid "Pending"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:19
-#: dist/audience-wizards.465ef24dd7707013533a.js:35
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:19
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:35
 msgid "Ready"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:19
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:19
 msgid "Skipped"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:19
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:19
 msgid "Unavailable"
 msgstr ""
 
 #. translators: %s: Prerequisite status
 #. Translators: Status of the prompt.
 #. Translators: %s: Plugin status
-#: dist/audience-wizards.465ef24dd7707013533a.js:20
-#: dist/audience-wizards.465ef24dd7707013533a.js:35
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:20
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:35
 #: dist/newspack-wizards.3d38b7c2696efc78d038.js:14
 #, js-format
 msgid "Status: %s"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:20
-#: dist/audience-wizards.465ef24dd7707013533a.js:32
-#: dist/audience-wizards.465ef24dd7707013533a.js:38
-#: dist/audience-wizards.465ef24dd7707013533a.js:41
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:20
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:32
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:38
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:41
 #: dist/newspack-wizards.3d38b7c2696efc78d038.js:14
 #: src/wizards/audience/components/payment-methods/index.js:39
 #: src/wizards/audience/components/payment-methods/index.js:54
@@ -5780,9 +5780,9 @@ msgstr ""
 msgid "Learn more"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:20
-#: dist/audience-wizards.465ef24dd7707013533a.js:35
-#: dist/audience-wizards.465ef24dd7707013533a.js:41
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:20
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:35
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:41
 #: dist/newspack-wizards.3d38b7c2696efc78d038.js:31
 #: dist/other-scripts/corrections-modal.js:7
 #: src/other-scripts/corrections-modal/index.js:391
@@ -5791,141 +5791,141 @@ msgstr ""
 
 #. Translators: Save or Update settings.
 #. Translators: %s is the email service provider title
-#: dist/audience-wizards.465ef24dd7707013533a.js:23
-#: dist/audience-wizards.465ef24dd7707013533a.js:26
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:23
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:26
 #: src/wizards/audience/components/settings.js:41
 #, js-format
 msgid "%s settings"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:23
-#: dist/audience-wizards.465ef24dd7707013533a.js:38
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:23
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:38
 #: dist/bylines.js:1
 #: src/bylines/index.js:423
 msgid "Update"
 msgstr ""
 
 #. Translators: %s is specific instructions for satisfying the prerequisite.
-#: dist/audience-wizards.465ef24dd7707013533a.js:26
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:26
 #, js-format
 msgid "%1$s%2$sReturn to the Audience Configuration page to complete the settings and activate%3$s."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:26
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:26
 msgid "Update "
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:26
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:26
 msgid "Save "
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:26
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:26
 msgid "Configure "
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:26
-#: dist/audience-wizards.465ef24dd7707013533a.js:38
-#: dist/audience-wizards.465ef24dd7707013533a.js:41
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:26
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:38
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:41
 #: src/wizards/audience/views/setup/campaign.js:83
 #: src/wizards/audience/views/setup/index.js:69
 msgid "Skip"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:26
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:26
 #: src/wizards/audience/components/mailchimp.js:46
 #: src/wizards/audience/components/settings.js:32
 msgid "Audience ID"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:26
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:26
 #: src/wizards/audience/components/active-campaign.js:46
 #: src/wizards/audience/components/settings.js:32
 msgid "Master List"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:26
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:26
 #: src/wizards/audience/components/mailchimp.js:47
 #: src/wizards/audience/components/settings.js:34
 msgid "Choose an audience to receive reader activity data."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:26
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:26
 #: src/wizards/audience/components/settings.js:35
 msgid "Choose a master list to which all registered readers will be added."
 msgstr ""
 
 #. Translators: %s is the email service provider title
-#: dist/audience-wizards.465ef24dd7707013533a.js:26
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:26
 #: src/wizards/audience/components/settings.js:43
 #, js-format
 msgid "Settings for the %s integration."
 msgstr ""
 
 #. Translators: 1 is the term used to refer to lists for a given email service provider and 2 is the email service provider title
-#: dist/audience-wizards.465ef24dd7707013533a.js:29
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:29
 #: src/wizards/audience/components/settings.js:51
 #, js-format
 msgid "No %1$s selected. You will not be able to send reader activity data to %2$s."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:29
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:29
 #: src/wizards/audience/components/active-campaign.js:52
 #: src/wizards/audience/components/mailchimp.js:52
 #: src/wizards/audience/components/settings.js:65
 msgid "None"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:29
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:29
 #: src/wizards/audience/components/mailchimp.js:58
 #: src/wizards/audience/components/settings.js:71
 msgid "Default reader status"
 msgstr ""
 
 #. Translators: %s is the email service provider title.
-#: dist/audience-wizards.465ef24dd7707013533a.js:32
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:32
 #: src/wizards/audience/components/settings.js:74
 #, js-format
 msgid "Choose which %s status readers should have by default if they are not subscribed to any newsletters"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:32
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:32
 #: src/wizards/audience/components/mailchimp.js:69
 #: src/wizards/audience/components/settings.js:86
 msgid "Transactional/Non-Subscribed"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:32
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:32
 #: src/wizards/audience/components/mailchimp.js:71
 #: src/wizards/audience/components/settings.js:88
 msgid "Subscribed"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:32
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:32
 #: src/wizards/audience/components/metadata-fields.js:16
 msgid "Metadata field settings"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:32
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:32
 #: src/wizards/audience/components/metadata-fields.js:17
 msgid "Select which data to sync for each contact."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:32
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:32
 #: src/wizards/audience/components/metadata-fields.js:20
 msgid "Metadata field prefix"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:32
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:32
 #: src/wizards/audience/components/metadata-fields.js:21
 msgid "A string to prefix metadata fields attached to each contact synced to the ESP. Required to ensure that metadata field names are unique. Default: NP_"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:32
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:32
 #: src/components/src/sortable-newsletter-list-control/index.js:42
 msgid "Checked by default"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:32
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:32
 #: dist/commons.js:13
 #: dist/newspack-wizards.3d38b7c2696efc78d038.js:14
 #: src/components/src/image-upload/index.js:98
@@ -5933,203 +5933,203 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:32
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:32
 #: src/components/src/sortable-newsletter-list-control/index.js:106
 msgid "Add more lists:"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:32
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:32
 #: src/components/src/sortable-newsletter-list-control/index.js:108
 msgid "Select lists:"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:32
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:32
 #: src/wizards/audience/components/salesforce/index.js:74
 msgid "We couldn’t establish a connection to Salesforce. Please verify your Consumer Key and Secret and try connecting again."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:32
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:32
 #: src/wizards/audience/components/salesforce/index.js:143
 msgid "Salesforce Settings"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:32
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:32
 #: src/wizards/audience/components/salesforce/index.js:149
 msgid "Your site is connected to Salesforce."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:32
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:32
 #: src/wizards/audience/components/salesforce/index.js:152
 msgid "Establish a connection to sync WooCommerce order data to Salesforce. To connect with Salesforce, create or choose a Connected App for this site in your Salesforce dashboard. Make sure to paste the full URL for this page ("
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:32
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:32
 #: src/wizards/audience/components/salesforce/index.js:163
 msgid "copied to clipboard!"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:32
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:32
 #: src/wizards/audience/components/salesforce/index.js:163
 msgid "copy to clipboard"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:32
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:32
 #: src/wizards/audience/components/salesforce/index.js:166
 msgid ") into the “Callback URL” field in the Connected App’s settings. "
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:32
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:32
 #: src/wizards/audience/components/salesforce/index.js:169
 msgid "Learn how to create a Connected App"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:32
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:32
 #: src/wizards/audience/views/setup/setup.js:83
 msgid "Newspack's Audience Management system is a set of features that aim to increase reader loyalty, promote engagement, and drive revenue. "
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:32
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:32
 #: src/wizards/audience/views/setup/setup.js:94
 msgid "The following plugins are required."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:32
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:32
 #: src/wizards/audience/views/setup/setup.js:96
 msgid "Complete these settings to enable Audience Management."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:32
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:32
 #: src/wizards/audience/views/setup/setup.js:99
 msgid "Audience Management is enabled."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:32
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:32
 #: src/wizards/audience/views/setup/setup.js:104
 msgid "Fetching status…"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:32
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:32
 #: src/wizards/audience/views/setup/setup.js:129
 msgid "Present newsletter signup after checkout and registration"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:32
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:32
 #: src/wizards/audience/views/setup/setup.js:130
 msgid "Ask readers to sign up for newsletters after creating an account or completing a purchase."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:32
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:32
 #: src/wizards/audience/views/setup/setup.js:150
 msgid "Initial list size"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:32
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:32
 #: src/wizards/audience/views/setup/setup.js:151
 msgid "Number of newsletters initially visible during signup. Additional newsletters will be hidden behind a \"See all\" button."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:32
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:32
 #: src/wizards/audience/views/setup/setup.js:165
 msgid "Email Service Provider (ESP) Advanced Settings"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:32
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:32
 #: src/wizards/audience/views/setup/setup.js:166
 msgid "Settings for Newspack Newsletters integration."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:32
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:32
 #: src/wizards/audience/views/setup/setup.js:169
 msgid "Newsletter subscription text on registration"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:32
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:32
 #: src/wizards/audience/views/setup/setup.js:170
 msgid "The text to display while subscribing to newsletters from the sign-in modal."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:32
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:32
 #: src/wizards/audience/views/setup/setup.js:174
 msgid "Configure options for syncing reader data to the connected ESP."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:32
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:32
 #: src/wizards/audience/views/setup/setup.js:177
 msgid "Sync contacts to ESP"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:32
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:32
 #: src/wizards/audience/views/setup/setup.js:229
 #: src/wizards/audience/views/setup/setup.js:236
 msgid "Sync user account deletion"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:32
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:32
 #: src/wizards/audience/views/setup/setup.js:230
 msgid "If enabled, the contact will be deleted from the ESP when a user account is deleted. If disabled, the contact will be unsubscribed from all lists, but not deleted."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:32
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:32
 #: src/wizards/audience/views/setup/setup.js:256
 msgid "Please select a Mailchimp Audience ID."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:32
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:32
 #: src/wizards/audience/views/setup/setup.js:261
 msgid "Please select an ActiveCampaign Master List."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:32
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:32
 #: src/wizards/audience/views/setup/setup.js:266
 msgid "Please select a Constant Contact Master List."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:32
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:32
 msgid "You have unsaved changes. Discard changes?"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:35
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:35
 msgid "Unsaved changes"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:35
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:35
 msgid "Select file"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:35
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:35
 msgid "Prompt saved."
 msgstr ""
 
 #. Translators: Save or Update settings.
-#: dist/audience-wizards.465ef24dd7707013533a.js:38
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:38
 #, js-format
 msgid "%s prompt settings"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:38
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:38
 msgid "Preview prompt"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:38
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:38
 msgid "We recommend"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:38
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:38
 #: src/wizards/audience/views/setup/campaign.js:54
 msgid "Set Up Audience Management Campaign"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:38
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:38
 #: src/wizards/audience/views/setup/campaign.js:55
 msgid "Preview and customize the prompts, or use our suggested defaults."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:38
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:38
 #: src/wizards/audience/views/setup/campaign.js:61
 msgid "Retrieving prompts…"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:38
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:38
 #: dist/billboard.js:12
 #: src/wizards/advertising/views/ad-units/index.js:68
 #: src/wizards/audience/views/setup/campaign.js:89
@@ -6137,96 +6137,96 @@ msgstr ""
 msgid "Back"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:38
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:38
 #: src/wizards/audience/views/setup/complete.js:19
 msgid "Your <strong>current segments and prompts</strong> will be deactivated and archived."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:38
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:38
 #: src/wizards/audience/views/setup/complete.js:23
 msgid "<strong>Reader registration</strong> will be activated to enable better targeting for driving engagement and conversations."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:38
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:38
 #: src/wizards/audience/views/setup/complete.js:29
 msgid "The <strong>Audience Management campaign</strong> will be activated with default segments and settings."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:38
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:38
 #: src/wizards/audience/views/setup/complete.js:35
 msgid "Setting up new segments…"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:38
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:38
 #: src/wizards/audience/views/setup/complete.js:36
 msgid "Activating reader registration…"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:38
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:38
 #: src/wizards/audience/views/setup/complete.js:37
 msgid "Activating Audience Management Campaign…"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:38
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:38
 #: src/wizards/audience/views/setup/complete.js:100
 msgid "Done!"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:38
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:38
 #: src/wizards/audience/views/setup/complete.js:133
 #: src/wizards/audience/views/setup/complete.js:169
 msgid "Enable Audience Management"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:38
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:38
 #: src/wizards/audience/views/setup/complete.js:136
 msgid "An easy way to let your readers register for your site, sign up for newsletters, or become donors and paid members. "
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:38
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:38
 #: src/wizards/audience/views/setup/complete.js:158
 msgid "You're all set to enable Audience Management!"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:38
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:38
 #: src/wizards/audience/views/setup/complete.js:159
 msgid "This is what will happen next:"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:38
-#: dist/audience-wizards.465ef24dd7707013533a.js:41
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:38
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:41
 #: src/wizards/audience/views/setup/content-gating.js:61
 #: src/wizards/audience/views/setup/index.js:105
 msgid "Content Gating"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:38
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:38
 #: src/wizards/audience/views/setup/content-gating.js:64
 msgid "WooCommerce Memberships integration to improve the reader experience with content gating. "
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:38
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:38
 #: src/wizards/audience/views/setup/content-gating.js:73
 msgid "Content Gate"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:38
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:38
 #: src/wizards/audience/views/setup/content-gating.js:50
 msgid "Configure the gate rendered on content with restricted access."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:38
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:38
 #: src/wizards/audience/views/setup/content-gating.js:52
 msgid "The gate is currently published."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:38
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:38
 #: src/wizards/audience/views/setup/content-gating.js:54
 msgid "The gate is currently a draft."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:38
-#: dist/audience-wizards.465ef24dd7707013533a.js:41
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:38
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:41
 #: dist/billboard.js:1
 #: dist/commons.js:13
 #: dist/componentsDemo.js:1
@@ -6248,38 +6248,38 @@ msgstr ""
 msgid "Configure"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:38
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:38
 #: src/wizards/audience/views/setup/content-gating.js:81
 msgid "Require membership in all plans"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:38
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:38
 #: src/wizards/audience/views/setup/content-gating.js:82
 msgid "When enabled, readers must belong to all membership plans that apply to a restricted content item before they are granted access. Otherwise, they will be able to unlock access to that item with membership in any single plan that applies to it."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:38
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:38
 #: src/wizards/audience/views/setup/content-gating.js:92
 msgid "Display memberships on the subscriptions tab"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:38
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:38
 #: src/wizards/audience/views/setup/content-gating.js:93
 msgid "Display memberships that don't have active subscriptions on the My Account Subscriptions tab, so readers can see information like expiration dates."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:38
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:38
 #: src/wizards/audience/components/payment-methods/stripe.js:69
 msgid "Stripe"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:38
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:38
 #: src/wizards/audience/components/payment-methods/stripe.js:72
 msgid "Enable the Stripe payment gateway for WooCommerce. "
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:38
-#: dist/audience-wizards.465ef24dd7707013533a.js:41
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:38
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:41
 #: dist/commons.js:13
 #: dist/newspack-wizards.3d38b7c2696efc78d038.js:5
 #: dist/newspack-wizards.3d38b7c2696efc78d038.js:8
@@ -6297,16 +6297,16 @@ msgstr ""
 msgid "Loading…"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:38
-#: dist/audience-wizards.465ef24dd7707013533a.js:41
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:38
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:41
 #: src/wizards/audience/components/payment-methods/payment-gateway.js:45
 #: src/wizards/audience/components/payment-methods/stripe.js:49
 #: src/wizards/audience/components/payment-methods/woopayments.js:45
 msgid "Connected - test mode"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:38
-#: dist/audience-wizards.465ef24dd7707013533a.js:41
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:38
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:41
 #: dist/newspack-wizards.3d38b7c2696efc78d038.js:1
 #: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
 #: src/wizards/audience/components/payment-methods/payment-gateway.js:47
@@ -6315,13 +6315,13 @@ msgstr ""
 msgid "Connected"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:38
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:38
 #: src/wizards/audience/components/payment-methods/stripe.js:46
 msgid "Needs attention"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:38
-#: dist/audience-wizards.465ef24dd7707013533a.js:41
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:38
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:41
 #: dist/commons.js:16
 #: dist/newspack-wizards.3d38b7c2696efc78d038.js:8
 #: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
@@ -6331,8 +6331,8 @@ msgstr ""
 msgid "Not connected"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:38
-#: dist/audience-wizards.465ef24dd7707013533a.js:41
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:38
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:41
 #: dist/commons.js:16
 #: dist/newspack-wizards.3d38b7c2696efc78d038.js:8
 #: dist/newspack-wizards.3d38b7c2696efc78d038.js:30
@@ -6343,174 +6343,174 @@ msgid "Connect"
 msgstr ""
 
 #. Translators: %s is the payment gateway name.
-#: dist/audience-wizards.465ef24dd7707013533a.js:41
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:41
 #: src/wizards/audience/components/payment-methods/payment-gateway.js:67
 #: src/wizards/audience/components/payment-methods/woopayments.js:67
 #, js-format
 msgid "Enable %s. "
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:41
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:41
 #: src/wizards/audience/components/payment-methods/index.js:31
 msgid "Payment Gateways"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:41
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:41
 #: src/wizards/audience/components/payment-methods/index.js:34
 msgid "Configure Newspack-supported payment gateways for WooCommerce. Payment gateways allow you to accept various payment methods from your readers. "
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:41
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:41
 #: src/wizards/audience/components/payment-methods/index.js:50
 msgid "Missing or invalid SSL configuration detected. To collect payments, the site must be secured with SSL. "
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:41
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:41
 #: src/wizards/audience/components/nrh-settings/index.js:44
 msgid "News Revenue Hub Settings"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:41
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:41
 #: src/wizards/audience/components/nrh-settings/index.js:45
 msgid "Configure your site’s connection to News Revenue Hub."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:41
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:41
 #: src/wizards/audience/components/nrh-settings/index.js:50
 msgid "Organization ID"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:41
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:41
 #: src/wizards/audience/components/nrh-settings/index.js:56
 msgid "Custom domain (optional)"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:41
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:41
 #: src/wizards/audience/components/nrh-settings/index.js:63
 msgid "Salesforce Campaign ID (optional)"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:41
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:41
 #: src/wizards/audience/components/nrh-settings/index.js:73
 msgid "Donor Landing Page"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:41
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:41
 #: src/wizards/audience/components/nrh-settings/index.js:81
 msgid "Search for a New Donor Landing Page"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:41
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:41
 #: src/wizards/audience/components/nrh-settings/index.js:93
 msgid "page"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:41
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:41
 #: src/wizards/audience/components/nrh-settings/index.js:94
 msgid "pages"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:41
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:41
 msgid "Billing Fields"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:41
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:41
 msgid "Configure the billing fields shown in the modal checkout form. Fields marked with (*) are required if shown. Note that for shippable products, address fields will always be shown."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:41
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:41
 msgid "Checkout Configuration"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:41
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:41
 msgid "Require sign in or create account before checkout"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:41
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:41
 msgid "Prompt users who are not logged in to sign in or register a new account before proceeding to checkout. When disabled, an account will automatically be created with the email address used at checkout."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:41
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:41
 msgid "Post-checkout success message"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:41
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:41
 msgid "The success message to display to readers after completing checkout."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:41
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:41
 msgid "Post-checkout registration success message"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:41
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:41
 msgid "The success message to display to new readers that have an account automatically created after completing checkout."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:41
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:41
 msgid "Checkout privacy policy text"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:41
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:41
 msgid "The privacy policy text to display at time of checkout for existing users. This will not show up unless a privacy page is set."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:41
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:41
 msgid "Subscription"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:41
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:41
 msgid "Manage the settings for subscription transparency and compliance."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:41
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:41
 msgid "Enable subscription confirmation checkbox"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:41
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:41
 msgid "Display a separate checkbox at checkout to confirm the user understands this is a recurring subscription and they can cancel anytime."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:41
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:41
 #: dist/collections-admin.js:1
 #: src/collections/admin/collection-meta-ctas-field.js:206
 msgid "Label"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:41
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:41
 msgid "Enable Terms & Conditions confirmation checkbox"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:41
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:41
 msgid "Display the 'I have read and accept the Terms & Conditions' checkbox at checkout. Ensure the Terms & Conditions include subscription details to comply with the FTC guidelines."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:41
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:41
 msgid "Text wrapped in {{ }} will be linked to the page set in the URL field."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:41
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:41
 #: dist/collections-admin.js:1
 #: dist/newspack-wizards.3d38b7c2696efc78d038.js:26
 #: src/collections/admin/collection-meta-ctas-field.js:225
 msgid "URL"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:41
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:41
 msgid "Please provide a URL for the Terms & Conditions page."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:41
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:41
 #: src/wizards/audience/views/setup/index.js:109
 #: src/wizards/audience/views/setup/payment.js:24
 msgid "Checkout & Payment"
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:41
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:41
 #: src/wizards/audience/views/setup/payment.js:25
 msgid "Reader revenue configuration for donations and subscriptions."
 msgstr ""
 
-#: dist/audience-wizards.465ef24dd7707013533a.js:41
+#: dist/audience-wizards.4742c1dac6d81c3c353c.js:41
 #: src/wizards/audience/views/setup/index.js:68
 msgid "Are you sure you want to skip this step? You can always come back later."
 msgstr ""

--- a/src/wizards/audience/components/lists-control/index.js
+++ b/src/wizards/audience/components/lists-control/index.js
@@ -34,7 +34,7 @@ export default function ListsControl( { label, help, placeholder, value, onChang
 				const values = Array.isArray( lists ) ? lists : Object.values( lists );
 				return ids
 					.map( id => {
-						const item = values.find( it => it.id === id );
+						const item = values.find( it => ( isNaN( it.id ) ? it.id : parseInt( it.id ) === id ) );
 						if ( item ) {
 							return getSuggestions( item );
 						}


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://linear.app/a8c/issue/NPPM-2166/segments-targeting-active-campaign-newsletter-lists-are-showing-as

This PR fixes an issue where saving a newsletter list segment criteria while ActiveCampaign is the ESP caused the saved list to revert to "Deleted list".

This happens because active campaign returns the id in string format despite being a number, and we are doing a strict comparison. This PR fixes this by checking if the ID is a number, and if it is, calling `parseInt` before comparing.

![Screenshot 2025-08-13 at 16 01 35](https://github.com/user-attachments/assets/4163b95f-ca65-4405-9419-65a3c8b5d56d)

### How to test the changes in this Pull Request:

1. Ensure Active Campaign is the active ESP
2. Go to Audience > Campaigns > Segments.
3. Start a new segment or edit an existing segment, and type a list name into the Subscribed to newsletter lists or Not subscribed to newsletter lists field.
4. Select the list name.
5. On `trunk` the name of the saved list will change to `Deleted list`. On this branch it should not.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->