### PR TITLE
fix: workaround issue and conflict with teams

### DIFF
--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -2268,6 +2268,13 @@ final class Reader_Activation {
 			// Unhook from WooCommerce as it's already been canonized above.
 			remove_filter( 'woocommerce_new_customer_data', [ __CLASS__, 'canonize_user_data' ], 10, 1 );
 			if ( function_exists( '\wc_create_new_customer' ) ) {
+
+				// Avoid an issue with Teams for Memberships plugin that messes up billing first and last name and display name.
+				// See SkyVerge\WooCommerce\Memberships\Teams\Frontend::save_team_member_name().
+				if ( function_exists( 'wc_memberships_for_teams' ) ) {
+					remove_action( 'woocommerce_created_customer', [ wc_memberships_for_teams()->get_frontend_instance(), 'save_team_member_name' ] );
+				}
+
 				/**
 				 * Create WooCommerce Customer if possible.
 				 * Email notification for WooCommerce is handled by the plugin.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The Teams for Memberships plugin has an action that saves the billing first and last name, and the display name, whenever a WC Customer is created.

The problem is that action is designed to be executed in some specific form in the admin, but it has no guardrails and it ends up being invoked also when we register a reader via RAS.

This is messing up the Display name and generating some conflicts with the Newsletter Subscription form block, because that block has a `last_name` field. Teams was then adding a metadata with only the billing last name to the user (but not the first).

As a result, when we sync the user to the ESP, and fetch the data from the customer [here](https://github.com/Automattic/newspack-plugin/blob/ac12cca41eca26a532e1f2dc2ea7c49258343566/includes/reader-activation/sync/class-woocommerce.php#L418), we end up with only the last name as the name, because firs_name returns empty.

This PR simply removes that action upon reader registration and fixes the issue.

### How to test the changes in this Pull Request:

On `trunk` or `release`

1. Activate Woo Memberships and Teams for Memberships
2. Activate RAS
3. Add a Newsletter Subscription block to a page, and enable the first and last name fields
4. As an anonymous reader, go to that page and submit the form
5. On the DB, observe that the user gets a `billing_last_name` metadata and that the display name is equal the login
6. On the connected ESP, confirm that the first name of the contact was replaced with the last name.

Checkout this branch and repeat the steps above:

* Confirm the `billing_last_name` meta is NOT created
* Confirm the display name looks correct
* Confirm the name on the ESP looks correct

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->