### PR TITLE
fix: check for gift memberships on content gate and sync - NPPM-2420

### DIFF
--- a/includes/plugins/woocommerce/class-woocommerce-connection.php
+++ b/includes/plugins/woocommerce/class-woocommerce-connection.php
@@ -270,6 +270,8 @@ class WooCommerce_Connection {
 	 * Can optionally pass an array of product IDs. If given, only subscriptions
 	 * that have at least one of the given product IDs will be returned.
 	 *
+	 * If the subscription was a gift, it will return true only if the given user is the recipient.
+	 *
 	 * @param int   $user_id User ID.
 	 * @param array $product_ids Optional array of product IDs to filter by.
 	 *
@@ -281,17 +283,23 @@ class WooCommerce_Connection {
 		}
 		$subcriptions = array_reduce(
 			array_keys( \wcs_get_users_subscriptions( $user_id ) ),
-			function( $acc, $subscription_id ) use ( $product_ids ) {
+			function( $acc, $subscription_id ) use ( $product_ids, $user_id ) {
 				$subscription = \wcs_get_subscription( $subscription_id );
+				$has_required_products = false;
 				if ( $subscription->has_status( self::ACTIVE_SUBSCRIPTION_STATUSES ) ) {
 					if ( ! empty( $product_ids ) ) {
 						foreach ( $product_ids as $product_id ) {
 							if ( $subscription->has_product( $product_id ) ) {
-								$acc[] = $subscription_id;
-								return $acc;
+								$has_required_products = true;
+								break;
 							}
 						}
 					} else {
+						$has_required_products = true;
+					}
+				}
+				if ( $has_required_products ) {
+					if ( ! class_exists( 'WCS_Gifting' ) || ! \WCS_Gifting::is_gifted_subscription( $subscription ) || \WCS_Gifting::get_recipient_user( $subscription ) === $user_id ) {
 						$acc[] = $subscription_id;
 					}
 				}

--- a/includes/plugins/woocommerce/class-woocommerce-connection.php
+++ b/includes/plugins/woocommerce/class-woocommerce-connection.php
@@ -299,7 +299,7 @@ class WooCommerce_Connection {
 					}
 				}
 				if ( $has_required_products ) {
-					if ( ! class_exists( 'WCS_Gifting' ) || ! \WCS_Gifting::is_gifted_subscription( $subscription ) || \WCS_Gifting::get_recipient_user( $subscription ) === $user_id ) {
+					if ( ! class_exists( 'WCS_Gifting' ) || ! \WCS_Gifting::is_gifted_subscription( $subscription ) || (int) \WCS_Gifting::get_recipient_user( $subscription ) === (int) $user_id ) {
 						$acc[] = $subscription_id;
 					}
 				}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes the logic that checks for active subscriptions and account for gifted subscriptions. For the purposes of this method, it should only return true if checking for the gitf recipient.

This method is used for content gate/access control checks and to fetch the data to sync to the ESP.

### How to test the changes in this Pull Request:

1. Set up a giftable subscription
2. Set up a membership plan that restricts content
3. Set up the Newspack Content gate
4. As an anonymous reader, buy a subscription as gift to someone else.
5. In another browser, claim the gift and log in with the gift recipient
6. Confirm that the gifter does not have access to restricted content
7. Confirm that the recipient is granted access to the restricted content
8. Make sure you have `define('NEWSPACK_LOG_LEVEL', 3);` on wp-config
9. As an admin, go to Users and find the gifter and the recipient
10. Click "Resync contact to ESP" and watch the logs
11. Confirm the recipient has the information about the subscription
12. Confirm the gifter does NOT have the info about the subscription


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->