### PR TITLE
hotfix: limit free trial purchases to 1 per user

### DIFF
--- a/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
+++ b/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
@@ -18,6 +18,7 @@ class WooCommerce_Subscriptions {
 	 */
 	public static function init() {
 		add_action( 'plugins_loaded', [ __CLASS__, 'woocommerce_subscriptions_integration_init' ] );
+		add_filter( 'woocommerce_subscriptions_product_limited_for_user', [ __CLASS__, 'maybe_limit_subscription_product_for_user' ], 10, 3 );
 	}
 
 	/**
@@ -97,6 +98,26 @@ class WooCommerce_Subscriptions {
 		 * @param string $frequency Frequency.
 		 */
 		return apply_filters( 'newspack_subscriptions_frequency_label', $label, $frequency );
+	}
+
+	/**
+	 * Maybe limit the subscription product for user.
+	 *
+	 * @param bool           $is_limited_for_user Whether the subscription product is limited for user.
+	 * @param int|WC_Product $product A WC_Product object or the ID of a product.
+	 * @param int            $user_id The user ID.
+	 */
+	public static function maybe_limit_subscription_product_for_user( $is_limited_for_user, $product, $user_id ) {
+		if ( ! $is_limited_for_user ) {
+			$product_id            = $product->get_id();
+			$is_free_trial_product = class_exists( 'WC_Subscriptions_Product' ) && \WC_Subscriptions_Product::get_trial_length( $product_id ) > 0;
+			$product_limitation    = \wcs_get_product_limitation( $product );
+			if ( $is_free_trial_product && 'active' === $product_limitation ) {
+				$is_limited_for_user = \wcs_user_has_subscription( $user_id, $product->get_id(), [ 'cancelled', 'on-hold', 'pending', 'pending-cancel' ] );
+			}
+		}
+
+		return $is_limited_for_user;
 	}
 }
 WooCommerce_Subscriptions::init();

--- a/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
+++ b/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
@@ -110,8 +110,15 @@ class WooCommerce_Subscriptions {
 	 * @param int            $user_id The user ID.
 	 */
 	public static function maybe_limit_subscription_product_for_user( $is_limited_for_user, $product, $user_id ) {
-		if ( ! $is_limited_for_user && 'active' === \wcs_get_product_limitation( $product ) ) {
+		$product_limitation = \wcs_get_product_limitation( $product );
+		if ( ! $is_limited_for_user && 'active' === $product_limitation ) {
 			$is_limited_for_user = \wcs_user_has_subscription( $user_id, $product->get_id(), [ 'active', 'on-hold', 'pending', 'pending-cancel' ] );
+		}
+
+		// Use custom error messaging if available.
+		if ( $is_limited_for_user && method_exists( 'Newspack_Blocks\Modal_Checkout', 'get_subscription_limited_message' ) && method_exists( 'Newspack_Blocks\Modal_Checkout', 'get_subscription_limited_message_any' ) ) {
+			$callback = 'active' === $product_limitation ? 'get_subscription_limited_message' : 'get_subscription_limited_message_any';
+			add_filter( 'woocommerce_cart_item_removed_message', [ 'Newspack_Blocks\Modal_Checkout', $callback ] );
 		}
 		return $is_limited_for_user;
 	}

--- a/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
+++ b/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
@@ -133,6 +133,17 @@ class WooCommerce_Subscriptions {
 	 */
 	public static function limit_free_trials_to_one_per_user( $trial_length, $product ) {
 		$user_id = get_current_user_id();
+
+		// If not logged in, try to get the user ID from the billing email.
+		if ( ! $user_id ) {
+			$billing_email = filter_input( INPUT_POST, 'billing_email', FILTER_SANITIZE_EMAIL );
+			if ( $billing_email ) {
+				$customer = \get_user_by( 'email', $billing_email );
+				if ( $customer ) {
+					$user_id = $customer->ID;
+				}
+			}
+		}
 		if ( $trial_length && $user_id && $product && $product->is_type( [ 'subscription', 'subscription_variation', 'variable-subscription' ] ) ) {
 			$user_subscriptions = array_values( \wcs_get_users_subscriptions( $user_id ) );
 			foreach ( $user_subscriptions as $subscription ) {

--- a/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
+++ b/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
@@ -135,14 +135,8 @@ class WooCommerce_Subscriptions {
 		$user_id = get_current_user_id();
 
 		// If not logged in, try to get the user ID from the billing email.
-		if ( ! $user_id ) {
-			$billing_email = filter_input( INPUT_POST, 'billing_email', FILTER_SANITIZE_EMAIL );
-			if ( $billing_email ) {
-				$customer = \get_user_by( 'email', $billing_email );
-				if ( $customer ) {
-					$user_id = $customer->ID;
-				}
-			}
+		if ( ! $user_id && method_exists( 'Newspack_Blocks\Modal_Checkout', 'get_user_id_from_email' ) ) {
+			$user_id = \Newspack_Blocks\Modal_Checkout::get_user_id_from_email();
 		}
 		if ( $trial_length && $user_id && $product && $product->is_type( [ 'subscription', 'subscription_variation', 'variable-subscription' ] ) ) {
 			$user_subscriptions = array_values( \wcs_get_users_subscriptions( $user_id ) );

--- a/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
+++ b/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
@@ -19,6 +19,7 @@ class WooCommerce_Subscriptions {
 	public static function init() {
 		add_action( 'plugins_loaded', [ __CLASS__, 'woocommerce_subscriptions_integration_init' ] );
 		add_filter( 'woocommerce_subscriptions_product_limited_for_user', [ __CLASS__, 'maybe_limit_subscription_product_for_user' ], 10, 3 );
+		add_filter( 'woocommerce_subscriptions_product_trial_length', [ __CLASS__, 'limit_free_trials_to_one_per_user' ], 10, 2 );
 	}
 
 	/**
@@ -101,23 +102,40 @@ class WooCommerce_Subscriptions {
 	}
 
 	/**
-	 * Maybe limit the subscription product for user.
+	 * Maybe limit the subscription product for user. If the product is limited to one active
+	 * subscription per user, treat on-hold, pending, and pending-cancel statuses as active.
 	 *
 	 * @param bool           $is_limited_for_user Whether the subscription product is limited for user.
 	 * @param int|WC_Product $product A WC_Product object or the ID of a product.
 	 * @param int            $user_id The user ID.
 	 */
 	public static function maybe_limit_subscription_product_for_user( $is_limited_for_user, $product, $user_id ) {
-		if ( ! $is_limited_for_user ) {
-			$product_id            = $product->get_id();
-			$is_free_trial_product = class_exists( 'WC_Subscriptions_Product' ) && \WC_Subscriptions_Product::get_trial_length( $product_id ) > 0;
-			$product_limitation    = \wcs_get_product_limitation( $product );
-			if ( $is_free_trial_product && 'active' === $product_limitation ) {
-				$is_limited_for_user = \wcs_user_has_subscription( $user_id, $product->get_id(), [ 'cancelled', 'on-hold', 'pending', 'pending-cancel' ] );
+		if ( ! $is_limited_for_user && 'active' === \wcs_get_product_limitation( $product ) ) {
+			$is_limited_for_user = \wcs_user_has_subscription( $user_id, $product->get_id(), [ 'active', 'on-hold', 'pending', 'pending-cancel' ] );
+		}
+		return $is_limited_for_user;
+	}
+
+	/**
+	 * Limit free trial purchases to one per user. If the user already has a subscription of any status,
+	 * return 0 to force no free trial period during checkout for this product.
+	 *
+	 * @param int        $trial_length The trial length.
+	 * @param WC_Product $product The product.
+	 * @return int The trial length.
+	 */
+	public static function limit_free_trials_to_one_per_user( $trial_length, $product ) {
+		$user_id = get_current_user_id();
+		if ( $trial_length && $user_id && $product && $product->is_type( [ 'subscription', 'subscription_variation', 'variable-subscription' ] ) ) {
+			$user_subscriptions = array_values( \wcs_get_users_subscriptions( $user_id ) );
+			foreach ( $user_subscriptions as $subscription ) {
+				if ( $subscription->has_product( $product->get_id() ) ) {
+					return 0;
+				}
 			}
 		}
 
-		return $is_limited_for_user;
+		return $trial_length;
 	}
 }
 WooCommerce_Subscriptions::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds filters to limit free trial subscriptions to one per user. Also looks for existing subscriptions with `pending` and `pending-cancel` statuses when determining whether a product with a limit of 1 active subscription per user can be purchased, as these statuses can transition to `active` via user action and are also considered "active" by the Memberships plugin.

Note that these changes have been proposed as an upstream fix in the WooCommerce Subscriptions plugin. If it gets merged and deployed to the Subscriptions plugin, we can deprecate the changes in this plugin.

See also https://github.com/Automattic/newspack-blocks/pull/2245

Closes NPPM-2302.

### How to test the changes in this Pull Request:

Check out this PR and https://github.com/Automattic/newspack-blocks/pull/2245. Follow testing instructions in https://github.com/woocommerce/woocommerce-subscriptions/pull/5181.

After the above, also test the following Newspack-specific features:

1. Attach the product to a Checkout Button block and start the transaction from there. When the product purchase is limited because you're logged into a reader account with an active (or `on-hold` or `pending-cancel`) subscription, confirm that the custom error message from https://github.com/Automattic/newspack-blocks/issues/2202 is shown instead of Woo's default "<product> has been removed from your cart because it can no longer be purchased" message.
2. Start a new session as an anonymous reader. Start checkout from the Checkout Button block and enter the email address for the same test reader account you've been using to test. Confirm that you're unable to complete checkout and that the custom error message is shown:

<img width="712" height="793" alt="Screenshot 2025-11-05 at 3 24 10 PM" src="https://github.com/user-attachments/assets/02425b8d-2ee4-4335-bb37-abba99059b06" />

3. As an admin, remove the setting to limit the product to 1 active subscription per user.
4. Log in as a reader who has a subscription of any status with the free product trial and start a transaction from the Checkout Button.
5. Confirm that you're able to complete the purchase at full price in the modal checkout, but that the product summary at the top of the modal and the transaction details before the final submit button both don't mention any free trial.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->