### PR TITLE
fix(woocommerce): image handling in paginated block

### DIFF
--- a/includes/plugins/class-perfmatters.php
+++ b/includes/plugins/class-perfmatters.php
@@ -223,11 +223,22 @@ class Perfmatters {
 		$options['lazyload']['youtube_preview_thumbnails'] = true;
 		$options['lazyload']['image_dimensions']           = true;
 
-		$parent_exclusions = empty( $options['lazyload']['lazy_loading_parent_exclusions'] ) ? [] : $options['lazyload']['lazy_loading_parent_exclusions'];
 		// Add our customizations to the front of the array to avoid confusion when editing the setting in the UI.
-		$options['lazyload']['lazy_loading_parent_exclusions'] = array_merge(
-			[ 'wp-block-jetpack-image-compare' ],
-			$parent_exclusions
+		$lazy_loading_exclusions = empty( $options['lazyload']['lazy_loading_exclusions'] ) ? [] : $options['lazyload']['lazy_loading_exclusions'];
+		$options['lazyload']['lazy_loading_exclusions'] = array_unique(
+			array_merge(
+				[
+					'attachment-woocommerce_thumbnail', // If WC product images are within a pagination, the pages loaded after pageload will not not have images handled otherwise.
+				],
+				$lazy_loading_exclusions
+			)
+		);
+		$parent_exclusions = empty( $options['lazyload']['lazy_loading_parent_exclusions'] ) ? [] : $options['lazyload']['lazy_loading_parent_exclusions'];
+		$options['lazyload']['lazy_loading_parent_exclusions'] = array_unique(
+			array_merge(
+				[ 'wp-block-jetpack-image-compare' ],
+				$parent_exclusions
+			)
 		);
 
 		// Fonts.

--- a/includes/plugins/class-perfmatters.php
+++ b/includes/plugins/class-perfmatters.php
@@ -224,16 +224,16 @@ class Perfmatters {
 		$options['lazyload']['image_dimensions']           = true;
 
 		// Add our customizations to the front of the array to avoid confusion when editing the setting in the UI.
-		$lazy_loading_exclusions = empty( $options['lazyload']['lazy_loading_exclusions'] ) ? [] : $options['lazyload']['lazy_loading_exclusions'];
+		$lazy_loading_exclusions = isset( $options['lazyload']['lazy_loading_exclusions'] ) && is_array( $options['lazyload']['lazy_loading_exclusions'] ) ? $options['lazyload']['lazy_loading_exclusions'] : [];
 		$options['lazyload']['lazy_loading_exclusions'] = array_unique(
 			array_merge(
 				[
-					'attachment-woocommerce_thumbnail', // If WC product images are within a pagination, the pages loaded after pageload will not not have images handled otherwise.
+					'attachment-woocommerce_thumbnail', // If WC product images are within a pagination, the pages loaded after pageload will not have images handled otherwise.
 				],
 				$lazy_loading_exclusions
 			)
 		);
-		$parent_exclusions = empty( $options['lazyload']['lazy_loading_parent_exclusions'] ) ? [] : $options['lazyload']['lazy_loading_parent_exclusions'];
+		$parent_exclusions = isset( $options['lazyload']['lazy_loading_parent_exclusions'] ) && is_array( $options['lazyload']['lazy_loading_parent_exclusions'] ) ? $options['lazyload']['lazy_loading_parent_exclusions'] : [];
 		$options['lazyload']['lazy_loading_parent_exclusions'] = array_unique(
 			array_merge(
 				[ 'wp-block-jetpack-image-compare' ],


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an issue where images in a WooCommerce block with pagination ("Hand-picked Products") had images not loaded when updating the page. This was caused by Perfmatters' optimisation, which was not handled by WC. 

### How to test the changes in this Pull Request:

1. On `trunk`, make sure you have Perfmatters and WooCommerce active 
1. Add a Campaigns' prompt containing a paginated "Hand-picked Products" block. The pages of the pagination should all include at least two products with images
1. Visit the front-end, observe that on pages other than the one loaded on page load, the images are empty (or only the first one is loaded)
1. Switch to this branch, observe images loading fine when progressing in pagination

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->