### PR TITLE
feat(rss): allow RSS feed customization with new extra tags filters

### DIFF
--- a/includes/optional-modules/class-rss.php
+++ b/includes/optional-modules/class-rss.php
@@ -1130,7 +1130,16 @@ class RSS {
 		$post = get_post();
 
 		if ( $settings['use_image_tags'] ) {
-			$thumbnail_url = get_the_post_thumbnail_url( $post, RSS_Add_Image::RSS_IMAGE_SIZE );
+			/**
+			 * Filter the image size used for RSS feed images in <image> tags.
+			 *
+			 * @param string  $size     The image size slug. Default is `Newspack\RSS_Add_Image::RSS_IMAGE_SIZE`.
+			 * @param array   $settings The feed settings array.
+			 * @param WP_Post $post     The current post object.
+			 */
+			$image_size    = apply_filters( 'newspack_rss_image_size', RSS_Add_Image::RSS_IMAGE_SIZE, $settings, $post );
+			$thumbnail_url = get_the_post_thumbnail_url( $post, $image_size );
+
 			if ( $thumbnail_url ) :
 				?>
 				<image><?php echo esc_url( $thumbnail_url ); ?></image>
@@ -1151,28 +1160,95 @@ class RSS {
 			$tags         = ( ! is_array( $tags ) ) ? [] : $tags;
 			$all_terms    = array_merge( $cats, $tags );
 			$terms_string = implode( ',', wp_list_pluck( $all_terms, 'name' ) );
-			?>
-			<tags><?php echo esc_html( $terms_string ); ?></tags>
-			<?php
+
+			/**
+			 * Filter the tags output format for RSS feeds.
+			 *
+			 * Return false to skip the default <tags> wrapper and output custom format.
+			 * Return a string to replace the default comma-separated format.
+			 * Allowed tags: <tag> (no attributes).
+			 *
+			 * @param string|false $output    Default comma-separated escaped string, or false to skip wrapper.
+			 * @param array        $all_terms Array of WP_Term objects (categories and tags merged).
+			 * @param array        $settings  The feed settings array.
+			 * @param WP_Post      $post      The current post object.
+			 */
+			$tags_output = apply_filters( 'newspack_rss_tags_output', esc_html( $terms_string ), $all_terms, $settings, $post );
+
+			if ( false !== $tags_output ) {
+				?>
+				<tags><?php echo wp_kses( $tags_output, [ 'tag' => [] ] ); ?></tags>
+				<?php
+			}
 		}
 
 		if ( $settings['use_media_tags'] ) {
 			$thumbnail_id = get_post_thumbnail_id();
 			if ( $thumbnail_id ) {
-				$thumbnail_data = wp_get_attachment_image_src( $thumbnail_id, RSS_Add_Image::RSS_IMAGE_SIZE );
+				/** This filter is documented above in the use_image_tags block */
+				$image_size     = apply_filters( 'newspack_rss_image_size', RSS_Add_Image::RSS_IMAGE_SIZE, $settings, $post );
+				$thumbnail_data = wp_get_attachment_image_src( $thumbnail_id, $image_size );
+
 				if ( $thumbnail_data ) {
 					$caption = get_the_post_thumbnail_caption();
+					/**
+					 * Filter the media content URL for RSS feeds.
+					 *
+					 * Allows URL transformations (e.g., wp_specialchars_decode for mobile apps).
+					 *
+					 * @param string  $url          The thumbnail URL from wp_get_attachment_image_src.
+					 * @param int     $thumbnail_id The attachment post ID.
+					 * @param array   $settings     The feed settings array.
+					 * @param WP_Post $post         The current post object.
+					 */
+					$media_url = apply_filters( 'newspack_rss_media_content_url', $thumbnail_data[0], $thumbnail_id, $settings, $post );
 					?>
-					<media:content type="<?php echo esc_attr( get_post_mime_type( $thumbnail_id ) ); ?>" url="<?php echo esc_url( $thumbnail_data[0] ); ?>">
+					<media:content type="<?php echo esc_attr( get_post_mime_type( $thumbnail_id ) ); ?>" url="<?php echo esc_url( $media_url ); ?>">
 						<?php if ( ! empty( $caption ) ) : ?>
 						<media:description><?php echo esc_html( $caption ); ?></media:description>
 						<?php endif; ?>
-						<media:thumbnail url="<?php echo esc_url( $thumbnail_data[0] ); ?>" width="<?php echo esc_attr( $thumbnail_data[1] ); ?>" height="<?php echo esc_attr( $thumbnail_data[2] ); ?>" />
+						<media:thumbnail url="<?php echo esc_url( $media_url ); ?>" width="<?php echo esc_attr( $thumbnail_data[1] ); ?>" height="<?php echo esc_attr( $thumbnail_data[2] ); ?>" />
 					</media:content>
 					<?php
+					/**
+					 * Fires after the media:content element to allow adding extra media elements.
+					 *
+					 * Use this to add custom media elements like <media:credit>, <media:copyright>, etc.
+					 *
+					 * Example:
+					 *     $credit = get_post_meta( $thumbnail_id, '_media_credit', true );
+					 *     if ( $credit ) {
+					 *         echo '<media:credit><![CDATA[' . esc_html( $credit ) . ']]></media:credit>';
+					 *     }
+					 *
+					 * @param int          $thumbnail_id   The attachment post ID.
+					 * @param array|false  $thumbnail_data Array with [url, width, height] or false.
+					 * @param string       $caption        The image caption from get_the_post_thumbnail_caption().
+					 * @param array        $settings       The feed settings array.
+					 * @param WP_Post      $post           The current post object.
+					 */
+					do_action( 'newspack_rss_after_media_content', $thumbnail_id, $thumbnail_data, $caption, $settings, $post );
 				}
 			}
 		}
+
+		/**
+		 * Fires after all standard RSS extra tags have been output.
+		 *
+		 * Use this hook to add completely custom tags to feed items (e.g., for mobile app
+		 * integrations like Pugpig, or other third-party services).
+		 *
+		 * Example:
+		 *     add_action( 'newspack_rss_after_extra_tags', function( $settings, $post ) {
+		 *         if ( my_is_special_feed() ) {
+		 *             echo '<custom_field>' . esc_html( get_post_meta( $post->ID, 'custom', true ) ) . '</custom_field>';
+		 *         }
+		 *     }, 10, 2 );
+		 *
+		 * @param array   $settings The feed settings array from get_feed_settings().
+		 * @param WP_Post $post     The current post object.
+		 */
+		do_action( 'newspack_rss_after_extra_tags', $settings, $post );
 	}
 
 	/**

--- a/tests/mocks/filter-input-mock.php
+++ b/tests/mocks/filter-input-mock.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Compatibility shim for filter_input() in PHPUnit tests.
+ *
+ * @package Newspack\Tests
+ */
+
+namespace Newspack;
+
+if ( ! function_exists( __NAMESPACE__ . '\\filter_input' ) ) {
+	/**
+	 * Provides access to $_GET during PHPUnit runs where filter_input() is not populated.
+	 *
+	 * @param int       $type          One of INPUT_* constants.
+	 * @param string    $variable_name Variable name.
+	 * @param int       $filter        Filter ID. Default: FILTER_DEFAULT.
+	 * @param array|int $options       Filter options (defaults to 0, matching PHP's signature).
+	 * @return mixed Sanitized value or null.
+	 */
+	function filter_input( $type, $variable_name, $filter = FILTER_DEFAULT, $options = 0 ) {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( INPUT_GET === $type && array_key_exists( $variable_name, $_GET ) ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			$value = $_GET[ $variable_name ];
+
+			return \filter_var( $value, $filter, $options );
+		}
+
+		return \filter_input( $type, $variable_name, $filter, $options );
+	}
+}

--- a/tests/unit-tests/rss.php
+++ b/tests/unit-tests/rss.php
@@ -7,7 +7,9 @@
 
 use Newspack\RSS;
 use Newspack\Optional_Modules;
+use Newspack\RSS_Add_Image;
 
+require_once __DIR__ . '/../mocks/filter-input-mock.php';
 /**
  * Tests the RSS core functionality.
  */
@@ -121,6 +123,37 @@ class Newspack_Test_RSS extends WP_UnitTestCase {
 	 */
 	private function set_test_settings( $settings ) {
 		$this->current_test_settings = $settings;
+	}
+
+	/**
+	 * Render the extra RSS tags for a post with the provided settings overrides.
+	 *
+	 * @param WP_Post $post      Post object.
+	 * @param array   $settings  Settings overrides for the feed.
+	 * @return string Captured markup from RSS::add_extra_tags().
+	 */
+	private function render_extra_tags_for_post( $post, $settings ) {
+		$_GET['partner-feed'] = 'test-rss-feed';
+		$this->set_test_settings(
+			array_merge(
+				[
+					'num_items_in_feed' => 10,
+				],
+				$settings
+			)
+		);
+
+		$GLOBALS['post'] = $post;
+		setup_postdata( $post );
+
+		ob_start();
+		RSS::add_extra_tags();
+		$output = ob_get_clean();
+
+		wp_reset_postdata();
+		unset( $_GET['partner-feed'] );
+
+		return $output;
 	}
 
 	/**
@@ -1000,5 +1033,186 @@ class Newspack_Test_RSS extends WP_UnitTestCase {
 		$query->get_posts();
 		$this->assertEquals( 1, $query->found_posts, 'Should find exactly one post' );
 		$this->assertEquals( $post1, $query->posts[0]->ID, 'Should return the post with all three taxonomy terms' );
+	}
+
+	/**
+	 * Test that RSS::add_extra_tags() applies the newspack_rss_image_size filter for <image> markup.
+	 */
+	public function test_add_extra_tags_applies_image_size_filter() {
+		$post_id       = $this->factory()->post->create();
+		$attachment_id = $this->factory()->attachment->create_object( 'image.jpg', $post_id, [ 'post_mime_type' => 'image/jpeg' ] );
+		set_post_thumbnail( $post_id, $attachment_id );
+
+		$post = get_post( $post_id );
+
+		$filtered  = false;
+		$size_used = null;
+
+		$image_size_filter = function ( $size, $settings, $filter_post ) use ( &$filtered ) {
+			$filtered = true;
+			$this->assertEquals( RSS_Add_Image::RSS_IMAGE_SIZE, $size, 'Expected image size filter to be applied for media tags.' );
+			$this->assertIsArray( $settings, 'Expected settings to be an array.' );
+			$this->assertInstanceOf( 'WP_Post', $filter_post, 'Expected filter post to be a WP_Post object.' );
+			return 'custom-rss-size';
+		};
+
+		$image_src_tracker = function ( $image, $attachment_id_param, $size ) use ( &$size_used, $attachment_id ) {
+			if ( $attachment_id === $attachment_id_param && null === $size_used ) {
+				$size_used = $size;
+			}
+			return $image;
+		};
+
+		add_filter( 'newspack_rss_image_size', $image_size_filter, 10, 3 );
+		add_filter( 'wp_get_attachment_image_src', $image_src_tracker, 10, 3 );
+
+		$output = $this->render_extra_tags_for_post(
+			$post,
+			[
+				'use_image_tags' => true,
+			]
+		);
+
+		remove_filter( 'newspack_rss_image_size', $image_size_filter, 10 );
+		remove_filter( 'wp_get_attachment_image_src', $image_src_tracker, 10 );
+
+		$this->assertTrue( $filtered, 'Expected newspack_rss_image_size filter to run.' );
+		$this->assertSame( 'custom-rss-size', $size_used, 'Expected image size filter value to be used.' );
+		$this->assertStringContainsString( '<image>', $output, 'Expected image tag markup in output.' );
+	}
+
+	/**
+	 * Test that RSS::add_extra_tags() allows replacing <tags> markup via newspack_rss_tags_output.
+	 */
+	public function test_add_extra_tags_supports_custom_tags_output() {
+		$category_id = $this->factory()->term->create(
+			[
+				'taxonomy' => 'category',
+				'name'     => 'TestCat',
+			]
+		);
+		$tag_id      = $this->factory()->term->create(
+			[
+				'taxonomy' => 'post_tag',
+				'name'     => 'TestTag',
+			]
+		);
+
+		$post_id = $this->factory()->post->create(
+			[
+				'post_category' => [ $category_id ],
+			]
+		);
+		wp_set_object_terms( $post_id, [ $tag_id ], 'post_tag' );
+		$post = get_post( $post_id );
+
+		$filtered    = false;
+		$tags_filter = function ( $output, $all_terms, $settings, $filter_post ) use ( &$filtered ) {
+			$filtered = true;
+			$this->assertIsString( $output, 'Expected output to be a string.' );
+			$this->assertIsArray( $all_terms, 'Expected all terms to be an array.' );
+			$this->assertIsArray( $settings, 'Expected settings to be an array.' );
+			$this->assertInstanceOf( 'WP_Post', $filter_post, 'Expected filter post to be a WP_Post object.' );
+
+			$nested = '';
+			foreach ( $all_terms as $term ) {
+				$nested .= '<tag>' . esc_html( $term->name ) . '</tag>';
+			}
+			return $nested;
+		};
+
+		add_filter( 'newspack_rss_tags_output', $tags_filter, 10, 4 );
+
+		$output            = $this->render_extra_tags_for_post(
+			$post,
+			[
+				'use_tags_tags' => true,
+			]
+		);
+		$normalized_output = preg_replace( '/\s+/', '', $output );
+
+		remove_filter( 'newspack_rss_tags_output', $tags_filter, 10 );
+
+		$this->assertTrue( $filtered, 'Expected newspack_rss_tags_output filter to run.' );
+		$this->assertStringContainsString( '<tags><tag>TestCat</tag><tag>TestTag</tag></tags>', $normalized_output, 'Expected tags output to be normalized.' );
+	}
+
+	/**
+	 * Test that RSS::add_extra_tags() applies media filters and fires the related actions.
+	 */
+	public function test_add_extra_tags_applies_media_filters_and_actions() {
+		$post_id       = $this->factory()->post->create();
+		$attachment_id = $this->factory()->attachment->create_object( 'image.jpg', $post_id, [ 'post_mime_type' => 'image/jpeg' ] );
+		set_post_thumbnail( $post_id, $attachment_id );
+		wp_update_post(
+			[
+				'ID'           => $attachment_id,
+				'post_excerpt' => 'Media caption',
+			]
+		);
+
+		$post = get_post( $post_id );
+
+		$image_size_filtered = false;
+		$size_used           = null;
+		$media_url_filtered  = false;
+		$media_url           = 'https://example.com/media-filtered.jpg';
+		$media_action        = new \MockAction();
+		$after_action        = new \MockAction();
+
+		$image_size_filter = function ( $size, $settings, $filter_post ) use ( &$image_size_filtered ) {
+			$image_size_filtered = true;
+			$this->assertIsArray( $settings, 'Expected settings to be an array.' );
+			$this->assertInstanceOf( 'WP_Post', $filter_post, 'Expected filter post to be a WP_Post object.' );
+			return 'media-custom-size';
+		};
+
+		$image_src_tracker = function ( $image, $attachment_id_param, $size ) use ( &$size_used, $attachment_id ) {
+			if ( $attachment_id === $attachment_id_param && null === $size_used ) {
+				$size_used = $size;
+			}
+			return $image;
+		};
+
+		$media_url_filter = function ( $url, $thumbnail_id, $settings, $filter_post ) use ( &$media_url_filtered, $media_url, $attachment_id ) {
+			$media_url_filtered = true;
+			$this->assertEquals( $attachment_id, $thumbnail_id, 'Expected attachment ID to match.' );
+			$this->assertIsArray( $settings, 'Expected settings to be an array.' );
+			$this->assertInstanceOf( 'WP_Post', $filter_post, 'Expected filter post to be a WP_Post object.' );
+			return $media_url;
+		};
+
+		add_filter( 'newspack_rss_image_size', $image_size_filter, 10, 3 );
+		add_filter( 'wp_get_attachment_image_src', $image_src_tracker, 10, 3 );
+		add_filter( 'newspack_rss_media_content_url', $media_url_filter, 10, 4 );
+
+		add_action( 'newspack_rss_after_media_content', [ $media_action, 'action' ], 10, 5 );
+		add_action( 'newspack_rss_after_extra_tags', [ $after_action, 'action' ], 10, 2 );
+
+		$output = $this->render_extra_tags_for_post(
+			$post,
+			[
+				'use_media_tags' => true,
+			]
+		);
+
+		remove_filter( 'newspack_rss_image_size', $image_size_filter, 10 );
+		remove_filter( 'wp_get_attachment_image_src', $image_src_tracker, 10 );
+		remove_filter( 'newspack_rss_media_content_url', $media_url_filter, 10 );
+		remove_action( 'newspack_rss_after_media_content', [ $media_action, 'action' ], 10 );
+		remove_action( 'newspack_rss_after_extra_tags', [ $after_action, 'action' ], 10 );
+
+		$this->assertTrue( $image_size_filtered, 'Expected image size filter to be applied for media tags.' );
+		$this->assertSame( 'media-custom-size', $size_used, 'Expected size used to be the custom size.' );
+		$this->assertTrue( $media_url_filtered, 'Expected media content URL filter to run.' );
+		$this->assertSame( 1, $media_action->get_call_count(), 'Expected after media content action to fire once.' );
+		$media_args = $media_action->get_args()[0];
+		$this->assertEquals( $attachment_id, $media_args[0], 'Expected attachment ID to match.' );
+		$this->assertIsArray( $media_args[1], 'Expected media args to be an array.' );
+		$this->assertIsString( $media_args[2], 'Expected media args to be a string.' );
+		$this->assertIsArray( $media_args[3], 'Expected media args to be an array.' );
+		$this->assertInstanceOf( 'WP_Post', $media_args[4], 'Expected media args to be a WP_Post object.' );
+		$this->assertSame( 1, $after_action->get_call_count(), 'Expected after extra tags action to fire once.' );
+		$this->assertStringContainsString( 'url="' . esc_url( $media_url ) . '"', $output, 'Expected media URL to be in output.' );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Make the RSS partner feed extensible so it allows customizing image sizing, rewriting media URLs, and injecting custom tags without overriding core templates.

- `newspack_rss_image_size`: Allow changing the attachment size used for both `<image>` and `<media:content>` output.
- `newspack_rss_tags_output`: Replace or suppress the `<tags>` element when the default comma-separated list isn't suitable.
- `newspack_rss_media_content_url`: Rewrite the media URL before it's printed in `<media:content>` and `<media:thumbnail>`.
- `newspack_rss_after_media_content`: Append extra Media RSS nodes immediately after the standard media block.
- `newspack_rss_after_extra_tags`: Inject any additional feed-specific markup after all Newspack-provided extras are rendered.

Closes NPPD-929.

### How to test the changes in this Pull Request:

1. In wp-admin, enable the RSS optional module, create a partner RSS feed, and enable image, media, and tags options.
2. Add temporary snippets that hook each new filter/action, load the feed at `/feed/?partner-feed=your-slug`, and verify:
    - Image size hook updates both `<image>` and `<media:content>` URLs.
    - Tags hook replaces or removes the `<tags>` element as configured.
    - Media URL hook rewrites the media URLs, and the two actions output the extra markup.
3. Remove the snippets and confirm the feed falls back to the original behaviour.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?