### PR TITLE
feat(collections): add css classes to meta elements

### DIFF
--- a/src/blocks/collections/class-collections-block.php
+++ b/src/blocks/collections/class-collections-block.php
@@ -318,7 +318,7 @@ final class Collections_Block {
 		if ( $attributes['showPeriod'] ) {
 			$period = Collection_Meta::get( $collection->ID, 'period' );
 			if ( $period ) {
-				$meta_parts[] = esc_html( $period );
+				$meta_parts[] = '<span class="wp-block-newspack-collections__period">' . esc_html( $period ) . '</span>';
 			}
 		}
 
@@ -328,27 +328,37 @@ final class Collections_Block {
 		if ( $attributes['showVolume'] ) {
 			$volume = Collection_Meta::get( $collection->ID, 'volume' );
 			if ( $volume ) {
-				/* translators: %s is the volume number of a collection */
-				$vol_number[] = sprintf( _x( 'Vol. %s', 'collection volume number', 'newspack-plugin' ), esc_html( $volume ) );
+				$vol_number[] = '<span class="wp-block-newspack-collections__volume">' .
+					sprintf(
+						/* translators: %s is the volume number of a collection */
+						_x( 'Vol. %s', 'collection volume number', 'newspack-plugin' ),
+						esc_html( $volume )
+					) .
+					'</span>';
 			}
 		}
 
 		if ( $attributes['showNumber'] ) {
 			$number = Collection_Meta::get( $collection->ID, 'number' );
 			if ( $number ) {
-				/* translators: %s is the issue number of a collection */
-				$vol_number[] = sprintf( _x( 'No. %s', 'collection issue number', 'newspack-plugin' ), esc_html( $number ) );
+				$vol_number[] = '<span class="wp-block-newspack-collections__number">' .
+					sprintf(
+						/* translators: %s is the issue number of a collection */
+						_x( 'No. %s', 'collection issue number', 'newspack-plugin' ),
+						esc_html( $number )
+					) .
+					'</span>';
 			}
 		}
 
 		if ( $vol_number ) {
-			$meta_parts[] = implode( ' / ', $vol_number );
+			$meta_parts[] = implode( ' <span class="wp-block-newspack-collections__divider">/</span> ', $vol_number );
 		}
 
 		// Render meta text.
 		if ( ! empty( $meta_parts ) ) {
 			// Use different separator based on layout.
-			$separator = 'list' === $attributes['layout'] ? ' / ' : '<br>';
+			$separator = 'list' === $attributes['layout'] ? ' <span class="wp-block-newspack-collections__divider">/</span> ' : '<br>';
 			$meta_text = implode( $separator, $meta_parts );
 			?>
 			<div class="wp-block-newspack-collections__meta has-medium-gray-color has-text-color has-small-font-size">

--- a/src/blocks/collections/components/CollectionItem.jsx
+++ b/src/blocks/collections/components/CollectionItem.jsx
@@ -74,36 +74,60 @@ const CollectionItem = ( { collection, attributes } ) => {
 		return next.slice( 0, numberOfCTAs || 1 );
 	}, [ collection.ctas, showSubscriptionUrl, showOrderUrl, specificCTAs, numberOfCTAs ] );
 
-	// Build meta text, memoized.
-	const metaText = useMemo( () => {
-		const metaParts = [];
+	// Build meta elements, memoized.
+	const metaElements = useMemo( () => {
+		const elements = [];
 
 		// Add period first.
 		if ( showPeriod && period ) {
-			metaParts.push( period );
+			elements.push(
+				<span key="period" className="wp-block-newspack-collections__period">
+					{ period }
+				</span>
+			);
 		}
 
-		const volNumber = [];
+		// Add separator if we have period and will have volume/number.
+		if ( showPeriod && period && ( ( showVolume && volume ) || ( showNumber && number ) ) ) {
+			const separator =
+				layout === 'list' ? (
+					<span key="period-sep" className="wp-block-newspack-collections__divider">
+						{ ' / ' }
+					</span>
+				) : (
+					<br key="period-sep" />
+				);
+			elements.push( separator );
+		}
 
+		// Volume.
 		if ( showVolume && volume ) {
-			volNumber.push( `Vol. ${ volume }` );
+			elements.push(
+				<span key="volume" className="wp-block-newspack-collections__volume">
+					{ `Vol. ${ volume }` }
+				</span>
+			);
 		}
 
+		// Separator between volume and number.
+		if ( showVolume && volume && showNumber && number ) {
+			elements.push(
+				<span key="vol-num-sep" className="wp-block-newspack-collections__divider">
+					{ ' / ' }
+				</span>
+			);
+		}
+
+		// Number.
 		if ( showNumber && number ) {
-			volNumber.push( `No. ${ number }` );
+			elements.push(
+				<span key="number" className="wp-block-newspack-collections__number">
+					{ `No. ${ number }` }
+				</span>
+			);
 		}
 
-		if ( volNumber.length ) {
-			metaParts.push( volNumber.join( ' / ' ) );
-		}
-
-		if ( metaParts.length ) {
-			// Use different separator based on layout.
-			const separator = layout === 'list' ? ' / ' : '<br>';
-			return metaParts.join( separator );
-		}
-
-		return '';
+		return elements;
 	}, [ showPeriod, period, showVolume, volume, showNumber, number, layout ] );
 
 	return (
@@ -143,9 +167,9 @@ const CollectionItem = ( { collection, attributes } ) => {
 					</h3>
 				) }
 
-				{ metaText && (
+				{ metaElements.length > 0 && (
 					<div className="wp-block-newspack-collections__meta has-medium-gray-color has-text-color has-small-font-size">
-						<RawHTML>{ metaText }</RawHTML>
+						{ metaElements }
 					</div>
 				) }
 

--- a/tests/unit-tests/collections/class-test-collections-block.php
+++ b/tests/unit-tests/collections/class-test-collections-block.php
@@ -327,7 +327,9 @@ class Test_Collections_Block extends \WP_UnitTestCase {
 		Collections_Block::render_collection_meta( $collection, $attributes );
 		$output = ob_get_clean();
 
-		$this->assertStringContainsString( $period . ' / Vol. ' . $volume, $output, 'Should use slash separator for list layout' );
+		$this->assertStringContainsString( $period, $output, 'Should contain period' );
+		$this->assertStringContainsString( 'Vol. ' . $volume, $output, 'Should contain volume' );
+		$this->assertStringContainsString( '>/</', $output, 'Should use slash separator for list layout' );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Added semantic CSS classes to Collection block meta fields (period, volume, number) for granular styling control. Previously, these fields were rendered as plain text without individual classes, making them difficult to style separately.

Before:
```html
<div class="wp-block-newspack-collections__meta">
    Sep 12-25, 2025<br>Vol. 23 / No. 50
</div>
```

After:
```html
<div class="wp-block-newspack-collections__meta">
    <span class="wp-block-newspack-collections__period">Sep 12-25, 2025</span><br>
    <span class="wp-block-newspack-collections__volume">Vol. 23</span>
    <span class="wp-block-newspack-collections__divider">/</span>
    <span class="wp-block-newspack-collections__number">No. 50</span>
</div>
```

Bear in mind that, depending on the layout (grid or list), it might render another divider element instead of the `<br>`.

Changes maintain backward compatibility and consistency between editor preview (React) and frontend display (PHP).

Closes NPPD-877.

### How to test the changes in this Pull Request:

1. Create a Collection with period, volume, and number meta fields populated.
1. Add a Collections block to a post/page and configure it to show meta fields.
1. Verify the new CSS classes are present in both the editor preview and the frontend output.
1. Test with different layouts (grid vs list) to ensure separators render correctly.
1. Confirm existing styling remains intact while new classes enable granular control.
1. Check that the archive and single collection pages don't have any visual changes. Only observable changes should be the HTML markup.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?