### PR TITLE
fix: ga4 events for gate interactions and tiered modal

### DIFF
--- a/includes/class-magic-link.php
+++ b/includes/class-magic-link.php
@@ -898,13 +898,18 @@ final class Magic_Link {
 		$metadata = apply_filters(
 			'newspack_otp_login_metadata',
 			[
-				'email'        => $email,
 				'login_method' => 'otp',
 			],
 			$email
 		);
 
-		return self::send_otp_request_response( __( 'Login successful!', 'newspack-plugin' ), true, [ 'metadata' => $metadata ] );
+		$data = [
+			'email'         => $email,
+			'existing_user' => true,
+			'metadata'      => $metadata,
+		];
+
+		return self::send_otp_request_response( __( 'Login successful!', 'newspack-plugin' ), true, $data );
 	}
 
 	/**

--- a/includes/class-magic-link.php
+++ b/includes/class-magic-link.php
@@ -890,7 +890,7 @@ final class Magic_Link {
 		}
 
 		/**
-		 * Filters the metadata to be saved for a reader registered via the auth modal.
+		 * Filters the metadata to be saved for a reader logged in via OTP.
 		 *
 		 * @param array  $metadata Metadata.
 		 * @param string $email    Email address of the reader.

--- a/includes/oauth/class-google-login.php
+++ b/includes/oauth/class-google-login.php
@@ -267,7 +267,6 @@ class Google_Login {
 				// Fail silently.
 			}
 		}
-		$metadata['registration_method'] = 'google';
 		if ( ! isset( $metadata['current_page_url'] ) ) {
 			$referrer = $request->get_header( 'referer' );
 			if ( \wp_http_validate_url( $referrer ) ) {
@@ -299,6 +298,8 @@ class Google_Login {
 			];
 
 			if ( $existing_user ) {
+				$metadata['login_method'] = 'google';
+
 				// Update user meta with connected account info.
 				\update_user_meta( $existing_user->ID, Reader_Activation::CONNECTED_ACCOUNT, 'google' );
 
@@ -306,6 +307,7 @@ class Google_Login {
 				$result  = Reader_Activation::set_current_reader( $existing_user->ID );
 				$message = __( 'Thank you for signing in!', 'newspack-plugin' );
 			} else {
+				$metadata['registration_method'] = 'google';
 				$result = Reader_Activation::register_reader( $email, '', true, $metadata );
 				// At this point the user will be logged in.
 			}
@@ -313,6 +315,7 @@ class Google_Login {
 				return $result;
 			}
 
+			$data['metadata'] = $metadata;
 			return \rest_ensure_response(
 				[
 					'data'    => $data,

--- a/includes/plugins/google-site-kit/class-googlesitekit.php
+++ b/includes/plugins/google-site-kit/class-googlesitekit.php
@@ -198,38 +198,44 @@ class GoogleSiteKit {
 			'logged_in' => is_user_logged_in() ? 'yes' : 'no',
 		];
 
-		// Get current post author name.
-		$author_name = '';
-		if ( function_exists( 'get_coauthors' ) ) {
-			$author_name = implode(
-				', ',
-				array_map(
-					function( $author ) {
-						return $author->display_name;
-					},
-					get_coauthors()
-				)
-			);
-		} else {
-			$post = get_post();
-			if ( null !== $post && is_numeric( $post->post_author ) ) {
-				// For some reason, get_the_author() does not work here.
-				$author_user = get_user_by( 'ID', $post->post_author );
-				if ( $author_user ) {
-					$author_name = $author_user->display_name;
+		// Single post params.
+		if ( is_singular() ) {
+			// Post ID.
+			$params['post_id'] = get_the_ID();
+
+			// Get current post author name.
+			$author_name = '';
+			if ( function_exists( 'get_coauthors' ) ) {
+				$author_name = implode(
+					', ',
+					array_map(
+						function( $author ) {
+							return $author->display_name;
+						},
+						get_coauthors()
+					)
+				);
+			} else {
+				$post = get_post();
+				if ( null !== $post && is_numeric( $post->post_author ) ) {
+					// For some reason, get_the_author() does not work here.
+					$author_user = get_user_by( 'ID', $post->post_author );
+					if ( $author_user ) {
+						$author_name = $author_user->display_name;
+					}
 				}
 			}
-		}
-		if ( ! empty( $author_name ) ) {
-			$params['author'] = $author_name;
+			if ( ! empty( $author_name ) ) {
+				$params['author'] = $author_name;
+			}
 		}
 
-		// Get current post categories.
+		// Get current post or archive categories.
 		$category_names = array_map(
 			function( $category ) {
 				return $category->name;
 			},
-			get_the_category()
+			is_category() ? [ get_queried_object() ] : get_the_category()
 		);
 		if ( ! empty( $category_names ) ) {
 			$params['categories'] = implode( ', ', $category_names );

--- a/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
+++ b/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
@@ -232,12 +232,14 @@ class Subscriptions_Tiers {
 			$price = $product->get_price_html();
 		}
 
+		$product_type = $product->is_type( 'variation' ) ? 'variation_id' : 'product_id';
+
 		?>
 		<label class="newspack-ui__input-card <?php echo $current ? esc_attr( 'current' ) : ''; ?>">
 			<?php if ( $current ) : ?>
 				<span class="newspack-ui__badge newspack-ui__badge--primary"><?php _e( 'Current', 'newspack-plugin' ); ?></span>
 			<?php endif; ?>
-			<input type="radio" name="product_id" value="<?php echo esc_attr( $product->get_id() ); ?>" <?php echo esc_attr( $selected ? 'checked' : '' ); ?>>
+			<input type="radio" name="<?php echo esc_attr( $product_type ); ?>" value="<?php echo esc_attr( $product->get_id() ); ?>" <?php echo esc_attr( $selected ? 'checked' : '' ); ?>>
 			<strong><?php echo esc_html( self::get_product_title( $product, $show_variation_attributes ) ); ?></strong>
 			<span class="newspack-ui__helper-text"><?php echo $price; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></span>
 		</label>
@@ -311,7 +313,8 @@ class Subscriptions_Tiers {
 	 * @param array|null  $switch_subscription Switch subscription data or null.
 	 */
 	public static function render_form( $product = null, $title = null, $button_label = null, $switch_subscription = null ) {
-		$tiers = self::get_tiers_by_frequency( $product );
+		$checkout_data = method_exists( 'Newspack_Blocks\Modal_Checkout\Checkout_Data', 'get_checkout_data' ) ? \Newspack_Blocks\Modal_Checkout\Checkout_data::get_checkout_data( $product ) : null;
+		$tiers         = self::get_tiers_by_frequency( $product );
 		if ( empty( $tiers ) ) {
 			return;
 		}
@@ -365,9 +368,8 @@ class Subscriptions_Tiers {
 			self::render_existing_subscription_info( $current_product, $user_subscription );
 			return;
 		}
-
 		?>
-		<form class="newspack__subscription-tiers__form" target="newspack_modal_checkout_iframe" data-title="<?php echo esc_attr( $title ); ?>">
+		<form class="newspack__subscription-tiers__form" target="newspack_modal_checkout_iframe" data-title="<?php echo esc_attr( $title ); ?>" data-checkout='<?php echo $checkout_data ? wp_json_encode( $checkout_data ) : ''; ?>'>
 			<?php if ( ! $is_single_tier ) : ?>
 				<div class="newspack-ui__segmented-control">
 					<?php

--- a/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
+++ b/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
@@ -313,8 +313,7 @@ class Subscriptions_Tiers {
 	 * @param array|null  $switch_subscription Switch subscription data or null.
 	 */
 	public static function render_form( $product = null, $title = null, $button_label = null, $switch_subscription = null ) {
-		$checkout_data = method_exists( 'Newspack_Blocks\Modal_Checkout\Checkout_Data', 'get_checkout_data' ) ? \Newspack_Blocks\Modal_Checkout\Checkout_data::get_checkout_data( $product ) : null;
-		$tiers         = self::get_tiers_by_frequency( $product );
+		$tiers = self::get_tiers_by_frequency( $product );
 		if ( empty( $tiers ) ) {
 			return;
 		}
@@ -369,7 +368,7 @@ class Subscriptions_Tiers {
 			return;
 		}
 		?>
-		<form class="newspack__subscription-tiers__form" target="newspack_modal_checkout_iframe" data-title="<?php echo esc_attr( $title ); ?>" data-checkout='<?php echo $checkout_data ? wp_json_encode( $checkout_data ) : ''; ?>'>
+		<form class="newspack__subscription-tiers__form" target="newspack_modal_checkout_iframe" data-title="<?php echo esc_attr( $title ); ?>">
 			<?php if ( ! $is_single_tier ) : ?>
 				<div class="newspack-ui__segmented-control">
 					<?php

--- a/src/memberships-gate/gate.js
+++ b/src/memberships-gate/gate.js
@@ -3,6 +3,7 @@
  * Internal dependencies
  */
 import './gate.scss';
+import { getEventPayload, sendEvent } from '../reader-activation/analytics';
 import { debugLog } from '../reader-activation/utils';
 
 const EVENT_NAME = 'np_gate_interaction';
@@ -144,7 +145,7 @@ function isVisible( el ) {
  *
  * @return {Array} The full event payload
  */
-function getEventPayload( payload, gate ) {
+function getGateEventPayload( payload, gate ) {
 	if ( gate ) {
 		gateInfo.gate_has_donation_block = isVisible( gate.querySelector( '.wp-block-newspack-blocks-donate' ) ) ? 'yes' : 'no';
 		gateInfo.gate_has_registration_block = isVisible( gate.querySelector( '.newspack-registration' ) ) ? 'yes' : 'no';
@@ -153,10 +154,7 @@ function getEventPayload( payload, gate ) {
 		gateInfo.gate_has_signin_link = isVisible( gate.querySelector( 'a[href="#signin_modal"]' ) ) ? 'yes' : 'no';
 	}
 
-	return {
-		...gateInfo,
-		...payload,
-	};
+	return getEventPayload( { ...payload, ...gateInfo } );
 }
 
 /**
@@ -174,7 +172,7 @@ function handleSeen( gate ) {
 	const payload = {
 		action: 'seen',
 	};
-	window.gtag( 'event', EVENT_NAME, getEventPayload( payload, gate ) );
+	sendEvent( getGateEventPayload( payload, gate ), EVENT_NAME );
 }
 
 /**
@@ -184,10 +182,7 @@ function handleDismissed() {
 	if ( 'function' !== typeof window.gtag ) {
 		return;
 	}
-	const payload = getEventPayload( {
-		action: 'dismissed',
-	} );
-	window.gtag( 'event', EVENT_NAME, payload );
+	sendEvent( getGateEventPayload( { action: 'dismissed' } ), EVENT_NAME );
 }
 
 /**
@@ -239,7 +234,7 @@ function handleFormSubmission( evt, gate ) {
 		}
 	}
 
-	window.gtag( 'event', EVENT_NAME, getEventPayload( payload, gate ) );
+	sendEvent( getGateEventPayload( payload, gate ), EVENT_NAME );
 }
 
 /**

--- a/src/reader-activation/analytics.js
+++ b/src/reader-activation/analytics.js
@@ -6,7 +6,7 @@
  *
  * @return {Object} Event payload.
  */
-const getEventPayload = ( payload = {}, data = {} ) => {
+export const getEventPayload = ( payload = {}, data = {} ) => {
 	const eventPayload = { ...payload };
 	if ( data?.newspack_popup_id ) {
 		eventPayload.newspack_popup_id = data.newspack_popup_id;
@@ -27,8 +27,19 @@ const getEventPayload = ( payload = {}, data = {} ) => {
  * @param {string} eventName Name of the event. Defaults to `np_reader_activation_interaction` but can be overriden if necessary.
  */
 
-const sendEvent = ( payload, eventName = 'np_reader_activation_interaction' ) => {
+export const sendEvent = ( payload, eventName = 'np_reader_activation_interaction' ) => {
 	if ( 'function' === typeof window.gtag && payload ) {
+		// Normalize boolean values to 'yes' or 'no'.
+		for ( const key of Object.keys( payload ) ) {
+			if ( typeof payload[ key ] === 'boolean' ) {
+				payload[ key ] = payload[ key ] ? 'yes' : 'no';
+			} else if ( payload[ key ] === 'true' ) {
+				payload[ key ] = 'yes';
+			} else if ( payload[ key ] === 'false' ) {
+				payload[ key ] = 'no';
+			}
+			payload[ key ] = payload[ key ].toString();
+		}
 		window.gtag( 'event', eventName, payload );
 	}
 };


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Some fixes for GA4 events triggered by SSO registration/login, content gate interactions, and the new tiered variation modal implemented in #4164. See also https://github.com/Automattic/newspack-blocks/pull/2218.

Closes NPPM-2262.

### How to test the changes in this Pull Request:

Check out https://github.com/Automattic/newspack-blocks/pull/2218 before testing.

All changes are for GA4 events, so make sure your testing site is connected to GA.

#### SSO registration/login

1. Make sure your testing site is connected to a hosted Newspack Manager instance and is connected to Google (Newspack > Settings > Google).
2. As a reader, view some content restricted by the gate and click on the registration link.
3. Click the Sign In button to open the login modal and register a new account via Google SSO.
4. After registration, inspect Network requests for `collect` requests (or view real-time events in Google Analytics) and confirm that you see an `np_reader_registered` event.
5. In a new browser session, click the Sign In link and sign into the same Google account via SSO.
7. Confirm that you see an `np_reader_logged_in` event.

#### OTP login event

1. In a new session, click the Sign In button to open the login modal and sign into an existing non-SSO account via OTP.
2. After submitting the OTP code, confirm that you see an `np_reader_logged_in` event.

#### Tiered variation modal and GA event parameters for variable and grouped products

1. Publish a content gate containing a Checkout Button block that's tied to a variable subscription product with no variation selected (so it will allow the reader to select a variation before proceeding to checkout).
2. As a reader, view the content gate and click on the Checkout Button block. Confirm that you see an `np_gate_interaction` event with the following parameters:
  - `action=opened_variations`
  - `product_id=<ID of parent product>`
  - `is_variable=yes`
  - `variation_ids=<comma-delimited list of the product's variation IDs>`
3. Select a variation and click "Purchase" to trigger the modal. Confirm you see an `np_modal_checkout_interaction` event with the following parameters:
  - `action=opened`
  - `product_id=<ID of variable subscription product>`
  - `is_variable=yes`
  - `variation_ids=<comma-delimited list of the product's variation IDs>`
4. Confirm that you can complete the purchase of the selected variation, and that you see GA4 events throughout your modal interactions with parameters containing the variation's pricing and frequency data (`amount`, `price_summary`, `summary_template`, `recurrence`)
5. Replace the Checkout Button product with a grouped product containing a simple subscription product and a variable subscription product with variations.
6. Repeat steps 2–4 and confirm that you see the same GA4 events with the same parameters, except:
  - `action=opened_grouped` instead of `opened_variations`
  - `is_grouped=yes` instead of `is_variable=yes`
  - `child_ids` instead of `variation_ids`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->