### PR TITLE
fix: correctly identify lists by id

### DIFF
--- a/src/wizards/audience/components/lists-control/index.js
+++ b/src/wizards/audience/components/lists-control/index.js
@@ -34,7 +34,7 @@ export default function ListsControl( { label, help, placeholder, value, onChang
 				const values = Array.isArray( lists ) ? lists : Object.values( lists );
 				return ids
 					.map( id => {
-						const item = values.find( it => ( isNaN( it.id ) ? it.id : parseInt( it.id ) === id ) );
+						const item = values.find( it => ( isNaN( it.id ) ? it.id : parseInt( it.id ) ) === id );
 						if ( item ) {
 							return getSuggestions( item );
 						}


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://linear.app/a8c/issue/NPPM-2194/newsletter-lists-in-campaign-segments-always-initializes-empty

In https://github.com/Automattic/newspack-plugin/pull/4143 I fixed an issue where active campaign lists were appearing with the default deleted list label. But unfortunately I introduced a new bug where these campaign segment criteria inputs don't render the expected value initially for autocomplete fields.

![Screenshot 2025-08-27 at 18 26 10](https://github.com/user-attachments/assets/fb663a39-2369-411d-9151-72515a429493)


### How to test the changes in this Pull Request:

1. As admin go to Audience > Campaigns > Segments and edit or create a new segment
2. In the Newsletter section of the segment editor, add a newsletter list to the `Not subscribed to newsletter lists` field and save
3. Reload the page 
4. On `trunk` the same input will render empty until you start typing something in it. On this branch it will load with the expected label

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->