### PR TITLE
fix: update download URL for db.php

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -92,7 +92,7 @@ install_wp() {
 		tar --strip-components=1 -zxmf $TMPDIR/wordpress.tar.gz -C $WP_CORE_DIR
 	fi
 
-	download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR/wp-content/db.php
+	download https://raw.githubusercontent.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR/wp-content/db.php
 }
 
 install_test_suite() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Updated the `bin/install-wp-tests.sh` script to use the more reliable `raw.githubusercontent.com` URL instead of the deprecated `raw.github.com` domain when downloading the `db.php` file. The legacy `raw.github.com` URL was intermittently returning 503 Service Unavailable errors, causing the downloaded `db.php` file to contain HTML error content instead of valid PHP code, which resulted in syntax errors and failing PHP tests.

Closes NPPM-2240.

### How to test the changes in this Pull Request:

1. Run `n test-php` locally to verify PHP tests pass without syntax errors in the downloaded `db.php` file. You might need to [comment this block](https://github.com/Automattic/newspack-plugin/blob/f4e77d5c4828c6a1979c6377ef2a2cc857f42276/bin/install-wp-tests.sh#L58-L60) so the line changed runs if the installation has already taken place before and the files are present:
```
	if [ -d $WP_CORE_DIR ]; then
		return;
	fi
```
2. After merging, check that the CircleCI test-php job now runs consistently without intermittent failures.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?