### PR TITLE
feat(content-gifting): custom article link expiration

### DIFF
--- a/includes/content-gate/content-gifting/class-content-gifting.php
+++ b/includes/content-gate/content-gifting/class-content-gifting.php
@@ -28,13 +28,6 @@ class Content_Gifting {
 	const GENERATE_ACTION = 'newspack_generate_content_key';
 
 	/**
-	 * The expiration time for the content key.
-	 *
-	 * @var int
-	 */
-	const KEY_EXPIRATION = 3600 * 24; // 24 hours
-
-	/**
 	 * The meta for content gifting, both enabled option and user keys.
 	 *
 	 * @var string
@@ -208,13 +201,15 @@ class Content_Gifting {
 	 */
 	public static function get_settings() {
 		return [
-			'enabled'      => self::is_enabled(),
-			'limit'        => self::get_gifting_limit(),
-			'interval'     => self::get_gifting_reset_interval(),
-			'cta_label'    => Content_Gifting_CTA::get_cta_label(),
-			'button_label' => Content_Gifting_CTA::get_button_label(),
-			'cta_url'      => Content_Gifting_CTA::get_cta_url(),
-			'style'        => Content_Gifting_CTA::get_style(),
+			'enabled'              => self::is_enabled(),
+			'limit'                => self::get_gifting_limit(),
+			'interval'             => self::get_gifting_reset_interval(),
+			'expiration_time'      => self::get_expiration_time(),
+			'expiration_time_unit' => self::get_expiration_time_unit(),
+			'cta_label'            => Content_Gifting_CTA::get_cta_label(),
+			'button_label'         => Content_Gifting_CTA::get_button_label(),
+			'cta_url'              => Content_Gifting_CTA::get_cta_url(),
+			'style'                => Content_Gifting_CTA::get_style(),
 		];
 	}
 
@@ -272,6 +267,114 @@ class Content_Gifting {
 			'day'   => __( 'Day', 'newspack-plugin' ),
 			'week'  => __( 'Week', 'newspack-plugin' ),
 			'month' => __( 'Month', 'newspack-plugin' ),
+		];
+	}
+
+	/**
+	 * Get expiration time.
+	 *
+	 * @return int The expiration time.
+	 */
+	public static function get_expiration_time() {
+		return (int) get_option( 'newspack_content_gifting_expiration_time', 5 );
+	}
+
+	/**
+	 * Set expiration time.
+	 *
+	 * @param int $expiration_time The expiration time.
+	 *
+	 * @return void
+	 */
+	public static function set_expiration_time( $expiration_time ) {
+		update_option( 'newspack_content_gifting_expiration_time', $expiration_time );
+	}
+
+	/**
+	 * Get expiration time unit.
+	 *
+	 * @return string The expiration time unit.
+	 */
+	public static function get_expiration_time_unit() {
+		return (string) get_option( 'newspack_content_gifting_expiration_time_unit', 'days' );
+	}
+
+	/**
+	 * Set expiration time unit.
+	 *
+	 * @param string $expiration_time_unit The expiration time unit.
+	 *
+	 * @return void|WP_Error The expiration time unit or an error.
+	 */
+	public static function set_expiration_time_unit( $expiration_time_unit ) {
+		$options = self::get_expiration_time_unit_options();
+		if ( ! isset( $options[ $expiration_time_unit ] ) ) {
+			return new WP_Error( 'invalid_time_unit', __( 'Must be one of the following: hours, days.', 'newspack-plugin' ) );
+		}
+		update_option( 'newspack_content_gifting_expiration_time_unit', $expiration_time_unit );
+	}
+
+	/**
+	 * Get expiration time in seconds.
+	 *
+	 * @return int The expiration time in seconds.
+	 */
+	public static function get_expiration_time_in_seconds() {
+		$expiration_time      = self::get_expiration_time();
+		$expiration_time_unit = self::get_expiration_time_unit();
+		switch ( $expiration_time_unit ) {
+			case 'hours':
+				return $expiration_time * HOUR_IN_SECONDS;
+			case 'days':
+				return $expiration_time * DAY_IN_SECONDS;
+			default:
+				return 0;
+		}
+	}
+
+	/**
+	 * Get expiration time label.
+	 *
+	 * @return string The expiration time label.
+	 */
+	public static function get_expiration_time_label() {
+		$time = self::get_expiration_time();
+		$unit = self::get_expiration_time_unit();
+
+		$unit_labels = [
+			'hours' => [
+				'singular' => __( 'hour', 'newspack-plugin' ),
+				'plural'   => __( 'hours', 'newspack-plugin' ),
+			],
+			'days'  => [
+				'singular' => __( 'day', 'newspack-plugin' ),
+				'plural'   => __( 'days', 'newspack-plugin' ),
+			],
+		];
+
+		if ( ! isset( $unit_labels[ $unit ] ) ) {
+			return '';
+		}
+
+		$labels = $unit_labels[ $unit ];
+		return sprintf(
+			// translators: %1$d is the expiration time, %2$s is the singular expiration time unit label, %3$s is the plural expiration time unit label.
+			_n( '%1$d %2$s', '%1$d %3$s', $time, 'newspack-plugin' ), // phpcs:ignore WordPress.WP.I18n.MismatchedPlaceholders
+			$time,
+			$labels['singular'],
+			$labels['plural']
+		);
+	}
+
+	/**
+	 * Get expiration time unit options.
+	 *
+	 * @return array The expiration time unit options.
+	 */
+	public static function get_expiration_time_unit_options() {
+		return [
+			'hours' => __( 'Hours', 'newspack-plugin' ),
+			'days'  => __( 'Days', 'newspack-plugin' ),
 		];
 	}
 
@@ -388,7 +491,13 @@ class Content_Gifting {
 		<p>
 			<?php
 			if ( ! is_wp_error( $key ) ) {
-				esc_html_e( 'Give someone 24-hour access to this article.', 'newspack-plugin' );
+				echo esc_html(
+					sprintf(
+						// translators: %s is the expiration time label.
+						__( 'Give someone access to this article for %s.', 'newspack-plugin' ),
+						self::get_expiration_time_label()
+					)
+				);
 			}
 			?>
 			<strong>
@@ -582,7 +691,7 @@ class Content_Gifting {
 			return false;
 		}
 
-		if ( $data['keys'][ $post_id ]['timestamp'] + self::KEY_EXPIRATION < time() ) {
+		if ( $data['keys'][ $post_id ]['timestamp'] + self::get_expiration_time_in_seconds() < time() ) {
 			return false;
 		}
 
@@ -647,7 +756,7 @@ class Content_Gifting {
 
 		// Cleanup expired keys.
 		foreach ( $user_data['keys'] as $key => $data ) {
-			if ( $data['timestamp'] + self::KEY_EXPIRATION < time() ) {
+			if ( $data['timestamp'] + self::get_expiration_time_in_seconds() < time() ) {
 				unset( $user_data['keys'][ $key ] );
 			}
 		}

--- a/includes/content-gate/content-gifting/class-content-gifting.php
+++ b/includes/content-gate/content-gifting/class-content-gifting.php
@@ -230,7 +230,7 @@ class Content_Gifting {
 	 * @return void
 	 */
 	public static function set_gifting_limit( $limit ) {
-		update_option( 'newspack_content_gifting_limit', $limit );
+		update_option( 'newspack_content_gifting_limit', $limit, false );
 	}
 
 	/**
@@ -254,7 +254,7 @@ class Content_Gifting {
 		if ( ! isset( $options[ $interval ] ) ) {
 			return new WP_Error( 'invalid_interval', __( 'Must be one of the following: day, week, month.', 'newspack-plugin' ) );
 		}
-		update_option( 'newspack_content_gifting_reset_interval', $interval );
+		update_option( 'newspack_content_gifting_reset_interval', $interval, false );
 	}
 
 	/**
@@ -287,7 +287,7 @@ class Content_Gifting {
 	 * @return void
 	 */
 	public static function set_expiration_time( $expiration_time ) {
-		update_option( 'newspack_content_gifting_expiration_time', $expiration_time );
+		update_option( 'newspack_content_gifting_expiration_time', $expiration_time, false );
 	}
 
 	/**
@@ -311,7 +311,7 @@ class Content_Gifting {
 		if ( ! isset( $options[ $expiration_time_unit ] ) ) {
 			return new WP_Error( 'invalid_time_unit', __( 'Must be one of the following: hours, days.', 'newspack-plugin' ) );
 		}
-		update_option( 'newspack_content_gifting_expiration_time_unit', $expiration_time_unit );
+		update_option( 'newspack_content_gifting_expiration_time_unit', $expiration_time_unit, false );
 	}
 
 	/**

--- a/includes/content-gate/content-gifting/class-content-gifting.php
+++ b/includes/content-gate/content-gifting/class-content-gifting.php
@@ -428,15 +428,16 @@ class Content_Gifting {
 				'newspack-content-gifting',
 				'newspack_content_gifting',
 				[
-					'ajax_url'     => add_query_arg(
+					'ajax_url'        => add_query_arg(
 						[
 							'action' => self::GENERATE_ACTION,
 							'nonce'  => wp_create_nonce( self::GENERATE_ACTION ),
 						],
 						admin_url( 'admin-ajax.php' )
 					),
-					'post_id'      => get_the_ID(),
-					'copied_label' => __( 'Link copied', 'newspack-plugin' ),
+					'post_id'         => get_the_ID(),
+					'copied_label'    => __( 'Link copied', 'newspack-plugin' ),
+					'expiration_time' => self::get_expiration_time_in_seconds(),
 				]
 			);
 		}

--- a/includes/wizards/audience/class-audience-wizard.php
+++ b/includes/wizards/audience/class-audience-wizard.php
@@ -619,6 +619,12 @@ class Audience_Wizard extends Wizard {
 			if ( isset( $args['content_gifting']['limit'] ) ) {
 				Content_Gifting::set_gifting_limit( (int) $args['content_gifting']['limit'] );
 			}
+			if ( isset( $args['content_gifting']['expiration_time'] ) ) {
+				Content_Gifting::set_expiration_time( (int) $args['content_gifting']['expiration_time'] );
+			}
+			if ( isset( $args['content_gifting']['expiration_time_unit'] ) ) {
+				Content_Gifting::set_expiration_time_unit( sanitize_text_field( $args['content_gifting']['expiration_time_unit'] ) );
+			}
 			if ( isset( $args['content_gifting']['interval'] ) ) {
 				Content_Gifting::set_gifting_reset_interval( sanitize_text_field( $args['content_gifting']['interval'] ) );
 			}

--- a/src/content-gate/content-gifting.js
+++ b/src/content-gate/content-gifting.js
@@ -102,7 +102,7 @@ domReady( () => {
 	const params = new URLSearchParams( window.location.search );
 	const contentKey = params.get( 'content_key' );
 	if ( contentKey ) {
-		document.cookie = `wp_newspack_content_key=${ contentKey }; path=/; max-age=${ 24 * 60 * 60 }`; // 24 hours
+		document.cookie = `wp_newspack_content_key=${ contentKey }; path=/; max-age=${ newspack_content_gifting.expiration_time }`;
 		params.delete( 'content_key' );
 		window.history.replaceState( {}, '', window.location.pathname + ( params.toString() ? '?' + params.toString() : '' ) );
 	}

--- a/src/wizards/audience/views/setup/content-gating.js
+++ b/src/wizards/audience/views/setup/content-gating.js
@@ -86,7 +86,7 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 			/>
 			<ActionCard
 				title={ __( 'Content Gifting', 'newspack-plugin' ) }
-				description={ __( 'Allow members to gift articles for 24 hours, up to the configured limit.', 'newspack-plugin' ) }
+				description={ __( 'Allow members to gift articles up to the configured limit.', 'newspack-plugin' ) }
 				toggleOnChange={ value => updateConfig( { content_gifting: { enabled: value } } ) }
 				toggleChecked={ config.content_gifting?.enabled }
 				hasGreyHeader={ config.content_gifting?.enabled }

--- a/src/wizards/audience/views/setup/content-gating.js
+++ b/src/wizards/audience/views/setup/content-gating.js
@@ -94,7 +94,7 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 			>
 				{ config.content_gifting?.enabled && (
 					<>
-						<Grid columns={ 2 } rowGap={ 16 }>
+						<Grid columns={ 2 } rowGap={ 32 }>
 							<Heading level={ 4 } style={ { gridColumn: '1 / -1' } }>
 								{ __( 'General Settings', 'newspack-plugin' ) }
 							</Heading>
@@ -122,8 +122,32 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 								] }
 								__next40pxDefaultSize
 							/>
+							<RangeControl
+								label={ __( 'Article link expiration time', 'newspack-plugin' ) }
+								help={ __( 'Time after which the article link expires.', 'newspack-plugin' ) }
+								min={ 1 }
+								max={ 60 }
+								value={ config.content_gifting.expiration_time || 5 }
+								onChange={ value =>
+									setConfig( { ...config, content_gifting: { ...config.content_gifting, expiration_time: value } } )
+								}
+								__next40pxDefaultSize
+							/>
+							<SelectControl
+								label={ __( 'Article link expiration time unit', 'newspack-plugin' ) }
+								help={ __( 'Unit of time for the article link expiration time.', 'newspack-plugin' ) }
+								value={ config.content_gifting.expiration_time_unit || 'days' }
+								onChange={ value =>
+									setConfig( { ...config, content_gifting: { ...config.content_gifting, expiration_time_unit: value } } )
+								}
+								options={ [
+									{ value: 'hours', label: __( 'Hours', 'newspack-plugin' ) },
+									{ value: 'days', label: __( 'Days', 'newspack-plugin' ) },
+								] }
+								__next40pxDefaultSize
+							/>
 						</Grid>
-						<Grid columns={ 2 } rowGap={ 16 }>
+						<Grid columns={ 2 } rowGap={ 32 }>
 							<Heading level={ 4 } style={ { gridColumn: '1 / -1' } }>
 								{ __( 'Recipient Banner', 'newspack-plugin' ) }
 							</Heading>

--- a/tests/unit-tests/content-gate/content-gifting.php
+++ b/tests/unit-tests/content-gate/content-gifting.php
@@ -132,9 +132,26 @@ class Test_Content_Gifting extends \WP_UnitTestCase {
 		$key = Content_Gifting::generate_key( $this->post_id );
 
 		// Manually change the timestamp to be right after the expiration time.
-		$expiration = Content_Gifting::KEY_EXPIRATION + 1;
+		$expiration = Content_Gifting::get_expiration_time_in_seconds() + 1;
 		$data = get_user_meta( $this->user_id, Content_Gifting::META, true );
 		$data['keys'][ $this->post_id ]['timestamp'] = time() - $expiration;
+		update_user_meta( $this->user_id, Content_Gifting::META, $data );
+
+		$data = Content_Gifting::get_key_data( $this->post_id, $key );
+		$this->assertEmpty( $data );
+	}
+
+	/**
+	 * Test get_key_data() with custom expiration time.
+	 */
+	public function test_get_key_data_custom_expiration_time() {
+		Content_Gifting::set_expiration_time( 1 );
+		Content_Gifting::set_expiration_time_unit( 'hours' );
+
+		$key = Content_Gifting::generate_key( $this->post_id );
+
+		$data = get_user_meta( $this->user_id, Content_Gifting::META, true );
+		$data['keys'][ $this->post_id ]['timestamp'] = time() - ( 60 * 60 * 2 ); // 2 hours ago.
 		update_user_meta( $this->user_id, Content_Gifting::META, $data );
 
 		$data = Content_Gifting::get_key_data( $this->post_id, $key );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

NPPD-1011

Implements configurable expiration for the gifted article link.

<img width="1087" height="987" alt="image" src="https://github.com/user-attachments/assets/e77f59f7-46b6-498e-88d2-b5881f6e2859" />

The default is 5 days, and the modal text has been updated to fit the dynamic value better:

<img width="446" height="385" alt="image" src="https://github.com/user-attachments/assets/eeaa8152-85ec-437c-89b7-5c899b0d4259" />

### How to test the changes in this Pull Request:

1. Confirm the new unit test is accurate
2. Navigate to Audience -> Configuration -> Content Gate
3. Tweak the default settings to 1 hour
4. Refresh the page and confirm the saved options persist
5. As a subscriber, generate an article link
6. In an anonymous session, access the link and confirm it unlocks the content and you get the banner CTA
7. Confirm the created cookie has an expiration that matches the configured link expiration
8. Wait an hour, reaccess the link, and confirm it no longer unlocks the content

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->