### PR TITLE
fix(my-account): support dynamic content around shortcode

### DIFF
--- a/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php
+++ b/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php
@@ -46,6 +46,7 @@ class My_Account_UI_V1 {
 		\add_action( 'newspack_woocommerce_after_account_addresses', [ __CLASS__, 'delete_address_modals' ] );
 		\add_action( 'woocommerce_after_save_address_validation', [ __CLASS__, 'handle_delete_address_submission' ], 10, 4 );
 		\add_filter( 'woocommerce_address_to_edit', [ __CLASS__, 'reorder_address_fields' ], PHP_INT_MAX, 2 );
+		\add_action( 'woocommerce_account_content', [ __CLASS__, 'render_content_around_shortcode' ], 0 );
 	}
 
 	/**
@@ -864,6 +865,48 @@ class My_Account_UI_V1 {
 		}
 
 		return $address;
+	}
+
+	/**
+	 * Render the content around the [woocommerce_my_account] shortcode inside the
+	 * woocommerce-MyAccount-content context.
+	 *
+	 * This is necessary because of the highly customized grid layout.
+	 */
+	public static function render_content_around_shortcode() {
+		// Only allow custom content under the dashboard (root) or edit-account (default redirect) pages.
+		global $wp;
+		if ( ! isset( $wp->query_vars['page'] ) && ! empty( $wp->query_vars ) && ! isset( $wp->query_vars['edit-account'] ) ) {
+			return;
+		}
+
+		$content = get_the_content();
+		if ( empty( $content ) ) {
+			return;
+		}
+		$parts = explode( '[woocommerce_my_account]', $content );
+
+		$before = ! empty( $parts[0] ) ? $parts[0] : '';
+		if ( ! empty( $before ) ) {
+			add_action(
+				'woocommerce_account_content',
+				function() use ( $before ) {
+					echo apply_filters( 'the_content', $before ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				},
+				9 // Right before the shortcode.
+			);
+		}
+
+		$after = ! empty( $parts[1] ) ? $parts[1] : '';
+		if ( ! empty( $after ) ) {
+			add_action(
+				'woocommerce_account_content',
+				function() use ( $after ) {
+					echo apply_filters( 'the_content', $after ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				},
+				11 // Right after the shortcode.
+			);
+		}
 	}
 }
 My_Account_UI_V1::init();

--- a/includes/plugins/woocommerce/my-account/templates/v1/my-account.php
+++ b/includes/plugins/woocommerce/my-account/templates/v1/my-account.php
@@ -32,7 +32,17 @@
 					?>
 
 					<div class="main-content">
-						<?php the_content(); ?>
+						<?php
+						/**
+						 * Given the highly customized grid layout, we'll be rendering the
+						 * shortcode directly and rely on a separate strategy to render
+						 * content around the shortcode.
+						 *
+						 * See My_Account_UI_V1::render_content_around_shortcode() for more
+						 * details.
+						 */
+						echo do_shortcode( '[woocommerce_my_account]' );
+						?>
 					</div>
 
 				<?php endwhile; ?>

--- a/src/my-account/v1/_content.scss
+++ b/src/my-account/v1/_content.scss
@@ -23,5 +23,8 @@
 		section + section {
 			margin-top: var(--newspack-ui-spacer-11);
 		}
+		.wp-block-details + .wp-block-details {
+			margin-top: 0;
+		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

NPPD-1005

The new grid introduced by My Account v1 doesn't support any content other than the `[woocommerce_my_account]` shortcode in the page.

Some publishers may use that to display an introduction to account management, FAQ, etc.

This PR adds support to content around the shortcode by implementing a custom strategy via the `woocommerce_account_content` hook.

The custom content should only render in the dashboard (root) or `edit-account` (default redirect) pages. We don't use the dashboard root page, so this is optional.

### How to test the changes in this Pull Request:

1. Edit the "My Account" page and add some content before and after the `[woocommerce_my_account]` shortcode
2. While on trunk, visit the My Account page as a reader
3. Confirm the content breaks the layout and is not readable
4. Checkout this branch and confirm the content renders in the appropriate place and the layout is preserved
5. Navigate to other My Account pages (subscriptions, newsletters) and confirm the content doesn't render in those areas

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->