### PR TITLE
feat(indesign-export): photo caption and credit

### DIFF
--- a/includes/optional-modules/indesign-export/class-indesign-converter.php
+++ b/includes/optional-modules/indesign-export/class-indesign-converter.php
@@ -84,7 +84,7 @@ class InDesign_Converter {
 		}
 
 		$content_parts[] = $this->process_post_content( $post->post_content, $options );
-		$content_parts[] = $this->process_featured_image_metadata( $post );
+		$content_parts[] = $this->process_post_images( $post );
 
 		return implode( "\r\n", array_filter( $content_parts ) );
 	}
@@ -393,72 +393,82 @@ class InDesign_Converter {
 	}
 
 	/**
-	 * Process the post featured image metadata to generate photo credit and caption tags.
+	 * Recursively get all the image blocks.
 	 *
-	 * @param \WP_Post $post Post object.
+	 * @param array $blocks Blocks to process.
 	 *
-	 * @return string Photo credit and caption tags.
+	 * @return array Image blocks.
 	 */
-	private function process_featured_image_metadata( $post ) {
-		$image_id = get_post_thumbnail_id( $post->ID );
-		if ( ! $image_id ) {
-			return '';
+	private function get_image_blocks( $blocks ) {
+		$block_names  = [ 'core/image', 'jetpack/slideshow', 'jetpack/tiled-gallery' ];
+		$image_blocks = [];
+		foreach ( $blocks as $block ) {
+			if ( in_array( $block['blockName'], $block_names, true ) ) {
+				$image_blocks[] = $block;
+			}
 		}
-		$caption = wp_get_attachment_caption( $image_id );
-		$credit  = get_post_meta( $image_id, '_media_credit', true ) ?? '';
-
-		if ( ! $caption && ! $credit ) {
-			return '';
+		if ( ! empty( $block['innerBlocks'] ) ) {
+			$image_blocks = array_merge( $image_blocks, $this->get_image_blocks( $block['innerBlocks'] ) );
 		}
-
-		$tag_content = "\r\n";
-		if ( $caption ) {
-			$tag_content .= '<pstyle:PhotoCaption>' . $caption . "\r\n";
-		}
-		if ( $credit ) {
-			$tag_content .= '<pstyle:PhotoCredit>' . $credit . "\r\n";
-		}
-		return $tag_content;
+		return $image_blocks;
 	}
 
 	/**
 	 * Process post images metadata to generate photo credit and caption tags.
 	 *
-	 * @param string $content Post content.
+	 * @param \WP_Post $post Post object.
 	 *
 	 * @return string Photo credit and caption tags.
 	 */
-	private function process_post_images_metadata( $content ) {
-		// Apply content filters so we get the full credit string.
-		$content = apply_filters( 'the_content', $content );
-
-		preg_match_all( '/<figcaption[^>]*>(.*?)<\/figcaption>/si', $content, $matches );
-		$figcaptions = $matches[1];
-
-		if ( empty( $figcaptions ) ) {
-			return '';
+	private function process_post_images( $post ) {
+		$images = [];
+		$featured_image_id = get_post_thumbnail_id( $post->ID );
+		if ( $featured_image_id ) {
+			$images[ $featured_image_id ] = true;
 		}
 
-		$tags = [];
-		foreach ( $figcaptions as $figcaption ) {
-			if ( preg_match( '/<span[^>]*class="image-credit"[^>]*>(.*)<\/span>(?!.*<\/span>)/si', $figcaption, $credit_match ) ) {
-				$credit_content = preg_replace( '/<span[^>]*class="credit-label-wrapper"[^>]*>.*?<\/span>/si', '', $credit_match[1] );
+		// Avoid processing images from Newspack Network Content Distribution.
+		if ( ! get_post_meta( $post->ID, 'newspack_network_post_id', true ) ) {
+			$blocks       = parse_blocks( $post->post_content );
+			$image_blocks = $this->get_image_blocks( $blocks );
 
-				$item['PhotoCredit']  = wp_strip_all_tags( $credit_content );
-				$item['PhotoCaption'] = wp_strip_all_tags( str_replace( $credit_match[0], '', $figcaption ) );
-			} else {
-				$item['PhotoCaption'] = wp_strip_all_tags( $figcaption );
+			foreach ( $image_blocks as $block ) {
+				if ( ! empty( $block['attrs']['id'] ) ) {
+					$images[ $block['attrs']['id'] ] = true;
+				}
+				if ( ! empty( $block['attrs']['ids'] ) && is_array( $block['attrs']['ids'] ) ) {
+					foreach ( $block['attrs']['ids'] as $id ) {
+						$images[ $id ] = true;
+					}
+				}
 			}
-			$tags[] = $item;
+		}
+
+		if ( empty( array_keys( $images ) ) ) {
+			return '';
 		}
 
 		$tag_content = "\r\n";
 
-		foreach ( $tags as $tag ) {
-			foreach ( $tag as $key => $value ) {
-				$tag_content .= '<pstyle:' . $key . '>' . $value . "\r\n";
+		foreach ( $images as $image_id => $insert_tag ) {
+			if ( ! $insert_tag ) {
+				continue;
 			}
+
+			$caption = wp_get_attachment_caption( $image_id );
+			$credit  = get_post_meta( $image_id, '_media_credit', true ) ?? '';
+
+			if ( ! $caption && ! $credit ) {
+				continue;
+			}
+
 			$tag_content .= "\r\n";
+			if ( $caption ) {
+				$tag_content .= '<pstyle:PhotoCaption>' . $caption . "\r\n";
+			}
+			if ( $credit ) {
+				$tag_content .= '<pstyle:PhotoCredit>' . $credit . "\r\n";
+			}
 		}
 
 		return $tag_content;

--- a/includes/optional-modules/indesign-export/class-indesign-converter.php
+++ b/includes/optional-modules/indesign-export/class-indesign-converter.php
@@ -422,9 +422,12 @@ class InDesign_Converter {
 	 */
 	private function process_post_images( $post ) {
 		$images = [];
+
 		$featured_image_id = get_post_thumbnail_id( $post->ID );
 		if ( $featured_image_id ) {
-			$images[ $featured_image_id ] = true;
+			if ( ! isset( $images[ $featured_image_id ] ) ) {
+				$images[ $featured_image_id ] = true;
+			}
 		}
 
 		// Avoid processing images from Newspack Network Content Distribution.
@@ -433,12 +436,15 @@ class InDesign_Converter {
 			$image_blocks = $this->get_image_blocks( $blocks );
 
 			foreach ( $image_blocks as $block ) {
-				if ( ! empty( $block['attrs']['id'] ) ) {
-					$images[ $block['attrs']['id'] ] = true;
+				$id = $block['attrs']['id'] ?? null;
+				if ( ! empty( $id ) && ! isset( $images[ $id ] ) ) {
+					$images[ $id ] = true;
 				}
 				if ( ! empty( $block['attrs']['ids'] ) && is_array( $block['attrs']['ids'] ) ) {
 					foreach ( $block['attrs']['ids'] as $id ) {
-						$images[ $id ] = true;
+						if ( ! isset( $images[ $id ] ) ) {
+							$images[ $id ] = true;
+						}
 					}
 				}
 			}

--- a/includes/optional-modules/indesign-export/class-indesign-converter.php
+++ b/includes/optional-modules/indesign-export/class-indesign-converter.php
@@ -406,9 +406,9 @@ class InDesign_Converter {
 			if ( in_array( $block['blockName'], $block_names, true ) ) {
 				$image_blocks[] = $block;
 			}
-		}
-		if ( ! empty( $block['innerBlocks'] ) ) {
-			$image_blocks = array_merge( $image_blocks, $this->get_image_blocks( $block['innerBlocks'] ) );
+			if ( ! empty( $block['innerBlocks'] ) ) {
+				$image_blocks = array_merge( $image_blocks, $this->get_image_blocks( $block['innerBlocks'] ) );
+			}
 		}
 		return $image_blocks;
 	}

--- a/includes/optional-modules/indesign-export/class-indesign-converter.php
+++ b/includes/optional-modules/indesign-export/class-indesign-converter.php
@@ -84,7 +84,7 @@ class InDesign_Converter {
 		}
 
 		$content_parts[] = $this->process_post_content( $post->post_content, $options );
-		$content_parts[] = $this->process_photo_metadata( $post->post_content );
+		$content_parts[] = $this->process_featured_image_metadata( $post );
 
 		return implode( "\r\n", array_filter( $content_parts ) );
 	}
@@ -393,13 +393,42 @@ class InDesign_Converter {
 	}
 
 	/**
-	 * Process photo metadata to generate photo credit and caption tags.
+	 * Process the post featured image metadata to generate photo credit and caption tags.
+	 *
+	 * @param \WP_Post $post Post object.
+	 *
+	 * @return string Photo credit and caption tags.
+	 */
+	private function process_featured_image_metadata( $post ) {
+		$image_id = get_post_thumbnail_id( $post->ID );
+		if ( ! $image_id ) {
+			return '';
+		}
+		$caption = wp_get_attachment_caption( $image_id );
+		$credit  = get_post_meta( $image_id, '_media_credit', true ) ?? '';
+
+		if ( ! $caption && ! $credit ) {
+			return '';
+		}
+
+		$tag_content = "\r\n";
+		if ( $caption ) {
+			$tag_content .= '<pstyle:PhotoCaption>' . $caption . "\r\n";
+		}
+		if ( $credit ) {
+			$tag_content .= '<pstyle:PhotoCredit>' . $credit . "\r\n";
+		}
+		return $tag_content;
+	}
+
+	/**
+	 * Process post images metadata to generate photo credit and caption tags.
 	 *
 	 * @param string $content Post content.
 	 *
 	 * @return string Photo credit and caption tags.
 	 */
-	private function process_photo_metadata( $content ) {
+	private function process_post_images_metadata( $content ) {
 		// Apply content filters so we get the full credit string.
 		$content = apply_filters( 'the_content', $content );
 

--- a/includes/optional-modules/indesign-export/class-indesign-converter.php
+++ b/includes/optional-modules/indesign-export/class-indesign-converter.php
@@ -83,8 +83,8 @@ class InDesign_Converter {
 			}
 		}
 
-		$post_content = $this->process_post_content( $post->post_content, $options );
-		$content_parts[] = $post_content;
+		$content_parts[] = $this->process_post_content( $post->post_content, $options );
+		$content_parts[] = $this->process_photo_metadata( $post->post_content );
 
 		return implode( "\r\n", array_filter( $content_parts ) );
 	}
@@ -390,6 +390,49 @@ class InDesign_Converter {
 		$content = trim( $content );
 
 		return $content;
+	}
+
+	/**
+	 * Process photo metadata to generate photo credit and caption tags.
+	 *
+	 * @param string $content Post content.
+	 *
+	 * @return string Photo credit and caption tags.
+	 */
+	private function process_photo_metadata( $content ) {
+		// Apply content filters so we get the full credit string.
+		$content = apply_filters( 'the_content', $content );
+
+		preg_match_all( '/<figcaption[^>]*>(.*?)<\/figcaption>/si', $content, $matches );
+		$figcaptions = $matches[1];
+
+		if ( empty( $figcaptions ) ) {
+			return '';
+		}
+
+		$tags = [];
+		foreach ( $figcaptions as $figcaption ) {
+			if ( preg_match( '/<span[^>]*class="image-credit"[^>]*>(.*)<\/span>(?!.*<\/span>)/si', $figcaption, $credit_match ) ) {
+				$credit_content = preg_replace( '/<span[^>]*class="credit-label-wrapper"[^>]*>.*?<\/span>/si', '', $credit_match[1] );
+
+				$item['PhotoCredit']  = wp_strip_all_tags( $credit_content );
+				$item['PhotoCaption'] = wp_strip_all_tags( str_replace( $credit_match[0], '', $figcaption ) );
+			} else {
+				$item['PhotoCaption'] = wp_strip_all_tags( $figcaption );
+			}
+			$tags[] = $item;
+		}
+
+		$tag_content = "\r\n";
+
+		foreach ( $tags as $tag ) {
+			foreach ( $tag as $key => $value ) {
+				$tag_content .= '<pstyle:' . $key . '>' . $value . "\r\n";
+			}
+			$tag_content .= "\r\n";
+		}
+
+		return $tag_content;
 	}
 
 	/**

--- a/includes/optional-modules/indesign-export/class-indesign-converter.php
+++ b/includes/optional-modules/indesign-export/class-indesign-converter.php
@@ -450,7 +450,7 @@ class InDesign_Converter {
 			}
 		}
 
-		if ( empty( array_keys( $images ) ) ) {
+		if ( empty( array_filter( $images ) ) ) {
 			return '';
 		}
 

--- a/tests/unit-tests/indesign-exporter/indesign-exporter.php
+++ b/tests/unit-tests/indesign-exporter/indesign-exporter.php
@@ -114,9 +114,6 @@ class Newspack_Test_InDesign_Exporter extends WP_UnitTestCase {
 		$this->assertStringNotContainsString( '<figure', $content );
 		$this->assertStringNotContainsString( '<figcaption', $content );
 		$this->assertStringNotContainsString( '<img', $content );
-
-		$this->assertStringContainsString( '<pstyle:PhotoCaption>My Caption', $content );
-		$this->assertStringContainsString( '<pstyle:PhotoCredit>My Credit', $content );
 	}
 
 	/**

--- a/tests/unit-tests/indesign-exporter/indesign-exporter.php
+++ b/tests/unit-tests/indesign-exporter/indesign-exporter.php
@@ -114,7 +114,6 @@ class Newspack_Test_InDesign_Exporter extends WP_UnitTestCase {
 		$this->assertStringNotContainsString( '<figure', $content );
 		$this->assertStringNotContainsString( '<figcaption', $content );
 		$this->assertStringNotContainsString( '<img', $content );
-		$this->assertStringNotContainsString( 'My Caption', $content );
 	}
 
 	/**

--- a/tests/unit-tests/indesign-exporter/indesign-exporter.php
+++ b/tests/unit-tests/indesign-exporter/indesign-exporter.php
@@ -117,6 +117,44 @@ class Newspack_Test_InDesign_Exporter extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test image processing.
+	 */
+	public function test_image_processing() {
+		$thumbnail_id = $this->factory->attachment->create();
+		wp_update_post(
+			[
+				'ID'           => $thumbnail_id,
+				'post_excerpt' => 'Featured Image Caption',
+			]
+		);
+		update_post_meta( $thumbnail_id, '_media_credit', 'Featured Image Credit' );
+
+		$image_id = $this->factory->attachment->create();
+		wp_update_post(
+			[
+				'ID'           => $image_id,
+				'post_excerpt' => 'Image Caption',
+			]
+		);
+		update_post_meta( $image_id, '_media_credit', 'Image Credit' );
+
+		$post_id = $this->factory->post->create(
+			[
+				'post_title'   => 'Test Post',
+				'post_content' => '<!-- wp:image {"id":' . $image_id . '} --><!-- /wp:image -->',
+			]
+		);
+		update_post_meta( $post_id, '_thumbnail_id', $thumbnail_id );
+
+		$converter = new InDesign_Converter();
+		$content = $converter->convert_post( $post_id );
+		$this->assertStringContainsString( '<pstyle:PhotoCaption>Featured Image Caption', $content );
+		$this->assertStringContainsString( '<pstyle:PhotoCredit>Featured Image Credit', $content );
+		$this->assertStringContainsString( '<pstyle:PhotoCaption>Image Caption', $content );
+		$this->assertStringContainsString( '<pstyle:PhotoCredit>Image Credit', $content );
+	}
+
+	/**
 	 * Test converting HTML entities.
 	 */
 	public function test_convert_html_entities() {

--- a/tests/unit-tests/indesign-exporter/indesign-exporter.php
+++ b/tests/unit-tests/indesign-exporter/indesign-exporter.php
@@ -105,7 +105,7 @@ class Newspack_Test_InDesign_Exporter extends WP_UnitTestCase {
 		$post_id = $this->factory->post->create(
 			[
 				'post_title'   => 'Test Post',
-				'post_content' => '<figure class="wp-block-image size-large"><img src="http://localhost/image.jpg" alt="" class="wp-image-1234"/><figcaption class="wp-element-caption">My Caption</figcaption></figure>',
+				'post_content' => '<figure class="wp-block-image size-large"><img src="http://localhost/image.jpg" alt="" class="wp-image-1234"/><figcaption class="wp-element-caption">My Caption <span class="image-credit"><span class="credit-label-wrapper">Credit:</span> <a href="http://localhost/credit">My Credit</a></span></figcaption></figure>',
 			]
 		);
 
@@ -114,6 +114,9 @@ class Newspack_Test_InDesign_Exporter extends WP_UnitTestCase {
 		$this->assertStringNotContainsString( '<figure', $content );
 		$this->assertStringNotContainsString( '<figcaption', $content );
 		$this->assertStringNotContainsString( '<img', $content );
+
+		$this->assertStringContainsString( '<pstyle:PhotoCaption>My Caption', $content );
+		$this->assertStringContainsString( '<pstyle:PhotoCredit>My Credit', $content );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

NPPD-853

Add photos caption and credit at the end of the exported file, e.g.:

```

<pstyle:PhotoCaption>Lorem ipsum dolor sit
<pstyle:PhotoCredit>John Doe

<pstyle:PhotoCaption>Another caption
<pstyle:PhotoCredit>Jane Smith
```

### How to test the changes in this Pull Request:

1. Draft a post without any images
2. Export the InDesign file and confirm it works and no photo caption or credit are added
3. Add a featured image and a few images to the post content, some with caption and credit, some with just caption or credit - make sure to use Image, Image Gallery, Jetpack Slideshow and Jetpack Tiled Gallery blocks
5. Export the file and confirm all images have their respective caption and credit with a line break between them

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->