### PR TITLE
feat(collections): implement design feedback for archive link

### DIFF
--- a/src/components/src/section-header/index.js
+++ b/src/components/src/section-header/index.js
@@ -21,15 +21,15 @@ import classnames from 'classnames';
 /**
  * Represents a section header component.
  *
- * @typedef {Object}   SectionHeaderProps
- * @property {boolean} [centered=false] - Indicates if the header is centered.
- * @property {?string} [className=null] - Additional CSS class name.
- * @property {string}  [description]    - Description of the section.
- * @property {number}  [heading=2]      - HTML heading level, e.g., 1 for h1, 2 for h2, etc.
- * @property {boolean} [isWhite=false]  - Indicates if the header should use a white theme.
- * @property {boolean} [noMargin=false] - Indicates if the header should have no margin.
- * @property {string}  title            - The title of the section.
- * @property {?string} [id=null]        - Optional ID for the header element.
+ * @typedef {Object} SectionHeaderProps
+ * @property {boolean}           [centered=false] - Indicates if the header is centered.
+ * @property {?string}           [className=null] - Additional CSS class name.
+ * @property {string|Function|*} [description]    - Description of the section.
+ * @property {number}            [heading=2]      - HTML heading level, e.g., 1 for h1, 2 for h2, etc.
+ * @property {boolean}           [isWhite=false]  - Indicates if the header should use a white theme.
+ * @property {boolean}           [noMargin=false] - Indicates if the header should have no margin.
+ * @property {string}            title            - The title of the section.
+ * @property {?string}           [id=null]        - Optional ID for the header element.
  */
 
 /**
@@ -77,6 +77,7 @@ const SectionHeader = ( {
 				{ typeof title === 'function' && <HeadingTag>{ title() }</HeadingTag> }
 				{ description && typeof description === 'string' && <p>{ description }</p> }
 				{ typeof description === 'function' && <p>{ description() }</p> }
+				{ description && typeof description !== 'string' && typeof description !== 'function' && <p>{ description }</p> }
 			</Grid>
 		</div>
 	);

--- a/src/wizards/newspack/views/settings/collections/index.tsx
+++ b/src/wizards/newspack/views/settings/collections/index.tsx
@@ -4,8 +4,7 @@
 
 import { __ } from '@wordpress/i18n';
 import { useState, useEffect, useMemo } from '@wordpress/element';
-import { ToggleControl, Tooltip, Icon } from '@wordpress/components';
-import { external } from '@wordpress/icons';
+import { ToggleControl } from '@wordpress/components';
 import { cleanForSlug } from '@wordpress/url';
 import WizardSection from '../../../../wizards-section';
 import WizardsActionCard from '../../../../wizards-action-card';
@@ -110,27 +109,7 @@ function Collections() {
 
 	return (
 		<div className="newspack-wizard__sections">
-			<h1 style={ { display: 'flex', alignItems: 'center' } }>
-				{ __( 'Collections Settings', 'newspack-plugin' ) }
-				{ apiData.module_enabled_collections && (
-					<Tooltip text={ __( 'View Collections', 'newspack-plugin' ) }>
-						<a
-							href={ collectionsArchiveUrl }
-							target="_blank"
-							rel="noopener noreferrer"
-							style={ {
-								display: 'inline-flex',
-								marginLeft: '8px',
-								color: '#757575',
-								textDecoration: 'none',
-							} }
-							aria-label={ __( 'View Collections', 'newspack-plugin' ) }
-						>
-							<Icon icon={ external } size={ 20 } />
-						</a>
-					</Tooltip>
-				) }
-			</h1>
+			<h1>{ __( 'Collections Settings', 'newspack-plugin' ) }</h1>
 
 			<WizardsActionCard
 				isMedium
@@ -180,7 +159,14 @@ function Collections() {
 
 					<WizardSection
 						title={ __( 'Collections Archive', 'newspack-plugin' ) }
-						description={ __( 'Customize the Collections archive page.', 'newspack-plugin' ) }
+						description={
+							<>
+								{ __( 'Customize the Collections archive page.', 'newspack-plugin' ) }{ ' ' }
+								<a href={ collectionsArchiveUrl } target="_blank" rel="noopener noreferrer" style={ { textDecoration: 'none' } }>
+									<span style={ { textDecoration: 'underline' } }>{ __( 'Open archive page', 'newspack-plugin' ) }</span> ↗
+								</a>
+							</>
+						}
 					>
 						<Grid columns={ 2 } gutter={ 32 }>
 							<SelectControl

--- a/src/wizards/newspack/views/settings/collections/index.tsx
+++ b/src/wizards/newspack/views/settings/collections/index.tsx
@@ -4,7 +4,7 @@
 
 import { __ } from '@wordpress/i18n';
 import { useState, useEffect, useMemo } from '@wordpress/element';
-import { ToggleControl } from '@wordpress/components';
+import { ExternalLink, ToggleControl } from '@wordpress/components';
 import { cleanForSlug } from '@wordpress/url';
 import WizardSection from '../../../../wizards-section';
 import WizardsActionCard from '../../../../wizards-action-card';
@@ -162,9 +162,7 @@ function Collections() {
 						description={
 							<>
 								{ __( 'Customize the Collections archive page.', 'newspack-plugin' ) }{ ' ' }
-								<a href={ collectionsArchiveUrl } target="_blank" rel="noopener noreferrer" style={ { textDecoration: 'none' } }>
-									<span style={ { textDecoration: 'underline' } }>{ __( 'Open archive page', 'newspack-plugin' ) }</span> ↗
-								</a>
+								<ExternalLink href={ collectionsArchiveUrl }>{ __( 'Open archive page', 'newspack-plugin' ) }</ExternalLink>
 							</>
 						}
 					>

--- a/src/wizards/wizards-section.tsx
+++ b/src/wizards/wizards-section.tsx
@@ -27,7 +27,7 @@ export default function WizardSection( {
 	className,
 }: {
 	title?: string;
-	description?: string;
+	description?: string | React.ReactNode;
 	children: React.ReactNode;
 	scrollToAnchor?: string | null;
 	className?: string;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR achieves two things:
- Add support for rendering React nodes within the description property of the `WizardSection` and `SectionHeader` components.
-  Implements feedback from @thomasguillot from here:
https://github.com/Automattic/newspack-plugin/pull/4203#issuecomment-3350264630
It will now render a link to the archive page in the Collections Archive section rather than the icon next to the main title.

Closes NPPD-903.

### How to test the changes in this Pull Request:

1. Navigate to Newspack Settings → Collections.
2. Enable the Collections module if not already enabled.
3. Verify that the "Open archive page ↗" appears in the "Collections Archive" section description.
4. Click the link to confirm it opens the Collections archive page in a new tab.
5. Test with custom slug: enable custom naming, set a custom slug, save settings, and verify the link uses the custom slug.
6. Verify that any other existing instances of the modified `WizardSection` and `SectionHeader` components are unaffected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?