### PR TITLE
fix: correctly filter sync mailchimp audience

### DIFF
--- a/src/wizards/audience/components/settings.js
+++ b/src/wizards/audience/components/settings.js
@@ -21,8 +21,9 @@ export default function Settings( { title, value, onChange } ) {
 			path: '/newspack-newsletters/v1/lists',
 		} )
 			.then( res => {
+				// For Mailchimp, filter out groups and tags, and only include remote lists.
 				const filteredLists = isMailchimp
-					? res.filter( list => ! [ 'group-', 'tag-', 'newspack-' ].some( subtype => list.id.includes( subtype ) ) )
+					? res.filter( list => 'remote' === list.type && ! [ 'group-', 'tag-' ].some( subtype => list.id.includes( subtype ) ) )
 					: res;
 				setLists( filteredLists );
 			} )

--- a/src/wizards/audience/components/settings.js
+++ b/src/wizards/audience/components/settings.js
@@ -21,7 +21,9 @@ export default function Settings( { title, value, onChange } ) {
 			path: '/newspack-newsletters/v1/lists',
 		} )
 			.then( res => {
-				const filteredLists = isMailchimp ? res.filter( list => list.type_label === 'Mailchimp Audience' ) : res;
+				const filteredLists = isMailchimp
+					? res.filter( list => ! [ 'group-', 'tag-', 'newspack-' ].some( subtype => list.id.includes( subtype ) ) )
+					: res;
 				setLists( filteredLists );
 			} )
 			.catch( setError )


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://linear.app/a8c/issue/NPPM-2170/la-silla-unable-to-select-mailchimp-audience-because-of-translations

This PR fixes an issue where our ESP sync settings were not correctly identifying Mailchimp lists when the publisher was using an non-English language. This was because our setting dropdown was searching for an english label when filtering.

We fix this by instead identifying Mailchimp audiences by id, filtering out groups and tags, as well as local lists.

![Screenshot 2025-08-15 at 11 13 27](https://github.com/user-attachments/assets/62f9e248-eef6-47bc-8be0-0e8536093d59)

**Note:** I thought we could also add some more specific entries to the newsletters `lists` endpoint response to identify these, but since this is specific to mailchimp, and we can filter them without needing to make a change in newsletters, I went this route. But let me know if you prefer to update the endpoint and use something more specific instead!

### How to test the changes in this Pull Request:

1. Ensure Mailchimp is the connected ESP
2. In WP-Admin, go to Audience > Configuration and scroll to the ESP Sync section
3. Verify the expected audiences are available in the Audience ID dropdown
4. Now change the ESP
5. Go back to the ESP Sync settings and verify the master list/audience dropdown still shows the expected options.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->