### PR TITLE
feat(content-gifting): metering support and CTA auth links

### DIFF
--- a/includes/content-gate/class-metering.php
+++ b/includes/content-gate/class-metering.php
@@ -47,7 +47,7 @@ class Metering {
 	 * @return bool
 	 */
 	public static function restrict_post( $restrict ) {
-		if ( self::is_metering() ) {
+		if ( $restrict && self::is_metering() ) {
 			return false;
 		}
 		return $restrict;
@@ -216,6 +216,14 @@ class Metering {
 	 * @return bool
 	 */
 	public static function is_frontend_metering() {
+		/**
+		 * This filter documented in the `is_metering` method.
+		 */
+		$short_circuit = apply_filters( 'newspack_content_gate_metering_short_circuit', null );
+		if ( null !== $short_circuit ) {
+			return false;
+		}
+
 		// Frotend metering strategy should only be applied for anonymous readers.
 		if ( \is_user_logged_in() ) {
 			return false;
@@ -248,6 +256,14 @@ class Metering {
 	 * @return bool
 	 */
 	public static function is_logged_in_metering_allowed( $post_id = null ) {
+		/**
+		 * This filter documented in the `is_metering` method.
+		 */
+		$short_circuit = apply_filters( 'newspack_content_gate_metering_short_circuit', null );
+		if ( null !== $short_circuit ) {
+			return false;
+		}
+
 		if ( ! $post_id ) {
 			$post_id = get_the_ID();
 		}
@@ -328,6 +344,24 @@ class Metering {
 	 * @return bool
 	 */
 	public static function is_metering() {
+		/**
+		 * Short-circuit the metering check. Anything other than null
+		 * will prevent the metering logic from running.
+		 *
+		 * The `is_logged_in_metering_allowed` method also updates the user meta
+		 * to track the content that's been allowed to access. This short-circuit
+		 * prevents this from running if we want the entire metering feature to be
+		 * skipped.
+		 *
+		 * @param mixed $short_circuit Short-circuit value. Default is null.
+		 *
+		 * @return mixed Short-circuit value.
+		 */
+		$short_circuit = apply_filters( 'newspack_content_gate_metering_short_circuit', null );
+		if ( null !== $short_circuit ) {
+			return false;
+		}
+
 		return self::is_frontend_metering() || self::is_logged_in_metering_allowed();
 	}
 

--- a/includes/content-gate/class-metering.php
+++ b/includes/content-gate/class-metering.php
@@ -224,7 +224,7 @@ class Metering {
 			return false;
 		}
 
-		// Frotend metering strategy should only be applied for anonymous readers.
+		// Frontend metering strategy should only be applied for anonymous readers.
 		if ( \is_user_logged_in() ) {
 			return false;
 		}

--- a/includes/content-gate/content-gifting/class-content-gifting-cta.php
+++ b/includes/content-gate/content-gifting/class-content-gifting-cta.php
@@ -175,7 +175,16 @@ class Content_Gifting_CTA {
 		<div class="newspack-ui">
 			<div class="banner newspack-content-gifting__cta <?php echo esc_attr( $style_class ); ?>">
 				<div class="wrapper newspack-content-gifting__cta__content">
-					<span class="newspack-ui__font--s"><?php echo esc_html( self::get_cta_label() ); ?></span>
+					<span class="newspack-ui__font--s">
+						<?php echo esc_html( self::get_cta_label() ); ?>
+						<?php if ( ! is_user_logged_in() ) : ?>
+							<?php if ( Metering::has_metering( get_the_ID() ) ) : ?>
+								<a href="#register_modal"><?php echo esc_html( __( 'Create an account', 'newspack-plugin' ) ); ?></a>
+							<?php else : ?>
+								<a href="#signin_modal"><?php echo esc_html( __( 'Sign in to an existing account', 'newspack-plugin' ) ); ?></a>
+							<?php endif; ?>
+						<?php endif; ?>
+					</span>
 					<?php self::print_subscribe_button(); ?>
 				</div>
 			</div>

--- a/includes/content-gate/content-gifting/class-content-gifting-cta.php
+++ b/includes/content-gate/content-gifting/class-content-gifting-cta.php
@@ -178,7 +178,7 @@ class Content_Gifting_CTA {
 					<div class="newspack-ui__font--s">
 						<?php echo esc_html( self::get_cta_label() ); ?>
 						<?php if ( ! is_user_logged_in() ) : ?>
-							<div className="newspack-ui__font--xs newspack-content-gifting__cta__content__links">
+							<div class="newspack-ui__font--xs newspack-content-gifting__cta__content__links">
 								<?php if ( Metering::has_metering( get_the_ID() ) ) : ?>
 									<a href="#register_modal"><?php echo esc_html( __( 'Create an account', 'newspack-plugin' ) ); ?></a>
 								<?php else : ?>

--- a/includes/content-gate/content-gifting/class-content-gifting-cta.php
+++ b/includes/content-gate/content-gifting/class-content-gifting-cta.php
@@ -175,16 +175,18 @@ class Content_Gifting_CTA {
 		<div class="newspack-ui">
 			<div class="banner newspack-content-gifting__cta <?php echo esc_attr( $style_class ); ?>">
 				<div class="wrapper newspack-content-gifting__cta__content">
-					<span class="newspack-ui__font--s">
+					<div class="newspack-ui__font--s">
 						<?php echo esc_html( self::get_cta_label() ); ?>
 						<?php if ( ! is_user_logged_in() ) : ?>
-							<?php if ( Metering::has_metering( get_the_ID() ) ) : ?>
-								<a href="#register_modal"><?php echo esc_html( __( 'Create an account', 'newspack-plugin' ) ); ?></a>
-							<?php else : ?>
-								<a href="#signin_modal"><?php echo esc_html( __( 'Sign in to an existing account', 'newspack-plugin' ) ); ?></a>
-							<?php endif; ?>
+							<div className="newspack-ui__font--xs newspack-content-gifting__cta__content__links">
+								<?php if ( Metering::has_metering( get_the_ID() ) ) : ?>
+									<a href="#register_modal"><?php echo esc_html( __( 'Create an account', 'newspack-plugin' ) ); ?></a>
+								<?php else : ?>
+									<a href="#signin_modal"><?php echo esc_html( __( 'Sign in to an existing account', 'newspack-plugin' ) ); ?></a>
+								<?php endif; ?>
+							</div>
 						<?php endif; ?>
-					</span>
+					</div>
 					<?php self::print_subscribe_button(); ?>
 				</div>
 			</div>

--- a/includes/content-gate/content-gifting/class-content-gifting.php
+++ b/includes/content-gate/content-gifting/class-content-gifting.php
@@ -396,26 +396,6 @@ class Content_Gifting {
 			$errors->add( 'not_enabled', __( 'Content gifting is not enabled.', 'newspack-plugin' ) );
 		}
 
-		// Check whether all gates have metering enabled.
-		$gates = array_filter(
-			Content_Gate::get_gates(),
-			function( $gate ) {
-				return $gate['status'] === 'publish';
-			}
-		);
-		if ( ! empty( $gates ) ) {
-			$all_gates_have_metering = true;
-			foreach ( $gates as $gate ) {
-				if ( ! isset( $gate['metering']['enabled'] ) || ! $gate['metering']['enabled'] ) {
-					$all_gates_have_metering = false;
-					break;
-				}
-			}
-			if ( $all_gates_have_metering ) {
-				$errors->add( 'all_gates_have_metering', __( 'Content gifting is not available because all gates have metering enabled.', 'newspack-plugin' ) );
-			}
-		}
-
 		if ( $return_errors ) {
 			return $errors;
 		}
@@ -454,21 +434,6 @@ class Content_Gifting {
 		 * @param bool $enabled Whether the content gifting is enabled.
 		 */
 		do_action( 'newspack_content_gifting_enabled_status_changed', $enabled );
-	}
-
-	/**
-	 * Whether to render the metering notice in the configuration wizard.
-	 *
-	 * @return bool
-	 */
-	public static function should_render_metering_notice() {
-		$gates = Content_Gate::get_gates();
-		foreach ( $gates as $gate ) {
-			if ( $gate['status'] === 'publish' && isset( $gate['metering'] ) && $gate['metering']['enabled'] ) {
-				return true;
-			}
-		}
-		return false;
 	}
 
 	/**
@@ -699,10 +664,6 @@ class Content_Gifting {
 
 		if ( Content_Gate::is_post_restricted( $post_id ) ) {
 			$errors->add( 'post_restricted', __( 'User does not have access to this post.', 'newspack-plugin' ) );
-		}
-
-		if ( Metering::has_metering( $post_id ) ) {
-			$errors->add( 'metering', __( 'Metered content cannot be gifted.', 'newspack-plugin' ) );
 		}
 
 		if ( $return_errors ) {

--- a/includes/content-gate/content-gifting/class-content-gifting.php
+++ b/includes/content-gate/content-gifting/class-content-gifting.php
@@ -41,6 +41,7 @@ class Content_Gifting {
 		add_action( 'init', [ __CLASS__, 'hook_gift_button' ] );
 		add_action( 'wp', [ __CLASS__, 'unrestrict_content' ], 5 );
 		add_filter( 'newspack_content_gate_restrict_post', [ __CLASS__, 'restrict_post' ] );
+		add_filter( 'newspack_content_gate_metering_short_circuit', [ __CLASS__, 'short_circuit_metering' ] );
 		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'enqueue_assets' ] );
 		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'enqueue_assets' ] );
 		add_action( 'wp_ajax_' . self::GENERATE_ACTION, [ __CLASS__, 'ajax_generate_content_key' ] );
@@ -155,7 +156,7 @@ class Content_Gifting {
 	 * Whether the current post has been gifted.
 	 *
 	 * @param int|null    $post_id The post ID. Default is the current post.
-	 * @param string|null $key     The content key. Default is the key from the query arg.
+	 * @param string|null $key     The content key. Default is from the request (query arg or cookie).
 	 *
 	 * @return bool
 	 */
@@ -636,6 +637,20 @@ class Content_Gifting {
 			return false;
 		}
 		return $restrict;
+	}
+
+	/**
+	 * Short-circuit the metering check.
+	 *
+	 * @param mixed $short_circuit Short-circuit value. Default is null.
+	 *
+	 * @return mixed Short-circuit value.
+	 */
+	public static function short_circuit_metering( $short_circuit ) {
+		if ( self::is_gifted_post( get_the_ID() ) ) {
+			return true;
+		}
+		return $short_circuit;
 	}
 
 	/**

--- a/includes/wizards/audience/class-audience-wizard.php
+++ b/includes/wizards/audience/class-audience-wizard.php
@@ -107,8 +107,18 @@ class Audience_Wizard extends Wizard {
 
 		$data['is_skipped_campaign_setup'] = Reader_Activation::is_skipped( 'ras_campaign' );
 
+		$gates        = Content_Gate::get_gates();
+		$has_metering = false;
+		foreach ( $gates as $gate ) {
+			if ( $gate['status'] === 'publish' && isset( $gate['metering'] ) && $gate['metering']['enabled'] ) {
+				$has_metering = true;
+				break;
+			}
+		}
+
 		$data['content_gifting'] = [
 			'can_use_gifting' => Content_Gifting::can_use_gifting( true ),
+			'has_metering'    => $has_metering,
 		];
 
 		wp_enqueue_script( 'newspack-wizards' );

--- a/includes/wizards/audience/class-audience-wizard.php
+++ b/includes/wizards/audience/class-audience-wizard.php
@@ -109,7 +109,6 @@ class Audience_Wizard extends Wizard {
 
 		$data['content_gifting'] = [
 			'can_use_gifting' => Content_Gifting::can_use_gifting( true ),
-			'metering_notice' => Content_Gifting::should_render_metering_notice(),
 		];
 
 		wp_enqueue_script( 'newspack-wizards' );

--- a/src/content-gate/content-gifting.js
+++ b/src/content-gate/content-gifting.js
@@ -1,7 +1,10 @@
 /* globals newspack_content_gifting */
 import domReady from '@wordpress/dom-ready';
+import { queuePageReload } from '../reader-activation/utils';
 
 import './content-gifting.scss';
+
+window.newspackRAS = window.newspackRAS || [];
 
 domReady( () => {
 	const setBodyOffset = () => {
@@ -107,5 +110,16 @@ domReady( () => {
 		document.cookie = `wp_newspack_content_key=${ contentKey }; path=/; max-age=${ newspack_content_gifting.expiration_time }`;
 		params.delete( 'content_key' );
 		window.history.replaceState( {}, '', window.location.pathname + ( params.toString() ? '?' + params.toString() : '' ) );
+	}
+
+	// Refresh the gifted post page after authenticating.
+	if ( document.body.classList.contains( 'newspack-is-gifted-post' ) ) {
+		window.newspackRAS.push( ras => {
+			ras.on( 'reader', ( { detail: { authenticated } } ) => {
+				if ( authenticated ) {
+					queuePageReload();
+				}
+			} );
+		} );
 	}
 } );

--- a/src/content-gate/content-gifting.scss
+++ b/src/content-gate/content-gifting.scss
@@ -81,6 +81,11 @@ body.newspack-is-gifted-post {
 					width: auto;
 				}
 			}
+
+			a {
+				color: var(--newspack-ui-color-primary-60);
+				text-decoration: underline;
+			}
 		}
 
 		&.is-style-light {

--- a/src/content-gate/content-gifting.scss
+++ b/src/content-gate/content-gifting.scss
@@ -86,9 +86,14 @@ body.newspack-is-gifted-post {
 				color: var(--newspack-ui-color-primary-60);
 				text-decoration: underline;
 			}
+
+			&__links {
+				color: var(--newspack-content-gifting__cta__content__links--color, inherit);
+			}
 		}
 
 		&.is-style-light {
+			--newspack-content-gifting__cta__content__links--color: var(--newspack-ui-color-neutral-60);
 			background: var(--newspack-ui-color-neutral-0);
 			color: var(--newspack-ui-color-neutral-90);
 		}

--- a/src/reader-activation/subscription-tiers-form.js
+++ b/src/reader-activation/subscription-tiers-form.js
@@ -1,27 +1,11 @@
 import { domReady } from '../utils';
-
-function handleCheckoutOverlayClose( { detail: { overlays } } ) {
-	setTimeout( () => {
-		if ( ! overlays.length ) {
-			window.location.reload();
-			window.newspackReaderActivation.off( 'overlay', handleCheckoutOverlayClose );
-		}
-	}, 50 );
-}
+import { queuePageReload } from './utils';
 
 function handleCheckoutClose( completed ) {
 	if ( ! completed ) {
 		return;
 	}
-	window.newspackRAS.push( ras => {
-		setTimeout( () => {
-			if ( ras.overlays.get().length ) {
-				ras.on( 'overlay', handleCheckoutOverlayClose );
-				return;
-			}
-			window.location.reload();
-		}, 50 );
-	} );
+	queuePageReload();
 }
 
 window.newspackRAS = window.newspackRAS || [];

--- a/src/wizards/audience/views/setup/content-gating.js
+++ b/src/wizards/audience/views/setup/content-gating.js
@@ -199,7 +199,7 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 							</ToggleGroupControl>
 							<div style={ { gridColumn: '1 / -1' } }>
 								<BaseControl id="newspack-content-gifting-cta-preview" label={ __( 'Preview', 'newspack-plugin' ) }>
-									<div className="newspack-content-gifting__cta-preview" inert="true">
+									<div className="newspack-content-gifting__cta-preview" inert>
 										<div className="newspack-ui">
 											<div
 												className={ `banner newspack-content-gifting__cta is-style-${

--- a/src/wizards/audience/views/setup/content-gating.js
+++ b/src/wizards/audience/views/setup/content-gating.js
@@ -66,6 +66,7 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 	};
 
 	const giftingErrors = Object.values( newspackAudience?.content_gifting?.can_use_gifting?.errors || {} ).flat();
+	const hasMetering = newspackAudience?.content_gifting?.has_metering;
 
 	return (
 		<WizardsTab
@@ -212,7 +213,11 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 																'This article has been gifted to you by someone who values great journalism.',
 																'newspack-plugin'
 															) }{ ' ' }
-														<a href="#signin_modal">{ __( 'Sign in to an existing account', 'newspack-plugin' ) }</a>
+														{ hasMetering ? (
+															<a href="#register_modal">{ __( 'Create an account', 'newspack-plugin' ) }</a>
+														) : (
+															<a href="#signin_modal">{ __( 'Sign in to an existing account', 'newspack-plugin' ) }</a>
+														) }
 													</span>
 													<button
 														className={ `newspack-ui__button newspack-ui__button--x-small ${

--- a/src/wizards/audience/views/setup/content-gating.js
+++ b/src/wizards/audience/views/setup/content-gating.js
@@ -98,15 +98,6 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 				{ config.content_gifting?.enabled && (
 					<>
 						{ giftingErrors.length > 0 && <Notice noticeText={ giftingErrors.join( ', ' ) } isError /> }
-						{ ! giftingErrors.length && newspackAudience.content_gifting.metering_notice && (
-							<Notice
-								noticeText={ __(
-									'You have a content gate with metering enabled. Mind that metered articles are not eligible for gifting.',
-									'newspack-plugin'
-								) }
-								isWarning
-							/>
-						) }
 						<Grid columns={ 2 } rowGap={ 32 }>
 							<Heading level={ 4 } style={ { gridColumn: '1 / -1' } }>
 								{ __( 'General Settings', 'newspack-plugin' ) }

--- a/src/wizards/audience/views/setup/content-gating.js
+++ b/src/wizards/audience/views/setup/content-gating.js
@@ -199,7 +199,7 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 							</ToggleGroupControl>
 							<div style={ { gridColumn: '1 / -1' } }>
 								<BaseControl id="newspack-content-gifting-cta-preview" label={ __( 'Preview', 'newspack-plugin' ) }>
-									<div className="newspack-content-gifting__cta-preview">
+									<div className="newspack-content-gifting__cta-preview" inert="true">
 										<div className="newspack-ui">
 											<div
 												className={ `banner newspack-content-gifting__cta is-style-${
@@ -207,18 +207,22 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 												}` }
 											>
 												<div className="wrapper newspack-content-gifting__cta__content">
-													<span className="newspack-ui__font--s">
+													<div className="newspack-ui__font--s">
 														{ config.content_gifting.cta_label ||
 															__(
 																'This article has been gifted to you by someone who values great journalism.',
 																'newspack-plugin'
 															) }{ ' ' }
-														{ hasMetering ? (
-															<a href="#register_modal">{ __( 'Create an account', 'newspack-plugin' ) }</a>
-														) : (
-															<a href="#signin_modal">{ __( 'Sign in to an existing account', 'newspack-plugin' ) }</a>
-														) }
-													</span>
+														<div className="newspack-ui__font--xs newspack-content-gifting__cta__content__links">
+															{ hasMetering ? (
+																<a href="#register_modal">{ __( 'Create an account', 'newspack-plugin' ) }</a>
+															) : (
+																<a href="#signin_modal">
+																	{ __( 'Sign in to an existing account', 'newspack-plugin' ) }
+																</a>
+															) }
+														</div>
+													</div>
 													<button
 														className={ `newspack-ui__button newspack-ui__button--x-small ${
 															( config.content_gifting.style || 'light' ) === 'dark'

--- a/src/wizards/audience/views/setup/content-gating.js
+++ b/src/wizards/audience/views/setup/content-gating.js
@@ -211,7 +211,8 @@ export default withWizardScreen( ( { wizardApiFetch } ) => {
 															__(
 																'This article has been gifted to you by someone who values great journalism.',
 																'newspack-plugin'
-															) }
+															) }{ ' ' }
+														<a href="#signin_modal">{ __( 'Sign in to an existing account', 'newspack-plugin' ) }</a>
 													</span>
 													<button
 														className={ `newspack-ui__button newspack-ui__button--x-small ${


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

NPPD-1050
p1764077974536149-slack-C068PRA8L15

Enable content gifting for metered content.

This introduces a few changes:

 - For logged-out recipients, the banner should render a "Create an account" link to the registration modal in case the content is metered. If not metered, the link should be for signing in:

<img width="1117" height="400" alt="image" src="https://github.com/user-attachments/assets/91b3e224-a5ab-455e-ad60-ad4f0b4c246f" />

<img width="1119" height="364" alt="image" src="https://github.com/user-attachments/assets/26b67df8-957d-4aab-b085-24397dc5cf20" />

- After signing in, the page refreshes to detect any existing subscription. Instead of adding yet another overlay-aware page refresh strategy, I'm proposing a couple of common utilities to handle overlay callbacks: `queuePageReload()` and `onOverlaysClose()`. They remove code duplicity and are now replacing every redirect and page refresh that needs to be mindful of overlays.

- Metering now has a short-circuit filter to prevent it from running. This is applied to all public methods that check metering. This allows the gift not to be included in the reader's metering count.

### How to test the changes in this Pull Request:

1. Edit your content gate and make sure metering is enabled
2. Enable content gifting and confirm there's no longer a metering warning
3. Confirm the preview renders the CTA with a "Create an account" link
4. As a subscriber, visit a restricted article and generate a gift link
5. Use the gift link in an anonymous session
6. Click the "Create an account" link from the CTA and go through the registration flow
7. Confirm the page refreshes only after the overlay is closed
8. Check the user meta and confirm the post ID is not recorded in the `np_content_metering_{gate_id}` meta
9. Edit the gate and deactivate metering
10. In another fresh session, visit the gift link
11. Confirm the CTA now shows "Sign in to an existing account"
12. Click and sign in with your subscriber account
13. Confirm the page refreshes, and you no longer see the banner, as you are a subscriber with access to the post

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->