### PR TITLE
fix: hide block visibility from all blocks

### DIFF
--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -46,6 +46,16 @@ final class Blocks {
 	public static function enqueue_block_editor_assets() {
 		Newspack::load_common_assets();
 
+		// Enqueue universal editor modifications.
+		\wp_enqueue_script(
+			'newspack-editor',
+			Newspack::plugin_url() . '/dist/editor.js',
+			[],
+			NEWSPACK_PLUGIN_VERSION,
+			true
+		);
+
+		// Blocks script depends on editor script to ensure filters run first.
 		\wp_enqueue_script(
 			'newspack-blocks',
 			Newspack::plugin_url() . '/dist/blocks.js',

--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -47,10 +47,11 @@ final class Blocks {
 		Newspack::load_common_assets();
 
 		// Enqueue universal editor modifications.
+		$editor_asset = require_once dirname( NEWSPACK_PLUGIN_FILE ) . '/dist/editor.asset.php';
 		\wp_enqueue_script(
 			'newspack-editor',
 			Newspack::plugin_url() . '/dist/editor.js',
-			[],
+			$editor_asset['dependencies'],
 			NEWSPACK_PLUGIN_VERSION,
 			true
 		);

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -1,0 +1,12 @@
+/**
+ * WordPress dependencies
+ */
+import { addFilter } from '@wordpress/hooks';
+
+/**
+ *  Remove 'visibility' option for all blocks.
+ */
+addFilter( 'blocks.registerBlockType', 'newspack/remove-block-visibility', settings => {
+	settings.supports = { ...settings.supports, visibility: false };
+	return settings;
+} );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -54,6 +54,7 @@ const entry = {
 	'my-account-v1': path.join( __dirname, 'src', 'my-account', 'v1', 'index.js' ),
 	'account-frontend': path.join( __dirname, 'src', 'my-account', 'v1', 'frontend.js' ),
 	admin: path.join( __dirname, 'src', 'admin', 'index.js' ),
+	editor: path.join( __dirname, 'src', 'editor', 'index.js' ),
 	'content-gate': path.join( __dirname, 'src', 'content-gate', 'gate.js' ),
 	'content-gate-metering': path.join( __dirname, 'src', 'content-gate', 'metering.js' ),
 	'indesign-export': path.join( __dirname, 'src', 'indesign-export', 'index.js' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR hides the new 'visibility' option from all Newspack sites. 

We're doing this for a couple reasons:
* We don't know how it will interact with other plugins/services used on our sites. For example, our Newsletter plugin ignores it on sent messages.
* Since the blocks are so wholly hidden (only available in the 'List' view after being hidden) it seems like it'd be easy for publishers to lose track of this kind of stuff

The Newsletter plugin has an identical snippet of code because it's available on WP.org and the feature is wholly broken in that plugin; I've opted to add it to this plugin as a more general thing. 

It may also make sense to move this in the classic theme if it's likely we'll use the 'visibility' feature in the block theme (for example, if we want to add hidden elements to template parts so they can be easily shown without having to spin up multiple parts/patterns just to add/remove one element from one of them).

Lastly, this change also means that blocks that have set not to be visible cannot be made visible again without editing the code -- you have to manually remove `{"metadata":{"blockVisibility":false}}` from the block markup.

### How to test the changes in this Pull Request:

1. On a site running WP 6.9, add a block to the editor and open the `...` menu in the Block toolbar; note you have a Hide option.

<img width="677" height="778" alt="CleanShot 2025-12-03 at 10 07 17" src="https://github.com/user-attachments/assets/d0607df5-2b6f-4d34-9911-fe410dbd291f" />

2. Apply this PR and run `npm run build`
3. Refresh the editor.
4. Open the `...` menu of a block in the Block Toolbar and confirm you don't see the 'Hide' option.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->