### PR TITLE
fix: ga4 events for gate interactions and tiered modal

### DIFF
--- a/includes/class-magic-link.php
+++ b/includes/class-magic-link.php
@@ -898,13 +898,18 @@ final class Magic_Link {
 		$metadata = apply_filters(
 			'newspack_otp_login_metadata',
 			[
-				'email'        => $email,
 				'login_method' => 'otp',
 			],
 			$email
 		);
 
-		return self::send_otp_request_response( __( 'Login successful!', 'newspack-plugin' ), true, [ 'metadata' => $metadata ] );
+		$data = [
+			'email'         => $email,
+			'existing_user' => true,
+			'metadata'      => $metadata,
+		];
+
+		return self::send_otp_request_response( __( 'Login successful!', 'newspack-plugin' ), true, $data );
 	}
 
 	/**

--- a/includes/class-magic-link.php
+++ b/includes/class-magic-link.php
@@ -890,7 +890,7 @@ final class Magic_Link {
 		}
 
 		/**
-		 * Filters the metadata to be saved for a reader registered via the auth modal.
+		 * Filters the metadata to be saved for a reader logged in via OTP.
 		 *
 		 * @param array  $metadata Metadata.
 		 * @param string $email    Email address of the reader.

--- a/includes/oauth/class-google-login.php
+++ b/includes/oauth/class-google-login.php
@@ -267,7 +267,6 @@ class Google_Login {
 				// Fail silently.
 			}
 		}
-		$metadata['registration_method'] = 'google';
 		if ( ! isset( $metadata['current_page_url'] ) ) {
 			$referrer = $request->get_header( 'referer' );
 			if ( \wp_http_validate_url( $referrer ) ) {
@@ -299,6 +298,8 @@ class Google_Login {
 			];
 
 			if ( $existing_user ) {
+				$metadata['login_method'] = 'google';
+
 				// Update user meta with connected account info.
 				\update_user_meta( $existing_user->ID, Reader_Activation::CONNECTED_ACCOUNT, 'google' );
 
@@ -306,6 +307,7 @@ class Google_Login {
 				$result  = Reader_Activation::set_current_reader( $existing_user->ID );
 				$message = __( 'Thank you for signing in!', 'newspack-plugin' );
 			} else {
+				$metadata['registration_method'] = 'google';
 				$result = Reader_Activation::register_reader( $email, '', true, $metadata );
 				// At this point the user will be logged in.
 			}
@@ -313,6 +315,7 @@ class Google_Login {
 				return $result;
 			}
 
+			$data['metadata'] = $metadata;
 			return \rest_ensure_response(
 				[
 					'data'    => $data,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Some fixes for GA4 events triggered by SSO registration/login, content gate interactions, and the new tiered variation modal implemented in #4164.

Closes NPPM-2262.

### How to test the changes in this Pull Request:

All changes are for GA4 events, so make sure your testing site is connected to GA.

#### SSO registration/login

1. Make sure your testing site is connected to a hosted Newspack Manager instance and is connected to Google (Newspack > Settings > Google).
2. As a reader, view some content restricted by the gate and click on the registration link.
3. Click the Sign In button to open the login modal and register a new account via Google SSO.
4. After registration, inspect Network requests for `collect` requests (or view real-time events in Google Analytics) and confirm that you see an `np_reader_registered` event.
5. In a new browser session, click the Sign In link and sign into the same Google account via SSO.
7. Confirm that you see an `np_reader_logged_in` event.

#### OTP login event

1. In a new session, click the Sign In button to open the login modal and sign into an existing non-SSO account via OTP.
2. After submitting the OTP code, confirm that you see an `np_reader_logged_in` event.

#### Tiered variation modal and GA event parameters for variable and grouped products

1. Publish a content gate containing a Checkout Button block that's tied to a variable subscription product with no variation selected (so it will allow the reader to select a variation before proceeding to checkout).
2. As a reader, view the content gate and click on the Checkout Button block. Confirm that you see an `np_gate_interaction` event with the following parameters:
  - `action=opened_variations`
  - `product_id=<ID of variable subscription product>`
  - `is_variable=yes`
  - `variation_ids=<comma-delimited list of the product's variation IDs>`
3. Select a variation and click "Purchase" to trigger the modal. Confirm you see an `np_modal_checkout_interaction` event with the following parameters:
  - `action=opened`
  - `product_id=<ID of variable subscription product>`
  - `is_variable=yes`
  - `variation_ids=<comma-delimited list of the product's variation IDs>`
  - `variation_id=<ID of the selected variation>`
4. Confirm that you can complete the purchase of the selected variation, and that you see GA4 events throughout your modal interactions with parameters containing the variation's pricing and frequency data (`amount`, `price_summary`, `summary_template`, `recurrence`)
5. Replace the Checkout Button product with a grouped product containing a simple subscription product and a variable subscription product with variations.
6. Repeat steps 2–4 and confirm that you see the same GA4 events with the same parameters, except with `is_grouped=yes` instead of `is_variation=yes` and with `variation_id` only if you check out with a variation, not the simple subscription product.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->