### PR TITLE
fix(content-gifting): ux tweaks and other fixes

### DIFF
--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -772,6 +772,7 @@ class Content_Gate {
 
 		return [
 			'id'            => $post->ID,
+			'status'        => $post->post_status,
 			'title'         => $post->post_title,
 			'description'   => $post->post_excerpt,
 			'metering'      => Metering::get_metering_settings( $post->ID ),

--- a/includes/content-gate/content-gifting/class-content-gifting.php
+++ b/includes/content-gate/content-gifting/class-content-gifting.php
@@ -123,6 +123,9 @@ class Content_Gifting {
 	 * @return array The filtered Jetpack sharing services.
 	 */
 	public static function filter_jetpack_sharing_services( $services ) {
+		if ( ! self::can_use_gifting() ) {
+			return $services;
+		}
 		$services['newspack-gift-article'] = 'Newspack_Jetpack_Gift_Article';
 		return $services;
 	}
@@ -379,6 +382,44 @@ class Content_Gifting {
 	}
 
 	/**
+	 * Whether content gifting can be used on the site.
+	 *
+	 * @param bool $return_errors Whether to return errors instead of a boolean.
+	 *
+	 * @return bool|WP_Error Whether content gifting can be used or an error.
+	 */
+	public static function can_use_gifting( $return_errors = false ) {
+		$errors = new WP_Error();
+
+		// Check whether content gifting is enabled.
+		if ( ! self::is_enabled() ) {
+			$errors->add( 'not_enabled', __( 'Content gifting is not enabled.', 'newspack-plugin' ) );
+		}
+
+		// Check whether all gates have metering enabled.
+		$all_gates_have_metering = false;
+		$gates = Content_Gate::get_gates();
+		if ( ! empty( $gates ) ) {
+			$all_gates_have_metering = true;
+			foreach ( $gates as $gate ) {
+				if ( $gate['status'] === 'publish' && isset( $gate['metering'] ) && ! $gate['metering']['enabled'] ) {
+					$all_gates_have_metering = false;
+					break;
+				}
+			}
+		}
+		if ( $all_gates_have_metering ) {
+			$errors->add( 'all_gates_have_metering', __( 'Content gifting is not available because all gates have metering enabled.', 'newspack-plugin' ) );
+		}
+
+		if ( $return_errors ) {
+			return $errors;
+		}
+
+		return ! $errors->has_errors();
+	}
+
+	/**
 	 * Whether content gifting is enabled.
 	 *
 	 * @return bool
@@ -409,6 +450,21 @@ class Content_Gifting {
 		 * @param bool $enabled Whether the content gifting is enabled.
 		 */
 		do_action( 'newspack_content_gifting_enabled_status_changed', $enabled );
+	}
+
+	/**
+	 * Whether to render the metering notice in the configuration wizard.
+	 *
+	 * @return bool
+	 */
+	public static function should_render_metering_notice() {
+		$gates = Content_Gate::get_gates();
+		foreach ( $gates as $gate ) {
+			if ( $gate['status'] === 'publish' && isset( $gate['metering'] ) && $gate['metering']['enabled'] ) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**

--- a/includes/content-gate/content-gifting/class-content-gifting.php
+++ b/includes/content-gate/content-gifting/class-content-gifting.php
@@ -397,19 +397,23 @@ class Content_Gifting {
 		}
 
 		// Check whether all gates have metering enabled.
-		$all_gates_have_metering = false;
-		$gates = Content_Gate::get_gates();
+		$gates = array_filter(
+			Content_Gate::get_gates(),
+			function( $gate ) {
+				return $gate['status'] === 'publish';
+			}
+		);
 		if ( ! empty( $gates ) ) {
 			$all_gates_have_metering = true;
 			foreach ( $gates as $gate ) {
-				if ( $gate['status'] === 'publish' && isset( $gate['metering'] ) && ! $gate['metering']['enabled'] ) {
+				if ( ! isset( $gate['metering']['enabled'] ) || ! $gate['metering']['enabled'] ) {
 					$all_gates_have_metering = false;
 					break;
 				}
 			}
-		}
-		if ( $all_gates_have_metering ) {
-			$errors->add( 'all_gates_have_metering', __( 'Content gifting is not available because all gates have metering enabled.', 'newspack-plugin' ) );
+			if ( $all_gates_have_metering ) {
+				$errors->add( 'all_gates_have_metering', __( 'Content gifting is not available because all gates have metering enabled.', 'newspack-plugin' ) );
+			}
 		}
 
 		if ( $return_errors ) {

--- a/includes/content-gate/content-gifting/class-content-gifting.php
+++ b/includes/content-gate/content-gifting/class-content-gifting.php
@@ -161,10 +161,10 @@ class Content_Gifting {
 			return false;
 		}
 
-		if ( isset( $_COOKIE['wp_newspack_content_key'] ) ) {
-			$key = sanitize_text_field( $_COOKIE['wp_newspack_content_key'] ); // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
-		} elseif ( isset( $_GET[ self::QUERY_ARG ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( isset( $_GET[ self::QUERY_ARG ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			$key = sanitize_text_field( $_GET[ self::QUERY_ARG ] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		} elseif ( isset( $_COOKIE['wp_newspack_content_key'] ) ) {
+			$key = sanitize_text_field( $_COOKIE['wp_newspack_content_key'] ); // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
 		}
 		if ( ! $key ) {
 			return false;

--- a/includes/wizards/audience/class-audience-wizard.php
+++ b/includes/wizards/audience/class-audience-wizard.php
@@ -107,6 +107,11 @@ class Audience_Wizard extends Wizard {
 
 		$data['is_skipped_campaign_setup'] = Reader_Activation::is_skipped( 'ras_campaign' );
 
+		$data['content_gifting'] = [
+			'can_use_gifting' => Content_Gifting::can_use_gifting( true ),
+			'metering_notice' => Content_Gifting::should_render_metering_notice(),
+		];
+
 		wp_enqueue_script( 'newspack-wizards' );
 
 		wp_localize_script(

--- a/src/content-gate/content-gifting.js
+++ b/src/content-gate/content-gifting.js
@@ -80,9 +80,11 @@ domReady( () => {
 					linkContainer.style.display = 'block';
 					if ( ! data.key ) {
 						urlInput.disabled = true;
+						urlInput.style.pointerEvents = 'none';
 						copyButton.disabled = true;
 					} else {
 						urlInput.disabled = false;
+						delete urlInput.style.pointerEvents;
 						copyButton.disabled = false;
 					}
 				} )

--- a/src/wizards/audience/views/setup/content-gating.js
+++ b/src/wizards/audience/views/setup/content-gating.js
@@ -65,7 +65,7 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 		return message;
 	};
 
-	const errors = Object.values( newspackAudience.content_gifting.can_use_gifting.errors );
+	const errors = Object.values( newspackAudience?.content_gifting?.can_use_gifting?.errors || {} );
 
 	return (
 		<WizardsTab

--- a/src/wizards/audience/views/setup/content-gating.js
+++ b/src/wizards/audience/views/setup/content-gating.js
@@ -65,7 +65,7 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 		return message;
 	};
 
-	const errors = Object.values( newspackAudience?.content_gifting?.can_use_gifting?.errors || {} );
+	const giftingErrors = Object.values( newspackAudience?.content_gifting?.can_use_gifting?.errors || {} ).flat();
 
 	return (
 		<WizardsTab
@@ -97,8 +97,8 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 			>
 				{ config.content_gifting?.enabled && (
 					<>
-						{ errors.length > 0 && <Notice noticeText={ errors.join( ', ' ) } isError /> }
-						{ ! errors.length && newspackAudience.content_gifting.metering_notice && (
+						{ giftingErrors.length > 0 && <Notice noticeText={ giftingErrors.join( ', ' ) } isError /> }
+						{ ! giftingErrors.length && newspackAudience.content_gifting.metering_notice && (
 							<Notice
 								noticeText={ __(
 									'You have a content gate with metering enabled. Mind that metered articles are not eligible for gifting.',

--- a/src/wizards/audience/views/setup/content-gating.js
+++ b/src/wizards/audience/views/setup/content-gating.js
@@ -1,3 +1,4 @@
+/* global newspackAudience */
 /**
  * WordPress dependencies
  */
@@ -64,6 +65,8 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 		return message;
 	};
 
+	const errors = Object.values( newspackAudience.content_gifting.can_use_gifting.errors );
+
 	return (
 		<WizardsTab
 			title={ __( 'Content Gating', 'newspack-plugin' ) }
@@ -94,6 +97,16 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 			>
 				{ config.content_gifting?.enabled && (
 					<>
+						{ errors.length > 0 && <Notice noticeText={ errors.join( ', ' ) } isError /> }
+						{ ! errors.length && newspackAudience.content_gifting.metering_notice && (
+							<Notice
+								noticeText={ __(
+									'You have a content gate with metering enabled. Mind that metered articles are not eligible for gifting.',
+									'newspack-plugin'
+								) }
+								isWarning
+							/>
+						) }
 						<Grid columns={ 2 } rowGap={ 32 }>
 							<Heading level={ 4 } style={ { gridColumn: '1 / -1' } }>
 								{ __( 'General Settings', 'newspack-plugin' ) }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

NPPD-1014 NPPD-1015 NPPD-1016 NPPD-1017

A few tweaks to content gifting:

1. Ensure the URL query arg takes precedent over the cookie
2. Render a warning notice in the wizard in case one of the published gates (not all) has metering on
3. Render an error notice in the wizard in case all published gates have metering on (no article will be giftable)
4. Hide the Jetpack sharing service button from the Jetpack admin area if gifting is not available (all gates have metering)
5. Prevent the member from selecting the mock URL input from the gifting modal if they've reached their limit

<img width="1085" height="277" alt="image" src="https://github.com/user-attachments/assets/bb616e44-883f-43ff-b49a-31daca2245ca" />

<img width="1081" height="278" alt="image" src="https://github.com/user-attachments/assets/ec51cfcb-1d9b-4f18-af72-0884c9ccefcd" />

### How to test the changes in this Pull Request:

1. As a member, generate 2 gift article links
2. As an anonymous reader, access the first link, then the second
3. Confirm that accessing the second link unlocks the article (the backend is not reading from the previous link cookie)
4. Create another membership plan
6. Edit our content gate and create a gate for the new membership plan
7. Enable metering for that gate and save
8. Back in the Content Gifting configuration, confirm you get a warning notice
9. Edit your main gate and enable metering for it as well
10. Back in the Content Gifting configuration, confirm you get an error notice
11. Go to the Jetpack sharing module settings
12. Confirm the "Gift an article" sharing service is not available
13. Edit your main gate and disable metering
14. Confirm the "Gift an article" sharing service is available again

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->