### PR TITLE
fix(update-payment-notice): don't render on checkout

### DIFF
--- a/includes/plugins/woocommerce/class-woocommerce-update-payment-notice.php
+++ b/includes/plugins/woocommerce/class-woocommerce-update-payment-notice.php
@@ -80,6 +80,11 @@ class WooCommerce_Update_Payment_Notice {
 			return;
 		}
 
+		// Don't show notices on the checkout page.
+		if ( function_exists( 'is_checkout' ) && is_checkout() ) {
+			return;
+		}
+
 		$notices = self::get_notices();
 		if ( empty( $notices ) ) {
 			return;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

NPPD-1054

Don't render the update payment notice on checkout pages:

| Before | After |
| --- | --- |
| <img width="1053" height="449" alt="image" src="https://github.com/user-attachments/assets/d9ed0017-13f3-42c3-897e-432651005e9b" /> | <img width="1056" height="464" alt="image" src="https://github.com/user-attachments/assets/aeb07b2c-a6b4-48f6-9c81-dc4e18c701dc" /> |

### How to test the changes in this Pull Request:

1. As a reader, purchase a subscription
2. As an admin, edit the subscription and create a pending renewal order to trigger the payment notice
3. Visit the homepage as a reader and confirm you get the notice
4. Trigger a modal checkout flow via a checkout button block and confirm the notice doesn't render in the modal

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->