### PR TITLE
fix: register with empty name fields

### DIFF
--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -2255,7 +2255,7 @@ final class Reader_Activation {
 				]
 			);
 
-			// Temporarily remove our canonize_user_data callback from the woocommercer hook.
+			// Unhook from WooCommerce as it's already been canonized above.
 			remove_filter( 'woocommerce_new_customer_data', [ __CLASS__, 'canonize_user_data' ], 10, 1 );
 			if ( function_exists( '\wc_create_new_customer' ) ) {
 				/**

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -2255,6 +2255,8 @@ final class Reader_Activation {
 				]
 			);
 
+			// Temporarily remove our canonize_user_data callback from the woocommercer hook.
+			remove_filter( 'woocommerce_new_customer_data', [ __CLASS__, 'canonize_user_data' ], 10, 1 );
 			if ( function_exists( '\wc_create_new_customer' ) ) {
 				/**
 				 * Create WooCommerce Customer if possible.
@@ -2265,6 +2267,7 @@ final class Reader_Activation {
 				$user_id = \wp_insert_user( $user_data );
 				\wp_new_user_notification( $user_id, null, 'user' );
 			}
+			add_filter( 'woocommerce_new_customer_data', [ __CLASS__, 'canonize_user_data' ], 10, 1 );
 
 			if ( \is_wp_error( $user_id ) ) {
 				Logger::error( 'User registration failed: ' . $user_id->get_error_message() );


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://linear.app/a8c/issue/NPPM-2198/name-fields-of-checkout-modal-not-saving-in-wp-account

This PR fixes an issue where we were incorrectly setting a readers first name to the default nicename generated from the readers email on registration. As a result, Woo would not update the first name during checkout since Woo skips this step in favor of any name data that is already set.

![Screenshot 2025-09-09 at 13 57 32](https://github.com/user-attachments/assets/bae01a6b-c035-4b5b-8f74-8512638ebddf)

![Screenshot 2025-09-09 at 13 57 17](https://github.com/user-attachments/assets/127198c5-99d1-41ad-85db-42768000911e)

### How to test the changes in this Pull Request:

1. Register as a new reader on the site (with Audience Management active and onboarded)
2. As admin, verify the new reader has an empty first and last name set via the User edit page in WP Admin
3. Again as the reader, go through modal checkout for any product or donation
4. Again as admin, verify the new reader name fields have been populated with the name fields entered during checkout

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->