### PR TITLE
fix(countdown-banner): don't show on unrestricted posts

### DIFF
--- a/includes/content-gate/class-metering-countdown.php
+++ b/includes/content-gate/class-metering-countdown.php
@@ -179,7 +179,7 @@ class Metering_Countdown {
 	 * @return void
 	 */
 	public static function print_cta() {
-		if ( ! self::is_enabled() ) {
+		if ( ! self::is_enabled() || ! Content_Gate::is_post_restricted() ) {
 			return;
 		}
 		$settings    = self::get_settings();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#4340 added some specific exclusions to ensure that certain posts and pages are never gated, but this wasn't also applied to the countdown banner.

### How to test the changes in this Pull Request:

1. On `trunk`, set up a countdown banner as described in #4315.
2. As a logged-in reader, visit Privacy Policy, Accessibility Statement, Terms & Conditions, Cart, Checkout, or My Account and observe that the countdown banner is rendered even though these pages aren't gated.
3. Check out this branch, refresh, and confirm that the banner isn't shown on these pages.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->