### PR TITLE
fix: Improve help text for Guest Contributor checkbox

### DIFF
--- a/includes/plugins/co-authors-plus/class-guest-contributor-role.php
+++ b/includes/plugins/co-authors-plus/class-guest-contributor-role.php
@@ -497,7 +497,7 @@ class Guest_Contributor_Role {
 						</label>
 						<p class="description">
 						<?php
-							esc_html_e( 'If this option is checked, the "Non Editing Contributor" role will be added to the user and they will be able to be assigned as a co-author of a post even if they are not allowed to edit posts. For users with edit access, this option has no effect.', 'newspack-plugin' );
+							esc_html_e( 'If this option is checked, the "Guest Contributor" role will be added to the user (on top of their current role) and they will be able to be assigned as a co-author of a post even if they are not allowed to edit posts. For users with edit access, this option has no effect.', 'newspack-plugin' );
 						?>
 						</p>
 					</td>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes and improves the help text on the Guest Contributor checkbox

Refs NPPM-2230

### How to test the changes in this Pull Request:

1. Check the copy

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->