### PR TITLE
feat(collections): collections block feedback

### DIFF
--- a/includes/collections/class-collection-meta.php
+++ b/includes/collections/class-collection-meta.php
@@ -245,6 +245,16 @@ class Collection_Meta {
 	 * @see Query_Helper::get_ctas()
 	 */
 	public static function get_collection_ctas_for_rest( $post ) {
-		return Query_Helper::get_ctas( $post['id'] );
+		return array_map(
+			function ( $cta ) {
+				return [
+					'label' => esc_html( $cta['label'] ?? '' ),
+					'url'   => esc_url( $cta['url'] ?? '' ),
+					'type'  => esc_attr( $cta['type'] ?? '' ),
+					'class' => esc_attr( $cta['class'] ?? '' ),
+				];
+			},
+			Query_Helper::get_ctas( $post['id'] )
+		);
 	}
 }

--- a/includes/collections/class-template-helper.php
+++ b/includes/collections/class-template-helper.php
@@ -563,7 +563,6 @@ class Template_Helper {
 			'selectedCollections' => $collections,
 			'columns'             => 6,
 			'showCategory'        => false,
-			'showSeeAllLink'      => false,
 		];
 
 		/**
@@ -604,7 +603,6 @@ class Template_Helper {
 				'showExcerpt'         => true,
 				'showCategory'        => false,
 				'numberOfCTAs'        => -1,
-				'showSeeAllLink'      => false,
 				'headingText'         => '',
 				'noPermalinks'        => false,
 			]

--- a/src/blocks/collections/block.json
+++ b/src/blocks/collections/block.json
@@ -103,14 +103,6 @@
 		"specificCTAs": {
 			"type": "string",
 			"default": ""
-		},
-		"showSeeAllLink": {
-			"type": "boolean",
-			"default": true
-		},
-		"seeAllLinkText": {
-			"type": "string",
-			"default": ""
 		}
 	},
 	"example": {
@@ -125,9 +117,7 @@
 			"showVolume": true,
 			"showNumber": true,
 			"showCTAs": true,
-			"numberOfCTAs": 1,
-			"showSeeAllLink": true,
-			"seeAllLinkText": "See all collections"
+			"numberOfCTAs": 1
 		}
 	},
 	"textdomain": "newspack-plugin",

--- a/src/blocks/collections/class-collections-block.php
+++ b/src/blocks/collections/class-collections-block.php
@@ -54,8 +54,6 @@ final class Collections_Block {
 		'showCTAs'            => true,
 		'numberOfCTAs'        => 1,
 		'specificCTAs'        => '',
-		'showSeeAllLink'      => true,
-		'seeAllLinkText'      => '',
 		'headingText'         => '',
 		'noPermalinks'        => false,
 	];
@@ -136,20 +134,6 @@ final class Collections_Block {
 		?>
 		<div <?php echo $wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 			<?php self::render_collections( $collections, $attributes ); ?>
-
-			<?php if ( $attributes['showSeeAllLink'] ) : ?>
-				<div class="wp-block-newspack-collections__see-all">
-					<a class="wp-block-button__link" href="<?php echo esc_url( get_post_type_archive_link( Post_Type::get_post_type() ) ); ?>">
-						<?php
-						if ( ! empty( $attributes['seeAllLinkText'] ) ) {
-							echo esc_html( $attributes['seeAllLinkText'] );
-						} else {
-							esc_html_e( 'See all', 'newspack-plugin' );
-						}
-						?>
-					</a>
-				</div>
-			<?php endif; ?>
 		</div>
 		<?php
 		return ob_get_clean();

--- a/src/blocks/collections/class-collections-block.php
+++ b/src/blocks/collections/class-collections-block.php
@@ -89,14 +89,8 @@ final class Collections_Block {
 	 * @return string The block HTML.
 	 */
 	public static function render_block( array $attributes ) {
-
-		$attributes = wp_parse_args( $attributes, self::DEFAULT_ATTRIBUTES );
-
-		// Sanitize and normalize attributes that are used in queries/output.
-		$attributes['numberOfItems'] = max( 1, absint( $attributes['numberOfItems'] ) );
-		$attributes['offset']        = max( 0, absint( $attributes['offset'] ) );
-		$attributes['columns']       = max( 1, absint( $attributes['columns'] ) );
-		$attributes['numberOfCTAs']  = ( -1 === (int) $attributes['numberOfCTAs'] ) ? -1 : max( 1, absint( $attributes['numberOfCTAs'] ) );
+		// Sanitize and normalize attributes.
+		$attributes = self::sanitize_attributes( wp_parse_args( $attributes, self::DEFAULT_ATTRIBUTES ) );
 
 		// Normalize selectedCollections to determine if we have post objects or IDs.
 		$normalized_posts = Template_Helper::normalize_post_list( (array) $attributes['selectedCollections'] );
@@ -137,6 +131,31 @@ final class Collections_Block {
 		</div>
 		<?php
 		return ob_get_clean();
+	}
+
+	/**
+	 * Sanitize and normalize attributes that are used in queries/output.
+	 *
+	 * @param array $attributes The block attributes.
+	 * @return array Sanitized attributes.
+	 */
+	public static function sanitize_attributes( array $attributes ) {
+		foreach ( [ 'numberOfItems', 'offset', 'columns', 'numberOfCTAs' ] as $attr ) {
+			if ( ! isset( $attributes[ $attr ] ) ) {
+				continue;
+			}
+
+			if ( 'numberOfCTAs' === $attr && -1 === (int) $attributes[ $attr ] ) {
+				$attributes[ $attr ] = -1;
+			} else {
+				$value               = absint( $attributes[ $attr ] );
+				$attributes[ $attr ] = $value > 0
+					? $value
+					: self::DEFAULT_ATTRIBUTES[ $attr ];
+			}
+		}
+
+		return $attributes;
 	}
 
 	/**

--- a/src/blocks/collections/components/InspectorPanel.jsx
+++ b/src/blocks/collections/components/InspectorPanel.jsx
@@ -44,8 +44,6 @@ const InspectorPanel = ( { attributes, setAttributes } ) => {
 		showCTAs,
 		numberOfCTAs,
 		specificCTAs,
-		showSeeAllLink,
-		seeAllLinkText,
 	} = attributes;
 
 	// Category suggestions.
@@ -132,25 +130,6 @@ const InspectorPanel = ( { attributes, setAttributes } ) => {
 							__next40pxDefaultSize
 						/>
 					</>
-				) }
-
-				<ToggleControl
-					label={ __( 'Show "See all" link', 'newspack-plugin' ) }
-					checked={ showSeeAllLink }
-					onChange={ value => setAttributes( { showSeeAllLink: value } ) }
-				/>
-
-				{ showSeeAllLink && (
-					<BaseControl id="see-all-text-control" aria-label={ __( '"See all" link text', 'newspack-plugin' ) }>
-						<input
-							type="text"
-							value={ seeAllLinkText ? seeAllLinkText : __( 'See all', 'newspack-plugin' ) }
-							onChange={ e => setAttributes( { seeAllLinkText: e.target.value } ) }
-							placeholder={ __( 'See all', 'newspack-plugin' ) }
-							className="components-text-control__input"
-							style={ { height: '40px' } }
-						/>
-					</BaseControl>
 				) }
 			</PanelBody>
 

--- a/src/blocks/collections/edit.jsx
+++ b/src/blocks/collections/edit.jsx
@@ -1,5 +1,5 @@
 import { __ } from '@wordpress/i18n';
-import { useBlockProps, BlockControls, RichText } from '@wordpress/block-editor';
+import { useBlockProps, BlockControls } from '@wordpress/block-editor';
 import { ToolbarGroup, ToolbarButton, Placeholder, Spinner } from '@wordpress/components';
 import { caution, list, grid, pullLeft, pullRight, postFeaturedImage } from '@wordpress/icons';
 import { useMemo } from '@wordpress/element';
@@ -7,13 +7,10 @@ import classnames from 'classnames';
 
 import { useCollections } from './hooks/useCollections';
 import CollectionItem from './components/CollectionItem';
-import usePreventNav from './hooks/usePreventNav';
 import InspectorPanel from './components/InspectorPanel';
 
 const Edit = ( { attributes, setAttributes } ) => {
-	const { layout, columns, imageAlignment, imageSize, showFeaturedImage, showSeeAllLink, seeAllLinkText } = attributes;
-
-	const preventNav = usePreventNav();
+	const { layout, columns, imageAlignment, imageSize, showFeaturedImage } = attributes;
 
 	// Fetch collections data.
 	const { collections, isLoading, hasCollections } = useCollections( attributes );
@@ -130,22 +127,6 @@ const Edit = ( { attributes, setAttributes } ) => {
 							<CollectionItem key={ collection.id } collection={ collection } attributes={ attributes } />
 						) ) }
 					</>
-				) }
-
-				{ /* See all link */ }
-				{ showSeeAllLink && hasCollections && (
-					<div className="wp-block-newspack-collections__see-all">
-						<RichText
-							tagName="a"
-							className="wp-block-button__link"
-							value={ seeAllLinkText || __( 'See all', 'newspack-plugin' ) }
-							onChange={ value => setAttributes( { seeAllLinkText: value } ) }
-							href="#"
-							onClick={ preventNav }
-							allowedFormats={ [] }
-							placeholder={ __( 'See all', 'newspack-plugin' ) }
-						/>
-					</div>
 				) }
 			</div>
 		</>

--- a/src/blocks/collections/styles/_ctas.scss
+++ b/src/blocks/collections/styles/_ctas.scss
@@ -9,16 +9,4 @@
 			width: 100%;
 		}
 	}
-
-	// See all collections link.
-	.wp-block-newspack-collections__see-all {
-		text-align: center;
-		grid-column: 1 / -1;
-
-		a:hover {
-			color: var(--newspack-theme-color-against-secondary);
-			background-color: var(--newspack-theme-color-bg-button-hover);
-		}
-	}
 }
-

--- a/tests/unit-tests/collections/class-test-collection-meta.php
+++ b/tests/unit-tests/collections/class-test-collection-meta.php
@@ -262,4 +262,60 @@ class Test_Collection_Meta extends WP_UnitTestCase {
 		$this->assertIsArray( $result, 'Result should be an array.' );
 		$this->assertEmpty( $result, 'Should return empty array when no CTAs.' );
 	}
+
+	/**
+	 * Test that get_collection_ctas_for_rest escapes malicious values.
+	 *
+	 * @covers \Newspack\Collections\Collection_Meta::get_collection_ctas_for_rest
+	 */
+	public function test_get_collection_ctas_for_rest_escaping() {
+		$ctas_data = [
+			[
+				'type'  => 'link',
+				'label' => '<script>alert("xss")</script>Malicious Label',
+				'url'   => 'javascript:alert("malicious")',
+			],
+			[
+				'type'  => 'link',
+				'label' => 'Safe & Good Label',
+				'url'   => 'https://example.com/page?param=value&other=test',
+			],
+			[
+				'type'  => 'link"',
+				'label' => 'Test',
+				'url'   => 'https://example.com',
+				'class' => 'btn" onclick="alert(\'xss\')" class="fake',
+			],
+		];
+
+		// Test all fields are properly escaped.
+		$expected = [
+			[
+				'type'  => 'link',
+				'label' => '&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;Malicious Label',
+				'url'   => '',
+				'class' => '',
+			],
+			[
+				'type'  => 'link',
+				'label' => 'Safe &amp; Good Label',
+				'url'   => 'https://example.com/page?param=value&#038;other=test',
+				'class' => '',
+			],
+			[
+				'type'  => 'link&quot;',
+				'label' => 'Test',
+				'url'   => 'https://example.com',
+				'class' => 'btn&quot; onclick=&quot;alert(&#039;xss&#039;)&quot; class=&quot;fake',
+			],
+		];
+
+		$collection_id = $this->create_test_collection();
+		Collection_Meta::set( $collection_id, 'ctas', $ctas_data );
+		$result = Collection_Meta::get_collection_ctas_for_rest( [ 'id' => $collection_id ] );
+
+		$this->assertIsArray( $result, 'Result should be an array.' );
+		$this->assertCount( 3, $result, 'Should return 3 CTAs.' );
+		$this->assertEquals( $expected, $result, 'All CTA fields should be properly escaped.' );
+	}
 }

--- a/tests/unit-tests/collections/class-test-collections-block.php
+++ b/tests/unit-tests/collections/class-test-collections-block.php
@@ -508,23 +508,44 @@ class Test_Collections_Block extends \WP_UnitTestCase {
 	/**
 	 * Test attribute sanitization.
 	 *
-	 * @covers \Newspack\Blocks\Collections\Collections_Block::render_block
+	 * @covers \Newspack\Blocks\Collections\Collections_Block::sanitize_attributes
 	 */
 	public function test_attribute_sanitization() {
 		$post_title    = 'Test Collection';
 		$collection_id = $this->create_test_collection( [ 'post_title' => $post_title ] );
 
 		// Test with negative and invalid values.
-		$attributes = [
-			'numberOfItems'       => -5,
+		$invalid_attributes = [
+			'numberOfItems'       => 'one',
 			'columns'             => 0,
 			'numberOfCTAs'        => -1,
+			'offset'              => -0.5,
 			'selectedCollections' => [ 'invalid', '123', $collection_id ],
 		];
 
-		$output = $this->render_collections_block( $attributes );
+		$sanitized = Collections_Block::sanitize_attributes( $invalid_attributes );
 
-		// Should still render successfully due to sanitization.
+		$this->assertEquals( Collections_Block::DEFAULT_ATTRIBUTES['numberOfItems'], $sanitized['numberOfItems'], 'Invalid numberOfItems should use default' );
+		$this->assertEquals( Collections_Block::DEFAULT_ATTRIBUTES['columns'], $sanitized['columns'], 'Invalid columns should use default' );
+		$this->assertEquals( Collections_Block::DEFAULT_ATTRIBUTES['offset'], $sanitized['offset'], 'Invalid offset should use default' );
+		$this->assertEquals( -1, $sanitized['numberOfCTAs'], 'Special value -1 for numberOfCTAs should be preserved' );
+
+		// Test with valid values that should be preserved (even if less than defaults).
+		$valid_attributes = [
+			'numberOfItems' => 2,
+			'columns'       => 1,
+			'numberOfCTAs'  => 3,
+		];
+
+		$sanitized_valid = Collections_Block::sanitize_attributes( $valid_attributes );
+
+		$this->assertEquals( 2, $sanitized_valid['numberOfItems'], 'Valid numberOfItems should be preserved' );
+		$this->assertEquals( 1, $sanitized_valid['columns'], 'Valid columns should be preserved' );
+		$this->assertEquals( 3, $sanitized_valid['numberOfCTAs'], 'Valid numberOfCTAs should be preserved' );
+
+		// Test rendering still works with invalid attributes.
+		$output = $this->render_collections_block( $invalid_attributes );
+
 		$this->assertStringContainsString( 'wp-block-newspack-collections', $output, 'Should contain block wrapper despite invalid attributes' );
 		$this->assertStringContainsString( $post_title, $output, 'Should contain collection title' );
 	}

--- a/tests/unit-tests/collections/class-test-collections-block.php
+++ b/tests/unit-tests/collections/class-test-collections-block.php
@@ -116,35 +116,6 @@ class Test_Collections_Block extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test render_block with see all link.
-	 *
-	 * @covers \Newspack\Blocks\Collections\Collections_Block::render_block
-	 */
-	public function test_render_block_with_custom_see_all_link() {
-		$this->create_test_collection();
-
-		$attributes = [
-			'seeAllLinkText' => 'View All Collections',
-		];
-		$output     = $this->render_collections_block( $attributes );
-
-		$this->assertStringContainsString( 'wp-block-newspack-collections__see-all', $output, 'Should contain see all wrapper' );
-		$this->assertStringContainsString( 'View All Collections', $output, 'Should contain custom see all text' );
-	}
-
-	/**
-	 * Test render_block with default see all text.
-	 *
-	 * @covers \Newspack\Blocks\Collections\Collections_Block::render_block
-	 */
-	public function test_render_block_with_default_see_all_link() {
-		$this->create_test_collection();
-		$output = $this->render_collections_block();
-
-		$this->assertStringContainsString( 'See all', $output, 'Should contain default see all text' );
-	}
-
-	/**
 	 * Test numberOfCTAs attribute handles -1 correctly for showing all CTAs.
 	 *
 	 * @covers \Newspack\Blocks\Collections\Collections_Block::render_block
@@ -170,7 +141,6 @@ class Test_Collections_Block extends \WP_UnitTestCase {
 			'selectedCollections' => [ $collection_id ],
 			'numberOfCTAs'        => -1,
 			'showCTAs'            => true,
-			'showSeeAllLink'      => false,
 		];
 
 		$output = $this->render_collections_block( $attributes );


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR addresses Collections Block feedback from previous PRs across security, functionality, and code quality:

1. Remove 'See All' CTA functionality and all the related code for see-all CTAs, as it will no longer be used. Conversation in #4166.
2. Escape CTA values (`label`, `url`, `type`, `class`) in `get_collection_ctas_for_rest()` used in REST responses, to match what `render_cta()` does. Conversation in #4172.
3. Improve attribute sanitization by using defaults for fallbacks instead of hardcoded values. Conversation in #4172.

### How to test the changes in this Pull Request:

1. Test removed 'See All' functionality:
    - Verify the Collections Block editor no longer shows see-all CTA options
2. Test CTA escaping:
    - Create a collection with malicious CTA data (`<script>` tags, `javascript:` URLs). Might require updating the DB.
    - Check REST API response contains escaped values, no raw malicious content
3. Test attribute sanitization:
      - Create Collections Block with invalid values (`numberOfItems: 0`, `columns: 'invalid'`)
      - Verify block uses defaults from `DEFAULT_ATTRIBUTES` array

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?