### PR TITLE
fix(my-account): add payment method query var

### DIFF
--- a/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php
+++ b/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php
@@ -36,6 +36,7 @@ class My_Account_UI_V1 {
 		\add_action( 'newspack_after_delete_account', [ __CLASS__, 'handle_after_delete_account' ] );
 		\add_action( 'wp_footer', [ __CLASS__, 'add_after_delete_account_notice' ] );
 		\add_action( 'woocommerce_subscription_details_table', [ __CLASS__, 'cancel_subscription_modal' ] );
+		\add_filter( 'query_vars', [ __CLASS__, 'query_vars' ] );
 		\add_filter( 'option_woocommerce_myaccount_add_payment_method_endpoint', [ __CLASS__, 'add_payment_method_endpoint' ] );
 		\add_filter( 'default_option_woocommerce_myaccount_add_payment_method_endpoint', [ __CLASS__, 'add_payment_method_endpoint' ] );
 		\add_action( 'template_redirect', [ __CLASS__, 'redirect_payment_information_endpoint' ] );
@@ -644,6 +645,9 @@ class My_Account_UI_V1 {
 		if ( ! \is_user_logged_in() || ! Reader_Activation::is_user_reader( \wp_get_current_user() ) ) {
 			return;
 		}
+		// Set the query var so payment gateways can detect the add-payment-method context.
+		global $wp;
+		$wp->query_vars['add-payment-method'] = true;
 		ob_start();
 		\woocommerce_account_add_payment_method();
 		$content = ob_get_clean();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

NPPD-997

In the native flow of adding payment methods, WooCommerce sets an `add-payment-method` query var, which is used by gateways to behave differently in this context.

This is currently missing in our v1 flow, which is addressed in this PR.

### How to test the changes in this Pull Request:

1. Enable Paypal payment gateway
2. While in trunk, enable My Account v1 and navigate to My Account -> Payment information
3. Click to "Add Payment Method" and confirm the Paypal gateway is listed but unusable
4. Checkout this branch, refresh the page and confirm the Paypal gateway is no longer listed
5. Complete the flow with a test card and confirm it works as expected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->