### PR TITLE
fix: add feature flag to email enhancements

### DIFF
--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -12,6 +12,7 @@ defined( 'ABSPATH' ) || exit;
 use Newspack\Optional_Modules\Collections;
 use Newspack\Memberships;
 use Newspack\Memberships\Metering;
+use Newspack\Content_Gate_Countdown_Block;
 
 /**
  * Newspack Blocks Class.
@@ -54,18 +55,19 @@ final class Blocks {
 			true
 		);
 		$script_data = [
-			'has_newsletters'         => class_exists( 'Newspack_Newsletters_Subscription' ),
-			'has_reader_activation'   => Reader_Activation::is_enabled(),
-			'newsletters_url'         => Wizards::get_wizard( 'newsletters' )->newsletters_settings_url(),
-			'has_google_oauth'        => Google_OAuth::is_oauth_configured(),
-			'google_logo_svg'         => \Newspack\Newspack_UI_Icons::get_svg( 'google' ),
-			'reader_activation_terms' => Reader_Activation::get_setting( 'terms_text' ),
-			'reader_activation_url'   => Reader_Activation::get_setting( 'terms_url' ),
-			'has_recaptcha'           => Recaptcha::can_use_captcha(),
-			'recaptcha_url'           => admin_url( 'admin.php?page=newspack-settings' ),
-			'corrections_enabled'     => wp_is_block_theme() && class_exists( 'Newspack\Corrections' ),
-			'collections_enabled'     => Collections::is_module_active(),
-			'has_memberships'         => Memberships::is_active(),
+			'has_newsletters'                  => class_exists( 'Newspack_Newsletters_Subscription' ),
+			'has_reader_activation'            => Reader_Activation::is_enabled(),
+			'newsletters_url'                  => Wizards::get_wizard( 'newsletters' )->newsletters_settings_url(),
+			'has_google_oauth'                 => Google_OAuth::is_oauth_configured(),
+			'google_logo_svg'                  => \Newspack\Newspack_UI_Icons::get_svg( 'google' ),
+			'reader_activation_terms'          => Reader_Activation::get_setting( 'terms_text' ),
+			'reader_activation_url'            => Reader_Activation::get_setting( 'terms_url' ),
+			'has_recaptcha'                    => Recaptcha::can_use_captcha(),
+			'recaptcha_url'                    => admin_url( 'admin.php?page=newspack-settings' ),
+			'corrections_enabled'              => wp_is_block_theme() && class_exists( 'Newspack\Corrections' ),
+			'collections_enabled'              => Collections::is_module_active(),
+			'has_memberships'                  => Memberships::is_active(),
+			'is_content_gate_countdown_active' => Content_Gate_Countdown_Block::is_active(),
 		];
 		if ( $script_data['has_memberships'] ) {
 			$script_data['content_gate_data'] = [

--- a/includes/plugins/woocommerce/class-woocommerce-emails.php
+++ b/includes/plugins/woocommerce/class-woocommerce-emails.php
@@ -44,6 +44,9 @@ class WooCommerce_Emails {
 	 * @param string $option Option name.
 	 */
 	public static function override_woocommerce_email_editor_option( $value, $option ) {
+		if ( ! self::is_active() ) {
+			return $value;
+		}
 		return self::is_enabled();
 	}
 
@@ -69,7 +72,7 @@ class WooCommerce_Emails {
 	 * Update any existing woocommerce block emails to the latest content if they haven't been customized.
 	 */
 	public static function update_woocommerce_emails_to_latest() {
-		if ( ! class_exists( '\Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCTransactionalEmails' ) ) {
+		if ( ! self::is_active() || ! class_exists( '\Automattic\WooCommerce\Internal\EmailEditor\WCTransactionalEmails\WCTransactionalEmails' ) ) {
 			return;
 		}
 		if ( 'yes' === self::is_enabled() && 'v1' !== get_option( self::WOOCOMMERCE_EMAILS_UPDATED_OPTION, '' ) ) {
@@ -92,6 +95,15 @@ class WooCommerce_Emails {
 			$email_template_generator->initialize();
 			update_option( self::WOOCOMMERCE_EMAILS_UPDATED_OPTION, 'v1' );
 		}
+	}
+
+	/**
+	 * Whether email enhancements are active.
+	 *
+	 * @return bool
+	 */
+	public static function is_active() {
+		return defined( 'NEWSPACK_EMAIL_ENHANCEMENTS' ) && NEWSPACK_EMAIL_ENHANCEMENTS;
 	}
 }
 WooCommerce_Emails::init();

--- a/includes/wizards/newspack/class-emails-section.php
+++ b/includes/wizards/newspack/class-emails-section.php
@@ -28,6 +28,9 @@ class Emails_Section extends Wizard_Section {
 	 * Register the endpoints needed for the wizard screens.
 	 */
 	public function register_rest_routes() {
+		if ( ! WooCommerce_Emails::is_active() ) {
+			return;
+		}
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
 			'wizard/' . $this->wizard_slug . '/emails',

--- a/includes/wizards/newspack/class-newspack-settings.php
+++ b/includes/wizards/newspack/class-newspack-settings.php
@@ -13,6 +13,7 @@ use Newspack\Wizard;
 use Newspack\Reader_Activation;
 use Newspack\Reader_Revenue_Emails;
 use Newspack\Everlit_Configuration_Manager;
+use Newspack\WooCommerce_Emails;
 use function Newspack\google_site_kit_available;
 
 defined( 'ABSPATH' ) || exit;
@@ -81,11 +82,12 @@ class Newspack_Settings extends Wizard {
 				'label'    => __( 'Emails', 'newspack-plugin' ),
 				'sections' => [
 					'emails' => [
-						'dependencies' => [
+						'dependencies'              => [
 							'newspackNewsletters' => is_plugin_active( 'newspack-newsletters/newspack-newsletters.php' ),
 						],
-						'all'          => Emails::get_emails( Reader_Activation::is_enabled() ? [] : array_values( Reader_Revenue_Emails::EMAIL_TYPES ), false ),
-						'postType'     => Emails::POST_TYPE,
+						'all'                       => Emails::get_emails( Reader_Activation::is_enabled() ? [] : array_values( Reader_Revenue_Emails::EMAIL_TYPES ), false ),
+						'postType'                  => Emails::POST_TYPE,
+						'isEmailEnhancementsActive' => WooCommerce_Emails::is_active(),
 					],
 				],
 			],

--- a/src/blocks/content-gate/countdown-box/class-content-gate-countdown-box-block.php
+++ b/src/blocks/content-gate/countdown-box/class-content-gate-countdown-box-block.php
@@ -11,6 +11,7 @@ defined( 'ABSPATH' ) || exit;
 
 use Newspack\Memberships;
 use Newspack\Memberships\Metering;
+use Newspack\Content_Gate_Countdown_Block;
 
 /**
  * Content Gate Countdown Box Block class.

--- a/src/blocks/content-gate/countdown/class-content-gate-countdown-block.php
+++ b/src/blocks/content-gate/countdown/class-content-gate-countdown-block.php
@@ -30,7 +30,7 @@ class Content_Gate_Countdown_Block {
 	 * @return void
 	 */
 	public static function enqueue_scripts() {
-		if ( ! Memberships::is_active() || ! is_singular() ) {
+		if ( ! self::is_active() || ! Memberships::is_active() || ! is_singular() ) {
 			return;
 		}
 		wp_enqueue_script(
@@ -87,6 +87,15 @@ class Content_Gate_Countdown_Block {
 				<span class='newspack-content-gate-countdown'>$countdown</span>
 			</div>"
 		);
+	}
+
+	/**
+	 * Whether the block is active.
+	 *
+	 * @return bool
+	 */
+	public static function is_active() {
+		return defined( 'NEWSPACK_CONTENT_GATE_COUNTDOWN_BLOCK' ) && NEWSPACK_CONTENT_GATE_COUNTDOWN_BLOCK;
 	}
 }
 

--- a/src/blocks/index.js
+++ b/src/blocks/index.js
@@ -52,8 +52,8 @@ const registerBlock = block => {
 	if ( collectionsBlocks.includes( name ) && ! newspack_blocks.collections_enabled ) {
 		return;
 	}
-	/** Do not register content gate blocks if Memberships is not active. */
-	if ( contentGateBlocks.includes( name ) && ! newspack_blocks.has_memberships ) {
+	/** Do not register content gate blocks if the feature or Memberships is not active. */
+	if ( contentGateBlocks.includes( name ) && ( ! newspack_blocks.has_memberships || ! newspack_blocks.is_content_gate_countdown_active ) ) {
 		return;
 	}
 

--- a/src/wizards/newspack/types/index.d.ts
+++ b/src/wizards/newspack/types/index.d.ts
@@ -78,6 +78,7 @@ declare global {
 						};
 						dependencies: Record< string, boolean >;
 						postType: string;
+						isEmailEnhancementsActive: boolean;
 					};
 				};
 			};

--- a/src/wizards/newspack/views/settings/emails/index.tsx
+++ b/src/wizards/newspack/views/settings/emails/index.tsx
@@ -15,15 +15,19 @@ import { default as EmailsSection } from './emails';
 import { default as SettingsSection } from './settings';
 import WizardSection from '../../../../wizards-section';
 
+const { emails } = window.newspackSettings;
+
 function Emails() {
 	return (
 		<WizardsTab title={ __( 'Emails', 'newspack-plugin' ) }>
 			<WizardSection>
 				<EmailsSection />
 			</WizardSection>
-			<WizardSection>
-				<SettingsSection />
-			</WizardSection>
+			{ emails?.sections?.emails?.isEmailEnhancementsActive && (
+				<WizardSection>
+					<SettingsSection />
+				</WizardSection>
+			) }
 		</WizardsTab>
 	);
 }


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR hides the Woo block email toggle and the content gate countdown block features behind feature flags.

### How to test the changes in this Pull Request:

#### Woo Block Email Editor Toggle
1. Navigate to Newspack > Settings > Email and verify there is not a toggle to enable the woocommerce email block editor
2. Navigate to WooCommerce > Settings > Emails and verify the emails list displays according to whatever is set in Woocommerce > Settings > Advanced > Features > Block Email Editor (alpha)
3. Enable the `NEWSPACK_EMAIL_ENHANCEMENTS` flag in wp-config (`define( 'NEWSPACK_EMAIL_ENHANCEMENTS', true );`)
4. Repeat steps 1 and 2 and confirm there is a toggle and the emails list displays according to whatever the toggle is set to

#### Content Gate Countdown Block
1. Ensure the countdown gate block is not available in the editor
2. Add the `NEWSPACK_CONTENT_GATE_COUNTDOWN_BLOCK` flag in wp-config (`define( 'NEWSPACK_CONTENT_GATE_COUNTDOWN_BLOCK', true );`)
3. Confirm the block is available in the editor
4. Confirm it renders as expected in both the front and backend

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->