### PR TITLE
feat(collections): add logic for opening links in new tabs

### DIFF
--- a/includes/collections/README.md
+++ b/includes/collections/README.md
@@ -92,7 +92,7 @@ The following table details all available meta fields for collections:
 | `newspack_collection_period` | String | Collection period | Text (e.g., "Spring 2025") |
 | `newspack_collection_subscribe_link` | String | Override global/category subscription link for this specific collection | Valid URL |
 | `newspack_collection_order_link` | String | Override global/category order link for this specific collection | Valid URL |
-| `newspack_collection_ctas` | Array | An array of CTAs (Call-to-Action buttons) | Array of objects with `label`, `type`, `id` and `url` properties |
+| `newspack_collection_ctas` | Array | An array of CTAs (Call-to-Action buttons) | Array of objects with `type` (`attachment` or `link`), `label` and `url` properties |
 | `newspack_collection_cover_story_img_visibility` | String | Override global setting for cover story image visibility | "inherit", "show", or "hide" |
 
 Sample `newspack_collection_ctas` post meta structure:

--- a/includes/collections/class-query-helper.php
+++ b/includes/collections/class-query-helper.php
@@ -168,15 +168,16 @@ class Query_Helper {
 					function ( $cta ) {
 						$label = $cta['label'] ?? '';
 						$url   = '';
+						$type  = $cta['type'] ?? '';
 						$class = $cta['class'] ?? '';
 
-						if ( 'attachment' === ( $cta['type'] ?? '' ) && ! empty( $cta['id'] ) ) {
+						if ( 'attachment' === $type && ! empty( $cta['id'] ) ) {
 							$url = wp_get_attachment_url( $cta['id'] );
 						} elseif ( ! empty( $cta['url'] ) ) {
 							$url = $cta['url'];
 						}
 
-						return ( $label && $url ) ? compact( 'url', 'label', 'class' ) : null;
+						return ( $label && $url ) ? compact( 'url', 'label', 'class', 'type' ) : null;
 					},
 					$ctas
 				)


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds some logic to make CTA links automatically open external links, attachments, and file downloads in new tabs while keeping internal navigation in the same tab.

**Links that will open in a new tab:**
- All attachment type CTAs (type: `attachment`)
- External links (different domain from current site)
- PDF files and other document formats (configurable via filter)

**Links that will keep loading in the current tab:**
- Internal links (same domain)
- Relative URLs
- Non-HTTP(S) schemes (mailto, tel, etc.)

The logic includes three filters for customization:
- `newspack_collections_new_tab_file_extensions`: For adding custom file extensions
- `newspack_collections_new_tab_internal_hosts`: For adding custom hosts that would be considered internal
- `newspack_collections_should_cta_open_in_new_tab`: For complete behavior override

Links that open in new tabs include `rel="noopener noreferrer"` for security.

Closes NPPD-871.

### How to test the changes in this Pull Request:

1. Create a Collection with mixed CTA types: Add CTAs with external URLs (e.g., `https://example.com`), internal links (e.g., /about), attachments, links with a PDF extension and relative URLs to test the different behaviors.
2. Verify that the new tab behavior matches the expected behavior from the PR details above.
3. Verify the new filters work as expected and allow you to override the existing behavior.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?