### PR TITLE
fix(stripe-gateway): disable Link by default on new installs

### DIFF
--- a/includes/plugins/class-woocommerce-gateway-stripe.php
+++ b/includes/plugins/class-woocommerce-gateway-stripe.php
@@ -169,17 +169,12 @@ class WooCommerce_Gateway_Stripe {
 		}
 
 		// Disable Link by Stripe for new installs.
-		if (
-			is_array( $settings['upe_checkout_experience_accepted_payments'] ) &&
-			! empty( $settings['upe_checkout_experience_accepted_payments'] ) &&
-			in_array( 'link', $settings['upe_checkout_experience_accepted_payments'], true )
-		) {
-			$settings['upe_checkout_experience_accepted_payments'] = array_diff(
-				$settings['upe_checkout_experience_accepted_payments'],
-				[ 'link' ]
-			);
+		$option_names = [ 'upe_checkout_experience_accepted_payments', 'stripe_upe_payment_method_order' ];
+		foreach ( $option_names as $option_name ) {
+			if ( is_array( $settings[ $option_name ] ) && ! empty( $settings[ $option_name ] ) && in_array( 'link', $settings[ $option_name ], true ) ) {
+				$settings[ $option_name ] = array_diff( $settings[ $option_name ], [ 'link' ] );
+			}
 		}
-
 		return $settings;
 	}
 }

--- a/includes/plugins/class-woocommerce-gateway-stripe.php
+++ b/includes/plugins/class-woocommerce-gateway-stripe.php
@@ -18,13 +18,8 @@ class WooCommerce_Gateway_Stripe {
 	 * Initialize hooks and filters.
 	 */
 	public static function init() {
-		/**
-		 * Disable Stripe Express Checkout feature flags.
-		 * This is a workaround for the Stripe Express Checkout feature flags
-		 * being enabled by default on new installs.
-		 */
-		add_filter( 'pre_update_option__wcstripe_feature_ece', [ __CLASS__, 'disable_express_checkout_feature_flag' ], 9, 2 );
-		add_filter( 'pre_update_option_woocommerce_stripe_settings', [ __CLASS__, 'disable_express_checkout_in_main_settings' ], 11, 2 );
+		add_filter( 'wc_stripe_settings', [ __CLASS__, 'disable_express_checkout_by_default' ] );
+		add_filter( 'pre_update_option_woocommerce_stripe_settings', [ __CLASS__, 'disable_link_by_default' ], 11, 2 );
 
 		add_filter( 'wc_stripe_generate_payment_request', [ __CLASS__, 'add_payment_request_metadata' ], 10, 2 );
 		add_filter( 'wc_stripe_intent_metadata', [ __CLASS__, 'add_intent_metadata' ], 10, 2 );
@@ -134,46 +129,47 @@ class WooCommerce_Gateway_Stripe {
 	 * Disable Stripe Express Checkout feature flag.
 	 *
 	 * @param array $flag Stripe Express Checkout feature flag.
-	 * @param array $old_value Old Stripe Express Checkout feature flag.
+	 * @param array $old_settings Old Stripe Express Checkout feature flag.
 	 * @return string
 	 */
-	public static function disable_express_checkout_feature_flag( $flag, $old_value ) {
+	public static function disable_express_checkout_feature_flag( $flag, $old_settings ) {
 		/**
 		 * If the Stripe Express Checkout feature flag is empty, it means this is a new install.
 		 * Save the settings as 'no' to prevent the Stripe Express Checkout from being enabled.
 		 */
-		if ( empty( $old_value ) && 'yes' === $flag ) {
+		if ( empty( $old_settings ) && 'yes' === $flag ) {
 			$flag = 'no';
 		}
 		return $flag;
 	}
 
 	/**
-	 * Disable Stripe Express Checkout in main settings.
+	 * Disable Apple/Google Pay by default.
 	 *
-	 * @param array $settings Stripe settings.
-	 * @param array $old_settings Old Stripe settings.
+	 * @param array $settings Stripe settings config.
 	 * @return array
 	 */
-	public static function disable_express_checkout_in_main_settings( $settings, $old_settings ) {
-		/**
-		 * If the old stripe settings are empty, it means this is a new install.
-		 */
-		if ( ! empty( $old_settings ) ) {
-			return $settings;
+	public static function disable_express_checkout_by_default( $settings ) {
+		if ( isset( $settings['payment_request']['default'] ) && 'yes' === $settings['payment_request']['default'] ) {
+			$settings['payment_request']['default'] = 'no';
 		}
+		return $settings;
+	}
 
-		// Disable Apple Pay/Google Pay for new installs.
-		if ( 'yes' === $settings['payment_request'] ) {
-			$settings['payment_request'] = 'no';
-		}
-
-		// Disable Link by Stripe for new installs.
-		$option_names = [ 'upe_checkout_experience_accepted_payments', 'stripe_upe_payment_method_order' ];
-		foreach ( $option_names as $option_name ) {
-			if ( is_array( $settings[ $option_name ] ) && ! empty( $settings[ $option_name ] ) && in_array( 'link', $settings[ $option_name ], true ) ) {
-				$settings[ $option_name ] = array_diff( $settings[ $option_name ], [ 'link' ] );
-			}
+	/**
+	 * Disable Stripe Link by default. This is a workaround for undoing enabling link by default for new installs.
+	 *
+	 * @param string $settings The new value of the option.
+	 * @param string $old_settings The old value of the option.
+	 */
+	public static function disable_link_by_default( $settings, $old_settings ) {
+		if (
+			! isset( $old_settings['upe_checkout_experience_accepted_payments'] ) && // Old setting is empty, so this is a new install.
+			isset( $settings['upe_checkout_experience_accepted_payments'] ) && // New setting has been set.
+			is_array( $settings['upe_checkout_experience_accepted_payments'] ) && // New setting is an array.
+			in_array( 'link', $settings['upe_checkout_experience_accepted_payments'], true ) // New setting contains 'link'.
+		) {
+			$settings['upe_checkout_experience_accepted_payments'] = array_diff( $settings['upe_checkout_experience_accepted_payments'], [ 'link' ] );
 		}
 		return $settings;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This was already done in #3918, but it looks like the sub-option name for this in the Stripe Gateway plugin has changed somewhere along the way. This PR handles the new option name as well as the old.

Closes NPPM-2295.

### How to test the changes in this Pull Request:

Make sure you're using the [latest public release of the Stripe Gateway plugin](https://github.com/woocommerce/woocommerce-gateway-stripe/releases/latest), and follow testing instructions from #3918.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->