### PR TITLE
fix: dont do any checks before init

### DIFF
--- a/includes/plugins/google-site-kit/class-googlesitekit-logger.php
+++ b/includes/plugins/google-site-kit/class-googlesitekit-logger.php
@@ -27,9 +27,18 @@ class GoogleSiteKit_Logger {
 	const LOG_CODE_DISCONNECTED = 'newspack_googlesitekit_disconnected';
 
 	/**
-	 * Initialize hooks and filters.
+	 * Initialize hooks.
+	 *
+	 * @return void
 	 */
 	public static function init() {
+		add_action( 'init', [ __CLASS__, 'init_hooks' ] );
+	}
+
+	/**
+	 * Initialize hooks and filters.
+	 */
+	public static function init_hooks() {
 		if (
 			! method_exists( 'Newspack_Manager', 'is_connected_to_production_manager' ) || (
 				method_exists( 'Newspack_Manager', 'is_connected_to_production_manager' )


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Delay any checks to the init hook.

### How to test the changes in this Pull Request:

1. Make sure the `cron_init` methos is still being invoked in admin

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->