### PR TITLE
fix(subscriptions): remove actions from gifted subscription

### DIFF
--- a/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions-gifting.php
+++ b/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions-gifting.php
@@ -21,6 +21,7 @@ class WooCommerce_Subscriptions_Gifting {
 		\add_filter( 'wcsg_require_shipping_address_for_virtual_products', '__return_false' );
 		\add_filter( 'default_option_woocommerce_subscriptions_gifting_gifting_checkbox_text', [ __CLASS__, 'default_gifting_checkbox_text' ] );
 		\add_filter( 'newpack_reader_activation_reader_is_without_password', [ __CLASS__, 'is_reader_without_password' ], 10, 2 );
+		\add_filter( 'wcs_view_subscription_actions', [ __CLASS__, 'view_subscription_actions' ], 12, 3 );
 	}
 
 	/**
@@ -79,6 +80,24 @@ class WooCommerce_Subscriptions_Gifting {
 			return 'true' === $user_needs_account_update;
 		}
 		return $is_reader_without_password;
+	}
+
+	/**
+	 * Remove actions from the gifted subscription page.
+	 *
+	 * Only the purchaser of the subscription should see the actions.
+	 *
+	 * @param array            $actions      Actions.
+	 * @param \WC_Subscription $subscription Subscription.
+	 * @param int              $user_id      The user ID.
+	 *
+	 * @return array
+	 */
+	public static function view_subscription_actions( $actions, $subscription, $user_id ) {
+		if ( function_exists( 'is_account_page' ) && is_account_page() && $subscription->get_customer_id() !== $user_id ) {
+			return [];
+		}
+		return $actions;
 	}
 }
 WooCommerce_Subscriptions_Gifting::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

NPPD-1055

Removes actions from the gifted subscription page, as the recipient does not have access to run them.

### How to test the changes in this Pull Request:

1. While on trunk, gift a subscription and sign in as the recipient
2. Visit My Account and access the subscription page
3. Try to "Cancel" the subscription
4. Confirm you get an error
5. Checkout this branch and refresh the subscription page
6. Confirm the actions are not rendered
7. Sign in as the purchaser and visit the subscription page
8. Confirm that the actions render and that you can cancel it

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->