### PR TITLE
Remove Nextdoor integration feature flag

### DIFF
--- a/includes/optional-modules/class-nextdoor.php
+++ b/includes/optional-modules/class-nextdoor.php
@@ -34,11 +34,6 @@ class Nextdoor {
 	 * Initialize the module.
 	 */
 	public static function init() {
-		// Feature flag it for now.
-		if ( ! defined( 'NEWSPACK_ENABLE_NEXTDOOR_INTEGRATION' ) || ! NEWSPACK_ENABLE_NEXTDOOR_INTEGRATION ) {
-			return;
-		}
-
 		// Only initialize if the module is active.
 		if ( ! Optional_Modules::is_optional_module_active( 'nextdoor' ) ) {
 			return;

--- a/includes/wizards/newspack/class-newspack-settings.php
+++ b/includes/wizards/newspack/class-newspack-settings.php
@@ -95,10 +95,9 @@ class Newspack_Settings extends Wizard {
 			'social'            => [
 				'label'    => __( 'Social', 'newspack-plugin' ),
 				'nextdoor' => [
-					'available_roles'      => Nextdoor::get_available_roles(),
-					'country_options'      => Nextdoor::get_available_countries(),
-					'redirect_uri'         => Nextdoor::get_redirect_uri(),
-					'feature_flag_enabled' => defined( 'NEWSPACK_ENABLE_NEXTDOOR_INTEGRATION' ) && NEWSPACK_ENABLE_NEXTDOOR_INTEGRATION,
+					'available_roles' => Nextdoor::get_available_roles(),
+					'country_options' => Nextdoor::get_available_countries(),
+					'redirect_uri'    => Nextdoor::get_redirect_uri(),
 				],
 			],
 			'syndication'       => [

--- a/src/wizards/newspack/types/index.d.ts
+++ b/src/wizards/newspack/types/index.d.ts
@@ -64,7 +64,6 @@ declare global {
 						value: string;
 					}[];
 					redirect_uri: string;
-					feature_flag_enabled: boolean;
 				};
 			};
 			connections: WizardTab;

--- a/src/wizards/newspack/views/settings/social/nextdoor.tsx
+++ b/src/wizards/newspack/views/settings/social/nextdoor.tsx
@@ -172,11 +172,6 @@ function Nextdoor() {
 		apiFetchToggle( { ...apiData, module_enabled_nextdoor: value }, true );
 	};
 
-	const feature_flag_enabled = window.newspackSettings?.social?.nextdoor?.feature_flag_enabled || false;
-	if ( ! feature_flag_enabled ) {
-		return null;
-	}
-
 	return (
 		<>
 			<WizardsActionCard

--- a/src/wizards/newspack/views/settings/social/nextdoor/onboarding/index.tsx
+++ b/src/wizards/newspack/views/settings/social/nextdoor/onboarding/index.tsx
@@ -12,7 +12,7 @@ import { ExternalLink } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import { ActionCard, Button, Card, Grid, Notice, SelectControl, TextControl } from '../../../../../../../components/src';
+import { ActionCard, Button, Card, Grid, Notice, SelectControl, TextControl } from '../../../../../../../../packages/components/src';
 import { OnboardingProps } from '../types';
 
 /**

--- a/src/wizards/newspack/views/settings/social/nextdoor/settings/index.tsx
+++ b/src/wizards/newspack/views/settings/social/nextdoor/settings/index.tsx
@@ -13,7 +13,7 @@ import { CheckboxControl, CardHeader, __experimentalHeading as Heading, CardBody
 /**
  * Internal dependencies
  */
-import { Button, Card, Grid, Notice } from '../../../../../../../components/src';
+import { Button, Card, Grid, Notice } from '../../../../../../../../packages/components/src';
 import { SettingsProps } from '../types';
 
 /**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR removes the feature flag for the Nextdoor integration, so it will be available for anyone that wants to activate it.

It also fixes a couple build errors I was encountering. Something must have changed between the time this integration was created and today. :)

### How to test the changes in this Pull Request:

1. `npm run build` should work.
2. In Newspack > Settings > Social there should be a toggle for enabling a Nextdoor integration:

<img width="1016" height="810" alt="Screenshot 2025-10-30 at 10 33 09 AM" src="https://github.com/user-attachments/assets/26c3f6dd-14ef-4763-8491-b152341ca393" />


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->