### PR TITLE
feat(pwa): display mode setting

### DIFF
--- a/includes/plugins/class-pwa.php
+++ b/includes/plugins/class-pwa.php
@@ -35,8 +35,11 @@ class PWA {
 			'wp_front_service_worker',
 			function () {
 				header( 'Cache-Control: max-age=86400, must-revalidate' );
-			} 
+			}
 		);
+
+		// Add web app manifest filter.
+		add_filter( 'web_app_manifest', [ __CLASS__, 'filter_web_app_manifest' ] );
 	}
 
 	/**
@@ -122,6 +125,20 @@ class PWA {
 	 */
 	public static function bypass_service_worker( WP_Service_Worker_Scripts $scripts ) {
 		unset( $scripts->registered['wp-offline-post-request-handling'] );
+	}
+
+	/**
+	 * Filter the web app manifest to include custom display mode.
+	 *
+	 * @param array $manifest The web app manifest array.
+	 * @return array The modified manifest.
+	 */
+	public static function filter_web_app_manifest( $manifest ) {
+		$display_mode = get_option( 'newspack_pwa_display_mode', '' );
+		if ( ! empty( $display_mode ) ) {
+			$manifest['display'] = $display_mode;
+		}
+		return $manifest;
 	}
 }
 PWA::init();

--- a/includes/wizards/class-setup-wizard.php
+++ b/includes/wizards/class-setup-wizard.php
@@ -381,13 +381,17 @@ class Setup_Wizard extends Wizard {
 			}
 		}
 
+		// Append PWA display mode option.
+		$theme_mods['pwa_display_mode'] = get_option( 'newspack_pwa_display_mode', 'minimal-ui' );
+
 		return rest_ensure_response(
 			[
 				'theme'             => Starter_Content::get_theme(),
 				'theme_mods'        => $theme_mods,
 				'homepage_patterns' => $this->get_homepage_patterns(),
 				'etc'               => [
-					'post_count' => wp_count_posts()->publish,
+					'post_count'     => wp_count_posts()->publish,
+					'has_pwa_plugin' => defined( 'PWA_PLUGIN_FILE' ),
 				],
 			]
 		);
@@ -517,6 +521,12 @@ class Setup_Wizard extends Wizard {
 			// Media credits are actually options, not theme mods.
 			if ( 'newspack_image_credits' === substr( $key, 0, 22 ) ) {
 				Newspack_Image_Credits::update_setting( $key, $value );
+				continue;
+			}
+
+			// PWA display mode is an option, not a theme mod.
+			if ( 'pwa_display_mode' === $key ) {
+				update_option( 'newspack_pwa_display_mode', $value );
 				continue;
 			}
 

--- a/src/wizards/newspack/views/settings/advanced-settings/index.tsx
+++ b/src/wizards/newspack/views/settings/advanced-settings/index.tsx
@@ -22,6 +22,7 @@ import FeaturedImagePostsAll from './featured-image-posts-all';
 import FeaturedImagePostsNew from './featured-image-posts-new';
 import MediaCredits from './media-credits';
 import AccessibilityStatement from './accessibility-statement';
+import PwaDisplayMode from './pwa-display-mode';
 
 export default function AdvancedSettings() {
 	const [ data, setData ] = hooks.useObjectState< AdvancedSettings >( {
@@ -29,6 +30,7 @@ export default function AdvancedSettings() {
 	} );
 	const [ etc, setEtc ] = hooks.useObjectState< Etc >( {
 		post_count: '0',
+		has_pwa_plugin: false,
 	} );
 
 	const [ recirculationData, setRecirculationData ] = hooks.useObjectState< Recirculation >( {
@@ -142,6 +144,11 @@ export default function AdvancedSettings() {
 			<WizardSection>
 				<AccessibilityStatement isFetching={ isFetching } />
 			</WizardSection>
+			{ etc.has_pwa_plugin ? (
+				<WizardSection title={ __( 'Progressive Web App', 'newspack-plugin' ) }>
+					<PwaDisplayMode data={ data } update={ setData } isFetching={ isFetching } />
+				</WizardSection>
+			) : null }
 			{ errorMessage && <Notice /> }
 			<div className="newspack-buttons-card">
 				<Button variant="primary" onClick={ save }>

--- a/src/wizards/newspack/views/settings/advanced-settings/pwa-display-mode.tsx
+++ b/src/wizards/newspack/views/settings/advanced-settings/pwa-display-mode.tsx
@@ -5,26 +5,26 @@ import { Grid, Notice } from '../../../../../components/src';
 
 interface PwaDisplayModeProps extends ThemeModComponentProps< AdvancedSettings > {}
 
-export default function PwaDisplayMode( { data, isFetching, update }: PwaDisplayModeProps ) {
-	const displayModeOptions = [
-		{
-			label: __( 'Fullscreen', 'newspack-plugin' ),
-			value: 'fullscreen',
-		},
-		{
-			label: __( 'Standalone', 'newspack-plugin' ),
-			value: 'standalone',
-		},
-		{
-			label: __( 'Minimal UI', 'newspack-plugin' ),
-			value: 'minimal-ui',
-		},
-		{
-			label: __( 'Browser', 'newspack-plugin' ),
-			value: 'browser',
-		},
-	];
+const DISPLAY_MODE_OPTIONS = [
+	{
+		label: __( 'Fullscreen', 'newspack-plugin' ),
+		value: 'fullscreen',
+	},
+	{
+		label: __( 'Standalone', 'newspack-plugin' ),
+		value: 'standalone',
+	},
+	{
+		label: __( 'Minimal UI', 'newspack-plugin' ),
+		value: 'minimal-ui',
+	},
+	{
+		label: __( 'Browser', 'newspack-plugin' ),
+		value: 'browser',
+	},
+];
 
+export default function PwaDisplayMode( { data, isFetching, update }: PwaDisplayModeProps ) {
 	return (
 		<Grid gutter={ 32 }>
 			<Grid columns={ 1 } gutter={ 16 }>
@@ -35,7 +35,7 @@ export default function PwaDisplayMode( { data, isFetching, update }: PwaDisplay
 						'newspack-plugin'
 					) }
 					value={ data.pwa_display_mode || 'minimal-ui' }
-					options={ displayModeOptions }
+					options={ DISPLAY_MODE_OPTIONS }
 					onChange={ ( pwa_display_mode: string ) => update( { pwa_display_mode } ) }
 					disabled={ isFetching }
 				/>

--- a/src/wizards/newspack/views/settings/advanced-settings/pwa-display-mode.tsx
+++ b/src/wizards/newspack/views/settings/advanced-settings/pwa-display-mode.tsx
@@ -1,0 +1,52 @@
+import { __ } from '@wordpress/i18n';
+import { SelectControl } from '@wordpress/components';
+
+import { Grid, Notice } from '../../../../../components/src';
+
+interface PwaDisplayModeProps extends ThemeModComponentProps< AdvancedSettings > {}
+
+export default function PwaDisplayMode( { data, isFetching, update }: PwaDisplayModeProps ) {
+	const displayModeOptions = [
+		{
+			label: __( 'Fullscreen', 'newspack-plugin' ),
+			value: 'fullscreen',
+		},
+		{
+			label: __( 'Standalone', 'newspack-plugin' ),
+			value: 'standalone',
+		},
+		{
+			label: __( 'Minimal UI', 'newspack-plugin' ),
+			value: 'minimal-ui',
+		},
+		{
+			label: __( 'Browser', 'newspack-plugin' ),
+			value: 'browser',
+		},
+	];
+
+	return (
+		<Grid gutter={ 32 }>
+			<Grid columns={ 1 } gutter={ 16 }>
+				<SelectControl
+					label={ __( 'Web App Display Mode', 'newspack-plugin' ) }
+					help={ __(
+						'Choose how your site appears when installed as a Progressive Web App. Fullscreen: Full screen without browser UI. Standalone: Looks like a standalone app. Minimal UI: Minimal browser controls. Browser: Standard browser experience.',
+						'newspack-plugin'
+					) }
+					value={ data.pwa_display_mode || 'minimal-ui' }
+					options={ displayModeOptions }
+					onChange={ ( pwa_display_mode: string ) => update( { pwa_display_mode } ) }
+					disabled={ isFetching }
+				/>
+				<Notice
+					noticeText={ __(
+						'This setting controls how your site appears when users install it as a Progressive Web App on their devices.',
+						'newspack-plugin'
+					) }
+					isInfo
+				/>
+			</Grid>
+		</Grid>
+	);
+}

--- a/src/wizards/newspack/views/settings/constants.ts
+++ b/src/wizards/newspack/views/settings/constants.ts
@@ -58,6 +58,8 @@ export const ADVANCED_SETTINGS_DEFAULTS = {
 	newspack_image_credits_prefix_label: 'Credit:',
 	newspack_image_credits_placeholder: null,
 	newspack_image_credits_auto_populate: false,
+	// PWA Display Mode.
+	pwa_display_mode: 'minimal-ui',
 };
 
 export const DEFAULT_THEME_MODS: ThemeMods = {

--- a/src/wizards/newspack/views/settings/theme-mods.d.ts
+++ b/src/wizards/newspack/views/settings/theme-mods.d.ts
@@ -13,6 +13,7 @@ type NewspackThemes = `newspack-${ ThemeNames }`;
  */
 interface Etc {
 	post_count: string;
+	has_pwa_plugin?: boolean;
 }
 
 /**
@@ -122,6 +123,9 @@ interface AdvancedSettings {
 		status: string;
 		pageUrl: string;
 	};
+
+	// PWA Display Mode.
+	pwa_display_mode: string;
 }
 
 interface MiscSettings {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a setting to control the ['display' value of the web app manifest](https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Manifest/Reference/display). This will allow publishers more control over the UX of their PWA app, as well as to allow [OneSignal to deliver push notifications on iOS](https://documentation.onesignal.com/docs/web-push-for-ios#required-manifest-fields).

<img width="541" height="263" alt="image" src="https://github.com/user-attachments/assets/cfba4f34-86f0-42c5-b1f3-2340f64f9427" />

### How to test the changes in this Pull Request:

1. Enable the `pwa` plugin
2. Visit `/wp-json/wp/v2/web-app-manifest` and observe the 'display' field has 'minimal-ui' value
3. Go to Newspack → Settings → Advanced Settings and adjust the value of "Web App Display Mode" to something else, Save
4. Reload the manifest file, observe the 'display' value updated accordingly

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->