### PR TITLE
fix: remove <br> from Collections meta in the grid layout [NPPM-2345]

### DIFF
--- a/src/blocks/collections/class-collections-block.php
+++ b/src/blocks/collections/class-collections-block.php
@@ -358,7 +358,7 @@ final class Collections_Block {
 		// Render meta text.
 		if ( ! empty( $meta_parts ) ) {
 			// Use different separator based on layout.
-			$separator = 'list' === $attributes['layout'] ? ' <span class="wp-block-newspack-collections__divider">/</span> ' : '<br>';
+			$separator = 'list' === $attributes['layout'] ? ' <span class="wp-block-newspack-collections__divider">/</span> ' : '';
 			$meta_text = implode( $separator, $meta_parts );
 			?>
 			<div class="wp-block-newspack-collections__meta has-medium-gray-color has-text-color has-small-font-size">

--- a/src/blocks/collections/styles/_layout-grid.scss
+++ b/src/blocks/collections/styles/_layout-grid.scss
@@ -62,6 +62,10 @@
 			margin: 24px 0 0;
 			font-size: var(--newspack-theme-font-size-base);
 		}
+
+		.wp-block-newspack-collections__period {
+			display: block;
+		}
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR removes a hardcoded `<br>` from the Grid layout of the Collections.

Note that this change will have minor breaking qualities: if anyone is hiding the `.wp-block-newspack-collections__period` class, this will very likely override it because it's a strong selector (`.wp-block-newspack-collections.layout-grid .wp-block-newspack-collections__period`). 

### How to test the changes in this Pull Request:

1. Apply this PR and run `npm run build`.
2. If you haven't already, populate the 'Number', 'Volume', and 'Period' fields of at least one Collection.
3. View the main /collections page and confirm the Period is on its own line:

<img width="203" height="383" alt="CleanShot 2025-10-30 at 12 42 08" src="https://github.com/user-attachments/assets/2cdca8b8-29a3-47d9-85ad-40d8fe5258ba" />

4. View the individual Collection and confirm the 'Period' is inline with the other Collection meta (note: there's a minor visual bug in this view that may make your collection really small if it doesn't have any stories assigned-- I'm looking into fixing this in the theme since that's where it's coming from!)

<img width="549" height="258" alt="CleanShot 2025-10-30 at 12 49 36" src="https://github.com/user-attachments/assets/a45c8bfe-8f32-4d8d-94ff-11e5925a0c65" />

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->