### PR TITLE
fix: don't attach an existing Collections taxonomy if it's already attached to a Collection CPT

### DIFF
--- a/includes/collections/class-sync.php
+++ b/includes/collections/class-sync.php
@@ -231,6 +231,13 @@ class Sync {
 			if ( empty( $existing_term ) ) {
 				self::create_linked_term( $post );
 			} else {
+				// Check if existing term is already linked to a Collection.
+				$existing_term_id = $existing_term[0];
+				$linked_post_id = self::get_collection_linked_to_term( $existing_term_id );
+				if ( $linked_post_id ) {
+					self::create_linked_term( $post );
+					return;
+				}
 				self::link_collection_and_term( $post_id, $existing_term[0] );
 			}
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Right now when you create a new Collection CPT, it looks for a `newspack_collection_taxonomy` term that matches the same name to use to connect posts and the CPT.

However, there's a weird edge case where, if you name Collections the same as an existing CPT, it will "steal" its taxonomy term. This ultimately makes it impossible to assign the original Collection to posts, even if you rename the second one. 

This PR tweaks the behaviour to check if the term exists AND if it's already assigned to a CPT. If it is, a new term should be created. This may not be the best approach to fixing this, though -- I'm open to feedback!! 

Note: this doesn't fix Collections that are already in the detached state 😕 If this makes sense, I think we'll need to do that manually as it comes up. 

### How to test the changes in this Pull Request:

1. Create and publish a Collection called "October 2025".
2. Create and publish a second Collection also called "October 2025". 
3. Change the name of the second Collection to something else (like "September 2025")
4. Create a new post and try to assign the "October 2025" Collection - it won't be returned. 
5. Apply this PR, and repeat steps 1-4 with new Collection names; confirm that both the second original Collection name and its copycat can be applied to a new post. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->