### PR TITLE
feat: add content gate settings skeleton

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -163,6 +163,7 @@ final class Newspack {
 		// Audience Wizard.
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/audience/class-audience-wizard.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/audience/class-audience-campaigns.php';
+		include_once NEWSPACK_ABSPATH . 'includes/wizards/audience/class-audience-content-gates.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/audience/class-audience-donations.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/audience/class-audience-subscriptions.php';
 

--- a/includes/class-wizards.php
+++ b/includes/class-wizards.php
@@ -63,6 +63,7 @@ class Wizards {
 			'advertising-sponsors'    => new Advertising_Sponsors(),
 			'audience'                => new Audience_Wizard(),
 			'audience-campaigns'      => new Audience_Campaigns(),
+			'audience-content-gates'  => new Audience_Content_Gates(),
 			'audience-donations'      => new Audience_Donations(),
 			'listings'                => new Listings_Wizard(),
 			'network'                 => new Network_Wizard(),

--- a/includes/wizards/audience/class-audience-content-gates.php
+++ b/includes/wizards/audience/class-audience-content-gates.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Audience Content Gates Wizard
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Audience Campaigns Wizard.
+ */
+class Audience_Content_Gates extends Wizard {
+
+	/**
+	 * Admin page slug.
+	 *
+	 * @var string
+	 */
+	protected $slug = 'newspack-audience-content-gates';
+
+	/**
+	 * Parent slug.
+	 *
+	 * @var string
+	 */
+	protected $parent_slug = 'newspack-audience';
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		parent::__construct();
+		add_action( 'rest_api_init', [ $this, 'register_api_endpoints' ] );
+	}
+
+	/**
+	 * Get the name for this wizard.
+	 *
+	 * @return string The wizard name.
+	 */
+	public function get_name() {
+		return esc_html__( 'Audience Management / Content Gates', 'newspack-plugin' );
+	}
+
+	/**
+	 * Enqueue scripts and styles.
+	 */
+	public function enqueue_scripts_and_styles() {
+		if ( ! $this->is_wizard_page() || ! $this->is_feature_enabled() ) {
+			return;
+		}
+
+		parent::enqueue_scripts_and_styles();
+
+		wp_enqueue_script( 'newspack-wizards' );
+
+		\wp_localize_script(
+			'newspack-wizards',
+			'newspackAudienceContentGates',
+			[
+				'api' => '/' . NEWSPACK_API_NAMESPACE . '/wizard/' . $this->slug,
+			]
+		);
+	}
+
+	/**
+	 * Add Audience top-level and Content Gate subpage to the /wp-admin menu.
+	 */
+	public function add_page() {
+		if ( ! $this->is_feature_enabled() ) {
+			return;
+		}
+
+		add_submenu_page(
+			$this->parent_slug,
+			$this->get_name(),
+			esc_html__( 'Content Gates', 'newspack-plugin' ),
+			$this->capability,
+			$this->slug,
+			[ $this, 'render_wizard' ]
+		);
+	}
+
+	/**
+	 * Register the endpoints needed for the wizard screens.
+	 */
+	public function register_api_endpoints() {
+		if ( ! $this->is_feature_enabled() ) {
+			return;
+		}
+	}
+
+	/**
+	 * Check feature flag status.
+	 *
+	 * @return bool
+	 */
+	public function is_feature_enabled() {
+		return defined( 'NEWSPACK_CONTENT_GATES' ) && NEWSPACK_CONTENT_GATES;
+	}
+}

--- a/src/wizards/audience/views/content-gates/content-gates.tsx
+++ b/src/wizards/audience/views/content-gates/content-gates.tsx
@@ -6,7 +6,6 @@
  * WordPress dependencies.
  */
 import { useState } from '@wordpress/element';
-import { Draggable } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**

--- a/src/wizards/audience/views/content-gates/content-gates.tsx
+++ b/src/wizards/audience/views/content-gates/content-gates.tsx
@@ -5,8 +5,9 @@
 /**
  * WordPress dependencies.
  */
-import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
+import { Draggable } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -44,7 +45,7 @@ const ContentGates = () => {
 						'newspack-plugin'
 					) }
 					value={ limitAnonymous }
-					onChange={ value => setLimitAnonymous( value ) }
+					onChange={ ( value: number ) => setLimitAnonymous( value ) }
 				/>
 				<TextControl
 					type={ 'number' }
@@ -54,7 +55,7 @@ const ContentGates = () => {
 						'newspack-plugin'
 					) }
 					value={ limitRegistered }
-					onChange={ value => setLimitRegistered( value ) }
+					onChange={ ( value: number ) => setLimitRegistered( value ) }
 				/>
 				<SelectControl
 					type={ 'select' }
@@ -64,7 +65,7 @@ const ContentGates = () => {
 						'newspack-plugin'
 					) }
 					value={ period }
-					onChange={ value => setPeriod( value ) }
+					onChange={ ( value: string ) => setPeriod( value ) }
 					options={ [
 						{
 							value: 'week',

--- a/src/wizards/audience/views/content-gates/content-gates.tsx
+++ b/src/wizards/audience/views/content-gates/content-gates.tsx
@@ -1,0 +1,83 @@
+/**
+ * Content Gate component.
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { Button, Grid, SelectControl, TextControl } from '../../../../../packages/components/src';
+import WizardsActionCard from '../../../wizards-action-card';
+import './style.scss';
+
+const ContentGates = () => {
+	const [ active, setActive ] = useState( false );
+	const [ limitAnonymous, setLimitAnonymous ] = useState( 0 );
+	const [ limitRegistered, setLimitRegistered ] = useState( 0 );
+	const [ period, setPeriod ] = useState( 'week' );
+
+	return (
+		<WizardsActionCard
+			isMedium
+			title={ __( 'Primary Content Gate', 'newspack' ) }
+			description={ __( 'Configure the content gate that is rendered for all content.', 'newspack-plugin' ) }
+			toggleChecked={ active }
+			hasGreyHeader={ active }
+			toggleOnChange={ () => setActive( ! active ) }
+			actionContent={
+				<Button variant="primary" onClick={ () => {} }>
+					{ __( 'Edit Content Gate', 'newspack' ) }
+				</Button>
+			}
+		>
+			<Grid columns={ 3 } gutter={ 32 }>
+				<TextControl
+					type={ 'number' }
+					label={ __( 'Article limit for anonymous viewers', 'newspack-plugin' ) }
+					help={ __(
+						'Number of times an anonymous reader can view gated content. If set to 0, anonymous readers will always render the gate.',
+						'newspack-plugin'
+					) }
+					value={ limitAnonymous }
+					onChange={ value => setLimitAnonymous( value ) }
+				/>
+				<TextControl
+					type={ 'number' }
+					label={ __( 'Article limit for registered viewers', 'newspack-plugin' ) }
+					help={ __(
+						'Number of times a registered reader can view gated content. If set to 0, registered readers will always render the gate.',
+						'newspack-plugin'
+					) }
+					value={ limitRegistered }
+					onChange={ value => setLimitRegistered( value ) }
+				/>
+				<SelectControl
+					type={ 'select' }
+					label={ __( 'Time period', 'newspack-plugin' ) }
+					help={ __(
+						'The time period during which the metering views will be counted. For example, if the metering period is set to "Weekly", the metering views will be reset every week.',
+						'newspack-plugin'
+					) }
+					value={ period }
+					onChange={ value => setPeriod( value ) }
+					options={ [
+						{
+							value: 'week',
+							label: __( 'Weekly', 'newspack-plugin' ),
+						},
+						{
+							value: 'month',
+							label: __( 'Monthly', 'newspack-plugin' ),
+						},
+					] }
+				/>
+			</Grid>
+		</WizardsActionCard>
+	);
+};
+export default ContentGates;

--- a/src/wizards/audience/views/content-gates/index.js
+++ b/src/wizards/audience/views/content-gates/index.js
@@ -1,0 +1,37 @@
+/**
+ * Content gates management screen.
+ */
+
+import '../../../../shared/js/public-path';
+
+/**
+ * WordPress dependencies.
+ */
+import { __ } from '@wordpress/i18n';
+import { forwardRef } from '@wordpress/element';
+
+/**
+ * Internal dependencies.
+ */
+import { Wizard, withWizard } from '../../../../../packages/components/src';
+import ContentGates from './content-gates';
+
+const AudienceContentGates = ( props, ref ) => {
+	return (
+		<Wizard
+			title={ __( 'Content Gating', 'newspack-plugin' ) }
+			description={ __( 'Configure content gating logic and appearance.', 'newspack-plugin' ) }
+			headerText={ __( 'Audience Management / Content Gates', 'newspack-plugin' ) }
+			ref={ ref }
+			sections={ [
+				{
+					label: __( 'Content Gate', 'newspack-plugin' ),
+					path: '/content-gates',
+					render: ContentGates,
+				},
+			] }
+		/>
+	);
+};
+
+export default withWizard( forwardRef( AudienceContentGates ) );

--- a/src/wizards/audience/views/content-gates/style.scss
+++ b/src/wizards/audience/views/content-gates/style.scss
@@ -1,0 +1,5 @@
+/**
+ * Content gates group
+ */
+
+@use "~@wordpress/base-styles/colors" as wp-colors;

--- a/src/wizards/index.tsx
+++ b/src/wizards/index.tsx
@@ -43,6 +43,10 @@ const components: Record< string, any > = {
 		label: __( 'Audience Campaigns', 'newspack-plugin' ),
 		component: lazy( () => import( /* webpackChunkName: "audience-wizards" */ './audience/views/campaigns' ) ),
 	},
+	'newspack-audience-content-gates': {
+		label: __( 'Audience Content Gates', 'newspack-plugin' ),
+		component: lazy( () => import( /* webpackChunkName: "audience-wizards" */ './audience/views/content-gates' ) ),
+	},
 	'newspack-audience-donations': {
 		label: __( 'Audience Donations', 'newspack-plugin' ),
 		component: lazy( () => import( /* webpackChunkName: "audience-wizards" */ './audience/views/donations' ) ),


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a skeleton menu for Content Gates

### How to test the changes in this Pull Request:

1. Add the `NEWSPACK_CONTENT_GATES` flag to `wp-config.php`
2. Navigate to Audience > Content Gates and verify the skeleton Content Gate settings are present

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->