### PR TITLE
fix(upgrade-subscription-link): remove query arg on load

### DIFF
--- a/src/reader-activation/subscription-tiers-form.js
+++ b/src/reader-activation/subscription-tiers-form.js
@@ -136,5 +136,13 @@ export default function init() {
 				} );
 			} );
 		} );
+
+		// Remove the `upgrade-subscription` query param from the URL.
+		const params = new URLSearchParams( window.location.search );
+		if ( params.get( 'upgrade-subscription' ) ) {
+			params.delete( 'upgrade-subscription' );
+			const newQueryString = params.toString() ? '?' + params.toString() : '';
+			window.history.replaceState( {}, '', window.location.pathname + newQueryString );
+		}
 	} );
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Removes the URL query arg on page render to avoid re-opening the modal on page refresh.

### How to test the changes in this Pull Request:

1. Go through the upgrade subscription link flow
2. Confirm the query arg is not present
3. Confirm the page refresh at the end of the flow doesn't render the modal again

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->