### PR TITLE
fix: add corrections on earlier the_content filter

### DIFF
--- a/includes/corrections/class-corrections.php
+++ b/includes/corrections/class-corrections.php
@@ -46,7 +46,7 @@ class Corrections {
 	 */
 	public static function init() {
 		add_action( 'init', [ __CLASS__, 'register_post_type' ] );
-		add_filter( 'the_content', [ __CLASS__, 'output_corrections_on_post' ] );
+		add_filter( 'the_content', [ __CLASS__, 'output_corrections_on_post' ], 1 );
 		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'wp_enqueue_scripts' ] );
 		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'wp_enqueue_scripts' ] );
 		add_action( 'rest_api_init', [ __CLASS__, 'register_rest_routes' ] );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Tweaks the `the_content` filter priority for adding corrections to as early as possible, so that a post's corrections are more likely to appear directly after the actual post content and not after any other additions that might be added via a `the_content` filter (such as Campaigns prompts).

Closes NPPM-2331.

### How to test the changes in this Pull Request:

1. On `release`, publish an inline Campaigns prompt that appears at 100% of the post content, then add a correction to a post.
2. Observe that on the front-end, the correction appears after the Campaigns prompt.
3. Check out this branch, refresh, and confirm that the correction now appears before the Campaigns prompt.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->