### PR TITLE
fix(ga4): always send reader-related custom params

### DIFF
--- a/includes/plugins/google-site-kit/class-googlesitekit.php
+++ b/includes/plugins/google-site-kit/class-googlesitekit.php
@@ -244,22 +244,21 @@ class GoogleSiteKit {
 			$params['categories'] = implode( ', ', $category_names );
 		}
 
-		$params['is_reader'] = 'no';
-		if ( is_user_logged_in() ) {
-			$current_user = wp_get_current_user();
-			$params['is_reader'] = Reader_Activation::is_user_reader( $current_user ) ? 'yes' : 'no';
+		$current_user = wp_get_current_user();
+		$is_logged_in = 0 < $current_user->ID;
+		$params['is_reader'] = $is_logged_in && Reader_Activation::is_user_reader( $current_user ) ? 'yes' : 'no';
+		if ( ! empty( $current_user->user_email ) ) {
 			$params['email_hash'] = md5( $current_user->user_email );
-
-			if ( method_exists( 'Newspack\Reader_Data', 'get_data' ) ) {
-				$reader_data = \Newspack\Reader_Data::get_data( get_current_user_id() );
-				// If the reader is signed up for any newsletters.
-				$params['is_newsletter_subscriber'] = empty( $reader_data['is_newsletter_subscriber'] ) ? 'no' : 'yes';
-				// If reader has donated.
-				$params['is_donor'] = empty( $reader_data['is_donor'] ) ? 'no' : 'yes';
-				// If reader has any currently active non-donation subscriptions.
-				$params['is_subscriber'] = empty( $reader_data['active_subscriptions'] ) ? 'no' : 'yes';
-			}
 		}
+
+		$reader_data = method_exists( 'Newspack\Reader_Data', 'get_data' ) ? Reader_Data::get_data( $current_user->ID ) : [];
+
+		// If the reader is signed up for any newsletters.
+		$params['is_newsletter_subscriber'] = empty( $reader_data['is_newsletter_subscriber'] ) ? 'no' : 'yes';
+		// If reader has donated.
+		$params['is_donor'] = empty( $reader_data['is_donor'] ) ? 'no' : 'yes';
+		// If reader has any currently active non-donation subscriptions.
+		$params['is_subscriber'] = empty( $reader_data['active_subscriptions'] ) ? 'no' : 'yes';
 
 		/**
 		 * Filters the custom parameters passed to GA4.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Ensures that GA4 custom parameters describing the reader's status are always sent with every event. This ensures these parameters will always have a value of `yes` or `no` instead of sometimes having a value of `(not set)` (which essentially means the same thing as `no`) when the parameter isn't included with certain events.

Note that this change means that these parameters will be sent with every GA4 for any site with the `NEWSPACK_GA_ENABLE_CUSTOM_FE_PARAMS` environment variable defined. Even if Audience Management features aren't enabled for the site, these parameters will be sent with `no` values.

Closes NPPM-2371.

### How to test the changes in this Pull Request:

1. Make sure your test site is connected to a GA4 account via Google Site Kit and has completed Audience Management setup. Check out this branch.
2. If not already defined, add `define( 'NEWSPACK_GA_ENABLE_CUSTOM_FE_PARAMS', true );` to wp-config.php.
3. In a new browser session, visit the site as a non-logged-in reader.
4. Using Tag Assistant or the dev tools Network tab to inspect `collect` requests, confirm that all GA4 events have `is_reader`, `is_newsletter_subscriber`, `is_donor`, and `is_subscriber` parameters with a value of `no`.

<img width="357" height="236" alt="Screenshot 2025-11-04 at 10 29 23 AM" src="https://github.com/user-attachments/assets/324e0445-daba-405d-9547-cfe3b502cfa4" />

5. Log into or register a reader account. Confirm that the `is_reader` param is now sent with a `yes` value.
6. Sign up for newsletters, complete a donation transaction, and purchase a subscription product. After each action, confirm that the corresponding parameter value gets sent with `yes` for subsequent events.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->