### PR TITLE
fix(my-account): set new payment method as default

### DIFF
--- a/includes/plugins/woocommerce/class-woocommerce-connection.php
+++ b/includes/plugins/woocommerce/class-woocommerce-connection.php
@@ -71,7 +71,7 @@ class WooCommerce_Connection {
 
 		// Automatically set newly added payment method as default and update subscriptions.
 		\add_action( 'woocommerce_new_payment_token', [ __CLASS__, 'set_payment_method_as_default' ], 10, 2 );
-		\add_action( 'woocommerce_add_payment_method_form_bottom', [ __CLASS__, 'add_payment_method_form_notice' ], 5 );
+		\add_action( 'wc_stripe_payment_fields_stripe', [ __CLASS__, 'add_payment_method_form_notice' ], 5 );
 
 		\add_filter( 'page_template', [ __CLASS__, 'page_template' ] );
 		\add_filter( 'get_post_metadata', [ __CLASS__, 'get_post_metadata' ], 10, 3 );
@@ -272,7 +272,8 @@ class WooCommerce_Connection {
 	}
 
 	/**
-	 * Set newly added payment method as default and update all active subscriptions.
+	 * Set newly added Stripe payment method as default and update all active
+	 * subscriptions.
 	 *
 	 * @param int               $token_id Payment token ID.
 	 * @param \WC_Payment_Token $token    Payment token object.
@@ -283,6 +284,11 @@ class WooCommerce_Connection {
 			return;
 		}
 
+		// Bail if not a Stripe token.
+		if ( 'stripe' !== $token->get_gateway_id() ) {
+			return;
+		}
+
 		// Set as default payment method for the customer.
 		$token->set_default( true );
 		$token->save();
@@ -290,18 +296,18 @@ class WooCommerce_Connection {
 	}
 
 	/**
-	 * Add a notice at the beginning of the add payment method form.
+	 * Add a notice to the Stripe gateway when adding a new payment method.
 	 */
 	public static function add_payment_method_form_notice() {
-		$user_id = get_current_user_id();
-		if ( ! $user_id ) {
+		// Bail if not in the payment methods page.
+		if ( ! function_exists( 'is_payment_methods_page' ) || ! is_payment_methods_page() ) {
 			return;
 		}
 
 		// Check if user has active subscriptions.
 		$has_active_subscriptions = false;
 		if ( function_exists( 'wcs_get_users_subscriptions' ) ) {
-			$subscriptions = \wcs_get_users_subscriptions( $user_id );
+			$subscriptions = wcs_get_users_subscriptions( get_current_user_id() );
 			foreach ( $subscriptions as $subscription ) {
 				if ( $subscription->has_status( self::ACTIVE_SUBSCRIPTION_STATUSES ) ) {
 					$has_active_subscriptions = true;
@@ -309,16 +315,16 @@ class WooCommerce_Connection {
 				}
 			}
 		}
-
-		if ( $has_active_subscriptions ) {
-			?>
-			<p class="newspack-payment-method-notice">
-				<?php
-				\esc_html_e( 'This will be automatically saved to your active subscriptions and set as your default payment method.', 'newspack-plugin' );
-				?>
-			</p>
-			<?php
+		if ( ! $has_active_subscriptions ) {
+			return;
 		}
+		?>
+		<p class="newspack-new-payment-method-notice">
+			<?php
+			\esc_html_e( 'The card will be automatically saved to your active subscriptions and set as your default payment method.', 'newspack-plugin' );
+			?>
+		</p>
+		<?php
 	}
 
 	/**

--- a/includes/plugins/woocommerce/class-woocommerce-connection.php
+++ b/includes/plugins/woocommerce/class-woocommerce-connection.php
@@ -65,7 +65,13 @@ class WooCommerce_Connection {
 		\add_action( 'woocommerce_payment_complete', [ __CLASS__, 'order_paid' ], 101 );
 		\add_action( 'woocommerce_after_checkout_validation', [ __CLASS__, 'rate_limit_checkout' ], 10, 2 );
 		\add_filter( 'woocommerce_add_payment_method_form_is_valid', [ __CLASS__, 'rate_limit_payment_methods' ] );
+
+		// Always save payment methods to existing subscriptions.
 		\add_filter( 'wc_stripe_save_to_subs_checked', '__return_true' );
+
+		// Automatically set newly added payment method as default and update subscriptions.
+		\add_action( 'woocommerce_new_payment_token', [ __CLASS__, 'set_payment_method_as_default' ], 10, 2 );
+		\add_action( 'woocommerce_add_payment_method_form_bottom', [ __CLASS__, 'add_payment_method_form_notice' ], 5 );
 
 		\add_filter( 'page_template', [ __CLASS__, 'page_template' ] );
 		\add_filter( 'get_post_metadata', [ __CLASS__, 'get_post_metadata' ], 10, 3 );
@@ -263,6 +269,56 @@ class WooCommerce_Connection {
 		}
 
 		return $is_valid;
+	}
+
+	/**
+	 * Set newly added payment method as default and update all active subscriptions.
+	 *
+	 * @param int               $token_id Payment token ID.
+	 * @param \WC_Payment_Token $token    Payment token object.
+	 */
+	public static function set_payment_method_as_default( $token_id, $token ) {
+		// Bail if not in the payment methods page.
+		if ( ! function_exists( 'is_payment_methods_page' ) || ! is_payment_methods_page() ) {
+			return;
+		}
+
+		// Set as default payment method for the customer.
+		$token->set_default( true );
+		$token->save();
+		\WC_Payment_Tokens::set_users_default( $token->get_user_id(), $token_id );
+	}
+
+	/**
+	 * Add a notice at the beginning of the add payment method form.
+	 */
+	public static function add_payment_method_form_notice() {
+		$user_id = get_current_user_id();
+		if ( ! $user_id ) {
+			return;
+		}
+
+		// Check if user has active subscriptions.
+		$has_active_subscriptions = false;
+		if ( function_exists( 'wcs_get_users_subscriptions' ) ) {
+			$subscriptions = \wcs_get_users_subscriptions( $user_id );
+			foreach ( $subscriptions as $subscription ) {
+				if ( $subscription->has_status( self::ACTIVE_SUBSCRIPTION_STATUSES ) ) {
+					$has_active_subscriptions = true;
+					break;
+				}
+			}
+		}
+
+		if ( $has_active_subscriptions ) {
+			?>
+			<p class="newspack-payment-method-notice">
+				<?php
+				\esc_html_e( 'This will be automatically saved to your active subscriptions and set as your default payment method.', 'newspack-plugin' );
+				?>
+			</p>
+			<?php
+		}
 	}
 
 	/**

--- a/includes/plugins/woocommerce/class-woocommerce-connection.php
+++ b/includes/plugins/woocommerce/class-woocommerce-connection.php
@@ -66,10 +66,8 @@ class WooCommerce_Connection {
 		\add_action( 'woocommerce_after_checkout_validation', [ __CLASS__, 'rate_limit_checkout' ], 10, 2 );
 		\add_filter( 'woocommerce_add_payment_method_form_is_valid', [ __CLASS__, 'rate_limit_payment_methods' ] );
 
-		// Always save payment methods to existing subscriptions.
+		// Always save Stripe payment method to existing subscriptions and set as default.
 		\add_filter( 'wc_stripe_save_to_subs_checked', '__return_true' );
-
-		// Automatically set newly added payment method as default and update subscriptions.
 		\add_action( 'woocommerce_new_payment_token', [ __CLASS__, 'set_payment_method_as_default' ], 10, 2 );
 		\add_action( 'wc_stripe_payment_fields_stripe', [ __CLASS__, 'add_payment_method_form_notice' ], 5 );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

NPPD-985

Via the `add_filter( 'wc_stripe_save_to_subs_checked', '__return_true' )` we enforce a new Stripe payment method to be set to all active subscriptions.

This is not properly communicated, and the payment method is also not automatically set as **Default**, which adds to the confusion.

This PR adds a paragraph inside the Stripe gateway form and automatically sets the new method as the default.

<img width="676" height="629" alt="image" src="https://github.com/user-attachments/assets/67985dab-942f-4555-a959-700acb14a495" />

### How to test the changes in this Pull Request:

1. Make sure you have Stripe as your payment gateway
2. As a reader with active subscriptions, visit "My Account -> Payment information"
3. Click to add a new payment method and confirm the new "The card will be automatically saved to your active subscriptions and set as your default payment method." paragraph
4. Add the new card and confirm it's set as default, and is set to your active subscriptions

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->