### PR TITLE
fix(my-account): select font size

### DIFF
--- a/src/my-account/v1/_forms.scss
+++ b/src/my-account/v1/_forms.scss
@@ -9,6 +9,9 @@
 		color: var(--newspack-ui-color-neutral-60);
 		font-size: var(--newspack-ui-font-size-xs);
 		line-height: var(--newspack-ui-line-height-xs);
+		.select2 .selection {
+			font-size: var(--newspack-ui-font-size-s);
+		}
 		.legend {
 			display: block;
 			margin: var(--newspack-ui-spacer-base) 0;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

NPPD-984

Fixes the font size for the select field when navigating the address form under My Account

### How to test the changes in this Pull Request:

1. Make sure you have My Account v1 enabled (`define( 'NEWSPACK_MY_ACCOUNT_VERSION', '1.0.0' );`)
2. As a reader, navigate to My Account -> Payment Information
3. Edit the Billing Address and confirm the country and state select field have the same size as the other fields

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->