### PR TITLE
hotfix: change sitekit check cadence

### DIFF
--- a/includes/plugins/google-site-kit/class-googlesitekit-logger.php
+++ b/includes/plugins/google-site-kit/class-googlesitekit-logger.php
@@ -67,10 +67,17 @@ class GoogleSiteKit_Logger {
 	public static function cron_init() {
 		register_deactivation_hook( NEWSPACK_PLUGIN_FILE, [ __CLASS__, 'cron_deactivate' ] );
 
+		// Switch the cadence of the cron job from hourly to daily so we need to unschedule any existing hourly jobs.
+		$cadence_updated_option = 'newspack_googlesitekit_cron_cadence_updated';
+		if ( ! get_option( $cadence_updated_option ) ) {
+			wp_clear_scheduled_hook( self::CRON_HOOK );
+			update_option( $cadence_updated_option, true );
+		}
+
 		if ( defined( 'NEWSPACK_CRON_DISABLE' ) && is_array( NEWSPACK_CRON_DISABLE ) && in_array( self::CRON_HOOK, NEWSPACK_CRON_DISABLE, true ) ) {
 			self::cron_deactivate();
 		} elseif ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
-			wp_schedule_event( time(), 'hourly', self::CRON_HOOK );
+			wp_schedule_event( time(), 'daily', self::CRON_HOOK );
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This is generating too many alerts for disconnected sites. No need to check that often.

### How to test the changes in this Pull Request:

1. On `trunk` run `wp cron event list` and confirm the `newspack_googlesitekit_disconnection_logger` event is scheduled hourly
2. Checkout this branch and visit the admin
3. Check the event again and see that it's now daily

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->