### PR TITLE
fix: make sure settingsTabs exists before checking for setup wizard

### DIFF
--- a/src/wizards/newspack/views/settings/theme-and-brand/footer.tsx
+++ b/src/wizards/newspack/views/settings/theme-and-brand/footer.tsx
@@ -9,7 +9,7 @@ import { __ } from '@wordpress/i18n';
 import { ToggleControl } from '@wordpress/components';
 
 const settingsTabs = window.newspackSettings;
-const isMultibrandedEnabled = 'additional-brands' in settingsTabs;
+const isMultibrandedEnabled = settingsTabs && 'additional-brands' in settingsTabs;
 /**
  * Internal dependencies
  */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This hotfix fixes an issue where the Setup Wizard is failing because the settingsTab isn't available to check when the branding settings wants to check them.

### How to test the changes in this Pull Request:

1. On a fresh site, install the `release` version of Newspack and try to run the wizard. Note you get a blank screen on the Setup screen.
2. Apply this PR.
3. Repeat step 1; confirm you can run the setup.
4. Navigate to Newspack > Settings > Theme & Brands and confirm you have an option to set the Footer Logo. 
5. Install and activate the Multibranded Sites plugin.
6. Repeat step 4 and confirm the Footer Logo option is no longer visible (since this is something we block when that plugin is enabled). 

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->