### PR TITLE
fix: clarify the media credit placeholder image's labelling

### DIFF
--- a/src/wizards/newspack/views/settings/advanced-settings/media-credits.tsx
+++ b/src/wizards/newspack/views/settings/advanced-settings/media-credits.tsx
@@ -58,7 +58,7 @@ export default function MediaCredits( { data, update }: ThemeModComponentProps< 
 								  }
 								: null
 						}
-						label={ __( 'Placeholder Image', 'newspack-plugin' ) }
+						label={ __( 'Image for Uncredited Media', 'newspack-plugin' ) }
 						buttonLabel={ __( 'Select', 'newspack-plugin' ) }
 						onChange={ ( image: null | PlaceholderImage ) => {
 							setImageThumbnail( image?.url || null );
@@ -68,7 +68,7 @@ export default function MediaCredits( { data, update }: ThemeModComponentProps< 
 							} );
 						} }
 						help={ __(
-							'A placeholder image to be displayed in place of images without credits. If none is chosen, the image will be displayed normally whether or not it has a credit.',
+							'Image shown in place of images that do not have a credit attached. Leave empty to display uncredited images as normal.',
 							'newspack-plugin'
 						) }
 					/>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR clarifies some language around the Media Credit fallback image - now that we're adding an actual fallback image for 404s, the two fields being one after the other can be easy to confuse, tripping up two members of the product team so far 😆 . 

See NPPM-2451.

### How to test the changes in this Pull Request:

1. Apply this PR and run `npm run build`.
2. Confirm the language is updated under Newspack > Settings > Advanced Settings, and that it makes sense to you:

<img width="1073" height="476" alt="CleanShot 2025-12-10 at 09 10 27" src="https://github.com/user-attachments/assets/6edf0407-fa6b-4939-9434-eedd9b94ac83" />

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->