### PR TITLE
fix: hide Content Gate CPT from WP Admin menu [NPPM-2411]

### DIFF
--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -168,11 +168,6 @@ class Content_Gate {
 	 * Register post type for custom gate.
 	 */
 	public static function register_post_type() {
-		$icon = sprintf(
-			'data:image/svg+xml;base64,%s',
-			base64_encode( Newspack_UI_Icons::get_svg( 'key' ) )
-		);
-
 		\register_post_type(
 			self::GATE_CPT,
 			[
@@ -187,9 +182,8 @@ class Content_Gate {
 				],
 				'public'       => false,
 				'show_ui'      => true,
-				'show_in_menu' => true,
+				'show_in_menu' => false,
 				'show_in_rest' => true,
-				'menu_icon'    => $icon,
 				'supports'     => [ 'editor', 'custom-fields', 'revisions', 'title' ],
 				'taxonomies'   => [ 'category', 'post_tag' ],
 			]


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR removes the Content Gate CPT as a top level item in the WP Admin menu.

### How to test the changes in this Pull Request:

1. Navigate to WP Admin and look in the sidebar; note that Content Gate is listed there (this happens on a fresh install without Woo even active). 

<img width="152" height="71" alt="CleanShot 2025-11-21 at 08 47 47" src="https://github.com/user-attachments/assets/4222f43f-fd71-4c22-8d0d-e0b92e6f72ba" />

2. Apply this PR.
3. Refresh WP Admin and confirm that Content Gate is gone.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->