### PR TITLE
Fix $order->update_meta_data call

### DIFF
--- a/includes/class-donations.php
+++ b/includes/class-donations.php
@@ -1027,7 +1027,7 @@ class Donations {
 					if ( ! $order ) {
 						continue;
 					}
-					$order->update_meta_data( $order_id, sanitize_text_field( $param ), sanitize_text_field( $value ) );
+					$order->update_meta_data( sanitize_text_field( $param ), sanitize_text_field( $value ) );
 					$order->save();
 				}
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

**Note: This is a hotfix.** Doesn't necessarily have to be released this week though.

Related to NEWS-54.

This PR fixes a bug that creates bad metadata on orders which have utm params.

### How to test the changes in this Pull Request:

1. Before applying this patch, go to a page that has a Donate block on it with a utm parameter e.g. `example.com/support-our-publication?utm_source=blah`. Checkout on that page using the Donate block and modal checkout.
2. [If you have the legacy WooCommerce sync to postmeta enabled or are not using HPOS] In MySQL run `select * from wp_postmeta where post_id = xxxx;` for the Order and associated Subscription IDs. Observe there is metadata there with a `meta_key` that is the same as the order/subscription ID:

<img width="818" height="142" alt="Screenshot 2025-10-15 at 11 14 54 AM" src="https://github.com/user-attachments/assets/22f46945-1241-40b3-b31e-8437ff466d3c" />

4. [If you are using HPOS, with or without the legacy sync to postmeta enabled] In MySQL run `select * from wp_wc_orders_meta where order_id = xxxx;` for the Order and associated Subscription IDs. Observe there is also metadata there with a `meta_key` that is the same as the order/subscription ID:

<img width="664" height="101" alt="Screenshot 2025-10-15 at 11 16 24 AM" src="https://github.com/user-attachments/assets/cdb50825-7d92-4da7-a862-0f6028dadc05" />

5. Apply this patch. Do a checkout again on a page with a utm param. Run the SQL query again. Observe the correct metadata is now present:

<img width="570" height="100" alt="Screenshot 2025-10-15 at 11 24 37 AM" src="https://github.com/user-attachments/assets/254507df-1766-4344-9edd-db50e0c01446" />

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->