### PR TITLE
Only defer newspack-plugin scripts if Audience Management is not enabled

### DIFF
--- a/includes/plugins/class-perfmatters.php
+++ b/includes/plugins/class-perfmatters.php
@@ -27,9 +27,8 @@ class Perfmatters {
 	 * Scripts to delay spec.
 	 */
 	private static function scripts_to_delay() {
-		return [
+		$scripts_to_delay = [
 			// Newspack.
-			'newspack-plugin',
 			'newspack-popups',
 			'newspack-blocks',
 			'newspack-newsletters',
@@ -74,6 +73,14 @@ class Perfmatters {
 			'ai_insert_code',
 			'doubleclick.net',
 		];
+
+		// Only delay newspack-plugin if reader activation is not enabled. Because there
+		// are buttons that do things, and they should do those things on the first click.
+		if ( ! Reader_Activation::is_enabled() ) {
+			$scripts_to_delay[] = 'newspack-plugin';
+		}
+
+		return $scripts_to_delay;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes NPPM-2105

The Perfmatters "Delay" feature waits X seconds or until the user does an interaction to load the delayed scripts. On desktop, moving the mouse counts as an interaction, but on mobile, the first interaction would be when someone touches the screen.

So, on mobile, if the first things someone does is click the Sign In icon soon after the page renders, the scripts will start loading in at that time, and their click on the Sign In doesn't do anything useful. We can solve this by not delaying the newspack-plugin scripts if Audience Management is enabled. This has tradeoffs though, in the form of slightly worse performance. If you don't think this is an acceptable tradeoff, LMK and we can figure something out (maybe breaking off the Audience Management scripts into their own file)

### How to test the changes in this Pull Request:

1. Before applying this patch, have Audience Management on a site and Perfmatters with the default script handling.
2. Open an incognito window and turn on the mobile responsive simulation. Load the site and immediately after the page renders, click the Sign In icon. Observe nothing happens except a `#` is appended to the current URL.

<img width="549" height="211" alt="Screenshot 2025-09-12 at 2 41 13 PM" src="https://github.com/user-attachments/assets/28ba5aa4-3b51-4545-8288-694345cb72c6" />

3. Apply this patch. Try the same thing. Observe the Sign In modal appears.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->