### PR TITLE
fix(lite-site): Allow line breaks

### DIFF
--- a/includes/lite-site/class-lite-site.php
+++ b/includes/lite-site/class-lite-site.php
@@ -466,6 +466,7 @@ class Lite_Site {
 				'href'  => true,
 				'title' => true,
 			],
+			'br'         => [],
 		];
 
 		// Strip all HTML except allowed elements.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://linear.app/a8c/issue/NPPD-41/lite-site-missing-line-breaks-in-single-paragraph-blocks .

This PR fixes an issue where line breaks were being stripped from content in the lite site view. The clean_content() method in the Lite_Site class was not including `<br>` tags in its list of allowed HTML elements, causing line breaks within paragraph blocks to be removed during content sanitization.

### How to test the changes in this Pull Request:

1. Create a post with a paragraph block that contains line breaks.
2. Enable the lite site feature for the site ( Settings > Lite Site ).
3. View the post on the lite site version ( https://example.com/text/<POST-ID> )
4. Verify that the line breaks are now preserved and displayed correctly.
5. Confirm that other HTML sanitization still works as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->