### PR TITLE
fix: update markup around Collections header

### DIFF
--- a/includes/templates/collections/archive-newspack-collection.php
+++ b/includes/templates/collections/archive-newspack-collection.php
@@ -23,7 +23,7 @@ do_action( 'newspack_collections_archive_start' );
 
 <section id="primary" class="content-area">
 	<header class="page-header">
-		<h1 class="page-title"><?php echo esc_html( Settings::get_collection_label() ); ?></h1>
+		<h1 class="page-title"><span class="page-description"><?php echo esc_html( Settings::get_collection_label() ); ?></span></h1>
 	</header><!-- .page-header -->
 
 	<main id="main" class="site-main">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This hotfix adds an additional span + CSS class around the Collections title. The theme breaks the headers into two parts, and the `<span class="page-description">` part wraps around the bigger text, so this'll fix a minor visual inconsistency between the regular archives and these archives when using the classic theme.

### How to test the changes in this Pull Request:

1. Load up your Collections landing page and note the title style; contrast it to regular archives:

<img width="1251" height="250" alt="CleanShot 2025-08-26 at 08 18 38" src="https://github.com/user-attachments/assets/e1340d08-5db1-4575-9851-05d072e8a79d" />

<img width="1216" height="174" alt="CleanShot 2025-08-26 at 08 19 47" src="https://github.com/user-attachments/assets/d731a46a-10a8-49cd-8fba-49e3639ee8c1" />

2. Apply this PR.
3. Confirm the title is now larger, something like: 

<img width="1260" height="296" alt="CleanShot 2025-08-26 at 08 16 58" src="https://github.com/user-attachments/assets/49ede948-0395-4f53-9256-b123746a94fd" />

(I'd also be up for messing with the spacing if that's something we'd like to try! The title's spacing is pretty far away from the sorting controls). 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->