### PR TITLE
fix(subscription-tiers-modal): skip private products

### DIFF
--- a/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
+++ b/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
@@ -303,6 +303,10 @@ class Subscriptions_Tiers {
 				continue;
 			}
 
+			if ( $product->get_status() === 'private' ) {
+				continue;
+			}
+
 			// Extract the variations if it's a variable subscription product.
 			if ( $product->is_type( 'variable-subscription' ) ) {
 				$variations = $product->get_available_variations();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Private products may be added to a grouped product to allow upgrades from a legacy subscription product. These products are currently being displayed in the subscription tiers modal.

### How to test the changes in this Pull Request:

1. Create a grouped product with 2 variable subscription products
2. Edit one of the variable subscription products and make it private
3. Add checkout button block to a page, targeting the grouped product
4. Visit the page and start checkout flow
5. Confirm the private product is not available

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->