### PR TITLE
fix(my-account): missing variable and template hook priority

### DIFF
--- a/includes/plugins/woocommerce/class-woocommerce-update-payment-notice.php
+++ b/includes/plugins/woocommerce/class-woocommerce-update-payment-notice.php
@@ -129,6 +129,9 @@ class WooCommerce_Update_Payment_Notice {
 				continue;
 			}
 
+			$product = array_values( $subscription->get_items() )[0]->get_product();
+			$is_donation = Donations::is_donation_product( $product->get_id() );
+
 			$link_attrs = [];
 			$url = $subscription->get_view_order_url();
 

--- a/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php
+++ b/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php
@@ -26,7 +26,7 @@ class My_Account_UI_V1 {
 	 * @codeCoverageIgnore
 	 */
 	public static function init() {
-		\add_filter( 'page_template', [ __CLASS__, 'page_template' ] );
+		\add_filter( 'page_template', [ __CLASS__, 'page_template' ], 11 );
 		\add_filter( 'body_class', [ __CLASS__, 'add_body_class' ] );
 		\add_action( 'wp_enqueue_scripts', [ __CLASS__, 'enqueue_assets' ], 11 );
 		\add_filter( 'wc_get_template', [ __CLASS__, 'wc_get_template' ], 10, 5 );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes a couple of issues with the new My Account template:

 - The v1 template is not getting rendered because of its hook priority
 - The update payment notice is missing the `is_donation` variable in the `get_notices()` method 

### How to test the changes in this Pull Request:

1. While on trunk, make sure you have `define( 'NEWSPACK_MY_ACCOUNT_VERSION', '1.0.0' );` in your `wp-config.php`
2. Visit the "My Account" page as a reader and confirm the template is not right - the site header and footer are rendering
3. Checkout this branch, refresh the page, and confirm the correct template renders

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->