### PR TITLE
feat(collections): remove feature flag

### DIFF
--- a/includes/optional-modules/class-collections.php
+++ b/includes/optional-modules/class-collections.php
@@ -57,15 +57,12 @@ class Collections {
 	 * @return bool True if Collections is enabled.
 	 */
 	public static function is_feature_enabled() {
-		// Check if the feature is enabled.
-		$is_enabled = defined( 'NEWSPACK_COLLECTIONS_ENABLED' ) ? constant( 'NEWSPACK_COLLECTIONS_ENABLED' ) : false;
-
 		/**
 		 * Filters whether the Collections feature is enabled.
 		 *
 		 * @param bool $is_enabled Whether the Collections module is enabled.
 		 */
-		return apply_filters( 'newspack_collections_enabled', $is_enabled );
+		return apply_filters( 'newspack_collections_enabled', true );
 	}
 
 	/**

--- a/src/wizards/newspack/views/settings/collections/index.tsx
+++ b/src/wizards/newspack/views/settings/collections/index.tsx
@@ -51,6 +51,7 @@ function Collections() {
 	>( {
 		path: '/newspack/v1/wizard/newspack-settings/collections',
 		apiNamespace: 'newspack-settings/collections',
+		refreshOn: [ 'POST' ],
 		data: {
 			...DEFAULT_COLLECTIONS_SETTINGS,
 			module_enabled_collections: false,

--- a/tests/unit-tests/collections/class-test-collections.php
+++ b/tests/unit-tests/collections/class-test-collections.php
@@ -30,22 +30,23 @@ class Test_Collections extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that the feature is disabled by default.
+	 * Test that the feature is enabled by default.
 	 *
 	 * @covers \Newspack\Optional_Modules\Collections::is_feature_enabled
 	 */
-	public function test_is_module_enabled_default_false() {
-		$this->assertFalse( Collections::is_feature_enabled(), 'Module should be disabled by default.' );
+	public function test_is_module_enabled_default_true() {
+		$this->assertTrue( Collections::is_feature_enabled(), 'Module should be enabled by default.' );
 	}
 
 	/**
-	 * Test that the feature is enabled when the filter returns true.
+	 * Test that the feature can be disabled with a filter.
 	 *
 	 * @covers \Newspack\Optional_Modules\Collections::is_feature_enabled
 	 */
-	public function test_is_feature_enabled_filter_true() {
-		add_filter( 'newspack_collections_enabled', '__return_true' );
-		$this->assertTrue( Collections::is_feature_enabled(), 'Feature should be enabled by filter.' );
+	public function test_is_feature_enabled_filter_false() {
+		add_filter( 'newspack_collections_enabled', '__return_false' );
+		$this->assertFalse( Collections::is_feature_enabled(), 'Feature should be disabled by filter.' );
+		remove_all_filters( 'newspack_collections_enabled' );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Remove the `NEWSPACK_COLLECTIONS_ENABLED` feature flag check.
The Collections feature is now available to everyone while preserving the conditional module loading.

Closes NPPD-687.

### How to test the changes in this Pull Request:

1. Verify the Collections tab (`/wp-admin/admin.php?page=newspack-settings#/collections`) appears in Newspack Settings regardless of the wp-config constants.
2. Confirm that the Collections functionality only loads when the "Collections Module" toggle is enabled.
3. Verify that the page refreshes when enabling/disabling the module and that the "Collections" sidebar menu item properly appears in the admin depending on the toggle state.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
