### PR TITLE
feat(rss): change rss media hook and use CDATA on media desc

### DIFF
--- a/includes/optional-modules/class-rss.php
+++ b/includes/optional-modules/class-rss.php
@@ -1205,29 +1205,23 @@ class RSS {
 					?>
 					<media:content type="<?php echo esc_attr( get_post_mime_type( $thumbnail_id ) ); ?>" url="<?php echo esc_url( $media_url ); ?>">
 						<?php if ( ! empty( $caption ) ) : ?>
-						<media:description><?php echo esc_html( $caption ); ?></media:description>
+						<media:description><![CDATA[<?php echo esc_html( $caption ); ?>]]></media:description>
 						<?php endif; ?>
 						<media:thumbnail url="<?php echo esc_url( $media_url ); ?>" width="<?php echo esc_attr( $thumbnail_data[1] ); ?>" height="<?php echo esc_attr( $thumbnail_data[2] ); ?>" />
+						<?php
+						/**
+						 * Fires inside the media:content element.
+						 *
+						 * @param int         $thumbnail_id   The attachment post ID.
+						 * @param array|false $thumbnail_data Array with [url, width, height] or false.
+						 * @param string      $caption        The image caption from get_the_post_thumbnail_caption().
+						 * @param array       $settings       The feed settings array.
+						 * @param WP_Post     $post           The current post object.
+						 */
+						do_action( 'newspack_rss_media_content', $thumbnail_id, $thumbnail_data, $caption, $settings, $post );
+						?>
 					</media:content>
 					<?php
-					/**
-					 * Fires after the media:content element to allow adding extra media elements.
-					 *
-					 * Use this to add custom media elements like <media:credit>, <media:copyright>, etc.
-					 *
-					 * Example:
-					 *     $credit = get_post_meta( $thumbnail_id, '_media_credit', true );
-					 *     if ( $credit ) {
-					 *         echo '<media:credit><![CDATA[' . esc_html( $credit ) . ']]></media:credit>';
-					 *     }
-					 *
-					 * @param int          $thumbnail_id   The attachment post ID.
-					 * @param array|false  $thumbnail_data Array with [url, width, height] or false.
-					 * @param string       $caption        The image caption from get_the_post_thumbnail_caption().
-					 * @param array        $settings       The feed settings array.
-					 * @param WP_Post      $post           The current post object.
-					 */
-					do_action( 'newspack_rss_after_media_content', $thumbnail_id, $thumbnail_data, $caption, $settings, $post );
 				}
 			}
 		}

--- a/tests/unit-tests/rss.php
+++ b/tests/unit-tests/rss.php
@@ -1185,8 +1185,7 @@ class Newspack_Test_RSS extends WP_UnitTestCase {
 		add_filter( 'newspack_rss_image_size', $image_size_filter, 10, 3 );
 		add_filter( 'wp_get_attachment_image_src', $image_src_tracker, 10, 3 );
 		add_filter( 'newspack_rss_media_content_url', $media_url_filter, 10, 4 );
-
-		add_action( 'newspack_rss_after_media_content', [ $media_action, 'action' ], 10, 5 );
+		add_action( 'newspack_rss_media_content', [ $media_action, 'action' ], 10, 5 );
 		add_action( 'newspack_rss_after_extra_tags', [ $after_action, 'action' ], 10, 2 );
 
 		$output = $this->render_extra_tags_for_post(
@@ -1199,7 +1198,7 @@ class Newspack_Test_RSS extends WP_UnitTestCase {
 		remove_filter( 'newspack_rss_image_size', $image_size_filter, 10 );
 		remove_filter( 'wp_get_attachment_image_src', $image_src_tracker, 10 );
 		remove_filter( 'newspack_rss_media_content_url', $media_url_filter, 10 );
-		remove_action( 'newspack_rss_after_media_content', [ $media_action, 'action' ], 10 );
+		remove_action( 'newspack_rss_media_content', [ $media_action, 'action' ], 10 );
 		remove_action( 'newspack_rss_after_extra_tags', [ $after_action, 'action' ], 10 );
 
 		$this->assertTrue( $image_size_filtered, 'Expected image size filter to be applied for media tags.' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR is a follow-up to #4231 and accomplishes two things:

- Changes `newspack_rss_after_media_content` action to `newspack_rss_media_content` to be able to include additional tags **_inside_** the `<media:content>`. The previous hook was only able to insert content after, which can already be accomplished via `newspack_rss_after_extra_tags`.
- Wraps `<media:description>` content in `<![CDATA[*]]>`.

Closes NPPD-929.

### How to test the changes in this Pull Request:

1. Follow the same test steps from #4231 in regards to the extra markup.
2. But in this case, check that any extra output added by the `newspack_rss_media_content` action appears within the `<media:content>` tag.
3. If there's a `<media:description>` present, it should be wrapped with CDATA. That description comes from a call to [get_the_post_thumbnail_caption()](https://developer.wordpress.org/reference/functions/get_the_post_thumbnail_caption/) on the attachment.
4. Check that the unit tests continue working.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?