### PR TITLE
fix: add default reader meta - NPPM-2440

### DIFF
--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -119,6 +119,11 @@ final class Reader_Activation {
 			\add_filter( 'lostpassword_errors', [ __CLASS__, 'rate_limit_lost_password' ], 10, 2 );
 			\add_filter( 'newspack_esp_sync_contact', [ __CLASS__, 'set_mailchimp_sync_contact_status' ], 10, 2 );
 			\add_filter( 'login_url', [ __CLASS__, 'redirect_oauth_to_ras_login' ], 10, 3 );
+
+			/**
+			 * If RAS is enabled, we assume that any user created by Woo is a reader, without a password and unverified.
+			 */
+			\add_action( 'woocommerce_created_customer', [ __CLASS__, 'add_default_reader_metadata' ] );
 		}
 	}
 
@@ -2291,14 +2296,7 @@ final class Reader_Activation {
 				return $user_id;
 			}
 
-			/**
-			 * Add default reader related meta.
-			 */
-			\update_user_meta( $user_id, self::READER, true );
-			/** Email is not yet verified. */
-			\update_user_meta( $user_id, self::EMAIL_VERIFIED, false );
-			/** User hasn't set their own password yet. */
-			\update_user_meta( $user_id, self::WITHOUT_PASSWORD, true );
+			self::add_default_reader_metadata( $user_id );
 
 			Logger::log( 'Created new reader user with ID ' . $user_id );
 
@@ -2920,6 +2918,19 @@ final class Reader_Activation {
 			'woocommerce_terms_confirmation_text'          => self::get_terms_confirmation_text(),
 			'woocommerce_terms_confirmation_url'           => self::get_terms_confirmation_url(),
 		];
+	}
+
+	/**
+	 * Add default reader related meta to a user that was just created.
+	 *
+	 * @param int $customer_id User ID.
+	 */
+	public static function add_default_reader_metadata( $customer_id ) {
+		\update_user_meta( $customer_id, self::READER, true );
+		/** Email is not yet verified. */
+		\update_user_meta( $customer_id, self::EMAIL_VERIFIED, false );
+		/** User hasn't set their own password yet. */
+		\update_user_meta( $customer_id, self::WITHOUT_PASSWORD, true );
 	}
 }
 Reader_Activation::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

When Woo creates a user as part of a flow, for example gifting a subscription, it was not adding RAS specific metadata.

This PR assumes that any programatically created user via Woo's method is a user without a password and unverified.

(Note: It's known that when a reader registers it will trigger the new callback twice (via hook and via the reader_register method). I think that's fine).

### How to test the changes in this Pull Request:

1. Create a giftable subscription
2. As a user, purchase this product as a gift
3. Check the email received by the gift recipient and visit my account
4. Try to login as a gift recipient and confirm you are not asked for a password. OTP is the default login strategy

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->