### PR TITLE
fix(subscription-switch): unhook direction text from checkout

### DIFF
--- a/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
+++ b/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
@@ -36,6 +36,14 @@ class Subscriptions_Tiers {
 		// Primary product rendering.
 		add_action( 'wp_footer', [ __CLASS__, 'print_primary_product_modal' ] );
 		add_filter( 'newspack_popups_assess_has_disabled_popups', [ __CLASS__, 'disable_popups' ] );
+
+		// Unhook Upgrade/Downgrade switch direction text.
+		add_action(
+			'init',
+			function() {
+				remove_filter( 'woocommerce_cart_item_subtotal', [ 'WC_Subscriptions_Switcher', 'add_cart_item_switch_direction' ], 10 );
+			}
+		);
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The direction text from Woo Subscriptions Switch may show inaccurate or confusing information, such as "Downgrade" for frequency changes.

This PR unhooks the filter to no longer display the switch direction text.

| Before | After |
| --- | --- |
| <img width="611" height="134" alt="image" src="https://github.com/user-attachments/assets/22fc5e77-7da4-48fb-950d-ac52b6ff4c98" />  | <img width="610" height="137" alt="image" src="https://github.com/user-attachments/assets/7aa423eb-3bfd-4dfc-a7ee-713fe0052821" /> |


### How to test the changes in this Pull Request:

1. As a reader, purchase a non-donation variable subscription
2. Go to My Account -> Subscriptions and access the new subscription
3. Click "Change Subscription"
4. Select an option and continue to checkout
5. Confirm the checkout summary table doesn't render "Downgrade" or "Upgrade" by the product name

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->