### PR TITLE
feat(collections): add archive link in settings page

### DIFF
--- a/src/wizards/newspack/views/settings/collections/index.tsx
+++ b/src/wizards/newspack/views/settings/collections/index.tsx
@@ -3,8 +3,10 @@
  */
 
 import { __ } from '@wordpress/i18n';
-import { useState, useEffect } from '@wordpress/element';
-import { ToggleControl } from '@wordpress/components';
+import { useState, useEffect, useMemo } from '@wordpress/element';
+import { ToggleControl, Tooltip, Icon } from '@wordpress/components';
+import { external } from '@wordpress/icons';
+import { cleanForSlug } from '@wordpress/url';
 import WizardSection from '../../../../wizards-section';
 import WizardsActionCard from '../../../../wizards-action-card';
 import useWizardApiFetchToggle from '../../../../hooks/use-wizard-api-fetch-toggle';
@@ -98,9 +100,37 @@ function Collections() {
 		} );
 	};
 
+	const DEFAULT_SLUG = 'collections';
+	const collectionsArchiveUrl = useMemo( () => {
+		const slug = cleanForSlug( settings.custom_naming_enabled && settings.custom_slug ? settings.custom_slug : DEFAULT_SLUG ) || DEFAULT_SLUG;
+		const base = new URL( window.newspack_urls?.site || window.location.origin );
+		base.pathname = base.pathname + ( ! base.pathname.endsWith( '/' ) ? '/' : '' );
+		return new URL( slug, base ).toString();
+	}, [ settings.custom_naming_enabled, settings.custom_slug ] );
+
 	return (
 		<div className="newspack-wizard__sections">
-			<h1>{ __( 'Collections Settings', 'newspack-plugin' ) }</h1>
+			<h1 style={ { display: 'flex', alignItems: 'center' } }>
+				{ __( 'Collections Settings', 'newspack-plugin' ) }
+				{ apiData.module_enabled_collections && (
+					<Tooltip text={ __( 'View Collections', 'newspack-plugin' ) }>
+						<a
+							href={ collectionsArchiveUrl }
+							target="_blank"
+							rel="noopener noreferrer"
+							style={ {
+								display: 'inline-flex',
+								marginLeft: '8px',
+								color: '#757575',
+								textDecoration: 'none',
+							} }
+							aria-label={ __( 'View Collections', 'newspack-plugin' ) }
+						>
+							<Icon icon={ external } size={ 20 } />
+						</a>
+					</Tooltip>
+				) }
+			</h1>
 
 			<WizardsActionCard
 				isMedium


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds a discrete external link icon next to the "Collections Settings" title that links to the Collections archive page. The link uses the custom slug if configured. This makes it easier for users to quickly navigate from the settings page to view their live Collections archive.

<img width="411" height="187" alt="image" src="https://github.com/user-attachments/assets/912bfc4c-7d5c-4676-9f35-15a70ced53a5" />

Closes NPPD-903.

### How to test the changes in this Pull Request:

1. Navigate to Newspack Settings → Collections.
2. Enable the Collections module if not already enabled.
3. Verify the external link icon appears next to "Collections Settings" title.
4. Click the icon to confirm it opens the Collections archive page in a new tab.
5. Test with custom slug: enable custom naming, set a custom slug, save settings, and verify the link uses the custom slug
6. Test accessibility: hover over the icon to see the tooltip, and verify screen reader compatibility

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?