### PR TITLE
test(collections): add unit tests for collections block

### DIFF
--- a/tests/unit-tests/collections/class-test-collection-meta.php
+++ b/tests/unit-tests/collections/class-test-collection-meta.php
@@ -196,4 +196,70 @@ class Test_Collection_Meta extends WP_UnitTestCase {
 		$this->assertEquals( [], Collection_Meta::sanitize_ctas( 123 ), 'Should return empty array for integer input' );
 		$this->assertEquals( [], Collection_Meta::sanitize_ctas( null ), 'Should return empty array for null input' );
 	}
+
+	/**
+	 * Test register_rest_fields method.
+	 *
+	 * @covers \Newspack\Collections\Collection_Meta::register_rest_fields
+	 */
+	public function test_register_rest_fields() {
+		// Initialize REST API.
+		Collection_Meta::register_rest_fields();
+
+		$post_type   = Post_Type::get_post_type();
+		$rest_fields = $GLOBALS['wp_rest_additional_fields'][ $post_type ] ?? [];
+
+		$this->assertArrayHasKey( 'ctas', $rest_fields, 'CTA field should be registered.' );
+		$this->assertEquals( [ Collection_Meta::class, 'get_collection_ctas_for_rest' ], $rest_fields['ctas']['get_callback'], 'Should have correct get callback.' );
+	}
+
+	/**
+	 * Test get_collection_ctas_for_rest method.
+	 *
+	 * @covers \Newspack\Collections\Collection_Meta::get_collection_ctas_for_rest
+	 */
+	public function test_get_collection_ctas_for_rest() {
+		$collection_id = $this->create_test_collection();
+
+		// Mock CTAs data.
+		$ctas_data = [
+			[
+				'type'  => 'link',
+				'label' => 'Subscribe',
+				'url'   => 'https://example.com/subscribe',
+			],
+			[
+				'type'  => 'link',
+				'label' => 'Order',
+				'url'   => 'https://example.com/order',
+			],
+		];
+
+		Collection_Meta::set( $collection_id, 'ctas', $ctas_data );
+
+		$post_data = [ 'id' => $collection_id ];
+		$result    = Collection_Meta::get_collection_ctas_for_rest( $post_data );
+
+		$this->assertIsArray( $result, 'Result should be an array.' );
+		$this->assertCount( 2, $result, 'Should return 2 CTAs.' );
+		$this->assertEquals( 'Subscribe', $result[0]['label'], 'First CTA should have correct label.' );
+		$this->assertEquals( 'https://example.com/subscribe', $result[0]['url'], 'First CTA should have correct URL.' );
+		$this->assertEquals( 'Order', $result[1]['label'], 'Second CTA should have correct label.' );
+		$this->assertEquals( 'https://example.com/order', $result[1]['url'], 'Second CTA should have correct URL.' );
+	}
+
+	/**
+	 * Test get_collection_ctas_for_rest with empty CTAs.
+	 *
+	 * @covers \Newspack\Collections\Collection_Meta::get_collection_ctas_for_rest
+	 */
+	public function test_get_collection_ctas_for_rest_empty() {
+		$collection_id = $this->create_test_collection();
+
+		$post_data = [ 'id' => $collection_id ];
+		$result    = Collection_Meta::get_collection_ctas_for_rest( $post_data );
+
+		$this->assertIsArray( $result, 'Result should be an array.' );
+		$this->assertEmpty( $result, 'Should return empty array when no CTAs.' );
+	}
 }

--- a/tests/unit-tests/collections/class-test-collections-block.php
+++ b/tests/unit-tests/collections/class-test-collections-block.php
@@ -1,0 +1,561 @@
+<?php
+/**
+ * Tests for the Collections_Block class.
+ *
+ * @package Newspack\Tests
+ * @covers \Newspack\Blocks\Collections\Collections_Block
+ */
+
+namespace Newspack\Tests\Unit\Collections;
+
+use Newspack\Blocks\Collections\Collections_Block;
+use Newspack\Collections\Post_Type;
+use Newspack\Collections\Collection_Meta;
+use Newspack\Collections\Collection_Category_Taxonomy;
+
+/**
+ * Tests for the Collections_Block class.
+ */
+class Test_Collections_Block extends \WP_UnitTestCase {
+	use Traits\Trait_Collections_Test;
+
+	/**
+	 * Set up the test environment.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		Post_Type::register_post_type();
+		Collection_Meta::register_meta();
+		Collection_Category_Taxonomy::register_taxonomy();
+
+		// Ensure the block is registered.
+		require_once NEWSPACK_ABSPATH . 'src/blocks/collections/index.php';
+		
+		if ( ! \WP_Block_Type_Registry::get_instance()->is_registered( Collections_Block::BLOCK_NAME ) ) {
+			Collections_Block::register_block();
+		}
+	}
+
+	/**
+	 * Tear down the test environment.
+	 */
+	public function tear_down() {
+		// Clean up registered blocks.
+		if ( \WP_Block_Type_Registry::get_instance()->is_registered( Collections_Block::BLOCK_NAME ) ) {
+			unregister_block_type( Collections_Block::BLOCK_NAME );
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Helper method to render block with proper WordPress context.
+	 *
+	 * @param array $attributes Block attributes.
+	 * @return string Rendered HTML.
+	 */
+	private function render_collections_block( $attributes = [] ) {
+		// Set block context for get_block_wrapper_attributes to work.
+		\WP_Block_Supports::$block_to_render = [
+			'blockName' => Collections_Block::BLOCK_NAME,
+			'attrs'     => $attributes,
+		];
+
+		$output = Collections_Block::render_block( $attributes );
+
+		// Clean up block context.
+		\WP_Block_Supports::$block_to_render = null;
+
+		return $output;
+	}
+
+	/**
+	 * Test block registration.
+	 *
+	 * @covers \Newspack\Blocks\Collections\Collections_Block::register_block
+	 */
+	public function test_register_block() {
+		$registered_blocks = \WP_Block_Type_Registry::get_instance()->get_all_registered();
+
+		$this->assertArrayHasKey( Collections_Block::BLOCK_NAME, $registered_blocks, 'Collections block should be registered' );
+		$this->assertInstanceOf( \WP_Block_Type::class, $registered_blocks[ Collections_Block::BLOCK_NAME ], 'Should be a WP_Block_Type instance' );
+		$this->assertEquals( [ Collections_Block::class, 'render_block' ], $registered_blocks[ Collections_Block::BLOCK_NAME ]->render_callback, 'Should have correct render callback' );
+	}
+
+	/**
+	 * Test render_block with no collections.
+	 *
+	 * @covers \Newspack\Blocks\Collections\Collections_Block::render_block
+	 */
+	public function test_render_block_no_collections() {
+		$output = $this->render_collections_block( [] );
+
+		$this->assertStringContainsString( 'wp-block-newspack-collections', $output, 'Should contain block wrapper class' );
+		$this->assertStringContainsString( 'No collections found.', $output, 'Should show no collections message' );
+	}
+
+	/**
+	 * Test render_block with collections.
+	 *
+	 * @covers \Newspack\Blocks\Collections\Collections_Block::render_block
+	 */
+	public function test_render_block_with_collections() {
+		$post_title = 'Test Collection';
+		$this->create_test_collection( [ 'post_title' => $post_title ] );
+
+		$attributes = [
+			'numberOfItems' => 1,
+		];
+
+		$output = $this->render_collections_block( $attributes );
+
+		$this->assertStringContainsString( 'wp-block-newspack-collections', $output, 'Should contain block wrapper class' );
+		$this->assertStringContainsString( $post_title, $output, 'Should contain collection title' );
+		$this->assertStringNotContainsString( 'No collections found.', $output, 'Should not show no collections message' );
+	}
+
+	/**
+	 * Test render_block with see all link.
+	 *
+	 * @covers \Newspack\Blocks\Collections\Collections_Block::render_block
+	 */
+	public function test_render_block_with_custom_see_all_link() {
+		$this->create_test_collection();
+
+		$attributes = [
+			'seeAllLinkText' => 'View All Collections',
+		];
+		$output     = $this->render_collections_block( $attributes );
+
+		$this->assertStringContainsString( 'wp-block-newspack-collections__see-all', $output, 'Should contain see all wrapper' );
+		$this->assertStringContainsString( 'View All Collections', $output, 'Should contain custom see all text' );
+	}
+
+	/**
+	 * Test render_block with default see all text.
+	 *
+	 * @covers \Newspack\Blocks\Collections\Collections_Block::render_block
+	 */
+	public function test_render_block_with_default_see_all_link() {
+		$this->create_test_collection();
+		$output = $this->render_collections_block();
+
+		$this->assertStringContainsString( 'See all', $output, 'Should contain default see all text' );
+	}
+
+	/**
+	 * Test get_block_classes method.
+	 *
+	 * @covers \Newspack\Blocks\Collections\Collections_Block::get_block_classes
+	 */
+	public function test_get_block_classes() {
+		// Test grid layout classes.
+		$attributes = [
+			'layout'         => 'grid',
+			'columns'        => 3,
+			'imageAlignment' => 'top',
+		];
+		$classes    = Collections_Block::get_block_classes( $attributes );
+
+		$this->assertStringContainsString( 'wp-block-newspack-collections', $classes, 'Should contain base class' );
+		$this->assertStringContainsString( 'layout-grid', $classes, 'Should contain layout class' );
+		$this->assertStringContainsString( 'columns-3', $classes, 'Should contain columns class' );
+		$this->assertStringContainsString( 'image-top', $classes, 'Should contain image alignment class' );
+
+		// Test list layout classes.
+		$attributes = [
+			'layout'         => 'list',
+			'imageAlignment' => 'left',
+			'imageSize'      => 'medium',
+		];
+		$classes    = Collections_Block::get_block_classes( $attributes );
+
+		$this->assertStringContainsString( 'layout-list', $classes, 'Should contain list layout class' );
+		$this->assertStringContainsString( 'image-left', $classes, 'Should contain image alignment class' );
+		$this->assertStringContainsString( 'image-size-medium', $classes, 'Should contain image size class for list' );
+	}
+
+	/**
+	 * Test get_image_size_from_attributes method.
+	 *
+	 * @covers \Newspack\Blocks\Collections\Collections_Block::get_image_size_from_attributes
+	 */
+	public function test_get_image_size_from_attributes() {
+		// Test small size.
+		$attributes = [ 'imageSize' => 'small' ];
+		$size       = Collections_Block::get_image_size_from_attributes( $attributes );
+		$this->assertEquals( 'medium', $size, 'Small should map to medium' );
+
+		// Test medium size.
+		$attributes = [ 'imageSize' => 'medium' ];
+		$size       = Collections_Block::get_image_size_from_attributes( $attributes );
+		$this->assertEquals( 'medium_large', $size, 'Medium should map to medium_large' );
+
+		// Test large size.
+		$attributes = [ 'imageSize' => 'large' ];
+		$size       = Collections_Block::get_image_size_from_attributes( $attributes );
+		$this->assertEquals( 'full', $size, 'Large should map to full' );
+
+		// Test default.
+		$attributes = [];
+		$size       = Collections_Block::get_image_size_from_attributes( $attributes );
+		$this->assertEquals( 'medium', $size, 'Default should be medium' );
+	}
+
+	/**
+	 * Test render_collection_categories with no categories.
+	 *
+	 * @covers \Newspack\Blocks\Collections\Collections_Block::render_collection_categories
+	 */
+	public function test_render_collection_categories_empty() {
+		$collection_id = $this->create_test_collection();
+		$collection    = get_post( $collection_id );
+
+		ob_start();
+		Collections_Block::render_collection_categories( $collection );
+		$output = ob_get_clean();
+
+		$this->assertEmpty( $output, 'Should produce no output when no categories' );
+	}
+
+	/**
+	 * Test render_collection_categories with categories.
+	 *
+	 * @covers \Newspack\Blocks\Collections\Collections_Block::render_collection_categories
+	 */
+	public function test_render_collection_categories_with_categories() {
+		$category_name = 'Test Category';
+		$this->set_current_user_role( 'administrator' );
+		$category_term = wp_insert_term( $category_name, Collection_Category_Taxonomy::get_taxonomy() );
+
+		$collection_id = $this->create_test_collection();
+		wp_set_object_terms( $collection_id, $category_term['term_id'], Collection_Category_Taxonomy::get_taxonomy() );
+
+		$collection = get_post( $collection_id );
+
+		ob_start();
+		Collections_Block::render_collection_categories( $collection );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'wp-block-newspack-collections__categories', $output, 'Should contain categories wrapper' );
+		$this->assertStringContainsString( 'wp-block-newspack-collections__category', $output, 'Should contain category link' );
+		$this->assertStringContainsString( $category_name, $output, 'Should contain category name' );
+	}
+
+	/**
+	 * Test render_collection_meta with all fields.
+	 *
+	 * @covers \Newspack\Blocks\Collections\Collections_Block::render_collection_meta
+	 */
+	public function test_render_collection_meta_all_fields() {
+		$period        = 'Spring 2024';
+		$volume        = '5';
+		$number        = '2';
+		$collection_id = $this->create_test_collection();
+
+		// Set meta fields.
+		Collection_Meta::set( $collection_id, 'period', $period );
+		Collection_Meta::set( $collection_id, 'volume', $volume );
+		Collection_Meta::set( $collection_id, 'number', $number );
+
+		$collection = get_post( $collection_id );
+		$attributes = [
+			'showPeriod' => true,
+			'showVolume' => true,
+			'showNumber' => true,
+			'layout'     => 'grid',
+		];
+
+		ob_start();
+		Collections_Block::render_collection_meta( $collection, $attributes );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'wp-block-newspack-collections__meta', $output, 'Should contain meta wrapper' );
+		$this->assertStringContainsString( $period, $output, 'Should contain period' );
+		$this->assertStringContainsString( 'Vol. ' . $volume, $output, 'Should contain volume' );
+		$this->assertStringContainsString( 'No. ' . $number, $output, 'Should contain number' );
+	}
+
+	/**
+	 * Test render_collection_meta with list layout (different separator).
+	 *
+	 * @covers \Newspack\Blocks\Collections\Collections_Block::render_collection_meta
+	 */
+	public function test_render_collection_meta_list_layout() {
+		$period        = 'Spring 2024';
+		$volume        = '5';
+		$collection_id = $this->create_test_collection();
+
+		Collection_Meta::set( $collection_id, 'period', $period );
+		Collection_Meta::set( $collection_id, 'volume', $volume );
+
+		$collection = get_post( $collection_id );
+		$attributes = [
+			'showPeriod' => true,
+			'showVolume' => true,
+			'showNumber' => false,
+			'layout'     => 'list',
+		];
+
+		ob_start();
+		Collections_Block::render_collection_meta( $collection, $attributes );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( $period . ' / Vol. ' . $volume, $output, 'Should use slash separator for list layout' );
+	}
+
+	/**
+	 * Test render_collection_ctas with no CTAs.
+	 *
+	 * @covers \Newspack\Blocks\Collections\Collections_Block::render_collection_ctas
+	 */
+	public function test_render_collection_ctas_empty() {
+		$collection_id = $this->create_test_collection();
+		$collection    = get_post( $collection_id );
+
+		$attributes = [
+			'showCTAs'            => true,
+			'numberOfCTAs'        => 1,
+			'showSubscriptionUrl' => true,
+			'showOrderUrl'        => true,
+		];
+
+		ob_start();
+		Collections_Block::render_collection_ctas( $collection, $attributes );
+		$output = ob_get_clean();
+
+		$this->assertEmpty( $output, 'Should produce no output when no CTAs' );
+	}
+
+	/**
+	 * Test render_collection_ctas with filtered CTAs.
+	 *
+	 * @covers \Newspack\Blocks\Collections\Collections_Block::render_collection_ctas
+	 */
+	public function test_render_collection_ctas_filtered() {
+		$collection_id = $this->create_test_collection();
+		$collection    = get_post( $collection_id );
+
+		// Mock CTAs data.
+		$ctas_data = [
+			[
+				'type'  => 'link',
+				'label' => 'Click Here',
+				'url'   => 'https://example.com/click-here',
+			],
+			[
+				'type'  => 'link',
+				'label' => 'Download',
+				'url'   => 'https://example.com/download',
+			],
+		];
+
+		Collection_Meta::set( $collection_id, 'ctas', $ctas_data );
+
+		// Test filtering out subscription URLs.
+		$attributes = [
+			'showCTAs'     => true,
+			'numberOfCTAs' => 3,
+		];
+
+		ob_start();
+		Collections_Block::render_collection_ctas( $collection, $attributes );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'wp-block-newspack-collections__ctas', $output, 'Should contain CTAs wrapper' );
+		$this->assertStringContainsString( 'Click Here', $output, 'Should contain Click Here CTA' );
+		$this->assertStringContainsString( 'Download', $output, 'Should contain Download CTA' );
+	}
+
+	/**
+	 * Test render_collection_ctas with specific CTAs filter.
+	 *
+	 * @covers \Newspack\Blocks\Collections\Collections_Block::render_collection_ctas
+	 */
+	public function test_render_collection_ctas_specific_filter() {
+		$collection_id = $this->create_test_collection();
+		$collection    = get_post( $collection_id );
+
+		// Mock CTAs data.
+		$ctas_data = [
+			[
+				'type'  => 'link',
+				'label' => 'Link 1',
+				'url'   => 'https://example.com/link',
+			],
+			[
+				'type'  => 'link',
+				'label' => 'Another Link',
+				'url'   => 'https://example.com/another-link',
+			],
+			[
+				'type'  => 'link',
+				'label' => 'Download',
+				'url'   => 'https://example.com/download',
+			],
+		];
+
+		Collection_Meta::set( $collection_id, 'ctas', $ctas_data );
+
+		// Test specific CTAs filter.
+		$attributes = [
+			'showCTAs'            => true,
+			'numberOfCTAs'        => 3,
+			'showSubscriptionUrl' => true,
+			'showOrderUrl'        => true,
+			'specificCTAs'        => 'Download,Another Link',
+		];
+
+		ob_start();
+		Collections_Block::render_collection_ctas( $collection, $attributes );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'Download', $output, 'Should contain Download CTA' );
+		$this->assertStringContainsString( 'Another Link', $output, 'Should contain Another Link CTA' );
+		$this->assertStringNotContainsString( 'Link 1', $output, 'Should not contain non-specified Link 1 CTA' );
+	}
+
+	/**
+	 * Test render_collection_ctas with CTA limit.
+	 *
+	 * @covers \Newspack\Blocks\Collections\Collections_Block::render_collection_ctas
+	 */
+	public function test_render_collection_ctas_with_limit() {
+		$collection_id = $this->create_test_collection();
+		$collection    = get_post( $collection_id );
+
+		// Mock CTAs data.
+		$ctas_data = [
+			[
+				'type'  => 'link',
+				'label' => 'Link 1',
+				'url'   => 'https://example.com/link-1',
+			],
+			[
+				'type'  => 'link',
+				'label' => 'Link 2',
+				'url'   => 'https://example.com/link-2',
+			],
+		];
+
+		Collection_Meta::set( $collection_id, 'ctas', $ctas_data );
+
+		// Test limit to 1 CTA.
+		$attributes = [
+			'showCTAs'            => true,
+			'numberOfCTAs'        => 1,
+			'showSubscriptionUrl' => true,
+			'showOrderUrl'        => true,
+		];
+
+		ob_start();
+		Collections_Block::render_collection_ctas( $collection, $attributes );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'Link 1', $output, 'Should contain first CTA' );
+		$this->assertStringNotContainsString( 'Link 2', $output, 'Should not contain second CTA due to limit' );
+	}
+
+	/**
+	 * Test attribute sanitization.
+	 *
+	 * @covers \Newspack\Blocks\Collections\Collections_Block::render_block
+	 */
+	public function test_attribute_sanitization() {
+		$post_title    = 'Test Collection';
+		$collection_id = $this->create_test_collection( [ 'post_title' => $post_title ] );
+
+		// Test with negative and invalid values.
+		$attributes = [
+			'numberOfItems'       => -5,
+			'columns'             => 0,
+			'numberOfCTAs'        => -1,
+			'selectedCollections' => [ 'invalid', '123', $collection_id ],
+		];
+
+		$output = $this->render_collections_block( $attributes );
+
+		// Should still render successfully due to sanitization.
+		$this->assertStringContainsString( 'wp-block-newspack-collections', $output, 'Should contain block wrapper despite invalid attributes' );
+		$this->assertStringContainsString( $post_title, $output, 'Should contain collection title' );
+	}
+
+	/**
+	 * Test newspack_collections_block_wrapper_classes filter.
+	 *
+	 * @covers \Newspack\Blocks\Collections\Collections_Block::render_block
+	 */
+	public function test_wrapper_classes_filter() {
+		$this->create_test_collection();
+
+		// Add filter to modify wrapper classes.
+		add_filter(
+			'newspack_collections_block_wrapper_classes',
+			function ( $classes ) {
+				return $classes . ' custom-wrapper-class';
+			},
+			10,
+			2
+		);
+		$output = $this->render_collections_block();
+
+		$this->assertStringContainsString( 'custom-wrapper-class', $output, 'Should contain custom wrapper class from filter' );
+
+		// Clean up.
+		remove_all_filters( 'newspack_collections_block_wrapper_classes' );
+	}
+
+	/**
+	 * Test newspack_collections_block_ctas filter.
+	 *
+	 * @covers \Newspack\Blocks\Collections\Collections_Block::render_collection_ctas
+	 */
+	public function test_ctas_filter() {
+		$collection_id = $this->create_test_collection();
+		$collection    = get_post( $collection_id );
+
+		// Mock CTAs data.
+		$ctas_data = [
+			[
+				'type'  => 'link',
+				'label' => 'Subscribe',
+				'url'   => 'https://example.com/subscribe',
+			],
+		];
+
+		Collection_Meta::set( $collection_id, 'ctas', $ctas_data );
+
+		// Add filter to modify CTAs.
+		add_filter(
+			'newspack_collections_block_ctas',
+			function ( $filtered_ctas ) {
+				// Add a custom CTA.
+				$filtered_ctas[] = [
+					'label' => 'Custom CTA',
+					'url'   => 'https://example.com/custom',
+				];
+				return $filtered_ctas;
+			},
+			10,
+			4
+		);
+
+		$attributes = [
+			'showCTAs'            => true,
+			'numberOfCTAs'        => 2,
+			'showSubscriptionUrl' => true,
+			'showOrderUrl'        => true,
+		];
+
+		ob_start();
+		Collections_Block::render_collection_ctas( $collection, $attributes );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'Subscribe', $output, 'Should contain original CTA' );
+		$this->assertStringContainsString( 'Custom CTA', $output, 'Should contain custom CTA from filter' );
+
+		// Clean up.
+		remove_all_filters( 'newspack_collections_block_ctas' );
+	}
+}

--- a/tests/unit-tests/collections/class-test-collections-block.php
+++ b/tests/unit-tests/collections/class-test-collections-block.php
@@ -31,7 +31,7 @@ class Test_Collections_Block extends \WP_UnitTestCase {
 
 		// Ensure the block is registered.
 		require_once NEWSPACK_ABSPATH . 'src/blocks/collections/index.php';
-		
+
 		if ( ! \WP_Block_Type_Registry::get_instance()->is_registered( Collections_Block::BLOCK_NAME ) ) {
 			Collections_Block::register_block();
 		}
@@ -329,34 +329,34 @@ class Test_Collections_Block extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test render_collection_ctas with filtered CTAs.
+	 * Test render_collection_ctas with subscription and order CTAs toggles.
 	 *
 	 * @covers \Newspack\Blocks\Collections\Collections_Block::render_collection_ctas
 	 */
-	public function test_render_collection_ctas_filtered() {
+	public function test_subscription_and_order_cta_toggles() {
 		$collection_id = $this->create_test_collection();
 		$collection    = get_post( $collection_id );
 
-		// Mock CTAs data.
+		// Add hierarchical CTAs.
+		Collection_Meta::set( $collection_id, 'subscribe_link', 'https://example.com/subscribe' );
+		Collection_Meta::set( $collection_id, 'order_link', 'https://example.com/order' );
+
+		// Additional CTA data.
 		$ctas_data = [
-			[
-				'type'  => 'link',
-				'label' => 'Click Here',
-				'url'   => 'https://example.com/click-here',
-			],
 			[
 				'type'  => 'link',
 				'label' => 'Download',
 				'url'   => 'https://example.com/download',
 			],
 		];
-
 		Collection_Meta::set( $collection_id, 'ctas', $ctas_data );
 
-		// Test filtering out subscription URLs.
+		// Test with both subscription and order URLs enabled.
 		$attributes = [
-			'showCTAs'     => true,
-			'numberOfCTAs' => 3,
+			'showCTAs'            => true,
+			'numberOfCTAs'        => 4,
+			'showSubscriptionUrl' => true,
+			'showOrderUrl'        => true,
 		];
 
 		ob_start();
@@ -364,7 +364,30 @@ class Test_Collections_Block extends \WP_UnitTestCase {
 		$output = ob_get_clean();
 
 		$this->assertStringContainsString( 'wp-block-newspack-collections__ctas', $output, 'Should contain CTAs wrapper' );
-		$this->assertStringContainsString( 'Click Here', $output, 'Should contain Click Here CTA' );
+		$this->assertStringContainsString( 'Subscribe', $output, 'Should contain Subscribe CTA' );
+		$this->assertStringContainsString( 'Order', $output, 'Should contain Order CTA' );
+		$this->assertStringContainsString( 'Download', $output, 'Should contain Download CTA' );
+
+		// Test with subscription URL disabled but order URL enabled.
+		$attributes['showSubscriptionUrl'] = false;
+
+		ob_start();
+		Collections_Block::render_collection_ctas( $collection, $attributes );
+		$output = ob_get_clean();
+
+		$this->assertStringNotContainsString( 'Subscribe', $output, 'Should not contain Subscribe CTA' );
+		$this->assertStringContainsString( 'Order', $output, 'Should contain Order CTA' );
+		$this->assertStringContainsString( 'Download', $output, 'Should contain Download CTA' );
+
+		// Test with both subscription and order URLs disabled.
+		$attributes['showOrderUrl'] = false;
+
+		ob_start();
+		Collections_Block::render_collection_ctas( $collection, $attributes );
+		$output = ob_get_clean();
+
+		$this->assertStringNotContainsString( 'Subscribe', $output, 'Should not contain Subscribe CTA' );
+		$this->assertStringNotContainsString( 'Order', $output, 'Should not contain Order CTA' );
 		$this->assertStringContainsString( 'Download', $output, 'Should contain Download CTA' );
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds unit tests for the new Collections block and other classes changed.

Closes NPPD-797.

### How to test the changes in this Pull Request:

1. Run the tests via `n test-php`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?