### PR TITLE
fix(indesign-export): remove feature flag

### DIFF
--- a/includes/optional-modules/class-indesign-exporter.php
+++ b/includes/optional-modules/class-indesign-exporter.php
@@ -56,14 +56,12 @@ class InDesign_Exporter {
 	 * @return bool True if InDesign Exporter is enabled.
 	 */
 	public static function is_feature_enabled() {
-		$is_enabled = defined( 'NEWSPACK_INDESIGN_EXPORT_ENABLED' ) ? constant( 'NEWSPACK_INDESIGN_EXPORT_ENABLED' ) : false;
-
 		/**
 		 * Filters whether the InDesign Export feature is enabled.
 		 *
 		 * @param bool $is_enabled Whether the InDesign Export module is enabled.
 		 */
-		return apply_filters( 'newspack_indesign_export_enabled', $is_enabled );
+		return apply_filters( 'newspack_indesign_export_enabled', true );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

NPPD-708

Remove the feature flag for the InDesign Export optional module.

### How to test the changes in this Pull Request:

1. Make sure you don't have the `NEWSPACK_INDESIGN_EXPORT_ENABLED` constant in your wp-config
2. Navigate to Newspack -> Settings -> Print
3. Confirm the `Enable InDesign Export` is available
4. Toggle it on and confirm the feature is working as expected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->