### PR TITLE
fix(subscriptions-tiers): standardize product input name

### DIFF
--- a/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
+++ b/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
@@ -391,14 +391,12 @@ class Subscriptions_Tiers {
 			$price = $product->get_price_html();
 		}
 
-		$product_type = $product->is_type( 'variation' ) ? 'variation_id' : 'product_id';
-
 		?>
 		<label class="newspack-ui__input-card <?php echo $current ? esc_attr( 'current' ) : ''; ?>">
 			<?php if ( $current ) : ?>
 				<span class="newspack-ui__badge newspack-ui__badge--primary"><?php _e( 'Current', 'newspack-plugin' ); ?></span>
 			<?php endif; ?>
-			<input type="radio" name="<?php echo esc_attr( $product_type ); ?>" value="<?php echo esc_attr( $product->get_id() ); ?>" <?php echo esc_attr( $selected ? 'checked' : '' ); ?>>
+			<input type="radio" name="product_id" value="<?php echo esc_attr( $product->get_id() ); ?>" <?php echo esc_attr( $selected ? 'checked' : '' ); ?>>
 			<strong><?php echo esc_html( self::get_product_title( $product, $show_variation_attributes ) ); ?></strong>
 			<span class="newspack-ui__helper-text"><?php echo $price; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></span>
 		</label>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Regular products and variations can be rendered in the same form, but should share the same radio input name; otherwise, multiple options can be selected, and the form selection will not behave as expected.

@dkoo I'm not sure exactly how this will impact the changes from #4209. Should we add a different hidden input to determine whether the selected option is a variation or a regular product? I'm not seeing how having `variation_id` instead of `product_id` impacts tracking.

### How to test the changes in this Pull Request:

1. Checkout the alpha branch
2. Configure a Grouped Product with a Simple Subscription and Variable Subscription
3. Set this product as the Primary Subscription Product in Audience -> Subscriptions
4. In a fresh session, visit the upgrade link
5. Confirm that both the simple subscription option and the variable subscription option can be selected
6. Checkout this branch and refresh the page
7. Confirm that only one option can be selected, and continuing the flow will persist the selected option

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->