### PR TITLE
fix: class to listen to 3rd party newsletters forms

### DIFF
--- a/src/reader-activation/index.js
+++ b/src/reader-activation/index.js
@@ -393,8 +393,10 @@ function attachAuthCookiesListener() {
  * Set the reader as newsletter subscriber once a newsletter form is submitted.
  */
 function attachNewsletterFormListener() {
-	const newspackForms = [ '.newspack-newsletters-subscribe', '.newspack-subscribe-form' ];
-	const thirdPartyForms = [ '.mc4wp-form' ];
+	const newspackForms = [ '.newspack-newsletters-subscribe' ];
+
+	// newspack-subscribe-form is a generic class that can be added to any 3rd party form. Once it's submitted, we consider the reader a newsletter subscriber.
+	const thirdPartyForms = [ '.mc4wp-form', '.newspack-subscribe-form' ];
 
 	const attachHandler = ( el, eventToListenTo = 'submit' ) => {
 		const form = 'FORM' === el.tagName ? el : el.querySelector( 'form' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a regression that made the integration with 3rd party forms break.

The `newspack-subscribe-form` is supposed to be a generic class that can be added to any 3rd party form. Once it's submitted, we consider the reader a newsletter subscriber. This is currently not working.

### How to test the changes in this Pull Request:

1. On `release`, add a third party form for example using gravity forms or plain HTML. Add the `newspack-subscribe-form` class to the form
2. As an anonymous reader, submit the form and confirm you are not flagged as newsletter subscribe
3. Checkout this branch and repeat the process. Confirm you are flagged.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->