### PR TITLE
fix: tweak configuration labels for the primary subscription product

### DIFF
--- a/src/wizards/audience/views/subscriptions/index.tsx
+++ b/src/wizards/audience/views/subscriptions/index.tsx
@@ -48,7 +48,7 @@ function AudienceSubscriptions( props: Record< string, any >, ref: React.Forward
 						<WizardsTab title={ __( 'Configuration', 'newspack-plugin' ) }>
 							<WizardSection>
 								<Card>
-									<h2>{ __( 'Primary Subscription Tier Product', 'newspack-plugin' ) }</h2>
+									<h2>{ __( 'Subscription Upgrade Link', 'newspack-plugin' ) }</h2>
 									{ primaryProduct && (
 										<Notice isDismissible={ false }>
 											{ __( 'Share the following URL to trigger the subscription upgrade:', 'newspack-plugin' ) }{ ' ' }
@@ -61,13 +61,12 @@ function AudienceSubscriptions( props: Record< string, any >, ref: React.Forward
 											</a>
 										</Notice>
 									) }
-									<p>
-										{ __(
+									<SelectControl
+										label={ __( 'Primary Subscription Product', 'newspack-plugin' ) }
+										help={ __(
 											'Select a grouped or variable subscription product to allow readers to change their active subscriptions amongst all of its linked products and variations.',
 											'newspack-plugin'
 										) }
-									</p>
-									<SelectControl
 										options={ [
 											{
 												value: '',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

**Note: this is a hotfix to the alpha branch**

p1761071604068639-slack-C015W6BES8J

Updates the labels for the primary subscription product configuration wizard:

<img width="1145" height="475" alt="image" src="https://github.com/user-attachments/assets/9334358a-72ea-4aaf-a120-e117499adabf" />

### How to test the changes in this Pull Request:

1. Navigate to Audience -> Subscriptions
2. Confirm the "Subscription Upgrade Link" card renders as in the image above

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->