### PR TITLE
fix(indesign-export): only register the attribute for allowed blocks

### DIFF
--- a/src/indesign-export/index.js
+++ b/src/indesign-export/index.js
@@ -3,7 +3,13 @@ import { __ } from '@wordpress/i18n';
 import { InspectorControls, useBlockEditingMode } from '@wordpress/block-editor';
 import { TextControl } from '@wordpress/components';
 
-const addAttribute = settings => {
+const ALLOWED_BLOCKS = [ 'core/paragraph', 'core/heading' ];
+
+const addAttribute = ( settings, name ) => {
+	if ( ! ALLOWED_BLOCKS.includes( name ) ) {
+		return settings;
+	}
+
 	settings.attributes = {
 		...settings.attributes,
 		indesignTag: {
@@ -22,7 +28,7 @@ const TagNameControl = ( { blockName, indesignTag, setAttributes } ) => {
 	}
 
 	// Only paragraphs and heading can have custom tag names.
-	if ( ! [ 'core/paragraph', 'core/heading' ].includes( blockName ) ) {
+	if ( ! ALLOWED_BLOCKS.includes( blockName ) ) {
 		return null;
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

NPPM-2322

The InDesign Tag attribute for blocks is only allowed for paragraphs and headings, but it's currently being registered to all blocks. This is causing a conflict with the Gravity Forms block, which sends the unallowed empty attribute to the API endpoint, causing an error.

### How to test the changes in this Pull Request:

1. Make sure you have the InDesign export enabled
2. While on trunk, add a Gravity Forms block to a post and confirm you get an error
3. Checkout this branch, build, refresh the page and confirm the error is gone
4. Confirm you are still able to save the InDesign Tag attribute (under the Advanced panel) for paragraphs and headings

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->