### PR TITLE
fix(media): move default image UI to Advanced Settings

### DIFF
--- a/includes/class-default-image.php
+++ b/includes/class-default-image.php
@@ -27,8 +27,6 @@ class Default_Image {
 	 * Add hooks.
 	 */
 	public static function init() {
-		add_filter( 'attachment_fields_to_save', [ __CLASS__, 'save_attachement_settings' ], 10, 2 );
-		add_filter( 'attachment_fields_to_edit', [ __CLASS__, 'add_attachment_field' ], 10, 2 );
 		add_action( 'template_redirect', [ __CLASS__, 'handle_not_found_image' ] );
 		add_action( 'wp_footer', [ __CLASS__, 'add_404_image_handler_function' ] );
 	}
@@ -51,44 +49,6 @@ class Default_Image {
 	}
 
 	/**
-	 * Add the relevant setting in the media editing screen.
-	 *
-	 * @param array   $fields Array of media editor field info.
-	 * @param WP_Post $post Post object for current attachment.
-	 * @return array Modified $fields.
-	 */
-	public static function add_attachment_field( $fields, $post ) {
-		$field_name = 'attachments[' . $post->ID . '][' . self::FIELD_NAME . ']';
-		$value = ( wp_get_attachment_url( $post->ID ) === get_option( self::OPTION_NAME ) );
-		$fields[ self::FIELD_NAME ] = [
-			'label' => __( 'Is default image?', 'newspack-image-credits' ),
-			'input' => 'html',
-			'html'  => '<input id="' . $field_name . '" name="' . $field_name . '" type="hidden" value="0" /><input id="' . $field_name . '" name="' . $field_name . '" type="checkbox" value="1" ' . checked( $value, true, false ) . ' />',
-			'helps' => __( 'Use this image as a default image, if the requested one is not found (404 status).', 'newspack-plugin' ),
-		];
-		return $fields;
-	}
-
-	/**
-	 * Save the relevant setting.
-	 *
-	 * @param array $post Array of post info.
-	 * @param array $attachment Array of media field input info.
-	 * @return array $post Unmodified post info.
-	 */
-	public static function save_attachement_settings( $post, $attachment ) {
-		if ( isset( $attachment[ self::FIELD_NAME ] ) ) {
-			if ( '1' === $attachment[ self::FIELD_NAME ] ) {
-				update_option( self::OPTION_NAME, wp_get_attachment_url( $post['ID'] ) );
-			} else {
-				delete_option( self::OPTION_NAME );
-			}
-		}
-
-		return $post;
-	}
-
-	/**
 	 * Add JavaScript function to handle 404 images.
 	 * If an image is served from a different domain, the `template_redirect` action won't catch a 404.
 	 * Adding a JS fallback ensures all images will have the default applied.
@@ -98,7 +58,7 @@ class Default_Image {
 		if ( ! empty( $default_image_url ) ) {
 			?>
 				<script>
-					document.querySelectorAll('img').forEach(function(imgEl) {
+					document.querySelectorAll('.content-area img').forEach(function(imgEl) {
 						imgEl.addEventListener('error', function(){
 							if (!imgEl.hasAttribute('data-404-handled')) {
 								imgEl.setAttribute('data-404-handled', 'true');

--- a/includes/wizards/class-setup-wizard.php
+++ b/includes/wizards/class-setup-wizard.php
@@ -384,6 +384,9 @@ class Setup_Wizard extends Wizard {
 		// Append PWA display mode option.
 		$theme_mods['pwa_display_mode'] = get_option( 'newspack_pwa_display_mode', 'minimal-ui' );
 
+		// Append post content fallback image option.
+		$theme_mods['post_content_fallback_image'] = get_option( Default_Image::OPTION_NAME, null );
+
 		return rest_ensure_response(
 			[
 				'theme'             => Starter_Content::get_theme(),
@@ -527,6 +530,12 @@ class Setup_Wizard extends Wizard {
 			// PWA display mode is an option, not a theme mod.
 			if ( 'pwa_display_mode' === $key ) {
 				update_option( 'newspack_pwa_display_mode', $value );
+				continue;
+			}
+
+			// Post content fallback image is an option, not a theme mod.
+			if ( 'post_content_fallback_image' === $key ) {
+				update_option( Default_Image::OPTION_NAME, $value );
 				continue;
 			}
 

--- a/src/wizards/newspack/views/settings/advanced-settings/index.tsx
+++ b/src/wizards/newspack/views/settings/advanced-settings/index.tsx
@@ -11,10 +11,10 @@ import { useEffect } from '@wordpress/element';
 /**
  * Internal dependencies.
  */
-import { DEFAULT_THEME_MODS } from '../constants';
+import { ADVANCED_SETTINGS_DEFAULTS } from '../constants';
 import WizardsTab from '../../../../wizards-tab';
 import WizardSection from '../../../../wizards-section';
-import { Button, hooks, Notice, utils } from '../../../../../../packages/components/src';
+import { Button, Grid, hooks, ImageUpload, Notice, utils } from '../../../../../../packages/components/src';
 import { useWizardApiFetch } from '../../../../hooks/use-wizard-api-fetch';
 import Recirculation from './recirculation';
 import AuthorBio from './author-bio';
@@ -26,7 +26,7 @@ import PwaDisplayMode from './pwa-display-mode';
 
 export default function AdvancedSettings() {
 	const [ data, setData ] = hooks.useObjectState< AdvancedSettings >( {
-		...DEFAULT_THEME_MODS,
+		...ADVANCED_SETTINGS_DEFAULTS,
 	} );
 	const [ etc, setEtc ] = hooks.useObjectState< Etc >( {
 		post_count: '0',
@@ -124,7 +124,7 @@ export default function AdvancedSettings() {
 				<AuthorBio update={ setData } data={ data } isFetching={ isFetching } />
 			</WizardSection>
 			<WizardSection
-				title={ __( 'Default Featured Image Position And Post Template', 'newspack-plugin' ) }
+				title={ __( 'Default Featured Image Position and Post Template', 'newspack-plugin' ) }
 				description={ __( 'Modify how the featured image and post template settings are applied to new posts.', 'newspack-plugin' ) }
 			>
 				<FeaturedImagePostsNew data={ data } update={ setData } />
@@ -140,6 +140,18 @@ export default function AdvancedSettings() {
 			</WizardSection>
 			<WizardSection title={ __( 'Media Credits', 'newspack-plugin' ) }>
 				<MediaCredits data={ data } update={ setData } />
+			</WizardSection>
+			<WizardSection
+				title={ __( 'Post content fallback image', 'newspack-plugin' ) }
+				description={ __( 'Select a fallback image to display when an image inside post content cannot be found.', 'newspack-plugin' ) }
+			>
+				<Grid>
+					<ImageUpload
+						image={ data.post_content_fallback_image ? { url: data.post_content_fallback_image } : null }
+						buttonLabel={ __( 'Select', 'newspack-plugin' ) }
+						onChange={ ( image: null | PlaceholderImage ) => setData( { post_content_fallback_image: image?.url || null } ) }
+					/>
+				</Grid>
 			</WizardSection>
 			<WizardSection>
 				<AccessibilityStatement isFetching={ isFetching } />

--- a/src/wizards/newspack/views/settings/advanced-settings/index.tsx
+++ b/src/wizards/newspack/views/settings/advanced-settings/index.tsx
@@ -142,7 +142,7 @@ export default function AdvancedSettings() {
 				<MediaCredits data={ data } update={ setData } />
 			</WizardSection>
 			<WizardSection
-				title={ __( 'Post content fallback image', 'newspack-plugin' ) }
+				title={ __( 'Image fallback', 'newspack-plugin' ) }
 				description={ __( 'Select a fallback image to display when an image inside post content cannot be found.', 'newspack-plugin' ) }
 			>
 				<Grid>

--- a/src/wizards/newspack/views/settings/constants.ts
+++ b/src/wizards/newspack/views/settings/constants.ts
@@ -60,6 +60,8 @@ export const ADVANCED_SETTINGS_DEFAULTS = {
 	newspack_image_credits_auto_populate: false,
 	// PWA Display Mode.
 	pwa_display_mode: 'minimal-ui',
+	// Post content fallback image.
+	newspack_default_image_url: undefined,
 };
 
 export const DEFAULT_THEME_MODS: ThemeMods = {

--- a/src/wizards/newspack/views/settings/theme-mods.d.ts
+++ b/src/wizards/newspack/views/settings/theme-mods.d.ts
@@ -6,7 +6,7 @@ type ThemeNames = 'theme' | 'scott' | 'nelson' | 'katharine' | 'sacha' | 'joseph
 /**
  * Theme names with `newspack` prefix.
  */
-type NewspackThemes = `newspack-${ ThemeNames }`;
+type NewspackThemes = `newspack-${ThemeNames}`;
 
 /**
  * Property on theme mods endpoint.
@@ -19,10 +19,10 @@ interface Etc {
 /**
  * Theme and brand schema.
  */
-interface ThemeData< T = {} > {
+interface ThemeData<T = {}> {
 	etc: Etc;
 	theme: '' | NewspackThemes;
-	theme_mods: ThemeMods< T >;
+	theme_mods: ThemeMods<T>;
 	homepage_patterns: HomepagePattern[];
 }
 
@@ -77,8 +77,8 @@ interface ThemeAndBrand {
 /**
  * Theme mods component.
  */
-type ThemeModComponentProps< T = ThemeMods > = {
-	update: ( a: Partial< T > ) => void;
+type ThemeModComponentProps<T = ThemeMods> = {
+	update: (a: Partial<T>) => void;
 	isFetching?: boolean;
 	data: T;
 };
@@ -126,6 +126,9 @@ interface AdvancedSettings {
 
 	// PWA Display Mode.
 	pwa_display_mode: string;
+
+	// Post content fallback image.
+	post_content_fallback_image?: string | null;
 }
 
 interface MiscSettings {
@@ -135,4 +138,4 @@ interface MiscSettings {
 	custom_css_post_id: number;
 }
 
-interface ThemeMods extends ThemeAndBrand, AdvancedSettings, MiscSettings {}
+interface ThemeMods extends ThemeAndBrand, AdvancedSettings, MiscSettings { }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Tweaks the "default image" feature implemented in #3811:

- Only loads the default/fallback image for broken images within the post or page content
- Moves the UI to select a default/fallback image from the Media Library to **Newspack > Advanced Settings**

Closes NPPM-2355.

### How to test the changes in this Pull Request:

1. Check out this branch and rebuild assets
2. Visit the Media Library, open some items, and confirm that the "Is default image?" checkbox and description are NOT shown as described in #3811
3. Visit **Newspack > Advanced Settings** and confirm there's a new section below the Media Credits section:

<img width="1091" height="473" alt="Screenshot 2025-11-10 at 10 53 15 AM" src="https://github.com/user-attachments/assets/68ffc9f4-c7ef-4009-b802-accb503ad5f4" />

4. Click "Select" and choose or upload an image in the Media Library modal. Confirm that a preview of the chosen image is rendered in the settings page

<img width="1107" height="773" alt="Screenshot 2025-11-10 at 10 53 48 AM" src="https://github.com/user-attachments/assets/e3946de2-37fc-4e05-9902-50316d9e2abd" />

5. Save settings, refresh, confirm that the selected image persists in the settings page
6. In a post, add an Image block to the post content, save, then delete this image from the Media Library
7. On the front-end, confirm that the post content fallback image you selected is rendered in place of the now-missing image
8. Add an image to somewhere outside of the post content (such as inside the header or footer using widgets), then delete this image from the Media Library
9. On the front-end, confirm that the image fails to load but is NOT replaced by the fallback image you selected (because it's not inside the post content)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->