### PR TITLE
feat(cover-fees): support non-donation purchases

### DIFF
--- a/includes/plugins/woocommerce/class-woocommerce-cover-fees.php
+++ b/includes/plugins/woocommerce/class-woocommerce-cover-fees.php
@@ -108,16 +108,15 @@ class WooCommerce_Cover_Fees {
 		if ( ! function_exists( 'is_checkout' ) || ! is_checkout() ) {
 			return false;
 		}
-		if ( ! Donations::is_donation_cart() ) {
-			// Only allow covering fees for donations.
-			return false;
-		}
 		if ( 0 < count( WC()->cart->get_coupon_discount_totals() ) ) {
 			// If the checkout has coupons applied, bail. This can be develped in the future,
 			// but at this point handling coupons + covering fees is an edge case.
 			return false;
 		}
 		if ( true !== boolval( get_option( 'newspack_donations_allow_covering_fees', true ) ) ) {
+			return false;
+		}
+		if ( ! Donations::is_donation_cart() && true == boolval( get_option( 'newspack_donations_allow_covering_fees_donations_only', true ) ) ) {
 			return false;
 		}
 		return true;

--- a/includes/wizards/audience/class-audience-donations.php
+++ b/includes/wizards/audience/class-audience-donations.php
@@ -124,46 +124,6 @@ class Audience_Donations extends Wizard {
 			]
 		);
 
-		// Save additional settings.
-		register_rest_route(
-			NEWSPACK_API_NAMESPACE,
-			'/wizard/' . $this->slug . '/settings/',
-			[
-				'methods'             => \WP_REST_Server::EDITABLE,
-				'callback'            => [ $this, 'api_update_additional_settings' ],
-				'permission_callback' => [ $this, 'api_permissions_check' ],
-				'args'                => [
-					'fee_multiplier'              => [
-						'sanitize_callback' => 'Newspack\newspack_clean',
-						'validate_callback' => function ( $value ) {
-							if ( (float) $value > 10 ) {
-								return new WP_Error(
-									'newspack_invalid_param',
-									__( 'Fee multiplier must be smaller than 10.', 'newspack' )
-								);
-							}
-							return true;
-						},
-					],
-					'fee_static'                  => [
-						'sanitize_callback' => 'Newspack\newspack_clean',
-					],
-					'allow_covering_fees'         => [
-						'sanitize_callback' => 'Newspack\newspack_string_to_bool',
-					],
-					'allow_covering_fees_default' => [
-						'sanitize_callback' => 'Newspack\newspack_string_to_bool',
-					],
-					'allow_covering_fees_label'   => [
-						'sanitize_callback' => 'Newspack\newspack_clean',
-					],
-					'location_code'               => [
-						'sanitize_callback' => 'Newspack\newspack_clean',
-					],
-				],
-			]
-		);
-
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
 			'/wizard/' . $this->slug . '/emails/(?P<id>\d+)',
@@ -173,44 +133,6 @@ class Audience_Donations extends Wizard {
 				'permission_callback' => [ $this, 'api_permissions_check' ],
 			]
 		);
-	}
-
-	/**
-	 * Handler for setting additional settings.
-	 *
-	 * @param object $settings Settings.
-	 * @return WP_REST_Response with the latest settings.
-	 */
-	public function update_additional_settings( $settings ) {
-		if ( isset( $settings['allow_covering_fees'] ) ) {
-			update_option( 'newspack_donations_allow_covering_fees', intval( $settings['allow_covering_fees'] ) );
-		}
-		if ( isset( $settings['allow_covering_fees_default'] ) ) {
-			update_option( 'newspack_donations_allow_covering_fees_default', $settings['allow_covering_fees_default'] );
-		}
-
-		if ( isset( $settings['allow_covering_fees_label'] ) ) {
-			update_option( 'newspack_donations_allow_covering_fees_label', sanitize_text_field( $settings['allow_covering_fees_label'] ) );
-		}
-		if ( isset( $settings['fee_multiplier'] ) ) {
-			update_option( 'newspack_blocks_donate_fee_multiplier', $settings['fee_multiplier'] );
-		}
-		if ( isset( $settings['fee_static'] ) ) {
-			update_option( 'newspack_blocks_donate_fee_static', $settings['fee_static'] );
-		}
-		return $this->fetch_all_data();
-	}
-
-	/**
-	 * Save additional payment method settings (e.g. transaction fees).
-	 *
-	 * @param WP_REST_Request $request Request object.
-	 * @return WP_REST_Response Response.
-	 */
-	public function api_update_additional_settings( $request ) {
-		$params = $request->get_params();
-		$result = $this->update_additional_settings( $params );
-		return \rest_ensure_response( $result );
 	}
 
 	/**
@@ -246,19 +168,12 @@ class Audience_Donations extends Wizard {
 		$platform = Donations::get_platform_slug();
 
 		$args = [
-			'platform_data'       => [
+			'platform_data'      => [
 				'platform' => $platform,
 			],
-			'additional_settings' => [
-				'allow_covering_fees'         => boolval( get_option( 'newspack_donations_allow_covering_fees', true ) ),
-				'allow_covering_fees_default' => boolval( get_option( 'newspack_donations_allow_covering_fees_default', false ) ),
-				'allow_covering_fees_label'   => get_option( 'newspack_donations_allow_covering_fees_label', '' ),
-				'fee_multiplier'              => get_option( 'newspack_blocks_donate_fee_multiplier', '2.9' ),
-				'fee_static'                  => get_option( 'newspack_blocks_donate_fee_static', '0.3' ),
-			],
-			'donation_data'       => Donations::get_donation_settings(),
-			'donation_page'       => Donations::get_donation_page_info(),
-			'product_validation'  => $this->validate_donation_products(),
+			'donation_data'      => Donations::get_donation_settings(),
+			'donation_page'      => Donations::get_donation_page_info(),
+			'product_validation' => $this->validate_donation_products(),
 		];
 		if ( 'wc' === $platform ) {
 			$plugin_status    = true;

--- a/includes/wizards/audience/class-audience-wizard.php
+++ b/includes/wizards/audience/class-audience-wizard.php
@@ -370,6 +370,55 @@ class Audience_Wizard extends Wizard {
 			]
 		);
 
+		// Cover fees settings.
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->slug . '/cover-fees',
+			[
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'api_get_cover_fees_settings' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+			]
+		);
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->slug . '/cover-fees',
+			[
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => [ $this, 'api_update_cover_fees_settings' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+				'args'                => [
+					'fee_multiplier'                     => [
+						'sanitize_callback' => 'Newspack\newspack_clean',
+						'validate_callback' => function ( $value ) {
+							if ( (float) $value > 10 ) {
+								return new WP_Error(
+									'newspack_invalid_param',
+									__( 'Fee multiplier must be smaller than 10.', 'newspack' )
+								);
+							}
+							return true;
+						},
+					],
+					'fee_static'                         => [
+						'sanitize_callback' => 'Newspack\newspack_clean',
+					],
+					'allow_covering_fees'                => [
+						'sanitize_callback' => 'Newspack\newspack_string_to_bool',
+					],
+					'allow_covering_fees_default'        => [
+						'sanitize_callback' => 'Newspack\newspack_string_to_bool',
+					],
+					'allow_covering_fees_label'          => [
+						'sanitize_callback' => 'Newspack\newspack_clean',
+					],
+					'allow_covering_fees_donations_only' => [
+						'sanitize_callback' => 'Newspack\newspack_string_to_bool',
+					],
+				],
+			]
+		);
+
 		// Save Stripe info.
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
@@ -916,5 +965,52 @@ class Audience_Wizard extends Wizard {
 		}
 
 		return $this->api_get_subscription_settings();
+	}
+
+	/**
+	 * Get cover fees settings.
+	 *
+	 * @return WP_REST_Response Response with the settings.
+	 */
+	public function api_get_cover_fees_settings() {
+		return rest_ensure_response(
+			[
+				'allow_covering_fees'                => boolval( get_option( 'newspack_donations_allow_covering_fees', true ) ),
+				'allow_covering_fees_default'        => boolval( get_option( 'newspack_donations_allow_covering_fees_default', false ) ),
+				'allow_covering_fees_label'          => get_option( 'newspack_donations_allow_covering_fees_label', '' ),
+				'allow_covering_fees_donations_only' => boolval( get_option( 'newspack_donations_allow_covering_fees_donations_only', false ) ),
+				'fee_multiplier'                     => get_option( 'newspack_blocks_donate_fee_multiplier', '2.9' ),
+				'fee_static'                         => get_option( 'newspack_blocks_donate_fee_static', '0.3' ),
+			]
+		);
+	}
+
+	/**
+	 * Update cover fees settings.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response Response with the updated settings.
+	 */
+	public function api_update_cover_fees_settings( $request ) {
+		$params = $request->get_params();
+		if ( isset( $params['allow_covering_fees'] ) ) {
+			update_option( 'newspack_donations_allow_covering_fees', intval( $params['allow_covering_fees'] ) );
+		}
+		if ( isset( $params['allow_covering_fees_default'] ) ) {
+			update_option( 'newspack_donations_allow_covering_fees_default', intval( $params['allow_covering_fees_default'] ) );
+		}
+		if ( isset( $params['allow_covering_fees_label'] ) ) {
+			update_option( 'newspack_donations_allow_covering_fees_label', sanitize_text_field( $params['allow_covering_fees_label'] ) );
+		}
+		if ( isset( $params['allow_covering_fees_donations_only'] ) ) {
+			update_option( 'newspack_donations_allow_covering_fees_donations_only', intval( $params['allow_covering_fees_donations_only'] ) );
+		}
+		if ( isset( $params['fee_multiplier'] ) ) {
+			update_option( 'newspack_blocks_donate_fee_multiplier', $params['fee_multiplier'] );
+		}
+		if ( isset( $params['fee_static'] ) ) {
+			update_option( 'newspack_blocks_donate_fee_static', $params['fee_static'] );
+		}
+		return $this->api_get_cover_fees_settings();
 	}
 }

--- a/includes/wizards/audience/class-audience-wizard.php
+++ b/includes/wizards/audience/class-audience-wizard.php
@@ -978,7 +978,7 @@ class Audience_Wizard extends Wizard {
 				'allow_covering_fees'                => boolval( get_option( 'newspack_donations_allow_covering_fees', true ) ),
 				'allow_covering_fees_default'        => boolval( get_option( 'newspack_donations_allow_covering_fees_default', false ) ),
 				'allow_covering_fees_label'          => get_option( 'newspack_donations_allow_covering_fees_label', '' ),
-				'allow_covering_fees_donations_only' => boolval( get_option( 'newspack_donations_allow_covering_fees_donations_only', false ) ),
+				'allow_covering_fees_donations_only' => boolval( get_option( 'newspack_donations_allow_covering_fees_donations_only', true ) ),
 				'fee_multiplier'                     => get_option( 'newspack_blocks_donate_fee_multiplier', '2.9' ),
 				'fee_static'                         => get_option( 'newspack_blocks_donate_fee_static', '0.3' ),
 			]

--- a/src/wizards/audience/components/cover-fees-settings/index.js
+++ b/src/wizards/audience/components/cover-fees-settings/index.js
@@ -2,88 +2,101 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { CheckboxControl } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
+import { CheckboxControl, ToggleControl } from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
-import { ActionCard, Button, Grid, TextControl } from '../../../../../packages/components/src';
-import { AUDIENCE_DONATIONS_WIZARD_SLUG } from '../../constants';
+import { Button, Grid, TextControl } from '../../../../../packages/components/src';
 import { useWizardData } from '../../../../../packages/components/src/wizard/store/utils';
 import { WIZARD_STORE_NAMESPACE } from '../../../../../packages/components/src/wizard/store';
+import WizardsSection from '../../../wizards-section';
 
 export const CoverFeesSettings = () => {
-	const { additional_settings: settings = {} } = useWizardData( AUDIENCE_DONATIONS_WIZARD_SLUG );
+	const settings = useWizardData( 'newspack-audience/cover-fees' );
 	const { updateWizardSettings } = useDispatch( WIZARD_STORE_NAMESPACE );
+	const isQuietLoading = useSelect( select => select( WIZARD_STORE_NAMESPACE ).isQuietLoading() ?? false, [] );
+
 	const changeHandler = ( key, value ) =>
 		updateWizardSettings( {
-			slug: AUDIENCE_DONATIONS_WIZARD_SLUG,
-			path: [ 'additional_settings', key ],
+			slug: 'newspack-audience/cover-fees',
+			path: [ key ],
 			value,
 		} );
 
 	const { saveWizardSettings } = useDispatch( WIZARD_STORE_NAMESPACE );
 	const onSave = () =>
 		saveWizardSettings( {
-			slug: AUDIENCE_DONATIONS_WIZARD_SLUG,
-			section: 'settings',
-			payloadPath: [ 'additional_settings' ],
+			slug: 'newspack-audience/cover-fees',
 		} );
 
 	return (
 		<>
-			<ActionCard
-				isMedium
+			<WizardsSection
 				title={ __( 'Collect transaction fees', 'newspack-plugin' ) }
-				description={ __( 'Allow donors to optionally cover transaction fees imposed by payment processors.', 'newspack-plugin' ) }
-				notificationLevel="info"
-				toggleChecked={ settings.allow_covering_fees }
-				toggleOnChange={ () => {
-					changeHandler( 'allow_covering_fees', ! settings.allow_covering_fees );
-					onSave();
-				} }
-				hasGreyHeader={ settings.allow_covering_fees }
-				hasWhiteHeader={ ! settings.allow_covering_fees }
-			>
-				{ settings.allow_covering_fees && (
-					<Grid noMargin rowGap={ 16 }>
-						<TextControl
-							type="number"
-							step="0.1"
-							value={ settings.fee_multiplier }
-							label={ __( 'Fee multiplier', 'newspack-plugin' ) }
-							onChange={ value => changeHandler( 'fee_multiplier', value ) }
-						/>
-						<TextControl
-							type="number"
-							step="0.1"
-							value={ settings.fee_static }
-							label={ __( 'Fee static portion', 'newspack-plugin' ) }
-							onChange={ value => changeHandler( 'fee_static', value ) }
-						/>
-						<TextControl
-							value={ settings.allow_covering_fees_label }
-							label={ __( 'Custom message', 'newspack-plugin' ) }
-							placeholder={ __( 'A message to explain the transaction fee option (optional).', 'newspack-plugin' ) }
-							onChange={ value => changeHandler( 'allow_covering_fees_label', value ) }
-						/>
-						<CheckboxControl
-							label={ __( 'Cover fees by default', 'newspack-plugin' ) }
-							checked={ settings.allow_covering_fees_default }
-							onChange={ () => changeHandler( 'allow_covering_fees_default', ! settings.allow_covering_fees_default ) }
-							help={ __( 'If enabled, the option to cover the transaction fee will be checked by default.', 'newspack-plugin' ) }
-						/>
-					</Grid>
+				description={ __(
+					'Allow readers to optionally cover transaction fees imposed by payment processors when making donations or subscribing.',
+					'newspack-plugin'
 				) }
-			</ActionCard>
-			{ settings.allow_covering_fees && (
+				className={ isQuietLoading ? 'is-fetching' : '' }
+			>
+				<ToggleControl
+					label={ __( 'Collect transaction fees', 'newspack-plugin' ) }
+					checked={ settings.allow_covering_fees }
+					disabled={ isQuietLoading }
+					onChange={ () => {
+						changeHandler( 'allow_covering_fees', ! settings.allow_covering_fees );
+						onSave();
+					} }
+				/>
+				<Grid rowGap={ 16 }>
+					<TextControl
+						type="number"
+						step="0.1"
+						value={ settings.fee_multiplier }
+						label={ __( 'Fee multiplier', 'newspack-plugin' ) }
+						onChange={ value => changeHandler( 'fee_multiplier', value ) }
+						disabled={ isQuietLoading }
+					/>
+					<TextControl
+						type="number"
+						step="0.1"
+						value={ settings.fee_static }
+						label={ __( 'Fee static portion', 'newspack-plugin' ) }
+						onChange={ value => changeHandler( 'fee_static', value ) }
+						disabled={ isQuietLoading }
+					/>
+					<TextControl
+						value={ settings.allow_covering_fees_label }
+						label={ __( 'Custom message', 'newspack-plugin' ) }
+						placeholder={ __( 'A message to explain the transaction fee option (optional).', 'newspack-plugin' ) }
+						onChange={ value => changeHandler( 'allow_covering_fees_label', value ) }
+						disabled={ isQuietLoading }
+					/>
+				</Grid>
+				<Grid rowGap={ 16 }>
+					<CheckboxControl
+						label={ __( 'Cover fees by default', 'newspack-plugin' ) }
+						checked={ settings.allow_covering_fees_default }
+						onChange={ () => changeHandler( 'allow_covering_fees_default', ! settings.allow_covering_fees_default ) }
+						help={ __( 'If enabled, the option to cover the transaction fee will be checked by default.', 'newspack-plugin' ) }
+						disabled={ isQuietLoading }
+					/>
+					<CheckboxControl
+						label={ __( 'Donations only', 'newspack-plugin' ) }
+						checked={ settings.allow_covering_fees_donations_only }
+						onChange={ () => changeHandler( 'allow_covering_fees_donations_only', ! settings.allow_covering_fees_donations_only ) }
+						help={ __( 'If enabled, the option to cover the transaction fee will only be available for donations.', 'newspack-plugin' ) }
+						disabled={ isQuietLoading }
+					/>
+				</Grid>
 				<div className="newspack-buttons-card">
-					<Button isPrimary onClick={ onSave }>
+					<Button isPrimary onClick={ onSave } disabled={ isQuietLoading }>
 						{ __( 'Save Settings', 'newspack-plugin' ) }
 					</Button>
 				</div>
-			) }
+			</WizardsSection>
 		</>
 	);
 };

--- a/src/wizards/audience/views/donations/configuration/index.tsx
+++ b/src/wizards/audience/views/donations/configuration/index.tsx
@@ -14,7 +14,6 @@ import { useWizardData } from '../../../../../../packages/components/src/wizard/
 import { WIZARD_STORE_NAMESPACE } from '../../../../../../packages/components/src/wizard/store';
 import WizardsTab from '../../../../wizards-tab';
 import { AUDIENCE_DONATIONS_WIZARD_SLUG } from '../../../constants';
-import { CoverFeesSettings } from '../../../components/cover-fees-settings';
 
 type FrequencySlug = 'once' | 'month' | 'year';
 
@@ -327,7 +326,6 @@ const Donation = () => {
 					{ __( 'Save Settings', 'newspack-plugin' ) }
 				</Button>
 			</div>
-			<CoverFeesSettings />
 		</WizardsTab>
 	);
 };

--- a/src/wizards/audience/views/setup/payment.js
+++ b/src/wizards/audience/views/setup/payment.js
@@ -14,9 +14,10 @@ import PaymentGateways from '../../components/payment-methods';
 import NRHSettings from '../../components/nrh-settings';
 import BillingFields from '../../components/billing-fields';
 import CheckoutConfiguration from '../../components/checkout-configuration';
+import { CoverFeesSettings } from '../../components/cover-fees-settings';
 import SubscriptionSettings from '../../components/subscription-settings';
 
-export default withWizardScreen( function () {
+export default withWizardScreen( function ( { wizardApiFetch } ) {
 	const data = useWizardData( 'newspack-audience/payment' );
 
 	return (
@@ -29,6 +30,7 @@ export default withWizardScreen( function () {
 			{ data?.platform_data?.platform === 'wc' && <BillingFields /> }
 			{ data?.platform_data?.platform === 'nrh' && <NRHSettings /> }
 			<CheckoutConfiguration />
+			{ data?.platform_data?.platform === 'wc' && <CoverFeesSettings wizardApiFetch={ wizardApiFetch } /> }
 			{ data?.platform_data?.platform === 'wc' && <SubscriptionSettings /> }
 		</WizardsTab>
 	);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

NPPD-183

Expands the "cover fee" functionality for any product. The configuration should now live under Audience -> Configuration -> Checkout & Payment, since it serves more than just donations:

| Before | After |
| --- | --- |
|  <img alt="image" src="https://github.com/user-attachments/assets/ffbf52e0-c499-4641-8b91-67fab4464a31" /> | <img alt="image" src="https://github.com/user-attachments/assets/9e0f7188-ebf4-4213-9f54-eaf65392191c" /> |

A new "Donations only" field was added and is checked by default, so it doesn't introduce any behavior change for current publishers. To enable all products, this new option must be checked off.

### How to test the changes in this Pull Request:

1. While on `trunk`, confirm you have "cover fee" enabled
2. Checkout this branch and, without any configuration change, confirm the cover fee continues to work as expected: available and working for donations only
3. Visit Audience -> Donations and confirm that the cover fees settings are not there
4. Visit Audience -> Configuration -> Payment & Checkout and confirm the new "Collect transaction fees" wizard section is rendered
5. Change some settings and toggle "Donations only" off
6. Purchase a subscription via the Checkout Button block and confirm the cover fee checkbox is available and reflects the applied configuration
7. Go through the checkout flow and confirm the fee is applied to the subscription

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->