### PR TITLE
fix: content gate metadata methods and params

### DIFF
--- a/includes/data-events/class-memberships.php
+++ b/includes/data-events/class-memberships.php
@@ -7,7 +7,7 @@
 
 namespace Newspack\Data_Events;
 
-use Newspack\Memberships as NewspackMemberships;
+use Newspack\Content_Gate;
 use Newspack\Reader_Activation;
 use Newspack\Data_Events;
 use WP_Error;
@@ -17,7 +17,7 @@ use WP_Error;
  */
 final class Memberships {
 
-	const METADATA_NAME = 'memberships_content_gate';
+	const METADATA_NAME = 'gate_post_id';
 
 	/**
 	 * The name of the action for form submissions
@@ -74,7 +74,7 @@ final class Memberships {
 	 */
 	public static function checkout_create_order_line_item( $item, $cart_item_key, $values, $order ) {
 		if ( ! empty( $values[ self::METADATA_NAME ] ) ) {
-			$order->add_meta_data( '_memberships_content_gate', $values[ self::METADATA_NAME ] );
+			$order->add_meta_data( '_gate_post_id', $values[ self::METADATA_NAME ] );
 		}
 	}
 
@@ -149,7 +149,7 @@ final class Memberships {
 			return;
 		}
 		$data = array_merge(
-			NewspackMemberships::get_gate_metadata(),
+			Content_Gate::get_gate_metadata(),
 			[
 				'action'      => self::FORM_SUBMISSION,
 				'action_type' => 'registration',
@@ -182,7 +182,7 @@ final class Memberships {
 			$action = self::FORM_SUBMISSION_FAILURE;
 		}
 		$data = array_merge(
-			NewspackMemberships::get_gate_metadata(),
+			Content_Gate::get_gate_metadata(),
 			[
 				'action'      => $action,
 				'action_type' => 'registration',
@@ -202,13 +202,13 @@ final class Memberships {
 	 * @return ?array
 	 */
 	private static function get_order_data( $order_id, $order ) {
-		$is_from_gate = $order->get_meta( '_memberships_content_gate' );
+		$is_from_gate = $order->get_meta( '_gate_post_id' ) ? $order->get_meta( '_gate_post_id' ) : $order->get_meta( '_memberships_content_gate' ); // Handle legacy _memberships_content_gate meta key.
 		if ( ! $is_from_gate ) {
 			return;
 		}
 		$item = array_shift( $order->get_items() );
 		$data = array_merge(
-			NewspackMemberships::get_gate_metadata(),
+			Content_Gate::get_gate_metadata(),
 			[
 				'action_type' => 'paid_membership',
 				'order_id'    => $order_id,

--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -7,6 +7,7 @@
 
 namespace Newspack;
 
+use Newspack\Content_Gate;
 use Newspack\WooCommerce_Connection;
 
 defined( 'ABSPATH' ) || exit;

--- a/src/blocks/content-gate/countdown-box/class-content-gate-countdown-box-block.php
+++ b/src/blocks/content-gate/countdown-box/class-content-gate-countdown-box-block.php
@@ -10,7 +10,7 @@ namespace Newspack;
 defined( 'ABSPATH' ) || exit;
 
 use Newspack\Memberships;
-use Newspack\Memberships\Metering;
+use Newspack\Metering;
 use Newspack\Content_Gate_Countdown_Block;
 
 /**

--- a/src/content-gate/gate.js
+++ b/src/content-gate/gate.js
@@ -103,7 +103,7 @@ function initReloadHandler() {
 }
 
 /**
- * Adds 'memberships_content_gate' hidden input to every form inside the gate.
+ * Adds 'gate_post_id' hidden input to every form inside the gate.
  *
  * @param {HTMLElement} gate The gate element.
  */
@@ -115,10 +115,10 @@ function addFormInputs( gate ) {
 		...gate.querySelectorAll( '.wp-block-newspack-blocks-donate form' ), // Donate block.
 	];
 	forms.forEach( form => {
-		if ( ! form.querySelector( 'input[name="memberships_content_gate"]' ) ) {
+		if ( ! form.querySelector( 'input[name="gate_post_id"]' ) ) {
 			const input = document.createElement( 'input' );
 			input.type = 'hidden';
-			input.name = 'memberships_content_gate';
+			input.name = 'gate_post_id';
 			input.value = newspack_content_gate.metadata?.gate_post_id || '1';
 			form.appendChild( input );
 			form.addEventListener( 'submit', evt => handleFormSubmission( evt, gate ) );

--- a/src/reader-activation-auth/auth-form.js
+++ b/src/reader-activation-auth/auth-form.js
@@ -288,8 +288,8 @@ window.newspackRAS.push( function ( readerActivation ) {
 						readerActivation.setAuthenticated( !! data.authenticated );
 						const activity = { email: data.email };
 						const body = new FormData( form );
-						if ( data.metadata?.gate_post_id || body.has( 'memberships_content_gate' ) ) {
-							activity.gate_post_id = data.metadata.gate_post_id || body.get( 'memberships_content_gate' );
+						if ( data.metadata?.gate_post_id || body.has( 'gate_post_id' ) ) {
+							activity.gate_post_id = data.metadata.gate_post_id || body.get( 'gate_post_id' );
 						}
 						if ( data.metadata?.newspack_popup_id || body.has( 'newspack_popup_id' ) ) {
 							activity.newspack_popup_id = data.metadata.newspack_popup_id || body.get( 'newspack_popup_id' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a fatal error due to referencing a method that moved from the `Newspack\Memberships` class to `Newspack\Content_Gate`. Also ensures that GA4 custom events receive the `gate_post_id` and `newspack_popup_id` params throughout auth and modal checkout flows by normalizing the param name from `memberships_content_gate` to `gate_post_id` (https://github.com/Automattic/newspack-blocks/pull/2121 attempted to do this with https://github.com/Automattic/newspack-blocks/commit/0c5301b38e93b2c958dc04c8bba6302ec397dc17#diff-f371eb641807afd155089ce67e2add277c8d7a9dfe029518e977527c7ca015c3R144-R148 but some flows still expected the `memberships_content_gate` param).

### How to test the changes in this Pull Request:

1. On `release` for this repo and Newspack Blocks, complete registration, login, and modal checkout flows from a content gate and a Campaigns prompt. Observe that:
  - Some GA4 events drop the `gate_post_id` and `newspack_popup` params
  - Upon completing a modal checkout from within a content gate, an error occurs while processing the transaction:

```
2025-11-11T14:54:12+00:00 Error scheduled action 4317730 (subscription payment) failed to finish processing due to the following exception: Call to undefined method Newspack\Memberships::get_gate_metadata() in /wordpress/plugins/newspack-plugin/6.24.1/includes/data-events/class-memberships.php:211
```

  - A potential fatal error when rendering a [Countdown block](https://github.com/Automattic/newspack-plugin/pull/4176):

```
PHP Fatal error:  Uncaught Error: Class "Newspack\Memberships\Metering" not found in /newspack-repos/newspack-plugin/src/blocks/content-gate/countdown-box/class-content-gate-countdown-box-block.php:48
Stack trace:
#0 /var/www/html/wp-includes/class-wp-block.php(586): Newspack\Content_Gate_Countdown_Box_Block::render_block()
#1 /var/www/html/wp-includes/blocks.php(2359): WP_Block->render()
#2 /var/www/html/wp-includes/blocks.php(2431): render_block()
#3 /var/www/html/wp-includes/class-wp-hook.php(324): do_blocks()
#4 /var/www/html/wp-includes/plugin.php(205): WP_Hook->apply_filters()
#5 /var/www/html/wp-includes/post-template.php(256): apply_filters()
#6 /newspack-repos/newspack-theme/newspack-theme/template-parts/content/content-single.php(45): the_content()
#7 /var/www/html/wp-includes/template.php(812): require('...')
#8 /var/www/html/wp-includes/template.php(745): load_template()
#9 /var/www/html/wp-includes/general-template.php(206): locate_template()
#10 /newspack-repos/newspack-theme/newspack-theme/single.php(44): get_template_part()
#11 /var/www/html/wp-includes/template-loader.php(106): include('...')
#12 /var/www/html/wp-blog-header.php(19): require_once('...')
#13 /var/www/html/index.php(17): require('...')
#14 {main}
  thrown in /newspack-repos/newspack-plugin/src/blocks/content-gate/countdown-box/class-content-gate-countdown-box-block.php on line 48
```

2. Check out this branch and https://github.com/Automattic/newspack-blocks/pull/2249.
3. Follow instructions from #3956 and confirm that `gate_post_id` and `newspack_popup_id` params are appended to all GA4 events from registration, login, and modal checkout flows originating from a content gate and Campaigns prompt, respectively.
4. Confirm no fatal error from completing the content gate > modal checkout transaction, and no fatal error when rendering the Countdown block

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->