### PR TITLE
fix(indesign): exporter formatting fixes

### DIFF
--- a/includes/optional-modules/class-indesign-exporter.php
+++ b/includes/optional-modules/class-indesign-exporter.php
@@ -37,6 +37,8 @@ class InDesign_Exporter {
 
 		require_once NEWSPACK_ABSPATH . 'includes/optional-modules/indesign-export/class-indesign-converter.php';
 
+		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'enqueue_block_editor_assets' ] );
+
 		$supported_post_types = self::get_supported_post_types();
 		foreach ( $supported_post_types as $post_type ) {
 			add_filter( "bulk_actions-edit-{$post_type}", [ __CLASS__, 'add_bulk_action' ] );
@@ -78,6 +80,25 @@ class InDesign_Exporter {
 		 * @param array $supported_post_types Array of post type names that support InDesign export.
 		 */
 		return apply_filters( 'newspack_indesign_export_supported_post_types', $supported_post_types );
+	}
+
+	/**
+	 * Enqueue block editor assets.
+	 */
+	public static function enqueue_block_editor_assets() {
+		$screen = get_current_screen();
+		if ( ! in_array( $screen->post_type, self::get_supported_post_types(), true ) ) {
+			return;
+		}
+
+		$asset = require NEWSPACK_ABSPATH . 'dist/indesign-export.asset.php';
+		wp_enqueue_script(
+			'newspack-indesign-export',
+			\Newspack\Newspack::plugin_url() . '/dist/indesign-export.js',
+			$asset['dependencies'],
+			$asset['version'],
+			true
+		);
 	}
 
 	/**

--- a/includes/optional-modules/indesign-export/class-indesign-converter.php
+++ b/includes/optional-modules/indesign-export/class-indesign-converter.php
@@ -249,6 +249,10 @@ class InDesign_Converter {
 			'/<\/em>/'                             => '<cTypeface:>',
 			'/<(?!img)i[^>]*>/'                    => '<cTypeface:Italic>',
 			'/<\/i>/'                              => '<cTypeface:>',
+			'/<sup[^>]*>/'                         => '<cPosition:Superscript>',
+			'/<\/sup>/'                            => '<cPosition:>',
+			'/<sub[^>]*>/'                         => '<cPosition:Subscript>',
+			'/<\/sub>/'                            => '<cPosition:>',
 
 			// Remove unsupported tags while preserving content.
 			'/<(?:div|ol|ul|a|img|figure)[^>]*>/'  => '',

--- a/includes/optional-modules/indesign-export/class-indesign-converter.php
+++ b/includes/optional-modules/indesign-export/class-indesign-converter.php
@@ -154,26 +154,12 @@ class InDesign_Converter {
 	 * @return string Processed content.
 	 */
 	private function process_post_content( $content, $options = [] ) {
-		$content = $this->remove_images_and_captions( $content );
 		$content = $this->process_headings( $content );
+		$content = $this->process_quotes( $content );
 		$content = $this->convert_html_to_indesign( $content );
 		$content = preg_replace( '/<!--.*?-->/s', '', $content );
 		$content = $this->convert_text_for_indesign( $content );
 		$content = $this->clean_whitespace( $content );
-
-		return $content;
-	}
-
-	/**
-	 * Remove images (figures) and captions from content.
-	 *
-	 * @param string $content Post content.
-	 * @return string Content without images and captions.
-	 */
-	private function remove_images_and_captions( $content ) {
-		$content = preg_replace( '/<figure[^>]*>.*?<\/figure>/is', '', $content );
-		$content = preg_replace( '/<figcaption[^>]*>.*?<\/figcaption>/is', '', $content );
-		$content = preg_replace( '/<img[^>]*>/i', '', $content );
 
 		return $content;
 	}
@@ -213,6 +199,33 @@ class InDesign_Converter {
 	}
 
 	/**
+	 * Process blockquotes and pullquotes.
+	 *
+	 * @param string $content Post content.
+	 * @return string Content with processed blockquotes and pullquotes.
+	 */
+	private function process_quotes( $content ) {
+		$pattern      = '/<blockquote[^>]*>(.*?)<\/blockquote>/is';
+		$cite_pattern = '/<cite[^>]*>(.*?)<\/cite>/is';
+
+		preg_match_all( $pattern, $content, $matches );
+		$blockquotes = $matches[1];
+
+		foreach ( $blockquotes as $blockquote ) {
+			$quote = $this->styles['pullquote'] . wp_strip_all_tags( preg_replace( $cite_pattern, '', $blockquote ) );
+
+			preg_match( $cite_pattern, $blockquote, $matches );
+			$cite = $matches[1];
+			if ( ! empty( $cite ) ) {
+				$quote .= "\r\n" . $this->styles['pullquote_name'] . wp_strip_all_tags( $cite );
+			}
+
+			$content = preg_replace( $pattern, $quote, $content, 1 );
+		}
+		return $content;
+	}
+
+	/**
 	 * Convert HTML elements to InDesign tagged text equivalents.
 	 *
 	 * @param string $content Post content.
@@ -220,34 +233,36 @@ class InDesign_Converter {
 	 */
 	private function convert_html_to_indesign( $content ) {
 		$conversions = [
-			// Blockquotes and pullquotes.
-			'/<blockquote[^>]*class="[^"]*wp-block-quote[^"]*"[^>]*>/' => $this->styles['pullquote'],
-			'/<blockquote[^>]*>/'                => $this->styles['pullquote'],
-			'/<cite[^>]*>/'                      => $this->styles['pullquote_name'],
-
 			// Paragraphs.
-			'/<(?!pstyle:)(p[^>]*)>/'            => $this->styles['paragraph'],
+			'/<(?!pstyle:)(p[^>]*)>/' => $this->styles['paragraph'],
+
+			// Lists. TODO: Handle numbered and nested lists.
+			'/<li[^>]*>/'             => '<bnListType:Bullet>',
+
+			// Line breaks.
+			'/<br[^>]*>/'             => '<0x000A>',
 
 			// Typography.
-			'/<strong[^>]*>/'                    => '<cTypeface:Bold>',
-			'/<\/strong>/'                       => '<cTypeface:>',
-			'/<b[^>]*>/'                         => '<cTypeface:Bold>',
-			'/<\/b>/'                            => '<cTypeface:>',
-			'/<em[^>]*>/'                        => '<cTypeface:Italic>',
-			'/<\/em>/'                           => '<cTypeface:>',
-			'/<i[^>]*>/'                         => '<cTypeface:Italic>',
-			'/<\/i>/'                            => '<cTypeface:>',
+			'/<strong[^>]*>/'         => '<cTypeface:Bold>',
+			'/<\/strong>/'            => '<cTypeface:>',
+			'/<em[^>]*>/'             => '<cTypeface:Italic>',
+			'/<\/em>/'                => '<cTypeface:>',
+			'/<i[^>]*>/'              => '<cTypeface:Italic>',
+			'/<\/i>/'                 => '<cTypeface:>',
 
-			// Remove links but keep content.
-			'/<a[^>]*>/'                         => '',
-			'/<\/a>/'                            => '',
+			// Remove unsupported tags while preserving content.
+			'/<(?:div|ol|ul|a|img|figure|figcaption)[^>]*>/' => '',
 
-			// Remove closing tags for block elements and add line breaks.
-			'/<\/(?:p|blockquote|cite|h[1-6])>/' => "\r\n",
+			// Remove closing tags and add line breaks.
+			'/<\/[^>]*>/'             => "\r\n",
 		];
 
 		foreach ( $conversions as $pattern => $replacement ) {
-			$content = preg_replace( $pattern, $replacement, $content );
+			$content = preg_replace(
+				$pattern,
+				$replacement,
+				$content
+			);
 		}
 
 		return $content;
@@ -274,7 +289,7 @@ class InDesign_Converter {
 			'’'  => "'",
 
 			// Ellipsis.
-			'…'  => '...',
+			'…'  => '<0x2026>',
 
 			// Special characters.
 			'•'  => '<CharStyle:bullet>n<CharStyle:>',

--- a/includes/optional-modules/indesign-export/class-indesign-converter.php
+++ b/includes/optional-modules/indesign-export/class-indesign-converter.php
@@ -230,28 +230,31 @@ class InDesign_Converter {
 	 */
 	private function convert_html_to_indesign( $content ) {
 		$conversions = [
+			// Remove figcaption entirely. TODO: Move them to the bottom of the export file.
+			'/<figcaption[^>]*>.*?<\/figcaption>/' => '',
+
 			// Paragraphs.
-			'/<(?!pstyle:)(p[^>]*)>/' => $this->styles['paragraph'],
+			'/<(?!pstyle:)(p[^>]*)>/'              => $this->styles['paragraph'],
 
 			// Lists. TODO: Handle numbered and nested lists.
-			'/<li[^>]*>/'             => '<bnListType:Bullet>',
+			'/<li[^>]*>/'                          => '<bnListType:Bullet>',
 
 			// Line breaks.
-			'/<br[^>]*>/'             => '<0x000A>',
+			'/<br[^>]*>/'                          => '<0x000A>',
 
 			// Typography.
-			'/<strong[^>]*>/'         => '<cTypeface:Bold>',
-			'/<\/strong>/'            => '<cTypeface:>',
-			'/<em[^>]*>/'             => '<cTypeface:Italic>',
-			'/<\/em>/'                => '<cTypeface:>',
-			'/<i[^>]*>/'              => '<cTypeface:Italic>',
-			'/<\/i>/'                 => '<cTypeface:>',
+			'/<strong[^>]*>/'                      => '<cTypeface:Bold>',
+			'/<\/strong>/'                         => '<cTypeface:>',
+			'/<em[^>]*>/'                          => '<cTypeface:Italic>',
+			'/<\/em>/'                             => '<cTypeface:>',
+			'/<(?!img)i[^>]*>/'                    => '<cTypeface:Italic>',
+			'/<\/i>/'                              => '<cTypeface:>',
 
 			// Remove unsupported tags while preserving content.
-			'/<(?:div|ol|ul|a|img|figure|figcaption)[^>]*>/' => '',
+			'/<(?:div|ol|ul|a|img|figure)[^>]*>/'  => '',
 
 			// Remove closing tags and add line breaks.
-			'/<\/[^>]*>/'             => "\r\n",
+			'/<\/[^>]*>/'                          => "\r\n",
 		];
 
 		foreach ( $conversions as $pattern => $replacement ) {

--- a/includes/optional-modules/indesign-export/class-indesign-converter.php
+++ b/includes/optional-modules/indesign-export/class-indesign-converter.php
@@ -257,8 +257,11 @@ class InDesign_Converter {
 			// Remove unsupported tags while preserving content.
 			'/<(?:div|ol|ul|a|img|figure)[^>]*>/'  => '',
 
-			// Remove closing tags and add line breaks.
-			'/<\/[^>]*>/'                          => "\r\n",
+			// Replace paragraphs end tags with line breaks.
+			'/<\/p>/'                              => "\r\n",
+
+			// Remove all closing tags.
+			'/<\/[^>]*>/'                          => '',
 		];
 
 		foreach ( $conversions as $pattern => $replacement ) {

--- a/includes/optional-modules/indesign-export/class-indesign-converter.php
+++ b/includes/optional-modules/indesign-export/class-indesign-converter.php
@@ -67,19 +67,19 @@ class InDesign_Converter {
 		$content_parts = [];
 
 		$content_parts[] = '<ASCII-WIN>';
-		$content_parts[] = $this->styles['headline'] . $this->convert_text_for_indesign( $post->post_title );
+		$content_parts[] = $this->styles['headline'] . $this->get_transformed_text( $post->post_title );
 
 		if ( $options['include_subtitle'] ) {
 			$subtitle = $this->get_post_subtitle( $post );
 			if ( $subtitle ) {
-				$content_parts[] = $this->styles['subhead'] . $this->convert_text_for_indesign( $subtitle );
+				$content_parts[] = $this->styles['subhead'] . $this->get_transformed_text( $subtitle );
 			}
 		}
 
 		if ( $options['include_byline'] ) {
 			$byline = $this->get_byline( $post );
 			if ( ! empty( $byline ) ) {
-				$content_parts[] = $this->styles['byline'] . $this->convert_text_for_indesign( $byline );
+				$content_parts[] = $this->styles['byline'] . $this->get_transformed_text( $byline );
 			}
 		}
 
@@ -149,23 +149,73 @@ class InDesign_Converter {
 	 * @return string Processed content.
 	 */
 	private function process_post_content( $content, $options = [] ) {
-		$content = $this->process_headings( $content );
+		if ( has_blocks( $content ) ) {
+			$content = $this->process_blocks( $content );
+		}
+		$content = $this->process_html_headings( $content );
 		$content = $this->process_quotes( $content );
 		$content = $this->convert_html_to_indesign( $content );
 		$content = preg_replace( '/<!--.*?-->/s', '', $content );
-		$content = $this->convert_text_for_indesign( $content );
+		$content = $this->get_transformed_text( $content );
 		$content = $this->clean_whitespace( $content );
 
 		return $content;
 	}
 
 	/**
+	 * Process blocks in the content.
+	 *
+	 * @param string $content Post content.
+	 *
+	 * @return string Content with processed blocks.
+	 */
+	private function process_blocks( $content ) {
+		$blocks = parse_blocks( $content );
+		$content = '';
+		foreach ( $blocks as $block ) {
+			$tag = $this->get_block_tag( $block );
+			if ( ! empty( $tag ) ) {
+				$content .= $tag . $this->get_transformed_text( preg_replace( '/^<[^>]+>(.*)<\/[^>]+>$/s', '$1', trim( $block['innerHTML'] ) ) );
+			} else {
+				$content .= serialize_block( $block );
+			}
+		}
+		return $content;
+	}
+
+	/**
+	 * Get the tag for a block.
+	 *
+	 * @param array $block Block data.
+	 *
+	 * @return string Block tag.
+	 */
+	private function get_block_tag( $block ) {
+		if ( ! empty( $block['attrs']['indesignTag'] ) ) {
+			return sprintf( '<%1$s>', $block['attrs']['indesignTag'] );
+		}
+
+		if ( 'core/paragraph' === $block['blockName'] ) {
+			return $this->styles['paragraph'];
+		}
+
+		if ( 'core/heading' === $block['blockName'] ) {
+			if ( 4 === $block['attrs']['level'] ) {
+				return $this->styles['subhead'];
+			}
+			return $this->styles['paragraph'];
+		}
+		return '';
+	}
+
+	/**
 	 * Process headings in the content.
 	 *
 	 * @param string $content Post content.
+	 *
 	 * @return string Content with processed subheads.
 	 */
-	private function process_headings( $content ) {
+	private function process_html_headings( $content ) {
 		$content = preg_replace_callback(
 			'/<h([2-6])[^>]*>(.*?)<\/h[2-6]>/is',
 			function ( $matches ) {
@@ -174,7 +224,7 @@ class InDesign_Converter {
 					 * Process subheadings (h4 elements) in the content.
 					 */
 					case '4':
-						return $this->styles['subhead'] . $this->convert_text_for_indesign( $matches[2] );
+						return $this->styles['subhead'] . $this->get_transformed_text( $matches[2] );
 					/**
 					 * TODO: Handle other heading levels as per requirements.
 					 * For now, treating them as regular paragraphs.
@@ -184,7 +234,7 @@ class InDesign_Converter {
 					case '5':
 					case '6':
 					default:
-						return $this->styles['paragraph'] . $this->convert_text_for_indesign( $matches[2] );
+						return $this->styles['paragraph'] . $this->get_transformed_text( $matches[2] );
 				}
 			},
 			$content
@@ -197,6 +247,7 @@ class InDesign_Converter {
 	 * Process blockquotes and pullquotes.
 	 *
 	 * @param string $content Post content.
+	 *
 	 * @return string Content with processed blockquotes and pullquotes.
 	 */
 	private function process_quotes( $content ) {
@@ -226,6 +277,7 @@ class InDesign_Converter {
 	 * Convert HTML elements to InDesign tagged text equivalents.
 	 *
 	 * @param string $content Post content.
+	 *
 	 * @return string Content with InDesign tags.
 	 */
 	private function convert_html_to_indesign( $content ) {
@@ -279,9 +331,10 @@ class InDesign_Converter {
 	 * Convert text for InDesign, handling special characters and typography.
 	 *
 	 * @param string $text Text to convert.
+	 *
 	 * @return string Converted text.
 	 */
-	private function convert_text_for_indesign( $text ) {
+	private function get_transformed_text( $text ) {
 		// Character conversions for InDesign Tagged Text.
 		$conversions = [
 			// Dashes.
@@ -329,6 +382,7 @@ class InDesign_Converter {
 	 * Clean up whitespace and line breaks.
 	 *
 	 * @param string $content Content to clean.
+	 *
 	 * @return string Cleaned content.
 	 */
 	private function clean_whitespace( $content ) {

--- a/includes/optional-modules/indesign-export/class-indesign-converter.php
+++ b/includes/optional-modules/indesign-export/class-indesign-converter.php
@@ -257,10 +257,10 @@ class InDesign_Converter {
 			// Remove unsupported tags while preserving content.
 			'/<(?:div|ol|ul|a|img|figure)[^>]*>/'  => '',
 
-			// Replace paragraphs end tags with line breaks.
-			'/<\/p>/'                              => "\r\n",
+			// Replace paragraphs and lists end tags with line breaks.
+			'/<\/(?:p|li|ul|ol)[^>]*>/'            => "\r\n",
 
-			// Remove all closing tags.
+			// Remove all remaining closing tags.
 			'/<\/[^>]*>/'                          => '',
 		];
 

--- a/includes/optional-modules/indesign-export/class-indesign-converter.php
+++ b/includes/optional-modules/indesign-export/class-indesign-converter.php
@@ -27,7 +27,6 @@ class InDesign_Converter {
 		'byline'            => '<pstyle:byline>By ',
 		'pullquote'         => '<pstyle:pullquote>',
 		'pullquote_name'    => '<pstyle:pullquotename>',
-		'end_of_story'      => '<cstyle:endbullet>n<cstyle:>',
 	];
 
 	/**
@@ -86,10 +85,6 @@ class InDesign_Converter {
 
 		$post_content = $this->process_post_content( $post->post_content, $options );
 		$content_parts[] = $post_content;
-
-		if ( ! empty( $this->styles['end_of_story'] ) ) {
-			$content_parts[] = $this->styles['end_of_story'];
-		}
 
 		return implode( "\r\n", array_filter( $content_parts ) );
 	}
@@ -215,9 +210,11 @@ class InDesign_Converter {
 			$quote = $this->styles['pullquote'] . wp_strip_all_tags( preg_replace( $cite_pattern, '', $blockquote ) );
 
 			preg_match( $cite_pattern, $blockquote, $matches );
-			$cite = $matches[1];
-			if ( ! empty( $cite ) ) {
-				$quote .= "\r\n" . $this->styles['pullquote_name'] . wp_strip_all_tags( $cite );
+			if ( ! empty( $matches ) ) {
+				$cite = $matches[1];
+				if ( ! empty( $cite ) ) {
+					$quote .= "\r\n" . $this->styles['pullquote_name'] . wp_strip_all_tags( $cite );
+				}
 			}
 
 			$content = preg_replace( $pattern, $quote, $content, 1 );
@@ -288,29 +285,8 @@ class InDesign_Converter {
 			'‘'  => "'",
 			'’'  => "'",
 
-			// Ellipsis.
-			'…'  => '<0x2026>',
-
 			// Special characters.
 			'•'  => '<CharStyle:bullet>n<CharStyle:>',
-
-			// accented characters.
-			'ā'  => '<0x0101>',
-			'à'  => '<0x00E0>',
-			'é'  => '<0x00E9>',
-			'è'  => '<0x00E8>',
-			'ê'  => '<0x00EA>',
-			'É'  => '<0x00C9>',
-			'È'  => '<0x00C8>',
-			'í'  => '<0x00ED>',
-			'ñ'  => '<0x00F1>',
-			'Ñ'  => '<0x00D1>',
-			'ö'  => '<0x00F6>',
-			'ô'  => '<0x00F4>',
-			'ő'  => '<0x0151>',
-			'û'  => '<0x00FB>',
-			'Û'  => '<0x00DB>',
-			'ú'  => '<0x00FA>',
 		];
 
 		$text = str_replace( array_keys( $conversions ), array_values( $conversions ), $text );
@@ -324,6 +300,17 @@ class InDesign_Converter {
 
 		// Remove non-breaking space UTF-8 character.
 		$text = str_replace( "\xC2\xA0", ' ', $text );
+
+		// Convert remaining special characters to hexadecimal unicode code points.
+		$char_length = mb_strlen( $text, 'UTF-8' );
+		for ( $i = 0; $i < $char_length; $i++ ) {
+			$char       = mb_substr( $text, $i, 1, 'UTF-8' );
+			$code_point = mb_ord( $char, 'UTF-8' );
+			if ( $code_point > 127 ) {
+				$text        = str_replace( $char, sprintf( '<0x%04X>', $code_point ), $text );
+				$char_length = mb_strlen( $text, 'UTF-8' );
+			}
+		}
 
 		return $text;
 	}

--- a/src/indesign-export/index.js
+++ b/src/indesign-export/index.js
@@ -1,0 +1,55 @@
+import { addFilter } from '@wordpress/hooks';
+import { __ } from '@wordpress/i18n';
+import { InspectorControls, useBlockEditingMode } from '@wordpress/block-editor';
+import { TextControl } from '@wordpress/components';
+
+const addAttribute = settings => {
+	settings.attributes = {
+		...settings.attributes,
+		indesignTag: {
+			type: 'string',
+			default: '',
+		},
+	};
+
+	return settings;
+};
+
+const TagNameControl = ( { blockName, indesignTag, setAttributes } ) => {
+	const blockEditingMode = useBlockEditingMode();
+	if ( blockEditingMode !== 'default' ) {
+		return null;
+	}
+
+	// Only paragraphs and heading can have custom tag names.
+	if ( ! [ 'core/paragraph', 'core/heading' ].includes( blockName ) ) {
+		return null;
+	}
+
+	return (
+		<InspectorControls group="advanced">
+			<TextControl
+				__nextHasNoMarginBottom
+				__next40pxDefaultSize
+				label={ __( 'InDesign Exporter Tag Name', 'newspack-plugin' ) }
+				help={ __( 'Define a custom tag name to be used in the Tagged Text export.', 'newspack-plugin' ) }
+				value={ indesignTag }
+				onChange={ value => setAttributes( { indesignTag: value } ) }
+			/>
+		</InspectorControls>
+	);
+};
+
+const addTagNameControl = BlockEdit => {
+	return props => {
+		return (
+			<>
+				<BlockEdit { ...props } />
+				<TagNameControl blockName={ props.name } indesignTag={ props.attributes.indesignTag } setAttributes={ props.setAttributes } />
+			</>
+		);
+	};
+};
+
+addFilter( 'blocks.registerBlockType', 'newspack-plugin/indesign-export', addAttribute );
+addFilter( 'editor.BlockEdit', 'newspack-plugin/indesign-export', addTagNameControl );

--- a/tests/unit-tests/indesign-exporter/indesign-exporter.php
+++ b/tests/unit-tests/indesign-exporter/indesign-exporter.php
@@ -148,4 +148,20 @@ class Newspack_Test_InDesign_Exporter extends WP_UnitTestCase {
 		$content = $converter->convert_post( $post_id );
 		$this->assertStringContainsString( '<0x00E0><0x00E1><0x00E2><0x00E3><0x00E4><0x00E5><0x00E6><0x00E7><0x00E8><0x00E9><0x00EA><0x00EB><0x00EC><0x00ED><0x00EE><0x00EF><0x00F1><0x00F2><0x00F3><0x00F4><0x00F5><0x00F6><0x00F8><0x00F9><0x00FA><0x00FB><0x00FC><0x00FD><0x00FF><0x0100><0x0101><0x0102><0x0103><0x2026><0x20AC>', $content );
 	}
+
+	/**
+	 * Test blocks with custom tags.
+	 */
+	public function test_convert_blocks_with_custom_tags() {
+		$post_id = $this->factory->post->create(
+			[
+				'post_title'   => 'Test Post',
+				'post_content' => '<!-- wp:paragraph {"indesignTag":"customparagraph"} --><p>This is a test post with custom tag.</p><!-- /wp:paragraph -->',
+			]
+		);
+
+		$converter = new InDesign_Converter();
+		$content = $converter->convert_post( $post_id );
+		$this->assertStringContainsString( '<customparagraph>This is a test post with custom tag.', $content );
+	}
 }

--- a/tests/unit-tests/indesign-exporter/indesign-exporter.php
+++ b/tests/unit-tests/indesign-exporter/indesign-exporter.php
@@ -83,6 +83,41 @@ class Newspack_Test_InDesign_Exporter extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test converting superscript and subscript.
+	 */
+	public function test_convert_superscript_and_subscript() {
+		$post_id = $this->factory->post->create(
+			[
+				'post_title'   => 'Test Post',
+				'post_content' => '<p>This is a test post with <sup>superscript</sup> and <sub>subscript</sub>.</p>',
+			]
+		);
+
+		$converter = new InDesign_Converter();
+		$content = $converter->convert_post( $post_id );
+		$this->assertStringContainsString( '<pstyle:text>This is a test post with <cPosition:Superscript>superscript<cPosition:> and <cPosition:Subscript>subscript<cPosition:>.', $content );
+	}
+
+	/**
+	 * Test cleaning img markup.
+	 */
+	public function test_clean_img_markup() {
+		$post_id = $this->factory->post->create(
+			[
+				'post_title'   => 'Test Post',
+				'post_content' => '<figure class="wp-block-image size-large"><img src="http://localhost/image.jpg" alt="" class="wp-image-1234"/><figcaption class="wp-element-caption">My Caption</figcaption></figure>',
+			]
+		);
+
+		$converter = new InDesign_Converter();
+		$content = $converter->convert_post( $post_id );
+		$this->assertStringNotContainsString( '<figure', $content );
+		$this->assertStringNotContainsString( '<figcaption', $content );
+		$this->assertStringNotContainsString( '<img', $content );
+		$this->assertStringNotContainsString( 'My Caption', $content );
+	}
+
+	/**
 	 * Test converting HTML entities.
 	 */
 	public function test_convert_html_entities() {

--- a/tests/unit-tests/indesign-exporter/indesign-exporter.php
+++ b/tests/unit-tests/indesign-exporter/indesign-exporter.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Tests the InDesign Exporter functionality.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Optional_Modules\InDesign_Export\InDesign_Converter;
+
+/**
+ * Tests the InDesign Exporter functionality.
+ */
+class Newspack_Test_InDesign_Exporter extends WP_UnitTestCase {
+	/**
+	 * Test converting a simple post.
+	 */
+	public function test_convert_simple_post() {
+		$post_id = $this->factory->post->create(
+			[
+				'post_title'   => 'Test Post',
+				'post_content' => '<p>This is a test post.</p>',
+			]
+		);
+
+		$converter = new InDesign_Converter();
+		$content = $converter->convert_post( $post_id );
+		$this->assertStringContainsString( '<ASCII-WIN>', $content );
+		$this->assertStringContainsString( '<pstyle:24head>Test Post', $content );
+		$this->assertStringContainsString( '<pstyle:text>This is a test post.', $content );
+	}
+
+	/**
+	 * Test converting blockquotes.
+	 */
+	public function test_convert_blockquote() {
+		$post_id = $this->factory->post->create(
+			[
+				'post_title'   => 'Test Post',
+				'post_content' => '<blockquote>This is a test blockquote.</blockquote> <blockquote><p>This is a test post with paragraph.</p><cite>John Doe</cite></blockquote>',
+			]
+		);
+
+		$converter = new InDesign_Converter();
+		$content = $converter->convert_post( $post_id );
+		$this->assertStringContainsString( '<pstyle:pullquote>This is a test blockquote.', $content );
+		$this->assertStringContainsString( '<pstyle:pullquote>This is a test post with paragraph.', $content );
+		$this->assertStringContainsString( '<pstyle:pullquotename>John Doe', $content );
+	}
+
+	/**
+	 * Test converting lists.
+	 */
+	public function test_convert_list() {
+		$post_id = $this->factory->post->create(
+			[
+				'post_title'   => 'Test Post',
+				'post_content' => '<ul><li>Item 1.</li><li>Item 2.</li></ul>',
+			]
+		);
+
+		$converter = new InDesign_Converter();
+		$content = $converter->convert_post( $post_id );
+		$this->assertStringContainsString( '<bnListType:Bullet>Item 1.', $content );
+		$this->assertStringContainsString( '<bnListType:Bullet>Item 2.', $content );
+	}
+
+	/**
+	 * Test cleaning HTML markup.
+	 */
+	public function test_clean_html_markup() {
+		$post_id = $this->factory->post->create(
+			[
+				'post_title'   => 'Test Post',
+				'post_content' => '<div><p>This is a test post.</p></div>',
+			]
+		);
+
+		$converter = new InDesign_Converter();
+		$content = $converter->convert_post( $post_id );
+		$this->assertStringContainsString( '<pstyle:text>This is a test post.', $content );
+		$this->assertStringNotContainsString( '<div>', $content );
+		$this->assertStringNotContainsString( '<p>', $content );
+	}
+
+	/**
+	 * Test converting HTML entities.
+	 */
+	public function test_convert_html_entities() {
+		$post_id = $this->factory->post->create(
+			[
+				'post_title'   => 'Test Post',
+				'post_content' => '<p>This is a test post with &nbsp;, &amp;, &lt;, &gt; and •.</p>',
+			]
+		);
+
+		$converter = new InDesign_Converter();
+		$content = $converter->convert_post( $post_id );
+		$this->assertStringContainsString( '<pstyle:text>This is a test post with  , &, <, > and <CharStyle:bullet>n<CharStyle:>.', $content );
+	}
+
+	/**
+	 * Test converting special characters.
+	 */
+	public function test_convert_special_characters() {
+		$post_id = $this->factory->post->create(
+			[
+				'post_title'   => 'Test Post',
+				'post_content' => '<p>àáâãäåæçèéêëìíîïñòóôõöøùúûüýÿĀāĂă…€</p>',
+			]
+		);
+
+		$converter = new InDesign_Converter();
+		$content = $converter->convert_post( $post_id );
+		$this->assertStringContainsString( '<0x00E0><0x00E1><0x00E2><0x00E3><0x00E4><0x00E5><0x00E6><0x00E7><0x00E8><0x00E9><0x00EA><0x00EB><0x00EC><0x00ED><0x00EE><0x00EF><0x00F1><0x00F2><0x00F3><0x00F4><0x00F5><0x00F6><0x00F8><0x00F9><0x00FA><0x00FB><0x00FC><0x00FD><0x00FF><0x0100><0x0101><0x0102><0x0103><0x2026><0x20AC>', $content );
+	}
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -53,6 +53,7 @@ const entry = {
 	admin: path.join( __dirname, 'src', 'admin', 'index.js' ),
 	'memberships-gate': path.join( __dirname, 'src', 'memberships-gate', 'gate.js' ),
 	'memberships-gate-metering': path.join( __dirname, 'src', 'memberships-gate', 'metering.js' ),
+	'indesign-export': path.join( __dirname, 'src', 'indesign-export', 'index.js' ),
 
 	// Newspack wizard assets.
 	...wizardsScriptFiles,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

NPPD-837 NPPD-839 NPPD-840 

Unit tests and several fixes to the InDesign exporter:

- Add support for bullet lists (for now, we'll treat `<ul>` and `<ol>` the same)
- Add support for `<sup>` and `<sub>` tags
- Fix the handling of blockquotes
- Improve coverage of special characters
- Fix bug with `<br />` being interpreted as bold style
- Support line breaks with `<br />`
- Remove unsupported HTML (`<div />`) from the markup
- Remove the "end of story" node

### Update

ab16f3c89ec6931c72a739966f0650d67018d951 introduces custom tag support for the **paragraph** and **heading** blocks:

<img width="1000" height="455" alt="image" src="https://github.com/user-attachments/assets/26492905-b4b5-47f8-832c-1c746295537f" />

With the `indesignTag` attribute set, it'll replace the default tag used for the inner HTML.

### How to test the changes in this Pull Request:

1. Copy the following post content into a new post draft:

```html
<!-- wp:paragraph -->
<p>Regular paragraph</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>Paragraph with <sup>sup</sup> and <sub>sub</sub></p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>Paragraph with<br>a line break</p>
<!-- /wp:paragraph -->

<!-- wp:quote {"className":"is-style-default"} -->
<blockquote class="wp-block-quote is-style-default"><!-- wp:paragraph -->
<p>A regular quote</p>
<!-- /wp:paragraph --></blockquote>
<!-- /wp:quote -->

<!-- wp:pullquote -->
<figure class="wp-block-pullquote"><blockquote><p>A Pullquote</p><cite>John</cite></blockquote></figure>
<!-- /wp:pullquote -->

<!-- wp:paragraph -->
<p>àáâãäåæçèéêëìíîïñòóôõöøùúûüýÿĀāĂăĄąĆćČčĎďĐđĒēĘęĚěĞğĨĩĪīĮįĶķĹĺĻļŃńŅņŇňŌōŎŏŐőŒœŔŕŖŗŘřŚśŞşŠšŢţŤťŨũŪūŬŭŮůŰűŲųŶŷŸŹźŻżŽžÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞß©®°±²³µ¶·¹¼½¾¢£¤¥§ª«¯´¸»¿–—''""…•€</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p><strong>Bold 1</strong>: Regular Text</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p><strong>Bold 2</strong>: Regular Text</p>
<!-- /wp:paragraph -->

<!-- wp:list -->
<ul class="wp-block-list"><!-- wp:list-item -->
<li>Bullet List Item 1</li>
<!-- /wp:list-item -->

<!-- wp:list-item -->
<li>Bullet List Item 2</li>
<!-- /wp:list-item --></ul>
<!-- /wp:list -->

<!-- wp:list {"ordered":true} -->
<ol class="wp-block-list"><!-- wp:list-item -->
<li>Numbered List Item 1</li>
<!-- /wp:list-item -->

<!-- wp:list-item -->
<li>Numbered List Item 2</li>
<!-- /wp:list-item --></ol>
<!-- /wp:list -->

<!-- wp:group {"className":"is-style-default","style":{"spacing":{"padding":{"top":"var:preset|spacing|80","bottom":"var:preset|spacing|80","left":"var:preset|spacing|80","right":"var:preset|spacing|80"}},"elements":{"link":{"color":{"text":"var:preset|color|white"}}}},"backgroundColor":"primary-variation","textColor":"white","layout":{"type":"constrained"}} -->
<div class="wp-block-group is-style-default has-white-color has-primary-variation-background-color has-text-color has-background has-link-color" style="padding-top:var(--wp--preset--spacing--80);padding-right:var(--wp--preset--spacing--80);padding-bottom:var(--wp--preset--spacing--80);padding-left:var(--wp--preset--spacing--80)"><!-- wp:paragraph -->
<p>Paragraph inside a group</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->

<!-- wp:paragraph -->
<p></p>
<!-- /wp:paragraph -->
```

2. While in the `release` branch, export the InDesign text file and open
4. Confirm the `<br/>` is being converted to `<cTypeface:Bold>`
5. Confirm the `<sup>` and `<sub>` tags are not properly handled and break the markup
6. Confirm the first blockquote renders with its paragraph, breaking the markup
7. Confirm the second blockquote never renders because it's been stripped for being inside the `<figure />` tag
8. Confirm only a few of the special characters were converted to the expected hexadecimal code
9. Confirm `<ul>` and `<ol>` tags render as plain HTML, which is unsupported markup
10. Confirm the `<div>` tag from the group block renders as plain HTML as well
11. Checkout this branch
12. Edit a paragraph block and set a `customtag` to it
13. Add a heading block and set a `customheading`
14. Confirm `<customtag>` and `<customheading>` are rendered for the changed blocks instead of the default tags
15. Confirm the issues above are fixed
16. Confirm the `<br/>` is converted to `<0x000A>`, representing a new line
17. Confirm the `<sup>` and `<sub>` are converted to the correct tag for InDesign
18. Confirm the `<ul>` and `<ol>` lists are converted to `<bnListType:Bullet>`
19. Confirm all special characters are converted to hexadecimal code points

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->