### PR TITLE
fix: prevent doubled URL in reader registration block magic link

### DIFF
--- a/src/blocks/reader-registration/index.php
+++ b/src/blocks/reader-registration/index.php
@@ -421,7 +421,7 @@ function process_form() {
 		$metadata['lists'] = $lists;
 	}
 	$metadata['referer']             = \wp_get_raw_referer(); // wp_get_referer() will return false because it's a POST request to the same page.
-	$metadata['current_page_url']    = \esc_url( $metadata['referer'] );
+	$metadata['current_page_url']    = $current_page_url;
 	$metadata['registration_method'] = 'registration-block';
 
 	/**

--- a/src/blocks/reader-registration/index.php
+++ b/src/blocks/reader-registration/index.php
@@ -421,7 +421,7 @@ function process_form() {
 		$metadata['lists'] = $lists;
 	}
 	$metadata['referer']             = \wp_get_raw_referer(); // wp_get_referer() will return false because it's a POST request to the same page.
-	$metadata['current_page_url']    = home_url( add_query_arg( array(), $metadata['referer'] ) );
+	$metadata['current_page_url']    = \esc_url( $metadata['referer'] );
 	$metadata['registration_method'] = 'registration-block';
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Fixes the malformed magic link URLs generated by the Reader Registration block that can cause 404 errors after authentication.

The `current_page_url` metadata was being constructed by passing a full URL to `home_url()`, which expects a path. This caused the site URL to be prepended to an already complete URL, resulting in doubled domains like `https://example.com/https://example.com/post/article/`. In some cases, the malformed URL still worked, likely due to WordPress's 404 redirect guessing mechanism or other server-level URL handling.

The fix reuses the `$current_page_url` variable that's already correctly constructed earlier in the same function using `home_url()` with just the path to avoid the double domain.

Fixes NPPM-2504.

### How to test the changes in this Pull Request:

1. Ensure WooCommerce Memberships plugin is active.
2. Create a membership plan with:
    - Grant access upon: "user account registration".
    - In the "Restrict Content" tab, add a rule for "Posts" and leave the title blank to apply to all posts for easier testing.
3. Go to the Newspack Content Gating settings (`/wp-admin/admin.php?page=newspack-audience#/content-gating`) and configure the gate to use the Non-Member Content block with a Reader Registration block inside. Sample editor markup:
```
<!-- wp:woocommerce-memberships/non-member-content {"membershipPlans":[YOUR_PLAN_ID]} -->
<div class="wp-block-woocommerce-memberships-non-member-content">
  <!-- wp:newspack/reader-registration {"title":"Continue Reading","lists":[]} -->
  <div class="wp-block-newspack-reader-registration"></div>
  <!-- /wp:newspack/reader-registration -->
</div>
<!-- /wp:woocommerce-memberships/non-member-content -->
```
4. Visit the post in an incognito window.
5. Open a post where the registration gate appears and enter an email address **that's already registered** in the reader registration block.
6. Check the magic link email received.
7. Verify that the magic link received in the email has a double domain (example: `https://example.com/https://example.com/post/article/...`).
8. Checkout the changes from this PR and repeat steps 4-7.
9. Verify that the URL received in the new email is correctly formatted (single domain, not doubled).
10. Click the link and confirm you're authenticated and redirected to the original post.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
