### PR TITLE
fix: less aggressive free trial abuse prevention

### DIFF
--- a/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
+++ b/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
@@ -255,7 +255,7 @@ class WooCommerce_Subscriptions {
 		if ( $trial_length && $user_id && $product && $product->is_type( [ 'subscription', 'subscription_variation', 'variable-subscription' ] ) ) {
 			$user_subscriptions = array_values( \wcs_get_users_subscriptions( $user_id ) );
 			foreach ( $user_subscriptions as $subscription ) {
-				if ( $subscription->has_product( $product->get_id() ) ) {
+				if ( $subscription->has_product( $product->get_id() ) && 'trash' !== $subscription->get_status() ) {
 					return 0;
 				}
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Free trial abuse prevention is mistakenly charging people the full amount in cases where the first payment attempt fail.

That's because when a first payment to buy a subscription fails, a subscription is created and then trashed. We are counting the trashed subscription as an existing previous subscription and therefore skipping free trial.

### How to test the changes in this Pull Request:

1. On `release`
2. As a visitor, try to buy a subscription that has a Free trial with an invalid card number
3. Confirm in the admin that you see a failed order and a trashed subscription
4. in the same reader session, try to buy it again now with a valid card
5. In the admin confirm that the last order charges the full amount
6. Checkout this branch and repeat the process
7. Confirm this time the successful order is still charing $0


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->