### PR TITLE
feat(payment-notice): detect equivalent subscription

### DIFF
--- a/includes/plugins/woocommerce/class-woocommerce-update-payment-notice.php
+++ b/includes/plugins/woocommerce/class-woocommerce-update-payment-notice.php
@@ -110,7 +110,7 @@ class WooCommerce_Update_Payment_Notice {
 	 * @return string[] The notices.
 	 */
 	private static function get_notices() {
-		if ( ! function_exists( 'wcs_get_subscriptions' ) ) {
+		if ( ! function_exists( 'wcs_get_subscriptions' ) || ! function_exists( 'wc_get_product' ) ) {
 			return [];
 		}
 
@@ -134,7 +134,25 @@ class WooCommerce_Update_Payment_Notice {
 				continue;
 			}
 
-			$product = array_values( $subscription->get_items() )[0]->get_product();
+			$line_item = reset( $subscription->get_items() );
+			$product   = wc_get_product( $line_item->get_product_id() );
+			// If the product has a parent, use the parent product.
+			if ( $product->get_parent_id() ) {
+				$product = wc_get_product( $product->get_parent_id() );
+			}
+			// If the product belongs to a grouped product, use the grouped product.
+			if ( class_exists( 'WC_Subscriptions_Product' ) && method_exists( 'WC_Subscriptions_Product', 'get_visible_grouped_parent_product_ids' ) ) {
+				$parent = \WC_Subscriptions_Product::get_visible_grouped_parent_product_ids( $product );
+				if ( ! empty( $parent ) ) {
+					$product = wc_get_product( reset( $parent ) );
+				}
+			}
+			// Check if there's another active subscription of the same grouped or variable product.
+			$active_subscriptions = WooCommerce_Subscriptions::get_user_subscription( $product );
+			if ( $active_subscriptions ) {
+				continue;
+			}
+
 			$is_donation = Donations::is_donation_product( $product->get_id() );
 
 			$link_attrs = [];


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

NPPD-1006

The "update payment" notice should not render if another equivalent subscription is active. This PR implements this strategy by detecting active subscriptions within the variable subscription or grouped product.

### How to test the changes in this Pull Request:

1. Create 3 variable subscription products and a grouped product, grouping only 2 of the variable subscription products
2. Create 2 checkout button blocks, targeting the grouped product and the ungrouped variable subscription product
3. As a reader, subscribe via both buttons
4. As an admin, generate a pending renewal order for each subscription:

<img width="307" height="166" alt="image" src="https://github.com/user-attachments/assets/923fdaac-5002-49f7-aeec-ab8a1302c221" />

5. Back as the reader, navigate to My Account and confirm you get both notices
6. Go through the checkout button flows again and make sure to select a different subscription product for the grouped product flow and a different variant for the variable subscription flow
7. Now that you have an equivalent subscription for both types of product setup, go to the My Account page
8. Confirm both notices are gone

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->