### PR TITLE
fix: keep prevent one and two col Collections block grid from being increased on smaller screens [NPPM-2285]

### DIFF
--- a/src/blocks/collections/styles/_layout-grid.scss
+++ b/src/blocks/collections/styles/_layout-grid.scss
@@ -9,12 +9,16 @@
 
 
 		// Mobile first: 2 columns.
-		grid-template-columns: repeat(2, minmax(0, 1fr));
+		&:not(.columns-1) {
+			grid-template-columns: repeat(2, minmax(0, 1fr));
+		}
 
 		// Tablet: 3 columns.
 		@media #{bp.$media-sm-up} {
-			grid-template-columns: repeat(3, minmax(0, 1fr));
-			gap: 16px;
+			&:not(.columns-1, .columns-2) {
+				grid-template-columns: repeat(3, minmax(0, 1fr));
+				gap: 16px;
+			}
 		}
 
 		// Medium screens: restore larger gap


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The Collections block drops down to three, then two columns as you shrink down the browser window. This can be a little strange with the one and two column layouts, though, since it increases their column counts. This PR makes the two column layout stay two columns on tablet-sized screens, and the one column layout stay one column on all screen sizes.

### How to test the changes in this Pull Request:

1. Add a couple Collections blocks to a page; make them one column and two column; if you add more, make them three and four column just to test for regressions. 
2. Shrink down the screen size; note that the one column switches to three, then two columns, and that the two column switches to three on tablet-sized screens. This isn't necessarily bad if there's more than one or two collections in the block (though it might be unexpected); it's very likely these lower column counts only show one or two covers, like in a CTA, in which case the column change adds extra space:

One column on tablet-sized screen:
<img width="438" height="348" alt="CleanShot 2025-10-06 at 10 44 44" src="https://github.com/user-attachments/assets/a42951f0-53ed-4ca8-985b-14a6a03eabbe" />

Two columns on tablet-sized screen:
<img width="444" height="346" alt="CleanShot 2025-10-06 at 10 45 02" src="https://github.com/user-attachments/assets/8dec9183-fd43-4a10-8012-43c61be9e093" />

One column on mobile-sized screen:
<img width="468" height="447" alt="CleanShot 2025-10-06 at 10 45 14" src="https://github.com/user-attachments/assets/0fa9dd24-9603-4d10-95d6-18b27cfd58c9" />

3. Apply this PR and run `npm run build`.
4. Confirm the one and two column layouts remain that way on all screensizes:

One and two column on a tablet-sized screen:

<img width="731" height="597" alt="CleanShot 2025-10-06 at 10 48 40" src="https://github.com/user-attachments/assets/2d67134f-96a2-466d-acdf-64a7fd4dcd32" />

One Column on a mobile sized screen:

<img width="425" height="677" alt="CleanShot 2025-10-06 at 10 47 33" src="https://github.com/user-attachments/assets/20f60391-44a8-4484-a839-9bf7711dc128" />

Two Columns on a mobile sized screen:
<img width="424" height="430" alt="CleanShot 2025-10-06 at 10 47 49" src="https://github.com/user-attachments/assets/9c18158d-dd90-44f5-b11e-bc6927ec40a4" />
5. Confirm the other column counts still work the same way. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->