### PR TITLE
feat(subscriptions): change frequency intervals strategy

### DIFF
--- a/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
+++ b/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
@@ -78,9 +78,14 @@ class WooCommerce_Subscriptions {
 			'week'    => __( 'Weekly', 'newspack-plugin' ),
 			'week_2'  => __( 'Bi-Weekly', 'newspack-plugin' ),
 			'month'   => __( 'Monthly', 'newspack-plugin' ),
+			'month_2' => __( 'Bimonthly', 'newspack-plugin' ),
 			'month_3' => __( 'Quarterly', 'newspack-plugin' ),
+			'month_4' => __( 'Four-monthly', 'newspack-plugin' ),
 			'month_6' => __( 'Semi-Annually', 'newspack-plugin' ),
 			'year'    => __( 'Yearly', 'newspack-plugin' ),
+			'year_2'  => __( 'Biennially', 'newspack-plugin' ),
+			'year_3'  => __( 'Triennially', 'newspack-plugin' ),
+			'year_4'  => __( 'Quadrennially', 'newspack-plugin' ),
 		];
 		// If frequency is not in the array, try to find the frequency without the interval.
 		if ( ! isset( $frequencies[ $frequency ] ) ) {

--- a/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
+++ b/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
@@ -68,31 +68,49 @@ class WooCommerce_Subscriptions {
 	/**
 	 * Get the label for a frequency.
 	 *
-	 * @param string $frequency Frequency.
+	 * @param string   $frequency Frequency.
+	 * @param int|null $interval  Optional interval. If not provided, the interval
+	 *                            can be extracted from the frequency string.
+	 *                            E.g. 'month_2' -> 2.
 	 *
 	 * @return string
 	 */
-	public static function get_frequency_label( $frequency ) {
-		$frequencies = [
-			'day'     => __( 'Daily', 'newspack-plugin' ),
-			'week'    => __( 'Weekly', 'newspack-plugin' ),
-			'week_2'  => __( 'Bi-Weekly', 'newspack-plugin' ),
-			'month'   => __( 'Monthly', 'newspack-plugin' ),
-			'month_2' => __( 'Bimonthly', 'newspack-plugin' ),
-			'month_3' => __( 'Quarterly', 'newspack-plugin' ),
-			'month_4' => __( 'Four-monthly', 'newspack-plugin' ),
-			'month_6' => __( 'Semi-Annually', 'newspack-plugin' ),
-			'year'    => __( 'Yearly', 'newspack-plugin' ),
-			'year_2'  => __( 'Biennially', 'newspack-plugin' ),
-			'year_3'  => __( 'Triennially', 'newspack-plugin' ),
-			'year_4'  => __( 'Quadrennially', 'newspack-plugin' ),
+	public static function get_frequency_label( $frequency, $interval = null ) {
+		$parts    = explode( '_', $frequency );
+		$period   = $parts[0] ?? '';
+		$interval = $interval ?? ( isset( $parts[1] ) ? (int) $parts[1] : 1 );
+		$interval = $interval > 0 ? $interval : 1;
+
+		$single_labels = [
+			'day'   => __( 'Daily', 'newspack-plugin' ),
+			'week'  => __( 'Weekly', 'newspack-plugin' ),
+			'month' => __( 'Monthly', 'newspack-plugin' ),
+			'year'  => __( 'Yearly', 'newspack-plugin' ),
 		];
-		// If frequency is not in the array, try to find the frequency without the interval.
-		if ( ! isset( $frequencies[ $frequency ] ) ) {
-			$frequency = explode( '_', $frequency )[0];
-			$label = $frequencies[ $frequency ] ?? ucfirst( $frequency );
+
+		// phpcs:disable WordPress.WP.I18n.MissingTranslatorsComment
+		$multiple_templates = [
+			'day'   => __( '%s Days', 'newspack-plugin' ),
+			'week'  => __( '%s Weeks', 'newspack-plugin' ),
+			'month' => __( '%s Months', 'newspack-plugin' ),
+			'year'  => __( '%s Years', 'newspack-plugin' ),
+		];
+		// phpcs:enable
+
+		if ( 1 === $interval ) {
+			$label = $single_labels[ $period ] ?? ucfirst( $period );
+		} elseif ( isset( $multiple_templates[ $period ] ) ) {
+				$label = sprintf(
+					$multiple_templates[ $period ],
+					number_format_i18n( $interval )
+				);
 		} else {
-			$label = $frequencies[ $frequency ];
+			$label = sprintf(
+				// translators: 1: Subscription interval. 2: Subscription period.
+				__( '%1$s %2$ss', 'newspack-plugin' ),
+				number_format_i18n( $interval ),
+				ucfirst( $period )
+			);
 		}
 
 		/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

NPPD-988

~Add support for Bimonthly, Four-monthly, Biennially, Triennially, and Quadrennially frequency intervals.~

After internal discussion, it was decided to simplify this strategy and have daily/monthly/yearly for singular intervals and "X Days/X Months/X Years" for multiple intervals.

### How to test the changes in this Pull Request:

1. Create 2 new variable subscription products with frequency as a variation attribute
2. For each product, configure each variation billing interval and period to match the new options:
   1. X every 1 day
   2. X every 2 days
   3. X every 1 month
   4. X every 2 months
   5. X every 1 year
   6. X every 2 years
3. Create a Grouped Product linking the 2 variable subscriptions
4. Edit a page and add a Checkout Button block targeting the grouped product
5. As a reader, click the Checkout Button
9. Confirm each variation matches the correct label

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->