### PR TITLE
feat(ras): implement OAuth redirect handling for RAS login

### DIFF
--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1484,7 +1484,8 @@ final class Reader_Activation {
 		$referer           = \wp_parse_url( \wp_get_referer() );
 		$labels            = self::get_reader_activation_labels( 'signin' );
 		// If there is a redirect parameter, use it as the auth callback URL.
-		$auth_callback_url = filter_input( INPUT_GET, 'redirect', FILTER_SANITIZE_URL ) ?? '#';
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$auth_callback_url = isset( $_GET['redirect'] ) ? \esc_url_raw( \wp_unslash( $_GET['redirect'] ) ) : '#';
 		if ( '#' === $auth_callback_url ) {
 			if ( Renewal::is_subscriptions_page() ) {
 				// If we are on the subscriptions page, set the auth callback URL to the subscriptions page.
@@ -1526,13 +1527,6 @@ final class Reader_Activation {
 				<input type="hidden" name="<?php echo \esc_attr( self::AUTH_FORM_ACTION ); ?>" value="1" />
 				<?php if ( ! empty( $referer['path'] ) ) : ?>
 					<input type="hidden" name="referer" value="<?php echo \esc_url( $referer['path'] ); ?>" />
-				<?php endif; ?>
-				<?php
-				// Add hidden redirect_url field if OAuth redirect is present.
-				$oauth_redirect = isset( $_GET['redirect'] ) ? \esc_url_raw( \wp_unslash( $_GET['redirect'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-				if ( ! empty( $oauth_redirect ) && self::is_oauth_redirect( $oauth_redirect ) ) :
-					?>
-					<input type="hidden" name="redirect_url" value="<?php echo \esc_attr( $oauth_redirect ); ?>" />
 				<?php endif; ?>
 				<input type="hidden" name="action" />
 				<p data-action="otp">
@@ -1832,26 +1826,6 @@ final class Reader_Activation {
 		if ( empty( $message ) ) {
 			$labels  = self::get_reader_activation_labels( 'signin' );
 			$message = $is_error ? $data->get_error_message() : $labels['success_message'];
-		}
-
-		// Add redirect_to for OAuth flows that need post-authentication redirect.
-		if ( ! $is_error && ! empty( $_POST['redirect_url'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
-			// $_POST is slashed, so unslash before sanitizing.
-			$redirect_url = \esc_url_raw( \wp_unslash( $_POST['redirect_url'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
-
-			// Validate it's a local redirect for security.
-			$redirect_host = \wp_parse_url( $redirect_url, PHP_URL_HOST );
-			$site_host     = \wp_parse_url( site_url(), PHP_URL_HOST );
-
-			if ( $redirect_host && $redirect_host === $site_host ) {
-				/**
-				 * Filters the redirect URL in the authentication response.
-				 *
-				 * @param string $redirect_url The redirect URL to include in the response.
-				 * @param array  $data         The response data array.
-				 */
-				$data['redirect_to'] = apply_filters( 'newspack_ras_auth_redirect_url', $redirect_url, $data );
-			}
 		}
 
 		\wp_send_json( compact( 'message', 'data' ), \is_wp_error( $data ) ? 400 : 200 );

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -60,6 +60,11 @@ final class Reader_Activation {
 	const SSO_REGISTRATION_METHODS = [ 'google' ];
 
 	/**
+	 * OAuth routes to intercept for RAS login redirection.
+	 */
+	const OAUTH_REDIRECT_ROUTES = [ '/oauth/authorize' ];
+
+	/**
 	 * Newsletters signup form.
 	 */
 	const NEWSLETTERS_SIGNUP_FORM_ACTION = 'reader-activation-newsletters-signup';
@@ -113,6 +118,7 @@ final class Reader_Activation {
 			\add_action( 'lostpassword_post', [ __CLASS__, 'set_password_reset_mail_content_type' ] );
 			\add_filter( 'lostpassword_errors', [ __CLASS__, 'rate_limit_lost_password' ], 10, 2 );
 			\add_filter( 'newspack_esp_sync_contact', [ __CLASS__, 'set_mailchimp_sync_contact_status' ], 10, 2 );
+			\add_filter( 'login_url', [ __CLASS__, 'redirect_oauth_to_ras_login' ], 10, 3 );
 		}
 	}
 
@@ -1520,6 +1526,13 @@ final class Reader_Activation {
 				<?php if ( ! empty( $referer['path'] ) ) : ?>
 					<input type="hidden" name="referer" value="<?php echo \esc_url( $referer['path'] ); ?>" />
 				<?php endif; ?>
+				<?php
+				// Add hidden redirect_url field if OAuth redirect is present.
+				$oauth_redirect = isset( $_GET['redirect'] ) ? \esc_url_raw( \wp_unslash( $_GET['redirect'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				if ( ! empty( $oauth_redirect ) && self::is_oauth_redirect( $oauth_redirect ) ) :
+					?>
+					<input type="hidden" name="redirect_url" value="<?php echo \esc_attr( $oauth_redirect ); ?>" />
+				<?php endif; ?>
 				<input type="hidden" name="action" />
 				<p data-action="otp">
 					<label><?php echo esc_html( $labels['otp_title'] ); ?></label>
@@ -1819,6 +1832,21 @@ final class Reader_Activation {
 			$labels  = self::get_reader_activation_labels( 'signin' );
 			$message = $is_error ? $data->get_error_message() : $labels['success_message'];
 		}
+
+		// Add redirect_to for OAuth flows that need post-authentication redirect.
+		if ( ! $is_error && ! empty( $_POST['redirect_url'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+			// $_POST is slashed, so unslash before sanitizing.
+			$redirect_url = \esc_url_raw( \wp_unslash( $_POST['redirect_url'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+
+			// Validate it's a local redirect for security.
+			$redirect_host = \wp_parse_url( $redirect_url, PHP_URL_HOST );
+			$site_host     = \wp_parse_url( site_url(), PHP_URL_HOST );
+
+			if ( $redirect_host && $redirect_host === $site_host ) {
+				$data['redirect_to'] = $redirect_url;
+			}
+		}
+
 		\wp_send_json( compact( 'message', 'data' ), \is_wp_error( $data ) ? 400 : 200 );
 	}
 
@@ -2692,6 +2720,54 @@ final class Reader_Activation {
 			return;
 		}
 		self::set_current_reader( $user );
+	}
+
+	/**
+	 * Check if a URL matches an OAuth redirect route.
+	 *
+	 * @param string $url The URL to check.
+	 * @return bool True if the URL path contains an OAuth route.
+	 */
+	private static function is_oauth_redirect( $url ) {
+		$url_path = \wp_parse_url( $url, PHP_URL_PATH ) ?? '';
+
+		return ! empty(
+			array_filter(
+				self::OAUTH_REDIRECT_ROUTES,
+				fn( $route ) => str_contains( $url_path, $route )
+			)
+		);
+	}
+
+	/**
+	 * Redirect OAuth authorization requests to RAS login instead of wp-login.php.
+	 *
+	 * This enables OAuth clients to use the RAS login screen which provides
+	 * Google SSO and a better user experience while maintaining PKCE OAuth 2.0 compatibility.
+	 *
+	 * This is a generic OAuth + RAS integration, not specific to any particular OAuth client.
+	 *
+	 * @param string $login_url    The login URL.
+	 * @param string $redirect     The path to redirect to on login.
+	 * @param bool   $force_reauth Whether to force reauthentication.
+	 * @return string Modified login URL for OAuth flows, original URL otherwise.
+	 */
+	public static function redirect_oauth_to_ras_login( $login_url, $redirect, $force_reauth ) {
+		// Only intercept OAuth authorization requests.
+		if ( ! self::is_oauth_redirect( $redirect ) || ! function_exists( 'wc_get_page_permalink' ) ) {
+			return $login_url;
+		}
+
+		// Redirect to RAS My Account page with OAuth redirect preserved.
+		$my_account_url = \wc_get_page_permalink( 'myaccount' );
+		$url            = add_query_arg( 'redirect', rawurlencode( $redirect ), $my_account_url );
+
+		// Preserve force_reauth if needed (for prompt=login flow).
+		if ( $force_reauth ) {
+			$url = add_query_arg( 'reauth', '1', $url );
+		}
+
+		return $url;
 	}
 
 	/**

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -382,6 +382,7 @@ final class Reader_Activation {
 			'woocommerce_enable_terms_confirmation'        => false,
 			'woocommerce_terms_confirmation_text'          => self::get_terms_confirmation_text(),
 			'woocommerce_terms_confirmation_url'           => self::get_terms_confirmation_url(),
+			'oauth_redirect_to_ras'                        => false,
 		];
 
 		/**
@@ -2767,8 +2768,8 @@ final class Reader_Activation {
 	 * @return string Modified login URL for OAuth flows, original URL otherwise.
 	 */
 	public static function redirect_oauth_to_ras_login( $login_url, $redirect, $force_reauth ) {
-		// Only intercept OAuth authorization requests.
-		if ( ! self::is_oauth_redirect( $redirect ) || ! function_exists( 'wc_get_page_permalink' ) ) {
+		// Only intercept OAuth authorization requests if the setting is enabled.
+		if ( ! self::get_setting( 'oauth_redirect_to_ras' ) || ! self::is_oauth_redirect( $redirect ) || ! function_exists( 'wc_get_page_permalink' ) ) {
 			return $login_url;
 		}
 

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1843,7 +1843,13 @@ final class Reader_Activation {
 			$site_host     = \wp_parse_url( site_url(), PHP_URL_HOST );
 
 			if ( $redirect_host && $redirect_host === $site_host ) {
-				$data['redirect_to'] = $redirect_url;
+				/**
+				 * Filters the redirect URL in the authentication response.
+				 *
+				 * @param string $redirect_url The redirect URL to include in the response.
+				 * @param array  $data         The response data array.
+				 */
+				$data['redirect_to'] = apply_filters( 'newspack_ras_auth_redirect_url', $redirect_url, $data );
 			}
 		}
 
@@ -2731,9 +2737,17 @@ final class Reader_Activation {
 	private static function is_oauth_redirect( $url ) {
 		$url_path = \wp_parse_url( $url, PHP_URL_PATH ) ?? '';
 
+		/**
+		 * Filters the list of OAuth routes that should redirect to RAS login.
+		 *
+		 * @param array  $routes Array of OAuth route paths.
+		 * @param string $url_path The URL path being checked.
+		 */
+		$routes = apply_filters( 'newspack_ras_oauth_redirect_routes', self::OAUTH_REDIRECT_ROUTES, $url_path );
+
 		return ! empty(
 			array_filter(
-				self::OAUTH_REDIRECT_ROUTES,
+				$routes,
 				fn( $route ) => str_contains( $url_path, $route )
 			)
 		);
@@ -2767,7 +2781,15 @@ final class Reader_Activation {
 			$url = add_query_arg( 'reauth', '1', $url );
 		}
 
-		return $url;
+		/**
+		 * Filters the OAuth redirect URL before returning.
+		 *
+		 * @param string $url          The RAS login URL with OAuth redirect parameters.
+		 * @param string $login_url    The original login URL.
+		 * @param string $redirect     The OAuth redirect URL.
+		 * @param bool   $force_reauth Whether to force reauthentication.
+		 */
+		return apply_filters( 'newspack_ras_oauth_redirect_url', $url, $login_url, $redirect, $force_reauth );
 	}
 
 	/**

--- a/src/reader-activation-auth/auth-form.js
+++ b/src/reader-activation-auth/auth-form.js
@@ -376,6 +376,8 @@ window.newspackRAS.push( function ( readerActivation ) {
 							try {
 								const redirectUrl = new URL( continueButton.href );
 								if ( redirectUrl.origin === window.location.origin ) {
+									continueButton.style.opacity = 0.5;
+									continueButton.style.pointerEvents = 'none';
 									window.location.href = redirectUrl.href;
 								}
 							} catch ( e ) {

--- a/src/reader-activation-auth/auth-form.js
+++ b/src/reader-activation-auth/auth-form.js
@@ -359,9 +359,20 @@ window.newspackRAS.push( function ( readerActivation ) {
 							}
 						}
 
-						// Auto-redirect by reading the Continue button's href.
 						const continueButton = container.querySelector( '.auth-callback' );
-						if ( continueButton?.href && continueButton.href !== window.location.href && continueButton.href !== '#' ) {
+
+						if ( data?.redirect_to && continueButton ) {
+							continueButton.setAttribute( 'href', data.redirect_to );
+						}
+
+						// Auto-redirect if we have a redirect query parameter.
+						const urlParams = new URLSearchParams( window.location.search );
+						if (
+							urlParams.has( 'redirect' ) &&
+							continueButton?.href &&
+							continueButton.href !== window.location.href &&
+							continueButton.href !== '#'
+						) {
 							try {
 								const redirectUrl = new URL( continueButton.href );
 								if ( redirectUrl.origin === window.location.origin ) {

--- a/src/reader-activation-auth/auth-form.js
+++ b/src/reader-activation-auth/auth-form.js
@@ -310,20 +310,6 @@ window.newspackRAS.push( function ( readerActivation ) {
 						}
 					}
 
-					// Redirect handling. Works for OAuth and other redirect flows.
-					if ( data?.redirect_to ) {
-						try {
-							const redirectUrl = new URL( data.redirect_to, window.location.origin );
-							if ( redirectUrl.origin === window.location.origin ) {
-								// Use redirectUrl.href instead of data.redirect_to to ensure proper normalization and prevent potential security issues.
-								window.location.href = redirectUrl.href;
-								return;
-							}
-						} catch ( e ) {
-							// Invalid URL format - silently ignore and continue with normal flow.
-						}
-					}
-
 					let callback;
 					if ( ! container.config?.skipNewslettersSignup && data?.registered && container.authCallback ) {
 						callback = ( authMessage, authData ) =>
@@ -373,10 +359,16 @@ window.newspackRAS.push( function ( readerActivation ) {
 							}
 						}
 
-						if ( data?.redirect_to ) {
-							const continueButton = container.querySelector( '.auth-callback' );
-							if ( continueButton ) {
-								continueButton.setAttribute( 'href', data.redirect_to );
+						// Auto-redirect by reading the Continue button's href.
+						const continueButton = container.querySelector( '.auth-callback' );
+						if ( continueButton?.href && continueButton.href !== window.location.href && continueButton.href !== '#' ) {
+							try {
+								const redirectUrl = new URL( continueButton.href );
+								if ( redirectUrl.origin === window.location.origin ) {
+									window.location.href = redirectUrl.href;
+								}
+							} catch ( e ) {
+								// Invalid URL - continue with normal flow.
 							}
 						}
 					}

--- a/src/reader-activation-auth/auth-form.js
+++ b/src/reader-activation-auth/auth-form.js
@@ -310,6 +310,20 @@ window.newspackRAS.push( function ( readerActivation ) {
 						}
 					}
 
+					// Redirect handling. Works for OAuth and other redirect flows.
+					if ( data?.redirect_to ) {
+						try {
+							const redirectUrl = new URL( data.redirect_to, window.location.origin );
+							if ( redirectUrl.origin === window.location.origin ) {
+								// Use redirectUrl.href instead of data.redirect_to to ensure proper normalization and prevent potential security issues.
+								window.location.href = redirectUrl.href;
+								return;
+							}
+						} catch ( e ) {
+							// Invalid URL format - silently ignore and continue with normal flow.
+						}
+					}
+
 					let callback;
 					if ( ! container.config?.skipNewslettersSignup && data?.registered && container.authCallback ) {
 						callback = ( authMessage, authData ) =>

--- a/src/wizards/audience/views/setup/setup.js
+++ b/src/wizards/audience/views/setup/setup.js
@@ -159,6 +159,17 @@ export default withWizardScreen(
 							) }
 						</ActionCard>
 
+						<ActionCard
+							title={ __( 'Use My Account login screen for OAuth clients', 'newspack-plugin' ) }
+							description={ __(
+								'Allow OAuth clients to redirect to the My Account login screen instead of the default WordPress login screen. Might require additional configuration.',
+								'newspack-plugin'
+							) }
+							isMedium
+							toggleChecked={ config.oauth_redirect_to_ras }
+							toggleOnChange={ value => updateConfig( 'oauth_redirect_to_ras', value ) }
+						/>
+
 						<hr />
 
 						<SectionHeader
@@ -276,6 +287,7 @@ export default withWizardScreen(
 										use_custom_lists: config.use_custom_lists,
 										newsletter_lists: config.newsletter_lists,
 										newsletter_list_initial_size: config.newsletter_list_initial_size,
+										oauth_redirect_to_ras: config.oauth_redirect_to_ras,
 										sync_esp: config.sync_esp,
 										sync_esp_delete: config.sync_esp_delete,
 										metadata_fields: config.metadata_fields,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds support for OAuth clients (like mobile apps) to use the RAS login screen instead of the default WordPress wp-login.php flow:
- OAuth clients can be configured to redirect to `/my-account/` to provide a branded login experience.
- It's opt-in. A new toggle in Audience Management > Configuration was added to enable the feature.
- The redirection preserves all OAuth parameters. Authorization codes, PKCE challenges, and redirect URLs are maintained through the authentication flow
- Auto-redirect after login. Users are automatically sent to the OAuth authorization endpoint (via JS) after successful authentication.

**How it works**
When enabled, OAuth authorization requests (`/oauth/authorize` by default, but can be extended via filters) are intercepted and redirected to the RAS My Account page. After the user authenticates, they're automatically redirected back to the OAuth flow to complete authorization.

**Extensibility**
Three new filters allow additional customization:
- `newspack_ras_oauth_redirect_routes` - Customize which OAuth routes trigger RAS redirect.
- `newspack_ras_oauth_redirect_url` - Modify the RAS login URL.
- `newspack_ras_auth_redirect_url` - Customize post-authentication redirect URL.

**Configuration**
Enable via Audience Management > Configuration > "Use My Account login screen for OAuth clients". You might need to configure an OAuth server to fully test the flow.

Closes NPPD-699 (please read the issue for additional instructions and context).

### How to test the changes in this Pull Request:

**Prerequisites**
1. Install and configure an OAuth server plugin. We'll test using [WP OAuth Server](https://wp-oauth.com/).
2. Create an OAuth client application with the following settings:
    - Grant Type: Authorization Code
    - Redirect URI: `https://example.com/` (or your test app's callback URL)
    - Scope: `openid offline_access`.
3. Take note of the created Client ID.

**Test 1: OAuth redirect to RAS (feature enabled)**
1. Go to Audience Management > Configuration in the admin.
2. Enable the toggle "Use My Account login screen for OAuth clients" and click on "Save Settings".
3. Navigate to: `https://your-site.com/oauth/authorize/?prompt=login&scope=openid+offline_access&code_challenge_method=S256&response_type=code&client_id=<YOUR_CLIENT_ID>&redirect_uri=https%3A%2F%2Fexample.com%2F&code_challenge=<SAMPLE_CHALLENGE>`
4. You should be redirected to `/my-account/` instead of `wp-login.php`.
5. Log in using email/password.
6. After successful login, you should be automatically redirected to the OAuth authorization endpoint, with all OAuth parameters preserved.
8. OAuth flow should complete and the browser navigate to `https://example.com/` with an authorization code appended to the URL (`?code=<CODE>`).

**Test 2: OAuth redirect to RAS with Google SSO (feature enabled)**
1. Ensure the "Use My Account login screen for OAuth clients" toggle is still enabled.
2. Navigate to the same OAuth URL as Test 1.
3. You should be redirected to `/my-account/`.
4. Click "Sign in with Google" button.
5. Complete Google authentication in the popup.
6. After the popup closes, you should be automatically redirected to the OAuth authorization endpoint, with all OAuth parameters preserved.
7. OAuth flow should complete and the browser navigate to `https://example.com/` with an authorization code appended, similar to Test 1.

**Test 3: OAuth redirect to RAS with OTP (feature enabled)**
1. Ensure the "Use My Account login screen for OAuth clients" toggle is still enabled.
2. Ensure email settings are configured with a valid sender email address (Audience > Configuration > Transactional Emails > Sender Email Address).
3. Navigate to the same OAuth URL as Test 1.
4. You should be redirected to `/my-account/`.
5. Enter an email address for an existing user account that was created, with or without a password. 
7. Click "Email me a one-time code instead" button.
8. Check your email (or MailHog if you're using the Docker environment) for the 6-digit OTP code.
9. Copy and paste the OTP code in the form.
10. After successful authentication, you should be automatically redirected to the OAuth authorization endpoint, with all OAuth parameters preserved.
11. OAuth flow should complete and the browser navigate to `https://example.com/` with an authorization code appended, similar to Test 1.

**Test 4: OAuth redirect with new account registration (feature enabled)**
1. Ensure the "Use My Account login screen for OAuth clients" toggle is still enabled.
2. Navigate to the same OAuth URL as Test 1.
3. On the `/my-account/` page, enter a new email address that doesn't exist in the system.
4. After successful registration, you should be automatically redirected to the OAuth authorization endpoint (no intermediate "success" screen should appear).
11. OAuth flow should complete and the browser navigate to `https://example.com/` with an authorization code appended, similar to Test 1.

**Test 5: OAuth redirect disabled (default behavior)**
1. Go to Audience Management > Configuration.
2. Disable the toggle "Use My Account login screen for OAuth clients" and click on "Save Settings"
3. Navigate to the same OAuth URL as Test 1
4. You should be redirected to `wp-login.php` (standard WordPress login).
5. OAuth flow should continue normally after login

**Test 6: Normal My Account login (no auto-redirect)**
1. Navigate directly to `/my-account/` (without any `redirect` query parameter).
2. Log in using email/password, Google SSO, or OTP/magic link.
3. After successful login, you should see the "Continue" button to navigate to the My Account page (no automatic redirect should occur).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?