### PR TITLE
fix(countdown-banner): never show more views than total

### DIFF
--- a/includes/content-gate/class-metering-countdown.php
+++ b/includes/content-gate/class-metering-countdown.php
@@ -189,7 +189,7 @@ class Metering_Countdown {
 		if ( false === $total_views ) {
 			return;
 		}
-		$views = Metering::get_current_user_metered_views();
+		$views = min( Metering::get_current_user_metered_views(), $total_views );
 		if ( $views === 0 || Metering::is_frontend_metering() ) {
 			$classes[] = 'newspack-countdown-banner__cta--hidden';
 		}

--- a/includes/content-gate/class-metering.php
+++ b/includes/content-gate/class-metering.php
@@ -293,7 +293,7 @@ class Metering {
 		}
 
 		// Aggregate metering by gate priority, if available.
-		$suffix = Content_Gate::is_newspack_feature_enabled() && $priority ? $priority : $gate_post_id;
+		$suffix = Content_Gate::is_newspack_feature_enabled() && ! Memberships::is_active() && $priority ? $priority : $gate_post_id;
 		$user_meta_key = self::METERING_META_KEY . '_' . $suffix;
 
 		$updated_user_data  = false;

--- a/src/content-gate/content-banner.js
+++ b/src/content-gate/content-banner.js
@@ -39,14 +39,18 @@ domReady( () => {
 	// Countdown banner.
 	window.newspackRAS?.push( ras => {
 		const views = document.querySelector( '.newspack-countdown-banner__views' );
-		if ( ! views || '0' !== views.textContent ) {
+		if ( ! views || 0 < parseInt( views.textContent ) ) {
 			return;
 		}
 		const data = ras?.store?.get( storeKey ) || {
 			content: [],
 		};
+		const total = parseInt( document.querySelector( '.newspack-countdown-banner__total_views' )?.textContent || 0 );
+		if ( ! total || 0 >= total ) {
+			return;
+		}
 		if ( data.content.length > 0 ) {
-			views.textContent = data.content.length;
+			views.textContent = Math.min( data.content.length, total );
 			cta.classList.remove( 'newspack-countdown-banner__cta--hidden' );
 		}
 	} );

--- a/src/content-gate/content-banner.scss
+++ b/src/content-gate/content-banner.scss
@@ -52,9 +52,15 @@ body .sd-social-icon .sd-content ul li[class*="share-"].share-newspack-gift-arti
 	margin-top: 1px;
 }
 
-body.newspack-is-gifted-post .site,
-body.newspack-has-countdown-banner .site {
-	padding-bottom: var(--newspack-content-banner-cta-offset, 72px);
+body.newspack-is-gifted-post,
+body.newspack-has-countdown-banner {
+	.site {
+		padding-bottom: var(--newspack-content-banner-cta-offset, 72px);
+	}
+
+	.newspack-lightbox-placement-bottom {
+		bottom: var(--newspack-content-banner-cta-offset, 72px);
+	}
 }
 
 .newspack-content-gifting,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Avoids a potential scenario where the number of counted views can be more than the total allowed metered views:

<img width="463" height="62" alt="Screenshot 2025-12-17 at 3 34 40 PM" src="https://github.com/user-attachments/assets/8e2575c0-24d7-40e7-9e3b-bd154b79b59a" />

In this scenario, the number of views shown will match the total, as the next newly metered article view will be gated.

Also, adjusts the positioning of bottom overlay prompts from Newspack Campaigns so that they're "attached" to the top of the banner instead of the bottom of the viewport.

### How to test the changes in this Pull Request:

#### Banner message

1. On `alpha`, activate Woo Memberships and publish a membership plan restricting posts based on subscription.
2. Publish a memberships gate with metering enabled and anonymous and registered views set to a value greater than 1 (e.g. `3`).
3. Enable the countdown banner in **Audience > Content Gating**.
4. As a reader, view exactly the number of allowed anonymous views and don't close out the browser session.
5. As an admin, edit the memberships gate and bump down the number of anonymous views to a value less than the prior value (e.g. `2`), and save.
6. As the reader, refresh the last post you viewed and observe that you see e.g. "3/2 free articles this month" in the countdown banner.
7. Register or log into an existing account that doesn't have the required subscription, and again view exactly the number allowed registered views.
8. As an admin, edit the memberships gate and bump down the number of registered views to a value less than the prior value.
9. As the reader, refresh the last viewed post and observe the same issue as in step 6.
10. Check out this branch, repeat testing steps, and confirm that the banner message always shows the number of views as the total allowed views, at maximum.
11. After bumping down the number of allowed views, confirm that as the reader the next restricted post you view is gated.

#### Bottom overlay prompts

1. Publish a bottom overlay prompt via **Audience > Campaigns**.
2. On `alpha`, view a metered restricted post in a fresh reader session and observe that the banner appears on top of the overlay prompt, partially or totally obscuring the prompt's content:

<img width="964" height="125" alt="Screenshot 2025-12-17 at 4 07 46 PM" src="https://github.com/user-attachments/assets/cc9e1203-ea75-453e-9043-5ce30a1b49c0" />

3. Check out this branch, refresh, and confirm that the prompt is positioned so that its content is not obscured by the banner:

<img width="959" height="252" alt="Screenshot 2025-12-17 at 4 07 52 PM" src="https://github.com/user-attachments/assets/ae035bff-6220-44a8-88f1-eb9ac832aae6" />

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->