### PR TITLE
feat(contrib-meter): add contribution meter block

### DIFF
--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -23,6 +23,7 @@ final class Blocks {
 		require_once NEWSPACK_ABSPATH . 'src/blocks/reader-registration/index.php';
 		require_once NEWSPACK_ABSPATH . 'src/blocks/content-gate/countdown/class-content-gate-countdown-block.php';
 		require_once NEWSPACK_ABSPATH . 'src/blocks/content-gate/countdown-box/class-content-gate-countdown-box-block.php';
+		require_once NEWSPACK_ABSPATH . 'src/blocks/contribution-meter/index.php';
 
 		if ( wp_is_block_theme() && class_exists( 'Newspack\Corrections' ) ) {
 			require_once NEWSPACK_ABSPATH . 'src/blocks/correction-box/class-correction-box-block.php';

--- a/includes/contribution-meter/class-contribution-meter.php
+++ b/includes/contribution-meter/class-contribution-meter.php
@@ -199,13 +199,14 @@ class Contribution_Meter {
 			$user_end_date_obj = new \DateTime( $end_date, wp_timezone() );
 			$end_date          = ( $user_end_date_obj < $yesterday ) ? $end_date : $yesterday->format( 'Y-m-d' );
 		} else {
-			// No user end date - apply the default max range.
+			// No user end date - apply the default max range from start date.
 			$max_end_date_range = get_option( self::MAX_END_DATE_RANGE_OPTION, self::DEFAULT_MAX_END_DATE_RANGE );
 
-			// Calculate maximum allowed end date from today + max range (e.g., today + 6 months).
-			$max_allowed_end_date = new \DateTime( $max_end_date_range, wp_timezone() );
+			// Calculate maximum allowed end date from start date + max range (e.g., start date + 6 months).
+			$max_allowed_end_date = new \DateTime( $start_date, wp_timezone() );
+			$max_allowed_end_date->modify( $max_end_date_range );
 
-			// Use the minimum of (yesterday, maximum allowed end date).
+			// Use the minimum between yesterday and the maximum allowed end date.
 			$end_date = ( $max_allowed_end_date < $yesterday ) ? $max_allowed_end_date->format( 'Y-m-d' ) : $yesterday->format( 'Y-m-d' );
 		}
 

--- a/includes/contribution-meter/class-contribution-meter.php
+++ b/includes/contribution-meter/class-contribution-meter.php
@@ -22,6 +22,17 @@ class Contribution_Meter {
 	const REST_ROUTE = '/contribution-meter';
 
 	/**
+	 * Default oldest allowed start date range (relative to today).
+	 * E.g., '-2 months' means start date cannot be earlier than 2 months ago.
+	 */
+	const DEFAULT_START_DATE_RANGE = '-2 months';
+
+	/**
+	 * Start date range option name.
+	 */
+	const START_DATE_RANGE_OPTION = 'newspack_contribution_meter_start_date_range';
+
+	/**
 	 * Default data collection end date range (relative to today).
 	 * E.g., '-1 day' means collect up to yesterday, excluding today.
 	 */
@@ -31,6 +42,16 @@ class Contribution_Meter {
 	 * End date range option name.
 	 */
 	const END_DATE_RANGE_OPTION = 'newspack_contribution_meter_end_date_range';
+
+	/**
+	 * Default maximum allowed end date range (relative to today).
+	 */
+	const DEFAULT_MAX_END_DATE_RANGE = '+6 months';
+
+	/**
+	 * Maximum end date range option name.
+	 */
+	const MAX_END_DATE_RANGE_OPTION = 'newspack_contribution_meter_max_end_date_range';
 
 	/**
 	 * Cache key prefix for contribution meter data.
@@ -63,6 +84,11 @@ class Contribution_Meter {
 						'type'              => 'string',
 						'validate_callback' => [ __CLASS__, 'validate_date' ],
 					],
+					'endDate'   => [
+						'required'          => false,
+						'type'              => 'string',
+						'validate_callback' => [ __CLASS__, 'validate_date' ],
+					],
 				],
 			]
 		);
@@ -75,6 +101,11 @@ class Contribution_Meter {
 	 * @return bool|\WP_Error True if valid, WP_Error if invalid.
 	 */
 	public static function validate_date( $date ) {
+		// Allow empty string for optional dates.
+		if ( empty( $date ) ) {
+			return true;
+		}
+
 		// Validate basic date format.
 		if ( ! preg_match( '/^\d{4}-\d{2}-\d{2}$/', $date ) ) {
 			return new \WP_Error( 'invalid_date', __( 'Invalid date format. Expected YYYY-MM-DD.', 'newspack-plugin' ) );
@@ -90,6 +121,40 @@ class Contribution_Meter {
 	}
 
 	/**
+	 * Validate that end date is after start date and doesn't exceed configured maximum.
+	 *
+	 * @param string $start_date Start date in YYYY-MM-DD format.
+	 * @param string $end_date   End date in YYYY-MM-DD format.
+	 * @return bool|\WP_Error True if valid, WP_Error if invalid.
+	 */
+	public static function validate_date_range( $start_date, $end_date ) {
+		$start = new \DateTime( $start_date, wp_timezone() );
+		$end   = new \DateTime( $end_date, wp_timezone() );
+
+		// End date must be after start date.
+		if ( $end < $start ) {
+			return new \WP_Error(
+				'invalid_date_range',
+				__( 'End date must be after start date.', 'newspack-plugin' )
+			);
+		}
+
+		// Get configured maximum end date range.
+		$max_end_date_range = get_option( self::MAX_END_DATE_RANGE_OPTION, self::DEFAULT_MAX_END_DATE_RANGE );
+		$max_end_date       = new \DateTime( $max_end_date_range, wp_timezone() );
+
+		// End date cannot exceed configured maximum.
+		if ( $end > $max_end_date ) {
+			return new \WP_Error(
+				'date_range_too_large',
+				__( 'End date exceeds the configured maximum date range.', 'newspack-plugin' )
+			);
+		}
+
+		return true;
+	}
+
+	/**
 	 * REST API callback to get contribution data.
 	 *
 	 * @param \WP_REST_Request $request Request object.
@@ -97,7 +162,17 @@ class Contribution_Meter {
 	 */
 	public static function api_get_contribution_data( $request ) {
 		$start_date = $request->get_param( 'startDate' );
-		$data       = self::get_contribution_data( $start_date );
+		$end_date   = $request->get_param( 'endDate' );
+
+		// Validate date range if end date is provided.
+		if ( ! empty( $end_date ) ) {
+			$validation = self::validate_date_range( $start_date, $end_date );
+			if ( is_wp_error( $validation ) ) {
+				return $validation;
+			}
+		}
+
+		$data = self::get_contribution_data( $start_date, $end_date );
 
 		if ( is_wp_error( $data ) ) {
 			return $data;
@@ -109,15 +184,30 @@ class Contribution_Meter {
 	/**
 	 * Get contribution data with caching.
 	 *
-	 * @param string $start_date Valid start date in YYYY-MM-DD format.
+	 * @param string      $start_date Valid start date in YYYY-MM-DD format.
+	 * @param string|null $end_date   Optional end date in YYYY-MM-DD format.
 	 * @return array|\WP_Error Array of contribution data or WP_Error on failure.
 	 */
-	public static function get_contribution_data( $start_date ) {
-		// Get the end range (e.g., '-1 day' means collect up to yesterday).
+	public static function get_contribution_data( $start_date, $end_date = null ) {
+		// Get the system default end date (e.g., '-1 day' means yesterday).
 		$end_date_range = get_option( self::END_DATE_RANGE_OPTION, self::DEFAULT_END_DATE_RANGE );
+		$yesterday      = new \DateTime( $end_date_range, wp_timezone() );
 
-		// Calculate the end date based on the configured range.
-		$end_date = ( new \DateTime( $end_date_range, wp_timezone() ) )->format( 'Y-m-d' );
+		// Determine the final end date.
+		if ( ! empty( $end_date ) ) {
+			// User provided an end date - use the minimum of (yesterday, user's end date).
+			$user_end_date_obj = new \DateTime( $end_date, wp_timezone() );
+			$end_date          = ( $user_end_date_obj < $yesterday ) ? $end_date : $yesterday->format( 'Y-m-d' );
+		} else {
+			// No user end date - apply the default max range.
+			$max_end_date_range = get_option( self::MAX_END_DATE_RANGE_OPTION, self::DEFAULT_MAX_END_DATE_RANGE );
+
+			// Calculate maximum allowed end date from today + max range (e.g., today + 6 months).
+			$max_allowed_end_date = new \DateTime( $max_end_date_range, wp_timezone() );
+
+			// Use the minimum of (yesterday, maximum allowed end date).
+			$end_date = ( $max_allowed_end_date < $yesterday ) ? $max_allowed_end_date->format( 'Y-m-d' ) : $yesterday->format( 'Y-m-d' );
+		}
 
 		// Generate cache key including end date for automatic invalidation when range changes.
 		$cache_key = self::CACHE_KEY_PREFIX . md5( $start_date . '_' . $end_date );

--- a/includes/contribution-meter/class-contribution-meter.php
+++ b/includes/contribution-meter/class-contribution-meter.php
@@ -176,8 +176,6 @@ class Contribution_Meter {
 	 */
 	private static function get_donation_revenue_via_order_query( $start_date, $end_date, $product_ids ) {
 		$statuses = apply_filters( 'newspack_contribution_meter_order_statuses', [ 'completed', 'processing' ] );
-		$after    = self::get_local_wc_datetime( $start_date );
-		$before   = self::get_local_wc_datetime( $end_date );
 
 		$query_args = [
 			'limit'        => 200,
@@ -187,7 +185,7 @@ class Contribution_Meter {
 			'return'       => 'ids',
 			'status'       => $statuses,
 			'type'         => 'shop_order',
-			'date_created' => '>= ' . $after->date_i18n( 'Y-m-d H:i:s' ) . '...<= ' . $before->date_i18n( 'Y-m-d H:i:s' ),
+			'date_created' => $start_date . '...' . $end_date,
 		];
 
 		$total_revenue = 0.0;
@@ -232,18 +230,6 @@ class Contribution_Meter {
 		} while ( $page <= $max_pages );
 
 		return $total_revenue;
-	}
-
-	/**
-	 * Convert a YYYY-MM-DD string into a WC_DateTime in the site's timezone.
-	 *
-	 * @param string $date Date string.
-	 * @return \WC_DateTime
-	 */
-	private static function get_local_wc_datetime( $date ) {
-		$timezone  = new \DateTimeZone( wc_timezone_string() );
-		$formatted = false !== strpos( $date, ' ' ) ? $date : $date . ' 00:00:00';
-		return new \WC_DateTime( $formatted, $timezone );
 	}
 
 	/**

--- a/includes/contribution-meter/class-contribution-meter.php
+++ b/includes/contribution-meter/class-contribution-meter.php
@@ -1,0 +1,187 @@
+<?php
+/**
+ * Newspack Contribution Meter.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Contribution_Meter;
+
+use Newspack\Donations;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Handles contribution meter data retrieval and calculations.
+ */
+class Contribution_Meter {
+
+	/**
+	 * REST route for contribution meter.
+	 */
+	const REST_ROUTE = '/contribution-meter';
+
+	/**
+	 * Cache duration in seconds for donation revenue calculations.
+	 */
+	const CACHE_DURATION = 600;
+
+	/**
+	 * Cache key prefix for contribution meter data.
+	 */
+	const CACHE_KEY_PREFIX = 'newspack_contribution_meter_';
+
+	/**
+	 * Initialize hooks and REST API endpoints.
+	 */
+	public static function init() {
+		add_action( 'rest_api_init', [ __CLASS__, 'register_rest_routes' ] );
+	}
+
+	/**
+	 * Register REST API routes for the contribution meter.
+	 */
+	public static function register_rest_routes() {
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			self::REST_ROUTE,
+			[
+				'methods'             => 'POST',
+				'callback'            => [ __CLASS__, 'api_get_contribution_data' ],
+				'permission_callback' => function () {
+					return current_user_can( 'edit_posts' );
+				},
+				'args'                => [
+					'startDate' => [
+						'required'          => true,
+						'type'              => 'string',
+						'validate_callback' => [ __CLASS__, 'validate_date' ],
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Validate date format and value.
+	 *
+	 * @param string $date Date string to validate.
+	 * @return bool|WP_Error True if valid, WP_Error if invalid.
+	 */
+	public static function validate_date( $date ) {
+		if ( ! preg_match( '/^\d{4}-\d{2}-\d{2}$/', $date ) ) {
+			return new \WP_Error( 'invalid_date', __( 'Invalid date format. Expected YYYY-MM-DD.', 'newspack-plugin' ) );
+		}
+		$date_obj = \DateTime::createFromFormat( 'Y-m-d', $date );
+		if ( ! $date_obj || $date_obj->format( 'Y-m-d' ) !== $date ) {
+			return new \WP_Error( 'invalid_date', __( 'Invalid date. Please provide a valid date.', 'newspack-plugin' ) );
+		}
+		return true;
+	}
+
+	/**
+	 * REST API callback to get contribution data.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response|WP_Error Response object or error.
+	 */
+	public static function api_get_contribution_data( $request ) {
+		$start_date = $request->get_param( 'startDate' );
+		$data       = self::get_contribution_data( $start_date );
+
+		if ( is_wp_error( $data ) ) {
+			return $data;
+		}
+
+		return rest_ensure_response( $data );
+	}
+
+	/**
+	 * Get contribution data with caching.
+	 *
+	 * @param string $start_date Valid start date in YYYY-MM-DD format.
+	 * @return array|WP_Error Array of contribution data or WP_Error on failure.
+	 */
+	public static function get_contribution_data( $start_date ) {
+		// Generate cache key based on start date.
+		$cache_key = self::CACHE_KEY_PREFIX . md5( $start_date );
+		$cached    = get_transient( $cache_key );
+
+		if ( false !== $cached ) {
+			return $cached;
+		}
+
+		$amount_raised = self::get_donation_revenue( $start_date );
+
+		if ( is_wp_error( $amount_raised ) ) {
+			return $amount_raised;
+		}
+
+		$data = [
+			'amountRaised' => $amount_raised,
+		];
+
+		/**
+		 * Filters the expiration time for contribution meter data.
+		 *
+		 * @param int $expiration Expiration time in seconds.
+		 */
+		$expiration = apply_filters( 'newspack_contribution_meter_cache_duration', self::CACHE_DURATION );
+
+		set_transient( $cache_key, $data, $expiration );
+
+		return $data;
+	}
+
+	/**
+	 * Get total donation revenue from a specific start date.
+	 *
+	 * @param string $start_date Start date in YYYY-MM-DD format.
+	 * @return float|WP_Error Total revenue or WP_Error on failure.
+	 */
+	public static function get_donation_revenue( $start_date ) {
+		if ( ! function_exists( 'wc_get_orders' ) || ! function_exists( 'wc_get_order' ) ) {
+			return new \WP_Error( 'woocommerce_inactive', __( 'WooCommerce is not active.', 'newspack-plugin' ) );
+		}
+
+		// Get all donation product IDs.
+		$donation_products    = Donations::get_donation_product_child_products_ids();
+		$donation_product_ids = array_filter( array_values( $donation_products ) );
+
+		if ( empty( $donation_product_ids ) ) {
+			return new \WP_Error( 'no_donation_products', __( 'No donation products found.', 'newspack-plugin' ) );
+		}
+
+		// Query orders from the start date.
+		$orders = \wc_get_orders(
+			[
+				'limit'        => -1,
+				'status'       => [ 'completed', 'processing' ],
+				'date_created' => '>=' . strtotime( $start_date ),
+				'return'       => 'ids',
+			]
+		);
+
+		$total = 0;
+
+		// Sum donation revenue from matching orders.
+		foreach ( $orders as $order_id ) {
+			$order = \wc_get_order( $order_id );
+
+			if ( ! $order ) {
+				continue;
+			}
+
+			foreach ( $order->get_items() as $item ) {
+				$product_id = $item->get_product_id();
+
+				// Only count items from donation products.
+				if ( in_array( $product_id, $donation_product_ids, true ) ) {
+					$total += (float) $item->get_total();
+				}
+			}
+		}
+
+		return $total;
+	}
+}

--- a/includes/contribution-meter/class-contribution-meter.php
+++ b/includes/contribution-meter/class-contribution-meter.php
@@ -81,7 +81,7 @@ class Contribution_Meter {
 	 * Validate date format and value.
 	 *
 	 * @param string $date Date string to validate.
-	 * @return bool|WP_Error True if valid, WP_Error if invalid.
+	 * @return bool|\WP_Error True if valid, WP_Error if invalid.
 	 */
 	public static function validate_date( $date ) {
 		// Validate basic date format.
@@ -116,8 +116,8 @@ class Contribution_Meter {
 	/**
 	 * REST API callback to get contribution data.
 	 *
-	 * @param WP_REST_Request $request Request object.
-	 * @return WP_REST_Response|WP_Error Response object or error.
+	 * @param \WP_REST_Request $request Request object.
+	 * @return \WP_REST_Response|\WP_Error Response object or error.
 	 */
 	public static function api_get_contribution_data( $request ) {
 		$start_date = $request->get_param( 'startDate' );
@@ -134,7 +134,7 @@ class Contribution_Meter {
 	 * Get contribution data with caching.
 	 *
 	 * @param string $start_date Valid start date in YYYY-MM-DD format.
-	 * @return array|WP_Error Array of contribution data or WP_Error on failure.
+	 * @return array|\WP_Error Array of contribution data or WP_Error on failure.
 	 */
 	public static function get_contribution_data( $start_date ) {
 		// Generate cache key based on start date.
@@ -165,7 +165,7 @@ class Contribution_Meter {
 	 * Get total donation revenue from a specific start date.
 	 *
 	 * @param string $start_date Start date in YYYY-MM-DD format.
-	 * @return float|WP_Error Total revenue or WP_Error on failure.
+	 * @return float|\WP_Error Total revenue or WP_Error on failure.
 	 */
 	public static function get_donation_revenue( $start_date ) {
 		if ( ! function_exists( 'wc_get_orders' ) || ! function_exists( 'wc_get_order' ) ) {
@@ -188,7 +188,7 @@ class Contribution_Meter {
 	 *
 	 * @param string $start_date  Start date in YYYY-MM-DD format.
 	 * @param array  $product_ids Donation product IDs to include.
-	 * @return float|WP_Error Total revenue or WP_Error on failure.
+	 * @return float|\WP_Error Total revenue or WP_Error on failure.
 	 */
 	private static function get_donation_revenue_via_order_query( $start_date, $product_ids ) {
 		$statuses = apply_filters( 'newspack_contribution_meter_order_statuses', [ 'completed', 'processing' ] );

--- a/includes/contribution-meter/class-contribution-meter.php
+++ b/includes/contribution-meter/class-contribution-meter.php
@@ -22,29 +22,20 @@ class Contribution_Meter {
 	const REST_ROUTE = '/contribution-meter';
 
 	/**
-	 * Cache duration in seconds for donation revenue calculations.
+	 * Default data collection end date range (relative to today).
+	 * E.g., '-1 day' means collect up to yesterday, excluding today.
 	 */
-	const CACHE_DURATION = 600;
+	const DEFAULT_END_DATE_RANGE = '-1 day';
 
 	/**
-	 * Cache duration option name.
+	 * End date range option name.
 	 */
-	const CACHE_DURATION_OPTION = 'newspack_contribution_meter_cache_duration';
+	const END_DATE_RANGE_OPTION = 'newspack_contribution_meter_end_date_range';
 
 	/**
 	 * Cache key prefix for contribution meter data.
 	 */
 	const CACHE_KEY_PREFIX = 'newspack_contribution_meter_';
-
-	/**
-	 * Maximum allowed date range for querying historical data.
-	 */
-	const MAX_DATE_RANGE = '-2 months';
-
-	/**
-	 * Maximum date range option name.
-	 */
-	const MAX_DATE_RANGE_OPTION = 'newspack_contribution_meter_max_date_range';
 
 	/**
 	 * Initialize hooks and REST API endpoints.
@@ -95,21 +86,6 @@ class Contribution_Meter {
 			return new \WP_Error( 'invalid_date', __( 'Invalid date. Please provide a valid date.', 'newspack-plugin' ) );
 		}
 
-		// Validate date range limit.
-		$max_range = get_option( self::MAX_DATE_RANGE_OPTION, self::MAX_DATE_RANGE );
-		$min_date  = new \DateTime( $max_range, new \DateTimeZone( 'UTC' ) );
-		$min_date->setTime( 0, 0, 0 ); // Normalize to midnight for date-only comparison.
-		if ( $date_obj < $min_date ) {
-			return new \WP_Error(
-				'date_too_old',
-				sprintf(
-					/* translators: %s: minimum allowed date */
-					__( 'Start date cannot be earlier than %s.', 'newspack-plugin' ),
-					$min_date->format( 'Y-m-d' )
-				)
-			);
-		}
-
 		return true;
 	}
 
@@ -137,15 +113,21 @@ class Contribution_Meter {
 	 * @return array|\WP_Error Array of contribution data or WP_Error on failure.
 	 */
 	public static function get_contribution_data( $start_date ) {
-		// Generate cache key based on start date.
-		$cache_key = self::CACHE_KEY_PREFIX . md5( $start_date );
+		// Get the end range (e.g., '-1 day' means collect up to yesterday).
+		$end_date_range = get_option( self::END_DATE_RANGE_OPTION, self::DEFAULT_END_DATE_RANGE );
+
+		// Calculate the end date based on the configured range.
+		$end_date = ( new \DateTime( $end_date_range, wp_timezone() ) )->format( 'Y-m-d' );
+
+		// Generate cache key including end date for automatic invalidation when range changes.
+		$cache_key = self::CACHE_KEY_PREFIX . md5( $start_date . '_' . $end_date );
 		$cached    = get_transient( $cache_key );
 
 		if ( false !== $cached ) {
 			return $cached;
 		}
 
-		$amount_raised = self::get_donation_revenue( $start_date );
+		$amount_raised = self::get_donation_revenue( $start_date, $end_date );
 
 		if ( is_wp_error( $amount_raised ) ) {
 			return $amount_raised;
@@ -155,19 +137,20 @@ class Contribution_Meter {
 			'amountRaised' => $amount_raised,
 		];
 
-		// Get cache duration from option, falling back to constant.
-		set_transient( $cache_key, $data, get_option( self::CACHE_DURATION_OPTION, self::CACHE_DURATION ) );
+		// Cache for 24 hours since we're querying historical (immutable) data.
+		set_transient( $cache_key, $data, DAY_IN_SECONDS );
 
 		return $data;
 	}
 
 	/**
-	 * Get total donation revenue from a specific start date.
+	 * Get total donation revenue from a specific date range.
 	 *
-	 * @param string $start_date Start date in YYYY-MM-DD format.
+	 * @param string $start_date Start date in YYYY-MM-DD format (inclusive).
+	 * @param string $end_date   End date in YYYY-MM-DD format (inclusive, entire day).
 	 * @return float|\WP_Error Total revenue or WP_Error on failure.
 	 */
-	public static function get_donation_revenue( $start_date ) {
+	public static function get_donation_revenue( $start_date, $end_date ) {
 		if ( ! function_exists( 'wc_get_orders' ) || ! function_exists( 'wc_get_order' ) ) {
 			return new \WP_Error( 'woocommerce_inactive', __( 'WooCommerce is not active.', 'newspack-plugin' ) );
 		}
@@ -180,20 +163,21 @@ class Contribution_Meter {
 			return new \WP_Error( 'no_donation_products', __( 'No donation products found.', 'newspack-plugin' ) );
 		}
 
-		return self::get_donation_revenue_via_order_query( $start_date, $donation_product_ids );
+		return self::get_donation_revenue_via_order_query( $start_date, $end_date, $donation_product_ids );
 	}
 
 	/**
 	 * Calculate donation revenue by iterating paginated WooCommerce orders.
 	 *
-	 * @param string $start_date  Start date in YYYY-MM-DD format.
+	 * @param string $start_date  Start date in YYYY-MM-DD format (inclusive).
+	 * @param string $end_date    End date in YYYY-MM-DD format (inclusive, all day).
 	 * @param array  $product_ids Donation product IDs to include.
 	 * @return float|\WP_Error Total revenue or WP_Error on failure.
 	 */
-	private static function get_donation_revenue_via_order_query( $start_date, $product_ids ) {
+	private static function get_donation_revenue_via_order_query( $start_date, $end_date, $product_ids ) {
 		$statuses = apply_filters( 'newspack_contribution_meter_order_statuses', [ 'completed', 'processing' ] );
-
-		$after = self::get_local_wc_datetime( $start_date );
+		$after    = self::get_local_wc_datetime( $start_date );
+		$before   = self::get_local_wc_datetime( $end_date );
 
 		$query_args = [
 			'limit'        => 200,
@@ -203,7 +187,7 @@ class Contribution_Meter {
 			'return'       => 'ids',
 			'status'       => $statuses,
 			'type'         => 'shop_order',
-			'date_created' => '>= ' . $after->date_i18n( 'Y-m-d H:i:s' ),
+			'date_created' => '>= ' . $after->date_i18n( 'Y-m-d H:i:s' ) . '...<= ' . $before->date_i18n( 'Y-m-d H:i:s' ),
 		];
 
 		$total_revenue = 0.0;

--- a/includes/contribution-meter/class-contribution-meter.php
+++ b/includes/contribution-meter/class-contribution-meter.php
@@ -37,6 +37,16 @@ class Contribution_Meter {
 	const CACHE_KEY_PREFIX = 'newspack_contribution_meter_';
 
 	/**
+	 * Maximum allowed date range for querying historical data.
+	 */
+	const MAX_DATE_RANGE = '-2 months';
+
+	/**
+	 * Maximum date range option name.
+	 */
+	const MAX_DATE_RANGE_OPTION = 'newspack_contribution_meter_max_date_range';
+
+	/**
 	 * Initialize hooks and REST API endpoints.
 	 */
 	public static function init() {
@@ -74,13 +84,32 @@ class Contribution_Meter {
 	 * @return bool|WP_Error True if valid, WP_Error if invalid.
 	 */
 	public static function validate_date( $date ) {
+		// Validate basic date format.
 		if ( ! preg_match( '/^\d{4}-\d{2}-\d{2}$/', $date ) ) {
 			return new \WP_Error( 'invalid_date', __( 'Invalid date format. Expected YYYY-MM-DD.', 'newspack-plugin' ) );
 		}
+
+		// Check if it's a valid date.
 		$date_obj = \DateTime::createFromFormat( 'Y-m-d', $date );
 		if ( ! $date_obj || $date_obj->format( 'Y-m-d' ) !== $date ) {
 			return new \WP_Error( 'invalid_date', __( 'Invalid date. Please provide a valid date.', 'newspack-plugin' ) );
 		}
+
+		// Validate date range limit.
+		$max_range = get_option( self::MAX_DATE_RANGE_OPTION, self::MAX_DATE_RANGE );
+		$min_date  = new \DateTime( $max_range, new \DateTimeZone( 'UTC' ) );
+		$min_date->setTime( 0, 0, 0 ); // Normalize to midnight for date-only comparison.
+		if ( $date_obj < $min_date ) {
+			return new \WP_Error(
+				'date_too_old',
+				sprintf(
+					/* translators: %s: minimum allowed date */
+					__( 'Start date cannot be earlier than %s.', 'newspack-plugin' ),
+					$min_date->format( 'Y-m-d' )
+				)
+			);
+		}
+
 		return true;
 	}
 

--- a/includes/contribution-meter/class-contribution-meter.php
+++ b/includes/contribution-meter/class-contribution-meter.php
@@ -27,6 +27,11 @@ class Contribution_Meter {
 	const CACHE_DURATION = 600;
 
 	/**
+	 * Cache duration option name.
+	 */
+	const CACHE_DURATION_OPTION = 'newspack_contribution_meter_cache_duration';
+
+	/**
 	 * Cache key prefix for contribution meter data.
 	 */
 	const CACHE_KEY_PREFIX = 'newspack_contribution_meter_';
@@ -121,14 +126,8 @@ class Contribution_Meter {
 			'amountRaised' => $amount_raised,
 		];
 
-		/**
-		 * Filters the expiration time for contribution meter data.
-		 *
-		 * @param int $expiration Expiration time in seconds.
-		 */
-		$expiration = apply_filters( 'newspack_contribution_meter_cache_duration', self::CACHE_DURATION );
-
-		set_transient( $cache_key, $data, $expiration );
+		// Get cache duration from option, falling back to constant.
+		set_transient( $cache_key, $data, get_option( self::CACHE_DURATION_OPTION, self::CACHE_DURATION ) );
 
 		return $data;
 	}

--- a/includes/contribution-meter/class-contribution-meter.php
+++ b/includes/contribution-meter/class-contribution-meter.php
@@ -146,43 +146,92 @@ class Contribution_Meter {
 
 		// Get all donation product IDs.
 		$donation_products    = Donations::get_donation_product_child_products_ids();
-		$donation_product_ids = array_filter( array_values( $donation_products ) );
+		$donation_product_ids = array_filter( array_map( 'intval', array_values( $donation_products ) ) );
 
 		if ( empty( $donation_product_ids ) ) {
 			return new \WP_Error( 'no_donation_products', __( 'No donation products found.', 'newspack-plugin' ) );
 		}
 
-		// Query orders from the start date.
-		$orders = \wc_get_orders(
-			[
-				'limit'        => -1,
-				'status'       => [ 'completed', 'processing' ],
-				'date_created' => '>=' . strtotime( $start_date ),
-				'return'       => 'ids',
-			]
-		);
+		return self::get_donation_revenue_via_order_query( $start_date, $donation_product_ids );
+	}
 
-		$total = 0;
+	/**
+	 * Calculate donation revenue by iterating paginated WooCommerce orders.
+	 *
+	 * @param string $start_date  Start date in YYYY-MM-DD format.
+	 * @param array  $product_ids Donation product IDs to include.
+	 * @return float|WP_Error Total revenue or WP_Error on failure.
+	 */
+	private static function get_donation_revenue_via_order_query( $start_date, $product_ids ) {
+		$statuses = apply_filters( 'newspack_contribution_meter_order_statuses', [ 'completed', 'processing' ] );
 
-		// Sum donation revenue from matching orders.
-		foreach ( $orders as $order_id ) {
-			$order = \wc_get_order( $order_id );
+		$after = self::get_local_wc_datetime( $start_date );
 
-			if ( ! $order ) {
-				continue;
+		$query_args = [
+			'limit'        => 200,
+			'paginate'     => true,
+			'orderby'      => 'date',
+			'order'        => 'DESC',
+			'return'       => 'ids',
+			'status'       => $statuses,
+			'type'         => 'shop_order',
+			'date_created' => '>= ' . $after->date_i18n( 'Y-m-d H:i:s' ),
+		];
+
+		$total_revenue = 0.0;
+		$page          = 1;
+		$max_pages     = 1;
+
+		do {
+			$query_args['page'] = $page;
+			$results            = wc_get_orders( $query_args );
+
+			if ( is_wp_error( $results ) ) {
+				return $results;
 			}
 
-			foreach ( $order->get_items() as $item ) {
-				$product_id = $item->get_product_id();
+			if ( is_object( $results ) ) {
+				$orders    = isset( $results->orders ) ? $results->orders : [];
+				$max_pages = max( 1, isset( $results->max_num_pages ) ? (int) $results->max_num_pages : 1 );
+			} else {
+				$orders    = (array) $results;
+				$max_pages = 1;
+			}
 
-				// Only count items from donation products.
-				if ( in_array( $product_id, $donation_product_ids, true ) ) {
-					$total += (float) $item->get_total();
+			if ( empty( $orders ) ) {
+				break;
+			}
+
+			foreach ( $orders as $order_id ) {
+				$order = wc_get_order( $order_id );
+				if ( ! $order ) {
+					continue;
+				}
+
+				foreach ( $order->get_items() as $item ) {
+					$product_id = $item->get_product_id();
+					if ( $product_id && in_array( (int) $product_id, $product_ids, true ) ) {
+						$total_revenue += (float) $item->get_total();
+					}
 				}
 			}
-		}
 
-		return $total;
+			$page++;
+		} while ( $page <= $max_pages );
+
+		return $total_revenue;
+	}
+
+	/**
+	 * Convert a YYYY-MM-DD string into a WC_DateTime in the site's timezone.
+	 *
+	 * @param string $date Date string.
+	 * @return \WC_DateTime
+	 */
+	private static function get_local_wc_datetime( $date ) {
+		$timezone  = new \DateTimeZone( wc_timezone_string() );
+		$formatted = false !== strpos( $date, ' ' ) ? $date : $date . ' 00:00:00';
+		return new \WC_DateTime( $formatted, $timezone );
 	}
 
 	/**

--- a/includes/contribution-meter/class-contribution-meter.php
+++ b/includes/contribution-meter/class-contribution-meter.php
@@ -184,4 +184,24 @@ class Contribution_Meter {
 
 		return $total;
 	}
+
+	/**
+	 * Format currency value.
+	 *
+	 * @param float $amount Amount to format.
+	 * @param array $args Optional formatting arguments.
+	 * @return string Formatted currency.
+	 */
+	public static function format_currency( $amount, $args = [] ) {
+		$defaults = [ 'decimals' => 0 ];
+		$args     = wp_parse_args( $args, $defaults );
+
+		if ( function_exists( 'wc_price' ) ) {
+			return wp_strip_all_tags( wc_price( $amount, $args ) );
+		}
+
+		// Fallback formatting.
+		$symbol = function_exists( 'get_woocommerce_currency_symbol' ) ? get_woocommerce_currency_symbol() : '$';
+		return $symbol . number_format( $amount, $args['decimals'], '.', ',' );
+	}
 }

--- a/src/blocks/contribution-meter/block.json
+++ b/src/blocks/contribution-meter/block.json
@@ -41,6 +41,16 @@
 			"type": "string",
 			"default": "s",
 			"enum": ["xs", "s", "m", "l"]
+		},
+		"previewMode": {
+			"type": "boolean",
+			"default": false
+		}
+	},
+	"example": {
+		"attributes": {
+			"previewMode": true,
+			"goalAmount": 2500
 		}
 	},
 	"style": "file:../../../dist/contribution-meter-block.css"

--- a/src/blocks/contribution-meter/block.json
+++ b/src/blocks/contribution-meter/block.json
@@ -9,14 +9,10 @@
 	"textdomain": "newspack-plugin",
 	"supports": {
 		"html": false,
-		"align": ["wide", "full"]
+		"align": ["wide", "full"],
+		"className": true
 	},
 	"attributes": {
-		"meterStyle": {
-			"type": "string",
-			"default": "linear",
-			"enum": ["linear", "circular"]
-		},
 		"goalAmount": {
 			"type": "number",
 			"default": 1000

--- a/src/blocks/contribution-meter/block.json
+++ b/src/blocks/contribution-meter/block.json
@@ -1,0 +1,51 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "newspack/contribution-meter",
+	"title": "Contribution Meter",
+	"category": "newspack",
+	"description": "Display progress toward your goal. Works seamlessly with the Donate block.",
+	"keywords": ["donations", "fundraising", "revenue", "progress", "goal", "campaign"],
+	"textdomain": "newspack-plugin",
+	"supports": {
+		"html": false,
+		"align": ["wide", "full"]
+	},
+	"attributes": {
+		"meterStyle": {
+			"type": "string",
+			"default": "linear",
+			"enum": ["linear", "circular"]
+		},
+		"goalAmount": {
+			"type": "number",
+			"default": 1000
+		},
+		"startDate": {
+			"type": "string",
+			"default": ""
+		},
+		"progressBarColor": {
+			"type": "string",
+			"default": ""
+		},
+		"showGoal": {
+			"type": "boolean",
+			"default": true
+		},
+		"showAmountRaised": {
+			"type": "boolean",
+			"default": true
+		},
+		"showPercentage": {
+			"type": "boolean",
+			"default": true
+		},
+		"thickness": {
+			"type": "string",
+			"default": "s",
+			"enum": ["xs", "s", "m", "l"]
+		}
+	},
+	"style": "file:../../../dist/contribution-meter-block.css"
+}

--- a/src/blocks/contribution-meter/block.json
+++ b/src/blocks/contribution-meter/block.json
@@ -21,6 +21,10 @@
 			"type": "string",
 			"default": ""
 		},
+		"endDate": {
+			"type": "string",
+			"default": ""
+		},
 		"progressBarColor": {
 			"type": "string",
 			"default": ""

--- a/src/blocks/contribution-meter/class-contribution-meter-block.php
+++ b/src/blocks/contribution-meter/class-contribution-meter-block.php
@@ -130,7 +130,7 @@ final class Contribution_Meter_Block {
 
 		$wrapper_attributes = get_block_wrapper_attributes(
 			[
-				'class' => esc_attr( $classes ),
+				'class' => esc_attr( 'newspack-ui newspack-ui__font--s ' . $classes ),
 			]
 		);
 

--- a/src/blocks/contribution-meter/class-contribution-meter-block.php
+++ b/src/blocks/contribution-meter/class-contribution-meter-block.php
@@ -81,19 +81,24 @@ final class Contribution_Meter_Block {
 			true
 		);
 
-		// Get WooCommerce currency settings.
-		$currency_data = [
+		// Calculate minimum allowed date.
+		$max_range = get_option( Contribution_Meter::MAX_DATE_RANGE_OPTION, Contribution_Meter::MAX_DATE_RANGE );
+		$min_date  = new \DateTime( $max_range, new \DateTimeZone( 'UTC' ) );
+
+		// Get WooCommerce currency settings and date restrictions.
+		$editor_data = [
 			'currencySymbol'    => function_exists( 'get_woocommerce_currency_symbol' ) ? get_woocommerce_currency_symbol() : '$',
 			'currencyPosition'  => function_exists( 'get_option' ) ? get_option( 'woocommerce_currency_pos', 'left' ) : 'left',
 			'thousandSeparator' => function_exists( 'wc_get_price_thousand_separator' ) ? wc_get_price_thousand_separator() : ',',
 			'decimalSeparator'  => function_exists( 'wc_get_price_decimal_separator' ) ? wc_get_price_decimal_separator() : '.',
 			'decimals'          => function_exists( 'wc_get_price_decimals' ) ? wc_get_price_decimals() : 2,
+			'minStartDate'      => $min_date->format( 'Y-m-d' ),
 		];
 
 		wp_localize_script(
 			'newspack-contribution-meter-editor-script',
 			'newspack_contribution_meter_data',
-			$currency_data
+			$editor_data
 		);
 	}
 

--- a/src/blocks/contribution-meter/class-contribution-meter-block.php
+++ b/src/blocks/contribution-meter/class-contribution-meter-block.php
@@ -187,33 +187,26 @@ final class Contribution_Meter_Block {
 	 * @return array Sanitized attributes.
 	 */
 	private static function sanitize_attributes( array $attributes ) {
-		// Sanitize meterStyle.
-		if ( ! in_array( $attributes['meterStyle'], [ 'linear', 'circular' ], true ) ) {
-			$attributes['meterStyle'] = 'linear';
-		}
-
 		// Sanitize thickness.
-		if ( ! in_array( $attributes['thickness'], [ 'xs', 's', 'm', 'l' ], true ) ) {
+		if ( ! in_array( $attributes['thickness'] ?? '', [ 'xs', 's', 'm', 'l' ], true ) ) {
 			$attributes['thickness'] = 's';
 		}
 
 		// Sanitize goal amount.
-		$attributes['goalAmount'] = absint( $attributes['goalAmount'] );
+		$attributes['goalAmount'] = absint( $attributes['goalAmount'] ?? 0 );
 
 		// Validate start date.
-		if ( is_wp_error( Contribution_Meter::validate_date( $attributes['startDate'] ) ) ) {
+		if ( is_wp_error( Contribution_Meter::validate_date( $attributes['startDate'] ?? '' ) ) ) {
 			$attributes['startDate'] = gmdate( 'Y-m-d' ); // Default to today if invalid.
 		}
 
 		// Sanitize color.
-		if ( ! empty( $attributes['progressBarColor'] ) ) {
-			$attributes['progressBarColor'] = sanitize_hex_color( $attributes['progressBarColor'] );
-		}
+		$attributes['progressBarColor'] = ! empty( $attributes['progressBarColor'] ) ? sanitize_hex_color( $attributes['progressBarColor'] ) : '';
 
 		// Sanitize booleans.
-		$attributes['showGoal']         = (bool) $attributes['showGoal'];
-		$attributes['showAmountRaised'] = (bool) $attributes['showAmountRaised'];
-		$attributes['showPercentage']   = (bool) $attributes['showPercentage'];
+		$attributes['showGoal']         = (bool) ( $attributes['showGoal'] ?? false );
+		$attributes['showAmountRaised'] = (bool) ( $attributes['showAmountRaised'] ?? false );
+		$attributes['showPercentage']   = (bool) ( $attributes['showPercentage'] ?? false );
 
 		return $attributes;
 	}

--- a/src/blocks/contribution-meter/class-contribution-meter-block.php
+++ b/src/blocks/contribution-meter/class-contribution-meter-block.php
@@ -1,0 +1,202 @@
+<?php
+/**
+ * Contribution Meter Block.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Blocks\Contribution_Meter;
+
+use Newspack\Contribution_Meter\Contribution_Meter;
+use Newspack\Blocks\Contribution_Meter\Meters\Loader;
+
+defined( 'ABSPATH' ) || exit;
+
+require_once __DIR__ . '/meters/class-loader.php';
+
+/**
+ * Contribution Meter Block Class.
+ */
+final class Contribution_Meter_Block {
+
+	/**
+	 * The block name.
+	 *
+	 * @var string
+	 */
+	public const BLOCK_NAME = 'newspack/contribution-meter';
+
+	/**
+	 * Default block attributes.
+	 */
+	public const DEFAULT_ATTRIBUTES = [
+		'meterStyle'       => 'linear',
+		'goalAmount'       => 1000,
+		'startDate'        => '',
+		'progressBarColor' => '',
+		'thickness'        => 's',
+		'showGoal'         => true,
+		'showAmountRaised' => true,
+		'showPercentage'   => true,
+	];
+
+
+	/**
+	 * Initializes the block.
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		add_action( 'init', [ __CLASS__, 'register_block' ] );
+		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'enqueue_editor_assets' ] );
+	}
+
+	/**
+	 * Register newspack contribution meter block.
+	 *
+	 * @return void
+	 */
+	public static function register_block() {
+		register_block_type_from_metadata(
+			__DIR__ . '/block.json',
+			[
+				'render_callback' => [ __CLASS__, 'render_block' ],
+			]
+		);
+	}
+
+	/**
+	 * Enqueue editor assets for the block.
+	 *
+	 * @return void
+	 */
+	public static function enqueue_editor_assets() {
+		// Enqueue the editor script.
+		$asset_file = include NEWSPACK_ABSPATH . '/dist/contribution-meter-block.asset.php';
+		wp_enqueue_script(
+			'newspack-contribution-meter-editor-script',
+			\Newspack\Newspack::plugin_url() . '/dist/contribution-meter-block.js',
+			$asset_file['dependencies'],
+			$asset_file['version'],
+			true
+		);
+
+		// Get WooCommerce currency settings.
+		$currency_data = [
+			'currencySymbol'    => function_exists( 'get_woocommerce_currency_symbol' ) ? get_woocommerce_currency_symbol() : '$',
+			'currencyPosition'  => function_exists( 'get_option' ) ? get_option( 'woocommerce_currency_pos', 'left' ) : 'left',
+			'thousandSeparator' => function_exists( 'wc_get_price_thousand_separator' ) ? wc_get_price_thousand_separator() : ',',
+			'decimalSeparator'  => function_exists( 'wc_get_price_decimal_separator' ) ? wc_get_price_decimal_separator() : '.',
+			'decimals'          => function_exists( 'wc_get_price_decimals' ) ? wc_get_price_decimals() : 2,
+		];
+
+		wp_localize_script(
+			'newspack-contribution-meter-editor-script',
+			'newspack_contribution_meter_data',
+			$currency_data
+		);
+	}
+
+	/**
+	 * Block render callback.
+	 *
+	 * @param array $attributes The block attributes.
+	 *
+	 * @return string The block HTML.
+	 */
+	public static function render_block( array $attributes ) {
+		// Sanitize and normalize attributes.
+		$attributes = self::sanitize_attributes( wp_parse_args( $attributes, self::DEFAULT_ATTRIBUTES ) );
+
+		// Get contribution data.
+		$contribution_data = Contribution_Meter::get_contribution_data( $attributes['startDate'] );
+
+		if ( is_wp_error( $contribution_data ) ) {
+			return sprintf(
+				'<div class="wp-block-newspack-contribution-meter"><p>%s</p></div>',
+				esc_html( $contribution_data->get_error_message() )
+			);
+		}
+
+		$amount_raised = $contribution_data['amountRaised'];
+		$goal          = $attributes['goalAmount'];
+
+		// Calculate percentage (can exceed 100%, floored to 1 decimal).
+		$percentage_raw = $goal > 0 ? ( $amount_raised / $goal ) * 100 : 0;
+		$percentage     = floor( $percentage_raw * 10 ) / 10;
+
+		// Build wrapper CSS classes.
+		$classes = self::get_block_classes( $attributes );
+
+		$wrapper_attributes = get_block_wrapper_attributes(
+			[
+				'class' => esc_attr( $classes ),
+			]
+		);
+
+		// Get meter class from loader.
+		$meter_class = Loader::get_meter_class( $attributes['meterStyle'] );
+
+		ob_start();
+		?>
+		<div <?php echo $wrapper_attributes; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
+			<?php $meter_class::render( $amount_raised, $goal, $percentage, $attributes ); ?>
+		</div>
+		<?php
+		return ob_get_clean();
+	}
+
+
+	/**
+	 * Get block CSS classes.
+	 *
+	 * @param array $attributes Block attributes.
+	 * @return string CSS classes.
+	 */
+	private static function get_block_classes( $attributes ) {
+		$classes = [
+			'contribution-meter--' . $attributes['meterStyle'],
+			'contribution-meter--thickness-' . $attributes['thickness'],
+		];
+
+		return implode( ' ', $classes );
+	}
+
+	/**
+	 * Sanitize and normalize attributes.
+	 *
+	 * @param array $attributes The block attributes.
+	 * @return array Sanitized attributes.
+	 */
+	private static function sanitize_attributes( array $attributes ) {
+		// Sanitize meterStyle.
+		if ( ! in_array( $attributes['meterStyle'], [ 'linear', 'circular' ], true ) ) {
+			$attributes['meterStyle'] = 'linear';
+		}
+
+		// Sanitize thickness.
+		if ( ! in_array( $attributes['thickness'], [ 'xs', 's', 'm', 'l' ], true ) ) {
+			$attributes['thickness'] = 's';
+		}
+
+		// Sanitize goal amount.
+		$attributes['goalAmount'] = absint( $attributes['goalAmount'] );
+
+		// Validate start date.
+		if ( is_wp_error( Contribution_Meter::validate_date( $attributes['startDate'] ) ) ) {
+			$attributes['startDate'] = gmdate( 'Y-m-d' ); // Default to today if invalid.
+		}
+
+		// Sanitize color.
+		if ( ! empty( $attributes['progressBarColor'] ) ) {
+			$attributes['progressBarColor'] = sanitize_hex_color( $attributes['progressBarColor'] );
+		}
+
+		// Sanitize booleans.
+		$attributes['showGoal']         = (bool) $attributes['showGoal'];
+		$attributes['showAmountRaised'] = (bool) $attributes['showAmountRaised'];
+		$attributes['showPercentage']   = (bool) $attributes['showPercentage'];
+
+		return $attributes;
+	}
+}

--- a/src/blocks/contribution-meter/class-contribution-meter-block.php
+++ b/src/blocks/contribution-meter/class-contribution-meter-block.php
@@ -30,7 +30,6 @@ final class Contribution_Meter_Block {
 	 * Default block attributes.
 	 */
 	public const DEFAULT_ATTRIBUTES = [
-		'meterStyle'       => 'linear',
 		'goalAmount'       => 1000,
 		'startDate'        => '',
 		'progressBarColor' => '',
@@ -123,6 +122,9 @@ final class Contribution_Meter_Block {
 	public static function render_block( array $attributes ) {
 		// Sanitize and normalize attributes.
 		$attributes = self::sanitize_attributes( wp_parse_args( $attributes, self::DEFAULT_ATTRIBUTES ) );
+
+		// Extract meter style from the block's class name.
+		$attributes['meterStyle'] = isset( $attributes['className'] ) && str_contains( $attributes['className'], 'is-style-circular' ) ? 'circular' : 'linear';
 
 		// Get contribution data.
 		$contribution_data = Contribution_Meter::get_contribution_data( $attributes['startDate'] );

--- a/src/blocks/contribution-meter/class-contribution-meter-block.php
+++ b/src/blocks/contribution-meter/class-contribution-meter-block.php
@@ -32,6 +32,7 @@ final class Contribution_Meter_Block {
 	public const DEFAULT_ATTRIBUTES = [
 		'goalAmount'       => 1000,
 		'startDate'        => '',
+		'endDate'          => '',
 		'progressBarColor' => '',
 		'thickness'        => 's',
 		'showGoal'         => true,
@@ -39,16 +40,6 @@ final class Contribution_Meter_Block {
 		'showPercentage'   => true,
 	];
 
-	/**
-	 * Default oldest allowed start date range (relative to today).
-	 * E.g., '-2 months' means start date cannot be earlier than 2 months ago.
-	 */
-	const DEFAULT_START_DATE_RANGE = '-2 months';
-
-	/**
-	 * Start date range option name.
-	 */
-	const START_DATE_RANGE_OPTION = 'newspack_contribution_meter_start_date_range';
 
 
 	/**
@@ -91,9 +82,13 @@ final class Contribution_Meter_Block {
 			true
 		);
 
-		// Calculate minimum allowed date.
-		$start_date_range = get_option( self::START_DATE_RANGE_OPTION, self::DEFAULT_START_DATE_RANGE );
+		// Calculate minimum allowed start date.
+		$start_date_range = get_option( Contribution_Meter::START_DATE_RANGE_OPTION, Contribution_Meter::DEFAULT_START_DATE_RANGE );
 		$min_date         = new \DateTime( $start_date_range, new \DateTimeZone( 'UTC' ) );
+
+		// Calculate maximum allowed end date.
+		$max_end_date_range = get_option( Contribution_Meter::MAX_END_DATE_RANGE_OPTION, Contribution_Meter::DEFAULT_MAX_END_DATE_RANGE );
+		$max_end_date       = new \DateTime( $max_end_date_range, new \DateTimeZone( 'UTC' ) );
 
 		// Get WooCommerce currency settings and date restrictions.
 		$editor_data = [
@@ -103,6 +98,7 @@ final class Contribution_Meter_Block {
 			'decimalSeparator'  => function_exists( 'wc_get_price_decimal_separator' ) ? wc_get_price_decimal_separator() : '.',
 			'decimals'          => function_exists( 'wc_get_price_decimals' ) ? wc_get_price_decimals() : 2,
 			'minStartDate'      => $min_date->format( 'Y-m-d' ),
+			'maxEndDate'        => $max_end_date->format( 'Y-m-d' ),
 		];
 
 		wp_localize_script(
@@ -126,8 +122,8 @@ final class Contribution_Meter_Block {
 		// Extract meter style from the block's class name.
 		$attributes['meterStyle'] = isset( $attributes['className'] ) && str_contains( $attributes['className'], 'is-style-circular' ) ? 'circular' : 'linear';
 
-		// Get contribution data.
-		$contribution_data = Contribution_Meter::get_contribution_data( $attributes['startDate'] );
+		// Get contribution data with optional end date.
+		$contribution_data = Contribution_Meter::get_contribution_data( $attributes['startDate'], $attributes['endDate'] );
 
 		if ( is_wp_error( $contribution_data ) ) {
 			return sprintf(
@@ -198,6 +194,11 @@ final class Contribution_Meter_Block {
 		// Validate start date.
 		if ( is_wp_error( Contribution_Meter::validate_date( $attributes['startDate'] ?? '' ) ) ) {
 			$attributes['startDate'] = gmdate( 'Y-m-d' ); // Default to today if invalid.
+		}
+
+		// Validate end date if provided.
+		if ( ! empty( $attributes['endDate'] ) && is_wp_error( Contribution_Meter::validate_date( $attributes['endDate'] ) ) ) {
+			$attributes['endDate'] = '';
 		}
 
 		// Sanitize color.

--- a/src/blocks/contribution-meter/class-contribution-meter-block.php
+++ b/src/blocks/contribution-meter/class-contribution-meter-block.php
@@ -40,6 +40,17 @@ final class Contribution_Meter_Block {
 		'showPercentage'   => true,
 	];
 
+	/**
+	 * Default oldest allowed start date range (relative to today).
+	 * E.g., '-2 months' means start date cannot be earlier than 2 months ago.
+	 */
+	const DEFAULT_START_DATE_RANGE = '-2 months';
+
+	/**
+	 * Start date range option name.
+	 */
+	const START_DATE_RANGE_OPTION = 'newspack_contribution_meter_start_date_range';
+
 
 	/**
 	 * Initializes the block.
@@ -82,8 +93,8 @@ final class Contribution_Meter_Block {
 		);
 
 		// Calculate minimum allowed date.
-		$max_range = get_option( Contribution_Meter::MAX_DATE_RANGE_OPTION, Contribution_Meter::MAX_DATE_RANGE );
-		$min_date  = new \DateTime( $max_range, new \DateTimeZone( 'UTC' ) );
+		$start_date_range = get_option( self::START_DATE_RANGE_OPTION, self::DEFAULT_START_DATE_RANGE );
+		$min_date         = new \DateTime( $start_date_range, new \DateTimeZone( 'UTC' ) );
 
 		// Get WooCommerce currency settings and date restrictions.
 		$editor_data = [

--- a/src/blocks/contribution-meter/components/CircularMeter.jsx
+++ b/src/blocks/contribution-meter/components/CircularMeter.jsx
@@ -67,7 +67,7 @@ const CircularMeter = ( { amountRaised, goal, percentage, showGoal, showAmountRa
 	}
 
 	return (
-		<div className="contribution-meter__circular">
+		<div className="contribution-meter__circular newspack-ui newspack-ui__font--s">
 			<div className="contribution-meter__circle-container">
 				<svg
 					className="contribution-meter__circle"
@@ -111,17 +111,23 @@ const CircularMeter = ( { amountRaised, goal, percentage, showGoal, showAmountRa
 					/>
 				</svg>
 
-				{ showPercentage && <div className="contribution-meter__circle-percentage">{ percentage }%</div> }
+				{ showPercentage && <div className="contribution-meter__circle-percentage newspack-ui__font--2xs">{ percentage }%</div> }
 			</div>
 
 			<div className="contribution-meter__data">
 				{ showAmountRaised && (
-					<span className="contribution-meter__amount-raised">
+					<span className="contribution-meter__amount-raised newspack-ui__font--m">
 						{ formatCurrency( amountRaised ) } { __( 'raised', 'newspack-plugin' ) }
 					</span>
 				) }
 				{ showGoal && (
-					<span className={ showAmountRaised ? 'contribution-meter__goal' : 'contribution-meter__goal contribution-meter__goal--primary' }>
+					<span
+						className={
+							showAmountRaised
+								? 'contribution-meter__goal'
+								: 'contribution-meter__goal contribution-meter__goal--primary newspack-ui__font--m'
+						}
+					>
 						{ formatCurrency( goal ) } { __( 'goal', 'newspack-plugin' ) }
 					</span>
 				) }

--- a/src/blocks/contribution-meter/components/CircularMeter.jsx
+++ b/src/blocks/contribution-meter/components/CircularMeter.jsx
@@ -67,7 +67,7 @@ const CircularMeter = ( { amountRaised, goal, percentage, showGoal, showAmountRa
 	}
 
 	return (
-		<div className="contribution-meter__circular newspack-ui newspack-ui__font--s">
+		<div className="contribution-meter__circular">
 			<div className="contribution-meter__circle-container">
 				<svg
 					className="contribution-meter__circle"

--- a/src/blocks/contribution-meter/components/CircularMeter.jsx
+++ b/src/blocks/contribution-meter/components/CircularMeter.jsx
@@ -1,0 +1,133 @@
+/**
+ * WordPress dependencies.
+ */
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies.
+ */
+import { formatCurrency } from '../utils/helpers';
+
+/**
+ * Thickness values in pixels for circular meter.
+ */
+const THICKNESS = {
+	xs: 4,
+	s: 8,
+	m: 12,
+	l: 16,
+};
+
+/**
+ * Calculate SVG circle parameters for circular progress indicator.
+ *
+ * @param {number} percentage Percentage value (can exceed 100).
+ * @param {number} thickness  Stroke thickness in pixels.
+ * @param {number} size       SVG viewBox size.
+ * @return {Object} Circle parameters { radius, circumference, offset }.
+ */
+const calculateCircle = ( percentage, thickness, size ) => {
+	const visualPercentage = percentage > 100 ? 100 : percentage; // Cap visual percentage at 100%.
+	const radius = size / 2 - thickness / 2;
+	const circumference = 2 * Math.PI * radius;
+	const offset = circumference - ( visualPercentage / 100 ) * circumference;
+
+	return {
+		radius,
+		circumference,
+		offset,
+	};
+};
+
+/**
+ * Circular progress indicator component.
+ *
+ * @param {Object}  props                  Component props.
+ * @param {number}  props.amountRaised     Amount raised.
+ * @param {number}  props.goal             Goal amount.
+ * @param {number}  props.percentage       Percentage completed (0-100).
+ * @param {boolean} props.showGoal         Whether to show goal amount.
+ * @param {boolean} props.showAmountRaised Whether to show amount raised.
+ * @param {boolean} props.showPercentage   Whether to show percentage.
+ * @param {string}  props.progressBarColor Custom progress bar color.
+ * @param {string}  props.thickness        Thickness size.
+ * @return {Element} CircularMeter component.
+ */
+const CircularMeter = ( { amountRaised, goal, percentage, showGoal, showAmountRaised, showPercentage, progressBarColor, thickness } ) => {
+	const viewBoxSize = 72;
+	const strokeWidth = THICKNESS[ thickness ] || THICKNESS.s;
+	const { radius, circumference, offset } = calculateCircle( percentage, strokeWidth, viewBoxSize );
+
+	const centerX = viewBoxSize / 2;
+	const centerY = viewBoxSize / 2;
+
+	const svgStyle = {};
+	if ( progressBarColor ) {
+		svgStyle.color = progressBarColor;
+	}
+
+	return (
+		<div className="contribution-meter__circular">
+			<div className="contribution-meter__circle-container">
+				<svg
+					className="contribution-meter__circle"
+					style={ svgStyle }
+					viewBox={ `0 0 ${ viewBoxSize } ${ viewBoxSize }` }
+					role="img"
+					aria-label={ __( 'Contribution progress indicator', 'newspack-plugin' ) }
+				>
+					<title>{ __( 'Contribution Meter', 'newspack-plugin' ) }</title>
+					<desc>
+						{ sprintf(
+							/* translators: 1: percentage, 2: formatted goal amount */
+							__( '%1$s%% progress toward %2$s goal', 'newspack-plugin' ),
+							percentage,
+							formatCurrency( goal )
+						) }
+					</desc>
+
+					{ /* Background track */ }
+					<circle
+						className="contribution-meter__circle-track"
+						cx={ centerX }
+						cy={ centerY }
+						r={ radius }
+						fill="none"
+						strokeWidth={ strokeWidth }
+					/>
+
+					{ /* Progress circle */ }
+					<circle
+						className="contribution-meter__circle-progress"
+						cx={ centerX }
+						cy={ centerY }
+						r={ radius }
+						fill="none"
+						strokeWidth={ strokeWidth }
+						strokeDasharray={ circumference }
+						strokeDashoffset={ offset }
+						strokeLinecap="butt"
+						transform={ `rotate(-90 ${ centerX } ${ centerY })` }
+					/>
+				</svg>
+
+				{ showPercentage && <div className="contribution-meter__circle-percentage">{ percentage }%</div> }
+			</div>
+
+			<div className="contribution-meter__data">
+				{ showAmountRaised && (
+					<span className="contribution-meter__amount-raised">
+						{ formatCurrency( amountRaised ) } { __( 'raised', 'newspack-plugin' ) }
+					</span>
+				) }
+				{ showGoal && (
+					<span className={ showAmountRaised ? 'contribution-meter__goal' : 'contribution-meter__goal contribution-meter__goal--primary' }>
+						{ formatCurrency( goal ) } { __( 'goal', 'newspack-plugin' ) }
+					</span>
+				) }
+			</div>
+		</div>
+	);
+};
+
+export default CircularMeter;

--- a/src/blocks/contribution-meter/components/InspectorPanel.jsx
+++ b/src/blocks/contribution-meter/components/InspectorPanel.jsx
@@ -77,6 +77,14 @@ const InspectorPanel = ( { attributes, setAttributes } ) => {
 				>
 					<DatePicker
 						currentDate={ currentStartDate }
+						isInvalidDate={ date => {
+							const minDateStr = window.newspack_contribution_meter_data?.minStartDate;
+							if ( ! minDateStr ) {
+								return false;
+							}
+							const minDate = new Date( minDateStr );
+							return date < minDate;
+						} }
 						onChange={ newDate => {
 							setAttributes( { startDate: newDate ? dateI18n( 'Y-m-d', newDate ) : '' } );
 						} }

--- a/src/blocks/contribution-meter/components/InspectorPanel.jsx
+++ b/src/blocks/contribution-meter/components/InspectorPanel.jsx
@@ -1,0 +1,126 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { InspectorControls, PanelColorSettings } from '@wordpress/block-editor';
+import {
+	PanelBody,
+	ToggleControl,
+	BaseControl,
+	DatePicker,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+} from '@wordpress/components';
+import { dateI18n } from '@wordpress/date';
+
+/**
+ * Inspector panel component for contribution meter block settings.
+ *
+ * @param {Object}   props               Component props.
+ * @param {Object}   props.attributes    Block attributes.
+ * @param {Function} props.setAttributes Function to update attributes.
+ * @return {Element} InspectorPanel component.
+ */
+const InspectorPanel = ( { attributes, setAttributes } ) => {
+	const { meterStyle, goalAmount, startDate, progressBarColor, thickness, showGoal, showAmountRaised, showPercentage } = attributes;
+
+	// Convert YYYY-MM-DD string to Date object at local midnight to avoid timezone issues.
+	// Only set currentStartDate if startDate exists, otherwise let DatePicker default to today.
+	const currentStartDate = startDate ? new Date( startDate + 'T00:00:00' ) : undefined;
+
+	const currencySymbol = window.newspack_contribution_meter_data?.currencySymbol || '$';
+
+	return (
+		<InspectorControls>
+			<PanelBody title={ __( 'Styles', 'newspack-plugin' ) }>
+				<ToggleGroupControl value={ meterStyle } onChange={ value => setAttributes( { meterStyle: value } ) } isBlock __next40pxDefaultSize>
+					<ToggleGroupControlOption label={ __( 'Linear', 'newspack-plugin' ) } value="linear" />
+					<ToggleGroupControlOption label={ __( 'Circular', 'newspack-plugin' ) } value="circular" />
+				</ToggleGroupControl>
+
+				<PanelColorSettings
+					title={ __( 'Color', 'newspack-plugin' ) }
+					colorSettings={ [
+						{
+							value: progressBarColor,
+							onChange: value => setAttributes( { progressBarColor: value } ),
+							label: __( 'Progress bar', 'newspack-plugin' ),
+						},
+					] }
+				/>
+			</PanelBody>
+
+			<PanelBody title={ __( 'Contribution data', 'newspack-plugin' ) }>
+				<BaseControl
+					id="contribution-meter-goal-amount"
+					label={ __( 'Goal amount', 'newspack-plugin' ) + ` (${ currencySymbol })` }
+					help={ __( 'Set the total contribution goal.', 'newspack-plugin' ) }
+				>
+					<input
+						id="contribution-meter-goal-amount"
+						type="number"
+						value={ goalAmount }
+						onChange={ e => setAttributes( { goalAmount: parseInt( e.target.value, 10 ) || 0 } ) }
+						min="0"
+						step="1"
+						className="components-text-control__input"
+					/>
+				</BaseControl>
+
+				<BaseControl
+					id="contribution-meter-start-date"
+					label={ __( 'Start date', 'newspack-plugin' ) }
+					help={ __( 'Contributions from this date are included in the total amount raised.', 'newspack-plugin' ) }
+				>
+					<DatePicker
+						currentDate={ currentStartDate }
+						onChange={ newDate => {
+							setAttributes( { startDate: newDate ? dateI18n( 'Y-m-d', newDate ) : '' } );
+						} }
+					/>
+				</BaseControl>
+			</PanelBody>
+
+			<PanelBody title={ __( 'Progress bar', 'newspack-plugin' ) } initialOpen={ false }>
+				<ToggleControl
+					label={ __( 'Show goal', 'newspack-plugin' ) }
+					checked={ showGoal }
+					onChange={ value => setAttributes( { showGoal: value } ) }
+					help={ __( 'Display the total target amount next to the progress bar.', 'newspack-plugin' ) }
+				/>
+
+				<ToggleControl
+					label={ __( 'Show amount raised', 'newspack-plugin' ) }
+					checked={ showAmountRaised }
+					onChange={ value => setAttributes( { showAmountRaised: value } ) }
+					help={ __( 'Display the total contributions received so far.', 'newspack-plugin' ) }
+				/>
+
+				<ToggleControl
+					label={ __( 'Show percentage', 'newspack-plugin' ) }
+					checked={ showPercentage }
+					onChange={ value => setAttributes( { showPercentage: value } ) }
+					help={ __( 'Display progress as a percentage of the goal.', 'newspack-plugin' ) }
+				/>
+
+				<ToggleGroupControl
+					label={ __( 'Thickness', 'newspack-plugin' ) }
+					value={ thickness }
+					onChange={ value => setAttributes( { thickness: value } ) }
+					isBlock
+					help={ __( 'Adjust the visual weight of the progress bar.', 'newspack-plugin' ) }
+					__next40pxDefaultSize
+				>
+					<ToggleGroupControlOption label={ __( 'XS', 'newspack-plugin' ) } value="xs" title={ __( 'Extra Small', 'newspack-plugin' ) } />
+					<ToggleGroupControlOption label={ __( 'S', 'newspack-plugin' ) } value="s" title={ __( 'Small', 'newspack-plugin' ) } />
+					<ToggleGroupControlOption label={ __( 'M', 'newspack-plugin' ) } value="m" title={ __( 'Medium', 'newspack-plugin' ) } />
+					<ToggleGroupControlOption label={ __( 'L', 'newspack-plugin' ) } value="l" title={ __( 'Large', 'newspack-plugin' ) } />
+				</ToggleGroupControl>
+			</PanelBody>
+		</InspectorControls>
+	);
+};
+
+export default InspectorPanel;

--- a/src/blocks/contribution-meter/components/InspectorPanel.jsx
+++ b/src/blocks/contribution-meter/components/InspectorPanel.jsx
@@ -39,18 +39,18 @@ const InspectorPanel = ( { attributes, setAttributes } ) => {
 					<ToggleGroupControlOption label={ __( 'Linear', 'newspack-plugin' ) } value="linear" />
 					<ToggleGroupControlOption label={ __( 'Circular', 'newspack-plugin' ) } value="circular" />
 				</ToggleGroupControl>
-
-				<PanelColorSettings
-					title={ __( 'Color', 'newspack-plugin' ) }
-					colorSettings={ [
-						{
-							value: progressBarColor,
-							onChange: value => setAttributes( { progressBarColor: value } ),
-							label: __( 'Progress bar', 'newspack-plugin' ),
-						},
-					] }
-				/>
 			</PanelBody>
+
+			<PanelColorSettings
+				title={ __( 'Color', 'newspack-plugin' ) }
+				colorSettings={ [
+					{
+						value: progressBarColor,
+						onChange: value => setAttributes( { progressBarColor: value } ),
+						label: __( 'Progress bar', 'newspack-plugin' ),
+					},
+				] }
+			/>
 
 			<PanelBody title={ __( 'Contribution data', 'newspack-plugin' ) }>
 				<BaseControl

--- a/src/blocks/contribution-meter/components/InspectorPanel.jsx
+++ b/src/blocks/contribution-meter/components/InspectorPanel.jsx
@@ -66,6 +66,7 @@ const InspectorPanel = ( { attributes, setAttributes } ) => {
 						min="0"
 						step="1"
 						className="components-text-control__input"
+						style={ { minHeight: '40px' } }
 					/>
 				</BaseControl>
 

--- a/src/blocks/contribution-meter/components/InspectorPanel.jsx
+++ b/src/blocks/contribution-meter/components/InspectorPanel.jsx
@@ -24,11 +24,14 @@ import { dateI18n } from '@wordpress/date';
  * @return {Element} InspectorPanel component.
  */
 const InspectorPanel = ( { attributes, setAttributes } ) => {
-	const { goalAmount, startDate, progressBarColor, thickness, showGoal, showAmountRaised, showPercentage } = attributes;
+	const { goalAmount, startDate, endDate, progressBarColor, thickness, showGoal, showAmountRaised, showPercentage } = attributes;
 
 	// Convert YYYY-MM-DD string to Date object at local midnight to avoid timezone issues.
 	// Only set currentStartDate if startDate exists, otherwise let DatePicker default to today.
 	const currentStartDate = startDate ? new Date( startDate + 'T00:00:00' ) : undefined;
+	const currentEndDate = endDate ? new Date( endDate + 'T00:00:00' ) : undefined;
+	const maxEndDateStr = window.newspack_contribution_meter_data?.maxEndDate;
+	const maxEndDate = maxEndDateStr ? new Date( maxEndDateStr + 'T00:00:00' ) : undefined;
 
 	const currencySymbol = window.newspack_contribution_meter_data?.currencySymbol || '$';
 
@@ -83,6 +86,53 @@ const InspectorPanel = ( { attributes, setAttributes } ) => {
 						} }
 					/>
 				</BaseControl>
+
+				<ToggleControl
+					label={ __( 'Set end date', 'newspack-plugin' ) }
+					checked={ !! endDate }
+					onChange={ value => {
+						if ( value ) {
+							// Set to today when toggled on
+							const today = new Date();
+							setAttributes( { endDate: dateI18n( 'Y-m-d', today ) } );
+						} else {
+							// Clear end date when toggled off
+							setAttributes( { endDate: '' } );
+						}
+					} }
+					help={ __(
+						'Enable this if the contribution meter should stop counting contributions after a specific date.',
+						'newspack-plugin'
+					) }
+				/>
+
+				{ endDate && (
+					<BaseControl
+						id="contribution-meter-end-date"
+						label={ __( 'End date', 'newspack-plugin' ) }
+						help={ __( 'Contributions up to and including this date are counted in the total amount raised.', 'newspack-plugin' ) }
+					>
+						<DatePicker
+							currentDate={ currentEndDate }
+							isInvalidDate={ date => {
+								// End date requires a start date and must be after start date.
+								if ( ! currentStartDate || date < currentStartDate ) {
+									return true;
+								}
+
+								// End date cannot exceed the configured maximum.
+								if ( maxEndDate && date > maxEndDate ) {
+									return true;
+								}
+
+								return false;
+							} }
+							onChange={ newDate => {
+								setAttributes( { endDate: newDate ? dateI18n( 'Y-m-d', newDate ) : '' } );
+							} }
+						/>
+					</BaseControl>
+				) }
 			</PanelBody>
 
 			<PanelBody title={ __( 'Progress bar', 'newspack-plugin' ) } initialOpen={ false }>

--- a/src/blocks/contribution-meter/components/InspectorPanel.jsx
+++ b/src/blocks/contribution-meter/components/InspectorPanel.jsx
@@ -24,7 +24,7 @@ import { dateI18n } from '@wordpress/date';
  * @return {Element} InspectorPanel component.
  */
 const InspectorPanel = ( { attributes, setAttributes } ) => {
-	const { meterStyle, goalAmount, startDate, progressBarColor, thickness, showGoal, showAmountRaised, showPercentage } = attributes;
+	const { goalAmount, startDate, progressBarColor, thickness, showGoal, showAmountRaised, showPercentage } = attributes;
 
 	// Convert YYYY-MM-DD string to Date object at local midnight to avoid timezone issues.
 	// Only set currentStartDate if startDate exists, otherwise let DatePicker default to today.
@@ -34,13 +34,6 @@ const InspectorPanel = ( { attributes, setAttributes } ) => {
 
 	return (
 		<InspectorControls>
-			<PanelBody title={ __( 'Styles', 'newspack-plugin' ) }>
-				<ToggleGroupControl value={ meterStyle } onChange={ value => setAttributes( { meterStyle: value } ) } isBlock __next40pxDefaultSize>
-					<ToggleGroupControlOption label={ __( 'Linear', 'newspack-plugin' ) } value="linear" />
-					<ToggleGroupControlOption label={ __( 'Circular', 'newspack-plugin' ) } value="circular" />
-				</ToggleGroupControl>
-			</PanelBody>
-
 			<PanelColorSettings
 				title={ __( 'Color', 'newspack-plugin' ) }
 				colorSettings={ [

--- a/src/blocks/contribution-meter/components/LinearMeter.jsx
+++ b/src/blocks/contribution-meter/components/LinearMeter.jsx
@@ -1,0 +1,100 @@
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { formatCurrency } from '../utils/helpers';
+
+/**
+ * Linear progress bar meter component.
+ *
+ * @param {Object}  props                  Component props.
+ * @param {number}  props.amountRaised     Amount raised.
+ * @param {number}  props.goal             Goal amount.
+ * @param {number}  props.percentage       Percentage completed (0-100).
+ * @param {boolean} props.showGoal         Whether to show goal amount.
+ * @param {boolean} props.showAmountRaised Whether to show amount raised.
+ * @param {boolean} props.showPercentage   Whether to show percentage.
+ * @param {string}  props.progressBarColor Custom progress bar color.
+ * @return {Element} LinearMeter component.
+ */
+const LinearMeter = ( { amountRaised, goal, percentage, showGoal, showAmountRaised, showPercentage, progressBarColor } ) => {
+	const barStyle = {};
+	if ( progressBarColor ) {
+		barStyle.color = progressBarColor;
+	}
+
+	const progressStyle = {
+		width: `${ percentage > 100 ? 100 : percentage }%`,
+	};
+
+	const hasAnyTextDisplay = showGoal || showAmountRaised || showPercentage;
+
+	// Determine text alignment class based on what's displayed.
+	let textAlignClass = '';
+	if ( showPercentage && ! showGoal && ! showAmountRaised ) {
+		textAlignClass = 'contribution-meter__text--center';
+	} else if ( ! showAmountRaised && showGoal && ! showPercentage ) {
+		textAlignClass = 'contribution-meter__text--right';
+	}
+
+	return (
+		<div className="contribution-meter__linear">
+			{ hasAnyTextDisplay && (
+				<div className={ `contribution-meter__text ${ textAlignClass }` }>
+					{ /* Percentage comes first when: Goal + Percentage (no raised) */ }
+					{ showPercentage && ! showAmountRaised && showGoal && <span className="contribution-meter__percentage">{ percentage }%</span> }
+
+					{ /* Raised + Goal combined */ }
+					{ showAmountRaised && showGoal && (
+						<span className="contribution-meter__amount-raised-goal">
+							{ sprintf(
+								/* translators: 1: amount raised, 2: goal amount */
+								__( '%1$s raised of %2$s goal', 'newspack-plugin' ),
+								formatCurrency( amountRaised ),
+								formatCurrency( goal )
+							) }
+						</span>
+					) }
+
+					{ /* Raised only */ }
+					{ showAmountRaised && ! showGoal && (
+						<span className="contribution-meter__amount-raised">
+							{ sprintf(
+								/* translators: %s: amount raised */
+								__( '%s raised', 'newspack-plugin' ),
+								formatCurrency( amountRaised )
+							) }
+						</span>
+					) }
+
+					{ /* Goal (when not combined with raised) */ }
+					{ ! showAmountRaised && showGoal && (
+						<span className="contribution-meter__goal">
+							{ sprintf(
+								/* translators: %s: goal amount */
+								__( '%s goal', 'newspack-plugin' ),
+								formatCurrency( goal )
+							) }
+						</span>
+					) }
+
+					{ /* Percentage comes last in all other cases */ }
+					{ showPercentage && ! ( ! showAmountRaised && showGoal ) && (
+						<span className="contribution-meter__percentage">{ percentage }%</span>
+					) }
+				</div>
+			) }
+			<div className="contribution-meter__bar-container" style={ barStyle }>
+				<div className="contribution-meter__bar-track">
+					<div className="contribution-meter__bar-progress" style={ progressStyle } />
+				</div>
+			</div>
+		</div>
+	);
+};
+
+export default LinearMeter;

--- a/src/blocks/contribution-meter/components/LinearMeter.jsx
+++ b/src/blocks/contribution-meter/components/LinearMeter.jsx
@@ -42,7 +42,7 @@ const LinearMeter = ( { amountRaised, goal, percentage, showGoal, showAmountRais
 	}
 
 	return (
-		<div className="contribution-meter__linear newspack-ui newspack-ui__font--s">
+		<div className="contribution-meter__linear">
 			{ hasAnyTextDisplay && (
 				<div className={ `contribution-meter__text ${ textAlignClass }` }>
 					{ /* Percentage comes first when: Goal + Percentage (no raised) */ }

--- a/src/blocks/contribution-meter/components/LinearMeter.jsx
+++ b/src/blocks/contribution-meter/components/LinearMeter.jsx
@@ -42,7 +42,7 @@ const LinearMeter = ( { amountRaised, goal, percentage, showGoal, showAmountRais
 	}
 
 	return (
-		<div className="contribution-meter__linear">
+		<div className="contribution-meter__linear newspack-ui newspack-ui__font--s">
 			{ hasAnyTextDisplay && (
 				<div className={ `contribution-meter__text ${ textAlignClass }` }>
 					{ /* Percentage comes first when: Goal + Percentage (no raised) */ }

--- a/src/blocks/contribution-meter/edit.jsx
+++ b/src/blocks/contribution-meter/edit.jsx
@@ -24,13 +24,7 @@ import { getDefaultStartDate } from './utils/helpers';
  * @return {string} Combined class names.
  */
 const buildClassNames = ( style, thickness ) => {
-	return [
-		'wp-block-newspack-contribution-meter',
-		`contribution-meter--${ style }`,
-		`contribution-meter--thickness-${ thickness }`,
-		'newspack-ui',
-		'newspack-ui__font--s',
-	].join( ' ' );
+	return [ `contribution-meter--${ style }`, `contribution-meter--thickness-${ thickness }`, 'newspack-ui', 'newspack-ui__font--s' ].join( ' ' );
 };
 
 /**
@@ -41,14 +35,26 @@ const buildClassNames = ( style, thickness ) => {
  * @param {Function} props.setAttributes Function to update attributes.
  * @return {Element} Edit component.
  */
+const PREVIEW_AMOUNT_RAISED = 1500;
+
 const Edit = ( { attributes, setAttributes } ) => {
-	const { className, goalAmount, startDate, progressBarColor, thickness, showGoal, showAmountRaised, showPercentage } = attributes;
+	const {
+		className,
+		goalAmount,
+		startDate,
+		progressBarColor,
+		thickness,
+		showGoal,
+		showAmountRaised,
+		showPercentage,
+		previewMode = false,
+	} = attributes;
 
 	// Extract meter style from className attribute (is-style-circular or default to linear).
 	const meterStyle = className && className.includes( 'is-style-circular' ) ? 'circular' : 'linear';
 
-	const [ contributionData, setContributionData ] = useState( null );
-	const [ isLoading, setIsLoading ] = useState( true );
+	const [ contributionData, setContributionData ] = useState( previewMode ? { amountRaised: PREVIEW_AMOUNT_RAISED } : null );
+	const [ isLoading, setIsLoading ] = useState( previewMode ? false : true );
 	const [ error, setError ] = useState( null );
 
 	// Set default start date if not set.
@@ -60,6 +66,10 @@ const Edit = ( { attributes, setAttributes } ) => {
 
 	// Fetch contribution data when startDate changes.
 	useEffect( () => {
+		if ( previewMode ) {
+			return;
+		}
+
 		if ( ! startDate ) {
 			setIsLoading( false );
 			return;
@@ -83,7 +93,7 @@ const Edit = ( { attributes, setAttributes } ) => {
 				setError( err.message || __( 'Failed to load contribution data.', 'newspack-plugin' ) );
 				setIsLoading( false );
 			} );
-	}, [ startDate ] );
+	}, [ startDate, previewMode ] );
 
 	// Get values and calculate percentage.
 	const amountRaised = contributionData?.amountRaised || 0;

--- a/src/blocks/contribution-meter/edit.jsx
+++ b/src/blocks/contribution-meter/edit.jsx
@@ -5,6 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { useBlockProps } from '@wordpress/block-editor';
 import { Placeholder, Spinner } from '@wordpress/components';
 import { useEffect, useState, useMemo } from '@wordpress/element';
+import { error as warning } from '@wordpress/icons';
 import apiFetch from '@wordpress/api-fetch';
 
 /**
@@ -23,7 +24,13 @@ import { getDefaultStartDate } from './utils/helpers';
  * @return {string} Combined class names.
  */
 const buildClassNames = ( style, thickness ) => {
-	return [ 'wp-block-newspack-contribution-meter', `contribution-meter--${ style }`, `contribution-meter--thickness-${ thickness }` ].join( ' ' );
+	return [
+		'wp-block-newspack-contribution-meter',
+		`contribution-meter--${ style }`,
+		`contribution-meter--thickness-${ thickness }`,
+		'newspack-ui',
+		'newspack-ui__font--s',
+	].join( ' ' );
 };
 
 /**
@@ -107,17 +114,16 @@ const Edit = ( { attributes, setAttributes } ) => {
 
 			<div { ...blockProps }>
 				{ isLoading && (
-					<Placeholder
-						icon={ <Spinner /> }
-						label={ __( 'Loading contribution data…', 'newspack-plugin' ) }
-						className="contribution-meter-loading"
-					/>
+					<Placeholder className="contribution-meter-loading">
+						<Spinner />
+						{ __( 'Loading contribution data…', 'newspack-plugin' ) }
+					</Placeholder>
 				) }
 
 				{ ! isLoading && error && (
 					<Placeholder
-						icon="warning"
-						label={ __( 'Contribution Meter', 'newspack-plugin' ) }
+						icon={ warning }
+						label={ __( 'Error', 'newspack-plugin' ) }
 						instructions={ error }
 						className="contribution-meter-error"
 					/>

--- a/src/blocks/contribution-meter/edit.jsx
+++ b/src/blocks/contribution-meter/edit.jsx
@@ -1,0 +1,137 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useBlockProps } from '@wordpress/block-editor';
+import { Placeholder, Spinner } from '@wordpress/components';
+import { useEffect, useState, useMemo } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import InspectorPanel from './components/InspectorPanel';
+import LinearMeter from './components/LinearMeter';
+import CircularMeter from './components/CircularMeter';
+import { getDefaultStartDate } from './utils/helpers';
+
+/**
+ * Build CSS class names for the block wrapper.
+ *
+ * @param {string} style     Meter style.
+ * @param {string} thickness Thickness size.
+ * @return {string} Combined class names.
+ */
+const buildClassNames = ( style, thickness ) => {
+	return [ 'wp-block-newspack-contribution-meter', `contribution-meter--${ style }`, `contribution-meter--thickness-${ thickness }` ].join( ' ' );
+};
+
+/**
+ * Edit component for the Contribution Meter block.
+ *
+ * @param {Object}   props               Component props.
+ * @param {Object}   props.attributes    Block attributes.
+ * @param {Function} props.setAttributes Function to update attributes.
+ * @return {Element} Edit component.
+ */
+const Edit = ( { attributes, setAttributes } ) => {
+	const { meterStyle, goalAmount, startDate, progressBarColor, thickness, showGoal, showAmountRaised, showPercentage } = attributes;
+	const [ contributionData, setContributionData ] = useState( null );
+	const [ isLoading, setIsLoading ] = useState( true );
+	const [ error, setError ] = useState( null );
+
+	// Set default start date if not set.
+	useEffect( () => {
+		if ( ! startDate ) {
+			setAttributes( { startDate: getDefaultStartDate() } );
+		}
+	}, [ startDate, setAttributes ] );
+
+	// Fetch contribution data when startDate changes.
+	useEffect( () => {
+		if ( ! startDate ) {
+			setIsLoading( false );
+			return;
+		}
+
+		setIsLoading( true );
+		setError( null );
+
+		apiFetch( {
+			path: '/newspack/v1/contribution-meter',
+			method: 'POST',
+			data: {
+				startDate,
+			},
+		} )
+			.then( data => {
+				setContributionData( data );
+				setIsLoading( false );
+			} )
+			.catch( err => {
+				setError( err.message || __( 'Failed to load contribution data.', 'newspack-plugin' ) );
+				setIsLoading( false );
+			} );
+	}, [ startDate ] );
+
+	// Get values and calculate percentage.
+	const amountRaised = contributionData?.amountRaised || 0;
+	const percentage = useMemo( () => {
+		if ( ! goalAmount || goalAmount <= 0 ) {
+			return 0;
+		}
+		const percentageRaw = ( amountRaised / goalAmount ) * 100;
+		return Math.floor( percentageRaw * 10 ) / 10;
+	}, [ amountRaised, goalAmount ] );
+
+	// Build CSS class names.
+	const className = useMemo( () => buildClassNames( meterStyle, thickness ), [ meterStyle, thickness ] );
+
+	const blockProps = useBlockProps( { className } );
+
+	// Shared meter props.
+	const meterProps = {
+		amountRaised,
+		goal: goalAmount,
+		percentage,
+		showGoal,
+		showAmountRaised,
+		showPercentage,
+		progressBarColor,
+		thickness,
+	};
+
+	return (
+		<>
+			<InspectorPanel attributes={ attributes } setAttributes={ setAttributes } />
+
+			<div { ...blockProps }>
+				{ isLoading && (
+					<Placeholder
+						icon={ <Spinner /> }
+						label={ __( 'Loading contribution data…', 'newspack-plugin' ) }
+						className="contribution-meter-loading"
+					/>
+				) }
+
+				{ ! isLoading && error && (
+					<Placeholder
+						icon="warning"
+						label={ __( 'Contribution Meter', 'newspack-plugin' ) }
+						instructions={ error }
+						className="contribution-meter-error"
+					/>
+				) }
+
+				{ ! isLoading && ! error && (
+					<>
+						{ meterStyle === 'linear' && <LinearMeter { ...meterProps } /> }
+						{ meterStyle === 'circular' && <CircularMeter { ...meterProps } /> }
+					</>
+				) }
+			</div>
+		</>
+	);
+};
+
+export default Edit;

--- a/src/blocks/contribution-meter/edit.jsx
+++ b/src/blocks/contribution-meter/edit.jsx
@@ -42,7 +42,11 @@ const buildClassNames = ( style, thickness ) => {
  * @return {Element} Edit component.
  */
 const Edit = ( { attributes, setAttributes } ) => {
-	const { meterStyle, goalAmount, startDate, progressBarColor, thickness, showGoal, showAmountRaised, showPercentage } = attributes;
+	const { className, goalAmount, startDate, progressBarColor, thickness, showGoal, showAmountRaised, showPercentage } = attributes;
+
+	// Extract meter style from className attribute (is-style-circular or default to linear).
+	const meterStyle = className && className.includes( 'is-style-circular' ) ? 'circular' : 'linear';
+
 	const [ contributionData, setContributionData ] = useState( null );
 	const [ isLoading, setIsLoading ] = useState( true );
 	const [ error, setError ] = useState( null );
@@ -92,9 +96,9 @@ const Edit = ( { attributes, setAttributes } ) => {
 	}, [ amountRaised, goalAmount ] );
 
 	// Build CSS class names.
-	const className = useMemo( () => buildClassNames( meterStyle, thickness ), [ meterStyle, thickness ] );
+	const blockClassName = useMemo( () => buildClassNames( meterStyle, thickness ), [ meterStyle, thickness ] );
 
-	const blockProps = useBlockProps( { className } );
+	const blockProps = useBlockProps( { className: blockClassName } );
 
 	// Shared meter props.
 	const meterProps = {

--- a/src/blocks/contribution-meter/edit.jsx
+++ b/src/blocks/contribution-meter/edit.jsx
@@ -42,6 +42,7 @@ const Edit = ( { attributes, setAttributes } ) => {
 		className,
 		goalAmount,
 		startDate,
+		endDate,
 		progressBarColor,
 		thickness,
 		showGoal,
@@ -83,6 +84,7 @@ const Edit = ( { attributes, setAttributes } ) => {
 			method: 'POST',
 			data: {
 				startDate,
+				...( endDate && { endDate } ),
 			},
 		} )
 			.then( data => {
@@ -93,7 +95,7 @@ const Edit = ( { attributes, setAttributes } ) => {
 				setError( err.message || __( 'Failed to load contribution data.', 'newspack-plugin' ) );
 				setIsLoading( false );
 			} );
-	}, [ startDate, previewMode ] );
+	}, [ startDate, endDate, previewMode ] );
 
 	// Get values and calculate percentage.
 	const amountRaised = contributionData?.amountRaised || 0;

--- a/src/blocks/contribution-meter/index.js
+++ b/src/blocks/contribution-meter/index.js
@@ -52,4 +52,9 @@ registerBlockStyle( name, {
 registerBlockStyle( name, {
 	name: 'circular',
 	label: __( 'Circular', 'newspack-plugin' ),
+	example: {
+		attributes: {
+			className: 'is-style-circular',
+		},
+	},
 } );

--- a/src/blocks/contribution-meter/index.js
+++ b/src/blocks/contribution-meter/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { registerBlockType } from '@wordpress/blocks';
+import { registerBlockType, registerBlockStyle } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -42,3 +42,14 @@ export const settings = {
 };
 
 registerBlockType( { name, ...metadata }, settings );
+
+registerBlockStyle( name, {
+	name: 'linear',
+	label: __( 'Linear', 'newspack-plugin' ),
+	isDefault: true,
+} );
+
+registerBlockStyle( name, {
+	name: 'circular',
+	label: __( 'Circular', 'newspack-plugin' ),
+} );

--- a/src/blocks/contribution-meter/index.js
+++ b/src/blocks/contribution-meter/index.js
@@ -1,0 +1,44 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import Edit from './edit';
+import { target as icon } from '../../../packages/icons';
+import colors from '../../../packages/colors/colors.module.scss';
+import './style.scss';
+
+export const title = __( 'Contribution Meter', 'newspack-plugin' );
+
+const { name } = metadata;
+
+export { metadata, name };
+
+export const settings = {
+	title,
+	icon: {
+		src: icon,
+		foreground: colors[ 'primary-400' ],
+	},
+	keywords: [
+		__( 'donations', 'newspack-plugin' ),
+		__( 'fundraising', 'newspack-plugin' ),
+		__( 'revenue', 'newspack-plugin' ),
+		__( 'progress', 'newspack-plugin' ),
+		__( 'goal', 'newspack-plugin' ),
+		__( 'campaign', 'newspack-plugin' ),
+		__( 'contribution', 'newspack-plugin' ),
+		__( 'meter', 'newspack-plugin' ),
+		__( 'newspack', 'newspack-plugin' ),
+	],
+	description: __( 'Display progress toward your goal. Works seamlessly with the Donate block.', 'newspack-plugin' ),
+	edit: Edit,
+	save: () => null, // Server-side rendered block.
+};
+
+registerBlockType( { name, ...metadata }, settings );

--- a/src/blocks/contribution-meter/index.php
+++ b/src/blocks/contribution-meter/index.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Contribution Meter Block loader.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Blocks\Contribution_Meter;
+
+use Newspack\Contribution_Meter\Contribution_Meter;
+
+defined( 'ABSPATH' ) || exit;
+
+require_once __DIR__ . '/class-contribution-meter-block.php';
+
+Contribution_Meter::init();
+Contribution_Meter_Block::init();

--- a/src/blocks/contribution-meter/meters/class-circular-meter.php
+++ b/src/blocks/contribution-meter/meters/class-circular-meter.php
@@ -94,7 +94,7 @@ class Circular_Meter implements Meter {
 				</svg>
 
 				<?php if ( $attributes['showPercentage'] ) : ?>
-					<div class="contribution-meter__circle-percentage">
+					<div class="contribution-meter__circle-percentage newspack-ui__font--2xs">
 						<?php echo esc_html( $percentage ); ?>%
 					</div>
 				<?php endif; ?>
@@ -102,12 +102,12 @@ class Circular_Meter implements Meter {
 
 			<div class="contribution-meter__data">
 				<?php if ( $attributes['showAmountRaised'] ) : ?>
-					<span class="contribution-meter__amount-raised">
+					<span class="contribution-meter__amount-raised newspack-ui__font--m">
 						<?php echo esc_html( Contribution_Meter::format_currency( $amount_raised ) ); ?> <?php esc_html_e( 'raised', 'newspack-plugin' ); ?>
 					</span>
 				<?php endif; ?>
 				<?php if ( $attributes['showGoal'] ) : ?>
-					<span class="contribution-meter__goal<?php echo ! $attributes['showAmountRaised'] ? ' contribution-meter__goal--primary' : ''; ?>">
+					<span class="contribution-meter__goal<?php echo ! $attributes['showAmountRaised'] ? ' contribution-meter__goal--primary newspack-ui__font--m' : ''; ?>">
 						<?php echo esc_html( Contribution_Meter::format_currency( $goal ) ); ?> <?php esc_html_e( 'goal', 'newspack-plugin' ); ?>
 					</span>
 				<?php endif; ?>

--- a/src/blocks/contribution-meter/meters/class-circular-meter.php
+++ b/src/blocks/contribution-meter/meters/class-circular-meter.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Circular Meter.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Blocks\Contribution_Meter\Meters;
+
+use Newspack\Contribution_Meter\Contribution_Meter;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Circular progress indicator meter.
+ */
+class Circular_Meter implements Meter {
+
+	/**
+	 * Thickness values in pixels.
+	 */
+	public const THICKNESS = [
+		'xs' => 4,
+		's'  => 8,
+		'm'  => 12,
+		'l'  => 16,
+	];
+
+	/**
+	 * Render the circular meter.
+	 *
+	 * @param float $amount_raised Amount raised.
+	 * @param int   $goal Goal amount.
+	 * @param float $percentage Percentage completed.
+	 * @param array $attributes Block attributes.
+	 */
+	public static function render( $amount_raised, $goal, $percentage, $attributes ) {
+		$viewbox_size      = 72;
+		$stroke_width      = isset( self::THICKNESS[ $attributes['thickness'] ] ) ? self::THICKNESS[ $attributes['thickness'] ] : self::THICKNESS['s'];
+		$visual_percentage = $percentage > 100 ? 100 : $percentage; // Cap visual progress at 100%.
+
+		$radius        = ( $viewbox_size / 2 ) - ( $stroke_width / 2 );
+		$circumference = 2 * M_PI * $radius;
+		$offset        = $circumference - ( ( $visual_percentage / 100 ) * $circumference );
+
+		$center_x = $viewbox_size / 2;
+		$center_y = $viewbox_size / 2;
+
+		$svg_style = '';
+		if ( ! empty( $attributes['progressBarColor'] ) ) {
+			$svg_style = sprintf( 'color: %s;', esc_attr( $attributes['progressBarColor'] ) );
+		}
+		?>
+		<div class="contribution-meter__circular">
+			<div class="contribution-meter__circle-container">
+				<svg class="contribution-meter__circle" viewBox="0 0 <?php echo esc_attr( $viewbox_size ); ?> <?php echo esc_attr( $viewbox_size ); ?>" role="img" aria-label="<?php esc_attr_e( 'Contribution progress indicator', 'newspack-plugin' ); ?>" <?php echo $svg_style ? 'style="' . esc_attr( $svg_style ) . '"' : ''; ?>>
+					<title><?php esc_html_e( 'Contribution Meter', 'newspack-plugin' ); ?></title>
+					<desc>
+						<?php
+						echo esc_html(
+							sprintf(
+								/* translators: 1: percentage, 2: formatted goal amount */
+								__( '%1$s%% progress toward %2$s goal', 'newspack-plugin' ),
+								$percentage,
+								Contribution_Meter::format_currency( $goal )
+							)
+						);
+						?>
+					</desc>
+
+					<!-- Background track -->
+					<circle
+						class="contribution-meter__circle-track"
+						cx="<?php echo esc_attr( $center_x ); ?>"
+						cy="<?php echo esc_attr( $center_y ); ?>"
+						r="<?php echo esc_attr( $radius ); ?>"
+						fill="none"
+						stroke-width="<?php echo esc_attr( $stroke_width ); ?>"
+					/>
+
+					<!-- Progress circle -->
+					<circle
+						class="contribution-meter__circle-progress"
+						cx="<?php echo esc_attr( $center_x ); ?>"
+						cy="<?php echo esc_attr( $center_y ); ?>"
+						r="<?php echo esc_attr( $radius ); ?>"
+						fill="none"
+						stroke-width="<?php echo esc_attr( $stroke_width ); ?>"
+						stroke-dasharray="<?php echo esc_attr( $circumference ); ?>"
+						stroke-dashoffset="<?php echo esc_attr( $offset ); ?>"
+						stroke-linecap="butt"
+						transform="rotate(-90 <?php echo esc_attr( $center_x ); ?> <?php echo esc_attr( $center_y ); ?>)"
+					/>
+				</svg>
+
+				<?php if ( $attributes['showPercentage'] ) : ?>
+					<div class="contribution-meter__circle-percentage">
+						<?php echo esc_html( $percentage ); ?>%
+					</div>
+				<?php endif; ?>
+			</div>
+
+			<div class="contribution-meter__data">
+				<?php if ( $attributes['showAmountRaised'] ) : ?>
+					<span class="contribution-meter__amount-raised">
+						<?php echo esc_html( Contribution_Meter::format_currency( $amount_raised ) ); ?> <?php esc_html_e( 'raised', 'newspack-plugin' ); ?>
+					</span>
+				<?php endif; ?>
+				<?php if ( $attributes['showGoal'] ) : ?>
+					<span class="contribution-meter__goal<?php echo ! $attributes['showAmountRaised'] ? ' contribution-meter__goal--primary' : ''; ?>">
+						<?php echo esc_html( Contribution_Meter::format_currency( $goal ) ); ?> <?php esc_html_e( 'goal', 'newspack-plugin' ); ?>
+					</span>
+				<?php endif; ?>
+			</div>
+		</div>
+		<?php
+	}
+}

--- a/src/blocks/contribution-meter/meters/class-linear-meter.php
+++ b/src/blocks/contribution-meter/meters/class-linear-meter.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Linear Meter.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Blocks\Contribution_Meter\Meters;
+
+use Newspack\Contribution_Meter\Contribution_Meter;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Linear progress bar meter.
+ */
+class Linear_Meter implements Meter {
+
+	/**
+	 * Render the linear meter.
+	 *
+	 * @param float $amount_raised Amount raised.
+	 * @param int   $goal Goal amount.
+	 * @param float $percentage Percentage completed.
+	 * @param array $attributes Block attributes.
+	 */
+	public static function render( $amount_raised, $goal, $percentage, $attributes ) {
+		$has_any_text = $attributes['showGoal'] || $attributes['showAmountRaised'] || $attributes['showPercentage'];
+
+		$bar_style = '';
+		if ( ! empty( $attributes['progressBarColor'] ) ) {
+			$bar_style = sprintf( 'color: %s;', esc_attr( $attributes['progressBarColor'] ) );
+		}
+
+		$progress_style = sprintf( 'width: %s%%;', esc_attr( $percentage > 100 ? 100 : $percentage ) ); // Cap visual progress at 100%.
+
+		// Determine text alignment class based on what's displayed.
+		$text_align_class = '';
+		if ( $attributes['showPercentage'] && ! $attributes['showGoal'] && ! $attributes['showAmountRaised'] ) {
+			$text_align_class = ' contribution-meter__text--center';
+		} elseif ( ! $attributes['showAmountRaised'] && $attributes['showGoal'] && ! $attributes['showPercentage'] ) {
+			$text_align_class = ' contribution-meter__text--right';
+		}
+		?>
+		<div class="contribution-meter__linear">
+			<?php if ( $has_any_text ) : ?>
+				<div class="contribution-meter__text<?php echo esc_attr( $text_align_class ); ?>">
+					<?php // Percentage comes first when: Goal + Percentage (no raised). ?>
+					<?php if ( $attributes['showPercentage'] && ! $attributes['showAmountRaised'] && $attributes['showGoal'] ) : ?>
+						<span class="contribution-meter__percentage">
+							<?php echo esc_html( $percentage ); ?>%
+						</span>
+					<?php endif; ?>
+
+					<?php // Raised + Goal combined. ?>
+					<?php if ( $attributes['showAmountRaised'] && $attributes['showGoal'] ) : ?>
+						<span class="contribution-meter__amount-raised-goal">
+							<?php
+							echo esc_html(
+								sprintf(
+									/* translators: 1: amount raised, 2: goal amount */
+									__( '%1$s raised of %2$s goal', 'newspack-plugin' ),
+									Contribution_Meter::format_currency( $amount_raised ),
+									Contribution_Meter::format_currency( $goal )
+								)
+							);
+							?>
+						</span>
+					<?php endif; ?>
+
+					<?php // Raised only. ?>
+					<?php if ( $attributes['showAmountRaised'] && ! $attributes['showGoal'] ) : ?>
+						<span class="contribution-meter__amount-raised">
+							<?php
+							echo esc_html(
+								sprintf(
+									/* translators: %s: amount raised */
+									__( '%s raised', 'newspack-plugin' ),
+									Contribution_Meter::format_currency( $amount_raised )
+								)
+							);
+							?>
+						</span>
+					<?php endif; ?>
+
+					<?php // Goal (when not combined with raised). ?>
+					<?php if ( ! $attributes['showAmountRaised'] && $attributes['showGoal'] ) : ?>
+						<span class="contribution-meter__goal">
+							<?php
+							echo esc_html(
+								sprintf(
+									/* translators: %s: goal amount */
+									__( '%s goal', 'newspack-plugin' ),
+									Contribution_Meter::format_currency( $goal )
+								)
+							);
+							?>
+						</span>
+					<?php endif; ?>
+
+					<?php // Percentage comes last in all other cases. ?>
+					<?php if ( $attributes['showPercentage'] && ! ( ! $attributes['showAmountRaised'] && $attributes['showGoal'] ) ) : ?>
+						<span class="contribution-meter__percentage">
+							<?php echo esc_html( $percentage ); ?>%
+						</span>
+					<?php endif; ?>
+				</div>
+			<?php endif; ?>
+			<div class="contribution-meter__bar-container" role="progressbar" aria-valuenow="<?php echo esc_attr( $percentage ); ?>" aria-valuemin="0" aria-valuemax="100" <?php echo $bar_style ? 'style="' . esc_attr( $bar_style ) . '"' : ''; ?>>
+				<div class="contribution-meter__bar-track">
+					<div class="contribution-meter__bar-progress" style="<?php echo esc_attr( $progress_style ); ?>"></div>
+				</div>
+			</div>
+		</div>
+		<?php
+	}
+}

--- a/src/blocks/contribution-meter/meters/class-loader.php
+++ b/src/blocks/contribution-meter/meters/class-loader.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Meter Loader.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Blocks\Contribution_Meter\Meters;
+
+defined( 'ABSPATH' ) || exit;
+
+// Load meter interface and implementations.
+require_once __DIR__ . '/interface-meter.php';
+require_once __DIR__ . '/class-linear-meter.php';
+require_once __DIR__ . '/class-circular-meter.php';
+
+/**
+ * Loader for meter types.
+ */
+class Loader {
+
+	/**
+	 * Meter type mapping.
+	 */
+	public const TYPES = [
+		'linear'   => Linear_Meter::class,
+		'circular' => Circular_Meter::class,
+	];
+
+	/**
+	 * Get meter class for a given style.
+	 *
+	 * @param string $style Meter style ('linear' or 'circular').
+	 * @return string Meter class name.
+	 */
+	public static function get_meter_class( $style ) {
+		return self::TYPES[ $style ] ?? self::TYPES['linear'];
+	}
+}

--- a/src/blocks/contribution-meter/meters/interface-meter.php
+++ b/src/blocks/contribution-meter/meters/interface-meter.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Meter Interface.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Blocks\Contribution_Meter\Meters;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Interface for contribution meter types.
+ */
+interface Meter {
+
+	/**
+	 * Render the meter.
+	 *
+	 * @param float $amount_raised Amount raised.
+	 * @param int   $goal Goal amount.
+	 * @param float $percentage Percentage completed.
+	 * @param array $attributes Block attributes.
+	 */
+	public static function render( $amount_raised, $goal, $percentage, $attributes );
+}

--- a/src/blocks/contribution-meter/style.scss
+++ b/src/blocks/contribution-meter/style.scss
@@ -3,23 +3,29 @@
  */
 
 .wp-block-newspack-contribution-meter {
+	color: inherit;
 	display: block;
+	font-weight: 600;
 	margin: 1em 0;
+
+	&.newspack-ui {
+		color: inherit;
+	}
 
 	// Linear meter styles.
 	.contribution-meter__linear {
+		color: inherit;
 		width: 100%;
 	}
 
 	.contribution-meter__text {
-		display: flex;
 		align-items: center;
-		justify-content: space-between;
-		margin-bottom: 0.75em;
-		font-size: 16px;
-		font-weight: 600;
-		line-height: 24px;
+		display: flex;
 		flex-wrap: wrap;
+		gap: var(--newspack-ui-spacer-3);
+		justify-content: space-between;
+		margin-bottom: var(--newspack-ui-spacer-base);
+		row-gap: calc(var(--newspack-ui-spacer-base) / 2);
 
 		> span {
 			display: inline-block;
@@ -39,23 +45,23 @@
 	}
 
 	.contribution-meter__bar-track {
-		position: relative;
-		width: 100%;
 		background-color: color-mix(in srgb, currentcolor 17%, transparent);
 		overflow: hidden;
+		position: relative;
+		width: 100%;
 	}
 
 	.contribution-meter__bar-progress {
-		position: relative;
-		height: 100%;
 		background-color: currentcolor;
-		transition: width 0.3s ease-in-out;
+		height: 100%;
+		position: relative;
+		transition: width 125ms ease-in-out;
 	}
 
 	// Thickness variations for linear (with matching border-radius).
 	&.contribution-meter--thickness-xs .contribution-meter__bar-track {
-		height: 4px;
 		border-radius: 2px;
+		height: 4px;
 	}
 
 	&.contribution-meter--thickness-xs .contribution-meter__bar-progress {
@@ -63,8 +69,8 @@
 	}
 
 	&.contribution-meter--thickness-s .contribution-meter__bar-track {
-		height: 8px;
 		border-radius: 4px;
+		height: 8px;
 	}
 
 	&.contribution-meter--thickness-s .contribution-meter__bar-progress {
@@ -72,8 +78,8 @@
 	}
 
 	&.contribution-meter--thickness-m .contribution-meter__bar-track {
-		height: 16px;
 		border-radius: 8px;
+		height: 16px;
 	}
 
 	&.contribution-meter--thickness-m .contribution-meter__bar-progress {
@@ -81,8 +87,8 @@
 	}
 
 	&.contribution-meter--thickness-l .contribution-meter__bar-track {
-		height: 32px;
 		border-radius: 16px;
+		height: 32px;
 	}
 
 	&.contribution-meter--thickness-l .contribution-meter__bar-progress {
@@ -91,23 +97,34 @@
 
 	// Circular meter styles.
 	.contribution-meter__circular {
-		display: flex;
-		flex-direction: row;
 		align-items: center;
-		gap: 16px;
+		color: inherit;
+		display: flex;
+		flex-direction: column;
+		gap: var(--newspack-ui-spacer-base);
+
+		@media (min-width: 600px) {
+			flex-direction: row;
+			gap: var(--newspack-ui-spacer-3);
+		}
 	}
 
 	.contribution-meter__circle-container {
-		position: relative;
 		flex-shrink: 0;
-		width: 72px;
-		height: 72px;
+		height: 104px;
+		position: relative;
+		width: 104px;
+
+		@media (min-width: 600px) {
+			height: 72px;
+			width: 72px;
+		}
 	}
 
 	.contribution-meter__circle {
 		display: block;
-		width: 72px;
-		height: 72px;
+		height: inherit;
+		width: inherit;
 	}
 
 	.contribution-meter__circle-track {
@@ -116,19 +133,16 @@
 
 	.contribution-meter__circle-progress {
 		stroke: currentcolor;
-		transition: stroke-dashoffset 0.3s ease-in-out;
+		transition: stroke-dashoffset 125ms ease-in-out;
 	}
 
 	.contribution-meter__circle-percentage {
-		position: absolute;
-		top: 50%;
 		left: 50%;
-		transform: translate(-50%, -50%);
-		font-size: 12px;
-		font-weight: 600;
-		line-height: 1;
 		margin: 0;
 		pointer-events: none;
+		position: absolute;
+		top: 50%;
+		transform: translate(-50%, -50%);
 	}
 
 	.contribution-meter__data {
@@ -136,60 +150,11 @@
 		flex-direction: column;
 		gap: 0;
 
-		.contribution-meter__amount-raised {
-			font-weight: 600;
-			font-size: 20px;
-			line-height: 1.6;
-		}
-
 		.contribution-meter__goal {
-			font-size: 16px;
-			font-weight: 600;
-			line-height: 1.5;
 			opacity: 0.65;
 
 			&--primary {
-				font-size: 20px;
-				line-height: 1.6;
 				opacity: 1;
-			}
-		}
-	}
-
-	// Responsive adjustments.
-	@media (max-width: 600px) {
-		.contribution-meter__text {
-			font-size: 0.85em;
-			gap: 0.4em;
-		}
-
-		.contribution-meter__percentage {
-			flex-basis: 100%;
-			margin-left: 0;
-			margin-top: 0.25em;
-			text-align: right;
-		}
-
-		.contribution-meter__circular {
-			flex-direction: column;
-		}
-
-		.contribution-meter__circle {
-			width: 100px;
-			height: 100px;
-		}
-
-		.contribution-meter__circle-percentage {
-			font-size: 1.2em;
-		}
-
-		.contribution-meter__data {
-			.contribution-meter__amount-raised {
-				font-size: 0.9em;
-			}
-
-			.contribution-meter__goal {
-				font-size: 0.85em;
 			}
 		}
 	}
@@ -197,10 +162,10 @@
 	// Editor-specific styles.
 	.contribution-meter-loading,
 	.contribution-meter-error {
-		min-height: 100px;
-		display: flex;
 		align-items: center;
+		display: flex;
 		justify-content: center;
+		min-height: 100px;
 
 		.components-placeholder__fieldset {
 			display: none;
@@ -209,12 +174,12 @@
 
 	// Alignment support.
 	&.alignwide {
-		width: 100%;
 		max-width: var(--wp--style--global--wide-size, 1280px);
+		width: 100%;
 	}
 
 	&.alignfull {
-		width: 100%;
 		max-width: none;
+		width: 100%;
 	}
 }

--- a/src/blocks/contribution-meter/style.scss
+++ b/src/blocks/contribution-meter/style.scss
@@ -3,7 +3,6 @@
  */
 
 .wp-block-newspack-contribution-meter {
-	color: inherit;
 	display: block;
 	font-weight: 600;
 	margin: 1em 0;
@@ -14,7 +13,6 @@
 
 	// Linear meter styles.
 	.contribution-meter__linear {
-		color: inherit;
 		width: 100%;
 	}
 
@@ -98,7 +96,6 @@
 	// Circular meter styles.
 	.contribution-meter__circular {
 		align-items: center;
-		color: inherit;
 		display: flex;
 		flex-direction: column;
 		gap: var(--newspack-ui-spacer-base);
@@ -163,12 +160,16 @@
 	.contribution-meter-loading,
 	.contribution-meter-error {
 		align-items: center;
-		display: flex;
 		justify-content: center;
-		min-height: 100px;
+		min-height: 159px;
 
 		.components-placeholder__fieldset {
-			display: none;
+			align-items: center;
+			justify-content: center;
+		}
+
+		.components-spinner {
+			margin: 0;
 		}
 	}
 

--- a/src/blocks/contribution-meter/style.scss
+++ b/src/blocks/contribution-meter/style.scss
@@ -1,0 +1,220 @@
+/**
+ * Contribution Meter Block Styles.
+ */
+
+.wp-block-newspack-contribution-meter {
+	display: block;
+	margin: 1em 0;
+
+	// Linear meter styles.
+	.contribution-meter__linear {
+		width: 100%;
+	}
+
+	.contribution-meter__text {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		margin-bottom: 0.75em;
+		font-size: 16px;
+		font-weight: 600;
+		line-height: 24px;
+		flex-wrap: wrap;
+
+		> span {
+			display: inline-block;
+		}
+
+		&--center {
+			justify-content: center;
+		}
+
+		&--right {
+			justify-content: flex-end;
+		}
+	}
+
+	.contribution-meter__bar-container {
+		width: 100%;
+	}
+
+	.contribution-meter__bar-track {
+		position: relative;
+		width: 100%;
+		background-color: color-mix(in srgb, currentcolor 17%, transparent);
+		overflow: hidden;
+	}
+
+	.contribution-meter__bar-progress {
+		position: relative;
+		height: 100%;
+		background-color: currentcolor;
+		transition: width 0.3s ease-in-out;
+	}
+
+	// Thickness variations for linear (with matching border-radius).
+	&.contribution-meter--thickness-xs .contribution-meter__bar-track {
+		height: 4px;
+		border-radius: 2px;
+	}
+
+	&.contribution-meter--thickness-xs .contribution-meter__bar-progress {
+		border-radius: 2px;
+	}
+
+	&.contribution-meter--thickness-s .contribution-meter__bar-track {
+		height: 8px;
+		border-radius: 4px;
+	}
+
+	&.contribution-meter--thickness-s .contribution-meter__bar-progress {
+		border-radius: 4px;
+	}
+
+	&.contribution-meter--thickness-m .contribution-meter__bar-track {
+		height: 16px;
+		border-radius: 8px;
+	}
+
+	&.contribution-meter--thickness-m .contribution-meter__bar-progress {
+		border-radius: 8px;
+	}
+
+	&.contribution-meter--thickness-l .contribution-meter__bar-track {
+		height: 32px;
+		border-radius: 16px;
+	}
+
+	&.contribution-meter--thickness-l .contribution-meter__bar-progress {
+		border-radius: 16px;
+	}
+
+	// Circular meter styles.
+	.contribution-meter__circular {
+		display: flex;
+		flex-direction: row;
+		align-items: center;
+		gap: 16px;
+	}
+
+	.contribution-meter__circle-container {
+		position: relative;
+		flex-shrink: 0;
+		width: 72px;
+		height: 72px;
+	}
+
+	.contribution-meter__circle {
+		display: block;
+		width: 72px;
+		height: 72px;
+	}
+
+	.contribution-meter__circle-track {
+		stroke: color-mix(in srgb, currentcolor 17%, transparent);
+	}
+
+	.contribution-meter__circle-progress {
+		stroke: currentcolor;
+		transition: stroke-dashoffset 0.3s ease-in-out;
+	}
+
+	.contribution-meter__circle-percentage {
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		transform: translate(-50%, -50%);
+		font-size: 12px;
+		font-weight: 600;
+		line-height: 1;
+		margin: 0;
+		pointer-events: none;
+	}
+
+	.contribution-meter__data {
+		display: flex;
+		flex-direction: column;
+		gap: 0;
+
+		.contribution-meter__amount-raised {
+			font-weight: 600;
+			font-size: 20px;
+			line-height: 1.6;
+		}
+
+		.contribution-meter__goal {
+			font-size: 16px;
+			font-weight: 600;
+			line-height: 1.5;
+			opacity: 0.65;
+
+			&--primary {
+				font-size: 20px;
+				line-height: 1.6;
+				opacity: 1;
+			}
+		}
+	}
+
+	// Responsive adjustments.
+	@media (max-width: 600px) {
+		.contribution-meter__text {
+			font-size: 0.85em;
+			gap: 0.4em;
+		}
+
+		.contribution-meter__percentage {
+			flex-basis: 100%;
+			margin-left: 0;
+			margin-top: 0.25em;
+			text-align: right;
+		}
+
+		.contribution-meter__circular {
+			flex-direction: column;
+		}
+
+		.contribution-meter__circle {
+			width: 100px;
+			height: 100px;
+		}
+
+		.contribution-meter__circle-percentage {
+			font-size: 1.2em;
+		}
+
+		.contribution-meter__data {
+			.contribution-meter__amount-raised {
+				font-size: 0.9em;
+			}
+
+			.contribution-meter__goal {
+				font-size: 0.85em;
+			}
+		}
+	}
+
+	// Editor-specific styles.
+	.contribution-meter-loading,
+	.contribution-meter-error {
+		min-height: 100px;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+
+		.components-placeholder__fieldset {
+			display: none;
+		}
+	}
+
+	// Alignment support.
+	&.alignwide {
+		width: 100%;
+		max-width: var(--wp--style--global--wide-size, 1280px);
+	}
+
+	&.alignfull {
+		width: 100%;
+		max-width: none;
+	}
+}

--- a/src/blocks/contribution-meter/utils/helpers.js
+++ b/src/blocks/contribution-meter/utils/helpers.js
@@ -1,0 +1,43 @@
+/**
+ * Utility functions for contribution meter calculations and formatting.
+ */
+
+/**
+ * Format currency value using WordPress settings.
+ *
+ * @param {number} amount Amount to format.
+ * @return {string} Formatted currency string.
+ */
+export const formatCurrency = amount => {
+	// Get currency settings from WordPress/WooCommerce if available.
+	const currencySymbol = window.newspack_contribution_meter_data?.currencySymbol || '$';
+	const currencyPosition = window.newspack_contribution_meter_data?.currencyPosition || 'left';
+	const thousandSeparator = window.newspack_contribution_meter_data?.thousandSeparator || ',';
+
+	// Format the number with no decimals.
+	const formatted = Math.round( amount )
+		.toString()
+		.replace( /\B(?=(\d{3})+(?!\d))/g, thousandSeparator );
+
+	// Apply currency symbol position.
+	switch ( currencyPosition ) {
+		case 'left':
+			return currencySymbol + formatted;
+		case 'right':
+			return formatted + currencySymbol;
+		case 'left_space':
+			return currencySymbol + ' ' + formatted;
+		case 'right_space':
+			return formatted + ' ' + currencySymbol;
+		default:
+			return currencySymbol + formatted;
+	}
+};
+
+/**
+ * Get default start date (today in YYYY-MM-DD format).
+ *
+ * @return {string} Today's date in YYYY-MM-DD format.
+ */
+export const getDefaultStartDate = ( d = new Date() ) =>
+	`${ d.getFullYear() }-${ String( d.getMonth() + 1 ).padStart( 2, '0' ) }-${ String( d.getDate() ).padStart( 2, '0' ) }`;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -47,6 +47,7 @@ const entry = {
 	'correction-item-block': path.join( __dirname, 'src', 'blocks', 'correction-item', 'index.js' ),
 	'content-gate-countdown-block': path.join( __dirname, 'src', 'blocks', 'content-gate', 'countdown', 'view.js' ),
 	'content-gate-countdown-box-block': path.join( __dirname, 'src', 'blocks', 'content-gate', 'countdown-box', 'index.js' ),
+	'contribution-meter-block': path.join( __dirname, 'src', 'blocks', 'contribution-meter', 'index.js' ),
 	'avatar-block': path.join( __dirname, 'src', 'blocks', 'avatar', 'index.js' ),
 	'my-account': path.join( __dirname, 'src', 'my-account', 'index.js' ),
 	'my-account-v0': path.join( __dirname, 'src', 'my-account', 'v0', 'index.js' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds a new block for displaying fundraising progress toward a goal, with data sourced from WooCommerce donation orders.

<img width="843" height="79" alt="image" src="https://github.com/user-attachments/assets/900a0ab2-382c-4902-8921-d4f0722baff1" />

**What it does**
- Tracks contributions (donations only) from a configurable start date.
- Shows goal amount, amount raised, and completion percentage. The visibility of these values is configurable.
- Available in linear (progress bar) and circular (ring) styles.
- Amount raised is updated via a cached REST API endpoint. Cache duration can be overridden via a DB option or a filter.

**Configuration**
- Set fundraising goal amount.
- Choose start date for tracking contributions.
- Toggle display of goal, amount raised, and percentage.
- Customize progress bar style, color, and thickness.

Closes NPPD-944.

### How to test the changes in this Pull Request:

1. Add a new "Contribution Meter" block to a post or page.
2. Set a goal amount and start date in the block inspector:
<img width="284" height="532" alt="image" src="https://github.com/user-attachments/assets/40aba808-c303-4fb5-b371-a3ba6ebe1ba1" />

3. Toggle visibility of goal, amount raised, and percentage to confirm they show/hide correctly. 
4. Switch between linear and circular meter styles, and adjust thickness settings.
5. Set a custom progress bar color and verify it displays correctly.

<img width="285" height="252" alt="image" src="https://github.com/user-attachments/assets/fd580575-bd7d-4479-95a4-d9cf9d738a60" />

6. Test that all the possible settings permutations match the designs: 

<img width="286" height="406" alt="image" src="https://github.com/user-attachments/assets/0ec68ed6-7e88-41b3-b3d9-eb41604ec967" />

7. Create test donation orders via WooCommerce and verify the meter reflects the correct revenue totals.
8. Change the start date and confirm that only donations after that date are counted.
9. Check that the data caches properly (subsequent loads don't re-query orders) and refreshes after the configured cache duration.
10. Apply wide and full alignment to the block to ensure proper display.
11. Check that the meters look the same in the editor and the frontend.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?