### PR TITLE
fix: update prompt_id to newspack_popup_id in the data events readme

### DIFF
--- a/includes/data-events/README.md
+++ b/includes/data-events/README.md
@@ -268,7 +268,7 @@ When a user interacts with a Newspack Popup's campaign prompt.
 
 | Name               | Type     | Obs                                                                                                                                          |
 | ------------------ | -------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| `prompt_id`        | `int`    |                                                                                                                                              |
+| `newspack_popup_id`| `int`    |                                                                                                                                              |
 | `prompt_title`     | `string` |                                                                                                                                              |
 | `prompt_frequency` | `string` |                                                                                                                                              |
 | `prompt_placement` | `string` |                                                                                                                                              |


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Updates the Data Events Readme as part of https://github.com/Automattic/newspack-popups/pull/1509

This should be tested as part of https://github.com/Automattic/newspack-popups/pull/1509 only because it shouldn't be merged until all of those changes are deemed okay.

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->