### PR TITLE
fix(recaptcha): log verification responses and errors

### DIFF
--- a/includes/class-recaptcha.php
+++ b/includes/class-recaptcha.php
@@ -416,10 +416,36 @@ final class Recaptcha {
 
 		// If the reCaptcha verification request fails.
 		if ( \is_wp_error( $captcha_verify ) ) {
+			// Log the error for debugging purposes.
+			Logger::newspack_log(
+				'newspack_recaptcha_verify',
+				'reCAPTCHA verification error',
+				[
+					'type' => 'debug',
+					'data' => [
+						'error'   => $captcha_verify->get_error_message(),
+						'version' => $version,
+					],
+				],
+				'error'
+			);
 			return $captcha_verify;
 		}
 
-		$captcha_verify = json_decode( $captcha_verify['body'], true );
+		$captcha_verify  = json_decode( $captcha_verify['body'], true );
+		$data            = $captcha_verify;
+		$data['version'] = $version;
+
+		// Log the verification response for debugging purposes.
+		Logger::newspack_log(
+			'newspack_recaptcha_verify',
+			'reCAPTCHA verification response',
+			[
+				'type' => 'debug',
+				'data' => $data,
+			],
+			'debug'
+		);
 
 		// If the reCaptcha verification request succeeds, but with error.
 		if ( ! boolval( $captcha_verify['success'] ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds some debug and error logging when a site makes a verification request (assessment) to the reCAPTCHA API. This will let us better estimate reCAPTCHA usage across the Newspack platform.

This only logs when the request is sent server-side—it doesn't separately log requests sent directly to the reCAPTCHA API via JS when using v2. This is because we double-verify captcha tokens fetched via JS with a server-side request to avoid unverified direct POST requests. Since the server-side requests are simply verifying the captcha token that was fetched on the front-end (and not fetching a new token to assess the validity of the request), I don't believe this counts as a separate assessment—but it's unclear from [Google's documentation](https://docs.cloud.google.com/recaptcha/docs/billing-information#how-it-works) exactly how they count assessments on their end.

Closes NPPD-900.

### How to test the changes in this Pull Request:

1. Check out this branch.
2. In **Newspack > Settings**, enable reCAPTCHA v2 and add credentials, if necessary
3. As a reader, perform actions across the site that are protected by reCAPTCHA:
  - Reader account registration via the Sign In modal or registration block
  - Newsletter signup via the Newsletter Subscription block
  - Checkout payment attempts via the modal checkout and regular Woo checkout

4. Confirm that for each action, the request is logged via `newspack_log` with info about the request: reCAPTCHA version (`v2_invisible` or `v3`), score (if using v3), timestamp of the challenge completion (if using v2), success status, hostname, etc.
5. Switch to using reCAPTCHA v3 and repeat the protected actions on the front-end. Confirm that the requests are logged with v3-appropriate data.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->