### PR TITLE
fix(collections): update all category/year url params

### DIFF
--- a/includes/collections/class-template-helper.php
+++ b/includes/collections/class-template-helper.php
@@ -153,7 +153,7 @@ class Template_Helper {
 		$query->set( 'posts_per_page', $posts_per_page );
 
 		// Handle category filtering.
-		$category = isset( $_GET['category'] ) ? sanitize_text_field( $_GET['category'] ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$category = isset( $_GET['np_collections_category'] ) ? sanitize_text_field( $_GET['np_collections_category'] ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( ! empty( $category ) ) {
 			$tax_query = [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 				[
@@ -166,7 +166,7 @@ class Template_Helper {
 		}
 
 		// Handle year filtering.
-		$year = isset( $_GET['year'] ) ? sanitize_text_field( $_GET['year'] ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$year = isset( $_GET['np_collections_year'] ) ? sanitize_text_field( $_GET['np_collections_year'] ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( ! empty( $year ) ) {
 			$query->set(
 				'date_query',

--- a/tests/unit-tests/collections/class-test-template-helper.php
+++ b/tests/unit-tests/collections/class-test-template-helper.php
@@ -103,7 +103,7 @@ class Test_Template_Helper extends \WP_UnitTestCase {
 		global $wp_query;
 
 		// Test category filtering.
-		$_GET['category'] = 'test-category';
+		$_GET['np_collections_category'] = 'test-category';
 		Template_Helper::archive_filters( $wp_query );
 		$tax_query = $wp_query->get( 'tax_query' );
 		$this->assertIsArray( $tax_query, 'Tax query should be an array.' );
@@ -111,7 +111,7 @@ class Test_Template_Helper extends \WP_UnitTestCase {
 		$this->assertEquals( 'test-category', $tax_query[0]['terms'], 'Terms should match.' );
 
 		// Test year filtering.
-		$_GET['year'] = '2023';
+		$_GET['np_collections_year'] = '2023';
 		Template_Helper::archive_filters( $wp_query );
 		$date_query = $wp_query->get( 'date_query' );
 		$this->assertIsArray( $date_query, 'Date query should be an array.' );
@@ -122,7 +122,7 @@ class Test_Template_Helper extends \WP_UnitTestCase {
 		$this->assertGreaterThan( 0, $posts_per_page, 'Posts per page should be greater than 0.' );
 
 		// Clean up.
-		unset( $_GET['category'], $_GET['year'] );
+		unset( $_GET['np_collections_category'], $_GET['np_collections_year'] );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

In https://github.com/Automattic/newspack-plugin/pull/4153, I updated the filtering params for category and year to avoid conflicts with jetpack search (or other plugins that might use these common terms). But I missed a spot which looks to break filtering

### How to test the changes in this Pull Request:

1. Enable collections
2. Add some category filters
3. On the frontend, ensure filtering by category and by year works as expected

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->