### PR TITLE
fix: handle store.set on button click and "enter" keyup, too

### DIFF
--- a/src/reader-activation/index.js
+++ b/src/reader-activation/index.js
@@ -401,6 +401,32 @@ function attachNewsletterFormListener() {
 		if ( ! form ) {
 			return;
 		}
+
+		// Some forms may have JS form submit handlers which may prevent other form submit handlers from being called.
+		// We attach event handlers on submit button clicks and 'Enter' key presses to ensure our handler is called.
+		form.setAttribute( 'data-submitted', 'false' );
+		const submitter = ( evt, button ) => {
+			evt.preventDefault();
+			form.setAttribute( 'data-submitted', 'true' );
+			store.set( 'is_newsletter_subscriber', true );
+			form.requestSubmit( button );
+		};
+
+		const submitButtons = [ ...form.querySelectorAll( 'input[type="submit"], button[type="submit"]' ) ];
+		if ( submitButtons.length ) {
+			submitButtons.forEach( button => {
+				button.addEventListener( 'click', e => {
+					if ( 'false' === form.getAttribute( 'data-submitted' ) ) {
+						submitter( e, button );
+					}
+				} );
+			} );
+			form.addEventListener( 'keyup', e => {
+				if ( e.key === 'Enter' && 'false' === form.getAttribute( 'data-submitted' ) ) {
+					submitter( e, submitButtons[ 0 ] );
+				}
+			} );
+		}
 		form.addEventListener( eventToListenTo, () => {
 			store.set( 'is_newsletter_subscriber', true );
 		} );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Addendum to #4276 to ensure that our handler is called even if a third-party form has other event handlers attached to the form `submit` event.

### How to test the changes in this Pull Request:

Follow instructions in #4276.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->