### PR TITLE
fix: repeat button block styles in collections for WP 6.9

### DIFF
--- a/src/blocks/collections/styles/_ctas.scss
+++ b/src/blocks/collections/styles/_ctas.scss
@@ -6,6 +6,9 @@
 		gap: 8px;
 
 		a {
+			align-content: center;
+			display: flex;
+			justify-content: center;
 			width: 100%;
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

WordPress 6.9 includes [some nice front-end performance improvements](https://make.wordpress.org/core/2025/11/18/wordpress-6-9-frontend-performance-field-guide/), including loading block styles on demand in classic themes like ours. 

Unfortunately, this is causing some weirdness where we rely on these styles loading - for example, in the Collections block we're counting on some styles from `wp-block-button__link`, but they're only loaded for the block when there's a button block on the page, and they're not loaded at all on the /collections archive pages. It's minor, but this leads to the button text not being centred.

This PR adds some duplicated styles to help fix. 

Edit to add: this seems to be the one spot where we're using this CSS class on a non `<button>` button and a non-WP Button block -- so hopefully this is the only case of it!

### How to test the changes in this Pull Request:

1. On a test site running the latest WP 6.9 RC, make sure you have some collections with CTAs.
2. View the /collections landing page on the front end - note the text alignment in your CTAs:

<img width="1018" height="450" alt="CleanShot 2025-11-19 at 17 18 23" src="https://github.com/user-attachments/assets/d673f16d-32af-4ae5-a859-893db8f27ef0" />

3. Apply this PR and run `npm run build`.
4. Confirm your CTAs now look okay:

<img width="1021" height="456" alt="CleanShot 2025-11-19 at 17 17 32" src="https://github.com/user-attachments/assets/f432e3ff-300d-4865-bdad-bfda02bd76c1" />

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->