### PR TITLE
fix(nrh): validation error in Donate block when no woocommerce

### DIFF
--- a/includes/wizards/audience/class-audience-donations.php
+++ b/includes/wizards/audience/class-audience-donations.php
@@ -369,6 +369,10 @@ class Audience_Donations extends Wizard {
 	protected function validate_donation_products() {
 		$validation_results = [];
 
+		if ( ! Donations::is_platform_wc() ) {
+			return $validation_results;
+		}
+
 		// Check if WooCommerce is active.
 		if ( ! class_exists( '\Newspack\WooCommerce_Product_Validator' ) ) {
 			return $validation_results;

--- a/src/wizards/audience/components/nrh-settings/index.js
+++ b/src/wizards/audience/components/nrh-settings/index.js
@@ -69,7 +69,6 @@ const NRHSettings = () => {
 			</div>
 			{ settings.hasOwnProperty( 'donor_landing_page' ) && (
 				<div>
-					<hr />
 					<h3>{ __( 'Donor Landing Page', 'newspack-plugin' ) }</h3>
 					<p className="components-base-control__help">
 						{ __(
@@ -101,6 +100,7 @@ const NRHSettings = () => {
 					{ __( 'Save Settings' ) }
 				</Button>
 			</div>
+			<hr />
 		</WizardsSection>
 	);
 };


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#4163 added WooCommerce product validation for the Donate block, but introduced a fatal error when WooCommerce isn't active on the site. This skips the product validation if not using Newspack's reader revenue platform.

Also moves an `<hr />` in the NRH settings wizard component to a place that makes more visual sense for the page.

Closes NPPM-2386.

### How to test the changes in this Pull Request:

1. On `release,` in **Audience Management > Configuration > Checkout & Payment**, set your reader revenue platform to News Revenue Hub. Note the new placement of the `<hr />` separator below the "Donor Landing Page" section instead of above it. Save.
2. Deactivate the `woocommerce` plugin if active on your site.
3. Add a Donate block to a post or page and observe an error that makes it impossible to configure the block:

<img width="816" height="61" alt="Screenshot 2025-11-10 at 11 27 43 AM" src="https://github.com/user-attachments/assets/6b3ffc9e-851a-451b-8255-79ecc05612a7" />

4. Check out this branch, refresh the post or page editor and confirm that the error doesn't happen and that you can configure the block as usual (especially the News Revenue Hub Settings sidebar panel), and that the block renders and behaves as expected on the front-end. For NRH blocks, it should redirect to a `fundjournalism.org` URL with a query string reflecting NRH and Donate block settings, e.g. `?amount=100.0&frequency=monthly&org_id=123456&campaign=nrh-campaign-name`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->