### PR TITLE
fix(indesign-exporter): caption and credit character encoding

### DIFF
--- a/includes/optional-modules/indesign-export/class-indesign-converter.php
+++ b/includes/optional-modules/indesign-export/class-indesign-converter.php
@@ -468,10 +468,10 @@ class InDesign_Converter {
 
 			$tag_content .= "\r\n";
 			if ( $caption ) {
-				$tag_content .= '<pstyle:PhotoCaption>' . $caption . "\r\n";
+				$tag_content .= '<pstyle:PhotoCaption>' . $this->get_transformed_text( $caption ) . "\r\n";
 			}
 			if ( $credit ) {
-				$tag_content .= '<pstyle:PhotoCredit>' . $credit . "\r\n";
+				$tag_content .= '<pstyle:PhotoCredit>' . $this->get_transformed_text( $credit ) . "\r\n";
 			}
 		}
 

--- a/tests/unit-tests/indesign-exporter/indesign-exporter.php
+++ b/tests/unit-tests/indesign-exporter/indesign-exporter.php
@@ -277,4 +277,30 @@ class Newspack_Test_InDesign_Exporter extends WP_UnitTestCase {
 		$content = $converter->convert_post( $post_id );
 		$this->assertStringContainsString( '<pstyle:hr>', $content );
 	}
+
+	/**
+	 * Test image caption and credit special characters.
+	 */
+	public function test_image_caption_and_credit_special_characters() {
+		$image_id = $this->factory->attachment->create();
+		wp_update_post(
+			[
+				'ID'           => $image_id,
+				'post_excerpt' => 'Image Caption with á é í ó ú ñ ç ð ð &nbsp;, &amp;, &lt;, &gt; and •.',
+			]
+		);
+		update_post_meta( $image_id, '_media_credit', 'Image Credit with á é í ó ú ñ ç ð ð &nbsp;, &amp;, &lt;, &gt; and •.' );
+
+		$post_id = $this->factory->post->create(
+			[
+				'post_title'   => 'Test Post',
+				'post_content' => '<!-- wp:image {"id":' . $image_id . '} --><figure class="wp-block-image"><img src="http://localhost/wp-content/uploads/2025/01/image.jpg" /><figcaption class="wp-element-caption">Image Caption with á é í ó ú ñ ç ð ð &nbsp;, &amp;, &lt;, &gt; and •.</figcaption></figure><!-- /wp:image -->',
+			]
+		);
+
+		$converter = new InDesign_Converter();
+		$content = $converter->convert_post( $post_id );
+		$this->assertStringContainsString( '<pstyle:PhotoCaption>Image Caption with <0x00E1> <0x00E9> <0x00ED> <0x00F3> <0x00FA> <0x00F1> <0x00E7> <0x00F0> <0x00F0>  , &, <, > and <CharStyle:bullet>n<CharStyle:>.', $content );
+		$this->assertStringContainsString( '<pstyle:PhotoCredit>Image Credit with <0x00E1> <0x00E9> <0x00ED> <0x00F3> <0x00FA> <0x00F1> <0x00E7> <0x00F0> <0x00F0>  , &, <, > and <CharStyle:bullet>n<CharStyle:>.', $content );
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

NPPM-2475

The images' caption and credit also need transformation, which is handled by this PR.

### How to test the changes in this Pull Request:

1. Draft a post with an image using special characters in its caption and credit: `Áéíóúãõâêû`
2. While in trunk, export the InDesign file and confirm the caption text is not transformed
3. Checkout this branch, export again, and confirm it's now transformed to `<0x00C1><0x00E9><0x00ED><0x00F3><0x00FA><0x00E3><0x00F5><0x00E2><0x00EA><0x00FB>`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->