### PR TITLE
fix(autocomplete): improve value parsing in AutocompleteTokenField and ListsControl components

### DIFF
--- a/packages/components/src/autocomplete-tokenfield/index.js
+++ b/packages/components/src/autocomplete-tokenfield/index.js
@@ -120,7 +120,7 @@ class AutocompleteTokenField extends Component {
 				Object.keys( validValues ).forEach( key => {
 					if ( validValues[ key ] === label ) {
 						// Preserve numeric or string type of values. Object.keys will convert numbers to strings.
-						const value = isNaN( parseInt( key ) ) ? key.toString() : parseInt( key );
+						const value = /^\d+$/.test( key.toString() ) ? parseInt( key ) : key.toString();
 						acc.push( { value, label } );
 					}
 				} );
@@ -131,7 +131,7 @@ class AutocompleteTokenField extends Component {
 
 		return labels.map( label =>
 			Object.keys( validValues )
-				.map( key => ( isNaN( parseInt( key ) ) ? key.toString() : parseInt( key ) ) )
+				.map( key => ( /^\d+$/.test( key.toString() ) ? parseInt( key ) : key.toString() ) )
 				.find( key => validValues[ key ] === label )
 		);
 	}

--- a/src/wizards/audience/components/lists-control/index.js
+++ b/src/wizards/audience/components/lists-control/index.js
@@ -10,7 +10,7 @@ import AutocompleteTokenField from '../../../../../packages/components/src/autoc
 
 export default function ListsControl( { label, help, placeholder, value, onChange, path, deletedItemLabel } ) {
 	const getSuggestions = item => ( {
-		value: isNaN( parseInt( item.id ) ) ? item.id.toString() : parseInt( item.id ),
+		value: /^\d+$/.test( item.id.toString() ) ? parseInt( item.id ) : item.id.toString(),
 		label: item.title || item.name || deletedItemLabel,
 	} );
 
@@ -34,11 +34,14 @@ export default function ListsControl( { label, help, placeholder, value, onChang
 				const values = Array.isArray( lists ) ? lists : Object.values( lists );
 				return ids
 					.map( id => {
-						const item = values.find( it => ( isNaN( it.id ) ? it.id : parseInt( it.id ) ) === id );
+						const item = values.find( it => {
+							const itId = /^\d+$/.test( it.id.toString() ) ? parseInt( it.id ) : it.id.toString();
+							return itId === id;
+						} );
 						if ( item ) {
 							return getSuggestions( item );
 						}
-						return deletedItemLabel ? getSuggestions( { id } ) : false;
+						return deletedItemLabel && id ? getSuggestions( { id } ) : false;
 					} )
 					.filter( Boolean );
 			} }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

NPPM-2320

The existing parsing strategy with `isNaN( parseInt( key ) )` doesn't work if the value is alphanumeric starting with a number. e.g. `parseInt( "1a23bc" ) === 1`

This PR changes the strategy to use the regex pattern `/^\d+$/.test( val.toString() )` instead.

### How to test the changes in this Pull Request:

The issue was identified when testing the component with Mailchimp audiences (not tags or groups)

1. Make sure you have Mailchimp as your ESP and a Mailchimp audience as am available subscription list
2. While on trunk, edit a campaign segment and select the Mailchimp audience in the "Subscribed to newsletter lists"
3. If the audience starts with a number, the selection will change to "Deleted list" because the transformed ID will not match a value from the list
4. Checkout this branch, refresh the page, and select the audience again
5. Select other items and save
6. Confirm the values persist

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->