### PR TITLE
feat(woocommerce): enable block emails

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -142,6 +142,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/newspack/class-newspack-dashboard.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/newspack/class-newspack-settings.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/newspack/class-custom-events-section.php';
+		include_once NEWSPACK_ABSPATH . 'includes/wizards/newspack/class-emails-section.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/newspack/class-syndication-section.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/newspack/class-seo-section.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/newspack/class-pixels-section.php';

--- a/includes/class-wizards.php
+++ b/includes/class-wizards.php
@@ -49,6 +49,7 @@ class Wizards {
 				[
 					'sections' => [
 						'custom-events' => 'Newspack\Wizards\Newspack\Custom_Events_Section',
+						'emails'        => 'Newspack\Wizards\Newspack\Emails_Section',
 						'social-pixels' => 'Newspack\Wizards\Newspack\Pixels_Section',
 						'recirculation' => 'Newspack\Wizards\Newspack\Recirculation_Section',
 						'syndication'   => 'Newspack\Wizards\Newspack\Syndication_Section',

--- a/includes/plugins/woocommerce/class-woocommerce-connection.php
+++ b/includes/plugins/woocommerce/class-woocommerce-connection.php
@@ -34,6 +34,7 @@ class WooCommerce_Connection {
 		include_once __DIR__ . '/class-woocommerce-logs.php';
 		include_once __DIR__ . '/class-woocommerce-cli.php';
 		include_once __DIR__ . '/class-woocommerce-cover-fees.php';
+		include_once __DIR__ . '/class-woocommerce-emails.php';
 		include_once __DIR__ . '/class-woocommerce-order-utm.php';
 		include_once __DIR__ . '/class-woocommerce-products.php';
 		include_once __DIR__ . '/class-woocommerce-duplicate-orders.php';

--- a/includes/plugins/woocommerce/class-woocommerce-emails.php
+++ b/includes/plugins/woocommerce/class-woocommerce-emails.php
@@ -23,10 +23,18 @@ class WooCommerce_Emails {
 	const WOOCOMMERCE_EMAIL_EDITOR_OPTION = 'newspack_woocommerce_feature_block_email_editor_enabled';
 
 	/**
+	 * Option to determine whether email templates have been updated.
+	 *
+	 * @var string
+	 */
+	const WOOCOMMERCE_EMAILS_UPDATED_OPTION = 'newspack_woocommerce_block_editor_emails_updated_to_latest';
+
+	/**
 	 * Initialize hooks.
 	 */
 	public static function init() {
 		add_filter( 'option_woocommerce_feature_block_email_editor_enabled', [ __CLASS__, 'override_woocommerce_email_editor_option' ], 10, 2 );
+		add_action( 'admin_init', [ __CLASS__, 'update_woocommerce_emails_to_latest' ] );
 	}
 
 	/**
@@ -55,6 +63,35 @@ class WooCommerce_Emails {
 	 */
 	public static function is_enabled() {
 		return get_option( self::WOOCOMMERCE_EMAIL_EDITOR_OPTION, 'yes' );
+	}
+
+	/**
+	 * Update any existing woocommerce block emails to the latest content if they haven't been customized.
+	 */
+	public static function update_woocommerce_emails_to_latest() {
+		if ( ! class_exists( '\Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCTransactionalEmails' ) ) {
+			return;
+		}
+		if ( 'yes' === self::is_enabled() && 'v1' !== get_option( self::WOOCOMMERCE_EMAILS_UPDATED_OPTION, '' ) ) {
+			$email_ids              = \Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCTransactionalEmails::get_transactional_emails();
+			$email_template_manager = \Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCTransactionalEmailPostsManager::get_instance();
+			foreach ( $email_ids as $email_id ) {
+				$template_id = $email_template_manager->get_email_template_post_id( $email_id );
+				if ( ! $template_id ) {
+					continue;
+				}
+				$publish_date       = get_the_date( 'Y-m-d H:i:s', $template_id );
+				$last_modified_date = get_the_modified_date( 'Y-m-d H:i:s', $template_id );
+				// Template has not been modified, so delete the post so we can regenerate the template.
+				if ( $publish_date === $last_modified_date ) {
+					wp_delete_post( $template_id, true );
+				}
+			}
+			delete_transient( 'wc_email_editor_initial_templates_generated' );
+			$email_template_generator = new \Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCTransactionalEmailPostsGenerator();
+			$email_template_generator->initialize();
+			update_option( self::WOOCOMMERCE_EMAILS_UPDATED_OPTION, 'v1' );
+		}
 	}
 }
 WooCommerce_Emails::init();

--- a/includes/plugins/woocommerce/class-woocommerce-emails.php
+++ b/includes/plugins/woocommerce/class-woocommerce-emails.php
@@ -20,44 +20,41 @@ class WooCommerce_Emails {
 	 *
 	 * @var string
 	 */
-	const WOOCOMMERCE_EMAILS_OPTION = 'newspack_woocommerce_feature_email_improvements_enabled';
+	const WOOCOMMERCE_EMAIL_EDITOR_OPTION = 'newspack_woocommerce_feature_block_email_editor_enabled';
 
 	/**
 	 * Initialize hooks.
 	 */
 	public static function init() {
-		add_filter( 'option_woocommerce_feature_email_improvements_enabled', [ __CLASS__, 'force_enable_woocommerce_emails' ], 10, 2 );
+		add_filter( 'option_woocommerce_feature_block_email_editor_enabled', [ __CLASS__, 'override_woocommerce_email_editor_option' ], 10, 2 );
 	}
 
 	/**
-	 * Force enable WooCommerce email improvements.
+	 * Force enable WooCommerce email editor.
 	 *
 	 * @param mixed  $value  Current value.
 	 * @param string $option Option name.
 	 */
-	public static function force_enable_woocommerce_emails( $value, $option ) {
-		if ( self::is_enabled() ) {
-			return 'yes';
-		}
-		return $value;
+	public static function override_woocommerce_email_editor_option( $value, $option ) {
+		return self::is_enabled();
 	}
 
 	/**
 	 * Update the option to enable WooCommerce block email editor.
 	 *
-	 * @param bool $enabled Whether to enable the feature.
+	 * @param bool $enable Whether to enable the feature.
 	 */
-	public static function set_enabled( $enabled ) {
-		update_option( self::WOOCOMMERCE_EMAILS_OPTION, $enabled ? 'yes' : 'no' );
+	public static function set_enabled( $enable ) {
+		update_option( self::WOOCOMMERCE_EMAIL_EDITOR_OPTION, $enable ? 'yes' : 'no' );
 	}
 
 	/**
 	 * Check if WooCommerce block email editor is enabled. Default to enabled.
 	 *
-	 * @return bool
+	 * @return string 'yes' if enabled, 'no' if not.
 	 */
 	public static function is_enabled() {
-		return 'yes' === get_option( self::WOOCOMMERCE_EMAILS_OPTION, 'yes' );
+		return get_option( self::WOOCOMMERCE_EMAIL_EDITOR_OPTION, 'yes' );
 	}
 }
 WooCommerce_Emails::init();

--- a/includes/plugins/woocommerce/class-woocommerce-emails.php
+++ b/includes/plugins/woocommerce/class-woocommerce-emails.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Enable Woos block email editor.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WooCommerce Emails class.
+ */
+class WooCommerce_Emails {
+	/**
+	 * Initialize hooks.
+	 */
+	public static function init() {
+	}
+}
+WooCommerce_Emails::init();

--- a/includes/plugins/woocommerce/class-woocommerce-emails.php
+++ b/includes/plugins/woocommerce/class-woocommerce-emails.php
@@ -9,14 +9,55 @@ namespace Newspack;
 
 defined( 'ABSPATH' ) || exit;
 
+use WP_REST_Request, WP_REST_Response, WP_REST_Server;
+
 /**
  * WooCommerce Emails class.
  */
 class WooCommerce_Emails {
 	/**
+	 * Option to track if the feature is enabled.
+	 *
+	 * @var string
+	 */
+	const WOOCOMMERCE_EMAILS_OPTION = 'newspack_woocommerce_feature_email_improvements_enabled';
+
+	/**
 	 * Initialize hooks.
 	 */
 	public static function init() {
+		add_filter( 'option_woocommerce_feature_email_improvements_enabled', [ __CLASS__, 'force_enable_woocommerce_emails' ], 10, 2 );
+	}
+
+	/**
+	 * Force enable WooCommerce email improvements.
+	 *
+	 * @param mixed  $value  Current value.
+	 * @param string $option Option name.
+	 */
+	public static function force_enable_woocommerce_emails( $value, $option ) {
+		if ( self::is_enabled() ) {
+			return 'yes';
+		}
+		return $value;
+	}
+
+	/**
+	 * Update the option to enable WooCommerce block email editor.
+	 *
+	 * @param bool $enabled Whether to enable the feature.
+	 */
+	public static function set_enabled( $enabled ) {
+		update_option( self::WOOCOMMERCE_EMAILS_OPTION, $enabled ? 'yes' : 'no' );
+	}
+
+	/**
+	 * Check if WooCommerce block email editor is enabled. Default to enabled.
+	 *
+	 * @return bool
+	 */
+	public static function is_enabled() {
+		return 'yes' === get_option( self::WOOCOMMERCE_EMAILS_OPTION, 'yes' );
 	}
 }
 WooCommerce_Emails::init();

--- a/includes/wizards/newspack/class-emails-section.php
+++ b/includes/wizards/newspack/class-emails-section.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Newspack's SEO Section.
+ * Newspack Emails Section.
  *
  * @package Newspack
  */
@@ -45,7 +45,7 @@ class Emails_Section extends Wizard_Section {
 				'callback'            => [ __CLASS__, 'api_update_email_settings' ],
 				'permission_callback' => [ $this, 'api_permissions_check' ],
 				'args'                => [
-					'enable_woocommerce_emails' => [
+					'enable_woocommerce_email_editor' => [
 						'type'              => 'boolean',
 						'required'          => true,
 						'sanitize_callback' => 'rest_sanitize_boolean',
@@ -64,8 +64,8 @@ class Emails_Section extends Wizard_Section {
 	public static function api_get_email_settings(): array {
 		$settings = [];
 		if ( class_exists( 'WooCommerce' ) ) {
-			$settings['admin_url']                 = admin_url( 'admin.php?page=wc-settings&tab=email' );
-			$settings['enable_woocommerce_emails'] = WooCommerce_Emails::is_enabled();
+			$settings['admin_url']                       = admin_url( 'admin.php?page=wc-settings&tab=email' );
+			$settings['enable_woocommerce_email_editor'] = 'yes' === WooCommerce_Emails::is_enabled();
 		}
 		return $settings;
 	}
@@ -78,9 +78,9 @@ class Emails_Section extends Wizard_Section {
 	 * @return WP_REST_Response Response.
 	 */
 	public static function api_update_email_settings( $request ) {
-		if ( $request->has_param( 'enable_woocommerce_emails' ) ) {
-			$is_enabled = filter_var( $request->get_param( 'enable_woocommerce_emails' ), FILTER_VALIDATE_BOOLEAN );
-			WooCommerce_Emails::set_enabled( $is_enabled );
+		if ( $request->has_param( 'enable_woocommerce_email_editor' ) ) {
+			$enable = filter_var( $request->get_param( 'enable_woocommerce_email_editor' ), FILTER_VALIDATE_BOOLEAN );
+			WooCommerce_Emails::set_enabled( $enable );
 		}
 		return rest_ensure_response( self::api_get_email_settings() );
 	}

--- a/includes/wizards/newspack/class-emails-section.php
+++ b/includes/wizards/newspack/class-emails-section.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Newspack's SEO Section.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Wizards\Newspack;
+
+use Newspack\Wizards\Wizard_Section;
+use Newspack\WooCommerce_Emails;
+use WP_REST_Server;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Emails Section Class.
+ */
+class Emails_Section extends Wizard_Section {
+	/**
+	 * Containing wizard slug.
+	 *
+	 * @var string
+	 */
+	protected $wizard_slug = 'newspack-settings';
+
+	/**
+	 * Register the endpoints needed for the wizard screens.
+	 */
+	public function register_rest_routes() {
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'wizard/' . $this->wizard_slug . '/emails',
+			[
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => [ __CLASS__, 'api_get_email_settings' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+			]
+		);
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'wizard/' . $this->wizard_slug . '/emails',
+			[
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => [ __CLASS__, 'api_update_email_settings' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+				'args'                => [
+					'enable_woocommerce_emails' => [
+						'type'              => 'boolean',
+						'required'          => true,
+						'sanitize_callback' => 'rest_sanitize_boolean',
+					],
+				],
+
+			]
+		);
+	}
+
+	/**
+	 * Get email settings.
+	 *
+	 * @return array
+	 */
+	public static function api_get_email_settings(): array {
+		$settings = [];
+		if ( class_exists( 'WooCommerce' ) ) {
+			$settings['admin_url']                 = admin_url( 'admin.php?page=wc-settings&tab=email' );
+			$settings['enable_woocommerce_emails'] = WooCommerce_Emails::is_enabled();
+		}
+		return $settings;
+	}
+
+	/**
+	 * API callback to update woocommerce email settings.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 *
+	 * @return WP_REST_Response Response.
+	 */
+	public static function api_update_email_settings( $request ) {
+		if ( $request->has_param( 'enable_woocommerce_emails' ) ) {
+			$is_enabled = filter_var( $request->get_param( 'enable_woocommerce_emails' ), FILTER_VALIDATE_BOOLEAN );
+			WooCommerce_Emails::set_enabled( $is_enabled );
+		}
+		return rest_ensure_response( self::api_get_email_settings() );
+	}
+}

--- a/src/wizards/newspack/views/settings/emails/index.tsx
+++ b/src/wizards/newspack/views/settings/emails/index.tsx
@@ -12,6 +12,7 @@ import { __ } from '@wordpress/i18n';
  */
 import WizardsTab from '../../../../wizards-tab';
 import { default as EmailsSection } from './emails';
+import { default as SettingsSection } from './settings';
 import WizardSection from '../../../../wizards-section';
 
 function Emails() {
@@ -19,6 +20,9 @@ function Emails() {
 		<WizardsTab title={ __( 'Emails', 'newspack-plugin' ) }>
 			<WizardSection>
 				<EmailsSection />
+			</WizardSection>
+			<WizardSection>
+				<SettingsSection />
 			</WizardSection>
 		</WizardsTab>
 	);

--- a/src/wizards/newspack/views/settings/emails/settings.tsx
+++ b/src/wizards/newspack/views/settings/emails/settings.tsx
@@ -20,7 +20,7 @@ import { SectionHeader } from '../../../../../components/src';
 const DATA_STORE_KEY = 'newspack-settings/emails';
 
 const Settings = () => {
-	const { enable_woocommerce_emails: isEnabled, admin_url: url } = useWizardData( DATA_STORE_KEY );
+	const { enable_woocommerce_email_editor: isEnabled, admin_url: url } = useWizardData( DATA_STORE_KEY );
 	const { saveWizardSettings } = useDispatch( WIZARD_STORE_NAMESPACE );
 
 	if ( typeof isEnabled !== 'boolean' || ! url ) {
@@ -31,7 +31,7 @@ const Settings = () => {
 		saveWizardSettings( {
 			slug: DATA_STORE_KEY,
 			updatePayload: {
-				path: [ 'enable_woocommerce_emails' ],
+				path: [ 'enable_woocommerce_email_editor' ],
 				value: ! isEnabled,
 			},
 		} );
@@ -45,7 +45,7 @@ const Settings = () => {
 			<SectionHeader heading={ 3 } title={ __( 'Transactional emails', 'newspack-plugin' ) } />
 			<WizardsActionCard
 				isSmall
-				key={ 'enable_woocommerce_emails' }
+				key={ 'enable_woocommerce_email_editor' }
 				href={ url }
 				title={ title }
 				titleLink={ url }

--- a/src/wizards/newspack/views/settings/emails/settings.tsx
+++ b/src/wizards/newspack/views/settings/emails/settings.tsx
@@ -1,0 +1,61 @@
+/**
+ * Newspack > Settings > Emails > Emails section
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { useDispatch } from '@wordpress/data';
+import { Fragment } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies.
+ */
+import WizardsActionCard from '../../../../wizards-action-card';
+import { useWizardData } from '../../../../../components/src/wizard/store/utils';
+import { WIZARD_STORE_NAMESPACE } from '../../../../../components/src/wizard/store';
+import { SectionHeader } from '../../../../../components/src';
+
+const DATA_STORE_KEY = 'newspack-settings/emails';
+
+const Settings = () => {
+	const { enable_woocommerce_emails: isEnabled, admin_url: url } = useWizardData( DATA_STORE_KEY );
+	const { saveWizardSettings } = useDispatch( WIZARD_STORE_NAMESPACE );
+
+	if ( typeof isEnabled !== 'boolean' || ! url ) {
+		return null;
+	}
+
+	const toggle = () => {
+		saveWizardSettings( {
+			slug: DATA_STORE_KEY,
+			updatePayload: {
+				path: [ 'enable_woocommerce_emails' ],
+				value: ! isEnabled,
+			},
+		} );
+	};
+
+	const title = __( "Use WooCommerce's block email editor (alpha)", 'newspack-plugin' );
+	const description = __( 'Enable the block-based email editor for transacitonal emails', 'newspack-plugin' );
+
+	return (
+		<Fragment>
+			<SectionHeader heading={ 3 } title={ __( 'Transactional emails', 'newspack-plugin' ) } />
+			<WizardsActionCard
+				isSmall
+				key={ 'enable_woocommerce_emails' }
+				href={ url }
+				title={ title }
+				titleLink={ url }
+				description={ description }
+				actionText={ __( 'Edit emails', 'newspack-plugin' ) }
+				toggleChecked={ isEnabled }
+				toggleOnChange={ toggle }
+			/>
+		</Fragment>
+	);
+};
+
+export default Settings;


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://linear.app/a8c/issue/NPPM-2045/evaluate-woo-block-based-email-builder-andor-update-transactional

This PR enables the new woo email block editor for publishers by default. This also adds a setting to our Newspack email settings since the Woo option is currently a burried in Woo advanced settings:

![Screenshot 2025-10-06 at 15 07 36](https://github.com/user-attachments/assets/2c0911bd-6e9d-48b1-aecf-ad823cc1c1dc)

Finally this adds a one time upgrade to any of the new email templates for publishers that enabled the feature before the text was updated by Woo to be more reasonable.

### How to test the changes in this Pull Request:

1. Before checkout out this branch, go to WooCommerce > Settings > Advanced > Features and enable the `Block Email Editor (alpha)` setting.
2. Now go to WooCommerce > Settings > Emails and choose one or two emails and edit with any custom content. Make note of which emails you edited!
3. Disable the setting from step 1
4. Checkout this branch and build
5. Confirm a new setting exists in Newspack > Settings > Emails as pictured above
6. Confirm the new Woo email editor is enabled (see step 2)
    
![Screenshot 2025-10-06 at 15 12 19](https://github.com/user-attachments/assets/251bdbc8-6c41-43fa-b277-db3498306320)

7. View the content from the emails you edited in step 2, and confirm the changes are still present
8. Now, using the toggle from step 5, disable the new email editor 
9. Confirm the block editor is no longer available and the previous woo email settings are present.

![Screenshot 2025-10-06 at 15 12 39](https://github.com/user-attachments/assets/b4336f80-0c4e-42a6-b7ab-6c4f61491f5a)

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->