### PR TITLE
feat(ras): OAuth OTP flow improvements

### DIFF
--- a/includes/class-magic-link.php
+++ b/includes/class-magic-link.php
@@ -516,11 +516,27 @@ final class Magic_Link {
 				'value'    => $token_data['otp']['code'],
 			];
 		}
-		return Emails::send_email(
+
+		/**
+		 * Filters the email config name for magic link/OTP authentication emails.
+		 * Allows overriding the email template used based on the current context.
+		 *
+		 * @param string   $email_config_name The email config name (e.g., 'reader-activation-otp-authentication').
+		 * @param string   $email_type        The email type key (e.g., 'OTP_AUTH', 'MAGIC_LINK').
+		 * @param \WP_User $user              The user receiving the email.
+		 * @param string   $redirect_to       The redirect URL after authentication.
+		 * @param array    $token_data        The token data including OTP information.
+		 */
+		$email_config_name = \apply_filters(
+			'newspack_magic_link_email_config',
 			Reader_Activation_Emails::EMAIL_TYPES[ $email_type ],
-			$user->user_email,
-			$email_placeholders
+			$email_type,
+			$user,
+			$redirect_to,
+			$token_data
 		);
+
+		return Emails::send_email( $email_config_name, $user->user_email, $email_placeholders );
 	}
 
 	/**

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -2712,7 +2712,7 @@ final class Reader_Activation {
 	 * @param string $url The URL to check.
 	 * @return bool True if the URL path contains an OAuth route.
 	 */
-	private static function is_oauth_redirect( $url ) {
+	public static function is_oauth_redirect( $url ) {
 		$url_path = \wp_parse_url( $url, PHP_URL_PATH ) ?? '';
 
 		/**

--- a/src/reader-activation-auth/auth-form.js
+++ b/src/reader-activation-auth/auth-form.js
@@ -40,6 +40,17 @@ window.newspackRAS.push( function ( readerActivation ) {
 			const messageContentElement = container.querySelector( '.response' );
 
 			/**
+			 * Check if the current URL has a redirect parameter.
+			 * Used to determine if we should pass the full URL to the backend during OAuth flows.
+			 *
+			 * @return {boolean} True if URL has a 'redirect' query parameter.
+			 */
+			const hasRedirectInUrl = () => {
+				const urlParams = new URLSearchParams( window.location.search );
+				return urlParams.has( 'redirect' );
+			};
+
+			/**
 			 * Set action listener on the given item.
 			 */
 			const setActionListener = item => {
@@ -216,9 +227,7 @@ window.newspackRAS.push( function ( readerActivation ) {
 						body.set( 'npe', emailInput.value );
 						body.set( 'action', 'link' );
 						const pendingCheckout = getPendingCheckout();
-						const urlParams = new URLSearchParams( window.location.search );
-						const hasRedirectParam = urlParams.has( 'redirect' );
-						if ( pendingCheckout || hasRedirectParam ) {
+						if ( pendingCheckout || hasRedirectInUrl() ) {
 							const url = new URL( window.location.href );
 							if ( pendingCheckout ) {
 								url.searchParams.set( 'checkout', 1 );
@@ -414,9 +423,7 @@ window.newspackRAS.push( function ( readerActivation ) {
 					return form.endLoginFlow( newspack_reader_activation_labels.invalid_email, 400 );
 				}
 				const pendingCheckout = getPendingCheckout();
-				const urlParams = new URLSearchParams( window.location.search );
-				const hasRedirectParam = urlParams.has( 'redirect' );
-				if ( pendingCheckout || hasRedirectParam ) {
+				if ( pendingCheckout || hasRedirectInUrl() ) {
 					const url = new URL( window.location.href );
 					if ( pendingCheckout ) {
 						url.searchParams.set( 'checkout', 1 );

--- a/src/reader-activation-auth/auth-form.js
+++ b/src/reader-activation-auth/auth-form.js
@@ -216,9 +216,13 @@ window.newspackRAS.push( function ( readerActivation ) {
 						body.set( 'npe', emailInput.value );
 						body.set( 'action', 'link' );
 						const pendingCheckout = getPendingCheckout();
-						if ( pendingCheckout ) {
+						const urlParams = new URLSearchParams( window.location.search );
+						const hasRedirectParam = urlParams.has( 'redirect' );
+						if ( pendingCheckout || hasRedirectParam ) {
 							const url = new URL( window.location.href );
-							url.searchParams.set( 'checkout', 1 );
+							if ( pendingCheckout ) {
+								url.searchParams.set( 'checkout', 1 );
+							}
 							body.set( 'redirect_url', url.toString() );
 						}
 						fetch( form.getAttribute( 'action' ) || window.location.pathname, {
@@ -410,9 +414,13 @@ window.newspackRAS.push( function ( readerActivation ) {
 					return form.endLoginFlow( newspack_reader_activation_labels.invalid_email, 400 );
 				}
 				const pendingCheckout = getPendingCheckout();
-				if ( pendingCheckout ) {
+				const urlParams = new URLSearchParams( window.location.search );
+				const hasRedirectParam = urlParams.has( 'redirect' );
+				if ( pendingCheckout || hasRedirectParam ) {
 					const url = new URL( window.location.href );
-					url.searchParams.set( 'checkout', 1 );
+					if ( pendingCheckout ) {
+						url.searchParams.set( 'checkout', 1 );
+					}
 					body.set( 'redirect_url', url.toString() );
 				}
 

--- a/tests/unit-tests/reader-activation.php
+++ b/tests/unit-tests/reader-activation.php
@@ -142,4 +142,33 @@ class Newspack_Test_Reader_Activation extends WP_UnitTestCase {
 		$this->assertFalse( Reader_Activation::is_user_reader( $user ) );
 		wp_delete_user( $reader_id ); // Clean up.
 	}
+
+	/**
+	 * Test is_oauth_redirect detection.
+	 */
+	public function test_is_oauth_redirect() {
+		$this->assertTrue( Reader_Activation::is_oauth_redirect( 'https://example.com/oauth/authorize?client_id=123' ) );
+		$this->assertFalse( Reader_Activation::is_oauth_redirect( 'https://example.com/my-account/' ) );
+		$this->assertFalse( Reader_Activation::is_oauth_redirect( 'https://example.com/' ) );
+		$this->assertFalse( Reader_Activation::is_oauth_redirect( '' ) );
+	}
+
+	/**
+	 * Test is_oauth_redirect filter can extend routes.
+	 */
+	public function test_is_oauth_redirect_filter() {
+		// Add a custom OAuth route via filter.
+		add_filter(
+			'newspack_ras_oauth_redirect_routes',
+			function ( $routes ) {
+				$routes[] = '/custom-oauth/';
+				return $routes;
+			}
+		);
+
+		$this->assertTrue(
+			Reader_Activation::is_oauth_redirect( 'https://example.com/custom-oauth/?param=value' ),
+			'Custom OAuth route should be detected after adding via filter.'
+		);
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

When users authenticate via OAuth flows, the authentication form now passes the full redirect URL to the backend, enabling backend email sending code to detect OAuth contexts.

This PR also adds a new `newspack_magic_link_email_config` filter that allows external plugins to override which email template is used for OTP/magic link emails based on the authentication context, and makes the `is_oauth_redirect()` method public so it can be reused externally.

Closes NPPD-1008 (please check the ticket for additional context and dependencies).

### How to test the changes in this Pull Request:

1. Enable the "Use My Account login screen for OAuth clients" toggle in Audience Management > Configuration.
2. Navigate to an OAuth authorization URL: `https://your-site.com/oauth/authorize/?prompt=login&scope=openid+offline_access&code_challenge_method=S256&response_type=code&client_id=<YOUR_CLIENT_ID>&redirect_uri=https%3A%2F%2Fexample.com%2F&code_challenge=<SAMPLE_CHALLENGE>`
3. You should be redirected to `/my-account/?redirect=<encoded_oauth_url>`.
4. Enter an email address and click "Continue" or request an OTP code.
   - Note: When the user doesn't have a password set, the email is requested as soon as they click "Continue". Otherwise, the next screen presents the option to use the password and a button to request an OTP. This flow hasn't changed, but testing both scenarios is recommended.
5. Open browser DevTools > Network tab and inspect the POST request to `/my-account/`.
6. Verify that the form data includes a `redirect_url` field containing the full URL with the redirect query parameter (e.g., `https://your-site.com/my-account/?redirect=...`).
7. Test a normal login flow on `/my-account/` (without the OAuth or redirect params) and verify it still works as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?