### PR TITLE
fix(bylines): display inline name for missing users

### DIFF
--- a/includes/bylines/class-bylines.php
+++ b/includes/bylines/class-bylines.php
@@ -206,6 +206,11 @@ class Bylines {
 			function( $matches ) {
 				$author_id = $matches[1];
 
+				$author = get_user_by( 'id', $author_id );
+				if ( ! $author ) {
+					return $matches[2];
+				}
+
 				return sprintf(
 					/* translators: 1: Author avatar. 2: author link. */
 					'<span class="author vcard"><a class="url fn n" href="%1$s">%2$s</a></span>',
@@ -229,7 +234,12 @@ class Bylines {
 		$avatars = '';
 
 		foreach ( $author_ids as $author_id ) {
-			$avatars .= '<span class="author-avatar">' . get_avatar( $author_id ) . '</span>';
+			$author = get_user_by( 'id', $author_id );
+			if ( ! $author ) {
+				continue;
+			}
+
+			$avatars .= '<span class="author-avatar">' . get_avatar( $author->ID ) . '</span>';
 		}
 
 		return $avatars;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Custom bylines are not aware of account deletion, so the `[Author id=00]` shortcode may refer to a non-existing author. In those cases, the inline name gets replaced with an empty string. This PR changes that behavior so the inline name is preserved.

### How to test the changes in this Pull Request:

1. While on release, create a post with multiple authors and a custom byline
2. Delete the user for one of the authors
3. Visit the post and confirm the byline is missing the author name
4. Checkout this branch, refresh the page, and confirm the byline preserves the author name but without a link

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->