### PR TITLE
feat(web-preview): update components with new dropdown menu and title

### DIFF
--- a/languages/newspack-plugin.pot
+++ b/languages/newspack-plugin.pot
@@ -8681,7 +8681,7 @@ msgstr ""
 #: dist/componentsDemo.js:1
 #: src/wizards/componentsDemo/index.js:159
 #: src/wizards/componentsDemo/index.js:164
-msgid "Preview Newspack Blog"
+msgid "Preview Newspack Site"
 msgstr ""
 
 #: dist/componentsDemo.js:1

--- a/packages/components/src/web-preview/index.js
+++ b/packages/components/src/web-preview/index.js
@@ -3,8 +3,8 @@
  */
 import { Component, createRef, Fragment, createPortal } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { closeSmall, desktop, mobile, tablet } from '@wordpress/icons';
-import { Button, ButtonGroup } from '@wordpress/components';
+import { close, desktop, mobile, tablet, check } from '@wordpress/icons';
+import { Button, DropdownMenu, MenuItem } from '@wordpress/components';
 
 /**
  * Internal dependencies.
@@ -62,7 +62,7 @@ class WebPreview extends Component {
 	 * Create JSX for the modal
 	 */
 	getWebPreviewModal = () => {
-		const { beforeLoad = () => {}, onClose = () => {}, url } = this.props;
+		const { beforeLoad = () => {}, onClose = () => {}, url, title } = this.props;
 		const { device, loaded, isPreviewVisible } = this.state;
 
 		if ( ! this.modalDOMElement || ! isPreviewVisible ) {
@@ -70,40 +70,68 @@ class WebPreview extends Component {
 		}
 
 		const classes = classnames( 'newspack-web-preview', device, loaded && 'is-loaded' );
+		let icon = mobile;
+		if ( device === 'desktop' ) {
+			icon = desktop;
+		} else if ( device === 'tablet' ) {
+			icon = tablet;
+		}
 		beforeLoad();
 		return createPortal(
 			<div className={ classes }>
 				<div className="newspack-web-preview__interior">
 					<div className="newspack-web-preview__toolbar">
-						<div className="newspack-web-preview__toolbar-left">
-							<ButtonGroup>
-								<Button
-									onClick={ () => this.setState( { device: 'desktop' } ) }
-									variant={ 'desktop' === device && 'primary' }
-									icon={ desktop }
-									label={ __( 'Preview Desktop Size', 'newspack-plugin' ) }
-								/>
-								<Button
-									onClick={ () => this.setState( { device: 'tablet' } ) }
-									variant={ 'tablet' === device && 'primary' }
-									icon={ tablet }
-									label={ __( 'Preview Tablet Size', 'newspack-plugin' ) }
-								/>
-								<Button
-									onClick={ () => this.setState( { device: 'phone' } ) }
-									variant={ 'phone' === device && 'primary' }
-									icon={ mobile }
-									label={ __( 'Preview Phone Size', 'newspack-plugin' ) }
-								/>
-							</ButtonGroup>
-						</div>
+						{ title && (
+							<div className="newspack-web-preview__toolbar-left">
+								<h2>{ title }</h2>
+							</div>
+						) }
 						<div className="newspack-web-preview__toolbar-right">
+							<DropdownMenu icon={ icon } label={ __( 'Preview Size', 'newspack-plugin' ) }>
+								{ ( { onClose: onDropdownClose } ) => (
+									<>
+										<MenuItem
+											icon={ device === 'desktop' ? check : null }
+											role="menuitemradio"
+											isSelected={ device === 'desktop' }
+											onClick={ () => {
+												this.setState( { device: 'desktop' } );
+												onDropdownClose();
+											} }
+										>
+											{ __( 'Desktop', 'newspack-plugin' ) }
+										</MenuItem>
+										<MenuItem
+											icon={ device === 'tablet' ? check : null }
+											role="menuitemradio"
+											isSelected={ device === 'tablet' }
+											onClick={ () => {
+												this.setState( { device: 'tablet' } );
+												onDropdownClose();
+											} }
+										>
+											{ __( 'Tablet', 'newspack-plugin' ) }
+										</MenuItem>
+										<MenuItem
+											icon={ device === 'phone' ? check : null }
+											role="menuitemradio"
+											isSelected={ device === 'phone' }
+											onClick={ () => {
+												this.setState( { device: 'phone' } );
+												onDropdownClose();
+											} }
+										>
+											{ __( 'Phone', 'newspack-plugin' ) }
+										</MenuItem>
+									</>
+								) }
+							</DropdownMenu>
 							<Button
 								onClick={ () => {
 									onClose();
 									this.setState( { isPreviewVisible: false, loaded: false } );
 								} }
-								icon={ closeSmall }
+								icon={ close }
 								label={ __( 'Close Preview', 'newspack-plugin' ) }
 							/>
 						</div>

--- a/packages/components/src/web-preview/style.scss
+++ b/packages/components/src/web-preview/style.scss
@@ -14,7 +14,7 @@
 	--wp-admin-theme-color-darker-20: #{colors.$primary-800};
 	--wp-admin-theme-color-darker-20--rgb: #{colors.$primary-800--rgb};
 
-	background: #{colors.$neutral-700};
+	background: colors.$neutral-700;
 	box-sizing: border-box;
 	height: 100%;
 	left: 0;
@@ -27,11 +27,11 @@
 	z-index: 99999;
 
 	&.phone iframe {
-		max-width: 380px;
+		max-width: 360px;
 	}
 
 	&.tablet iframe {
-		max-width: 768px;
+		max-width: 780px;
 	}
 
 	&.is-loaded iframe {
@@ -46,7 +46,7 @@
 		animation: appear-animation 125ms ease-in-out;
 		animation-fill-mode: forwards;
 		background: white;
-		border-radius: 2px;
+		border-radius: 8px;
 		overflow: hidden;
 		height: 100%;
 		width: 100%;
@@ -54,19 +54,18 @@
 
 	&__content {
 		background: wp-colors.$gray-100;
-		height: calc(100% - 49px);
+		height: calc(100% - 72px);
 		-webkit-overflow-scrolling: touch;
 		overflow-x: hidden;
 		width: 100%;
 
 		iframe {
-			background: #fff;
+			background: white;
 			display: block;
 			height: 100%;
 			margin: 0 auto;
 			max-width: 100%;
 			opacity: 0;
-			outline: 1px solid wp-colors.$gray-300;
 			padding: 0;
 			pointer-events: all;
 			transition: max-width 125ms ease-in-out, opacity 250ms ease-in-out;
@@ -85,62 +84,23 @@
 	}
 
 	&__toolbar {
+		align-items: center;
 		border-bottom: 1px solid wp-colors.$gray-300;
 		display: flex;
-		padding: 6px;
+		justify-content: space-between;
+		height: 71px;
+		padding: 0 24px;
 
 		&-left {
-			flex: 0 0 auto;
-
-			.newspack-button-group {
-				display: flex;
-				margin: 0;
-			}
-
-			.newspack-button {
-				display: none;
-				padding: 0 !important;
-
-				&.is-selected {
-					background: var(--wp-admin-theme-color);
-					color: white;
-
-					&:active,
-					&:focus,
-					&:hover {
-						box-shadow: none !important;
-						color: white;
-						outline: none;
-					}
-
-					&:focus {
-						box-shadow: inset 0 0 0 1px var(--wp-admin-theme-color), inset 0 0 0 3px white !important;
-					}
-				}
-
-				@media screen and ( min-width: 528px ) {
-					&.is-phone,
-					&.is-tablet {
-						display: flex;
-					}
-				}
-
-				@media screen and ( min-width: 816px ) {
-					&.is-desktop {
-						display: flex;
-					}
-				}
-			}
+			display: flex;
 		}
 
 		&-right {
-			display: flex;
-			flex: 1;
-			justify-content: flex-end;
-		}
-
-		.newspack-button {
-			border-radius: 0 !important;
+			display: grid;
+			gap: 8px;
+			grid-template-columns: repeat(2, 1fr);
+			justify-self: end;
+			margin-left: auto;
 		}
 	}
 }

--- a/src/wizards/componentsDemo/index.js
+++ b/src/wizards/componentsDemo/index.js
@@ -156,14 +156,15 @@ class ComponentsDemo extends Component {
 					<Card>
 						<h2>{ __( 'Web Previews', 'newspack-plugin' ) }</h2>
 						<Card buttonsCard noBorder className="items-center">
-							<WebPreview url="//newspack.com/" label={ __( 'Preview Newspack Blog', 'newspack-plugin' ) } variant="primary" />
+							<WebPreview url="//newspack.com/" label={ __( 'Preview Newspack Site', 'newspack-plugin' ) } variant="primary" />
 							<WebPreview
 								url="//newspack.com/"
 								renderButton={ ( { showPreview } ) => (
 									<a href="#" onClick={ showPreview }>
-										{ __( 'Preview Newspack Blog', 'newspack-plugin' ) }
+										{ __( 'Preview Newspack Site', 'newspack-plugin' ) }
 									</a>
 								) }
+								title={ __( 'Preview Newspack Site', 'newspack-plugin' ) }
 							/>
 						</Card>
 					</Card>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR updates our `WebPreview` component so it's more inline with Core. For the "Preview Size" we're using the same idea as the editor with the `DropdownMenu`. We can now have add a title (might be useful when preview segments...)

__Before:__
<img width="3024" height="1898" alt="1 before" src="https://github.com/user-attachments/assets/5726ec71-d68e-4c7a-a579-dd622b03dc46" />

__After:__
<img width="3024" height="1898" alt="2 after" src="https://github.com/user-attachments/assets/4e55d0fc-d86e-46c3-aa9c-c0647bffe86c" />


### How to test the changes in this Pull Request:

1. Navigate somewhere we use a `WebPreview` component (e.g. Components demo or Segments)
2. Open a `WebPreview`
3. Switch to this branch and retry

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->