### PR TITLE
fix(metering): get current user metered views

### DIFF
--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -71,7 +71,7 @@ final class Blocks {
 			$script_data['content_gate_data'] = [
 				'anonymous_metered_views' => Metering::get_total_metered_views( false ),
 				'loggedin_metered_views'  => Metering::get_total_metered_views( true ),
-				'metered_views'           => Metering::get_metered_views(),
+				'metered_views'           => Metering::get_current_user_metered_views(),
 				'metering_period'         => Metering::get_metering_period(),
 			];
 		}

--- a/includes/plugins/wc-memberships/class-metering.php
+++ b/includes/plugins/wc-memberships/class-metering.php
@@ -315,30 +315,22 @@ class Metering {
 	}
 
 	/**
-	 * Get number of metered views for the user.
-	 *
-	 * @param int|null $user_id User ID. Default is current user.
+	 * Get number of metered views for the current user.
 	 *
 	 * @return int Number of metered views.
 	 */
-	public static function get_metered_views( $user_id = null ) {
-		if ( ! $user_id ) {
-			$user_id = get_current_user_id();
-		}
-		// For anonymous users, return the anonymous count.
-		if ( ! $user_id ) {
-			$gate_post_id = Memberships::get_gate_post_id();
-			return (int) \get_post_meta( $gate_post_id, 'metering_anonymous_count', true );
+	public static function get_current_user_metered_views() {
+		if ( ! is_user_logged_in() ) {
+			return 0;
 		}
 
-		// For logged-in users, calculate the remaining views based on their metering data.
-		$gate_post_id       = Memberships::get_gate_post_id();
-		$user_meta_key      = self::METERING_META_KEY . '_' . $gate_post_id;
-		$user_metering_data = \get_user_meta( $user_id, $user_meta_key, true );
-		if ( ! is_array( $user_metering_data ) || ! isset( $user_metering_data['content'] ) ) {
-			return $count;
+		$gate_post_id  = Memberships::get_gate_post_id();
+		$meta_key      = self::METERING_META_KEY . '_' . $gate_post_id;
+		$metering_data = \get_user_meta( get_current_user_id(), $meta_key, true );
+		if ( ! is_array( $metering_data ) || ! isset( $metering_data['content'] ) ) {
+			return 0;
 		}
-		return count( $user_metering_data['content'] );
+		return count( $metering_data['content'] );
 	}
 
 	/**

--- a/src/blocks/content-gate/countdown/class-content-gate-countdown-block.php
+++ b/src/blocks/content-gate/countdown/class-content-gate-countdown-block.php
@@ -70,7 +70,7 @@ class Content_Gate_Countdown_Block {
 		if ( false === $total_views ) {
 			return '';
 		}
-		$views     = Metering::get_metered_views( get_current_user_id() );
+		$views     = Metering::get_current_user_metered_views();
 		$countdown = sprintf(
 			/* translators: 1: current number of metered views, 2: total metered views. */
 			__( '%1$d/%2$d', 'newspack-plugin' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

There's a missing `$count` variable from #4176 that slipped by me during review. This PR is meant to address that, but while at it, I also propose some changes to this public method so it's more predictable and generic.

The `// For logged-in users, calculate the remaining views based on their metering data.` comment is also not accurate and represents a previous approach.

### How to test the changes in this Pull Request:

Same as #4176

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->