### PR TITLE
fix(subscriptions): migrated subscription switch

### DIFF
--- a/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
+++ b/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
@@ -24,7 +24,10 @@ class WooCommerce_Subscriptions {
 	}
 
 	/**
-	 * Filter to allow migrated subscription switches.
+	 * Filter to allow migrated subscription withou a last order date to switch.
+	 *
+	 * This filter will also populate the subscription's last order date meta with
+	 * the scheduled start date.
 	 *
 	 * @param bool                   $can_switch   Whether the item can be switched.
 	 * @param \WC_Order_Item_Product $item         An order item on the subscription to switch, or cart item to add.
@@ -37,13 +40,29 @@ class WooCommerce_Subscriptions {
 			$no_last_order_date = 0 === $subscription->get_date( 'last_order_date_created' );
 
 			// Bail if the subscription has a last order date, as we're only handling
-			// migrated subscription switches, which don't have a last order date.
+			// subscriptions without it.
 			if ( ! $no_last_order_date ) {
 				return $can_switch;
 			}
 
-			$product_id = wcs_get_canonical_product_id( $item );
+			// Detect whether it's a migrated subscription.
+			$migrated_meta = [ '_piano_subscription_id', '_stripe_subscription_id' ];
+			$migrated = false;
+			foreach ( $migrated_meta as $meta ) {
+				if ( $subscription->get_meta( $meta ) ) {
+					$migrated = true;
+					break;
+				}
+			}
+			if ( ! $migrated ) {
+				return $can_switch;
+			}
 
+			// Set the last order date meta to the scheduled start date.
+			$subscription->set_last_order_date_created( $subscription->get_date( 'start' ) );
+			$subscription->save();
+
+			$product_id = wcs_get_canonical_product_id( $item );
 			// Run other standard checks to see if the item can be switched.
 			// @see WC_Subscriptions_Switcher::can_user_perform_action().
 			$is_product_switchable = 'line_item' == $item['type'] && wcs_is_product_switchable_type( $product_id );

--- a/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
+++ b/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
@@ -24,7 +24,7 @@ class WooCommerce_Subscriptions {
 	}
 
 	/**
-	 * Filter to allow migrated subscription withou a last order date to switch.
+	 * Filter to allow migrated subscription without a last order date to switch.
 	 *
 	 * This filter will also populate the subscription's last order date meta with
 	 * the scheduled start date.

--- a/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
+++ b/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
@@ -65,7 +65,7 @@ class WooCommerce_Subscriptions {
 			$product_id = wcs_get_canonical_product_id( $item );
 			// Run other standard checks to see if the item can be switched.
 			// @see WC_Subscriptions_Switcher::can_user_perform_action().
-			$is_product_switchable = 'line_item' == $item['type'] && wcs_is_product_switchable_type( $product_id );
+			$is_product_switchable = 'line_item' === $item['type'] && wcs_is_product_switchable_type( $product_id );
 			$is_active             = $subscription->has_status( 'active' );
 			$can_be_updated        = $subscription->payment_method_supports( 'subscription_amount_changes' ) && $subscription->payment_method_supports( 'subscription_date_changes' );
 

--- a/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
+++ b/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
@@ -20,6 +20,42 @@ class WooCommerce_Subscriptions {
 		add_action( 'plugins_loaded', [ __CLASS__, 'woocommerce_subscriptions_integration_init' ] );
 		add_filter( 'woocommerce_subscriptions_product_limited_for_user', [ __CLASS__, 'maybe_limit_subscription_product_for_user' ], 10, 3 );
 		add_filter( 'woocommerce_subscriptions_product_trial_length', [ __CLASS__, 'limit_free_trials_to_one_per_user' ], 10, 2 );
+		add_filter( 'woocommerce_subscriptions_can_item_be_switched', [ __CLASS__, 'allow_migrated_subscription_switch' ], 10, 3 );
+	}
+
+	/**
+	 * Filter to allow migrated subscription switches.
+	 *
+	 * @param bool                   $can_switch   Whether the item can be switched.
+	 * @param \WC_Order_Item_Product $item         An order item on the subscription to switch, or cart item to add.
+	 * @param \WC_Subscription       $subscription An instance of WC_Subscription.
+	 *
+	 * @return bool Whether the item can be switched.
+	 */
+	public static function allow_migrated_subscription_switch( $can_switch, $item, $subscription ) {
+		if ( ! $can_switch ) {
+			$no_last_order_date = 0 === $subscription->get_date( 'last_order_date_created' );
+
+			// Bail if the subscription has a last order date, as we're only handling
+			// migrated subscription switches, which don't have a last order date.
+			if ( ! $no_last_order_date ) {
+				return $can_switch;
+			}
+
+			$product_id = wcs_get_canonical_product_id( $item );
+
+			// Run other standard checks to see if the item can be switched.
+			// @see WC_Subscriptions_Switcher::can_user_perform_action().
+			$is_product_switchable = 'line_item' == $item['type'] && wcs_is_product_switchable_type( $product_id );
+			$is_active             = $subscription->has_status( 'active' );
+			$can_be_updated        = $subscription->payment_method_supports( 'subscription_amount_changes' ) && $subscription->payment_method_supports( 'subscription_date_changes' );
+
+			if ( $is_product_switchable && $is_active && $can_be_updated ) {
+				return true;
+			}
+		}
+
+		return $can_switch;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

NPPM-2434

Migrated subscriptions don't have an initial order, which is required by Woo Subscription to allow switches. This is checked via the `last_order_date_created` meta.

This PR implements a strategy to backfill this meta using the scheduled start date value. This should happen on demand while generating the switch cart.

### How to test the changes in this Pull Request:

1. Make sure you have a variable subscription or a grouped product as your primary subscription product (Audience -> Subscriptions)
2. Manually create a subscription for a reader via wp-admin (WooCommerce -> Subscriptions -> Add Subscription)
3. Make sure to add a line item for a variant of the primary subscription product
4. In a new session, visit the site with `?upgrade-subscription=1` and sign in as the reader
5. Confirm you are not able to continue checkout, as the strategy is only meant for migrated subscriptions
6. Manually set a `_piano_subscription_id` or `_stripe_subscription_id` order meta with any value to the subscription
7. Visit the `?upgrade-subscription=1` again and confirm you are able to complete the switch

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->