### PR TITLE
fix(memberships-gate): incorrect ternary operator fails to get stored gate ID

### DIFF
--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -410,7 +410,7 @@ class Content_Gate {
 	 * @return int|false Post ID or false if not set.
 	 */
 	public static function get_gate_post_id( $post_id = null ) {
-		$gate_post_id = intval( self::$gate_post_id ?? \get_option( 'newspack_memberships_gate_post_id' ) );
+		$gate_post_id = intval( self::$gate_post_id ? self::$gate_post_id : \get_option( 'newspack_memberships_gate_post_id' ) );
 		if ( ! $gate_post_id ) {
 			$gate_post_id = false;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#4202 implemented an incorrect ternary operator that results in failing to fetch the correct gate post ID when editing the content gate from the Audience > Configuration > Content Gates wizard page.

### How to test the changes in this Pull Request:

1. On `release`, enable WooCommerce + Memberships and ensure that the `NEWSPACK_CONTENT_GATES` constant is NOT defined in wp-config.php.
2. Visit **Audience > Configuration > Content Gates** and edit the content gate, publish + save.
3. **Visit Audience > Configuration > Content Gates** again, edit the content gate, and observe that it creates and shows a new content gate post. 
4. Check out this branch, edit the content gate again, and confirm it shows the most recently created content gate.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->