### PR TITLE
fix(newspack-ui): remove margin-top for helper text when inside input-card

### DIFF
--- a/src/newspack-ui/scss/elements/forms/_labels.scss
+++ b/src/newspack-ui/scss/elements/forms/_labels.scss
@@ -42,6 +42,10 @@
 				+ .newspack-ui__input-card {
 					margin-top: calc(var(--newspack-ui-spacer-2) * -1);
 				}
+
+				.newspack-ui__helper-text {
+					margin-top: 0;
+				}
 			}
 
 			// 'Selected' badge


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Small fix that removes the 8px margin-top that the helper text has by default when it's inside an input-card

__Before:__
<img width="784" height="500" alt="" src="https://github.com/user-attachments/assets/84b0d980-d7dd-456b-a5c2-1642de4ad979" />

__After:__
<img width="782" height="478" alt="" src="https://github.com/user-attachments/assets/b9a076bb-fb6e-40cb-b4d1-fd3d42fe054c" />

### How to test the changes in this Pull Request:

1. Open a checkout modal with an input-card, notice gap between price and title
2. Switch to this branch
3. Refresh page and notice gap is gone

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->