### PR TITLE
feat(content-gating): add Content Gate settings page

### DIFF
--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -430,7 +430,7 @@ class Content_Gate {
 	 *
 	 * @return bool
 	 */
-	public static function has_metering( $post_type = self::GATE_CPT ) {
+	public static function is_metering_enabled( $post_type = self::GATE_CPT ) {
 		$gates = self::get_gates( $post_type );
 		foreach ( $gates as $gate ) {
 			if ( $gate['metering']['enabled'] ) {

--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -406,6 +406,23 @@ class Content_Gate {
 	}
 
 	/**
+	 * Whether any gates of the given type has metering enabled.
+	 *
+	 * @param string $post_type Post type.
+	 *
+	 * @return bool
+	 */
+	public static function has_metering( $post_type = self::GATE_CPT ) {
+		$gates = self::get_gates( $post_type );
+		foreach ( $gates as $gate ) {
+			if ( $gate['metering']['enabled'] ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
 	 * Public method for marking the gate as rendered.
 	 */
 	public static function mark_gate_as_rendered() {

--- a/includes/content-gate/class-metering-countdown.php
+++ b/includes/content-gate/class-metering-countdown.php
@@ -49,10 +49,10 @@ class Metering_Countdown {
 	public static function get_settings( $key = null ) {
 		$settings = self::get_default_settings();
 		if ( $key && isset( $settings[ $key ] ) ) {
-			return get_option( self::OPTION_PREFIX . $key, $settings[ $key ] );
+			return self::sanitize_setting( $key, get_option( self::OPTION_PREFIX . $key, $settings[ $key ] ) );
 		}
 		foreach ( $settings as $key => $value ) {
-			$settings[ $key ] = get_option( self::OPTION_PREFIX . $key, $value );
+			$settings[ $key ] = self::sanitize_setting( $key, get_option( self::OPTION_PREFIX . $key, $value ) );
 		}
 		return $settings;
 	}
@@ -93,6 +93,9 @@ class Metering_Countdown {
 	public static function update_settings( $settings ) {
 		$current_settings = self::get_settings();
 		foreach ( $settings as $key => $value ) {
+			if ( ! isset( $current_settings[ $key ] ) ) {
+				continue;
+			}
 			$sanitized = self::sanitize_setting( $key, $value );
 			if ( is_wp_error( $sanitized ) ) {
 				return $sanitized;

--- a/includes/wizards/audience/class-audience-content-gates.php
+++ b/includes/wizards/audience/class-audience-content-gates.php
@@ -98,6 +98,17 @@ class Audience_Content_Gates extends Wizard {
 				'available_content_rules' => Content_Gate::get_content_rules(),
 			]
 		);
+
+		\wp_localize_script(
+			'newspack-wizards',
+			'newspackAudience',
+			[
+				'content_gifting' => [
+					'can_use_gifting' => Content_Gifting::can_use_gifting( true ),
+					'has_metering'    => Content_Gate::has_metering(),
+				],
+			]
+		);
 	}
 
 	/**
@@ -142,6 +153,29 @@ class Audience_Content_Gates extends Wizard {
 				'methods'             => 'GET',
 				'callback'            => [ $this, 'get_config' ],
 				'permission_callback' => [ $this, 'api_permissions_check' ],
+			]
+		);
+
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->slug . '/config',
+			[
+				'methods'             => 'POST',
+				'callback'            => [ $this, 'update_config' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+				'args'                => [
+					'config' => [
+						'type'       => 'object',
+						'properties' => [
+							'countdown_banner' => [
+								'type' => 'object',
+							],
+							'content_gifting'  => [
+								'type' => 'object',
+							],
+						],
+					],
+				],
 			]
 		);
 
@@ -427,6 +461,51 @@ class Audience_Content_Gates extends Wizard {
 			],
 		];
 		return rest_ensure_response( $config );
+	}
+
+	/**
+	 * Update the config.
+	 *
+	 * @param \WP_REST_Request $request The request object.
+	 *
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function update_config( $request ) {
+		$args = $request->get_params();
+
+		if ( isset( $args['countdown_banner'] ) ) {
+			Metering_Countdown::update_settings( $args['countdown_banner'] );
+		}
+		if ( isset( $args['content_gifting'] ) ) {
+			if ( isset( $args['content_gifting']['enabled'] ) ) {
+				Content_Gifting::set_enabled( (bool) $args['content_gifting']['enabled'] );
+			}
+			if ( isset( $args['content_gifting']['limit'] ) ) {
+				Content_Gifting::set_gifting_limit( (int) $args['content_gifting']['limit'] );
+			}
+			if ( isset( $args['content_gifting']['expiration_time'] ) ) {
+				Content_Gifting::set_expiration_time( (int) $args['content_gifting']['expiration_time'] );
+			}
+			if ( isset( $args['content_gifting']['expiration_time_unit'] ) ) {
+				Content_Gifting::set_expiration_time_unit( sanitize_text_field( $args['content_gifting']['expiration_time_unit'] ) );
+			}
+			if ( isset( $args['content_gifting']['interval'] ) ) {
+				Content_Gifting::set_gifting_reset_interval( sanitize_text_field( $args['content_gifting']['interval'] ) );
+			}
+			if ( isset( $args['content_gifting']['cta_label'] ) ) {
+				Content_Gifting_CTA::set_cta_label( sanitize_text_field( $args['content_gifting']['cta_label'] ) );
+			}
+			if ( isset( $args['content_gifting']['button_label'] ) ) {
+				Content_Gifting_CTA::set_button_label( sanitize_text_field( $args['content_gifting']['button_label'] ) );
+			}
+			if ( isset( $args['content_gifting']['cta_url'] ) ) {
+				Content_Gifting_CTA::set_cta_url( sanitize_text_field( $args['content_gifting']['cta_url'] ) );
+			}
+			if ( isset( $args['content_gifting']['style'] ) ) {
+				Content_Gifting_CTA::set_style( sanitize_text_field( $args['content_gifting']['style'] ) );
+			}
+		}
+		return rest_ensure_response( self::get_config() );
 	}
 
 	/**

--- a/includes/wizards/audience/class-audience-content-gates.php
+++ b/includes/wizards/audience/class-audience-content-gates.php
@@ -158,22 +158,65 @@ class Audience_Content_Gates extends Wizard {
 
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
-			'/wizard/' . $this->slug . '/config',
+			'/wizard/' . $this->slug . '/content-gifting',
 			[
 				'methods'             => 'POST',
-				'callback'            => [ $this, 'update_config' ],
+				'callback'            => [ $this, 'update_content_gifting' ],
 				'permission_callback' => [ $this, 'api_permissions_check' ],
 				'args'                => [
-					'config' => [
-						'type'       => 'object',
-						'properties' => [
-							'countdown_banner' => [
-								'type' => 'object',
-							],
-							'content_gifting'  => [
-								'type' => 'object',
-							],
-						],
+					'button_label'         => [
+						'type' => 'string',
+					],
+					'cta_label'            => [
+						'type' => 'string',
+					],
+					'cta_url'              => [
+						'type' => 'string',
+					],
+					'enabled'              => [
+						'type' => 'boolean',
+					],
+					'expiration_time'      => [
+						'type' => 'integer',
+					],
+					'expiration_time_unit' => [
+						'type' => 'string',
+					],
+					'interval'             => [
+						'type' => 'string',
+					],
+					'limit'                => [
+						'type' => 'integer',
+					],
+					'style'                => [
+						'type' => 'string',
+					],
+				],
+			]
+		);
+
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->slug . '/countdown-banner',
+			[
+				'methods'             => 'POST',
+				'callback'            => [ $this, 'update_countdown_banner' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+				'args'                => [
+					'button_label' => [
+						'type' => 'string',
+					],
+					'cta_label'    => [
+						'type' => 'string',
+					],
+					'cta_url'      => [
+						'type' => 'string',
+					],
+					'enabled'      => [
+						'type' => 'boolean',
+					],
+					'style'        => [
+						'type' => 'string',
 					],
 				],
 			]
@@ -471,48 +514,56 @@ class Audience_Content_Gates extends Wizard {
 	}
 
 	/**
-	 * Update the config.
+	 * Update content gifting settings.
 	 *
 	 * @param \WP_REST_Request $request The request object.
 	 *
 	 * @return \WP_REST_Response|\WP_Error
 	 */
-	public function update_config( $request ) {
+	public function update_content_gifting( $request ) {
 		$args = $request->get_params();
 
-		if ( isset( $args['countdown_banner'] ) ) {
-			Metering_Countdown::update_settings( $args['countdown_banner'] );
+		if ( isset( $args['enabled'] ) ) {
+			Content_Gifting::set_enabled( (bool) $args['enabled'] );
 		}
-		if ( isset( $args['content_gifting'] ) ) {
-			if ( isset( $args['content_gifting']['enabled'] ) ) {
-				Content_Gifting::set_enabled( (bool) $args['content_gifting']['enabled'] );
-			}
-			if ( isset( $args['content_gifting']['limit'] ) ) {
-				Content_Gifting::set_gifting_limit( (int) $args['content_gifting']['limit'] );
-			}
-			if ( isset( $args['content_gifting']['expiration_time'] ) ) {
-				Content_Gifting::set_expiration_time( (int) $args['content_gifting']['expiration_time'] );
-			}
-			if ( isset( $args['content_gifting']['expiration_time_unit'] ) ) {
-				Content_Gifting::set_expiration_time_unit( sanitize_text_field( $args['content_gifting']['expiration_time_unit'] ) );
-			}
-			if ( isset( $args['content_gifting']['interval'] ) ) {
-				Content_Gifting::set_gifting_reset_interval( sanitize_text_field( $args['content_gifting']['interval'] ) );
-			}
-			if ( isset( $args['content_gifting']['cta_label'] ) ) {
-				Content_Gifting_CTA::set_cta_label( sanitize_text_field( $args['content_gifting']['cta_label'] ) );
-			}
-			if ( isset( $args['content_gifting']['button_label'] ) ) {
-				Content_Gifting_CTA::set_button_label( sanitize_text_field( $args['content_gifting']['button_label'] ) );
-			}
-			if ( isset( $args['content_gifting']['cta_url'] ) ) {
-				Content_Gifting_CTA::set_cta_url( sanitize_text_field( $args['content_gifting']['cta_url'] ) );
-			}
-			if ( isset( $args['content_gifting']['style'] ) ) {
-				Content_Gifting_CTA::set_style( sanitize_text_field( $args['content_gifting']['style'] ) );
-			}
+		if ( isset( $args['limit'] ) ) {
+			Content_Gifting::set_gifting_limit( (int) $args['limit'] );
 		}
-		return rest_ensure_response( self::get_config() );
+		if ( isset( $args['expiration_time'] ) ) {
+			Content_Gifting::set_expiration_time( (int) $args['expiration_time'] );
+		}
+		if ( isset( $args['expiration_time_unit'] ) ) {
+			Content_Gifting::set_expiration_time_unit( sanitize_text_field( $args['expiration_time_unit'] ) );
+		}
+		if ( isset( $args['interval'] ) ) {
+			Content_Gifting::set_gifting_reset_interval( sanitize_text_field( $args['interval'] ) );
+		}
+		if ( isset( $args['cta_label'] ) ) {
+			Content_Gifting_CTA::set_cta_label( sanitize_text_field( $args['cta_label'] ) );
+		}
+		if ( isset( $args['button_label'] ) ) {
+			Content_Gifting_CTA::set_button_label( sanitize_text_field( $args['button_label'] ) );
+		}
+		if ( isset( $args['cta_url'] ) ) {
+			Content_Gifting_CTA::set_cta_url( sanitize_text_field( $args['cta_url'] ) );
+		}
+		if ( isset( $args['style'] ) ) {
+			Content_Gifting_CTA::set_style( sanitize_text_field( $args['style'] ) );
+		}
+		return rest_ensure_response( Content_Gifting::get_settings() );
+	}
+
+	/**
+	 * Update countdown banner settings.
+	 *
+	 * @param \WP_REST_Request $request The request object.
+	 *
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function update_countdown_banner( $request ) {
+		$args = $request->get_params();
+		$updated = Metering_Countdown::update_settings( $args );
+		return rest_ensure_response( $updated );
 	}
 
 	/**

--- a/includes/wizards/audience/class-audience-content-gates.php
+++ b/includes/wizards/audience/class-audience-content-gates.php
@@ -104,7 +104,7 @@ class Audience_Content_Gates extends Wizard {
 			'newspackAudience',
 			[
 				'content_gifting' => [
-					'can_use_gifting' => Content_Gifting::can_use_gifting( true ),
+					'can_use_gifting' => Content_Gifting::can_use_gifting(),
 					'has_metering'    => Content_Gate::has_metering(),
 				],
 			]

--- a/includes/wizards/audience/class-audience-content-gates.php
+++ b/includes/wizards/audience/class-audience-content-gates.php
@@ -562,8 +562,7 @@ class Audience_Content_Gates extends Wizard {
 	 */
 	public function update_countdown_banner( $request ) {
 		$args = $request->get_params();
-		$updated = Metering_Countdown::update_settings( $args );
-		return rest_ensure_response( $updated );
+		return rest_ensure_response( Metering_Countdown::update_settings( $args ) );
 	}
 
 	/**

--- a/includes/wizards/audience/class-audience-content-gates.php
+++ b/includes/wizards/audience/class-audience-content-gates.php
@@ -140,7 +140,7 @@ class Audience_Content_Gates extends Wizard {
 			'/wizard/' . $this->slug,
 			[
 				'methods'             => 'GET',
-				'callback'            => [ $this, 'get_gates' ],
+				'callback'            => [ $this, 'get_config' ],
 				'permission_callback' => [ $this, 'api_permissions_check' ],
 			]
 		);
@@ -418,8 +418,15 @@ class Audience_Content_Gates extends Wizard {
 	 *
 	 * @return \WP_REST_Response
 	 */
-	public function get_gates() {
-		return rest_ensure_response( Content_Gate::get_gates() );
+	public function get_config() {
+		$config = [
+			'gates'  => Content_Gate::get_gates(),
+			'config' => [
+				'countdown_banner' => Metering_Countdown::get_settings(),
+				'content_gifting'  => Content_Gifting::get_settings(),
+			],
+		];
+		return rest_ensure_response( $config );
 	}
 
 	/**

--- a/includes/wizards/audience/class-audience-content-gates.php
+++ b/includes/wizards/audience/class-audience-content-gates.php
@@ -105,7 +105,7 @@ class Audience_Content_Gates extends Wizard {
 			[
 				'content_gifting' => [
 					'can_use_gifting' => Content_Gifting::can_use_gifting(),
-					'has_metering'    => Content_Gate::has_metering(),
+					'has_metering'    => Content_Gate::is_metering_enabled(),
 				],
 			]
 		);

--- a/includes/wizards/audience/class-audience-wizard.php
+++ b/includes/wizards/audience/class-audience-wizard.php
@@ -108,18 +108,9 @@ class Audience_Wizard extends Wizard {
 
 		$data['is_skipped_campaign_setup'] = Reader_Activation::is_skipped( 'ras_campaign' );
 
-		$gates        = Memberships::get_gates();
-		$has_metering = false;
-		foreach ( $gates as $gate ) {
-			if ( $gate['status'] === 'publish' && isset( $gate['metering'] ) && $gate['metering']['enabled'] ) {
-				$has_metering = true;
-				break;
-			}
-		}
-
 		$data['content_gifting'] = [
 			'can_use_gifting' => Content_Gifting::can_use_gifting( true ),
-			'has_metering'    => $has_metering,
+			'has_metering'    => Content_Gate::has_metering( Memberships::GATE_CPT ),
 		];
 
 		wp_enqueue_script( 'newspack-wizards' );

--- a/includes/wizards/audience/class-audience-wizard.php
+++ b/includes/wizards/audience/class-audience-wizard.php
@@ -110,7 +110,7 @@ class Audience_Wizard extends Wizard {
 
 		$data['content_gifting'] = [
 			'can_use_gifting' => Content_Gifting::can_use_gifting( true ),
-			'has_metering'    => Content_Gate::has_metering( Memberships::GATE_CPT ),
+			'has_metering'    => Content_Gate::is_metering_enabled( Memberships::GATE_CPT ),
 		];
 
 		wp_enqueue_script( 'newspack-wizards' );

--- a/packages/components/src/action-card/action-card.d.ts
+++ b/packages/components/src/action-card/action-card.d.ts
@@ -14,6 +14,7 @@ export interface ActionCardProps {
 	isMedium?: boolean;
 	disabled?: boolean | string;
 	hasGreyHeader?: boolean;
+	heading?: number;
 	toggleChecked?: boolean;
 	toggleOnChange?: (a: boolean) => void;
 	togglePosition?: 'leading' | 'trailing';

--- a/packages/components/src/action-card/index.js
+++ b/packages/components/src/action-card/index.js
@@ -36,6 +36,7 @@ const ActionCard = ( {
 	collapse,
 	disabled,
 	title,
+	heading = 2,
 	description,
 	handoff,
 	editLink,
@@ -121,6 +122,7 @@ const ActionCard = ( {
 	const hasInternalLink = href && href.indexOf( 'http' ) !== 0;
 	const isDisplayingSecondaryAction = secondaryActionText && onSecondaryActionClick;
 	const badges = ! Array.isArray( badge ) && badge ? [ badge ] : badge;
+	const HeadingTag = `h${ heading }`;
 
 	const cardContent = (
 		<>
@@ -151,7 +153,7 @@ const ActionCard = ( {
 				) }
 				<div className="newspack-action-card__region newspack-action-card__region-center">
 					<Grid columns={ 1 } gutter={ 8 } noMargin>
-						<h2>
+						<HeadingTag>
 							<span className="newspack-action-card__title" { ...titleProps }>
 								{ titleLink && <a href={ titleLink }>{ title }</a> }
 								{ ! titleLink && expandable && (
@@ -170,7 +172,7 @@ const ActionCard = ( {
 										{ badgeText }
 									</span>
 								) ) }
-						</h2>
+						</HeadingTag>
 						{ description && (
 							<p>
 								{ typeof description === 'string' && description }

--- a/src/wizards/audience/views/content-gates/content-gate-settings.tsx
+++ b/src/wizards/audience/views/content-gates/content-gate-settings.tsx
@@ -58,7 +58,7 @@ export default function ContentGateSettings( { gate, onDelete, onSave }: Content
 				},
 			}
 		);
-	}, [ gate, accessRules, contentRules, metering, status, wizardApiFetch, onSave ] );
+	}, [ accessRules, contentRules, metering, status ] );
 
 	// Update status and trigger save.
 	useEffect( () => {
@@ -68,20 +68,20 @@ export default function ContentGateSettings( { gate, onDelete, onSave }: Content
 		handleSave();
 	}, [ isEditingStatus, status, handleSave ] );
 
-	const handleDelete = useCallback( () => onDelete( gate.id ), [ gate.id, onDelete ] );
-	const handleRestore = useCallback( () => {
+	const handleDelete = () => onDelete( gate.id );
+	const handleRestore = () => {
 		setIsEditingStatus( true );
 		setStatus( 'draft' );
-	}, [] );
+	};
 
-	const handlePublish = useCallback( () => {
+	const handlePublish = () => {
 		// eslint-disable-next-line no-alert
 		if ( ! confirm( __( 'Are you sure you want to publish this content gate?', 'newspack-plugin' ) ) ) {
 			return;
 		}
 		setIsEditingStatus( true );
 		setStatus( 'publish' );
-	}, [] );
+	};
 
 	return (
 		<>

--- a/src/wizards/audience/views/content-gates/content-gates.tsx
+++ b/src/wizards/audience/views/content-gates/content-gates.tsx
@@ -13,7 +13,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { Button, Card, Modal, SectionHeader, TextControl } from '../../../../../packages/components/src';
+import { Button, Card, Modal, Notice, SectionHeader, TextControl } from '../../../../../packages/components/src';
 import { useWizardData } from '../../../../../packages/components/src/wizard/store/utils';
 import { useWizardApiFetch } from '../../../hooks/use-wizard-api-fetch';
 import WizardsActionCard from '../../../wizards-action-card';
@@ -53,13 +53,21 @@ const getGateStatusBadgeLevel = ( status: GateStatus ) => {
 
 const ContentGates = () => {
 	const wizardData = useWizardData( 'newspack-audience-content-gates' ) as WizardData;
-	const { wizardApiFetch, isFetching } = useWizardApiFetch( AUDIENCE_CONTENT_GATES_WIZARD_SLUG );
-	const [ gates, setGates ] = useState< Gate[] >( Array.isArray( wizardData?.gates ) ? wizardData?.gates : [] );
+	const { wizardApiFetch, isFetching, errorMessage, resetError } = useWizardApiFetch( AUDIENCE_CONTENT_GATES_WIZARD_SLUG );
+	const [ hasCompletedInitialFetch, setHasCompletedInitialFetch ] = useState( false );
+	const [ gates, setGates ] = useState< Gate[] >( Array.isArray( wizardData?.gates ) ? wizardData.gates : [] );
 	const [ showModal, setShowModal ] = useState( false );
 	const [ newGateName, setNewGateName ] = useState( '' );
 	const [ isInFlight, setIsInFlight ] = useState( false );
-
+	const [ error, setError ] = useState< string | null >( null );
 	const ref = useRef( null );
+
+	useEffect( () => {
+		if ( Array.isArray( wizardData?.gates ) && ! hasCompletedInitialFetch ) {
+			setGates( wizardData.gates );
+			setHasCompletedInitialFetch( true );
+		}
+	}, [ wizardData, hasCompletedInitialFetch ] );
 
 	useEffect( () => {
 		if ( isFetching ) {
@@ -70,15 +78,21 @@ const ContentGates = () => {
 	}, [ isFetching ] );
 
 	useEffect( () => {
-		if ( Array.isArray( wizardData?.gates ) ) {
-			setGates( wizardData?.gates );
+		if ( errorMessage ) {
+			setError( errorMessage );
 		}
-	}, [ wizardData ] );
+	}, [ errorMessage ] );
+
+	const resetErrors = () => {
+		setError( null );
+		resetError();
+	};
 
 	const handleCreateGate = () => {
 		if ( isInFlight ) {
 			return;
 		}
+		resetErrors();
 		setIsInFlight( true );
 		wizardApiFetch< Gate >(
 			{
@@ -100,9 +114,6 @@ const ContentGates = () => {
 					setShowModal( false );
 					setNewGateName( '' );
 				},
-				onError( error ) {
-					console.error( error ); // eslint-disable-line no-console
-				},
 				onFinally() {
 					setIsInFlight( false );
 				},
@@ -118,6 +129,7 @@ const ContentGates = () => {
 				return;
 			}
 		}
+		resetErrors();
 		wizardApiFetch(
 			{
 				path: `/newspack/v1/wizard/${ AUDIENCE_CONTENT_GATES_WIZARD_SLUG }/${ id }`,
@@ -138,9 +150,6 @@ const ContentGates = () => {
 						);
 					}
 				},
-				onError( error ) {
-					console.error( error ); // eslint-disable-line no-console
-				},
 			}
 		);
 	};
@@ -152,6 +161,7 @@ const ContentGates = () => {
 		const oldGates = [ ...gates ];
 		setGates( updates );
 		setIsInFlight( true );
+		resetErrors();
 		apiFetch< Gate >( {
 			path: `/newspack/v1/wizard/${ AUDIENCE_CONTENT_GATES_WIZARD_SLUG }/priority`,
 			method: 'POST',
@@ -159,8 +169,8 @@ const ContentGates = () => {
 				gates: updates.map( g => ( { id: g.id, priority: g.priority } ) ),
 			},
 		} )
-			.catch( ( error: WpFetchError ) => {
-				console.error( error ); // eslint-disable-line no-console
+			.catch( ( fetchError: WpFetchError ) => {
+				setError( fetchError.message );
 				setGates( oldGates );
 			} )
 			.finally( () => setIsInFlight( false ) );
@@ -172,6 +182,7 @@ const ContentGates = () => {
 
 	return (
 		<>
+			{ error && <Notice isError noticeText={ error } /> }
 			<Card noBorder headerActions>
 				<SectionHeader heading={ 1 } title={ __( 'Content Gates', 'newspack-plugin' ) } noMargin />
 				<Button variant="secondary" onClick={ () => setShowModal( true ) }>

--- a/src/wizards/audience/views/content-gates/content-gates.tsx
+++ b/src/wizards/audience/views/content-gates/content-gates.tsx
@@ -54,24 +54,12 @@ const getGateStatusBadgeLevel = ( status: GateStatus ) => {
 const ContentGates = () => {
 	const wizardData = useWizardData( 'newspack-audience-content-gates' ) as WizardData;
 	const { wizardApiFetch, isFetching } = useWizardApiFetch( AUDIENCE_CONTENT_GATES_WIZARD_SLUG );
-	const [ hasCompletedInitialFetch, setHasCompletedInitialFetch ] = useState( false );
-	const [ gates, setGates ] = useState< Gate[] >( Array.isArray( wizardData ) ? wizardData : [] );
+	const [ gates, setGates ] = useState< Gate[] >( Array.isArray( wizardData?.gates ) ? wizardData?.gates : [] );
 	const [ showModal, setShowModal ] = useState( false );
 	const [ newGateName, setNewGateName ] = useState( '' );
 	const [ isInFlight, setIsInFlight ] = useState( false );
 
 	const ref = useRef( null );
-
-	useEffect( () => {
-		if ( Array.isArray( wizardData ) && ! hasCompletedInitialFetch ) {
-			setGates( wizardData );
-			setHasCompletedInitialFetch( true );
-			return;
-		}
-		if ( wizardData?.error ) {
-			console.error( wizardData.error ); // eslint-disable-line no-console
-		}
-	}, [ wizardData, hasCompletedInitialFetch ] );
 
 	useEffect( () => {
 		if ( isFetching ) {
@@ -80,6 +68,12 @@ const ContentGates = () => {
 			setIsInFlight( false );
 		}
 	}, [ isFetching ] );
+
+	useEffect( () => {
+		if ( Array.isArray( wizardData?.gates ) ) {
+			setGates( wizardData?.gates );
+		}
+	}, [ wizardData ] );
 
 	const handleCreateGate = () => {
 		if ( isInFlight ) {

--- a/src/wizards/audience/views/content-gates/content-gates.tsx
+++ b/src/wizards/audience/views/content-gates/content-gates.tsx
@@ -190,7 +190,7 @@ const ContentGates = () => {
 	};
 
 	return (
-		<>
+		<div className="newspack-content-gates__gates">
 			{ error && <Notice isError noticeText={ error } /> }
 			<Card noBorder headerActions>
 				<SectionHeader heading={ 1 } title={ __( 'Content Gates', 'newspack-plugin' ) } noMargin />
@@ -268,7 +268,7 @@ const ContentGates = () => {
 					);
 				} ) }
 			</div>
-		</>
+		</div>
 	);
 };
 export default ContentGates;

--- a/src/wizards/audience/views/content-gates/content-gates.tsx
+++ b/src/wizards/audience/views/content-gates/content-gates.tsx
@@ -6,6 +6,7 @@
  * WordPress dependencies.
  */
 import apiFetch from '@wordpress/api-fetch';
+import { useDispatch } from '@wordpress/data';
 import { useEffect, useRef, useState } from '@wordpress/element';
 import { ENTER } from '@wordpress/keycodes';
 import { __ } from '@wordpress/i18n';
@@ -15,6 +16,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { Button, Card, Modal, Notice, SectionHeader, TextControl } from '../../../../../packages/components/src';
 import { useWizardData } from '../../../../../packages/components/src/wizard/store/utils';
+import { WIZARD_STORE_NAMESPACE } from '../../../../../packages/components/src/wizard/store';
 import { useWizardApiFetch } from '../../../hooks/use-wizard-api-fetch';
 import WizardsActionCard from '../../../wizards-action-card';
 import ContentGateSettings from './content-gate-settings';
@@ -53,21 +55,23 @@ const getGateStatusBadgeLevel = ( status: GateStatus ) => {
 
 const ContentGates = () => {
 	const wizardData = useWizardData( 'newspack-audience-content-gates' ) as WizardData;
+	const { updateWizardSettings } = useDispatch( WIZARD_STORE_NAMESPACE );
 	const { wizardApiFetch, isFetching, errorMessage, resetError } = useWizardApiFetch( AUDIENCE_CONTENT_GATES_WIZARD_SLUG );
-	const [ hasCompletedInitialFetch, setHasCompletedInitialFetch ] = useState( false );
-	const [ gates, setGates ] = useState< Gate[] >( Array.isArray( wizardData?.gates ) ? wizardData.gates : [] );
 	const [ showModal, setShowModal ] = useState( false );
 	const [ newGateName, setNewGateName ] = useState( '' );
 	const [ isInFlight, setIsInFlight ] = useState( false );
 	const [ error, setError ] = useState< string | null >( null );
 	const ref = useRef( null );
 
-	useEffect( () => {
-		if ( Array.isArray( wizardData?.gates ) && ! hasCompletedInitialFetch ) {
-			setGates( wizardData.gates );
-			setHasCompletedInitialFetch( true );
-		}
-	}, [ wizardData, hasCompletedInitialFetch ] );
+	const gates = ( wizardData?.gates || [] ) as Gate[];
+
+	const onChange = ( newGates: Gate[] ) => {
+		updateWizardSettings( {
+			slug: AUDIENCE_CONTENT_GATES_WIZARD_SLUG,
+			path: [ 'gates' ],
+			value: newGates,
+		} );
+	};
 
 	useEffect( () => {
 		if ( isFetching ) {
@@ -104,13 +108,14 @@ const ContentGates = () => {
 			},
 			{
 				onSuccess( data ) {
-					setGates( [
+					const newGates = [
 						...gates.map( g => {
 							g.isExpanded = false;
 							return g;
 						} ),
 						{ ...data, isExpanded: true },
-					] );
+					];
+					onChange( newGates );
 					setShowModal( false );
 					setNewGateName( '' );
 				},
@@ -138,16 +143,16 @@ const ContentGates = () => {
 			{
 				onSuccess() {
 					if ( currentStatus === 'trash' ) {
-						setGates( gates.filter( g => g.id !== id ) );
+						const newGates = gates.filter( g => g.id !== id );
+						onChange( newGates );
 					} else {
-						setGates(
-							gates.map( g => {
-								if ( g.id === id ) {
-									g.status = 'trash';
-								}
-								return g;
-							} )
-						);
+						const newGates = gates.map( g => {
+							if ( g.id === id ) {
+								g.status = 'trash';
+							}
+							return g;
+						} );
+						onChange( newGates );
 					}
 				},
 			}
@@ -159,7 +164,7 @@ const ContentGates = () => {
 			return;
 		}
 		const oldGates = [ ...gates ];
-		setGates( updates );
+		onChange( updates );
 		setIsInFlight( true );
 		resetErrors();
 		apiFetch< Gate >( {
@@ -171,13 +176,17 @@ const ContentGates = () => {
 		} )
 			.catch( ( fetchError: WpFetchError ) => {
 				setError( fetchError.message );
-				setGates( oldGates );
+				onChange( oldGates );
 			} )
 			.finally( () => setIsInFlight( false ) );
 	};
 
 	const handleSaveGate = ( gate: Gate ) => {
-		setGates( gates.map( g => ( g.id === gate.id ? gate : g ) ) );
+		if ( isInFlight ) {
+			return;
+		}
+		const newGates = gates.map( g => ( g.id === gate.id ? gate : g ) );
+		onChange( newGates );
 	};
 
 	return (

--- a/src/wizards/audience/views/content-gates/content-gifting.tsx
+++ b/src/wizards/audience/views/content-gates/content-gifting.tsx
@@ -35,14 +35,14 @@ const ContentGiftingSettings = () => {
 		resetError();
 		wizardApiFetch(
 			{
-				path: '/newspack/v1/wizard/newspack-audience-content-gates/config',
+				path: '/newspack/v1/wizard/newspack-audience-content-gates/content-gifting',
 				method: 'POST',
 				quiet: true,
-				data: newConfig,
+				data: newConfig.content_gifting,
 			},
 			{
 				onSuccess( data ) {
-					onChange( data.config );
+					onChange( { ...wizardData?.config, content_gifting: data } );
 				},
 			}
 		);

--- a/src/wizards/audience/views/content-gates/content-gifting.tsx
+++ b/src/wizards/audience/views/content-gates/content-gifting.tsx
@@ -51,7 +51,7 @@ const ContentGiftingSettings = () => {
 	return (
 		<>
 			{ errorMessage && <Notice isError noticeText={ errorMessage } /> }
-			<ContentGifting config={ wizardData?.config || {} } setConfig={ onChange } updateConfig={ updateConfig } />
+			<ContentGifting config={ wizardData?.config || {} } setConfig={ onChange } updateConfig={ updateConfig } noBorder />
 		</>
 	);
 };

--- a/src/wizards/audience/views/content-gates/content-gifting.tsx
+++ b/src/wizards/audience/views/content-gates/content-gifting.tsx
@@ -1,5 +1,5 @@
 /**
- * Content Gate component.
+ * Content Gifting settings page.
  */
 
 /**
@@ -15,11 +15,10 @@ import { useWizardData } from '../../../../../packages/components/src/wizard/sto
 import { WIZARD_STORE_NAMESPACE } from '../../../../../packages/components/src/wizard/store';
 import { useWizardApiFetch } from '../../../hooks/use-wizard-api-fetch';
 import ContentGifting from '../setup/content-gifting';
-import CountdownBanner from '../setup/countdown-banner';
 import { AUDIENCE_CONTENT_GATES_WIZARD_SLUG } from './consts';
 import './style.scss';
 
-const ContentGateSettings = () => {
+const ContentGiftingSettings = () => {
 	const wizardData = useWizardData( AUDIENCE_CONTENT_GATES_WIZARD_SLUG ) as WizardData;
 	const { updateWizardSettings } = useDispatch( WIZARD_STORE_NAMESPACE );
 	const { wizardApiFetch, errorMessage, resetError } = useWizardApiFetch( AUDIENCE_CONTENT_GATES_WIZARD_SLUG );
@@ -53,9 +52,8 @@ const ContentGateSettings = () => {
 		<>
 			{ errorMessage && <Notice isError noticeText={ errorMessage } /> }
 			<ContentGifting config={ wizardData?.config || {} } setConfig={ onChange } updateConfig={ updateConfig } />
-			<CountdownBanner config={ wizardData?.config || {} } setConfig={ onChange } updateConfig={ updateConfig } />
 		</>
 	);
 };
 
-export default ContentGateSettings;
+export default ContentGiftingSettings;

--- a/src/wizards/audience/views/content-gates/countdown-banner.tsx
+++ b/src/wizards/audience/views/content-gates/countdown-banner.tsx
@@ -35,14 +35,14 @@ const CountdownBannerSettings = () => {
 		resetError();
 		wizardApiFetch(
 			{
-				path: '/newspack/v1/wizard/newspack-audience-content-gates/config',
+				path: '/newspack/v1/wizard/newspack-audience-content-gates/countdown-banner',
 				method: 'POST',
 				quiet: true,
-				data: newConfig,
+				data: newConfig.countdown_banner,
 			},
 			{
 				onSuccess( data ) {
-					onChange( data.config );
+					onChange( { ...wizardData?.config, countdown_banner: data } );
 				},
 			}
 		);

--- a/src/wizards/audience/views/content-gates/countdown-banner.tsx
+++ b/src/wizards/audience/views/content-gates/countdown-banner.tsx
@@ -51,7 +51,7 @@ const CountdownBannerSettings = () => {
 	return (
 		<>
 			{ errorMessage && <Notice isError noticeText={ errorMessage } /> }
-			<CountdownBanner config={ wizardData?.config || {} } setConfig={ onChange } updateConfig={ updateConfig } />
+			<CountdownBanner config={ wizardData?.config || {} } setConfig={ onChange } updateConfig={ updateConfig } noBorder />
 		</>
 	);
 };

--- a/src/wizards/audience/views/content-gates/countdown-banner.tsx
+++ b/src/wizards/audience/views/content-gates/countdown-banner.tsx
@@ -1,0 +1,59 @@
+/**
+ * Metered Countdown settings page.
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { useDispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { Notice } from '../../../../../packages/components/src';
+import { useWizardData } from '../../../../../packages/components/src/wizard/store/utils';
+import { WIZARD_STORE_NAMESPACE } from '../../../../../packages/components/src/wizard/store';
+import { useWizardApiFetch } from '../../../hooks/use-wizard-api-fetch';
+import CountdownBanner from '../setup/countdown-banner';
+import { AUDIENCE_CONTENT_GATES_WIZARD_SLUG } from './consts';
+import './style.scss';
+
+const CountdownBannerSettings = () => {
+	const wizardData = useWizardData( AUDIENCE_CONTENT_GATES_WIZARD_SLUG ) as WizardData;
+	const { updateWizardSettings } = useDispatch( WIZARD_STORE_NAMESPACE );
+	const { wizardApiFetch, errorMessage, resetError } = useWizardApiFetch( AUDIENCE_CONTENT_GATES_WIZARD_SLUG );
+
+	const onChange = ( newConfig: GateSettings ) => {
+		updateWizardSettings( {
+			slug: AUDIENCE_CONTENT_GATES_WIZARD_SLUG,
+			path: [ 'config' ],
+			value: newConfig,
+		} );
+	};
+
+	const updateConfig = ( newConfig: GateSettings ) => {
+		resetError();
+		wizardApiFetch(
+			{
+				path: '/newspack/v1/wizard/newspack-audience-content-gates/config',
+				method: 'POST',
+				quiet: true,
+				data: newConfig,
+			},
+			{
+				onSuccess( data ) {
+					onChange( data.config );
+				},
+			}
+		);
+	};
+
+	return (
+		<>
+			{ errorMessage && <Notice isError noticeText={ errorMessage } /> }
+			<CountdownBanner config={ wizardData?.config || {} } setConfig={ onChange } updateConfig={ updateConfig } />
+		</>
+	);
+};
+
+export default CountdownBannerSettings;

--- a/src/wizards/audience/views/content-gates/index.js
+++ b/src/wizards/audience/views/content-gates/index.js
@@ -8,30 +8,17 @@ import '../../../../shared/js/public-path';
  * WordPress dependencies.
  */
 import { __ } from '@wordpress/i18n';
-import { forwardRef, useEffect, useState } from '@wordpress/element';
+import { forwardRef } from '@wordpress/element';
 
 /**
  * Internal dependencies.
  */
 import { Wizard, withWizard } from '../../../../../packages/components/src';
-import { useWizardData } from '../../../../../packages/components/src/wizard/store/utils';
 import ContentGates from './content-gates';
+import ContentGateSettings from './settings';
 import { AUDIENCE_CONTENT_GATES_WIZARD_SLUG } from './consts';
 
 const AudienceContentGates = ( props, ref ) => {
-	const wizardData = useWizardData( 'newspack-audience-content-gates' );
-	const [ hasCompletedInitialFetch, setHasCompletedInitialFetch ] = useState( false );
-
-	useEffect( () => {
-		if ( Array.isArray( wizardData ) && ! hasCompletedInitialFetch ) {
-			setHasCompletedInitialFetch( true );
-			return;
-		}
-		if ( wizardData?.error ) {
-			console.error( wizardData.error ); // eslint-disable-line no-console
-		}
-	}, [ wizardData, hasCompletedInitialFetch ] );
-
 	return (
 		<Wizard
 			apiSlug={ AUDIENCE_CONTENT_GATES_WIZARD_SLUG }
@@ -41,9 +28,14 @@ const AudienceContentGates = ( props, ref ) => {
 			ref={ ref }
 			sections={ [
 				{
-					label: __( 'Content Gate', 'newspack-plugin' ),
+					label: __( 'Content Gates', 'newspack-plugin' ),
 					path: '/content-gates',
 					render: ContentGates,
+				},
+				{
+					label: __( 'Settings', 'newspack-plugin' ),
+					path: '/settings',
+					render: ContentGateSettings,
 				},
 			] }
 		/>

--- a/src/wizards/audience/views/content-gates/index.js
+++ b/src/wizards/audience/views/content-gates/index.js
@@ -8,16 +8,30 @@ import '../../../../shared/js/public-path';
  * WordPress dependencies.
  */
 import { __ } from '@wordpress/i18n';
-import { forwardRef } from '@wordpress/element';
+import { forwardRef, useEffect, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies.
  */
 import { Wizard, withWizard } from '../../../../../packages/components/src';
+import { useWizardData } from '../../../../../packages/components/src/wizard/store/utils';
 import ContentGates from './content-gates';
 import { AUDIENCE_CONTENT_GATES_WIZARD_SLUG } from './consts';
 
 const AudienceContentGates = ( props, ref ) => {
+	const wizardData = useWizardData( 'newspack-audience-content-gates' );
+	const [ hasCompletedInitialFetch, setHasCompletedInitialFetch ] = useState( false );
+
+	useEffect( () => {
+		if ( Array.isArray( wizardData ) && ! hasCompletedInitialFetch ) {
+			setHasCompletedInitialFetch( true );
+			return;
+		}
+		if ( wizardData?.error ) {
+			console.error( wizardData.error ); // eslint-disable-line no-console
+		}
+	}, [ wizardData, hasCompletedInitialFetch ] );
+
 	return (
 		<Wizard
 			apiSlug={ AUDIENCE_CONTENT_GATES_WIZARD_SLUG }

--- a/src/wizards/audience/views/content-gates/index.js
+++ b/src/wizards/audience/views/content-gates/index.js
@@ -15,7 +15,8 @@ import { forwardRef } from '@wordpress/element';
  */
 import { Wizard, withWizard } from '../../../../../packages/components/src';
 import ContentGates from './content-gates';
-import ContentGateSettings from './settings';
+import ContentGiftingSettings from './content-gifting';
+import CountdownBannerSettings from './countdown-banner';
 import { AUDIENCE_CONTENT_GATES_WIZARD_SLUG } from './consts';
 
 const AudienceContentGates = ( props, ref ) => {
@@ -33,9 +34,14 @@ const AudienceContentGates = ( props, ref ) => {
 					render: ContentGates,
 				},
 				{
-					label: __( 'Settings', 'newspack-plugin' ),
-					path: '/settings',
-					render: ContentGateSettings,
+					label: __( 'Content Gifting', 'newspack-plugin' ),
+					path: '/content-gifting',
+					render: ContentGiftingSettings,
+				},
+				{
+					label: __( 'Metered Countdown', 'newspack-plugin' ),
+					path: '/metered-countdown',
+					render: CountdownBannerSettings,
 				},
 			] }
 		/>

--- a/src/wizards/audience/views/content-gates/settings.tsx
+++ b/src/wizards/audience/views/content-gates/settings.tsx
@@ -1,0 +1,61 @@
+/**
+ * Content Gate component.
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { useDispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { Notice } from '../../../../../packages/components/src';
+import { useWizardData } from '../../../../../packages/components/src/wizard/store/utils';
+import { WIZARD_STORE_NAMESPACE } from '../../../../../packages/components/src/wizard/store';
+import { useWizardApiFetch } from '../../../hooks/use-wizard-api-fetch';
+import ContentGifting from '../setup/content-gifting';
+import CountdownBanner from '../setup/countdown-banner';
+import { AUDIENCE_CONTENT_GATES_WIZARD_SLUG } from './consts';
+import './style.scss';
+
+const ContentGateSettings = () => {
+	const wizardData = useWizardData( AUDIENCE_CONTENT_GATES_WIZARD_SLUG ) as WizardData;
+	const { updateWizardSettings } = useDispatch( WIZARD_STORE_NAMESPACE );
+	const { wizardApiFetch, errorMessage, resetError } = useWizardApiFetch( AUDIENCE_CONTENT_GATES_WIZARD_SLUG );
+
+	const onChange = ( newConfig: GateSettings ) => {
+		updateWizardSettings( {
+			slug: AUDIENCE_CONTENT_GATES_WIZARD_SLUG,
+			path: [ 'config' ],
+			value: newConfig,
+		} );
+	};
+
+	const updateConfig = ( newConfig: GateSettings ) => {
+		resetError();
+		wizardApiFetch(
+			{
+				path: '/newspack/v1/wizard/newspack-audience-content-gates/config',
+				method: 'POST',
+				quiet: true,
+				data: newConfig,
+			},
+			{
+				onSuccess( data ) {
+					onChange( data.config );
+				},
+			}
+		);
+	};
+
+	return (
+		<>
+			{ errorMessage && <Notice isError noticeText={ errorMessage } /> }
+			<ContentGifting config={ wizardData?.config || {} } setConfig={ onChange } updateConfig={ updateConfig } />
+			<CountdownBanner config={ wizardData?.config || {} } setConfig={ onChange } updateConfig={ updateConfig } />
+		</>
+	);
+};
+
+export default ContentGateSettings;

--- a/src/wizards/audience/views/content-gates/style.scss
+++ b/src/wizards/audience/views/content-gates/style.scss
@@ -8,7 +8,7 @@
 	.newspack-card:not(.newspack-settings__no-border) .newspack-action-card__region-children > .newspack-grid {
 		margin-top: 0 !important;
 	}
-	.newspack-content-gates {
+	.newspack-content-gates__gates {
 		&__title {
 			margin: 0;
 			min-width: 200px !important;

--- a/src/wizards/audience/views/content-gates/style.scss
+++ b/src/wizards/audience/views/content-gates/style.scss
@@ -5,10 +5,7 @@
 @use "~@wordpress/base-styles/colors" as wp-colors;
 
 .audience_page_newspack-audience-content-gates {
-	.newspack-card:not(.newspack-settings__no-border) .newspack-action-card__region-children > .newspack-grid {
-		margin-top: 0 !important;
-	}
-	.newspack-content-gates__gates {
+	.newspack-content-gates {
 		&__title {
 			margin: 0;
 			min-width: 200px !important;

--- a/src/wizards/audience/views/content-gates/types/index.d.ts
+++ b/src/wizards/audience/views/content-gates/types/index.d.ts
@@ -76,6 +76,24 @@ type Gate = {
 	collapse?: boolean;
 };
 
+type ContentGiftingConfig = {
+	enabled: boolean;
+	limit: number;
+	interval: string;
+	expiration_time: number;
+	expiration_time_unit: string;
+	cta_label: string;
+	button_label: string;
+};
+
+type MeteringCountdownConfig = {
+	enabled: boolean;
+	style: string;
+	cta_label: string;
+	button_label: string;
+	cta_url: string;
+};
+
 type GateSettings = {
 	content_gifting?: ContentGiftingConfig;
 	countdown_banner?: MeteringCountdownConfig;

--- a/src/wizards/audience/views/content-gates/types/index.d.ts
+++ b/src/wizards/audience/views/content-gates/types/index.d.ts
@@ -72,3 +72,11 @@ type Gate = {
 	isExpanded?: boolean;
 	collapse?: boolean;
 };
+
+type GateConfig = {
+	gates: Gate[],
+	config: {
+		countdown_banner: MeteringCountdownConfig;
+		content_gifting: ContentGiftingConfig;
+	}
+};

--- a/src/wizards/audience/views/content-gates/types/index.d.ts
+++ b/src/wizards/audience/views/content-gates/types/index.d.ts
@@ -73,10 +73,12 @@ type Gate = {
 	collapse?: boolean;
 };
 
+type GateSettings = {
+	content_gifting?: ContentGiftingConfig;
+	countdown_banner?: MeteringCountdownConfig;
+};
+
 type GateConfig = {
-	gates: Gate[],
-	config: {
-		countdown_banner: MeteringCountdownConfig;
-		content_gifting: ContentGiftingConfig;
-	}
+	gates: Gate[];
+	config: GateSettings
 };

--- a/src/wizards/audience/views/setup/content-gifting.js
+++ b/src/wizards/audience/views/setup/content-gifting.js
@@ -20,7 +20,7 @@ import {
 } from '@wordpress/components';
 import { ActionCard, Grid, Notice } from '../../../../../packages/components/src';
 
-export default function ContentGifting( { config, setConfig, updateConfig } ) {
+export default function ContentGifting( { config, setConfig, updateConfig, noBorder = false } ) {
 	const giftingErrors = Object.values( newspackAudience?.content_gifting?.can_use_gifting?.errors || {} ).flat();
 	const hasMetering = newspackAudience?.content_gifting?.has_metering;
 
@@ -30,8 +30,9 @@ export default function ContentGifting( { config, setConfig, updateConfig } ) {
 			description={ __( 'Allow members to gift articles up to the configured limit.', 'newspack-plugin' ) }
 			toggleOnChange={ value => updateConfig( { content_gifting: { enabled: value } } ) }
 			toggleChecked={ config.content_gifting?.enabled }
-			hasGreyHeader={ config.content_gifting?.enabled }
+			hasGreyHeader={ ! noBorder && config.content_gifting?.enabled }
 			togglePosition="trailing"
+			noBorder={ noBorder }
 		>
 			{ config.content_gifting?.enabled && (
 				<>

--- a/src/wizards/audience/views/setup/content-gifting.js
+++ b/src/wizards/audience/views/setup/content-gifting.js
@@ -27,6 +27,7 @@ export default function ContentGifting( { config, setConfig, updateConfig, noBor
 	return (
 		<ActionCard
 			title={ __( 'Content Gifting', 'newspack-plugin' ) }
+			heading={ noBorder ? 1 : 2 }
 			description={ __( 'Allow members to gift articles up to the configured limit.', 'newspack-plugin' ) }
 			toggleOnChange={ value => updateConfig( { content_gifting: { enabled: value } } ) }
 			toggleChecked={ config.content_gifting?.enabled }

--- a/src/wizards/audience/views/setup/countdown-banner.js
+++ b/src/wizards/audience/views/setup/countdown-banner.js
@@ -1,3 +1,5 @@
+/* global newspackAudience */
+
 /**
  * WordPress dependencies
  */
@@ -13,9 +15,11 @@ import {
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 } from '@wordpress/components';
 
-import { ActionCard, Grid } from '../../../../../packages/components/src';
+import { ActionCard, Grid, Notice } from '../../../../../packages/components/src';
 
 export default function CountdownBanner( { config, setConfig, updateConfig } ) {
+	const hasMetering = newspackAudience?.content_gifting?.has_metering;
+
 	return (
 		<ActionCard
 			title={ __( 'Countdown Banner', 'newspack-plugin' ) }
@@ -27,6 +31,12 @@ export default function CountdownBanner( { config, setConfig, updateConfig } ) {
 		>
 			{ config.countdown_banner?.enabled && (
 				<>
+					{ ! hasMetering && (
+						<Notice
+							isWarning
+							noticeText={ __( 'Metering is not enabled. Countdown banner will not be displayed.', 'newspack-plugin' ) }
+						/>
+					) }
 					<Grid columns={ 2 } rowGap={ 16 }>
 						<TextControl
 							label={ __( 'Message', 'newspack-plugin' ) }

--- a/src/wizards/audience/views/setup/countdown-banner.js
+++ b/src/wizards/audience/views/setup/countdown-banner.js
@@ -1,5 +1,3 @@
-/* global newspackAudience */
-
 /**
  * WordPress dependencies
  */
@@ -15,28 +13,21 @@ import {
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 } from '@wordpress/components';
 
-import { ActionCard, Grid, Notice } from '../../../../../packages/components/src';
+import { ActionCard, Grid } from '../../../../../packages/components/src';
 
-export default function CountdownBanner( { config, setConfig, updateConfig } ) {
-	const hasMetering = newspackAudience?.content_gifting?.has_metering;
-
+export default function CountdownBanner( { config, setConfig, updateConfig, noBorder = false } ) {
 	return (
 		<ActionCard
 			title={ __( 'Countdown Banner', 'newspack-plugin' ) }
 			description={ __( 'Show a countdown banner before content is restricted by a metered content gate.', 'newspack-plugin' ) }
 			toggleOnChange={ value => updateConfig( { countdown_banner: { enabled: value } } ) }
 			toggleChecked={ config.countdown_banner?.enabled }
-			hasGreyHeader={ config.countdown_banner?.enabled }
+			hasGreyHeader={ ! noBorder && config.countdown_banner?.enabled }
 			togglePosition="trailing"
+			noBorder={ noBorder }
 		>
 			{ config.countdown_banner?.enabled && (
 				<>
-					{ ! hasMetering && (
-						<Notice
-							isWarning
-							noticeText={ __( 'Metering is not enabled. Countdown banner will not be displayed.', 'newspack-plugin' ) }
-						/>
-					) }
 					<Grid columns={ 2 } rowGap={ 16 }>
 						<TextControl
 							label={ __( 'Message', 'newspack-plugin' ) }

--- a/src/wizards/audience/views/setup/countdown-banner.js
+++ b/src/wizards/audience/views/setup/countdown-banner.js
@@ -19,6 +19,7 @@ export default function CountdownBanner( { config, setConfig, updateConfig, noBo
 	return (
 		<ActionCard
 			title={ __( 'Countdown Banner', 'newspack-plugin' ) }
+			heading={ noBorder ? 1 : 2 }
 			description={ __( 'Show a countdown banner before content is restricted by a metered content gate.', 'newspack-plugin' ) }
 			toggleOnChange={ value => updateConfig( { countdown_banner: { enabled: value } } ) }
 			toggleChecked={ config.countdown_banner?.enabled }

--- a/src/wizards/audience/views/setup/style.scss
+++ b/src/wizards/audience/views/setup/style.scss
@@ -1,6 +1,6 @@
 @use "~@wordpress/base-styles/colors" as wp-colors;
 
-.newspack-card:not(.newspack-settings__no-border) .newspack-action-card__region-children > .newspack-grid.newspack-ras-campaign__grid {
+.newspack-content-gates__gate .newspack-card:not(.newspack-settings__no-border) .newspack-action-card__region-children > .newspack-grid.newspack-ras-campaign__grid {
 	margin-top: 0 !important;
 }
 

--- a/src/wizards/types/hooks.d.ts
+++ b/src/wizards/types/hooks.d.ts
@@ -13,12 +13,13 @@ interface ApiFetchOptions {
 	data?: any;
 	/** Display simplified loading status during request */
 	isQuietFetch?: boolean;
+	quiet?: boolean;
 	/** Throw errors to be caught in hooks/components */
 	isLocalError?: boolean;
 	/** Should this request be cached. If omitted and `GET` method is used the request will cache automatically */
 	isCached?: boolean;
 	/** Update a specific cacheKey, requires `{ [path]: method }` format */
-	updateCacheKey?: { [ k: string ]: ApiMethods };
+	updateCacheKey?: { [k: string]: ApiMethods };
 	/** Will purge and replace cache keys matching method. Well suited for endpoints where only the `method` changes */
 	updateCacheMethods?: ApiMethods[];
 }
@@ -26,10 +27,10 @@ interface ApiFetchOptions {
 /**
  * API callback functions
  */
-interface ApiFetchCallbacks< T > {
+interface ApiFetchCallbacks<T> {
 	onStart?: () => void;
-	onSuccess?: ( data: T ) => void;
-	onError?: ( error: any ) => void;
+	onSuccess?: (data: T) => void;
+	onError?: (error: any) => void;
 	onFinally?: () => void;
 }
 
@@ -49,12 +50,12 @@ type WpFetchError = Error & {
 type WizardData = {
 	error: WizardApiError | null;
 } & {
-	[ key: string ]: { [ k in ApiMethods ]?: Record< string, any > | null };
+	[key: string]: { [k in ApiMethods]?: Record<string, any> | null };
 };
 
 // Define the type for the selector's return value
 type WizardSelector = {
-	getWizardData: ( slug: string ) => WizardData;
+	getWizardData: (slug: string) => WizardData;
 	isLoading: () => boolean;
 };
 
@@ -79,20 +80,20 @@ type ProductValidation = {
 };
 type AudienceDonationsWizardData = {
 	donation_data:
-		| { errors: { [ key: string ]: string[] } }
-		| {
-				amounts: {
-					[ Key in FrequencySlug as string ]: [ number, number, number, number ];
-				};
-				disabledFrequencies: {
-					[ Key in FrequencySlug as string ]: boolean;
-				};
-				currencySymbol: string;
-				tiered: boolean;
-				minimumDonation: string;
-				billingFields: string[];
-				trashed: string[];
-		  };
+	| { errors: { [key: string]: string[] } }
+	| {
+		amounts: {
+			[Key in FrequencySlug as string]: [number, number, number, number];
+		};
+		disabledFrequencies: {
+			[Key in FrequencySlug as string]: boolean;
+		};
+		currencySymbol: string;
+		tiered: boolean;
+		minimumDonation: string;
+		billingFields: string[];
+		trashed: string[];
+	};
 	platform_data: {
 		platform: string;
 	};
@@ -101,10 +102,10 @@ type AudienceDonationsWizardData = {
 		status: string;
 	};
 	available_billing_fields: {
-		[ key: string ]: AudienceFieldConfig;
+		[key: string]: AudienceFieldConfig;
 	};
 	order_notes_field: AudienceFieldConfig;
 	product_validation: {
-		[ key: string ]: ProductValidation;
+		[key: string]: ProductValidation;
 	};
 };


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a new "Settings" page to the Content Gating wizard to contain global settings such as Content Gifting and Countdown Banner options. Closes NPPD-1047.

Attempts to reuse and minimize changes to the existing `ContentGifting` and `CountdownBanner` components.

Also adds error handling to the Content Gates page.

### How to test the changes in this Pull Request:

1. Check out this branch and navigate to **Audience > Content Gates**. Confirm there are now two tabs:

<img width="418" height="113" alt="Screenshot 2025-12-15 at 5 02 04 PM" src="https://github.com/user-attachments/assets/992d8996-cd4c-4f5b-9581-afe2d0558fc8" />

2. In the Content Gates tab, smoke test the UI for adding, editing, and deleting content gates. Confirm that all changes persist after both switching back and forth between this and the Settings tab, and after a page refresh.
3. In the Settings tab, confirm that you see the same Content Gifting and Countdown Banner settings cards as in **Audience > Configuration > Content Gating**. 
4. Smoke test changing/saving settings in both cards and confirm that changes persist after both switching back and forth between this and the Content Gates tab, and after a page refresh. Also confirm that any changes here are persisted in the **Audience > Configuration > Content Gating** page, and vice versa.
5. Smoke test front-end functionality for the Content Gifting and Countdown Banner and ensure that behavior matches configuration.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->