### PR TITLE
fix(action-card): use JSX variable instead of new component for children

### DIFF
--- a/packages/components/src/action-card/index.js
+++ b/packages/components/src/action-card/index.js
@@ -113,7 +113,7 @@ const ActionCard = ( {
 	const isDisplayingSecondaryAction = secondaryActionText && onSecondaryActionClick;
 	const badges = ! Array.isArray( badge ) && badge ? [ badge ] : badge;
 
-	const Component = () => (
+	const cardContent = (
 		<>
 			<div className="newspack-action-card__region newspack-action-card__region-top">
 				{ toggleOnChange && <ToggleControl checked={ toggleChecked } onChange={ toggleOnChange } disabled={ disabled } /> }
@@ -306,7 +306,7 @@ const ActionCard = ( {
 									/>
 								</div>
 							</div>
-							<Component />
+							{ cardContent }
 						</Card>
 					) }
 				</Draggable>
@@ -316,7 +316,7 @@ const ActionCard = ( {
 
 	return (
 		<Card className={ classes } onClick={ simple && onClick } id={ id ?? null } noBorder={ noBorder }>
-			<Component />
+			{ cardContent }
 		</Card>
 	);
 };


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The changes from #4248 introduced an issue with rerenders. By creating a new component, the component's children get recreated every rerender.

This PR tweaks the strategy by using a JSX variable, which will preserve the children across rerenders.

### How to test the changes in this Pull Request:

1. While in trunk, run the following:
```js
function Component() {
  useEffect( () => {
    console.log( 'Component mounted' );
  }, [] );

  return null;
}

export default function Test() {
  const [ counter, setCounter ] = useState( 0 );

  return (
    <ActionCard>
      <p>Counter: { counter }</p>
      <button onClick={ () => setCounter( counter + 1 ) }>Increment</button>
      <Component />
    </ActionCard>
  );
}
```
2. Confirm that every state change calls `Component mounted`
3. Checkout this branch, run the same code, and confirm the component is not re-mounted on every state change

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->