### PR TITLE
feat: listen to gforms events for newsletters

### DIFF
--- a/src/reader-activation/index.js
+++ b/src/reader-activation/index.js
@@ -1,4 +1,4 @@
-/* globals newspack_ras_config, newspack_reader_data */
+/* globals newspack_ras_config, newspack_reader_data, gform */
 
 window.newspack_ras_config = window.newspack_ras_config || {};
 
@@ -384,8 +384,10 @@ function attachAuthCookiesListener() {
  * Set the reader as newsletter subscriber once a newsletter form is submitted.
  */
 function attachNewsletterFormListener() {
-	const newspackForms = [ '.newspack-newsletters-subscribe', '.newspack-subscribe-form' ];
-	const thirdPartyForms = [ '.mc4wp-form' ];
+	const newspackForms = [ '.newspack-newsletters-subscribe' ];
+
+	// newspack-subscribe-form is a generic class that can be added to any 3rd party form. Once it's submitted, we consider the reader a newsletter subscriber.
+	const thirdPartyForms = [ '.mc4wp-form', '.newspack-subscribe-form' ];
 
 	const attachHandler = ( el, eventToListenTo = 'submit' ) => {
 		const form = 'FORM' === el.tagName ? el : el.querySelector( 'form' );
@@ -397,9 +399,35 @@ function attachNewsletterFormListener() {
 		} );
 	};
 
-	// For third-party forms, set reader data on form submit. For first-party forms, listen for the custom event upon successful signup response.
-	document.querySelectorAll( thirdPartyForms.join( ',' ) ).forEach( el => attachHandler( el ) );
+	const gformIds = [];
+
+	// For third-party forms, set reader data on form submit. Also detect Gravity Forms.
+	document.querySelectorAll( thirdPartyForms.join( ',' ) ).forEach( el => {
+		// If the form id stats with gform_ and it has a data-formid prop, it's a gravity form.
+		const isGravityForm = el.id.startsWith( 'gform_' ) && el.hasAttribute( 'data-formid' );
+		if ( isGravityForm ) {
+			gformIds.push( parseInt( el.getAttribute( 'data-formid' ) ) );
+			return;
+		}
+		// If not a gravity form, just attach the handler.
+		attachHandler( el );
+	} );
+
+	// First-party forms success event listener.
 	document.querySelectorAll( newspackForms.join( ',' ) ).forEach( el => attachHandler( el, 'newspack-newsletters-subscribe-success' ) );
+
+	// Gravity forms handlers.
+	document.addEventListener( 'gform/post_render', event => {
+		if ( gformIds.includes( event.detail.formId ) ) {
+			if ( ! window.gform ) {
+				return;
+			}
+			gform.utils.addAsyncFilter( 'gform/submission/pre_submission', async data => {
+				store.set( 'is_newsletter_subscriber', true );
+				return data;
+			} );
+		}
+	} );
 }
 
 const readerActivation = {

--- a/src/reader-activation/index.js
+++ b/src/reader-activation/index.js
@@ -418,10 +418,7 @@ function attachNewsletterFormListener() {
 
 	// Gravity forms handlers.
 	document.addEventListener( 'gform/post_render', event => {
-		if ( gformIds.includes( event.detail.formId ) ) {
-			if ( ! window.gform ) {
-				return;
-			}
+		if ( window.gform?.utils?.addAsyncFilter && gformIds.includes( event.detail?.formId ) ) {
 			gform.utils.addAsyncFilter( 'gform/submission/pre_submission', async data => {
 				store.set( 'is_newsletter_subscriber', true );
 				return data;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Add a specific listener for Gravity Forms forms.

Apparently, our generic solution to use the `newspack-subscribe-form` css class used to work, but it hasn't been working for a while. There was a regression added a while ago, which we tried to fix in https://github.com/Automattic/newspack-plugin/pull/4276, but with no success. Showing that this has been broken for a long time.

This PR uses GForms JS api to add a specific listener.

### How to test the changes in this Pull Request:

1. Install and activate Gravity Forms
2. Create a new form
3. In the form settings, add the `newspack-subscribe-form` CSS class to the form
4. Add the form to a page
5. As an anonymous reader in a new session, visit that page
6. Submit the form
7. Inspect the Browser Local storage and confirm you now see a key `np_reader_1_is_newsletter_subscriber` with `true` as the value.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->