### PR TITLE
fix: don’t add overlays to ras store if locked via front-end metering

### DIFF
--- a/src/memberships-gate/metering.js
+++ b/src/memberships-gate/metering.js
@@ -47,15 +47,25 @@ function getUserData( store ) {
 	return data;
 }
 
-function lockContent() {
+function lockContent( ras ) {
 	const content = document.querySelector( '.entry-content' );
 	if ( ! content ) {
 		return;
 	}
+	document.body.classList.add( 'newspack-content-locked' );
+
 	// Remove campaign prompts.
 	const prompts = document.querySelectorAll( '.newspack-popup' );
+	const overlays = ras?.overlays?.get() || [];
 	prompts.forEach( prompt => {
 		prompt.parentNode.removeChild( prompt );
+		if ( overlays.length ) {
+			overlays.forEach( overlay => {
+				if ( 0 === overlay.indexOf( 'prompt_' ) ) {
+					ras.overlays.remove( overlay );
+				}
+			} );
+		}
 	} );
 	// Replace content.
 	content.innerHTML = settings.excerpt;
@@ -76,7 +86,7 @@ function meter( ras ) {
 	let locked = false;
 	// Lock content if reached limit, remove gate content if not.
 	if ( settings.count <= data.content.length && ! data.content.includes( settings.post_id ) ) {
-		lockContent();
+		lockContent( ras );
 		ras.dispatchActivity( 'metering_restricted', { post_id: settings.post_id, metering: data } );
 		locked = true;
 	} else {

--- a/src/reader-activation-auth/auth-modal.js
+++ b/src/reader-activation-auth/auth-modal.js
@@ -173,7 +173,7 @@ export function openAuthModal( config = {} ) {
 	document.body.style.overflow = 'hidden';
 	modal.setAttribute( 'data-state', 'open' );
 	if ( window.newspackReaderActivation?.overlays ) {
-		modal.overlayId = window.newspackReaderActivation.overlays.add();
+		modal.overlayId = window.newspackReaderActivation.overlays.add( 'auth-modal' );
 		a11y.trapFocus( modal );
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a bug where if an overlay prompt would appear on a page that's content gated via front-end metering, fulfilling the gate's requirements would not automatically refresh the page. This happens because front-end metering removes all Campaigns prompt elements from the DOM when locking a post, but the Campaigns segmentation JS may still add overlay prompts that would otherwise be displayed to the `overlays` store array.

See also https://github.com/Automattic/newspack-popups/pull/1480.

### How to test the changes in this Pull Request:

1. On `release` for both this repo and `newspack-popups`, publish the following:
  - An overlay prompt that appears on every page to all readers
  - A membership plan that restricts all posts based on user registration
  - A content gate containing a login and/or registration link with metering enabled for anonymous readers.

2. In a new browser session, visit the site and view enough articles to trigger the content gate.
3. Using the login or registration link, log in or register to bypass the content gate. Observe that the page does NOT automatically refresh after all modals are dismissed. Optionally, also run `newspackReaderActivation.overlays.get()
` in the browser console and observe that it returns a non-empty array.
4. Check out this branch and https://github.com/Automattic/newspack-popups/pull/1480. Repeat steps 2-3 and confirm that the page does refresh after dismissing all modals.
5. Visit other pages on the site and confirm that all Campaigns prompts still appear as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->