### PR TITLE
fix(memberships): use gate ID for metering meta key

### DIFF
--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -74,6 +74,15 @@ class Content_Gate {
 	}
 
 	/**
+	 * Whether the first-party Newspack feature is enabled.
+	 *
+	 * @return bool
+	 */
+	public static function is_newspack_feature_enabled() {
+		return defined( 'NEWSPACK_CONTENT_GATES' ) && NEWSPACK_CONTENT_GATES;
+	}
+
+	/**
 	 * Restrict the post.
 	 *
 	 * @param \WP_Post  $post Post object.

--- a/includes/content-gate/class-metering.php
+++ b/includes/content-gate/class-metering.php
@@ -248,7 +248,8 @@ class Metering {
 		}
 
 		// Aggregate metering by gate priority, if available.
-		$user_meta_key = self::METERING_META_KEY . '_' . ( $priority ? $priority : $gate_post_id );
+		$suffix = Content_Gate::is_newspack_feature_enabled() && $priority ? $priority : $gate_post_id;
+		$user_meta_key = self::METERING_META_KEY . '_' . $suffix;
 
 		$updated_user_data  = false;
 		$user_metering_data = \get_user_meta( get_current_user_id(), $user_meta_key, true );

--- a/includes/wizards/audience/class-audience-content-gates.php
+++ b/includes/wizards/audience/class-audience-content-gates.php
@@ -91,7 +91,7 @@ class Audience_Content_Gates extends Wizard {
 	 * @return bool
 	 */
 	public function is_feature_enabled() {
-		return defined( 'NEWSPACK_CONTENT_GATES' ) && NEWSPACK_CONTENT_GATES;
+		return Content_Gate::is_newspack_feature_enabled();
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

While testing for #4315, I discovered a bug that causes sites to store and read metering data from the wrong meta key if using Woo Memberships for content gating. This would only affects sites that have previously enabled the experimental content gating UI already, so it shouldn't affect any sites in production.

### How to test the changes in this Pull Request:

1. Make sure `NEWSPACK_CONTENT_GATES` is not defined in wp-config.php.
2. With Woo Memberships enabled and with a plan that restricts content by active subscription, publish a content gate with metering enabled for anonymous and logged-in readers.
3. As a reader, confirm that metering works as expected while both not logged in and logged in.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->