### PR TITLE
fix: keep statuses when saving linked memberships

### DIFF
--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -1209,9 +1209,6 @@ class Memberships {
 		// Get the original post data before the update.
 		$original_post = get_post( $post_id );
 
-		error_log( print_r( $original_post, true ) );
-		error_log( print_r( $post, true ) );
-
 		// Restore original status if it was changed.
 		if ( $original_post && $original_post->post_status !== $post->post_status ) {
 			wp_update_post(

--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -1133,18 +1133,18 @@ class Memberships {
 			jQuery(document).ready(function($) {
 				function disableFields() {
 					// Disable Status field (Select2-based)
-					$(".plan-details #post_status").prop("disabled", true).css("opacity", "0.6");
+					$(".plan-details #post_status").prop("readonly", true).css("opacity", "0.6");
 					$("#post_status").next(".select2-container").css("opacity", "0.6").css("pointer-events", "none");
 
 					// Disable Member since fields
-					$("#_start_date").prop("disabled", true).css("opacity", "0.6");
+					$("#_start_date").prop("readonly", true).css("opacity", "0.6");
 					$("#_start_date").next(".ui-datepicker-trigger").css("display", "none");
 
 					// Disable Expires fields
-					$("#_end_date").prop("disabled", true).css("opacity", "0.6");
+					$("#_end_date").prop("readonly", true).css("opacity", "0.6");
 					$("#_end_date").next(".ui-datepicker-trigger").css("display", "none");
 
-					// Add visual indication that fields are disabled
+					// Add visual indication that fields are readonly
 					$("#post_status, #_start_date, #_end_date").each(function() {
 						var container = $(this).closest("p, .form-field");
 						if (!container.find(".subscription-linked-notice").length) {
@@ -1208,6 +1208,9 @@ class Memberships {
 
 		// Get the original post data before the update.
 		$original_post = get_post( $post_id );
+
+		error_log( print_r( $original_post, true ) );
+		error_log( print_r( $post, true ) );
 
 		// Restore original status if it was changed.
 		if ( $original_post && $original_post->post_status !== $post->post_status ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an issue that was changing the Memberships statuses unintentionally when saving.

### How to test the changes in this Pull Request:

1. As a reader, buy a subscription that grants you access to a memberships
2. You want to have a membership that is linked to a subscription
3. On `release` notice the disabled "Status" field and Save the membership without making any changes to it
4. Notice that the status goes to Pending
5. Repeat the process on this branch.
6. Notice that the status is not changed
7. Notice the Status field is still blocked


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->