### PR TITLE
feat(content-gate): add countdown block

### DIFF
--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -70,7 +70,7 @@ final class Blocks {
 			$script_data['content_gate_data'] = [
 				'anonymous_metered_views' => Metering::get_total_metered_views( false ),
 				'loggedin_metered_views'  => Metering::get_total_metered_views( true ),
-				'remaining_metered_views' => Metering::get_remaining_metered_views(),
+				'metered_views'           => Metering::get_metered_views(),
 				'metering_period'         => Metering::get_metering_period(),
 			];
 		}

--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -7,11 +7,11 @@
 
 namespace Newspack;
 
-use Newspack\Memberships;
-
 defined( 'ABSPATH' ) || exit;
 
 use Newspack\Optional_Modules\Collections;
+use Newspack\Memberships;
+use Newspack\Memberships\Metering;
 
 /**
  * Newspack Blocks Class.
@@ -52,23 +52,32 @@ final class Blocks {
 			NEWSPACK_PLUGIN_VERSION,
 			true
 		);
+		$script_data = [
+			'has_newsletters'         => class_exists( 'Newspack_Newsletters_Subscription' ),
+			'has_reader_activation'   => Reader_Activation::is_enabled(),
+			'newsletters_url'         => Wizards::get_wizard( 'newsletters' )->newsletters_settings_url(),
+			'has_google_oauth'        => Google_OAuth::is_oauth_configured(),
+			'google_logo_svg'         => \Newspack\Newspack_UI_Icons::get_svg( 'google' ),
+			'reader_activation_terms' => Reader_Activation::get_setting( 'terms_text' ),
+			'reader_activation_url'   => Reader_Activation::get_setting( 'terms_url' ),
+			'has_recaptcha'           => Recaptcha::can_use_captcha(),
+			'recaptcha_url'           => admin_url( 'admin.php?page=newspack-settings' ),
+			'corrections_enabled'     => wp_is_block_theme() && class_exists( 'Newspack\Corrections' ),
+			'collections_enabled'     => Collections::is_module_active(),
+			'has_content_gate'        => Memberships::has_gate(),
+		];
+		if ( Memberships::is_active() ) {
+			$script_data['content_gate_data'] = [
+				'anonymous_metered_views' => Metering::get_total_metered_views( false ),
+				'loggedin_metered_views'  => Metering::get_total_metered_views( true ),
+				'remaining_metered_views' => Metering::get_remaining_metered_views(),
+				'metering_period'         => Metering::get_metering_period(),
+			];
+		}
 		\wp_localize_script(
 			'newspack-blocks',
 			'newspack_blocks',
-			[
-				'has_newsletters'         => class_exists( 'Newspack_Newsletters_Subscription' ),
-				'has_reader_activation'   => Reader_Activation::is_enabled(),
-				'newsletters_url'         => Wizards::get_wizard( 'newsletters' )->newsletters_settings_url(),
-				'has_google_oauth'        => Google_OAuth::is_oauth_configured(),
-				'google_logo_svg'         => \Newspack\Newspack_UI_Icons::get_svg( 'google' ),
-				'reader_activation_terms' => Reader_Activation::get_setting( 'terms_text' ),
-				'reader_activation_url'   => Reader_Activation::get_setting( 'terms_url' ),
-				'has_recaptcha'           => Recaptcha::can_use_captcha(),
-				'recaptcha_url'           => admin_url( 'admin.php?page=newspack-settings' ),
-				'corrections_enabled'     => wp_is_block_theme() && class_exists( 'Newspack\Corrections' ),
-				'collections_enabled'     => Collections::is_module_active(),
-				'has_content_gate'        => Memberships::is_active() && Memberships::has_gate(),
-			]
+			$script_data
 		);
 		\wp_enqueue_style(
 			'newspack-blocks',

--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -7,6 +7,8 @@
 
 namespace Newspack;
 
+use Newspack\Memberships;
+
 defined( 'ABSPATH' ) || exit;
 
 use Newspack\Optional_Modules\Collections;
@@ -20,6 +22,7 @@ final class Blocks {
 	 */
 	public static function init() {
 		require_once NEWSPACK_ABSPATH . 'src/blocks/reader-registration/index.php';
+		require_once NEWSPACK_ABSPATH . 'src/blocks/content-gate-countdown/class-content-gate-countdown-block.php';
 
 		if ( wp_is_block_theme() && class_exists( 'Newspack\Corrections' ) ) {
 			require_once NEWSPACK_ABSPATH . 'src/blocks/correction-box/class-correction-box-block.php';

--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -67,6 +67,7 @@ final class Blocks {
 				'recaptcha_url'           => admin_url( 'admin.php?page=newspack-settings' ),
 				'corrections_enabled'     => wp_is_block_theme() && class_exists( 'Newspack\Corrections' ),
 				'collections_enabled'     => Collections::is_module_active(),
+				'has_content_gate'        => Memberships::is_active() && Memberships::has_gate(),
 			]
 		);
 		\wp_enqueue_style(

--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -64,9 +64,9 @@ final class Blocks {
 			'recaptcha_url'           => admin_url( 'admin.php?page=newspack-settings' ),
 			'corrections_enabled'     => wp_is_block_theme() && class_exists( 'Newspack\Corrections' ),
 			'collections_enabled'     => Collections::is_module_active(),
-			'has_content_gate'        => Memberships::has_gate(),
+			'has_memberships'         => Memberships::is_active(),
 		];
-		if ( Memberships::is_active() ) {
+		if ( $script_data['has_memberships'] ) {
 			$script_data['content_gate_data'] = [
 				'anonymous_metered_views' => Metering::get_total_metered_views( false ),
 				'loggedin_metered_views'  => Metering::get_total_metered_views( true ),

--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -691,7 +691,7 @@ class Memberships {
 			/**
 			 * Filter the list of blocks to exclude from the excerpt.
 			 *
-			 * @param array $excluded_blocks Array of block names to exclude. i.e. [ 'core/image', 'newspack/content-gate-countdown' ].
+			 * @param array $excluded_blocks Array of blocks to exclude. i.e. [ 'core/image', 'newspack/content-gate-countdown' ].
 			 *
 			 * @return array
 			 */

--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -686,6 +686,29 @@ class Memberships {
 			$content = explode( '<!--more-->', $content )[0];
 		} else {
 			$count = (int) get_post_meta( $gate_post_id, 'visible_paragraphs', true );
+			// Remove all spaces.
+			$content = preg_replace( '/\s+/', ' ', $content );
+			/**
+			 * Filter the list of blocks to exclude from the excerpt.
+			 *
+			 * @param array $excluded_blocks Array of block names to exclude. i.e. [ 'core/image', 'newspack/content-gate-countdown' ].
+			 *
+			 * @return array
+			 */
+			$excluded_blocks = apply_filters( 'newspack_memberships_excerpt_excluded_blocks', [ 'newspack/content-gate-countdown' ] );
+			// Remove unwanted blocks from the content.
+			foreach ( $excluded_blocks as $block ) {
+				[ $category, $name ] = explode( '/', $block );
+				if ( ! $category || ! $name ) {
+					continue;
+				}
+				if ( 'core' === $category ) {
+					$regex = $name;
+				} else {
+					$regex = "$category\/$name";
+				}
+				$content = preg_replace( "/<!-- wp:$regex {?.*?}? -->.*?<!-- \/wp:$regex -->/s", '', $content );
+			}
 			// Split into paragraphs.
 			$content = explode( '</p>', $content );
 			// Extract the first $x paragraphs only.

--- a/includes/plugins/wc-memberships/class-metering.php
+++ b/includes/plugins/wc-memberships/class-metering.php
@@ -300,6 +300,21 @@ class Metering {
 	}
 
 	/**
+	 * Get the metering period for a post.
+	 *
+	 * @param int|null $post_id Post ID. Default is current post.
+	 *
+	 * @return string Metered period (day, week, month).
+	 */
+	public static function get_metering_period( $post_id = null ) {
+		if ( ! $post_id ) {
+			$post_id = get_the_ID();
+		}
+		$gate_post_id = Memberships::get_gate_post_id( $post_id );
+		return \get_post_meta( $gate_post_id, 'metering_period', true );
+	}
+
+	/**
 	 * Get number of remaining metered views for the user.
 	 *
 	 * @param int|null $user_id User ID. Default is current user.
@@ -326,6 +341,24 @@ class Metering {
 		}
 		$used_views = count( $user_metering_data['content'] );
 		return max( 0, $count - $used_views );
+	}
+
+	/**
+	 * Get total number of metered views for post.
+	 *
+	 * @param int|null $post_id Post ID. Default is current post.
+	 *
+	 * @return int|boolean Total number of metered views if metering is enabled, otherwise false.
+	 */
+	public static function get_total_metered_views( $post_id = null ) {
+		if ( ! $post_id ) {
+			$post_id = get_the_ID();
+		}
+		$gate_post_id = Memberships::get_gate_post_id( $post_id );
+		if ( ! $gate_post_id ) {
+			return false;
+		}
+		return (int) \get_post_meta( $gate_post_id, 'metering_registered_count', true );
 	}
 }
 Metering::init();

--- a/includes/plugins/wc-memberships/class-metering.php
+++ b/includes/plugins/wc-memberships/class-metering.php
@@ -298,5 +298,34 @@ class Metering {
 		self::$article_view = $activity;
 		return $activity;
 	}
+
+	/**
+	 * Get number of remaining metered views for the user.
+	 *
+	 * @param int|null $user_id User ID. Default is current user.
+	 *
+	 * @return int Number of remaining metered views.
+	 */
+	public static function get_remaining_metered_views( $user_id = null ) {
+		if ( ! $user_id ) {
+			$user_id = get_current_user_id();
+		}
+		// For anonymous users, return the anonymous count.
+		if ( ! $user_id ) {
+			$gate_post_id = Memberships::get_gate_post_id();
+			return (int) \get_post_meta( $gate_post_id, 'metering_anonymous_count', true );
+		}
+
+		// For logged-in users, calculate the remaining views based on their metering data.
+		$gate_post_id       = Memberships::get_gate_post_id();
+		$count              = (int) \get_post_meta( $gate_post_id, 'metering_registered_count', true );
+		$user_meta_key      = self::METERING_META_KEY . '_' . $gate_post_id;
+		$user_metering_data = \get_user_meta( $user_id, $user_meta_key, true );
+		if ( ! is_array( $user_metering_data ) || ! isset( $user_metering_data['content'] ) ) {
+			return $count;
+		}
+		$used_views = count( $user_metering_data['content'] );
+		return max( 0, $count - $used_views );
+	}
 }
 Metering::init();

--- a/includes/plugins/wc-memberships/class-metering.php
+++ b/includes/plugins/wc-memberships/class-metering.php
@@ -315,13 +315,13 @@ class Metering {
 	}
 
 	/**
-	 * Get number of remaining metered views for the user.
+	 * Get number of metered views for the user.
 	 *
 	 * @param int|null $user_id User ID. Default is current user.
 	 *
-	 * @return int Number of remaining metered views.
+	 * @return int Number of metered views.
 	 */
-	public static function get_remaining_metered_views( $user_id = null ) {
+	public static function get_metered_views( $user_id = null ) {
 		if ( ! $user_id ) {
 			$user_id = get_current_user_id();
 		}
@@ -333,14 +333,12 @@ class Metering {
 
 		// For logged-in users, calculate the remaining views based on their metering data.
 		$gate_post_id       = Memberships::get_gate_post_id();
-		$count              = (int) \get_post_meta( $gate_post_id, 'metering_registered_count', true );
 		$user_meta_key      = self::METERING_META_KEY . '_' . $gate_post_id;
 		$user_metering_data = \get_user_meta( $user_id, $user_meta_key, true );
 		if ( ! is_array( $user_metering_data ) || ! isset( $user_metering_data['content'] ) ) {
 			return $count;
 		}
-		$used_views = count( $user_metering_data['content'] );
-		return max( 0, $count - $used_views );
+		return count( $user_metering_data['content'] );
 	}
 
 	/**

--- a/includes/plugins/wc-memberships/class-metering.php
+++ b/includes/plugins/wc-memberships/class-metering.php
@@ -344,19 +344,19 @@ class Metering {
 	}
 
 	/**
-	 * Get total number of metered views for post.
+	 * Get total number of metered views for current post.
 	 *
-	 * @param int|null $post_id Post ID. Default is current post.
+	 * @param boolean $is_logged_in Whether to check for logged-in or anonymous users. Default is false (anonymous).
 	 *
 	 * @return int|boolean Total number of metered views if metering is enabled, otherwise false.
 	 */
-	public static function get_total_metered_views( $post_id = null ) {
-		if ( ! $post_id ) {
-			$post_id = get_the_ID();
-		}
-		$gate_post_id = Memberships::get_gate_post_id( $post_id );
+	public static function get_total_metered_views( $is_logged_in = false ) {
+		$gate_post_id = Memberships::get_gate_post_id( get_the_ID() );
 		if ( ! $gate_post_id ) {
 			return false;
+		}
+		if ( ! $is_logged_in ) {
+			return (int) \get_post_meta( $gate_post_id, 'metering_anonymous_count', true );
 		}
 		return (int) \get_post_meta( $gate_post_id, 'metering_registered_count', true );
 	}

--- a/packages/icons/index.js
+++ b/packages/icons/index.js
@@ -33,3 +33,4 @@ export { default as searchEmpty } from './src/search-empty';
 export { default as tabItem } from './src/tab-item';
 export { default as tabs } from './src/tabs';
 export { default as theme } from './src/theme';
+export { default as countdown } from './src/content-gate-countdown';

--- a/packages/icons/src/content-gate-countdown.js
+++ b/packages/icons/src/content-gate-countdown.js
@@ -1,0 +1,13 @@
+/**
+ * WordPress dependencies
+ */
+import { SVG, Path } from '@wordpress/primitives';
+
+const countdown = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+		<Path d="M19 6.5H5a.5.5 0 0 0-.5.5v10a.5.5 0 0 0 .5.5h14a.5.5 0 0 0 .5-.5V7a.5.5 0 0 0-.5-.5ZM5 5h14a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2Z" />
+		<Path d="M13.202 15V9.4h1.008l2.392 3.616V9.4h1.024V15h-.84l-2.56-3.84V15h-1.024ZM9.147 15.68 11.29 9.4h1l-2.144 6.28h-1ZM6.91 15v-4.152a2.303 2.303 0 0 1-.332.176 1.63 1.63 0 0 1-.372.112l-.088-.864a1.18 1.18 0 0 0 .384-.172c.141-.09.272-.197.392-.32.12-.125.205-.252.256-.38h.784V15H6.91Z" />
+	</SVG>
+);
+
+export default countdown;

--- a/src/blocks/content-gate-countdown/block.json
+++ b/src/blocks/content-gate-countdown/block.json
@@ -10,6 +10,7 @@
     }
   },
   "supports": {
+		"align": [ "wide", "full" ],
     "html": false,
     "color": {
       "link": true,

--- a/src/blocks/content-gate-countdown/block.json
+++ b/src/blocks/content-gate-countdown/block.json
@@ -1,7 +1,12 @@
 {
   "name": "newspack/content-gate-countdown",
   "category": "newspack",
-  "attributes": {},
+  "attributes": {
+    "text": {
+      "type": "string",
+      "default": ""
+    }
+  },
   "supports": {
     "html": false,
     "color": {

--- a/src/blocks/content-gate-countdown/block.json
+++ b/src/blocks/content-gate-countdown/block.json
@@ -1,4 +1,6 @@
 {
+  "$schema": "https://schemas.wp.org/trunk/block.json",
+  "apiVersion": 3,
   "name": "newspack/content-gate-countdown",
   "category": "newspack",
   "attributes": {
@@ -32,6 +34,5 @@
       }
     }
   },
-  "textdomain": "newspack-plugin",
-  "usesContext": [ "postId" ]
+  "textdomain": "newspack-plugin"
 }

--- a/src/blocks/content-gate-countdown/block.json
+++ b/src/blocks/content-gate-countdown/block.json
@@ -1,31 +1,36 @@
 {
-	"name": "newspack/content-gate-countdown",
-	"category": "newspack",
-	"attributes": {},
-	"supports": {
-		"html": false,
-		"color": {
-			"link": true,
-			"__experimentalDefaultControls": {
-				"background": true,
-				"text": true
-			}
-		},
-		"typography": {
-			"fontSize": true,
-			"lineHeight": true,
-			"textAlign": true,
-			"__experimentalFontFamily": true,
-			"__experimentalTextDecoration": true,
-			"__experimentalFontStyle": true,
-			"__experimentalFontWeight": true,
-			"__experimentalLetterSpacing": true,
-			"__experimentalTextTransform": true,
-			"__experimentalWritingMode": true,
-			"__experimentalDefaultControls": {
-				"fontSize": true
-			}
-		}
-	},
-	"textdomain": "newspack-plugin"
+  "name": "newspack/content-gate-countdown",
+  "category": "newspack",
+  "attributes": {
+    "text": {
+      "type": "string"
+    }
+  },
+  "supports": {
+    "html": false,
+    "color": {
+      "link": true,
+      "__experimentalDefaultControls": {
+        "background": true,
+        "text": true
+      }
+    },
+    "typography": {
+      "fontSize": true,
+      "lineHeight": true,
+      "textAlign": true,
+      "__experimentalFontFamily": true,
+      "__experimentalTextDecoration": true,
+      "__experimentalFontStyle": true,
+      "__experimentalFontWeight": true,
+      "__experimentalLetterSpacing": true,
+      "__experimentalTextTransform": true,
+      "__experimentalWritingMode": true,
+      "__experimentalDefaultControls": {
+        "fontSize": true
+      }
+    }
+  },
+  "textdomain": "newspack-plugin",
+  "usesContext": [ "postId" ]
 }

--- a/src/blocks/content-gate-countdown/block.json
+++ b/src/blocks/content-gate-countdown/block.json
@@ -1,11 +1,7 @@
 {
   "name": "newspack/content-gate-countdown",
   "category": "newspack",
-  "attributes": {
-    "text": {
-      "type": "string"
-    }
-  },
+  "attributes": {},
   "supports": {
     "html": false,
     "color": {

--- a/src/blocks/content-gate-countdown/block.json
+++ b/src/blocks/content-gate-countdown/block.json
@@ -1,0 +1,31 @@
+{
+	"name": "newspack/content-gate-countdown",
+	"category": "newspack",
+	"attributes": {},
+	"supports": {
+		"html": false,
+		"color": {
+			"link": true,
+			"__experimentalDefaultControls": {
+				"background": true,
+				"text": true
+			}
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"textAlign": true,
+			"__experimentalFontFamily": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalFontStyle": true,
+			"__experimentalFontWeight": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalTextTransform": true,
+			"__experimentalWritingMode": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true
+			}
+		}
+	},
+	"textdomain": "newspack-plugin"
+}

--- a/src/blocks/content-gate-countdown/class-content-gate-countdown-block.php
+++ b/src/blocks/content-gate-countdown/class-content-gate-countdown-block.php
@@ -29,7 +29,7 @@ class Content_Gate_Countdown_Block {
 	 * @return void
 	 */
 	public static function enqueue_scripts() {
-		if ( ! Memberships::is_active() || ! Memberships::has_gate() ) {
+		if ( ! Memberships::is_active() || ! is_singular() ) {
 			return;
 		}
 		wp_enqueue_style(
@@ -51,9 +51,6 @@ class Content_Gate_Countdown_Block {
 	 * Register the block.
 	 */
 	public static function register_block() {
-		if ( ! Memberships::is_active() || ! Memberships::has_gate() ) {
-			return;
-		}
 		register_block_type_from_metadata(
 			__DIR__ . '/block.json',
 			[
@@ -67,21 +64,19 @@ class Content_Gate_Countdown_Block {
 	 *
 	 * @param array  $attributes The block attributes.
 	 * @param string $content    The block content.
-	 * @param object $block      The block.
 	 *
 	 * @return string The block HTML.
 	 */
-	public static function render_block( array $attributes, string $content, $block ) {
+	public static function render_block( array $attributes, string $content ) {
 		if ( ! Metering::is_metering() ) {
 			return '';
 		}
-		$post_id     = $block->context['postId'] ?? get_the_ID();
 		$total_views = Metering::get_total_metered_views( \is_user_logged_in() );
 		if ( false === $total_views ) {
 			return '';
 		}
 		$remaining_views = Metering::get_remaining_metered_views( get_current_user_id() );
-		$countdown = sprintf(
+		$countdown       = sprintf(
 			/* translators: 1: remaining metered views, 2: total metered views. */
 			__( '%1$d/%2$d', 'newspack-plugin' ),
 			max( 0, $total_views - $remaining_views ),
@@ -95,16 +90,12 @@ class Content_Gate_Countdown_Block {
 					'free articles this %s',
 					'newspack-plugin'
 				),
-				Metering::get_metering_period( $post_id )
+				Metering::get_metering_period()
 			);
-		}
-		$actions = '';
-		foreach ( $block->inner_blocks as $inner_block ) {
-			$actions .= $inner_block->render();
 		}
 		$block_wrapper_attributes = get_block_wrapper_attributes(
 			[
-				'class' => 'newspack-content-gate-countdown',
+				'class' => 'newspack-content-gate-countdown__wrapper',
 			]
 		);
 		$block_content = "<div $block_wrapper_attributes>
@@ -113,9 +104,7 @@ class Content_Gate_Countdown_Block {
 					<span class='newspack-content-gate-countdown__countdown'>$countdown</span>
 					<p>$text</p>
 				</div>
-				<div class='newspack-content-gate-countdown__actions'>
-					$actions
-				</div>
+				$content
 			</div>
 		</div>";
 

--- a/src/blocks/content-gate-countdown/class-content-gate-countdown-block.php
+++ b/src/blocks/content-gate-countdown/class-content-gate-countdown-block.php
@@ -41,7 +41,7 @@ class Content_Gate_Countdown_Block {
 		wp_enqueue_script(
 			'newspack-content-gate-countdown-block',
 			\Newspack\Newspack::plugin_url() . '/dist/content-gate-countdown-block.js',
-			[],
+			[ 'wp-i18n' ],
 			NEWSPACK_PLUGIN_VERSION,
 			true
 		);

--- a/src/blocks/content-gate-countdown/class-content-gate-countdown-block.php
+++ b/src/blocks/content-gate-countdown/class-content-gate-countdown-block.php
@@ -76,25 +76,28 @@ class Content_Gate_Countdown_Block {
 			return '';
 		}
 		$post_id     = $block->context['postId'] ?? get_the_ID();
-		$total_views = Metering::get_total_metered_views( $post_id );
+		$total_views = Metering::get_total_metered_views( \is_user_logged_in() );
 		if ( false === $total_views ) {
 			return '';
 		}
 		$remaining_views = Metering::get_remaining_metered_views( get_current_user_id() );
-		$notice          = sprintf(
-			/* translators: %s - metered content period (week, month, etc. */
-			__(
-				'free articles this %s',
-				'newspack-plugin'
-			),
-			Metering::get_metering_period()
-		);
 		$countdown = sprintf(
 			/* translators: 1: remaining metered views, 2: total metered views. */
 			__( '%1$d/%2$d', 'newspack-plugin' ),
-			$remaining_views,
+			max( 0, $total_views - $remaining_views ),
 			$total_views
 		);
+		$text = isset( $attributes['text'] ) ? $attributes['text'] : '';
+		if ( empty( $text ) ) {
+			$text = sprintf(
+				/* translators: %s - metered content period (week, month, etc. */
+				__(
+					'free articles this %s',
+					'newspack-plugin'
+				),
+				Metering::get_metering_period( $post_id )
+			);
+		}
 		$actions = '';
 		foreach ( $block->inner_blocks as $inner_block ) {
 			$actions .= $inner_block->render();
@@ -106,9 +109,9 @@ class Content_Gate_Countdown_Block {
 		);
 		$block_content = "<div $block_wrapper_attributes>
 			<div class='newspack-content-gate-countdown__content'>
-				<div class='newspack-content-gate-countdown__notice'>
+				<div class='newspack-content-gate-countdown__text'>
 					<span class='newspack-content-gate-countdown__countdown'>$countdown</span>
-					<p>$notice</p>
+					<p>$text</p>
 				</div>
 				<div class='newspack-content-gate-countdown__actions'>
 					$actions

--- a/src/blocks/content-gate-countdown/class-content-gate-countdown-block.php
+++ b/src/blocks/content-gate-countdown/class-content-gate-countdown-block.php
@@ -33,12 +33,6 @@ class Content_Gate_Countdown_Block {
 		if ( ! Memberships::is_active() || ! is_singular() ) {
 			return;
 		}
-		wp_enqueue_style(
-			'newspack-content-gate-countdown-block',
-			\Newspack\Newspack::plugin_url() . '/dist/content-gate-countdown-block.css',
-			[],
-			NEWSPACK_PLUGIN_VERSION
-		);
 		wp_enqueue_script(
 			'newspack-content-gate-countdown-block',
 			\Newspack\Newspack::plugin_url() . '/dist/content-gate-countdown-block.js',

--- a/src/blocks/content-gate-countdown/class-content-gate-countdown-block.php
+++ b/src/blocks/content-gate-countdown/class-content-gate-countdown-block.php
@@ -7,6 +7,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
+use Newspack;
 use Newspack\Memberships;
 use Newspack\Memberships\Metering;
 
@@ -19,17 +20,33 @@ class Content_Gate_Countdown_Block {
 	 */
 	public static function init() {
 		add_action( 'init', [ __CLASS__, 'register_block' ] );
+		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'enqueue_scripts' ] );
+	}
+
+	/**
+	 * Enqueue block scripts and styles.
+	 *
+	 * @return void
+	 */
+	public static function enqueue_scripts() {
+		if ( ! Memberships::is_active() || ! Memberships::has_gate() ) {
+			return;
+		}
+		wp_enqueue_style(
+			'newspack-content-gate-countdown-block',
+			\Newspack\Newspack::plugin_url() . '/dist/content-gate-countdown-block.css',
+			[],
+			NEWSPACK_PLUGIN_VERSION
+		);
 	}
 
 	/**
 	 * Register the block.
 	 */
 	public static function register_block() {
-		// Only register if Memberships is active.
-		if ( ! Memberships::is_active() ) {
+		if ( ! Memberships::is_active() || ! Memberships::has_gate() ) {
 			return;
 		}
-
 		register_block_type_from_metadata(
 			__DIR__ . '/block.json',
 			[
@@ -37,7 +54,6 @@ class Content_Gate_Countdown_Block {
 			]
 		);
 	}
-
 
 	/**
 	 * Block render callback.
@@ -66,7 +82,12 @@ class Content_Gate_Countdown_Block {
 			),
 			Metering::get_metering_period()
 		);
-		$text    = isset( $attributes['text'] ) ? $attributes['text'] : __( 'Get unlimited access.', 'newspack-plugin' );
+		$countdown = sprintf(
+			/* translators: 1: remaining metered views, 2: total metered views. */
+			__( '%1$d/%2$d', 'newspack-plugin' ),
+			$remaining_views,
+			$total_views
+		);
 		$actions = '';
 		foreach ( $block->inner_blocks as $inner_block ) {
 			$actions .= $inner_block->render();
@@ -79,7 +100,7 @@ class Content_Gate_Countdown_Block {
 		$block_content = "<div $block_wrapper_attributes>
 			<div class='newspack-content-gate-countdown__content'>
 				<div class='newspack-content-gate-countdown__notice'>
-					<span class='newspack-content-gate-countdown__countdown'>$remaining_views / $total_views</span>
+					<span class='newspack-content-gate-countdown__countdown'>$countdown</span>
 					<p>$notice</p>
 				</div>
 				<div class='newspack-content-gate-countdown__actions'>

--- a/src/blocks/content-gate-countdown/class-content-gate-countdown-block.php
+++ b/src/blocks/content-gate-countdown/class-content-gate-countdown-block.php
@@ -14,7 +14,6 @@ use Newspack\Memberships\Metering;
  * Content Gate Countdown Block class.
  */
 class Content_Gate_Countdown_Block {
-
 	/**
 	 * Initialize the block.
 	 */
@@ -53,33 +52,40 @@ class Content_Gate_Countdown_Block {
 		if ( ! Metering::is_metering() ) {
 			return '';
 		}
-
-		$remaining_views = Metering::get_remaining_metered_views( get_current_user_id() );
-		$text            = isset( $attributes['text'] ) ? $attributes['text'] : '';
-		if ( empty( $text ) ) {
-			$text = $remaining_views > 0 ?
-			sprintf(
-				/* translators: %d - number of remaining views. */
-				_n(
-					'You have %s free article left.',
-					'You have %s free articles left.',
-					$remaining_views,
-					'newspack-plugin'
-				),
-				$remaining_views
-			) :
-			__( 'You have no free articles left.', 'newspack-plugin' );
+		$post_id     = $block->context['postId'] ?? get_the_ID();
+		$total_views = Metering::get_total_metered_views( $post_id );
+		if ( false === $total_views ) {
+			return '';
 		}
-
+		$remaining_views = Metering::get_remaining_metered_views( get_current_user_id() );
+		$notice          = sprintf(
+			/* translators: %s - metered content period (week, month, etc. */
+			__(
+				'free articles this %s',
+				'newspack-plugin'
+			),
+			Metering::get_metering_period()
+		);
+		$text    = isset( $attributes['text'] ) ? $attributes['text'] : __( 'Get unlimited access.', 'newspack-plugin' );
+		$buttons = '';
+		foreach ( $block->inner_blocks as $inner_block ) {
+			$buttons .= $inner_block->render();
+		}
 		$block_wrapper_attributes = get_block_wrapper_attributes(
 			[
 				'class' => 'newspack-content-gate-countdown',
 			]
 		);
-
 		$block_content = "<div $block_wrapper_attributes>
 			<div class='newspack-content-gate-countdown__content'>
-				<p>$text</p>
+				<div class='newspack-content-gate-countdown__notice'>
+					<span class='newspack-content-gate-countdown__views'>$remaining_views / $total_views</span>
+					<p>$notice</p>
+				</div>
+				<div class='newspack-content-gate-countdown__actions'>
+					<p>$text</p>
+					$buttons
+				</div>
 			</div>
 		</div>";
 

--- a/src/blocks/content-gate-countdown/class-content-gate-countdown-block.php
+++ b/src/blocks/content-gate-countdown/class-content-gate-countdown-block.php
@@ -76,11 +76,11 @@ class Content_Gate_Countdown_Block {
 		if ( false === $total_views ) {
 			return '';
 		}
-		$remaining_views = Metering::get_remaining_metered_views( get_current_user_id() );
-		$countdown       = sprintf(
-			/* translators: 1: remaining metered views, 2: total metered views. */
+		$views     = Metering::get_metered_views( get_current_user_id() );
+		$countdown = sprintf(
+			/* translators: 1: current number of metered views, 2: total metered views. */
 			__( '%1$d/%2$d', 'newspack-plugin' ),
-			$remaining_views,
+			$views,
 			$total_views
 		);
 		$text = isset( $attributes['text'] ) ? esc_html( $attributes['text'] ) : '';

--- a/src/blocks/content-gate-countdown/class-content-gate-countdown-block.php
+++ b/src/blocks/content-gate-countdown/class-content-gate-countdown-block.php
@@ -67,9 +67,9 @@ class Content_Gate_Countdown_Block {
 			Metering::get_metering_period()
 		);
 		$text    = isset( $attributes['text'] ) ? $attributes['text'] : __( 'Get unlimited access.', 'newspack-plugin' );
-		$buttons = '';
+		$actions = '';
 		foreach ( $block->inner_blocks as $inner_block ) {
-			$buttons .= $inner_block->render();
+			$actions .= $inner_block->render();
 		}
 		$block_wrapper_attributes = get_block_wrapper_attributes(
 			[
@@ -79,12 +79,11 @@ class Content_Gate_Countdown_Block {
 		$block_content = "<div $block_wrapper_attributes>
 			<div class='newspack-content-gate-countdown__content'>
 				<div class='newspack-content-gate-countdown__notice'>
-					<span class='newspack-content-gate-countdown__views'>$remaining_views / $total_views</span>
+					<span class='newspack-content-gate-countdown__countdown'>$remaining_views / $total_views</span>
 					<p>$notice</p>
 				</div>
 				<div class='newspack-content-gate-countdown__actions'>
-					<p>$text</p>
-					$buttons
+					$actions
 				</div>
 			</div>
 		</div>";

--- a/src/blocks/content-gate-countdown/class-content-gate-countdown-block.php
+++ b/src/blocks/content-gate-countdown/class-content-gate-countdown-block.php
@@ -82,7 +82,7 @@ class Content_Gate_Countdown_Block {
 			max( 0, $total_views - $remaining_views ),
 			$total_views
 		);
-		$text = isset( $attributes['text'] ) ? $attributes['text'] : '';
+		$text = isset( $attributes['text'] ) ? esc_html( $attributes['text'] ) : '';
 		if ( empty( $text ) ) {
 			$text = sprintf(
 				/* translators: %s - metered content period (week, month, etc. */

--- a/src/blocks/content-gate-countdown/class-content-gate-countdown-block.php
+++ b/src/blocks/content-gate-countdown/class-content-gate-countdown-block.php
@@ -5,9 +5,10 @@
  * @package Newspack
  */
 
+namespace Newspack;
+
 defined( 'ABSPATH' ) || exit;
 
-use Newspack;
 use Newspack\Memberships;
 use Newspack\Memberships\Metering;
 
@@ -68,7 +69,7 @@ class Content_Gate_Countdown_Block {
 	 * @return string The block HTML.
 	 */
 	public static function render_block( array $attributes, string $content ) {
-		if ( ! Metering::is_metering() ) {
+		if ( ! Metering::is_metering() || ! Memberships::is_post_restricted() ) {
 			return '';
 		}
 		$total_views = Metering::get_total_metered_views( \is_user_logged_in() );
@@ -79,7 +80,7 @@ class Content_Gate_Countdown_Block {
 		$countdown       = sprintf(
 			/* translators: 1: remaining metered views, 2: total metered views. */
 			__( '%1$d/%2$d', 'newspack-plugin' ),
-			max( 0, $total_views - $remaining_views ),
+			$remaining_views,
 			$total_views
 		);
 		$text = isset( $attributes['text'] ) ? esc_html( $attributes['text'] ) : '';

--- a/src/blocks/content-gate-countdown/class-content-gate-countdown-block.php
+++ b/src/blocks/content-gate-countdown/class-content-gate-countdown-block.php
@@ -42,7 +42,7 @@ class Content_Gate_Countdown_Block {
 		wp_enqueue_script(
 			'newspack-content-gate-countdown-block',
 			\Newspack\Newspack::plugin_url() . '/dist/content-gate-countdown-block.js',
-			[ 'wp-i18n' ],
+			[ 'wp-i18n', 'newspack-memberships-gate-metering' ],
 			NEWSPACK_PLUGIN_VERSION,
 			true
 		);

--- a/src/blocks/content-gate-countdown/class-content-gate-countdown-block.php
+++ b/src/blocks/content-gate-countdown/class-content-gate-countdown-block.php
@@ -38,6 +38,13 @@ class Content_Gate_Countdown_Block {
 			[],
 			NEWSPACK_PLUGIN_VERSION
 		);
+		wp_enqueue_script(
+			'newspack-content-gate-countdown-block',
+			\Newspack\Newspack::plugin_url() . '/dist/content-gate-countdown-block.js',
+			[],
+			NEWSPACK_PLUGIN_VERSION,
+			true
+		);
 	}
 
 	/**

--- a/src/blocks/content-gate-countdown/class-content-gate-countdown-block.php
+++ b/src/blocks/content-gate-countdown/class-content-gate-countdown-block.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Content Gate Countdown Block
+ *
+ * @package Newspack
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+use Newspack\Memberships;
+use Newspack\Memberships\Metering;
+
+/**
+ * Content Gate Countdown Block class.
+ */
+class Content_Gate_Countdown_Block {
+
+	/**
+	 * Initialize the block.
+	 */
+	public static function init() {
+		add_action( 'init', [ __CLASS__, 'register_block' ] );
+	}
+
+	/**
+	 * Register the block.
+	 */
+	public static function register_block() {
+		// Only register if Memberships is active.
+		if ( ! Memberships::is_active() ) {
+			return;
+		}
+
+		register_block_type_from_metadata(
+			__DIR__ . '/block.json',
+			[
+				'render_callback' => [ __CLASS__, 'render_block' ],
+			]
+		);
+	}
+
+
+	/**
+	 * Block render callback.
+	 *
+	 * @param array  $attributes The block attributes.
+	 * @param string $content    The block content.
+	 * @param object $block      The block.
+	 *
+	 * @return string The block HTML.
+	 */
+	public static function render_block( array $attributes, string $content, $block ) {
+		if ( ! Metering::is_metering() ) {
+			return '';
+		}
+
+		$remaining_views = Metering::get_remaining_metered_views( get_current_user_id() );
+		$text            = isset( $attributes['text'] ) ? $attributes['text'] : '';
+		if ( empty( $text ) ) {
+			$text = $remaining_views > 0 ?
+			sprintf(
+				/* translators: %d - number of remaining views. */
+				_n(
+					'You have %s free article left.',
+					'You have %s free articles left.',
+					$remaining_views,
+					'newspack-plugin'
+				),
+				$remaining_views
+			) :
+			__( 'You have no free articles left.', 'newspack-plugin' );
+		}
+
+		$block_wrapper_attributes = get_block_wrapper_attributes(
+			[
+				'class' => 'newspack-content-gate-countdown',
+			]
+		);
+
+		$block_content = "<div $block_wrapper_attributes>
+			<div class='newspack-content-gate-countdown__content'>
+				<p>$text</p>
+			</div>
+		</div>";
+
+		return $block_content;
+	}
+}
+
+Content_Gate_Countdown_Block::init();

--- a/src/blocks/content-gate-countdown/edit.jsx
+++ b/src/blocks/content-gate-countdown/edit.jsx
@@ -3,7 +3,7 @@
 /**
  * WordPress dependencies
  */
-import { useBlockProps, InnerBlocks, InspectorControls } from '@wordpress/block-editor';
+import { useBlockProps, useInnerBlocksProps, InspectorControls } from '@wordpress/block-editor';
 import { PanelBody, Placeholder, TextareaControl } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { caution } from '@wordpress/icons';
@@ -15,7 +15,30 @@ import { useState } from '@wordpress/element';
  * @return {JSX.Element} The Content Gate Countdown block.
  */
 export default function Edit( { attributes, setAttributes } ) {
-	const blockProps = useBlockProps();
+	const blockProps = useBlockProps( { className: 'newspack-content-gate-countdown__wrapper' } );
+	const { children, ...innerBlockProps } = useInnerBlocksProps(
+		{ className: 'newspack-content-gate-countdown__actions' },
+		{
+			allowedBlocks: [ 'core/paragraph', 'core/heading', 'core/buttons', 'newspack-blocks/checkout-button' ],
+			template: [
+				[
+					'core/paragraph',
+					{
+						align: 'center',
+						content: __( 'Get unlimited access.', 'newspack-plugin' ),
+						style: { typography: { fontWeight: '700' } },
+					},
+				],
+				[
+					'newspack-blocks/checkout-button',
+					{
+						text: __( 'Subscribe now', 'newspack-plugin' ),
+						align: 'center',
+					},
+				],
+			],
+		}
+	);
 	const {
 		metering_period: meteringPeriod,
 		loggedin_metered_views: loggedinViews,
@@ -65,7 +88,7 @@ export default function Edit( { attributes, setAttributes } ) {
 				</PanelBody>
 			</InspectorControls>
 
-			<div className="newspack-content-gate-countdown" { ...blockProps }>
+			<div { ...blockProps }>
 				<div className="newspack-content-gate-countdown__content">
 					<div className="newspack-content-gate-countdown__text">
 						<span className="newspack-content-gate-countdown__countdown">
@@ -77,28 +100,7 @@ export default function Edit( { attributes, setAttributes } ) {
 						</span>
 						<p>{ text }</p>
 					</div>
-					<div className="newspack-content-gate-countdown__actions">
-						<InnerBlocks
-							allowedBlocks={ [ 'newspack-blocks/checkout-button', 'core/buttons', 'core/paragraph', 'core/heading' ] }
-							template={ [
-								[
-									'core/paragraph',
-									{
-										content: __( 'Get unlimited access.', 'newspack-plugin' ),
-										align: 'center',
-										style: { typography: { fontWeight: '700' } },
-									},
-								],
-								[
-									'newspack-blocks/checkout-button',
-									{
-										text: __( 'Subscribe now', 'newspack-plugin' ),
-										align: 'center',
-									},
-								],
-							] }
-						/>
-					</div>
+					<div { ...innerBlockProps }>{ children }</div>
 				</div>
 			</div>
 		</>

--- a/src/blocks/content-gate-countdown/edit.jsx
+++ b/src/blocks/content-gate-countdown/edit.jsx
@@ -34,6 +34,8 @@ export default function Edit( { attributes, setAttributes } ) {
 					{
 						text: __( 'Subscribe now', 'newspack-plugin' ),
 						align: 'center',
+						backgroundColor: 'primary',
+						textColor: 'secondary',
 					},
 				],
 			],
@@ -63,14 +65,16 @@ export default function Edit( { attributes, setAttributes } ) {
 
 	if ( ! totalViews ) {
 		return (
-			<Placeholder
-				icon={ caution }
-				label={ __(
-					'The content gate countdown block will only display in restricted content when metering is enabled.',
-					'newspack-plugin'
-				) }
-				className="no-metering"
-			/>
+			<div { ...blockProps }>
+				<Placeholder
+					icon={ caution }
+					label={ __(
+						'The content gate countdown block will only display in restricted content when metering is enabled.',
+						'newspack-plugin'
+					) }
+					className="no-metering"
+				/>
+			</div>
 		);
 	}
 
@@ -94,7 +98,7 @@ export default function Edit( { attributes, setAttributes } ) {
 						<span className="newspack-content-gate-countdown__countdown">
 							{ sprintf(
 								/* translators: 1: remaining metered views, 2: total metered views. */ __( '%1$d/%2$d', 'newspack-plugin' ),
-								Math.max( 0, parseInt( totalViews ) - parseInt( remainingViews ) ),
+								parseInt( remainingViews ),
 								parseInt( totalViews )
 							) }
 						</span>

--- a/src/blocks/content-gate-countdown/edit.jsx
+++ b/src/blocks/content-gate-countdown/edit.jsx
@@ -1,0 +1,53 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useBlockProps, InspectorControls, RichText } from '@wordpress/block-editor';
+import { PanelBody, TextareaControl } from '@wordpress/components';
+
+/**
+ * Edit function for the Content Gate Countdown block.
+ *
+ * @param {Object}   props               The block properties.
+ * @param {Object}   props.attributes    The block attributes.
+ * @param {Function} props.setAttributes The block attributes setter.
+ *
+ * @return {JSX.Element} The Content Gate Countdown block.
+ */
+export default function Edit( { attributes, setAttributes } ) {
+	const blockProps = useBlockProps();
+	const { text } = attributes;
+
+	const placeholder = __( 'Add countdown text…', 'newspack-plugin' );
+
+	const handleChange = value => {
+		setAttributes( { text: value } );
+	};
+
+	return (
+		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Content Gate Countdown Settings', 'newspack-plugin' ) }>
+					<TextareaControl
+						label={ __( 'Countdown Text', 'newspack-plugin' ) }
+						value={ text }
+						onChange={ value => handleChange( value ) }
+						placeholder={ placeholder }
+						help={ __( 'This text will be shown alongside the countdown timer on the frontend.', 'newspack-plugin' ) }
+					/>
+				</PanelBody>
+			</InspectorControls>
+
+			<div { ...blockProps }>
+				<RichText
+					aria-label={ __( 'Countdown text' ) }
+					placeholder={ placeholder || __( 'Add text…' ) }
+					value={ text }
+					onChange={ value => handleChange( value ) }
+					withoutInteractiveFormatting
+					identifier="text"
+				/>
+			</div>
+		</>
+	);
+}

--- a/src/blocks/content-gate-countdown/edit.jsx
+++ b/src/blocks/content-gate-countdown/edit.jsx
@@ -1,30 +1,81 @@
+/* globals newspack_blocks */
+
 /**
  * WordPress dependencies
  */
-import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
+import { useBlockProps, InnerBlocks, InspectorControls } from '@wordpress/block-editor';
+import { PanelBody, Placeholder, TextareaControl } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
+import { caution } from '@wordpress/icons';
+import { useState } from '@wordpress/element';
 
 /**
  * Edit function for the Content Gate Countdown block.
  *
  * @return {JSX.Element} The Content Gate Countdown block.
  */
-export default function Edit() {
+export default function Edit( { attributes, setAttributes } ) {
 	const blockProps = useBlockProps();
+	const {
+		metering_period: meteringPeriod,
+		loggedin_metered_views: loggedinViews,
+		anonymous_metered_views: anonymousViews,
+		remaining_metered_views: remainingViews,
+	} = newspack_blocks.content_gate_data || {};
+	const [ text, setText ] = useState(
+		attributes.text
+			? attributes.text
+			: sprintf(
+					/* translators: %s is the metered period, e.g. "month" or "week". */
+					__( 'free articles this %s', 'newspack-plugin' ),
+					meteringPeriod
+			  )
+	);
+	// Admin is always logged in, so if no loggedin metered views are set, use the anonymous views instead.
+	const totalViews = loggedinViews > 0 ? loggedinViews : anonymousViews;
+	const handleChange = value => {
+		setAttributes( { text: value } );
+		setText( value );
+	};
+
+	if ( ! totalViews ) {
+		return (
+			<Placeholder
+				icon={ caution }
+				label={ __(
+					'The content gate countdown block will only display in restricted content when metering is enabled.',
+					'newspack-plugin'
+				) }
+				className="no-metering"
+			/>
+		);
+	}
 
 	return (
 		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Countdown Settings', 'newspack-plugin' ) } initialOpen={ true }>
+					<TextareaControl
+						label={ __( 'Countdown text', 'newspack-plugin' ) }
+						rows="3"
+						help={ __( 'The text that appears next to the countdown.', 'newspack-plugin' ) }
+						value={ text }
+						onChange={ handleChange }
+					/>
+				</PanelBody>
+			</InspectorControls>
+
 			<div className="newspack-content-gate-countdown" { ...blockProps }>
 				<div className="newspack-content-gate-countdown__content">
-					<div className="newspack-content-gate-countdown__notice">
+					<div className="newspack-content-gate-countdown__text">
 						<span className="newspack-content-gate-countdown__countdown">
 							{ sprintf(
 								/* translators: 1: remaining metered views, 2: total metered views. */ __( '%1$d/%2$d', 'newspack-plugin' ),
-								3,
-								3
+								Math.max( 0, parseInt( totalViews ) - parseInt( remainingViews ) ),
+								parseInt( totalViews )
 							) }
 						</span>
-						<p>{ __( 'free articles this month', 'newspack-plugin' ) }</p>
+						<p>{ text }</p>
 					</div>
 					<div className="newspack-content-gate-countdown__actions">
 						<InnerBlocks
@@ -43,7 +94,6 @@ export default function Edit() {
 									{
 										text: __( 'Subscribe now', 'newspack-plugin' ),
 										align: 'center',
-										layout: { type: 'flex', justifyContent: 'center' },
 									},
 								],
 							] }

--- a/src/blocks/content-gate-countdown/edit.jsx
+++ b/src/blocks/content-gate-countdown/edit.jsx
@@ -1,9 +1,9 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
-import { useBlockProps, InspectorControls, RichText } from '@wordpress/block-editor';
+import { useBlockProps, InspectorControls, InnerBlocks, RichText } from '@wordpress/block-editor';
 import { PanelBody, TextareaControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Edit function for the Content Gate Countdown block.
@@ -18,10 +18,8 @@ export default function Edit( { attributes, setAttributes } ) {
 	const blockProps = useBlockProps();
 	const { text } = attributes;
 
-	const placeholder = __( 'Add countdown text…', 'newspack-plugin' );
-
-	const handleChange = value => {
-		setAttributes( { text: value } );
+	const handleChange = ( key, value ) => {
+		setAttributes( { [ key ]: value } );
 	};
 
 	return (
@@ -29,24 +27,37 @@ export default function Edit( { attributes, setAttributes } ) {
 			<InspectorControls>
 				<PanelBody title={ __( 'Content Gate Countdown Settings', 'newspack-plugin' ) }>
 					<TextareaControl
-						label={ __( 'Countdown Text', 'newspack-plugin' ) }
+						label={ __( 'Text', 'newspack-plugin' ) }
 						value={ text }
-						onChange={ value => handleChange( value ) }
-						placeholder={ placeholder }
-						help={ __( 'This text will be shown alongside the countdown timer on the frontend.', 'newspack-plugin' ) }
+						onChange={ value => handleChange( 'text', value ) }
+						placeholder={ __( 'Get unlimited access.', 'newspack-plugin' ) }
+						help={ __( 'The call to action text that appears above the subscribe button.', 'newspack-plugin' ) }
 					/>
 				</PanelBody>
 			</InspectorControls>
 
 			<div { ...blockProps }>
-				<RichText
-					aria-label={ __( 'Countdown text' ) }
-					placeholder={ placeholder || __( 'Add text…' ) }
-					value={ text }
-					onChange={ value => handleChange( value ) }
-					withoutInteractiveFormatting
-					identifier="text"
-				/>
+				<div className="wp-block-newspack-content-gate-countdown__content">
+					<div className="wp-block-newspack-content-gate-countdown__notice">
+						{ ' ' }
+						<span className="wp-block-newspack-content-gate-countdown__views">3 / 3</span>
+						<p>{ __( 'remaining articles this month.', 'newspack-plugin' ) }</p>
+					</div>
+					<div className="wp-blocks-newspack-content-gate-countdown__actions">
+						<RichText
+							tagName="div"
+							className="wp-block-newspack-blocks-content-gate-countdown__text"
+							value={ text }
+							onChange={ value => handleChange( 'text', value ) }
+							placeholder={ __( 'CTA text…', 'newspack-plugin' ) }
+							allowedFormats={ [] }
+						/>
+						<InnerBlocks
+							allowedBlocks={ [ 'newspack-blocks/checkout-button', 'core/buttons' ] }
+							template={ [ [ 'newspack-blocks/checkout-button', { text: __( 'Subscribe now', 'newspack-plugin' ) } ] ] }
+						/>
+					</div>
+				</div>
 			</div>
 		</>
 	);

--- a/src/blocks/content-gate-countdown/edit.jsx
+++ b/src/blocks/content-gate-countdown/edit.jsx
@@ -1,60 +1,33 @@
 /**
  * WordPress dependencies
  */
-import { useBlockProps, InspectorControls, InnerBlocks, RichText } from '@wordpress/block-editor';
-import { PanelBody, TextareaControl } from '@wordpress/components';
+import { useBlockProps, InspectorControls, InnerBlocks } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Edit function for the Content Gate Countdown block.
  *
- * @param {Object}   props               The block properties.
- * @param {Object}   props.attributes    The block attributes.
- * @param {Function} props.setAttributes The block attributes setter.
- *
  * @return {JSX.Element} The Content Gate Countdown block.
  */
-export default function Edit( { attributes, setAttributes } ) {
+export default function Edit() {
 	const blockProps = useBlockProps();
-	const { text } = attributes;
-
-	const handleChange = ( key, value ) => {
-		setAttributes( { [ key ]: value } );
-	};
 
 	return (
 		<>
-			<InspectorControls>
-				<PanelBody title={ __( 'Content Gate Countdown Settings', 'newspack-plugin' ) }>
-					<TextareaControl
-						label={ __( 'Text', 'newspack-plugin' ) }
-						value={ text }
-						onChange={ value => handleChange( 'text', value ) }
-						placeholder={ __( 'Get unlimited access.', 'newspack-plugin' ) }
-						help={ __( 'The call to action text that appears above the subscribe button.', 'newspack-plugin' ) }
-					/>
-				</PanelBody>
-			</InspectorControls>
-
-			<div { ...blockProps }>
-				<div className="wp-block-newspack-content-gate-countdown__content">
-					<div className="wp-block-newspack-content-gate-countdown__notice">
-						{ ' ' }
-						<span className="wp-block-newspack-content-gate-countdown__views">3 / 3</span>
+			<InspectorControls />
+			<div className="newspack-content-gate-countdown" { ...blockProps }>
+				<div className="newspack-content-gate-countdown__content">
+					<div className="newspack-content-gate-countdown__notice">
+						<span className="newspack-content-gate-countdown__countdown">3 / 3</span>
 						<p>{ __( 'remaining articles this month.', 'newspack-plugin' ) }</p>
 					</div>
-					<div className="wp-blocks-newspack-content-gate-countdown__actions">
-						<RichText
-							tagName="div"
-							className="wp-block-newspack-blocks-content-gate-countdown__text"
-							value={ text }
-							onChange={ value => handleChange( 'text', value ) }
-							placeholder={ __( 'CTA text…', 'newspack-plugin' ) }
-							allowedFormats={ [] }
-						/>
+					<div className="newspack-content-gate-countdown__actions">
 						<InnerBlocks
-							allowedBlocks={ [ 'newspack-blocks/checkout-button', 'core/buttons' ] }
-							template={ [ [ 'newspack-blocks/checkout-button', { text: __( 'Subscribe now', 'newspack-plugin' ) } ] ] }
+							allowedBlocks={ [ 'newspack-blocks/checkout-button', 'core/buttons', 'core/paragraph' ] }
+							template={ [
+								[ 'core/paragraph', { content: __( 'Get unlimited access.', 'newspack-plugin' ) } ],
+								[ 'newspack-blocks/checkout-button', { text: __( 'Subscribe now', 'newspack-plugin' ), align: 'center' } ],
+							] }
 						/>
 					</div>
 				</div>

--- a/src/blocks/content-gate-countdown/edit.jsx
+++ b/src/blocks/content-gate-countdown/edit.jsx
@@ -45,7 +45,7 @@ export default function Edit( { attributes, setAttributes } ) {
 		metering_period: meteringPeriod,
 		loggedin_metered_views: loggedinViews,
 		anonymous_metered_views: anonymousViews,
-		remaining_metered_views: remainingViews,
+		metered_views: views,
 	} = newspack_blocks.content_gate_data || {};
 	const [ text, setText ] = useState(
 		attributes.text
@@ -97,8 +97,8 @@ export default function Edit( { attributes, setAttributes } ) {
 					<div className="newspack-content-gate-countdown__text">
 						<span className="newspack-content-gate-countdown__countdown">
 							{ sprintf(
-								/* translators: 1: remaining metered views, 2: total metered views. */ __( '%1$d/%2$d', 'newspack-plugin' ),
-								parseInt( remainingViews ),
+								/* translators: 1: current number of metered views, 2: total metered views. */ __( '%1$d/%2$d', 'newspack-plugin' ),
+								parseInt( views ),
 								parseInt( totalViews )
 							) }
 						</span>

--- a/src/blocks/content-gate-countdown/edit.jsx
+++ b/src/blocks/content-gate-countdown/edit.jsx
@@ -1,8 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { useBlockProps, InspectorControls, InnerBlocks } from '@wordpress/block-editor';
-import { __ } from '@wordpress/i18n';
+import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Edit function for the Content Gate Countdown block.
@@ -14,19 +14,38 @@ export default function Edit() {
 
 	return (
 		<>
-			<InspectorControls />
 			<div className="newspack-content-gate-countdown" { ...blockProps }>
 				<div className="newspack-content-gate-countdown__content">
 					<div className="newspack-content-gate-countdown__notice">
-						<span className="newspack-content-gate-countdown__countdown">3 / 3</span>
-						<p>{ __( 'remaining articles this month.', 'newspack-plugin' ) }</p>
+						<span className="newspack-content-gate-countdown__countdown">
+							{ sprintf(
+								/* translators: 1: remaining metered views, 2: total metered views. */ __( '%1$d/%2$d', 'newspack-plugin' ),
+								3,
+								3
+							) }
+						</span>
+						<p>{ __( 'free articles this month', 'newspack-plugin' ) }</p>
 					</div>
 					<div className="newspack-content-gate-countdown__actions">
 						<InnerBlocks
-							allowedBlocks={ [ 'newspack-blocks/checkout-button', 'core/buttons', 'core/paragraph' ] }
+							allowedBlocks={ [ 'newspack-blocks/checkout-button', 'core/buttons', 'core/paragraph', 'core/heading' ] }
 							template={ [
-								[ 'core/paragraph', { content: __( 'Get unlimited access.', 'newspack-plugin' ) } ],
-								[ 'newspack-blocks/checkout-button', { text: __( 'Subscribe now', 'newspack-plugin' ), align: 'center' } ],
+								[
+									'core/paragraph',
+									{
+										content: __( 'Get unlimited access.', 'newspack-plugin' ),
+										align: 'center',
+										style: { typography: { fontWeight: '700' } },
+									},
+								],
+								[
+									'newspack-blocks/checkout-button',
+									{
+										text: __( 'Subscribe now', 'newspack-plugin' ),
+										align: 'center',
+										layout: { type: 'flex', justifyContent: 'center' },
+									},
+								],
 							] }
 						/>
 					</div>

--- a/src/blocks/content-gate-countdown/index.js
+++ b/src/blocks/content-gate-countdown/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { InnerBlocks } from '@wordpress/block-editor';
+import { useInnerBlocksProps } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -28,5 +28,11 @@ export const settings = {
 	keywords: [ __( 'countdown', 'newspack-plugin' ), __( 'content gate', 'newspack-plugin' ) ],
 	description: __( 'A countdown for content gate metering functionality.', 'newspack-plugin' ),
 	edit: Edit,
-	save: props => <InnerBlocks.Content { ...props } />,
+	save: () => (
+		<div
+			{ ...useInnerBlocksProps.save( {
+				className: 'newspack-content-gate-countdown__actions',
+			} ) }
+		/>
+	),
 };

--- a/src/blocks/content-gate-countdown/index.js
+++ b/src/blocks/content-gate-countdown/index.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { InnerBlocks } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -27,5 +28,5 @@ export const settings = {
 	keywords: [ __( 'countdown', 'newspack-plugin' ), __( 'content gate', 'newspack-plugin' ) ],
 	description: __( 'A countdown for content gate metering functionality.', 'newspack-plugin' ),
 	edit: Edit,
-	save: () => null, // Server-side rendering
+	save: props => <InnerBlocks.Content { ...props } />,
 };

--- a/src/blocks/content-gate-countdown/index.js
+++ b/src/blocks/content-gate-countdown/index.js
@@ -1,0 +1,31 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import Edit from './edit';
+import { countdown as icon } from '../../../packages/icons';
+import colors from '../../../packages/colors/colors.module.scss';
+import './style.scss';
+
+export const title = __( 'Content Gate Countdown', 'newspack-plugin' );
+
+const { name } = metadata;
+
+export { metadata, name };
+
+export const settings = {
+	title,
+	icon: {
+		src: icon,
+		foreground: colors[ 'primary-400' ],
+	},
+	keywords: [ __( 'countdown', 'newspack-plugin' ), __( 'content gate', 'newspack-plugin' ) ],
+	description: __( 'A countdown for content gate metering functionality.', 'newspack-plugin' ),
+	edit: Edit,
+	save: () => null, // Server-side rendering
+};

--- a/src/blocks/content-gate-countdown/style.scss
+++ b/src/blocks/content-gate-countdown/style.scss
@@ -1,3 +1,5 @@
+$breakpoint-md: 782px;
+
 .newspack-content-gate-countdown {
 	width: 100%;
 
@@ -14,7 +16,7 @@
 			0 5px 10px var(--newspack-ui-color-neutral-10, rgba(0, 0, 0, 0.1)),
 			0 2px 5px var(--newspack-ui-color-neutral-20, rgba(0, 0, 0, 0.06));
 
-		@media screen and ( min-width: 744px ) {
+		@media screen and ( min-width: $breakpoint-md ) {
 			flex-direction: row;
 			justify-content: flex-start;
 		}
@@ -24,7 +26,7 @@
 		display: flex;
 		flex-direction: row;
 		align-items: center;
-		justify-content: flex-start;
+		justify-content: center;
 		gap: 10px;
 		width: 100%;
 
@@ -33,9 +35,9 @@
 			text-transform: uppercase;
 		}
 
-		@media screen and ( min-width: 744px ) {
+		@media screen and ( min-width: $breakpoint-md ) {
 			width: 200px;
-			justify-content: center;
+			justify-content: flex-start;
 		}
 	}
 
@@ -51,7 +53,7 @@
 		width: 100%;
 		padding-right: 0;
 
-		@media screen and ( min-width: 744px ) {
+		@media screen and ( min-width: $breakpoint-md ) {
 			width: calc(100% - 200px);
 			padding-right: 200px;
 		}

--- a/src/blocks/content-gate-countdown/style.scss
+++ b/src/blocks/content-gate-countdown/style.scss
@@ -1,0 +1,19 @@
+.newspack-content-gate-countdown {
+	width: 100%;
+	padding: 1rem;
+
+	&__content {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		flex: 1;
+
+		p {
+			color: #333;
+			margin: 0 0 0.5rem 0;
+			font-size: 1rem;
+			line-height: 1.4;
+		}
+	}
+}

--- a/src/blocks/content-gate-countdown/style.scss
+++ b/src/blocks/content-gate-countdown/style.scss
@@ -1,69 +1,71 @@
 $breakpoint-md: 782px;
 
-.newspack-content-gate-countdown {
+.newspack-content-gate-countdown__wrapper {
 	width: 100%;
 
-	&__content {
-		width: 100%;
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-		justify-content: center;
-		gap: 1em;
-		padding: 1rem;
-		font-family: var(--newspack-ui-font-family), system-ui, sans-serif !important;
-		box-shadow:
-			0 5px 10px var(--newspack-ui-color-neutral-10, rgba(0, 0, 0, 0.1)),
-			0 2px 5px var(--newspack-ui-color-neutral-20, rgba(0, 0, 0, 0.06));
+	.newspack-content-gate-countdown {
+		&__content {
+			width: 100%;
+			display: flex;
+			flex-direction: column;
+			align-items: center;
+			justify-content: center;
+			gap: 1em;
+			padding: 1rem;
+			font-family: var(--newspack-ui-font-family), system-ui, sans-serif !important;
+			box-shadow:
+				0 5px 10px var(--newspack-ui-color-neutral-10, rgba(0, 0, 0, 0.1)),
+				0 2px 5px var(--newspack-ui-color-neutral-20, rgba(0, 0, 0, 0.06));
 
-		@media screen and ( min-width: $breakpoint-md ) {
+			@media screen and ( min-width: $breakpoint-md ) {
+				flex-direction: row;
+				justify-content: flex-start;
+			}
+		}
+
+		&__text {
+			display: flex;
 			flex-direction: row;
-			justify-content: flex-start;
-		}
-	}
+			align-items: center;
+			justify-content: center;
+			gap: 10px;
+			width: 100%;
 
-	&__text {
-		display: flex;
-		flex-direction: row;
-		align-items: center;
-		justify-content: center;
-		gap: 10px;
-		width: 100%;
+			p {
+				font-size: 0.8em;
+				text-transform: uppercase;
+				opacity: 0.5;
+			}
 
-		p {
-			font-size: 0.8em;
-			text-transform: uppercase;
-			opacity: 0.5;
-		}
-
-		@media screen and ( min-width: $breakpoint-md ) {
-			width: 200px;
-			justify-content: flex-start;
-		}
-	}
-
-	&__countdown {
-		display: flex;
-		font-size: 1.5em;
-		font-weight: 700;
-		max-width: 100px;
-	}
-
-	&__actions {
-		width: 100%;
-		padding-right: 0;
-
-		& > *:first-child {
-			margin-top: 0;
+			@media screen and ( min-width: $breakpoint-md ) {
+				width: 200px;
+				justify-content: flex-start;
+			}
 		}
 
-		& > *:last-child {
-			margin-bottom: 0;
+		&__countdown {
+			display: flex;
+			font-size: 1.5em;
+			font-weight: 700;
+			max-width: 100px;
 		}
 
-		@media screen and ( min-width: $breakpoint-md ) {
-			width: calc(100% - 200px);
-			padding-right: calc(1em + 200px);
+		&__actions {
+			width: 100%;
+			padding-right: 0;
+
+			& > *:first-child {
+				margin-top: 0;
+			}
+
+			& > *:last-child {
+				margin-bottom: 0;
+			}
+
+			@media screen and ( min-width: $breakpoint-md ) {
+				width: calc(100% - 200px);
+				padding-right: calc(1em + 200px);
+			}
 		}
 	}
 }

--- a/src/blocks/content-gate-countdown/style.scss
+++ b/src/blocks/content-gate-countdown/style.scss
@@ -9,7 +9,7 @@ $breakpoint-md: 782px;
 		flex-direction: column;
 		align-items: center;
 		justify-content: center;
-		gap: 10px;
+		gap: 1em;
 		padding: 1rem;
 		font-family: var(--newspack-ui-font-family), system-ui, sans-serif !important;
 		box-shadow:
@@ -22,7 +22,7 @@ $breakpoint-md: 782px;
 		}
 	}
 
-	&__notice {
+	&__text {
 		display: flex;
 		flex-direction: row;
 		align-items: center;
@@ -33,6 +33,7 @@ $breakpoint-md: 782px;
 		p {
 			font-size: 0.8em;
 			text-transform: uppercase;
+			opacity: 0.5;
 		}
 
 		@media screen and ( min-width: $breakpoint-md ) {
@@ -45,8 +46,7 @@ $breakpoint-md: 782px;
 		display: flex;
 		font-size: 1.5em;
 		font-weight: 700;
-		white-space: nowrap;
-		width: 50px;
+		max-width: 100px;
 	}
 
 	&__actions {
@@ -63,7 +63,7 @@ $breakpoint-md: 782px;
 
 		@media screen and ( min-width: $breakpoint-md ) {
 			width: calc(100% - 200px);
-			padding-right: 200px;
+			padding-right: calc(1em + 200px);
 		}
 	}
 }

--- a/src/blocks/content-gate-countdown/style.scss
+++ b/src/blocks/content-gate-countdown/style.scss
@@ -4,10 +4,20 @@
 	&__content {
 		width: 100%;
 		display: flex;
-		flex-direction: row;
+		flex-direction: column;
 		align-items: center;
-		justify-content: flex-start;
+		justify-content: center;
+		gap: 10px;
 		padding: 1rem;
+		font-family: var(--newspack-ui-font-family), system-ui, sans-serif !important;
+		box-shadow:
+			0 5px 10px var(--newspack-ui-color-neutral-10, rgba(0, 0, 0, 0.1)),
+			0 2px 5px var(--newspack-ui-color-neutral-20, rgba(0, 0, 0, 0.06));
+
+		@media screen and ( min-width: 744px ) {
+			flex-direction: row;
+			justify-content: flex-start;
+		}
 	}
 
 	&__notice {
@@ -15,25 +25,35 @@
 		flex-direction: row;
 		align-items: center;
 		justify-content: flex-start;
-		flex: 1;
+		gap: 10px;
+		width: 100%;
+
+		p {
+			font-size: 0.8em;
+			text-transform: uppercase;
+		}
+
+		@media screen and ( min-width: 744px ) {
+			width: 200px;
+			justify-content: center;
+		}
 	}
 
 	&__countdown {
 		display: flex;
-		flex-direction: row;
-		align-items: center;
-		justify-content: flex-start;
-		margin-left: 1rem;
-		font-size: 1.5rem;
-		width: 100px;
+		font-size: 1.5em;
+		font-weight: 700;
+		white-space: nowrap;
+		width: 50px;
 	}
 
 	&__actions {
 		width: 100%;
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-		justify-content: center;
-		flex: 3;
+		padding-right: 0;
+
+		@media screen and ( min-width: 744px ) {
+			width: calc(100% - 200px);
+			padding-right: 200px;
+		}
 	}
 }

--- a/src/blocks/content-gate-countdown/style.scss
+++ b/src/blocks/content-gate-countdown/style.scss
@@ -1,19 +1,39 @@
 .newspack-content-gate-countdown {
 	width: 100%;
-	padding: 1rem;
 
 	&__content {
+		width: 100%;
+		display: flex;
+		flex-direction: row;
+		align-items: center;
+		justify-content: flex-start;
+		padding: 1rem;
+	}
+
+	&__notice {
+		display: flex;
+		flex-direction: row;
+		align-items: center;
+		justify-content: flex-start;
+		flex: 1;
+	}
+
+	&__countdown {
+		display: flex;
+		flex-direction: row;
+		align-items: center;
+		justify-content: flex-start;
+		margin-left: 1rem;
+		font-size: 1.5rem;
+		width: 100px;
+	}
+
+	&__actions {
+		width: 100%;
 		display: flex;
 		flex-direction: column;
 		align-items: center;
 		justify-content: center;
-		flex: 1;
-
-		p {
-			color: #333;
-			margin: 0 0 0.5rem 0;
-			font-size: 1rem;
-			line-height: 1.4;
-		}
+		flex: 3;
 	}
 }

--- a/src/blocks/content-gate-countdown/style.scss
+++ b/src/blocks/content-gate-countdown/style.scss
@@ -53,6 +53,14 @@ $breakpoint-md: 782px;
 		width: 100%;
 		padding-right: 0;
 
+		& > *:first-child {
+			margin-top: 0;
+		}
+
+		& > *:last-child {
+			margin-bottom: 0;
+		}
+
 		@media screen and ( min-width: $breakpoint-md ) {
 			width: calc(100% - 200px);
 			padding-right: 200px;

--- a/src/blocks/content-gate-countdown/view.js
+++ b/src/blocks/content-gate-countdown/view.js
@@ -1,0 +1,4 @@
+/**
+ * Internal dependencies
+ */
+import './style.scss';

--- a/src/blocks/content-gate-countdown/view.js
+++ b/src/blocks/content-gate-countdown/view.js
@@ -22,7 +22,7 @@ domReady( () => {
 		if ( authenticated ) {
 			return;
 		}
-		const storeKey = 'metering-' + gate_id || 0;
+		const storeKey = 'metering-' + ( gate_id || 0 );
 		const { content } = ras?.store?.get( storeKey ) || { content: [] };
 		const countdownEl = document.querySelector( '.newspack-content-gate-countdown__countdown' );
 		if ( ! countdownEl ) {

--- a/src/blocks/content-gate-countdown/view.js
+++ b/src/blocks/content-gate-countdown/view.js
@@ -24,9 +24,6 @@ domReady( () => {
 		}
 		const storeKey = 'metering-' + gate_id || 0;
 		const { content } = ras?.store?.get( storeKey ) || { content: [] };
-		if ( content.length > count ) {
-			return;
-		}
 		const countdownEl = document.querySelector( '.newspack-content-gate-countdown__countdown' );
 		if ( ! countdownEl ) {
 			return;

--- a/src/blocks/content-gate-countdown/view.js
+++ b/src/blocks/content-gate-countdown/view.js
@@ -30,7 +30,7 @@ domReady( () => {
 		}
 		// Replace countdown for anonymous users.
 		const countdown = sprintf(
-			/* translators: 1: remaining metered views, 2: total metered views. */ __( '%1$d/%2$d', 'newspack-plugin' ),
+			/* translators: 1: current number of metered views, 2: total metered views. */ __( '%1$d/%2$d', 'newspack-plugin' ),
 			content.length,
 			count
 		);

--- a/src/blocks/content-gate-countdown/view.js
+++ b/src/blocks/content-gate-countdown/view.js
@@ -31,7 +31,7 @@ domReady( () => {
 		// Replace countdown for anonymous users.
 		const countdown = sprintf(
 			/* translators: 1: remaining metered views, 2: total metered views. */ __( '%1$d/%2$d', 'newspack-plugin' ),
-			Math.max( 0, count - content.length ),
+			content.length,
 			count
 		);
 		countdownEl.textContent = countdown;

--- a/src/blocks/content-gate-countdown/view.js
+++ b/src/blocks/content-gate-countdown/view.js
@@ -1,4 +1,42 @@
+/* globals newspack_metering_settings */
+
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+
 /**
  * Internal dependencies
  */
 import './style.scss';
+import { domReady } from '../../utils';
+
+domReady( () => {
+	if ( typeof newspack_metering_settings === 'undefined' ) {
+		return;
+	}
+	const { count, gate_id } = newspack_metering_settings;
+	window.newspackRAS = window.newspackRAS || [];
+	window.newspackRAS.push( ras => {
+		const { authenticated } = ras?.getReader() || { authenticated: false };
+		if ( authenticated ) {
+			return;
+		}
+		const storeKey = 'metering-' + gate_id || 0;
+		const { content } = ras?.store?.get( storeKey ) || { content: [] };
+		if ( content.length > count ) {
+			return;
+		}
+		const countdownEl = document.querySelector( '.newspack-content-gate-countdown__countdown' );
+		if ( ! countdownEl ) {
+			return;
+		}
+		// Replace countdown for anonymous users.
+		const countdown = sprintf(
+			/* translators: 1: remaining metered views, 2: total metered views. */ __( '%1$d/%2$d', 'newspack-plugin' ),
+			Math.max( 0, count - content.length ),
+			count
+		);
+		countdownEl.textContent = countdown;
+	} );
+} );

--- a/src/blocks/index.js
+++ b/src/blocks/index.js
@@ -13,13 +13,14 @@ import * as correctionBox from './correction-box';
 import * as correctionItem from './correction-item';
 import * as avatar from './avatar';
 import * as collections from './collections';
+import * as contentGateCountdown from './content-gate-countdown';
 
 /**
  * Block Scripts
  */
 import './core-image';
 
-export const blocks = [ readerRegistration, correctionBox, correctionItem, avatar, collections ];
+export const blocks = [ readerRegistration, correctionBox, correctionItem, avatar, collections, contentGateCountdown ];
 
 const readerActivationBlocks = [ 'newspack/reader-registration' ];
 const correctionBlocks = [ 'newspack/correction-box', 'newspack/correction-item' ];

--- a/src/blocks/index.js
+++ b/src/blocks/index.js
@@ -25,6 +25,7 @@ export const blocks = [ readerRegistration, correctionBox, correctionItem, avata
 const readerActivationBlocks = [ 'newspack/reader-registration' ];
 const correctionBlocks = [ 'newspack/correction-box', 'newspack/correction-item' ];
 const collectionsBlocks = [ 'newspack/collections' ];
+const contentGateBlocks = [ 'newspack/content-gate-countdown' ];
 
 /**
  * Function to register an individual block.
@@ -42,14 +43,16 @@ const registerBlock = block => {
 	if ( readerActivationBlocks.includes( name ) && ! newspack_blocks.has_reader_activation ) {
 		return;
 	}
-
 	/** Do not register correction blocks if it's disabled. */
 	if ( correctionBlocks.includes( name ) && ! newspack_blocks.corrections_enabled ) {
 		return;
 	}
-
 	/** Do not register collections blocks if Collections module is disabled. */
 	if ( collectionsBlocks.includes( name ) && ! newspack_blocks.collections_enabled ) {
+		return;
+	}
+	/** Do not register content gate blocks if there is no gate. */
+	if ( contentGateBlocks.includes( name ) && ! newspack_blocks.has_content_gate ) {
 		return;
 	}
 

--- a/src/blocks/index.js
+++ b/src/blocks/index.js
@@ -51,8 +51,8 @@ const registerBlock = block => {
 	if ( collectionsBlocks.includes( name ) && ! newspack_blocks.collections_enabled ) {
 		return;
 	}
-	/** Do not register content gate blocks if there is no gate. */
-	if ( contentGateBlocks.includes( name ) && ! newspack_blocks.has_content_gate ) {
+	/** Do not register content gate blocks if Memberships is not active. */
+	if ( contentGateBlocks.includes( name ) && ! newspack_blocks.has_memberships ) {
 		return;
 	}
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -45,6 +45,7 @@ const entry = {
 	'reader-registration-block': path.join( __dirname, 'src', 'blocks', 'reader-registration', 'view.js' ),
 	'correction-box-block': path.join( __dirname, 'src', 'blocks', 'correction-box', 'index.js' ),
 	'correction-item-block': path.join( __dirname, 'src', 'blocks', 'correction-item', 'index.js' ),
+	'content-gate-countdown-block': path.join( __dirname, 'src', 'blocks', 'content-gate-countdown', 'view.js' ),
 	'avatar-block': path.join( __dirname, 'src', 'blocks', 'avatar', 'index.js' ),
 	'my-account': path.join( __dirname, 'src', 'my-account', 'index.js' ),
 	'my-account-v0': path.join( __dirname, 'src', 'my-account', 'v0', 'index.js' ),


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://linear.app/a8c/issue/NPPM-2204/content-restriction-block-shows-countdown-before-you-hit-the-wall-you

This PR adds a new content gate countdown block that displays the remaining free metered views for a post or page:

![Screenshot 2025-09-15 at 19 45 53](https://github.com/user-attachments/assets/be407a4a-9420-4a15-81d4-b21c14c86cda)

### How to test the changes in this Pull Request:

1. First create some memberships and have some readers that are members and non-members
2. Create some content gates for these memberships, making sure each has metering active
3. Add the content gate countdown block to several of the restricted posts/pages in which the block has been added
4. Test that the block
  - appears on the frontend when within the metered view limit
  - countsdown as the reader views more relevant content
  - appears on the frontend for posts that have already been viewed when the limit is reached
  - does not appear on the frontend for newly viewed posts whenever the limit is reached (gate should be displayed instead)
  - does not appear for members who have access
  - Be sure to also test the for logged in members, logged in non-members, and logged out readers

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->