### PR TITLE
feat: add media credits to RSS feeds

### DIFF
--- a/includes/class-newspack-image-credits.php
+++ b/includes/class-newspack-image-credits.php
@@ -46,6 +46,7 @@ class Newspack_Image_Credits {
 		add_filter( 'ajax_query_attachments_args', [ __CLASS__, 'filter_ajax_query_attachments' ] );
 		add_filter( 'wp_generate_attachment_metadata', [ __CLASS__, 'populate_credit' ], 10, 3 );
 		add_action( 'init', [ __CLASS__, 'register_meta' ] );
+		add_action( 'newspack_rss_media_content', [ __CLASS__, 'add_media_credit_to_feeds' ] );
 	}
 
 	/**
@@ -577,6 +578,20 @@ class Newspack_Image_Credits {
 					'show_in_rest'   => true,
 				]
 			);
+		}
+	}
+
+	/**
+	 * Add media credit inside media content for Custom RSS feeds.
+	 *
+	 * @param int $thumbnail_id Thumbnail attachment ID.
+	 */
+	public static function add_media_credit_to_feeds( $thumbnail_id ): void {
+		$media_credit = get_post_meta( $thumbnail_id, self::MEDIA_CREDIT_META, true );
+		if ( ! empty( $media_credit ) ) {
+			?>
+			<media:credit><![CDATA[<?php echo esc_html( $media_credit ); ?>]]></media:credit>
+			<?php
 		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a media:credit node to the RSS feeds for the thumbnails

### How to test the changes in this Pull Request:

1. Create a custom RSS feed
2. Add a post to the feed with a featured image with info in the credits
3. Confirm there's a `media:credit` entry inside the `media:content` tag

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->