### PR TITLE
fix(my-account): safe content argument to skip sanitization

### DIFF
--- a/includes/class-newspack-ui.php
+++ b/includes/class-newspack-ui.php
@@ -198,6 +198,7 @@ class Newspack_UI {
 	 *     @type string $id The modal ID.
 	 *     @type string $title The modal title.
 	 *     @type string $content The modal content HTML.
+	 *     @type bool   $content_is_safe Whether the content is already safe HTML.
 	 *     @type string $footer The modal footer HTML.
 	 *     @type string $form The form method to use. If given, modal content and action buttons will be wrapped in a form element.
 	 *     @type array $actions {
@@ -247,53 +248,57 @@ class Newspack_UI {
 				<section class="newspack-ui__modal__content">
 				<?php endif; ?>
 						<?php
-						echo wp_kses(
-							$args['content'],
-							array_merge(
-								\wp_kses_allowed_html( 'post' ),
-								Newspack_UI_Icons::sanitize_svgs(),
-								[
-									'input'    => [
-										'type'          => true,
-										'name'          => true,
-										'id'            => true,
-										'class'         => true,
-										'tabindex'      => true,
-										'placeholder'   => true,
-										'required'      => true,
-										'aria-hidden'   => true,
-										'aria-required' => true,
-										'value'         => true,
-										'disabled'      => true,
-										'checked'       => true,
-									],
-									'select'   => [
-										'name'             => true,
-										'id'               => true,
-										'class'            => true,
-										'tabindex'         => true,
-										'required'         => true,
-										'aria-hidden'      => true,
-										'aria-required'    => true,
-										'value'            => true,
-										'disabled'         => true,
-										'multiple'         => true,
-										'autocomplete'     => true,
-										'data-label'       => true,
-										'data-placeholder' => true,
-									],
-									'option'   => [
-										'value'    => true,
-										'selected' => true,
-										'disabled' => true,
-									],
-									'noscript' => [],
-									'iframe'   => [
-										'src' => true,
-									],
-								]
-							)
-						);
+						if ( ! empty( $args['content_is_safe'] ) ) {
+							echo $args['content']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+						} else {
+							echo wp_kses(
+								$args['content'],
+								array_merge(
+									\wp_kses_allowed_html( 'post' ),
+									Newspack_UI_Icons::sanitize_svgs(),
+									[
+										'input'    => [
+											'type'        => true,
+											'name'        => true,
+											'id'          => true,
+											'class'       => true,
+											'tabindex'    => true,
+											'placeholder' => true,
+											'required'    => true,
+											'aria-hidden' => true,
+											'aria-required' => true,
+											'value'       => true,
+											'disabled'    => true,
+											'checked'     => true,
+										],
+										'select'   => [
+											'name'         => true,
+											'id'           => true,
+											'class'        => true,
+											'tabindex'     => true,
+											'required'     => true,
+											'aria-hidden'  => true,
+											'aria-required' => true,
+											'value'        => true,
+											'disabled'     => true,
+											'multiple'     => true,
+											'autocomplete' => true,
+											'data-label'   => true,
+											'data-placeholder' => true,
+										],
+										'option'   => [
+											'value'    => true,
+											'selected' => true,
+											'disabled' => true,
+										],
+										'noscript' => [],
+										'iframe'   => [
+											'src' => true,
+										],
+									]
+								)
+							);
+						}
 						?>
 						<?php
 						if ( ! empty( $args['actions'] ) ) :

--- a/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php
+++ b/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php
@@ -649,14 +649,15 @@ class My_Account_UI_V1 {
 		$content = ob_get_clean();
 		Newspack_UI::generate_modal(
 			[
-				'id'         => 'add-payment-method',
-				'title'      => __( 'Add Payment Method', 'newspack-plugin' ),
-				'content'    => $content,
-				'size'       => 'medium',
-				'form'       => 'POST',
-				'form_class' => 'newspack-ui__accordion newspack-ui__accordion--open',
-				'form_id'    => 'add_payment_method',
-				'actions'    => [
+				'id'              => 'add-payment-method',
+				'title'           => __( 'Add Payment Method', 'newspack-plugin' ),
+				'content'         => $content,
+				'content_is_safe' => true, // Allow the contents of `woocommerce_account_add_payment_method` to be rendered as is.
+				'size'            => 'medium',
+				'form'            => 'POST',
+				'form_class'      => 'newspack-ui__accordion newspack-ui__accordion--open',
+				'form_id'         => 'add_payment_method',
+				'actions'         => [
 					'cancel' => [
 						'label'  => __( 'Cancel', 'newspack-plugin' ),
 						'type'   => 'ghost',
@@ -681,40 +682,44 @@ class My_Account_UI_V1 {
 		$address_types = \apply_filters( 'woocommerce_my_account_get_addresses', $address_types );
 		foreach ( $address_types as $address_type => $address_name ) {
 			$address = \wc_get_account_formatted_address( $address_type );
+
 			ob_start();
 			\woocommerce_account_edit_address( $address_type );
-				$content          = ob_get_clean();
-				$edit_address_url = \add_query_arg(
-					'edit-address',
-					$address_type,
-					\wc_get_endpoint_url( 'edit-address', $address_type )
-				);
-				Newspack_UI::generate_modal(
-					[
-						'id'          => 'edit-address-' . $address_type,
-						'title'       => ! empty( $address ) ? sprintf(
-							// Translators: %s is the address type.
-							__( 'Edit %s address', 'newspack-plugin' ),
-							$address_type
-						) : sprintf(
-							// Translators: %s is the address type.
-							__( 'Add %s address', 'newspack-plugin' ),
-							$address_type
-						),
-						'content'     => $content,
-						'size'        => 'medium',
-						'form'        => 'POST',
-						'form_id'     => 'edit_address_' . $address_type,
-						'form_action' => $edit_address_url,
-						'actions'     => [
-							'cancel' => [
-								'label'  => __( 'Cancel', 'newspack-plugin' ),
-								'type'   => 'ghost',
-								'action' => 'close',
-							],
+			$content = ob_get_clean();
+
+			$edit_address_url = \add_query_arg(
+				'edit-address',
+				$address_type,
+				\wc_get_endpoint_url( 'edit-address', $address_type )
+			);
+
+			Newspack_UI::generate_modal(
+				[
+					'id'              => 'edit-address-' . $address_type,
+					'title'           => ! empty( $address ) ? sprintf(
+						// Translators: %s is the address type.
+						__( 'Edit %s address', 'newspack-plugin' ),
+						$address_type
+					) : sprintf(
+						// Translators: %s is the address type.
+						__( 'Add %s address', 'newspack-plugin' ),
+						$address_type
+					),
+					'content'         => $content,
+					'content_is_safe' => true, // Allow the contents of `woocommerce_account_edit_address` to be rendered as is.
+					'size'            => 'medium',
+					'form'            => 'POST',
+					'form_id'         => 'edit_address_' . $address_type,
+					'form_action'     => $edit_address_url,
+					'actions'         => [
+						'cancel' => [
+							'label'  => __( 'Cancel', 'newspack-plugin' ),
+							'type'   => 'ghost',
+							'action' => 'close',
 						],
-					]
-				);
+					],
+				]
+			);
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

NPPD-989

Modal content from Woo template tags may include markup from hooks. This markup can be script and style tags, which should be allowed.

This PR introduces a `content_is_safe` flag so the modal content renders without sanitization.

### How to test the changes in this Pull Request:

1. While on trunk, make sure you have My Account v1 enabled
2. Configure and enable reCAPTCHA (Newspack -> Settings -> Connections)
3. As a reader, add a new payment method (My Account -> Payment information)
4. Confirm the reCAPTCHA script tag is sanitized and its contents printed:

<img width="668" height="886" alt="image" src="https://github.com/user-attachments/assets/affa4bd4-76c0-4e37-9799-811a81299789" />

5. Checkout this branch, refresh the page, and confirm the script is preserved in the markup
 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->