### PR TITLE
feat(woocommerce): add custom currency symbol option

### DIFF
--- a/includes/plugins/woocommerce/class-woocommerce-connection.php
+++ b/includes/plugins/woocommerce/class-woocommerce-connection.php
@@ -38,6 +38,7 @@ class WooCommerce_Connection {
 		include_once __DIR__ . '/class-woocommerce-products.php';
 		include_once __DIR__ . '/class-woocommerce-duplicate-orders.php';
 		include_once __DIR__ . '/class-woocommerce-update-payment-notice.php';
+		include_once __DIR__ . '/class-woocommerce-custom-currency-symbol.php';
 
 		\add_action( 'admin_init', [ __CLASS__, 'disable_woocommerce_setup' ] );
 		\add_action( 'wp_loaded', [ __CLASS__, 'disable_legacy_form_checkout' ], 1 );

--- a/includes/plugins/woocommerce/class-woocommerce-custom-currency-symbol.php
+++ b/includes/plugins/woocommerce/class-woocommerce-custom-currency-symbol.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Add custom currency symbol option to WooCommerce settings.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WooCommerce Custom Currency Symbol class.
+ */
+class WooCommerce_Custom_Currency_Symbol {
+	const OPTION_KEY = 'newspack_woocommerce_custom_currency_symbol';
+
+	/**
+	 * Initialize hooks.
+	 */
+	public static function init() {
+		\add_filter( 'woocommerce_general_settings', [ __CLASS__, 'add_currency_symbol_setting' ] );
+		\add_filter( 'woocommerce_currency_symbol', [ __CLASS__, 'filter_currency_symbol' ], 10, 2 );
+	}
+
+	/**
+	 * Add custom currency symbol field to WooCommerce currency options.
+	 *
+	 * @param array $settings WooCommerce general settings.
+	 * @return array Modified settings.
+	 */
+	public static function add_currency_symbol_setting( $settings ) {
+		$new_settings = [];
+
+		foreach ( $settings as $setting ) {
+			$new_settings[] = $setting;
+
+			if ( isset( $setting['id'] ) && 'woocommerce_price_num_decimals' === $setting['id'] ) {
+				$new_settings[] = [
+					'title'    => __( 'Custom currency symbol', 'newspack-plugin' ),
+					'desc'     => __( 'Enter a custom symbol to override the default currency symbol.', 'newspack-plugin' ),
+					'id'       => self::OPTION_KEY,
+					'type'     => 'text',
+					'default'  => '',
+					'css'      => 'width: 100px;',
+					'desc_tip' => true,
+				];
+			}
+		}
+
+		return $new_settings;
+	}
+
+	/**
+	 * Filter the currency symbol if a custom one is set.
+	 *
+	 * @param string $currency_symbol The currency symbol.
+	 * @param string $currency The currency code.
+	 * @return string Modified currency symbol.
+	 */
+	public static function filter_currency_symbol( $currency_symbol, $currency ) {
+		$custom_symbol = get_option( self::OPTION_KEY, '' );
+
+		if ( ! empty( $custom_symbol ) ) {
+			return $custom_symbol;
+		}
+
+		return $currency_symbol;
+	}
+}
+WooCommerce_Custom_Currency_Symbol::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds the ability to define a custom currency symbol. 

<img width="408" height="81" alt="image" src="https://github.com/user-attachments/assets/411416f2-d36b-414f-9811-6b798376e9c1" />

### How to test the changes in this Pull Request:

1. Check if the currency is displayed as expected in a WC context (e.g. product page)
1. Visit WooCommerce → Settings, scroll to "Custom currency symbol" and set a custom symbol
2. Observe new currency symbol is used in WC context

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->