### PR TITLE
feat(my-account): add delete payment method modal confirmation

### DIFF
--- a/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php
+++ b/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php
@@ -40,6 +40,7 @@ class My_Account_UI_V1 {
 		\add_filter( 'default_option_woocommerce_myaccount_add_payment_method_endpoint', [ __CLASS__, 'add_payment_method_endpoint' ] );
 		\add_action( 'template_redirect', [ __CLASS__, 'redirect_payment_information_endpoint' ] );
 		\add_action( 'newspack_woocommerce_after_account_payment_methods', [ __CLASS__, 'add_payment_method_modal' ] );
+		\add_action( 'newspack_woocommerce_after_account_payment_methods', [ __CLASS__, 'delete_payment_method_modals' ] );
 		\add_action( 'newspack_woocommerce_after_account_addresses', [ __CLASS__, 'add_address_modals' ] );
 		\add_action( 'newspack_woocommerce_after_account_addresses', [ __CLASS__, 'delete_address_modals' ] );
 		\add_action( 'woocommerce_after_save_address_validation', [ __CLASS__, 'handle_delete_address_submission' ], 10, 4 );
@@ -520,6 +521,95 @@ class My_Account_UI_V1 {
 			if ( \trailingslashit( \wc_get_account_endpoint_url( 'edit-address' ) ) === $current_url ) {
 				\wp_safe_redirect( \wc_get_account_endpoint_url( 'payment-methods' ) );
 				exit;
+			}
+		}
+	}
+
+	/**
+	 * Render confirmation modals for deleting saved payment methods.
+	 *
+	 * @param bool $has_methods Whether there are saved payment methods to render.
+	 */
+	public static function delete_payment_method_modals( $has_methods ) {
+		if ( ! $has_methods ) {
+			return;
+		}
+
+		$saved_methods = \wc_get_customer_saved_methods_list( \get_current_user_id() );
+
+		if ( empty( $saved_methods ) || ! is_array( $saved_methods ) ) {
+			return;
+		}
+
+		foreach ( $saved_methods as $methods ) {
+			foreach ( $methods as $method ) {
+				$delete_url = $method['actions']['delete']['url'] ?? '';
+
+				if ( empty( $delete_url ) ) {
+					continue;
+				}
+
+				$modal_suffix = \sanitize_html_class( md5( $delete_url ) );
+				$brand        = ! empty( $method['method']['brand'] ) ? \wc_get_credit_card_type_label( $method['method']['brand'] ) : '';
+				$last4        = $method['method']['last4'] ?? '';
+				$expires      = $method['expires'] ?? '';
+
+				ob_start();
+				?>
+				<p><?php \esc_html_e( 'Are you sure you want to delete this payment method from your account?', 'newspack-plugin' ); ?></p>
+				<div class="payment-method-preview newspack-ui__font--s newspack-ui__font--bold">
+					<?php
+					$lines = [];
+
+					if ( $brand ) {
+						$lines[] = $brand;
+					}
+
+					if ( $last4 ) {
+						$lines[] = sprintf(
+							/* translators: last 4 digits. */
+							__( 'Ending in %s', 'newspack-plugin' ),
+							$last4
+						);
+					}
+
+					if ( $expires ) {
+						$lines[] = sprintf(
+							/* translators: expiration date. */
+							__( 'Exp. %s', 'newspack-plugin' ),
+							$expires
+						);
+					}
+
+					if ( ! empty( $lines ) ) {
+						echo implode( '<br>', array_map( 'esc_html', $lines ) );
+					}
+					?>
+				</div>
+				<?php
+				$content = ob_get_clean();
+
+				Newspack_UI::generate_modal(
+					[
+						'id'          => 'delete-payment-method-' . $modal_suffix,
+						'title'       => __( 'Delete payment method', 'newspack-plugin' ),
+						'content'     => $content,
+						'size'        => 'small',
+						'form'        => 'GET',
+						'form_action' => $delete_url,
+						'actions'     => [
+							'delete' => [
+								'label' => __( 'Delete payment method', 'newspack-plugin' ),
+								'type'  => 'destructive',
+							],
+							'cancel' => [
+								'label'  => __( 'Cancel', 'newspack-plugin' ),
+								'type'   => 'ghost',
+								'action' => 'close',
+							],
+						],
+					]
+				);
 			}
 		}
 	}

--- a/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php
+++ b/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php
@@ -554,6 +554,17 @@ class My_Account_UI_V1 {
 				$last4        = $method['method']['last4'] ?? '';
 				$expires      = $method['expires'] ?? '';
 
+				// Parse the URL to extract query parameters.
+				$parsed_url   = \wp_parse_url( $delete_url );
+				$query_params = [];
+
+				if ( ! empty( $parsed_url['query'] ) ) {
+					\parse_str( $parsed_url['query'], $query_params );
+				}
+
+				// Reconstruct the base URL without query parameters.
+				$form_action_base = \remove_query_arg( array_keys( $query_params ), $delete_url );
+
 				ob_start();
 				?>
 				<p><?php \esc_html_e( 'Are you sure you want to delete this payment method from your account?', 'newspack-plugin' ); ?></p>
@@ -587,6 +598,15 @@ class My_Account_UI_V1 {
 					?>
 				</div>
 				<?php
+				// Add query parameters as hidden form fields.
+				foreach ( $query_params as $param_name => $param_value ) {
+					printf(
+						'<input type="hidden" name="%1$s" value="%2$s">',
+						\esc_attr( $param_name ),
+						\esc_attr( $param_value )
+					);
+				}
+
 				$content = ob_get_clean();
 
 				Newspack_UI::generate_modal(
@@ -596,7 +616,7 @@ class My_Account_UI_V1 {
 						'content'     => $content,
 						'size'        => 'small',
 						'form'        => 'GET',
-						'form_action' => $delete_url,
+						'form_action' => $form_action_base,
 						'actions'     => [
 							'delete' => [
 								'label' => __( 'Delete payment method', 'newspack-plugin' ),

--- a/includes/plugins/woocommerce/my-account/templates/v1/payment-information.php
+++ b/includes/plugins/woocommerce/my-account/templates/v1/payment-information.php
@@ -23,7 +23,11 @@ $types         = \wc_get_account_payment_methods_types();
 		<div class="newspack-my-account__payment-methods newspack-ui__row newspack-ui__row--no-padding">
 		<?php $payment_method_columns = \wc_get_account_payment_methods_columns(); ?>
 		<?php foreach ( $saved_methods as $type => $methods ) : // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited ?>
-			<?php foreach ( $methods as $method ) : ?>
+			<?php
+			foreach ( $methods as $method ) :
+				$delete_url          = $method['actions']['delete']['url'] ?? '';
+				$delete_modal_suffix = $delete_url ? md5( $delete_url ) : '';
+				?>
 				<div class="newspack-ui__box newspack-ui__box--border payment-method<?php echo ! empty( $method['is_default'] ) ? ' default-payment-method' : ''; ?>">
 					<div class="payment-method__content">
 					<?php
@@ -112,11 +116,25 @@ $types         = \wc_get_account_payment_methods_types();
 												if ( 'delete' === $key || 'wcs_deletion_error' === $key ) {
 													$action['name'] = __( 'Delete payment method', 'newspack-plugin' ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 												}
+
+												$action_classes = trim( 'newspack-ui__button newspack-ui__button--ghost ' . \sanitize_html_class( $key ) . ( 'wcs_deletion_error' === $key ? ' disabled' : '' ) );
+												$attribute_html = '';
+
+												if ( 'delete' === $key && ! empty( $delete_modal_suffix ) ) {
+													$action_classes .= ' newspack-my-account__delete-payment-method';
+													$attribute_html  = sprintf( ' data-payment-method="%s"', esc_attr( $delete_modal_suffix ) );
+												}
 												?>
 												<li>
-													<a href="<?php echo \esc_url( $action['url'] ); ?>" class="newspack-ui__button newspack-ui__button--ghost <?php echo \sanitize_html_class( $key ); ?> <?php echo 'wcs_deletion_error' === $key ? 'disabled' : ''; ?>">
-														<?php echo \esc_html( $action['name'] ); ?>
-													</a>
+													<?php
+													printf(
+														'<a href="%1$s" class="%2$s"%3$s>%4$s</a>',
+														esc_url( $action['url'] ),
+														esc_attr( $action_classes ),
+														wp_kses_data( $attribute_html ),
+														esc_html( $action['name'] )
+													);
+													?>
 												</li>
 											<?php endforeach; ?>
 											</ul>

--- a/src/my-account/v1/payment-information.js
+++ b/src/my-account/v1/payment-information.js
@@ -36,10 +36,10 @@ function setupModalHandlers( selector, modalId, dataAttribute = null ) {
 
 			// Handle dynamic modal IDs when data attributes are provided.
 			const type = dataAttribute ? button.getAttribute( dataAttribute ) : '';
-			modalId = modalId + ( type ? `-${ type }` : '' );
+			const targetModalId = modalId + ( type ? `-${ type }` : '' );
 
 			// Open modal and handle common behavior.
-			const modal = document.getElementById( modalId );
+			const modal = document.getElementById( targetModalId );
 			if ( modal ) {
 				modal.setAttribute( 'data-state', 'open' );
 				button.closest( 'div' ).classList.remove( 'newspack-ui--loading' );

--- a/src/my-account/v1/payment-information.js
+++ b/src/my-account/v1/payment-information.js
@@ -53,6 +53,9 @@ domReady( function () {
 	// Add payment method modal.
 	setupModalHandlers( '.newspack-my-account__add-payment-method', 'newspack-my-account__add-payment-method' );
 
+	// Delete payment method modals.
+	setupModalHandlers( '.newspack-my-account__delete-payment-method', 'newspack-my-account__delete-payment-method', 'data-payment-method' );
+
 	// Edit address modals.
 	setupModalHandlers( '.newspack-my-account__edit-address', 'newspack-my-account__edit-address', 'data-address-type' );
 

--- a/src/my-account/v1/payment-information.js
+++ b/src/my-account/v1/payment-information.js
@@ -43,6 +43,10 @@ function setupModalHandlers( selector, modalId, dataAttribute = null ) {
 			if ( modal ) {
 				modal.setAttribute( 'data-state', 'open' );
 				button.closest( 'div' ).classList.remove( 'newspack-ui--loading' );
+				const dropdown = button.closest( '.newspack-ui__dropdown' );
+				if ( dropdown ) {
+					dropdown.classList.remove( 'active' );
+				}
 				jQuery( document.body ).trigger( 'refresh' );
 			}
 		} );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds a confirmation flow before removing saved payment methods. Each delete action now opens a modal with the card brand/last four/expiry, and now all the dropdowns close once the modal appears (including address-related modals).

<img width="430" height="381" alt="image" src="https://github.com/user-attachments/assets/49e73977-83cc-4db0-b7b8-259b4065e2f4" />


Closes NPPD-909.

### How to test the changes in this Pull Request:

1. Log in as a reader with multiple saved payment methods and visit My Account → Payment information.
2. Open the overflow menu for any deletable card and click "Delete payment method"
3. Confirm a modal appears with the corresponding brand/last four/expiry and that the dropdown (three-dot menu) automatically closes.
4. Click "Cancel" and verify that the card remains and that the menu items can be selected again.
5. Reopen the modal for the same card, click "Delete payment method" and make sure the card is removed after the page refresh.
6. Test setting up a different default payment method. The dropdown menu should be kept open, but with the options deactivated while the page refreshes (same behavior as before).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?