### PR TITLE
test: fix flaky rss test and invalid covers annotations

### DIFF
--- a/tests/unit-tests/collections/class-test-post-meta.php
+++ b/tests/unit-tests/collections/class-test-post-meta.php
@@ -45,7 +45,9 @@ class Test_Post_Meta extends WP_UnitTestCase {
 	/**
 	 * Test that the meta is sanitized as a number.
 	 *
-	 * @covers \Newspack\Collections\Post_Meta::sanitize_meta
+	 * @covers \Newspack\Collections\Post_Meta::set
+	 * @covers \Newspack\Collections\Post_Meta::get
+	 * @covers \Newspack\Collections\Post_Meta::get_meta_definitions
 	 */
 	public function test_post_meta_sanitization() {
 		$post_id = $this->factory()->post->create();

--- a/tests/unit-tests/collections/class-test-sync.php
+++ b/tests/unit-tests/collections/class-test-sync.php
@@ -33,7 +33,7 @@ class Test_Sync extends \WP_UnitTestCase {
 	 *
 	 * @covers \Newspack\Collections\Sync::handle_post_save
 	 * @covers \Newspack\Collections\Sync::create_linked_term
-	 * @covers \Newspack\Collections\Taxonomy::find_term_by_name
+	 * @covers \Newspack\Collections\Collection_Taxonomy::find_term_by_name
 	 */
 	public function test_create_collection_term_from_post() {
 		$post_id = $this->create_test_collection();

--- a/tests/unit-tests/corrections.php
+++ b/tests/unit-tests/corrections.php
@@ -35,7 +35,7 @@ class Test_Corrections extends WP_UnitTestCase {
 	/**
 	 * Test that the corrections feature is disabled.
 	 *
-	 * @covers Corrections::register_rest_routes
+	 * @covers \Newspack\Corrections::register_rest_routes
 	 */
 	public function test_register_rest_routes() {
 		do_action( 'rest_api_init' );
@@ -68,7 +68,7 @@ class Test_Corrections extends WP_UnitTestCase {
 	/**
 	 * Test that an invalid post ID returns a WP_Error.
 	 *
-	 * @covers Corrections::rest_save_corrections
+	 * @covers \Newspack\Corrections::rest_save_corrections
 	 */
 	public function test_invalid_post_id_returns_error() {
 		$request = new WP_REST_Request( WP_REST_Server::CREATABLE, '/' . NEWSPACK_API_NAMESPACE . '/corrections/9999999' );
@@ -83,7 +83,7 @@ class Test_Corrections extends WP_UnitTestCase {
 	/**
 	 * Test that a new correction is created.
 	 *
-	 * @covers Corrections::rest_save_corrections
+	 * @covers \Newspack\Corrections::rest_save_corrections
 	 */
 	public function test_new_correction_is_created() {
 		$corrections = array(
@@ -116,7 +116,7 @@ class Test_Corrections extends WP_UnitTestCase {
 	/**
 	 * Test that an existing correction is updated.
 	 *
-	 * @covers Corrections::rest_save_corrections
+	 * @covers \Newspack\Corrections::rest_save_corrections
 	 */
 	public function test_existing_correction_is_updated() {
 		$initial_data = array(
@@ -157,7 +157,7 @@ class Test_Corrections extends WP_UnitTestCase {
 	/**
 	 * Test that multiple corrections are saved.
 	 *
-	 * @covers Corrections::rest_save_corrections
+	 * @covers \Newspack\Corrections::rest_save_corrections
 	 */
 	public function test_multiple_corrections_are_saved() {
 		$corrections = array(
@@ -197,7 +197,7 @@ class Test_Corrections extends WP_UnitTestCase {
 	/**
 	 * Test that a correction is deleted.
 	 *
-	 * @covers Corrections::rest_save_corrections
+	 * @covers \Newspack\Corrections::rest_save_corrections
 	 */
 	public function test_correction_is_deleted() {
 		$correction_1 = array(
@@ -259,7 +259,7 @@ class Test_Corrections extends WP_UnitTestCase {
 	/**
 	 * Test that a correction created and added to a post and is returned.
 	 *
-	 * @covers Corrections::add_correction
+	 * @covers \Newspack\Corrections::add_correction
 	 */
 	public function test_add_correction() {
 		$correction = array(
@@ -294,7 +294,7 @@ class Test_Corrections extends WP_UnitTestCase {
 	/**
 	 * Test that a correction created and added to a post and is returned.
 	 *
-	 * @covers Corrections::get_corrections
+	 * @covers \Newspack\Corrections::get_corrections
 	 */
 	public function test_get_corrections() {
 		$time = time() - 60 * 60;
@@ -352,7 +352,7 @@ class Test_Corrections extends WP_UnitTestCase {
 	/**
 	 * Test that a correction created and added to a post and is returned.
 	 *
-	 * @covers Corrections::get_corrections
+	 * @covers \Newspack\Corrections::get_corrections
 	 */
 	public function test_get_corrections_with_no_corrections() {
 		$corrections = Corrections::get_corrections( self::$post_id );
@@ -362,7 +362,7 @@ class Test_Corrections extends WP_UnitTestCase {
 	/**
 	 * Test that a created correction is updated.
 	 *
-	 * @covers Corrections::update_correction
+	 * @covers \Newspack\Corrections::update_correction
 	 */
 	public function test_update_correction() {
 		$correction = array(
@@ -399,7 +399,7 @@ class Test_Corrections extends WP_UnitTestCase {
 	/**
 	 * Test that created corrections are deleted.
 	 *
-	 * @covers Corrections::delete_corrections
+	 * @covers \Newspack\Corrections::delete_corrections
 	 */
 	public function test_delete_corrections() {
 		$correction_1 = array(
@@ -436,7 +436,7 @@ class Test_Corrections extends WP_UnitTestCase {
 	/**
 	 * Test that correction type is returned as "Correction".
 	 *
-	 * @covers Corrections::get_correction_type
+	 * @covers \Newspack\Corrections::get_correction_type
 	 */
 	public function test_get_correction_type_is_correction() {
 		$correction = array(
@@ -457,7 +457,7 @@ class Test_Corrections extends WP_UnitTestCase {
 	/**
 	 * Test that correction type is returned as "Clarification".
 	 *
-	 * @covers Corrections::get_correction_type
+	 * @covers \Newspack\Corrections::get_correction_type
 	 */
 	public function test_get_correction_type_is_clarification() {
 		$clarification = array(
@@ -478,7 +478,7 @@ class Test_Corrections extends WP_UnitTestCase {
 	/**
 	 * Test that the corrections are output on the post.
 	 *
-	 * @covers Corrections::output_corrections_on_post
+	 * @covers \Newspack\Corrections::output_corrections_on_post
 	 */
 	public function test_output_corrections_on_post_appends_markup() {
 		$correction_1 = array(
@@ -534,7 +534,7 @@ class Test_Corrections extends WP_UnitTestCase {
 	/**
 	 * Test scripts and styles are enqueued correctly.
 	 *
-	 * @covers Corrections::wp_enqueue_scripts
+	 * @covers \Newspack\Corrections::wp_enqueue_scripts
 	 */
 	public function test_enqueue_scripts_and_styles() {
 		Corrections::wp_enqueue_scripts();
@@ -547,7 +547,7 @@ class Test_Corrections extends WP_UnitTestCase {
 	/**
 	 * Test corrections post type registration.
 	 *
-	 * @covers Corrections::register_post_type
+	 * @covers \Newspack\Corrections::register_post_type
 	 */
 	public function test_register_post_type() {
 		$post_type_exists = post_type_exists( Corrections::POST_TYPE );
@@ -565,7 +565,7 @@ class Test_Corrections extends WP_UnitTestCase {
 	/**
 	 * Test correction type labels.
 	 *
-	 * @covers Corrections::get_correction_type_label
+	 * @covers \Newspack\Corrections::get_correction_type_label
 	 */
 	public function test_correction_type_labels() {
 		$correction    = [
@@ -600,7 +600,7 @@ class Test_Corrections extends WP_UnitTestCase {
 	/**
 	 * Test that corrections status is updated when post status changes.
 	 *
-	 * @covers Corrections::update_corrections_status
+	 * @covers \Newspack\Corrections::update_corrections_status
 	 */
 	public function test_update_corrections_status() {
 		$correction = array(
@@ -642,7 +642,7 @@ class Test_Corrections extends WP_UnitTestCase {
 	/**
 	 * Test that corrections are set to private when the post is scheduled.
 	 *
-	 * @covers Corrections::update_corrections_status
+	 * @covers \Newspack\Corrections::update_corrections_status
 	 */
 	public function test_corrections_set_to_private_when_post_scheduled() {
 		$correction = array(
@@ -676,8 +676,8 @@ class Test_Corrections extends WP_UnitTestCase {
 	/**
 	 * Test that corrections can be filtered by supported post types.
 	 *
-	 * @covers Corrections::get_supported_post_types
-	 * @covers Corrections::is_supported_post_type
+	 * @covers \Newspack\Corrections::get_supported_post_types
+	 * @covers \Newspack\Corrections::is_supported_post_type
 	 */
 	public function test_get_supported_post_types() {
 		$supported_types = Corrections::get_supported_post_types();

--- a/tests/unit-tests/rss.php
+++ b/tests/unit-tests/rss.php
@@ -434,8 +434,9 @@ class Newspack_Test_RSS extends WP_UnitTestCase {
 		// Verify the query returns the correct posts (only post1 and post2).
 		$query->get_posts();
 		$this->assertEquals( 2, $query->found_posts, 'Should find exactly two posts' );
-		$this->assertEquals( $post1, $query->posts[0]->ID, 'Should return only the post in cat1' );
-		$this->assertEquals( $post2, $query->posts[1]->ID, 'Should return only the post in cat2' );
+		$post_ids = wp_list_pluck( $query->posts, 'ID' );
+		$this->assertContains( $post1, $post_ids, 'Should return post1' );
+		$this->assertContains( $post2, $post_ids, 'Should return post2' );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes proposed in this Pull Request:
Fixes occasional test failures and PHPUnit coverage warnings:
- Fixed flaky `test_rss_category_exclusion` that failed intermittently due to non-deterministic post ordering.
- Corrected 22 invalid `@covers` annotations that were causing PHPUnit warnings during coverage analysis.

Closes NPPM-2276.

### How to test the changes in this Pull Request:

1. Run tests multiple times to verify RSS test no longer fails.
2. Run tests with coverage to verify no `@covers` warnings. If using the Docker image, it can be done via:
```bash
docker exec newspack_dev sh -c "cd /newspack-repos/newspack-plugin && XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-text"
```
3. Verify all tests pass.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
