### PR TITLE
fix: move some Collection margin styles from the block to theme

### DIFF
--- a/src/blocks/collections/styles/_layout-grid.scss
+++ b/src/blocks/collections/styles/_layout-grid.scss
@@ -5,8 +5,6 @@
 	&.layout-grid {
 		display: grid;
 		gap: 32px;
-		margin-top: 32px;
-
 
 		// Mobile first: 2 columns.
 		&:not(.columns-1) {
@@ -68,4 +66,3 @@
 		}
 	}
 }
-

--- a/src/blocks/collections/styles/_layout-grid.scss
+++ b/src/blocks/collections/styles/_layout-grid.scss
@@ -66,3 +66,10 @@
 		}
 	}
 }
+
+/* Archive specific styles */
+.post-type-archive-newspack_collection {
+	.wp-block-newspack-collections.layout-grid {
+		margin-top: 32px;
+	}
+}

--- a/src/blocks/collections/styles/_layout-list.scss
+++ b/src/blocks/collections/styles/_layout-list.scss
@@ -175,6 +175,10 @@
 	}
 
 	.wp-block-newspack-collections.layout-list {
-		margin-bottom: 64px;
+		margin-bottom: 32px;
+
+		@media #{bp.$media-lg-up} {
+			margin-bottom: 64px;
+		}
 	}
 }

--- a/src/blocks/collections/styles/_layout-list.scss
+++ b/src/blocks/collections/styles/_layout-list.scss
@@ -3,8 +3,6 @@
 .wp-block-newspack-collections {
 	// Layout: List.
 	&.layout-list {
-		margin-bottom: 32px;
-
 		.wp-block-newspack-collections__item {
 			display: grid;
 			grid-template-columns: 1fr;

--- a/src/blocks/collections/styles/_layout-list.scss
+++ b/src/blocks/collections/styles/_layout-list.scss
@@ -167,3 +167,10 @@
 		}
 	}
 }
+
+/* Single Collection styles */
+.single-newspack_collection {
+	.wp-block-newspack-collections.layout-list {
+		margin-bottom: 32px;
+	}
+}

--- a/src/blocks/collections/styles/_layout-list.scss
+++ b/src/blocks/collections/styles/_layout-list.scss
@@ -170,7 +170,11 @@
 
 /* Single Collection styles */
 .single-newspack_collection {
+	&.has-sidebar .site-main {
+		display: block;
+	}
+
 	.wp-block-newspack-collections.layout-list {
-		margin-bottom: 32px;
+		margin-bottom: 64px;
 	}
 }

--- a/src/collections/frontend/_recent.scss
+++ b/src/collections/frontend/_recent.scss
@@ -2,7 +2,6 @@
 
 /* Recent collections styles */
 .collections-recent {
-	$header-offset: -16px; // Negative margin to compensate for Collections block's intrinsic flex gap spacing.
 	width: 100%;
 
 	&__header {
@@ -11,7 +10,7 @@
 		align-items: flex-end;
 		width: 100%;
 		flex-wrap: wrap;
-		margin-bottom: $header-offset;
+		margin-bottom: 16px;
 
 		h2,
 		p {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Along with https://github.com/Automattic/newspack-theme/pull/2581, this PR makes some Collection block styles a bit more specific:

When on the archive page, the grid view of the blocks need a top margin of `32px`. And when on the single Collection view, the blocks need a bottom margin of `32px`. However, having these margins applied to the blocks themselves means we can't use tricks wrapping the block in a Stack block with other blocks to reduce the spacing between them (a trick we use a lot with Headings + other blocks).

These PRs move the general top and bottom margins from the block styles to the theme styles and use the template classes to make them more specific.

### How to test the changes in this Pull Request:

1. Make sure you have a few Collections set up on your site. 
2. Apply this PR and https://github.com/Automattic/newspack-theme/pull/2581.
3. Add two Collections Blocks to a page, one using the Grid layout and one using the List layout; publish. 
4. Possibly not the best way to test this, but on the front-end, use the element inspector and confirm there's a `margin: 32px 0` coming from the theme on each block, but no other top/bottom margin. You can confirm that by "turning off" the theme-based margin and seeing that the blocks don't have it anymore.
5. View the Collections archive landing page; inspect the grid of Collections and confirm that it has a top margin of `32px` coming from the theme and targeting the `.layout-grid` class only when inside the `.post-type-archive-newspack_collection` body class.
6. View an individual Collection and inspect the Collection at the top of the page; confirm that it has a bottom margin of `32px` coming from the theme only when it's inside the `.single-newspack_collection` class.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->