### PR TITLE
fix: prevent an infinite loop/error transforming galleries to image blocks when they have credits [NPPM-2323]

### DIFF
--- a/src/blocks/core-image/index.tsx
+++ b/src/blocks/core-image/index.tsx
@@ -54,7 +54,7 @@ const AttributesLoader = ( { setAttributes, attributes }: ImageBlockTypes.Attrib
 				setAttributes( { meta: { _media_credit, _media_credit_url, _navis_media_credit_org } } );
 			}
 		}
-	}, [ meta, attributes?.meta?._media_credit, attributes?.meta?._media_credit_url, attributes?.meta?._navis_media_credit_org ] );
+	}, [ meta ] );
 
 	return <></>;
 };


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes an issue where galleries can't be transformed into image blocks when one of those images has a credit.

### How to test the changes in this Pull Request:

1. Set up a gallery block; add at least three images and make sure one has a credit.
2. Click the Gallery icon in the block toolbar, and try to transform the block into Image blocks.
3. Note the browser error.
4. Apply this PR and run `npm run build`.
5. Repeat steps 1 and 2; confirm that you no longer get an error. 
6. Just to make sure I haven't introduced a regression, retest the steps here transforming an Image block with a credit into a synced pattern: https://github.com/Automattic/newspack-plugin/pull/3230

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->