### PR TITLE
fix(content-gating): never gate special pages

### DIFF
--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -127,6 +127,10 @@ class Content_Gate {
 		if ( function_exists( 'is_checkout' ) && is_checkout() ) {
 			return;
 		}
+		// Never on Accessibility Statement page.
+		if ( $post->ID === get_theme_mod( 'accessibility_statement_page_id' ) ) {
+			return;
+		}
 		// If no other restrictions apply.
 		if ( ! self::is_post_restricted( $post->ID ) ) {
 			return;

--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -107,11 +107,19 @@ class Content_Gate {
 		if ( is_admin() ) {
 			return;
 		}
+		// Never in Privacy Policy page.
+		if ( is_privacy_policy() ) {
+			return;
+		}
 		// Never in My Account pages.
 		if ( function_exists( 'is_account_page' ) && is_account_page() ) {
 			return;
 		}
-		// If no restrictions apply.
+		// Never in Terms and Conditions page.
+		if ( function_exists( 'wc_terms_and_conditions_page_id' ) && $post->ID === wc_terms_and_conditions_page_id() ) {
+			return;
+		}
+		// If no other restrictions apply.
 		if ( ! self::is_post_restricted( $post->ID ) ) {
 			return;
 		}

--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -119,6 +119,14 @@ class Content_Gate {
 		if ( function_exists( 'wc_terms_and_conditions_page_id' ) && $post->ID === wc_terms_and_conditions_page_id() ) {
 			return;
 		}
+		// Never in WooCommerce cart page.
+		if ( function_exists( 'is_cart' ) && is_cart() ) {
+			return;
+		}
+		// Never in WooCommerce checkout page.
+		if ( function_exists( 'is_checkout' ) && is_checkout() ) {
+			return;
+		}
 		// If no other restrictions apply.
 		if ( ! self::is_post_restricted( $post->ID ) ) {
 			return;

--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -107,6 +107,11 @@ class Content_Gate {
 		if ( is_admin() ) {
 			return;
 		}
+		// Never in My Account pages.
+		if ( function_exists( 'is_account_page' ) && is_account_page() ) {
+			return;
+		}
+		// If no restrictions apply.
 		if ( ! self::is_post_restricted( $post->ID ) ) {
 			return;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

For Newspack content gating features, certain special pages should never be subject to content restrictions, even if they would otherwise be captured by content rules for a gate. This PR ensures that the Privacy Policy, Accessibility Statement, Terms & Conditions, Cart, Checkout, and all My Account pages are never restricted.

### How to test the changes in this Pull Request:

1. With Woo Memberships disabled and `define( 'NEWSPACK_CONTENT_GATES', true );` in wp-config.php, publish a content gate with any access rules and a "post types" content rule with a value including "Pages".
2. Ensure your Privacy Policy page (Settings > Privacy), Accessibility Statement (automatically created by the Newspack Theme), and Woo's Cart, Checkout, Terms & Conditions, and My Account pages (automatically created when WooCommerce is first activated) are published.
3. On `trunk`, visit these pages as a reader and observe that their content is restricted by the content gate published in step 1.
4. Also visit WooCommerce's default Shop page and attempt to purchase a product through the standard Woo cart/checkout flow, and observe that the cart and checkout pages are also restricted by the gate.
5. Check out this branch and confirm that none of these pages are restricted, but that all other pages are.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->