### PR TITLE
fix(collections): remove collection-related taxonomies from quick edit

### DIFF
--- a/includes/collections/class-collection-section-taxonomy.php
+++ b/includes/collections/class-collection-section-taxonomy.php
@@ -129,13 +129,14 @@ class Collection_Section_Taxonomy {
 		];
 
 		$args = [
-			'labels'            => $labels,
-			'description'       => __( 'Taxonomy for organizing posts into sections within collections.', 'newspack-plugin' ),
-			'public'            => true,
-			'show_in_menu'      => false, // Hide in the posts menu (but show in the collections menu).
-			'show_admin_column' => true,
-			'show_in_rest'      => true,
-			'rewrite'           => [
+			'labels'             => $labels,
+			'description'        => __( 'Taxonomy for organizing posts into sections within collections.', 'newspack-plugin' ),
+			'public'             => true,
+			'show_in_menu'       => false, // Hide in the posts menu (but show in the collections menu).
+			'show_admin_column'  => true,
+			'show_in_quick_edit' => false,
+			'show_in_rest'       => true,
+			'rewrite'            => [
 				'slug' => Settings::get_setting( 'custom_naming_enabled', false ) ? Settings::get_setting( 'custom_slug', 'collection' ) . '-section' : 'collection-section',
 			],
 		];

--- a/includes/collections/class-collection-taxonomy.php
+++ b/includes/collections/class-collection-taxonomy.php
@@ -87,15 +87,16 @@ class Collection_Taxonomy {
 		];
 
 		$args = [
-			'labels'            => $labels,
-			'description'       => __( 'Internal taxonomy for associating collections with posts.', 'newspack-plugin' ),
-			'public'            => false,
-			'show_ui'           => true,
-			'show_in_menu'      => false,
-			'show_admin_column' => true,
-			'query_var'         => false,
-			'rewrite'           => false,
-			'show_in_rest'      => true,
+			'labels'             => $labels,
+			'description'        => __( 'Internal taxonomy for associating collections with posts.', 'newspack-plugin' ),
+			'public'             => false,
+			'show_ui'            => true,
+			'show_in_menu'       => false,
+			'show_admin_column'  => true,
+			'show_in_quick_edit' => false,
+			'query_var'          => false,
+			'rewrite'            => false,
+			'show_in_rest'       => true,
 		];
 
 		register_taxonomy( self::get_taxonomy(), [ 'post' ], $args );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Disable Collections and Collection Sections from Quick Edit to prevent comma-splitting issues. When editors use Quick Edit on posts, WordPress splits taxonomy terms at commas, breaking Collections like "Oct 1, 2025" into separate terms. This fix removes both taxonomies from the post list Quick Edit interface while preserving all other functionality.

Closes NPPD-913.

### How to test the changes in this Pull Request:

1. Create a Collection with a comma in the name through the CPT page (e.g., "October 1, 2025").
2. Create a Collection Section with a comma in the name (e.g., "News, Weather").
3. Assign both to a post.
4. Go to the Posts list and click Quick Edit on that post.
5. Verify that Collections and Collection Sections fields are no longer visible.
6. Verify the Collection and Section still appear in the admin columns.
7. Edit the post normally (not Quick Edit) and verify you can still manage Collections and Sections.
8. Go to Collections → Sections taxonomy screen and verify the quick edit functionality for the order field still works.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?