### PR TITLE
feat: include prompt_title with newspack_popup_id for data events

### DIFF
--- a/includes/class-donations.php
+++ b/includes/class-donations.php
@@ -749,6 +749,7 @@ class Donations {
 					'nyp'               => class_exists( 'WC_Name_Your_Price_Helpers' ) ? (float) \WC_Name_Your_Price_Helpers::standardize_number( $donation_value ) : null,
 					'referer'           => $referer,
 					'newspack_popup_id' => filter_input( INPUT_GET, 'newspack_popup_id', FILTER_SANITIZE_NUMBER_INT ),
+					'prompt_title'      => filter_input( INPUT_GET, 'prompt_title', FILTER_SANITIZE_SPECIAL_CHARS ),
 				]
 			);
 			\WC()->cart->add_to_cart(
@@ -821,6 +822,9 @@ class Donations {
 	public static function checkout_create_order_line_item( $item, $cart_item_key, $values, $order ) {
 		if ( ! empty( $values['newspack_popup_id'] ) ) {
 			$order->add_meta_data( '_newspack_popup_id', $values['newspack_popup_id'] );
+		}
+		if ( ! empty( $values['prompt_title'] ) ) {
+			$order->add_meta_data( '_prompt_title', $values['prompt_title'] );
 		}
 		if ( ! empty( $values['referer'] ) ) {
 			$order->add_meta_data( '_newspack_referer', $values['referer'] );

--- a/includes/data-events/class-woo-user-registration.php
+++ b/includes/data-events/class-woo-user-registration.php
@@ -60,6 +60,9 @@ final class Woo_User_Registration {
 			if ( ! empty( $values['newspack_popup_id'] ) ) {
 				self::$metadata['newspack_popup_id'] = $values['newspack_popup_id'];
 			}
+			if ( ! empty( $values['prompt_title'] ) ) {
+				self::$metadata['prompt_title'] = $values['prompt_title'];
+			}
 			if ( ! empty( $values['referer'] ) ) {
 				self::$metadata['referer'] = $values['referer'];
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR, along with https://github.com/Automattic/newspack-blocks/pull/2271 and https://github.com/Automattic/newspack-popups/pull/1508, adds the prompt_title to the modal checkout data events.

See https://github.com/Automattic/newspack-blocks/pull/2271 for testing steps.

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->