### PR TITLE
fix: corrections remove space if correction time is empty

### DIFF
--- a/includes/corrections/class-corrections.php
+++ b/includes/corrections/class-corrections.php
@@ -475,15 +475,14 @@ class Corrections {
 				$correction_date    = \get_the_date( get_option( 'date_format' ), $correction->ID );
 				$correction_time    = \get_the_time( get_option( 'time_format' ), $correction->ID );
 				$correction_heading = sprintf(
-					'%s, %s %s:',
+					'%s, %s%s:',
 					self::get_correction_type( $correction->ID ),
 					$correction_date,
-					$correction_time
+					$correction_time ? ' ' . $correction_time : ''
 				);
 				?>
 				<p class="correction">
 					<a class="correction-title" href="<?php echo esc_url( $corrections_archive_url ); ?>"><?php echo esc_html( $correction_heading ); ?></a>
-
 					<span class="correction-content"><?php echo esc_html( $correction_content ); ?></span>
 				</p>
 			<?php endforeach; ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Removes space if correction-time is empty. 

<img width="848" height="50" alt="Screenshot 2026-01-06 at 3 43 16 PM" src="https://github.com/user-attachments/assets/6b676e45-020a-4a5d-972a-afd2bd9329c3" />

### How to test the changes in this Pull Request:

1. Create 1 or more corrections for a post.
2. View post and confirm space is no longer there.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
