### PR TITLE
feat(variation-modal): display variation description

### DIFF
--- a/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
+++ b/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
@@ -391,7 +391,8 @@ class Subscriptions_Tiers {
 			$price = $product->get_price_html();
 		}
 
-		$description = $product->get_description();
+		$should_render_description = ! defined( 'NEWSPACK_DISABLE_SUBSCRIPTION_DESCRIPTION' ) || ! NEWSPACK_DISABLE_SUBSCRIPTION_DESCRIPTION;
+		$description               = $product->get_description();
 
 		?>
 		<label class="newspack-ui__input-card <?php echo $current ? esc_attr( 'current' ) : ''; ?>">
@@ -400,7 +401,7 @@ class Subscriptions_Tiers {
 			<?php endif; ?>
 			<input type="radio" name="product_id" value="<?php echo esc_attr( $product->get_id() ); ?>" <?php echo esc_attr( $selected ? 'checked' : '' ); ?>>
 			<strong><?php echo esc_html( self::get_product_title( $product, $show_variation_attributes ) ); ?></strong>
-			<?php if ( $description ) : ?>
+			<?php if ( $should_render_description && $description ) : ?>
 				<span class="newspack-ui__helper-text"><?php echo $description; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></span>
 			<?php endif; ?>
 			<span class="newspack-ui__helper-text"><?php echo $price; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></span>

--- a/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
+++ b/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
@@ -391,6 +391,8 @@ class Subscriptions_Tiers {
 			$price = $product->get_price_html();
 		}
 
+		$description = $product->get_description();
+
 		?>
 		<label class="newspack-ui__input-card <?php echo $current ? esc_attr( 'current' ) : ''; ?>">
 			<?php if ( $current ) : ?>
@@ -398,6 +400,9 @@ class Subscriptions_Tiers {
 			<?php endif; ?>
 			<input type="radio" name="product_id" value="<?php echo esc_attr( $product->get_id() ); ?>" <?php echo esc_attr( $selected ? 'checked' : '' ); ?>>
 			<strong><?php echo esc_html( self::get_product_title( $product, $show_variation_attributes ) ); ?></strong>
+			<?php if ( $description ) : ?>
+				<span class="newspack-ui__helper-text"><?php echo $description; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></span>
+			<?php endif; ?>
 			<span class="newspack-ui__helper-text"><?php echo $price; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></span>
 		</label>
 		<?php


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

NPPM-2370

Variation attributes are no longer part of the variation modal, which can be problematic for anything outside of frequency-based variations.

This PR implements rendering the variation description in the variation and subscription tiers modals:

<img width="819" height="983" alt="image" src="https://github.com/user-attachments/assets/a8ec95f8-6233-4566-a6b8-c63b383e490a" />

<img width="465" height="697" alt="image" src="https://github.com/user-attachments/assets/e2694200-58d3-45f2-8802-f187c56826b8" />


### How to test the changes in this Pull Request:

1. Create a variable subscription product in which all variations share the same frequency setup
2. Edit each variation to have descriptions
3. Add a Checkout Button targeting the new product and allowing readers to select the variation
4. Visit the page and start the flow
5. Confirm the description renders for each option

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->