### PR TITLE
fix(content-gates): resolve fatals and mismatched data types

### DIFF
--- a/includes/content-gate/class-content-restriction-control.php
+++ b/includes/content-gate/class-content-restriction-control.php
@@ -122,7 +122,7 @@ class Content_Restriction_Control {
 			}
 
 			foreach ( $content_rules as $content_rule ) {
-				if ( $content_rule['slug'] === 'post_type' ) {
+				if ( $content_rule['slug'] === 'post_types' ) {
 					$post_type = get_post_type( $post_id );
 					if ( ! in_array( $post_type, $content_rule['value'], true ) ) {
 						continue 2;

--- a/includes/content-gate/content-gifting/class-content-gifting.php
+++ b/includes/content-gate/content-gifting/class-content-gifting.php
@@ -40,7 +40,7 @@ class Content_Gifting {
 	public static function init() {
 		add_action( 'init', [ __CLASS__, 'hook_gift_button' ] );
 		add_action( 'wp', [ __CLASS__, 'unrestrict_content' ], 5 );
-		add_filter( 'newspack_content_gate_restrict_post', [ __CLASS__, 'restrict_post' ] );
+		add_filter( 'newspack_content_gate_restrict_post', [ __CLASS__, 'restrict_post' ], 10, 2 );
 		add_filter( 'newspack_content_gate_metering_short_circuit', [ __CLASS__, 'short_circuit_metering' ] );
 		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'enqueue_assets' ] );
 		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'enqueue_assets' ] );

--- a/includes/wizards/audience/class-audience-content-gates.php
+++ b/includes/wizards/audience/class-audience-content-gates.php
@@ -232,8 +232,8 @@ class Audience_Content_Gates extends Wizard {
 	 */
 	public function sanitize_gate( $gate ) {
 		return [
-			'title'         => sanitize_text_field( $gate['title'] ),
-			'description'   => sanitize_text_field( $gate['description'] ),
+			'title'         => isset( $gate['title'] ) ? sanitize_text_field( $gate['title'] ) : __( 'Untitled Content Gate', 'newspack-plugin' ),
+			'description'   => isset( $gate['description'] ) ? sanitize_text_field( $gate['description'] ) : '',
 			'metering'      => $this->sanitize_metering( $gate['metering'] ),
 			'access_rules'  => $this->sanitize_rules( $gate['access_rules'] ),
 			'content_rules' => $this->sanitize_rules( $gate['content_rules'], 'content' ),
@@ -249,6 +249,15 @@ class Audience_Content_Gates extends Wizard {
 	 * @return array The sanitized metering.
 	 */
 	public function sanitize_metering( $metering ) {
+		$metering = wp_parse_args(
+			$metering,
+			[
+				'enabled'          => false,
+				'anonymous_count'  => 0,
+				'registered_count' => 0,
+				'period'           => 'month',
+			]
+		);
 		return [
 			'enabled'          => boolval( $metering['enabled'] ),
 			'anonymous_count'  => intval( $metering['anonymous_count'] ),
@@ -267,6 +276,9 @@ class Audience_Content_Gates extends Wizard {
 	 */
 	public function sanitize_rules( $rules, $type = 'access' ) {
 		$sanitized_rules = [];
+		if ( ! is_array( $rules ) ) {
+			return $sanitized_rules;
+		}
 		foreach ( $rules as $rule ) {
 			$sanitized = $type === 'access' ? $this->sanitize_access_rule( $rule ) : $this->sanitize_content_rule( $rule );
 			if ( ! is_wp_error( $sanitized ) ) {
@@ -299,7 +311,16 @@ class Audience_Content_Gates extends Wizard {
 			if ( ! is_array( $access_rule['value'] ) ) {
 				return new \WP_Error( 'invalid_access_rule_value', __( 'Invalid access rule value.', 'newspack-plugin' ), [ 'status' => 400 ] );
 			}
-			$value = array_values( array_filter( array_map( 'sanitize_text_field', $access_rule['value'] ) ) );
+			$value = array_values(
+				array_filter(
+					array_map(
+						function( $value ) {
+							return is_numeric( $value ) ? intval( $value ) : sanitize_text_field( $value );
+						},
+						$access_rule['value']
+					)
+				)
+			);
 		} else {
 			$value = sanitize_text_field( $access_rule['value'] );
 		}

--- a/includes/wizards/audience/class-audience-content-gates.php
+++ b/includes/wizards/audience/class-audience-content-gates.php
@@ -233,7 +233,6 @@ class Audience_Content_Gates extends Wizard {
 	public function sanitize_gate( $gate ) {
 		return [
 			'title'         => isset( $gate['title'] ) ? sanitize_text_field( $gate['title'] ) : __( 'Untitled Content Gate', 'newspack-plugin' ),
-			'description'   => isset( $gate['description'] ) ? sanitize_text_field( $gate['description'] ) : '',
 			'metering'      => $this->sanitize_metering( $gate['metering'] ),
 			'access_rules'  => $this->sanitize_rules( $gate['access_rules'] ),
 			'content_rules' => $this->sanitize_rules( $gate['content_rules'], 'content' ),

--- a/src/wizards/audience/views/content-gates/access-rule-control.tsx
+++ b/src/wizards/audience/views/content-gates/access-rule-control.tsx
@@ -1,7 +1,12 @@
 /**
  * WordPress dependencies.
  */
-import { CheckboxControl, SelectControl, TextControl } from '@wordpress/components';
+import { CheckboxControl, TextControl } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { FormTokenField } from '../../../../../packages/components/src';
 
 const noop = () => {};
 
@@ -16,12 +21,12 @@ export default function AccessRuleControl( { slug, value, onChange }: GateAccess
 	}
 	if ( rule.options && rule.options.length > 0 ) {
 		return (
-			<SelectControl
+			<FormTokenField
 				label={ rule.name }
-				value={ value as string }
-				onChange={ onChange }
-				options={ rule.options.map( option => ( { value: option.value, label: option.label } ) ) }
-				help={ rule.description }
+				value={ rule.options.filter( o => value.includes( o.value ) ).map( o => o.label ) }
+				onChange={ ( items: string[] ) => onChange( rule.options?.filter( o => items.includes( o.label ) ).map( o => o.value ) ?? [] ) }
+				suggestions={ rule.options.map( o => o.label ) }
+				__experimentalExpandOnFocus={ true }
 			/>
 		);
 	}


### PR DESCRIPTION
See discussion in #4251. As [mentioned](https://github.com/Automattic/newspack-plugin/pull/4251#pullrequestreview-3532591528):

- Fixes several issues with the `sanitize_gate` method (UI has no expected `description` field, `sanitize_access_rule` converts an array of product IDs to strings via `sanitize_text_field`, etc)
- Changes the UI element for selecting subscription products to a `FormTokenField`: the UI only let you choose a single value, but the back-end expects an array of values. 
- Corrects the content rule slug when evaluating the `post_types` rule (note plural)
- Fixes a fatal error due to mismatched parameters from the `newspack_content_gate_restrict_post` filter hook in `class-content-gifting.php`