### PR TITLE
fix(content-gating): stop running `restrict_post` after gate is rendered

### DIFF
--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -508,7 +508,9 @@ class Content_Gate {
 
 		// Wrap gate in a div for styling.
 		$gate = '<div class="newspack-content-gate__gate newspack-content-gate__inline-gate">' . $gate . '</div>';
-		return $gate;
+
+		// Strip line breaks and tabs.
+		return preg_replace( '/\s+/S', ' ', $gate );
 	}
 
 	/**

--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -517,7 +517,7 @@ class Content_Gate {
 	 * @return string
 	 */
 	public static function get_inline_gate_html() {
-		$gate_content = preg_replace( '/\s+/', ' ', self::get_inline_gate_content() );
+		$gate_content = preg_replace( '/\s+/S', ' ', self::get_inline_gate_content() );
 		return apply_filters( 'newspack_gate_content', $gate_content );
 	}
 

--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -90,6 +90,9 @@ class Content_Gate {
 	 * @param \WP_Query $query Query object.
 	 */
 	public static function restrict_post( $post, $query ) {
+		if ( self::has_rendered() ) {
+			return;
+		}
 		if ( ! $query->is_main_query() ) {
 			return;
 		}

--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -55,16 +55,18 @@ class Content_Gate {
 		add_action( 'the_post', [ __CLASS__, 'restrict_post' ], 10, 2 );
 
 		/** Add gate content filters to mimic 'the_content'. See 'wp-includes/default-filters.php' for reference. */
-		add_filter( 'newspack_gate_content', 'capital_P_dangit', 11 );
-		add_filter( 'newspack_gate_content', [ __CLASS__, 'do_blocks' ], 9 ); // Custom implementation of do_blocks().
-		add_filter( 'newspack_gate_content', 'wptexturize' );
-		add_filter( 'newspack_gate_content', 'convert_smilies', 20 );
-		add_filter( 'newspack_gate_content', 'wpautop' );
-		add_filter( 'newspack_gate_content', 'shortcode_unautop' );
-		add_filter( 'newspack_gate_content', 'prepend_attachment' );
-		add_filter( 'newspack_gate_content', 'wp_filter_content_tags' );
-		add_filter( 'newspack_gate_content', 'wp_replace_insecure_home_url' );
-		add_filter( 'newspack_gate_content', 'do_shortcode', 11 ); // AFTER wpautop().
+		if ( ! self::has_rendered() ) {
+			add_filter( 'newspack_gate_content', 'capital_P_dangit', 11 );
+			add_filter( 'newspack_gate_content', [ __CLASS__, 'do_blocks' ], 9 ); // Custom implementation of do_blocks().
+			add_filter( 'newspack_gate_content', 'wptexturize' );
+			add_filter( 'newspack_gate_content', 'convert_smilies', 20 );
+			add_filter( 'newspack_gate_content', 'wpautop' );
+			add_filter( 'newspack_gate_content', 'shortcode_unautop' );
+			add_filter( 'newspack_gate_content', 'prepend_attachment' );
+			add_filter( 'newspack_gate_content', 'wp_filter_content_tags' );
+			add_filter( 'newspack_gate_content', 'wp_replace_insecure_home_url' );
+			add_filter( 'newspack_gate_content', 'do_shortcode', 11 ); // AFTER wpautop().
+		}
 
 		include __DIR__ . '/class-access-rules.php';
 		include __DIR__ . '/class-content-restriction-control.php';
@@ -539,9 +541,9 @@ class Content_Gate {
 		$use_more_tag = get_post_meta( $gate_post_id, 'use_more_tag', true );
 		// Use <!--more--> as threshold if it exists.
 		if ( $use_more_tag && strpos( $content, '<!--more-->' ) ) {
-			$content = apply_filters( 'the_content', explode( '<!--more-->', $content )[0] );
+			$content = apply_filters( 'newspack_gate_content', explode( '<!--more-->', $content )[0] );
 		} else {
-			$content = apply_filters( 'the_content', $content );
+			$content = apply_filters( 'newspack_gate_content', $content );
 			$count   = max( 1, (int) get_post_meta( $gate_post_id, 'visible_paragraphs', true ) );
 			// Split into paragraphs.
 			$content = explode( '</p>', $content );

--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -154,7 +154,7 @@ class Content_Gate {
 
 		$content = self::get_restricted_post_excerpt( $post );
 
-		$post->post_content   = $content . self::get_inline_gate_content();
+		$post->post_content = $content . self::get_inline_gate_html();
 		$post->post_excerpt   = $content;
 		$post->comment_status = 'closed';
 		$post->comment_count  = 0;
@@ -517,7 +517,8 @@ class Content_Gate {
 	 * @return string
 	 */
 	public static function get_inline_gate_html() {
-		return apply_filters( 'newspack_gate_content', self::get_inline_gate_content() );
+		$gate_content = preg_replace( '/\s+/', ' ', self::get_inline_gate_content() );
+		return apply_filters( 'newspack_gate_content', $gate_content );
 	}
 
 	/**

--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -205,7 +205,7 @@ class Content_Gate {
 	 * @return string
 	 */
 	public static function restore_wpautop_hook( $content ) {
-		$current_priority = has_filter( 'newspack_gate_content', '_restore_wpautop_hook' );
+		$current_priority = has_filter( 'newspack_gate_content', [ __CLASS__, 'restore_wpautop_hook' ] );
 
 		add_filter( 'newspack_gate_content', 'wpautop', $current_priority - 1 );
 		remove_filter( 'newspack_gate_content', [ __CLASS__, 'restore_wpautop_hook' ], $current_priority );

--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -510,7 +510,7 @@ class Content_Gate {
 		$gate = '<div class="newspack-content-gate__gate newspack-content-gate__inline-gate">' . $gate . '</div>';
 
 		// Strip line breaks and tabs.
-		return preg_replace( '/\s+/S', ' ', $gate );
+		return $gate;
 	}
 
 	/**
@@ -541,9 +541,9 @@ class Content_Gate {
 		$use_more_tag = get_post_meta( $gate_post_id, 'use_more_tag', true );
 		// Use <!--more--> as threshold if it exists.
 		if ( $use_more_tag && strpos( $content, '<!--more-->' ) ) {
-			$content = apply_filters( 'newspack_gate_content', explode( '<!--more-->', $content )[0] );
+			$content = apply_filters( 'the_content', explode( '<!--more-->', $content )[0] );
 		} else {
-			$content = apply_filters( 'newspack_gate_content', $content );
+			$content = apply_filters( 'the_content', $content );
 			$count   = max( 1, (int) get_post_meta( $gate_post_id, 'visible_paragraphs', true ) );
 			// Split into paragraphs.
 			$content = explode( '</p>', $content );

--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -154,7 +154,7 @@ class Content_Gate {
 
 		$content = self::get_restricted_post_excerpt( $post );
 
-		$post->post_content = $content . self::get_inline_gate_content();
+		$post->post_content   = $content . self::get_inline_gate_content();
 		$post->post_excerpt   = $content;
 		$post->comment_status = 'closed';
 		$post->comment_count  = 0;

--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -154,7 +154,7 @@ class Content_Gate {
 
 		$content = self::get_restricted_post_excerpt( $post );
 
-		$post->post_content = $content . self::get_inline_gate_html();
+		$post->post_content = $content . self::get_inline_gate_content();
 		$post->post_excerpt   = $content;
 		$post->comment_status = 'closed';
 		$post->comment_count  = 0;
@@ -517,8 +517,7 @@ class Content_Gate {
 	 * @return string
 	 */
 	public static function get_inline_gate_html() {
-		$gate_content = preg_replace( '/\s+/S', ' ', self::get_inline_gate_content() );
-		return apply_filters( 'newspack_gate_content', $gate_content );
+		return apply_filters( 'newspack_gate_content', self::get_inline_gate_content() );
 	}
 
 	/**

--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -55,18 +55,16 @@ class Content_Gate {
 		add_action( 'the_post', [ __CLASS__, 'restrict_post' ], 10, 2 );
 
 		/** Add gate content filters to mimic 'the_content'. See 'wp-includes/default-filters.php' for reference. */
-		if ( ! self::has_rendered() ) {
-			add_filter( 'newspack_gate_content', 'capital_P_dangit', 11 );
-			add_filter( 'newspack_gate_content', [ __CLASS__, 'do_blocks' ], 9 ); // Custom implementation of do_blocks().
-			add_filter( 'newspack_gate_content', 'wptexturize' );
-			add_filter( 'newspack_gate_content', 'convert_smilies', 20 );
-			add_filter( 'newspack_gate_content', 'wpautop' );
-			add_filter( 'newspack_gate_content', 'shortcode_unautop' );
-			add_filter( 'newspack_gate_content', 'prepend_attachment' );
-			add_filter( 'newspack_gate_content', 'wp_filter_content_tags' );
-			add_filter( 'newspack_gate_content', 'wp_replace_insecure_home_url' );
-			add_filter( 'newspack_gate_content', 'do_shortcode', 11 ); // AFTER wpautop().
-		}
+		add_filter( 'newspack_gate_content', 'capital_P_dangit', 11 );
+		add_filter( 'newspack_gate_content', [ __CLASS__, 'do_blocks' ], 9 ); // Custom implementation of do_blocks().
+		add_filter( 'newspack_gate_content', 'wptexturize' );
+		add_filter( 'newspack_gate_content', 'convert_smilies', 20 );
+		add_filter( 'newspack_gate_content', 'wpautop' );
+		add_filter( 'newspack_gate_content', 'shortcode_unautop' );
+		add_filter( 'newspack_gate_content', 'prepend_attachment' );
+		add_filter( 'newspack_gate_content', 'wp_filter_content_tags' );
+		add_filter( 'newspack_gate_content', 'wp_replace_insecure_home_url' );
+		add_filter( 'newspack_gate_content', 'do_shortcode', 11 ); // AFTER wpautop().
 
 		include __DIR__ . '/class-access-rules.php';
 		include __DIR__ . '/class-content-restriction-control.php';
@@ -194,10 +192,25 @@ class Content_Gate {
 		$priority = has_filter( 'newspack_gate_content', 'wpautop' );
 		if ( false !== $priority && doing_filter( 'newspack_gate_content' ) && has_blocks( $content ) ) {
 			remove_filter( 'newspack_gate_content', 'wpautop', $priority );
-			add_filter( 'newspack_gate_content', '_restore_wpautop_hook', $priority + 1 );
+			add_filter( 'newspack_gate_content', [ __CLASS__, 'restore_wpautop_hook' ], $priority + 1 );
 		}
 
 		return $output;
+	}
+
+	/**
+	 * _restore_wpautop_hook filter, but for the newspack_gate_content filter instead of the_content
+	 *
+	 * @param string $content Content.
+	 * @return string
+	 */
+	public static function restore_wpautop_hook( $content ) {
+		$current_priority = has_filter( 'newspack_gate_content', '_restore_wpautop_hook' );
+
+		add_filter( 'newspack_gate_content', 'wpautop', $current_priority - 1 );
+		remove_filter( 'newspack_gate_content', [ __CLASS__, 'restore_wpautop_hook' ], $current_priority );
+
+		return $content;
 	}
 
 	/**

--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -508,8 +508,6 @@ class Content_Gate {
 
 		// Wrap gate in a div for styling.
 		$gate = '<div class="newspack-content-gate__gate newspack-content-gate__inline-gate">' . $gate . '</div>';
-
-		// Strip line breaks and tabs.
 		return $gate;
 	}
 

--- a/src/wizards/audience/views/content-gates/metering.tsx
+++ b/src/wizards/audience/views/content-gates/metering.tsx
@@ -1,13 +1,13 @@
 /**
  * WordPress dependencies.
  */
-import { SelectControl, CheckboxControl, TextControl } from '@wordpress/components';
+import { CheckboxControl, __experimentalNumberControl as NumberControl } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import { ActionCard, Card, Grid } from '../../../../../packages/components/src';
+import { ActionCard, Card, Grid, Notice, SelectControl } from '../../../../../packages/components/src';
 
 interface MeteringProps {
 	metering: Metering;
@@ -29,27 +29,36 @@ export default function Metering( { metering, onChange }: MeteringProps ) {
 					checked={ metering.enabled }
 					onChange={ () => onChange( prevMetering => ( { ...prevMetering, enabled: ! prevMetering.enabled } ) ) }
 				/>
+				{ metering.enabled && parseInt( metering.anonymous_count ) === 0 && parseInt( metering.registered_count ) === 0 && (
+					<Notice
+						isWarning
+						noticeText={ __(
+							'Metering is enabled but no views are available. Content will be gated for all readers.',
+							'newspack-plugin'
+						) }
+					/>
+				) }
 			</Card>
 			{ metering.enabled && (
 				<Grid columns={ 2 } gutter={ 32 } noMargin={ true }>
-					<TextControl
-						type={ 'number' }
+					<NumberControl
 						label={ __( 'Free views for anonymous viewers', 'newspack-plugin' ) }
 						help={ __(
 							'Number of times an anonymous reader can view gated content. If set to 0, anonymous readers will always render the gate.',
 							'newspack-plugin'
 						) }
-						value={ metering.anonymous_count }
+						min={ 0 }
+						value={ parseInt( metering.anonymous_count ) }
 						onChange={ v => onChange( prevMetering => ( { ...prevMetering, anonymous_count: parseInt( v ) } ) ) }
 					/>
-					<TextControl
-						type={ 'number' }
+					<NumberControl
 						label={ __( 'Free views for registered viewers', 'newspack-plugin' ) }
 						help={ __(
 							'Number of times a registered reader can view gated content. If set to 0, registered readers will always render the gate.',
 							'newspack-plugin'
 						) }
-						value={ metering.registered_count }
+						min={ 0 }
+						value={ parseInt( metering.registered_count ) }
 						onChange={ v => onChange( prevMetering => ( { ...prevMetering, registered_count: parseInt( v ) } ) ) }
 					/>
 					<SelectControl


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes some minor bugs in the rendering of content gates:

- Avoids repeat runs of `restrict_post()` if the gate has been rendered for the current post already. This avoids potential rendering errors resulting from passing the post content and gate through `the_content` filters multiple times.
- Apply `the_content` filters instead of `newspack_gate_content` inside `get_restricted_post_excerpt()`, to avoid adding unintended `<br />` elements and `nbsp;` characters to the gate content markup.

Also ensures that the number inputs for anonymous and registered metering views must be positive numbers, and adds a warning hint in the content gate settings component that explains that setting both anonymous and registered metering views to `0` is effectively the same as having metering disabled:

<img width="1013" height="298" alt="Screenshot 2025-12-17 at 11 30 24 AM" src="https://github.com/user-attachments/assets/277426a3-ab55-4bcf-8b63-37cb04569546" />

### How to test the changes in this Pull Request:

1. On `trunk`, set `define( 'NEWSPACK_CONTENT_GATES', true );` in wp-config.php and deactivate WooCommerce Memberships.
2. In **Audience > Content Gates**, publish a single content gate for Post Type: Posts with metering enabled. Confirm that you can't set anonymous or registered views to values below 0, and that if you set both anonymous and registered views to `0`, you see the warning as in the above screenshot.
3. Save the gate with some non-zero number of anonymous and registered views. In the gate's content, insert a pattern that contains login/register buttons and a Checkout Button (I used the "Paywall with One Tier and Metering" block pattern), and set the gate style to "Inline".
4. On the front-end, view posts until you see the content gate. Observe that some elements have extra whitespace:

<img width="177" height="95" alt="Screenshot 2025-12-17 at 12 22 19 PM" src="https://github.com/user-attachments/assets/f948df55-1325-4c6e-9478-4f1b584652d6" />

5. In a post that will be gated, insert some Page Break blocks into the content.
6. On the front-end, view the post with the page breaks and observe that the inline gate renders with malformed markup:
 
<img width="600" height="492" alt="Screenshot 2025-12-17 at 12 24 58 PM" src="https://github.com/user-attachments/assets/15649008-b471-4862-b761-68f1e1265326" />

7. Check out this branch and view gated posts both with and without page breaks. Confirm that the inline gate renders as expected with no visual issues, and that all interactive elements such as buttons/links still function as expected.

<img width="709" height="383" alt="Screenshot 2025-12-17 at 12 29 24 PM" src="https://github.com/user-attachments/assets/c0a99c65-5216-4446-99c2-b6685d059696" />

8. Change the gate to "Overlay" style and view the gated posts again. Confirm that the gate renders as an overlay with no visual or functional issues.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->