### PR TITLE
feat: add post_id as custom GA parameter

### DIFF
--- a/includes/plugins/google-site-kit/class-googlesitekit.php
+++ b/includes/plugins/google-site-kit/class-googlesitekit.php
@@ -198,10 +198,13 @@ class GoogleSiteKit {
 			'logged_in' => is_user_logged_in() ? 'yes' : 'no',
 		];
 
+		$categories = [];
+
 		// Single post params.
 		if ( is_singular() ) {
 			// Post ID.
 			$params['post_id'] = get_the_ID();
+			$categories        = get_the_category();
 
 			// Get current post author name.
 			$author_name = '';
@@ -235,7 +238,7 @@ class GoogleSiteKit {
 			function( $category ) {
 				return $category->name;
 			},
-			is_category() ? [ get_queried_object() ] : get_the_category()
+			is_category() ? [ get_queried_object() ] : $categories
 		);
 		if ( ! empty( $category_names ) ) {
 			$params['categories'] = implode( ', ', $category_names );

--- a/includes/plugins/google-site-kit/class-googlesitekit.php
+++ b/includes/plugins/google-site-kit/class-googlesitekit.php
@@ -198,38 +198,44 @@ class GoogleSiteKit {
 			'logged_in' => is_user_logged_in() ? 'yes' : 'no',
 		];
 
-		// Get current post author name.
-		$author_name = '';
-		if ( function_exists( 'get_coauthors' ) ) {
-			$author_name = implode(
-				', ',
-				array_map(
-					function( $author ) {
-						return $author->display_name;
-					},
-					get_coauthors()
-				)
-			);
-		} else {
-			$post = get_post();
-			if ( null !== $post && is_numeric( $post->post_author ) ) {
-				// For some reason, get_the_author() does not work here.
-				$author_user = get_user_by( 'ID', $post->post_author );
-				if ( $author_user ) {
-					$author_name = $author_user->display_name;
+		// Single post params.
+		if ( is_singular() ) {
+			// Post ID.
+			$params['post_id'] = get_the_ID();
+
+			// Get current post author name.
+			$author_name = '';
+			if ( function_exists( 'get_coauthors' ) ) {
+				$author_name = implode(
+					', ',
+					array_map(
+						function( $author ) {
+							return $author->display_name;
+						},
+						get_coauthors()
+					)
+				);
+			} else {
+				$post = get_post();
+				if ( null !== $post && is_numeric( $post->post_author ) ) {
+					// For some reason, get_the_author() does not work here.
+					$author_user = get_user_by( 'ID', $post->post_author );
+					if ( $author_user ) {
+						$author_name = $author_user->display_name;
+					}
 				}
 			}
-		}
-		if ( ! empty( $author_name ) ) {
-			$params['author'] = $author_name;
+			if ( ! empty( $author_name ) ) {
+				$params['author'] = $author_name;
+			}
 		}
 
-		// Get current post categories.
+		// Get current post or archive categories.
 		$category_names = array_map(
 			function( $category ) {
 				return $category->name;
 			},
-			get_the_category()
+			is_category() ? [ get_queried_object() ] : get_the_category()
 		);
 		if ( ! empty( $category_names ) ) {
 			$params['categories'] = implode( ', ', $category_names );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds `post_id` as a custom GA parameter. Also ensures that parameters that only apply to singular posts/pages are only sent in a singular context.

Closes NPPM-2268.

### How to test the changes in this Pull Request:

1. Connect Google Analytics via Site Kit and add the `NEWSPACK_GA_ENABLE_CUSTOM_FE_PARAMS` param as `true` to wp-config.php.
2. View a single post or page. Confirm that all GA events now have a `post_id` param with the singular post ID.
3. View a non-category archive. Confirm that custom params that only pertain to singular posts are not sent to GA:
  - `post_id`
  - `author`
  - `categories`
4. Visit a category archive. Confirm that the `categories` param is sent with the category of the viewed archive.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->