### PR TITLE
Hotfix/add thumb position rss - NPPD-1007

### DIFF
--- a/includes/optional-modules/class-rss.php
+++ b/includes/optional-modules/class-rss.php
@@ -1188,6 +1188,10 @@ class RSS {
 				/** This filter is documented above in the use_image_tags block */
 				$image_size     = apply_filters( 'newspack_rss_image_size', RSS_Add_Image::RSS_IMAGE_SIZE, $settings, $post );
 				$thumbnail_data = wp_get_attachment_image_src( $thumbnail_id, $image_size );
+				$thumbnail_position = get_post_meta( $post->ID, 'newspack_featured_image_position', true );
+				if ( empty( $thumbnail_position ) ) {
+					$thumbnail_position = 'default';
+				}
 
 				if ( $thumbnail_data ) {
 					$caption = get_the_post_thumbnail_caption();
@@ -1203,6 +1207,7 @@ class RSS {
 					 */
 					$media_url = apply_filters( 'newspack_rss_media_content_url', $thumbnail_data[0], $thumbnail_id, $settings, $post );
 					?>
+					<thumbnail_position><?php echo esc_html( $thumbnail_position ); ?></thumbnail_position>
 					<media:content type="<?php echo esc_attr( get_post_mime_type( $thumbnail_id ) ); ?>" url="<?php echo esc_url( $media_url ); ?>">
 						<?php if ( ! empty( $caption ) ) : ?>
 						<media:description><![CDATA[<?php echo esc_html( $caption ); ?>]]></media:description>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a new tag to the RSS feeds with the thumbnail position. This allows consumers to properly handle thumbnails, especially when they should be hidden.

### How to test the changes in this Pull Request:

1. Set the thumbnail position for a few posts with different values
2. Create a RSS feed that will return those posts
3. Check the feed contains the new `thumbnail_position` tag with the correct values.
4. Check that posts without any value set have the `default` value returned


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->