### PR TITLE
feat(InDesign): inline image caption, horizontal rule, headings and blockquotes

### DIFF
--- a/includes/optional-modules/indesign-export/class-indesign-converter.php
+++ b/includes/optional-modules/indesign-export/class-indesign-converter.php
@@ -28,6 +28,7 @@ class InDesign_Converter {
 		'byline'            => '<pstyle:byline>By ',
 		'pullquote'         => '<pstyle:pullquote>',
 		'pullquote_name'    => '<pstyle:pullquotename>',
+		'blockquote'        => '<pstyle:blockquote>',
 	];
 
 	/**
@@ -236,21 +237,25 @@ class InDesign_Converter {
 		$pattern      = '/<blockquote[^>]*>(.*?)<\/blockquote>/is';
 		$cite_pattern = '/<cite[^>]*>(.*?)<\/cite>/is';
 
-		preg_match_all( $pattern, $content, $matches );
-		$blockquotes = $matches[1];
+		preg_match_all( $pattern, $content, $quote_matches );
+		$quotes = $quote_matches[1];
 
-		foreach ( $blockquotes as $blockquote ) {
-			$quote = $this->styles['pullquote'] . wp_strip_all_tags( preg_replace( $cite_pattern, '', $blockquote ) );
+		foreach ( $quotes as $i => $quote ) {
+			$tag = $this->styles['pullquote'];
+			if ( strpos( $quote_matches[0][ $i ], 'wp-block-quote' ) !== false ) {
+				$tag = $this->styles['blockquote'];
+			}
+			$quote_content = $tag . wp_strip_all_tags( preg_replace( $cite_pattern, '', $quote ) );
 
-			preg_match( $cite_pattern, $blockquote, $matches );
-			if ( ! empty( $matches ) ) {
-				$cite = $matches[1];
+			preg_match( $cite_pattern, $quote, $cite_matches );
+			if ( ! empty( $cite_matches ) ) {
+				$cite = $cite_matches[1];
 				if ( ! empty( $cite ) ) {
-					$quote .= "\r\n" . $this->styles['pullquote_name'] . wp_strip_all_tags( $cite );
+					$quote_content .= "\r\n" . $this->styles['pullquote_name'] . wp_strip_all_tags( $cite );
 				}
 			}
 
-			$content = preg_replace( $pattern, $quote, $content, 1 );
+			$content = preg_replace( $pattern, $quote_content, $content, 1 );
 		}
 		return $content;
 	}

--- a/includes/optional-modules/indesign-export/class-indesign-converter.php
+++ b/includes/optional-modules/indesign-export/class-indesign-converter.php
@@ -23,6 +23,7 @@ class InDesign_Converter {
 		'headline'          => '<pstyle:24head>',
 		'initial_paragraph' => '<pstyle:dropcap>',
 		'paragraph'         => '<pstyle:text>',
+		'horizontal_rule'   => '<pstyle:hr>',
 		'subhead'           => '<pstyle:12sub>',
 		'byline'            => '<pstyle:byline>By ',
 		'pullquote'         => '<pstyle:pullquote>',
@@ -200,10 +201,7 @@ class InDesign_Converter {
 		}
 
 		if ( 'core/heading' === $block['blockName'] ) {
-			if ( 4 === $block['attrs']['level'] ) {
-				return $this->styles['subhead'];
-			}
-			return $this->styles['paragraph'];
+			return sprintf( '<pstyle:h%d>', $block['attrs']['level'] ?? 2 ); // Default to h2 if level is not set.
 		}
 		return '';
 	}
@@ -217,25 +215,9 @@ class InDesign_Converter {
 	 */
 	private function process_html_headings( $content ) {
 		$content = preg_replace_callback(
-			'/<h([2-6])[^>]*>(.*?)<\/h[2-6]>/is',
+			'/<h([1-6])[^>]*>(.*?)<\/h[2-6]>/is',
 			function ( $matches ) {
-				switch ( $matches[1] ) {
-					/**
-					 * Process subheadings (h4 elements) in the content.
-					 */
-					case '4':
-						return $this->styles['subhead'] . $this->get_transformed_text( $matches[2] );
-					/**
-					 * TODO: Handle other heading levels as per requirements.
-					 * For now, treating them as regular paragraphs.
-					 */
-					case '2':
-					case '3':
-					case '5':
-					case '6':
-					default:
-						return $this->styles['paragraph'] . $this->get_transformed_text( $matches[2] );
-				}
+				return sprintf( '<pstyle:h%d>%s', $matches[1], $this->get_transformed_text( $matches[2] ) );
 			},
 			$content
 		);
@@ -282,7 +264,7 @@ class InDesign_Converter {
 	 */
 	private function convert_html_to_indesign( $content ) {
 		$conversions = [
-			// Remove figcaption entirely. TODO: Move them to the bottom of the export file.
+			// Remove figcaption entirely.
 			'/<figcaption[^>]*>.*?<\/figcaption>/' => '',
 
 			// Paragraphs.
@@ -293,6 +275,9 @@ class InDesign_Converter {
 
 			// Line breaks.
 			'/<br[^>]*>/'                          => '<0x000A>',
+
+			// Horizontal rules.
+			'/<hr[^>]*>/'                          => $this->styles['horizontal_rule'],
 
 			// Typography.
 			'/<strong[^>]*>/'                      => '<cTypeface:Bold>',
@@ -421,7 +406,8 @@ class InDesign_Converter {
 	 * @return string Photo credit and caption tags.
 	 */
 	private function process_post_images( $post ) {
-		$images = [];
+		$images          = [];
+		$inline_captions = [];
 
 		$featured_image_id = get_post_thumbnail_id( $post->ID );
 		if ( $featured_image_id ) {
@@ -447,6 +433,13 @@ class InDesign_Converter {
 						}
 					}
 				}
+				// Preg match figcaption content.
+				if ( ! empty( $block['innerHTML'] ) ) {
+					preg_match( '/<figcaption[^>]*>(.*?)<\/figcaption>/', $block['innerHTML'], $matches );
+					if ( ! empty( $matches ) ) {
+						$inline_captions[ $id ] = $matches[1];
+					}
+				}
 			}
 		}
 
@@ -461,7 +454,7 @@ class InDesign_Converter {
 				continue;
 			}
 
-			$caption = wp_get_attachment_caption( $image_id );
+			$caption = $inline_captions[ $image_id ] ?? wp_get_attachment_caption( $image_id );
 			$credit  = get_post_meta( $image_id, '_media_credit', true ) ?? '';
 
 			if ( ! $caption && ! $credit ) {

--- a/includes/optional-modules/indesign-export/class-indesign-converter.php
+++ b/includes/optional-modules/indesign-export/class-indesign-converter.php
@@ -216,7 +216,7 @@ class InDesign_Converter {
 	 */
 	private function process_html_headings( $content ) {
 		$content = preg_replace_callback(
-			'/<h([1-6])[^>]*>(.*?)<\/h[2-6]>/is',
+			'/<h([1-6])[^>]*>(.*?)<\/h[1-6]>/is',
 			function ( $matches ) {
 				return sprintf( '<pstyle:h%d>%s', $matches[1], $this->get_transformed_text( $matches[2] ) );
 			},

--- a/tests/unit-tests/indesign-exporter/indesign-exporter.php
+++ b/tests/unit-tests/indesign-exporter/indesign-exporter.php
@@ -30,21 +30,36 @@ class Newspack_Test_InDesign_Exporter extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test converting pullquotes.
+	 */
+	public function test_convert_pullquote() {
+		$post_id = $this->factory->post->create(
+			[
+				'post_title'   => 'Test Post',
+				'post_content' => '<blockquote><p>A pullquote content</p><cite>John Doe</cite></blockquote>',
+			]
+		);
+
+		$converter = new InDesign_Converter();
+		$content = $converter->convert_post( $post_id );
+		$this->assertStringContainsString( '<pstyle:pullquote>A pullquote content', $content );
+		$this->assertStringContainsString( '<pstyle:pullquotename>John Doe', $content );
+	}
+
+	/**
 	 * Test converting blockquotes.
 	 */
 	public function test_convert_blockquote() {
 		$post_id = $this->factory->post->create(
 			[
 				'post_title'   => 'Test Post',
-				'post_content' => '<blockquote>This is a test blockquote.</blockquote> <blockquote><p>This is a test post with paragraph.</p><cite>John Doe</cite></blockquote>',
+				'post_content' => '<blockquote class="wp-block-quote">This is a blockquote.</blockquote>',
 			]
 		);
 
 		$converter = new InDesign_Converter();
 		$content = $converter->convert_post( $post_id );
-		$this->assertStringContainsString( '<pstyle:pullquote>This is a test blockquote.', $content );
-		$this->assertStringContainsString( '<pstyle:pullquote>This is a test post with paragraph.', $content );
-		$this->assertStringContainsString( '<pstyle:pullquotename>John Doe', $content );
+		$this->assertStringContainsString( '<pstyle:blockquote>This is a blockquote.', $content );
 	}
 
 	/**
@@ -155,6 +170,30 @@ class Newspack_Test_InDesign_Exporter extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test image with custom caption.
+	 */
+	public function test_image_with_custom_caption() {
+		$image_id = $this->factory->attachment->create();
+		wp_update_post(
+			[
+				'ID'           => $image_id,
+				'post_excerpt' => 'Image Caption',
+			]
+		);
+
+		$post_id = $this->factory->post->create(
+			[
+				'post_title'   => 'Test Post',
+				'post_content' => '<!-- wp:image {"id":' . $image_id . '} --><figure class="wp-block-image"><img src="http://localhost/wp-content/uploads/2025/01/image.jpg" /><figcaption class="wp-element-caption">Custom Caption</figcaption></figure><!-- /wp:image -->',
+			]
+		);
+
+		$converter = new InDesign_Converter();
+		$content = $converter->convert_post( $post_id );
+		$this->assertStringContainsString( '<pstyle:PhotoCaption>Custom Caption', $content );
+	}
+
+	/**
 	 * Test converting HTML entities.
 	 */
 	public function test_convert_html_entities() {
@@ -200,5 +239,42 @@ class Newspack_Test_InDesign_Exporter extends WP_UnitTestCase {
 		$converter = new InDesign_Converter();
 		$content = $converter->convert_post( $post_id );
 		$this->assertStringContainsString( '<customparagraph>This is a test post with custom tag.', $content );
+	}
+
+	/**
+	 * Test headings.
+	 */
+	public function test_convert_headings() {
+		$post_id = $this->factory->post->create(
+			[
+				'post_title'   => 'Test Post',
+				'post_content' => '<h1>Heading 1</h1><h2>Heading 2</h2><h3>Heading 3</h3><h4>Heading 4</h4><h5>Heading 5</h5><h6>Heading 6</h6>',
+			]
+		);
+
+		$converter = new InDesign_Converter();
+		$content = $converter->convert_post( $post_id );
+		$this->assertStringContainsString( '<pstyle:h1>Heading 1', $content );
+		$this->assertStringContainsString( '<pstyle:h2>Heading 2', $content );
+		$this->assertStringContainsString( '<pstyle:h3>Heading 3', $content );
+		$this->assertStringContainsString( '<pstyle:h4>Heading 4', $content );
+		$this->assertStringContainsString( '<pstyle:h5>Heading 5', $content );
+		$this->assertStringContainsString( '<pstyle:h6>Heading 6', $content );
+	}
+
+	/**
+	 * Test horizontal rule.
+	 */
+	public function test_convert_horizontal_rule() {
+		$post_id = $this->factory->post->create(
+			[
+				'post_title'   => 'Test Post',
+				'post_content' => '<hr>',
+			]
+		);
+
+		$converter = new InDesign_Converter();
+		$content = $converter->convert_post( $post_id );
+		$this->assertStringContainsString( '<pstyle:hr>', $content );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

NPPM-2243

Implements the following:

- Standardize content headings so they render `<pstyle:h1>`, `<pstyle:h2>`, `<pstyle:h3>`, and so on.
- Allow a custom caption placed inline to take over the original image caption
- Add support for `<hr />` as `<pstyle:hr>`
- Differentiate between pullquote and blockquote and render blockquotes as `<pstyle:blockquote>`

### How to test the changes in this Pull Request:

1. Draft a new post with the following content:
   1. Image block with a custom caption applied inline (not saved in the image)
   2. Quote block
   3. Pullquote block
   4. Headings from 1 to 6
   5. Separator block (hr)
2. Export to InDesign and confirm each block is exported correctly

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->