### PR TITLE
feat: rename newsletter tracking

### DIFF
--- a/includes/wizards/class-newsletters-wizard.php
+++ b/includes/wizards/class-newsletters-wizard.php
@@ -424,6 +424,11 @@ class Newsletters_Wizard extends Wizard {
 				];
 			}
 
+			$tabs[] = [
+				'textContent' => esc_html__( 'Tracking', 'newspack-plugin' ),
+				'href'        => admin_url( 'edit.php?post_type=' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT . '&page=' . $this->slug . '#/tracking' ),
+			];
+
 			return $tabs;
 		}
 

--- a/src/wizards/newsletters/index.js
+++ b/src/wizards/newsletters/index.js
@@ -31,7 +31,7 @@ class NewslettersWizard extends Component {
 				path: '/',
 			},
 			{
-				label: __( 'Tracking', 'newspack-plugin' ),
+				label: __( 'Ads Tracking', 'newspack-plugin' ),
 				path: '/tracking',
 			},
 		];

--- a/src/wizards/newsletters/views/tracking/index.js
+++ b/src/wizards/newsletters/views/tracking/index.js
@@ -52,17 +52,17 @@ export default withWizardScreen( () => {
 
 	return (
 		<>
-			<h1>{ __( 'Tracking', 'newspack-plugin' ) }</h1>
+			<h1>{ __( 'Ads Tracking', 'newspack-plugin' ) }</h1>
 			<ActionCard
 				title={ __( 'Click-tracking', 'newspack-plugin' ) }
-				description={ __( 'Track the clicks on the links in your newsletter.', 'newspack-plugin' ) }
+				description={ __( 'Track the clicks on ads in your newsletter.', 'newspack-plugin' ) }
 				disabled={ inFlight }
 				toggleOnChange={ handleChange( 'click' ) }
 				toggleChecked={ tracking.click }
 			/>
 			<ActionCard
-				title={ __( 'Tracking pixel', 'newspack-plugin' ) }
-				description={ __( 'Track the opens of your newsletter.', 'newspack-plugin' ) }
+				title={ __( 'Ads impressions', 'newspack-plugin' ) }
+				description={ __( 'Track the impressions of ads in your newsletter.', 'newspack-plugin' ) }
 				disabled={ inFlight }
 				toggleOnChange={ handleChange( 'pixel' ) }
 				toggleChecked={ tracking.pixel }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Tracking is only meant to track Ads. We only track clicks on ads. We only show the number on ads. We need the settings screen to reflect that.

### How to test the changes in this Pull Request:

1. Visit Newsletters > Advertising and confirm you see a new tab called "Tracking"

<img width="324" height="125" alt="image" src="https://github.com/user-attachments/assets/c36028b7-5333-4238-88ec-bedb6402c83e" />


2. Click that link and confirm you are taken to Settings > Ads Tracking

<img width="932" height="441" alt="image" src="https://github.com/user-attachments/assets/4a2d7286-fbe9-472c-b69c-cec6c059bf4d" />


3. Confirm all the copy look good

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->