### PR TITLE
feat(my-account): add "Product" column to the Subscriptions page

### DIFF
--- a/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php
+++ b/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php
@@ -162,6 +162,8 @@ class My_Account_UI_V1 {
 				return __DIR__ . '/templates/v1/payment-information.php';
 			case 'myaccount/form-edit-address.php':
 				return __DIR__ . '/templates/v1/form-edit-address.php';
+			case 'myaccount/my-subscriptions.php':
+				return __DIR__ . '/templates/v1/my-subscriptions.php';
 			default:
 				return $template;
 		}

--- a/includes/plugins/woocommerce/my-account/templates/v1/my-subscriptions.php
+++ b/includes/plugins/woocommerce/my-account/templates/v1/my-subscriptions.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * My Subscriptions section on the My Account page
+ *
+ * This is a modified version of the WooCommerce Subscriptions template.
+ * It adds a "Product" column to the subscriptions table and removes the subscription ID column.
+ *
+ * @author   Newspack
+ * @category WooCommerce Subscriptions/Templates
+ * @package  Newspack
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+?>
+<div class="woocommerce_account_subscriptions">
+
+	<?php if ( ! empty( $subscriptions ) ) : ?>
+	<table class="my_account_subscriptions my_account_orders woocommerce-orders-table woocommerce-MyAccount-subscriptions shop_table shop_table_responsive woocommerce-orders-table--subscriptions">
+
+	<thead>
+		<tr>
+			<th class="subscription-product-name woocommerce-orders-table__header woocommerce-orders-table__header-order-product-name woocommerce-orders-table__header-subscription-product-name"><span class="nobr"><?php esc_html_e( 'Product', 'newspack-plugin' ); ?></span></th>
+			<th class="subscription-status order-status woocommerce-orders-table__header woocommerce-orders-table__header-order-status woocommerce-orders-table__header-subscription-status"><span class="nobr"><?php esc_html_e( 'Status', 'newspack-plugin' ); ?></span></th>
+			<th class="subscription-next-payment order-date woocommerce-orders-table__header woocommerce-orders-table__header-order-date woocommerce-orders-table__header-subscription-next-payment"><span class="nobr"><?php echo esc_html_x( 'Next payment', 'table heading', 'newspack-plugin' ); ?></span></th>
+			<th class="subscription-total order-total woocommerce-orders-table__header woocommerce-orders-table__header-order-total woocommerce-orders-table__header-subscription-total"><span class="nobr"><?php echo esc_html_x( 'Total', 'table heading', 'newspack-plugin' ); ?></span></th>
+			<th class="subscription-actions order-actions woocommerce-orders-table__header woocommerce-orders-table__header-order-actions woocommerce-orders-table__header-subscription-actions">&nbsp;</th>
+		</tr>
+	</thead>
+
+	<tbody>
+		<?php foreach ( $subscriptions as $subscription_id => $subscription ) : ?>
+		<tr class="order woocommerce-orders-table__row woocommerce-orders-table__row--status-<?php echo esc_attr( $subscription->get_status() ); ?>">
+			<td class="subscription-product-name woocommerce-orders-table__cell woocommerce-orders-table__cell-subscription-product-name woocommerce-orders-table__cell-order-product-name" data-title="<?php esc_attr_e( 'Product', 'newspack-plugin' ); ?>">
+				<?php
+				$items = $subscription->get_items();
+				if ( ! empty( $items ) ) {
+					$item = reset( $items );
+					echo esc_html( $item->get_name() );
+				}
+				?>
+			</td>
+			<td class="subscription-status order-status woocommerce-orders-table__cell woocommerce-orders-table__cell-subscription-status woocommerce-orders-table__cell-order-status" data-title="<?php esc_attr_e( 'Status', 'newspack-plugin' ); ?>">
+				<?php echo esc_attr( wcs_get_subscription_status_name( $subscription->get_status() ) ); ?>
+			</td>
+			<td class="subscription-next-payment order-date woocommerce-orders-table__cell woocommerce-orders-table__cell-subscription-next-payment woocommerce-orders-table__cell-order-date" data-title="<?php echo esc_attr_x( 'Next Payment', 'table heading', 'newspack-plugin' ); ?>">
+				<?php echo esc_attr( $subscription->get_date_to_display( 'next_payment' ) ); ?>
+				<?php if ( ! $subscription->is_manual() && $subscription->has_status( 'active' ) && $subscription->get_time( 'next_payment' ) > 0 ) : ?>
+				<br/><small><?php echo esc_html( $subscription->get_payment_method_to_display( 'customer' ) ); ?></small>
+				<?php endif; ?>
+			</td>
+			<td class="subscription-total order-total woocommerce-orders-table__cell woocommerce-orders-table__cell-subscription-total woocommerce-orders-table__cell-order-total" data-title="<?php echo esc_attr_x( 'Total', 'Used in data attribute. Escaped', 'newspack-plugin' ); ?>">
+				<?php echo wp_kses_post( $subscription->get_formatted_order_total() ); ?>
+			</td>
+			<td class="subscription-actions order-actions woocommerce-orders-table__cell woocommerce-orders-table__cell-subscription-actions woocommerce-orders-table__cell-order-actions">
+				<a href="<?php echo esc_url( $subscription->get_view_order_url() ); ?>" class="woocommerce-button button view<?php echo esc_attr( wc_wp_theme_get_element_class_name( 'button' ) ? ' ' . wc_wp_theme_get_element_class_name( 'button' ) : '' ); ?>"><?php echo esc_html_x( 'View', 'view a subscription', 'newspack-plugin' ); ?></a>
+				<?php do_action( 'woocommerce_my_subscriptions_actions', $subscription ); ?>
+			</td>
+		</tr>
+		<?php endforeach; ?>
+	</tbody>
+
+	</table>
+		<?php if ( 1 < $max_num_pages ) : ?>
+			<div class="woocommerce-pagination woocommerce-pagination--without-numbers woocommerce-Pagination">
+			<?php if ( 1 !== $current_page ) : ?>
+				<a class="woocommerce-button woocommerce-button--previous woocommerce-Button woocommerce-Button--previous button" href="<?php echo esc_url( wc_get_endpoint_url( 'subscriptions', $current_page - 1 ) ); ?>"><?php esc_html_e( 'Previous', 'newspack-plugin' ); ?></a>
+			<?php endif; ?>
+
+			<?php if ( intval( $max_num_pages ) !== $current_page ) : ?>
+				<a class="woocommerce-button woocommerce-button--next woocommerce-Button woocommerce-Button--next button" href="<?php echo esc_url( wc_get_endpoint_url( 'subscriptions', $current_page + 1 ) ); ?>"><?php esc_html_e( 'Next', 'newspack-plugin' ); ?></a>
+			<?php endif; ?>
+			</div>
+		<?php endif; ?>
+	<?php else : ?>
+		<p class="no_subscriptions woocommerce-message woocommerce-message--info woocommerce-Message woocommerce-Message--info woocommerce-info">
+			<?php
+			if ( 1 < $current_page ) :
+				printf(
+					// translators: %1$s: opening anchor tag. %2$s: closing anchor tag.
+					esc_html__( 'You have reached the end of subscriptions. Go to the %1$sfirst page%2$s.', 'newspack-plugin' ),
+					'<a href="' . esc_url( wc_get_endpoint_url( 'subscriptions', 1 ) ) . '">',
+					'</a>'
+				);
+			else :
+				esc_html_e( 'You have no active subscriptions.', 'newspack-plugin' );
+				?>
+				<a class="woocommerce-Button button" href="<?php echo esc_url( apply_filters( 'woocommerce_return_to_shop_redirect', wc_get_page_permalink( 'shop' ) ) ); ?>">
+					<?php esc_html_e( 'Browse products', 'newspack-plugin' ); ?>
+				</a>
+				<?php
+			endif;
+			?>
+		</p>
+
+	<?php endif; ?>
+
+</div>

--- a/includes/plugins/woocommerce/my-account/templates/v1/navigation.php
+++ b/includes/plugins/woocommerce/my-account/templates/v1/navigation.php
@@ -5,7 +5,6 @@
  * @package Newspack
  */
 
-use Newspack;
 use Newspack\Newspack_UI_Icons;
 
 if ( ! defined( 'ABSPATH' ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Pulls the "My Subscriptions" template page from the Woo Subscriptions plugin and modifies it to remove the subscription ID column and add a column for the product name.

| Before | After |
| --- | --- |
|  <img width="1220" height="858" alt="image" src="https://github.com/user-attachments/assets/a785cdf0-568e-4cf3-b037-177b7ed1ffae" /> | <img width="1219" height="858" alt="image" src="https://github.com/user-attachments/assets/7d6bfc5a-5533-433a-befb-cd4625f4a833" /> |

### How to test the changes in this Pull Request:

1. As a reader with multiple active subscriptions, navigate to My Account -> Subscriptions
2. Confirm the table renders as in the image above: without the subscription ID column and with a product column with the correct product name

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->