### PR TITLE
feat(subscription-tiers): introduce "Sign In" link

### DIFF
--- a/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
+++ b/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
@@ -835,6 +835,12 @@ class Subscriptions_Tiers {
 			return;
 		}
 
+		// If coming from a subscription switch link, the reader must be logged in.
+		// The authentication flow will be handled in the frontend.
+		if ( self::should_attempt_to_switch_subscription() && ! is_user_logged_in() ) {
+			return;
+		}
+
 		if ( ! class_exists( '\Newspack_Blocks\Modal_Checkout' ) ) {
 			return;
 		}

--- a/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
+++ b/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
@@ -34,7 +34,7 @@ class Subscriptions_Tiers {
 		add_filter( 'option_woocommerce_subscriptions_order_button_text', [ __CLASS__, 'order_button_text' ], 9 );
 
 		// Primary product rendering.
-		add_action( 'wp_footer', [ __CLASS__, 'print_primary_product_modal' ] );
+		add_action( 'wp_footer', [ __CLASS__, 'print_product_modal' ] );
 		add_filter( 'newspack_popups_assess_has_disabled_popups', [ __CLASS__, 'disable_popups' ] );
 
 		// Unhook Upgrade/Downgrade switch direction text.
@@ -91,6 +91,20 @@ class Subscriptions_Tiers {
 		 * @param string $query_param The URL query parameter.
 		 */
 		return apply_filters( 'newspack_subscriptions_upgrade_subscription_query_param', 'upgrade-subscription' );
+	}
+
+	/**
+	 * Get the URL for triggering the tiers modal for a given product.
+	 *
+	 * @return string The URL for triggering the tiers modal.
+	 */
+	public static function get_tiers_modal_query_param() {
+		/**
+		 * Filters the URL query parameter that triggers the tiers modal.
+		 *
+		 * @param string $query_param The URL query parameter.
+		 */
+		return apply_filters( 'newspack_subscriptions_purchase_product_query_param', 'tiers-modal' );
 	}
 
 	/**
@@ -608,7 +622,7 @@ class Subscriptions_Tiers {
 
 		$should_render_tabs = ! $is_single_tier || $is_nyp;
 		?>
-		<form class="newspack__subscription-tiers__form <?php echo esc_attr( $is_nyp ? 'nyp' : '' ); ?>" target="newspack_modal_checkout_iframe" data-title="<?php echo esc_attr( $title ); ?>">
+		<form class="newspack__subscription-tiers__form <?php echo esc_attr( $is_nyp ? 'nyp' : '' ); ?>" target="newspack_modal_checkout_iframe" data-title="<?php echo esc_attr( $title ); ?>" data-product-id="<?php echo esc_attr( $product ? $product->get_id() : '' ); ?>">
 			<?php if ( $should_render_tabs ) : ?>
 				<div class="newspack-ui__segmented-control">
 					<?php
@@ -651,6 +665,13 @@ class Subscriptions_Tiers {
 
 			<button type="submit" class="newspack-ui__button newspack-ui__button--primary newspack-ui__button--wide"><?php echo esc_html( $button_label ); ?></button>
 			<button type="button" class="newspack-ui__button newspack-ui__button--ghost newspack-ui__button--wide newspack-ui__modal__cancel"><?php _e( 'Cancel', 'newspack-plugin' ); ?></button>
+
+			<?php if ( ! is_user_logged_in() ) : ?>
+				<p>
+					<?php _e( 'Already have an account?', 'newspack-plugin' ); ?>
+					<a href="<?php echo esc_url( wc_get_account_endpoint_url( 'edit-account' ) ); ?>" class="signin-link"><?php _e( 'Sign in', 'newspack-plugin' ); ?></a>
+				</p>
+			<?php endif; ?>
 		</form>
 		<?php
 	}
@@ -709,13 +730,22 @@ class Subscriptions_Tiers {
 	/**
 	 * Render primary product modal.
 	 */
-	public static function print_primary_product_modal() {
-		$query_param = self::get_upgrade_subscription_query_param();
-		if ( empty( $_GET[ $query_param ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	public static function print_product_modal() {
+		$upgrade_query_param = self::get_upgrade_subscription_query_param();
+		$tiers_query_param   = self::get_tiers_modal_query_param();
+		if ( empty( $_GET[ $upgrade_query_param ] ) && ! isset( $_GET[ $tiers_query_param ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			return;
 		}
 
-		$product = self::get_primary_subscription_tier_product();
+		if ( ! empty( $_GET[ $tiers_query_param ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$product = wc_get_product( absint( $_GET[ $tiers_query_param ] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			if ( ! $product ) {
+				return;
+			}
+		} else {
+			$product = self::get_primary_subscription_tier_product();
+		}
+
 		if ( ! $product ) {
 			return;
 		}
@@ -748,14 +778,7 @@ class Subscriptions_Tiers {
 				];
 			}
 		}
-
-		$title = sanitize_text_field( $_GET[ $query_param ] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		// If the query param value is "1", let the modal decide the title.
-		if ( $title === '1' ) {
-			$title = null;
-		}
-
-		self::render_modal( $product, $title, $title, $switch_data, 'open' );
+		self::render_modal( $product, null, null, $switch_data, 'open' );
 	}
 
 	/**

--- a/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
+++ b/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
@@ -848,7 +848,8 @@ class Subscriptions_Tiers {
 	 */
 	public static function disable_popups( $disabled ) {
 		$query_param = self::get_upgrade_subscription_query_param();
-		if ( ! empty( $_GET[ $query_param ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$tiers_query_param = self::get_tiers_modal_query_param();
+		if ( ! empty( $_GET[ $query_param ] ) || ! empty( $_GET[ $tiers_query_param ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			return true;
 		}
 		return $disabled;

--- a/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
+++ b/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
@@ -665,7 +665,7 @@ class Subscriptions_Tiers {
 
 			<button type="submit" class="newspack-ui__button newspack-ui__button--primary newspack-ui__button--wide"><?php echo esc_html( $button_label ); ?></button>
 			<?php if ( ! is_user_logged_in() ) : ?>
-				<button type="button" class="newspack-ui__button newspack-ui__button--ghost newspack-ui__button--wide signin-link">
+				<button type="button" class="newspack-ui__button newspack-ui__button--secondary newspack-ui__button--wide signin-link">
 					<?php _e( 'Sign in to an existing account', 'newspack-plugin' ); ?>
 				</button>
 			<?php endif; ?>

--- a/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
+++ b/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
@@ -26,15 +26,15 @@ class Subscriptions_Tiers {
 	public static function init_hooks() {
 		add_filter( 'woocommerce_subscriptions_switch_link_text', [ __CLASS__, 'switch_link_text' ], 11, 3 );
 		add_filter( 'woocommerce_subscriptions_switch_link_text', [ __CLASS__, 'cache_switch_subscription_link_data' ], 10, 4 );
-		add_action( 'wp_footer', [ __CLASS__, 'print_switch_subscription_modal' ] );
+		add_action( 'wp_footer', [ __CLASS__, 'print_switch_subscription_link_modal' ] );
 
 		// Order button text.
 		add_filter( 'wcs_place_subscription_order_text', [ __CLASS__, 'order_button_text' ], 9 );
 		add_filter( 'woocommerce_order_button_text', [ __CLASS__, 'order_button_text' ], 20 );
 		add_filter( 'option_woocommerce_subscriptions_order_button_text', [ __CLASS__, 'order_button_text' ], 9 );
 
-		// Primary product rendering.
-		add_action( 'wp_footer', [ __CLASS__, 'print_product_modal' ] );
+		// Link-triggered modal rendering.
+		add_action( 'wp_footer', [ __CLASS__, 'print_modal' ] );
 		add_filter( 'newspack_popups_assess_has_disabled_popups', [ __CLASS__, 'disable_popups' ] );
 
 		// Unhook Upgrade/Downgrade switch direction text.
@@ -127,9 +127,9 @@ class Subscriptions_Tiers {
 	}
 
 	/**
-	 * Modal switch subscription template.
+	 * Print modals for switch subscription links rendered in the page.
 	 */
-	public static function print_switch_subscription_modal() {
+	public static function print_switch_subscription_link_modal() {
 		if ( empty( self::$switch_subscription_links ) ) {
 			return;
 		}
@@ -664,14 +664,12 @@ class Subscriptions_Tiers {
 			<?php endif; ?>
 
 			<button type="submit" class="newspack-ui__button newspack-ui__button--primary newspack-ui__button--wide"><?php echo esc_html( $button_label ); ?></button>
-			<button type="button" class="newspack-ui__button newspack-ui__button--ghost newspack-ui__button--wide newspack-ui__modal__cancel"><?php _e( 'Cancel', 'newspack-plugin' ); ?></button>
-
 			<?php if ( ! is_user_logged_in() ) : ?>
-				<p>
-					<?php _e( 'Already have an account?', 'newspack-plugin' ); ?>
-					<a href="<?php echo esc_url( wc_get_account_endpoint_url( 'edit-account' ) ); ?>" class="signin-link"><?php _e( 'Sign in', 'newspack-plugin' ); ?></a>
-				</p>
+				<button type="button" class="newspack-ui__button newspack-ui__button--ghost newspack-ui__button--wide signin-link">
+					<?php _e( 'Sign in to an existing account', 'newspack-plugin' ); ?>
+				</button>
 			<?php endif; ?>
+			<button type="button" class="newspack-ui__button newspack-ui__button--ghost newspack-ui__button--wide newspack-ui__modal__cancel"><?php _e( 'Cancel', 'newspack-plugin' ); ?></button>
 		</form>
 		<?php
 	}
@@ -728,35 +726,69 @@ class Subscriptions_Tiers {
 	}
 
 	/**
-	 * Render primary product modal.
+	 * Whether the modal should be printed.
 	 */
-	public static function print_product_modal() {
+	protected static function should_print_modal() {
+		// Upgrade subscription link.
 		$upgrade_query_param = self::get_upgrade_subscription_query_param();
-		$tiers_query_param   = self::get_tiers_modal_query_param();
-		if ( empty( $_GET[ $upgrade_query_param ] ) && ! isset( $_GET[ $tiers_query_param ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			return;
+		if ( ! empty( $_GET[ $upgrade_query_param ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return true;
 		}
 
+		// Tiers modal link.
+		$tiers_query_param = self::get_tiers_modal_query_param();
 		if ( ! empty( $_GET[ $tiers_query_param ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$product = wc_get_product( absint( $_GET[ $tiers_query_param ] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			if ( ! $product ) {
-				return;
-			}
-		} else {
-			$product = self::get_primary_subscription_tier_product();
+			return true;
 		}
 
-		if ( ! $product ) {
-			return;
+		return false;
+	}
+
+	/**
+	 * Should attempt to switch the subscription.
+	 *
+	 * @return bool Whether to attempt to switch the subscription.
+	 */
+	protected static function should_attempt_to_switch_subscription() {
+		$upgrade_query_param = self::get_upgrade_subscription_query_param();
+		if ( ! empty( $_GET[ $upgrade_query_param ] ) || ! empty( $_GET['switch'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Get the product from the query param.
+	 *
+	 * @return \WC_Product|null Product or null if no product is found.
+	 */
+	protected static function get_product_from_query_param() {
+		$upgrade_query_param = self::get_upgrade_subscription_query_param();
+		if ( ! empty( $_GET[ $upgrade_query_param ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return self::get_primary_subscription_tier_product();
 		}
 
-		if ( class_exists( '\Newspack_Blocks\Modal_Checkout' ) ) {
-			\Newspack_Blocks\Modal_Checkout::enqueue_modal();
+		$tiers_query_param = self::get_tiers_modal_query_param();
+		if ( ! empty( $_GET[ $tiers_query_param ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return wc_get_product( absint( $_GET[ $tiers_query_param ] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		}
+		return null;
+	}
+
+	/**
+	 * Get the switch data from the given product for the current user.
+	 *
+	 * @param \WC_Product $product Product.
+	 *
+	 * @return array|null Switch data or null if no switch data is found.
+	 */
+	public static function get_product_switch_data( $product ) {
+		$switch_data = null;
+		if ( ! is_user_logged_in() ) {
+			return $switch_data;
 		}
 
 		$user_subscription = self::get_user_subscription( $product );
-		$switch_data       = null;
-
 		if ( $user_subscription ) {
 			$product_id = $product->get_id();
 			$item       = null;
@@ -778,6 +810,32 @@ class Subscriptions_Tiers {
 				];
 			}
 		}
+		return $switch_data;
+	}
+
+	/**
+	 * Render link-triggered modal.
+	 */
+	public static function print_modal() {
+		if ( ! self::should_print_modal() ) {
+			return;
+		}
+
+		$product = self::get_product_from_query_param();
+		if ( ! $product ) {
+			return;
+		}
+
+		if ( ! class_exists( '\Newspack_Blocks\Modal_Checkout' ) ) {
+			return;
+		}
+		\Newspack_Blocks\Modal_Checkout::enqueue_modal();
+
+		$switch_data = null;
+		if ( self::should_attempt_to_switch_subscription() ) {
+			$switch_data = self::get_product_switch_data( $product );
+		}
+
 		self::render_modal( $product, null, null, $switch_data, 'open' );
 	}
 

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -308,6 +308,9 @@ final class Reader_Activation {
 				'newsletters_success'      => __( 'Signup successful!', 'newspack-plugin' ),
 				'newsletters_title'        => __( 'Sign up for newsletters', 'newspack-plugin' ),
 				'auth_form_action'         => self::AUTH_FORM_ACTION,
+				// Subscription tiers labels.
+				'sign_in_to_upgrade'       => __( 'Sign in to upgrade', 'newspack-plugin' ),
+				'register_to_upgrade'      => __( 'Register to upgrade', 'newspack-plugin' ),
 			];
 
 			/**

--- a/src/reader-activation-auth/auth-form.js
+++ b/src/reader-activation-auth/auth-form.js
@@ -270,9 +270,6 @@ window.newspackRAS.push( function ( readerActivation ) {
 				if ( container.config?.closeOnSuccess ) {
 					form.style.opacity = 1;
 				}
-				submitButtons.forEach( button => {
-					button.disabled = false;
-				} );
 				if ( message ) {
 					const messageNode = document.createElement( 'p' );
 					messageNode.innerHTML = message;
@@ -280,6 +277,9 @@ window.newspackRAS.push( function ( readerActivation ) {
 					if ( status !== 200 ) {
 						form.setMessageContent( message, true );
 						messageContentElement.querySelectorAll( '[data-set-action]' ).forEach( setActionListener );
+						submitButtons.forEach( button => {
+							button.disabled = false;
+						} );
 					}
 				}
 				if ( status === 200 ) {
@@ -434,6 +434,9 @@ window.newspackRAS.push( function ( readerActivation ) {
 										if ( data.action === 'otp' || data.action === 'pwd' ) {
 											form.style.opacity = 1;
 										}
+										submitButtons.forEach( button => {
+											button.disabled = false;
+										} );
 									} else {
 										form.endLoginFlow( message, status, data );
 									}
@@ -450,9 +453,6 @@ window.newspackRAS.push( function ( readerActivation ) {
 									} else if ( status !== 200 && ! container.config?.closeOnSuccess ) {
 										form.style.opacity = 1;
 									}
-									submitButtons.forEach( button => {
-										button.disabled = false;
-									} );
 								} );
 						} )
 						.catch( () => {
@@ -461,5 +461,9 @@ window.newspackRAS.push( function ( readerActivation ) {
 				}
 			} );
 		} );
+
+		// Dispatch an event to notify that the auth form is ready.
+		document._newspackReaderAuthFormReady = true;
+		document.dispatchEvent( new CustomEvent( 'newspack-reader-auth-form-ready', { detail: { containers } } ) );
 	} );
 } );

--- a/src/reader-activation-auth/auth-modal.js
+++ b/src/reader-activation-auth/auth-modal.js
@@ -1,6 +1,7 @@
 /* globals newspack_reader_activation_labels */
 export const SIGN_IN_MODAL_HASHES = [ 'signin_modal', 'register_modal' ];
 import * as a11y from './accessibility.js';
+
 /**
  * Get the authentication modal container.
  *
@@ -8,6 +9,22 @@ import * as a11y from './accessibility.js';
  */
 export function getModalContainer() {
 	return document.querySelector( '.newspack-reader-auth-modal .newspack-reader-auth' );
+}
+
+/**
+ * Add a callback to be called when the auth form is ready.
+ *
+ * @param {Function} callback The callback to call when the auth form is ready.
+ *
+ * @return {void}
+ */
+export function onAuthFormReady( callback ) {
+	// If the auth form is already ready, call the callback immediately.
+	if ( document._newspackReaderAuthFormReady ) {
+		callback();
+		return;
+	}
+	document.addEventListener( 'newspack-reader-auth-form-ready', callback );
 }
 
 /**
@@ -163,12 +180,15 @@ export function openAuthModal( config = {} ) {
 	if ( config.initialState ) {
 		initialFormAction = config.initialState;
 	}
-	container.setFormAction( initialFormAction, true );
 
-	// Default to signin action if otp and timer has expired.
-	if ( initialFormAction === 'otp' && window?.newspackReaderActivation?.getOTPTimeRemaining() <= 0 ) {
-		container.setFormAction( 'signin' );
-	}
+	onAuthFormReady( () => {
+		container.setFormAction( initialFormAction, true );
+		// Default to signin action if otp and timer has expired.
+		if ( initialFormAction === 'otp' && window?.newspackReaderActivation?.getOTPTimeRemaining() <= 0 ) {
+			container.setFormAction( 'signin' );
+		}
+	} );
+
 	document.body.classList.add( 'newspack-signin' );
 	document.body.style.overflow = 'hidden';
 	modal.setAttribute( 'data-state', 'open' );

--- a/src/reader-activation/index.js
+++ b/src/reader-activation/index.js
@@ -10,6 +10,7 @@ import overlays from './overlays.js';
 import initAnalytics from './analytics.js';
 import setupArticleViewsAggregates from './article-view.js';
 import initSubscriptionTiersForm from './subscription-tiers-form.js';
+import { openAuthModal as _openAuthModal } from '../reader-activation-auth/auth-modal.js';
 
 /**
  * Reader Activation Library.
@@ -144,27 +145,24 @@ const authStrategies = [ 'pwd', 'link' ];
  * @param {Object} config Config.
  */
 export function openAuthModal( config = {} ) {
-	// Set default config.
 	config = {
-		...{
-			onSuccess: null,
-			onDismiss: null,
-			onError: null,
-			initialState: null,
-			skipSuccess: false,
-			skipNewslettersSignup: false,
-			labels: {
-				signin: {
-					title: window.newspack_reader_activation_labels.signin.title,
-				},
-				register: {
-					title: window.newspack_reader_activation_labels.register.title,
-				},
+		onSuccess: null,
+		onDismiss: null,
+		onError: null,
+		initialState: null,
+		skipSuccess: false,
+		skipNewslettersSignup: false,
+		labels: {
+			signin: {
+				title: window.newspack_reader_activation_labels.signin.title,
 			},
-			content: null,
-			trigger: null,
-			closeOnSuccess: true,
+			register: {
+				title: window.newspack_reader_activation_labels.register.title,
+			},
 		},
+		content: null,
+		trigger: null,
+		closeOnSuccess: true,
 		...config,
 	};
 
@@ -174,14 +172,7 @@ export function openAuthModal( config = {} ) {
 		}
 		return;
 	}
-	if ( readerActivation._openAuthModal ) {
-		readerActivation._openAuthModal( config );
-	} else {
-		console.warn( 'Authentication modal not available' ); // eslint-disable-line no-console
-		if ( config.onError && typeof config.onError === 'function' ) {
-			config.onError();
-		}
-	}
+	_openAuthModal( config );
 }
 
 /**

--- a/src/reader-activation/index.js
+++ b/src/reader-activation/index.js
@@ -155,10 +155,10 @@ export function openAuthModal( config = {} ) {
 			skipNewslettersSignup: false,
 			labels: {
 				signin: {
-					title: null,
+					title: window.newspack_reader_activation_labels.signin.title,
 				},
 				register: {
-					title: null,
+					title: window.newspack_reader_activation_labels.register.title,
 				},
 			},
 			content: null,

--- a/src/reader-activation/subscription-tiers-form.js
+++ b/src/reader-activation/subscription-tiers-form.js
@@ -28,16 +28,41 @@ window.newspackRAS = window.newspackRAS || [];
 
 export default function init() {
 	domReady( () => {
-		// Remove modal query params from the URL.
 		const params = new URLSearchParams( window.location.search );
 		const isSwitchingSubscription = params.get( 'upgrade-subscription' ) || params.get( 'switch' );
+
+		// Remove modal query params from the URL.
 		if ( params.get( 'upgrade-subscription' ) || params.get( 'tiers-modal' ) || params.get( 'switch' ) ) {
-			params.delete( 'upgrade-subscription' );
-			params.delete( 'tiers-modal' );
-			params.delete( 'switch' );
-			const newQueryString = params.toString() ? '?' + params.toString() : '';
+			const newParams = new URLSearchParams( params );
+			newParams.delete( 'upgrade-subscription' );
+			newParams.delete( 'tiers-modal' );
+			newParams.delete( 'switch' );
+			const newQueryString = newParams.toString() ? '?' + newParams.toString() : '';
 			window.history.replaceState( {}, '', window.location.pathname + newQueryString );
 		}
+
+		// Handle authentication flow for switching subscriptions.
+		window.newspackRAS.push( ras => {
+			const reader = ras.getReader();
+			if ( isSwitchingSubscription && ! reader?.authenticated ) {
+				ras.openAuthModal( {
+					labels: {
+						signin: {
+							title: window.newspack_reader_activation_labels.sign_in_to_upgrade,
+						},
+						register: {
+							title: window.newspack_reader_activation_labels.register_to_upgrade,
+						},
+					},
+					skipSuccess: true,
+					skipNewslettersSignup: true,
+					closeOnSuccess: false,
+					onSuccess: () => {
+						window.location.href = window.location.pathname + '?' + params.toString();
+					},
+				} );
+			}
+		} );
 
 		const forms = document.querySelectorAll( '.newspack__subscription-tiers__form' );
 		if ( ! forms.length ) {

--- a/src/reader-activation/subscription-tiers-form.js
+++ b/src/reader-activation/subscription-tiers-form.js
@@ -158,6 +158,7 @@ export default function init() {
 					}
 					window.newspackRAS.push( ras => {
 						ras.openAuthModal( {
+							skipSuccess: true,
 							skipNewslettersSignup: true,
 							onSuccess: () => {
 								// Append the 'tiers-modal' query param to the URL.

--- a/src/reader-activation/subscription-tiers-form.js
+++ b/src/reader-activation/subscription-tiers-form.js
@@ -24,6 +24,8 @@ function handleCheckoutClose( completed ) {
 	} );
 }
 
+window.newspackRAS = window.newspackRAS || [];
+
 export default function init() {
 	domReady( () => {
 		const forms = document.querySelectorAll( '.newspack__subscription-tiers__form' );
@@ -135,12 +137,47 @@ export default function init() {
 					onClose: () => handleCheckoutClose( completed ),
 				} );
 			} );
+
+			const signinLink = form.querySelector( '.signin-link' );
+			if ( signinLink ) {
+				signinLink.addEventListener( 'click', ev => {
+					ev.preventDefault();
+					if ( modal ) {
+						modal.setAttribute( 'data-state', 'closed' );
+					}
+					window.newspackRAS.push( ras => {
+						ras.openAuthModal( {
+							labels: {
+								signin: {
+									title: null,
+								},
+								register: {
+									title: null,
+								},
+							},
+							skipNewslettersSignup: true,
+							onSuccess: () => {
+								// Append the 'tiers-modal' query param to the URL.
+								const params = new URLSearchParams( window.location.search );
+								params.set( 'tiers-modal', form.dataset.productId || '' );
+								window.location.href = window.location.pathname + '?' + params.toString();
+							},
+							onDismiss: () => {
+								if ( modal ) {
+									modal.setAttribute( 'data-state', 'open' );
+								}
+							},
+						} );
+					} );
+				} );
+			}
 		} );
 
 		// Remove the `upgrade-subscription` query param from the URL.
 		const params = new URLSearchParams( window.location.search );
-		if ( params.get( 'upgrade-subscription' ) ) {
+		if ( params.get( 'upgrade-subscription' ) || params.get( 'tiers-modal' ) ) {
 			params.delete( 'upgrade-subscription' );
+			params.delete( 'tiers-modal' );
 			const newQueryString = params.toString() ? '?' + params.toString() : '';
 			window.history.replaceState( {}, '', window.location.pathname + newQueryString );
 		}

--- a/src/reader-activation/subscription-tiers-form.js
+++ b/src/reader-activation/subscription-tiers-form.js
@@ -28,6 +28,17 @@ window.newspackRAS = window.newspackRAS || [];
 
 export default function init() {
 	domReady( () => {
+		// Remove modal query params from the URL.
+		const params = new URLSearchParams( window.location.search );
+		const isSwitchingSubscription = params.get( 'upgrade-subscription' ) || params.get( 'switch' );
+		if ( params.get( 'upgrade-subscription' ) || params.get( 'tiers-modal' ) || params.get( 'switch' ) ) {
+			params.delete( 'upgrade-subscription' );
+			params.delete( 'tiers-modal' );
+			params.delete( 'switch' );
+			const newQueryString = params.toString() ? '?' + params.toString() : '';
+			window.history.replaceState( {}, '', window.location.pathname + newQueryString );
+		}
+
 		const forms = document.querySelectorAll( '.newspack__subscription-tiers__form' );
 		if ( ! forms.length ) {
 			return;
@@ -158,9 +169,12 @@ export default function init() {
 							skipNewslettersSignup: true,
 							onSuccess: () => {
 								// Append the 'tiers-modal' query param to the URL.
-								const params = new URLSearchParams( window.location.search );
-								params.set( 'tiers-modal', form.dataset.productId || '' );
-								window.location.href = window.location.pathname + '?' + params.toString();
+								const urlParams = new URLSearchParams( window.location.search );
+								urlParams.set( 'tiers-modal', form.dataset.productId || '' );
+								if ( isSwitchingSubscription ) {
+									urlParams.set( 'switch', '1' );
+								}
+								window.location.href = window.location.pathname + '?' + urlParams.toString();
 							},
 							onDismiss: () => {
 								if ( modal ) {
@@ -172,14 +186,5 @@ export default function init() {
 				} );
 			}
 		} );
-
-		// Remove the `upgrade-subscription` query param from the URL.
-		const params = new URLSearchParams( window.location.search );
-		if ( params.get( 'upgrade-subscription' ) || params.get( 'tiers-modal' ) ) {
-			params.delete( 'upgrade-subscription' );
-			params.delete( 'tiers-modal' );
-			const newQueryString = params.toString() ? '?' + params.toString() : '';
-			window.history.replaceState( {}, '', window.location.pathname + newQueryString );
-		}
 	} );
 }

--- a/src/reader-activation/subscription-tiers-form.js
+++ b/src/reader-activation/subscription-tiers-form.js
@@ -160,10 +160,10 @@ export default function init() {
 						ras.openAuthModal( {
 							labels: {
 								signin: {
-									title: null,
+									title: window.newspack_reader_activation_labels.signin.title,
 								},
 								register: {
-									title: null,
+									title: window.newspack_reader_activation_labels.register.title,
 								},
 							},
 							skipNewslettersSignup: true,

--- a/src/reader-activation/subscription-tiers-form.js
+++ b/src/reader-activation/subscription-tiers-form.js
@@ -158,14 +158,6 @@ export default function init() {
 					}
 					window.newspackRAS.push( ras => {
 						ras.openAuthModal( {
-							labels: {
-								signin: {
-									title: window.newspack_reader_activation_labels.signin.title,
-								},
-								register: {
-									title: window.newspack_reader_activation_labels.register.title,
-								},
-							},
 							skipNewslettersSignup: true,
 							onSuccess: () => {
 								// Append the 'tiers-modal' query param to the URL.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

NPPD-958

Implements a Sign In button in subscription tiers modals:

<img width="468" height="533" alt="image" src="https://github.com/user-attachments/assets/30bde53e-32ea-4b0d-9351-73bc3f12ceba" />

<img width="451" height="580" alt="image" src="https://github.com/user-attachments/assets/bcbff136-db20-448b-8c6d-a1bf4f8c046a" />

This allows the modal to be aware of the reader's existing subscriptions from the start, properly handling subscription switches.

### How to test the changes in this Pull Request:

1. Setup a primary subscription product in Audience -> Subscriptions
2. In a fresh session, go through the `?upgrade-subscription=1` link flow and purchase the subscription with a new email
3. Reset your session, go to the upgrade link again, and Sign In via the modal button
4. Confirm that after signing in, you get the upgrade modal again, but it allows you to upgrade instead of a new purchase
5. Edit a page and add Checkout Button blocks targeting a Grouped Product and a Variable Subscription
6. In a fresh session, go through each checkout button flow and confirm you can sign in and continue the flow

**Note: There's an ongoing discussion in NPPD-959 about re-purchasing a grouped product sibling. This is not covered in this hotfix PR and will be handled separately.**

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->