### PR TITLE
fix(contrib-meter): ensure percentage follows bar progress when using linear style

### DIFF
--- a/src/blocks/contribution-meter/components/LinearMeter.jsx
+++ b/src/blocks/contribution-meter/components/LinearMeter.jsx
@@ -35,16 +35,16 @@ const LinearMeter = ( { amountRaised, goal, percentage, showGoal, showAmountRais
 
 	// Determine text alignment class based on what's displayed.
 	let textAlignClass = '';
-	if ( showPercentage && ! showGoal && ! showAmountRaised ) {
-		textAlignClass = 'contribution-meter__text--center';
-	} else if ( ! showAmountRaised && showGoal && ! showPercentage ) {
+	if ( ( showPercentage && ! showGoal && ! showAmountRaised ) || ( ! showAmountRaised && showGoal && ! showPercentage ) ) {
 		textAlignClass = 'contribution-meter__text--right';
 	}
+
+	const textStyle = showPercentage && ! showGoal && ! showAmountRaised ? { width: progressStyle.width } : undefined;
 
 	return (
 		<div className="contribution-meter__linear">
 			{ hasAnyTextDisplay && (
-				<div className={ `contribution-meter__text ${ textAlignClass }` }>
+				<div className={ `contribution-meter__text ${ textAlignClass }` } style={ textStyle }>
 					{ /* Percentage comes first when: Goal + Percentage (no raised) */ }
 					{ showPercentage && ! showAmountRaised && showGoal && <span className="contribution-meter__percentage">{ percentage }%</span> }
 

--- a/src/blocks/contribution-meter/meters/class-linear-meter.php
+++ b/src/blocks/contribution-meter/meters/class-linear-meter.php
@@ -36,15 +36,21 @@ class Linear_Meter implements Meter {
 
 		// Determine text alignment class based on what's displayed.
 		$text_align_class = '';
-		if ( $attributes['showPercentage'] && ! $attributes['showGoal'] && ! $attributes['showAmountRaised'] ) {
-			$text_align_class = ' contribution-meter__text--center';
-		} elseif ( ! $attributes['showAmountRaised'] && $attributes['showGoal'] && ! $attributes['showPercentage'] ) {
+		if (
+			( $attributes['showPercentage'] && ! $attributes['showGoal'] && ! $attributes['showAmountRaised'] ) ||
+			( ! $attributes['showAmountRaised'] && $attributes['showGoal'] && ! $attributes['showPercentage'] )
+		) {
 			$text_align_class = ' contribution-meter__text--right';
 		}
+		$text_style = '';
+		if ( $attributes['showPercentage'] && ! $attributes['showGoal'] && ! $attributes['showAmountRaised'] ) {
+			$text_style = $progress_style;
+		}
+
 		?>
 		<div class="contribution-meter__linear">
 			<?php if ( $has_any_text ) : ?>
-				<div class="contribution-meter__text<?php echo esc_attr( $text_align_class ); ?>">
+				<div class="contribution-meter__text<?php echo esc_attr( $text_align_class ); ?>"<?php $text_style && printf( ' style="%s"', esc_attr( $text_style ) ); ?>>
 					<?php // Percentage comes first when: Goal + Percentage (no raised). ?>
 					<?php if ( $attributes['showPercentage'] && ! $attributes['showAmountRaised'] && $attributes['showGoal'] ) : ?>
 						<span class="contribution-meter__percentage">

--- a/src/blocks/contribution-meter/style.scss
+++ b/src/blocks/contribution-meter/style.scss
@@ -29,10 +29,6 @@
 			display: inline-block;
 		}
 
-		&--center {
-			justify-content: center;
-		}
-
 		&--right {
 			justify-content: flex-end;
 		}

--- a/src/blocks/contribution-meter/style.scss
+++ b/src/blocks/contribution-meter/style.scss
@@ -31,6 +31,7 @@
 
 		&--right {
 			justify-content: flex-end;
+			min-width: fit-content;
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

I missed something in the original PR review. When the meter is in its linear style and only the percentage is shown, the percentage text always sits in the centre. It should follow the position of the filled bar instead. I hadn’t represented that properly in Figma/Vercel.

This PR fixes that, so the percentage now aligns with the progress of the bar.

cc @rbcorrales 

__Before:__
<img width="1680" height="606" alt="" src="https://github.com/user-attachments/assets/ce931dd4-d4d7-4aa6-978e-0220ec6e1435" />

__After:__
<img width="1734" height="600" alt="" src="https://github.com/user-attachments/assets/3d50261b-f7d5-4829-8505-40e3f789e593" />

### How to test the changes in this Pull Request:

1. Add multiple linear meter on a page, with different target values enable just the %.
2. Notice no matter what, the % is centered.
3. Switch to this branch and refresh – it should now be level with the progress bar
4. Test other settings (show goals etc...) to make sure I didn't break the other combinations

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->