### PR TITLE
feat: add support for displaying tags as labels

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -235,6 +235,9 @@ final class Newspack {
 		// Filter by authors in the Posts page.
 		include_once NEWSPACK_ABSPATH . 'includes/author-filter/class-author-filter.php';
 
+		// Display tags as labels.
+		include_once NEWSPACK_ABSPATH . 'includes/tag-labels/class-tag-labels.php';
+
 		// Load the general Newspack UI front-end styles.
 		include_once NEWSPACK_ABSPATH . 'includes/class-newspack-ui.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-newspack-ui-icons.php';

--- a/includes/tag-labels/class-tag-labels.php
+++ b/includes/tag-labels/class-tag-labels.php
@@ -151,7 +151,7 @@ class Tag_Labels {
 				aria-describedby="<?php echo esc_attr( self::TAG_LABEL_FLAG_META_KEY ); ?>-description"
 				type="text"
 				name="<?php echo esc_attr( self::TAG_LABEL_FLAG_META_KEY ); ?>"
-				placeholder="Enter custom label text"
+				placeholder="<?php echo esc_attr__( 'Enter custom label text', 'newspack-plugin' ); ?>"
 				value=""
 				disabled
 			>

--- a/includes/tag-labels/class-tag-labels.php
+++ b/includes/tag-labels/class-tag-labels.php
@@ -127,17 +127,21 @@ class Tag_Labels {
 	 * @param WP_Term $term The current WP_Term object.
 	 */
 	public static function edit_term( $term ) {
+		$checkbox_id = self::TAG_LABEL_META_KEY;
 		$is_label = self::is_tag_label( $term );
 
 		$label = self::get_tag_label_for_term( $term );
 		$label_flag  = $label ? $label['flag'] : $term->name;
+
+		$input_label_flag = ( $term->name === $label_flag ) ? '' : $label_flag;
 		?>
 		<tr class="form-field newspack-label-enable term-<?php echo esc_attr( self::TAG_LABEL_META_KEY ); ?>-wrap">
 			<th scope="row"><label for="<?php echo esc_attr( $checkbox_id ); ?>"><?php esc_html_e( 'Use as label', 'newspack-plugin' ); ?></label></th>
 			<td>
 				<input
+					aria-describedby="<?php echo esc_attr( self::TAG_LABEL_META_KEY ); ?>-description"
 					type="checkbox"
-					name="<?php echo esc_attr( self::TAG_LABEL_META_KEY ); ?>"
+					name="<?php echo esc_attr( $checkbox_id ); ?>"
 					value="true"
 					<?php
 						checked( $is_label, true );
@@ -152,16 +156,12 @@ class Tag_Labels {
 			<th scope="row"><label for="<?php echo esc_attr( self::TAG_LABEL_FLAG_META_KEY ); ?>"><?php esc_html_e( 'Label flag', 'newspack-plugin' ); ?></label></th>
 			<td>
 				<input
+					aria-describedby="<?php echo esc_attr( self::TAG_LABEL_FLAG_META_KEY ); ?>-description"
 					type="text"
 					name="<?php echo esc_attr( self::TAG_LABEL_FLAG_META_KEY ); ?>"
 					placeholder="<?php echo esc_attr( $term->name ); ?>"
+					value="<?php echo esc_attr( $input_label_flag ); ?>"
 					<?php
-					if ( $term->name === $label_flag ) {
-							echo ' value=""';
-					} else {
-							echo ' value="' . esc_attr( $label_flag ) . '"';
-					}
-
 					if ( ! $is_label ) {
 						echo ' disabled'; }
 					?>
@@ -183,6 +183,9 @@ class Tag_Labels {
 
 		// See wp-admin/edit-tag-form.php for where this is set.
 		check_admin_referer( 'update-tag_' . $term_id );
+
+		if ( ! current_user_can( 'edit_term', $term_id ) ) {
+			return; }
 
 		// Save label data if label is enabled; otherwise kill it.
 		if ( ! empty( $_POST[ self::TAG_LABEL_META_KEY ] ) ) {

--- a/includes/tag-labels/class-tag-labels.php
+++ b/includes/tag-labels/class-tag-labels.php
@@ -187,6 +187,7 @@ class Tag_Labels {
 			<input
 				aria-describedby="<?php echo esc_attr( self::TAG_LABEL_META_KEY ); ?>-description"
 				type="checkbox"
+				id="<?php echo esc_attr( $checkbox_id ); ?>"
 				name="<?php echo esc_attr( $checkbox_id ); ?>"
 				value="true"
 			>
@@ -199,6 +200,7 @@ class Tag_Labels {
 			<input
 				aria-describedby="<?php echo esc_attr( self::TAG_LABEL_FLAG_META_KEY ); ?>-description"
 				type="text"
+				id="<?php echo esc_attr( self::TAG_LABEL_FLAG_META_KEY ); ?>"
 				name="<?php echo esc_attr( self::TAG_LABEL_FLAG_META_KEY ); ?>"
 				placeholder="<?php echo esc_attr__( 'Enter custom label text', 'newspack-plugin' ); ?>"
 				value=""
@@ -234,6 +236,7 @@ class Tag_Labels {
 				<input
 					aria-describedby="<?php echo esc_attr( self::TAG_LABEL_META_KEY ); ?>-description"
 					type="checkbox"
+					id="<?php echo esc_attr( $checkbox_id ); ?>"
 					name="<?php echo esc_attr( $checkbox_id ); ?>"
 					value="true"
 					<?php
@@ -251,6 +254,7 @@ class Tag_Labels {
 				<input
 					aria-describedby="<?php echo esc_attr( self::TAG_LABEL_FLAG_META_KEY ); ?>-description"
 					type="text"
+					id="<?php echo esc_attr( self::TAG_LABEL_FLAG_META_KEY ); ?>"
 					name="<?php echo esc_attr( self::TAG_LABEL_FLAG_META_KEY ); ?>"
 					placeholder="<?php echo esc_attr( $term->name ); ?>"
 					value="<?php echo esc_attr( $input_label_flag ); ?>"

--- a/includes/tag-labels/class-tag-labels.php
+++ b/includes/tag-labels/class-tag-labels.php
@@ -99,10 +99,14 @@ class Tag_Labels {
 	 * Initialize hooks.
 	 */
 	public static function init() {
+		add_action( 'post_tag_pre_add_form', array( __CLASS__, 'enqueue_scripts' ) );
 		add_action( 'post_tag_term_edit_form_top', array( __CLASS__, 'enqueue_scripts' ) );
 
+		add_action( 'post_tag_add_form_fields', [ __CLASS__, 'add_term' ] );
 		add_action( 'post_tag_edit_form_fields', [ __CLASS__, 'edit_term' ] );
-		add_action( 'edited_post_tag', [ __CLASS__, 'save_term' ] );
+
+		add_action( 'created_post_tag', [ __CLASS__, 'save_new_term' ] );
+		add_action( 'edited_post_tag', [ __CLASS__, 'save_existing_term' ] );
 	}
 
 	/**
@@ -121,7 +125,45 @@ class Tag_Labels {
 	}
 
 	/**
-	 * Add term edit fields.
+	 * Term creation fields.
+	 *
+	 * Toggle to determine if the term is a label.
+	 * Also, override for flag (text used on label).
+	 */
+	public static function add_term() {
+		$checkbox_id = self::TAG_LABEL_META_KEY;
+		?>
+		<div class="form-field newspack-label-enable term-<?php echo esc_attr( self::TAG_LABEL_META_KEY ); ?>-wrap">
+			<label for="<?php echo esc_attr( $checkbox_id ); ?>"><?php esc_html_e( 'Display as label', 'newspack-plugin' ); ?></label>
+			<input
+				aria-describedby="<?php echo esc_attr( self::TAG_LABEL_META_KEY ); ?>-description"
+				type="checkbox"
+				name="<?php echo esc_attr( $checkbox_id ); ?>"
+				value="true"
+			>
+			<p class="description" id="<?php echo esc_attr( self::TAG_LABEL_META_KEY ); ?>-description">
+				<?php echo esc_html__( 'Show this tag as a highlighted label wherever posts are displayed.', 'newspack-plugin' ); ?>
+			</p>
+		</div>
+		<div class="form-field newspack-label-setting term-<?php echo esc_attr( self::TAG_LABEL_FLAG_META_KEY ); ?>-wrap" style="display: none;">
+			<label for="<?php echo esc_attr( self::TAG_LABEL_FLAG_META_KEY ); ?>"><?php esc_html_e( 'Label text', 'newspack-plugin' ); ?></label>
+			<input
+				aria-describedby="<?php echo esc_attr( self::TAG_LABEL_FLAG_META_KEY ); ?>-description"
+				type="text"
+				name="<?php echo esc_attr( self::TAG_LABEL_FLAG_META_KEY ); ?>"
+				placeholder="Enter custom label text"
+				value=""
+				disabled
+			>
+			<p class="description" id="<?php echo esc_attr( self::TAG_LABEL_FLAG_META_KEY ); ?>-description">
+				<?php echo esc_html__( 'Custom text to display instead of the tag name.', 'newspack-plugin' ); ?>
+			</p>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Term edit fields.
 	 *
 	 * Toggle to determine if the term is a label.
 	 * Also, override for flag (text used on label).
@@ -176,19 +218,13 @@ class Tag_Labels {
 		<?php
 	}
 
+	// phpcs:disable WordPress.Security.NonceVerification.Missing -- nonce verified in accessors
 	/**
-	 * Store our custom term meta when term is saved
+	 * Store custom term meta on save.
 	 *
 	 * @param int $term_id Term ID.
 	 */
-	public static function save_term( $term_id ) {
-
-		// See wp-admin/edit-tag-form.php for where this is set.
-		check_admin_referer( 'update-tag_' . $term_id );
-
-		if ( ! current_user_can( 'edit_term', $term_id ) ) {
-			return;
-		}
+	private static function save_term( $term_id ) {
 
 		// Save label data if label is enabled; otherwise kill it.
 		if ( ! empty( $_POST[ self::TAG_LABEL_META_KEY ] ) ) {
@@ -204,6 +240,38 @@ class Tag_Labels {
 			delete_term_meta( $term_id, self::TAG_LABEL_META_KEY );
 			delete_term_meta( $term_id, self::TAG_LABEL_FLAG_META_KEY );
 		}
+	}
+	// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+	/**
+	 * Save label settings for new term.
+	 *
+	 * @param int $term_id Term ID.
+	 */
+	public static function save_new_term( $term_id ) {
+
+		check_admin_referer( 'add-tag', '_wpnonce_add-tag' );
+		if ( ! current_user_can( 'edit_term', $term_id ) ) {
+			return;
+		}
+
+			self::save_term( $term_id );
+	}
+
+	/**
+	 * Save label settings for existing term.
+	 *
+	 * @param int $term_id Term ID.
+	 */
+	public static function save_existing_term( $term_id ) {
+
+		// See wp-admin/edit-tag-form.php for this nonce.
+		check_admin_referer( 'update-tag_' . $term_id );
+		if ( ! current_user_can( 'edit_term', $term_id ) ) {
+			return;
+		}
+
+		self::save_term( $term_id );
 	}
 }
 

--- a/includes/tag-labels/class-tag-labels.php
+++ b/includes/tag-labels/class-tag-labels.php
@@ -213,6 +213,7 @@ class Tag_Labels {
 				<?php echo esc_html__( 'Custom text to display instead of the tag name.', 'newspack-plugin' ); ?>
 			</p>
 		</div>
+		<?php wp_nonce_field( 'newspack_tag_labels_save', 'newspack_tag_labels_nonce' ); ?>
 		<?php
 	}
 
@@ -271,16 +272,29 @@ class Tag_Labels {
 				</p>
 			</td>
 		</tr>
+		<?php wp_nonce_field( 'newspack_tag_labels_save', 'newspack_tag_labels_nonce' ); ?>
 		<?php
 	}
 
-	// phpcs:disable WordPress.Security.NonceVerification.Missing -- nonce verified upstream
 	/**
 	 * Store custom term meta on save.
+	 *
+	 * Bails on any term mutation that didn't originate from this UI's form — `created_post_tag`
+	 * and `edited_post_tag` also fire on REST edits, importers, and third-party
+	 * `wp_update_term()` calls, none of which post our fields.
 	 *
 	 * @param int $term_id Term ID.
 	 */
 	public static function save_term( $term_id ) {
+		if ( ! isset( $_POST['newspack_tag_labels_nonce'] )
+			|| ! wp_verify_nonce(
+				sanitize_text_field( wp_unslash( $_POST['newspack_tag_labels_nonce'] ) ),
+				'newspack_tag_labels_save'
+			)
+		) {
+			return;
+		}
+
 		if ( ! current_user_can( 'manage_categories' ) ) {
 			return;
 		}
@@ -299,7 +313,6 @@ class Tag_Labels {
 			delete_term_meta( $term_id, self::TAG_LABEL_META_KEY );
 		}
 	}
-	// phpcs:enable WordPress.Security.NonceVerification.Missing
 }
 
 Tag_Labels::init();

--- a/includes/tag-labels/class-tag-labels.php
+++ b/includes/tag-labels/class-tag-labels.php
@@ -96,6 +96,55 @@ class Tag_Labels {
 	}
 
 	/**
+	 * Generates HTML for given tag labels.
+	 *
+	 * @param array  $labels        Labels to display.
+	 * @param bool   $links         Whether to include links to tag archives.
+	 * @param array  $outer_classes Classes to apply to the outer container.
+	 * @param array  $inner_classes Classes to apply to the inner container.
+	 * @param string $outer_element HTML element to use for the outer container.
+	 *
+	 * @return string Tag labels as HTML.
+	 */
+	public static function generate_html( $labels = null, $links = true, $outer_classes = array( 'tag-labels' ), $inner_classes = array( 'tag-label', 'flag' ), $outer_element = 'span' ) {
+		if ( empty( $labels ) ) {
+			return '';
+		}
+
+		$outer_element = in_array( $outer_element, [ 'span', 'div' ], true ) ? $outer_element : 'span';
+
+		$labels_html  = '';
+		$labels_html .= '<' . $outer_element . ' class="' . join( ' ', array_map( 'esc_attr', $outer_classes ) ) . '">';
+		foreach ( $labels as $label ) {
+			if ( $links && isset( $label['flag'] ) && $label['link'] ) {
+				$labels_html .= '<a class="' . join( ' ', array_map( 'esc_attr', $inner_classes ) ) . '" href="' . esc_url( $label['link'] ) . '" rel="tag">' . esc_html( $label['flag'] ) . '</a>';
+			} elseif ( isset( $label['flag'] ) ) {
+				$labels_html .= '<span class="' . join( ' ', array_map( 'esc_attr', $inner_classes ) ) . '">' . esc_html( $label['flag'] ) . '</span>';
+			}
+		}
+		$labels_html .= '</' . $outer_element . '><!-- .tag-labels -->';
+
+		return $labels_html;
+	}
+
+	/**
+	 * Outputs HTML for given tag labels.
+	 *
+	 * @param array  $labels        Labels to display.
+	 * @param bool   $links         Whether to include links to tag archives.
+	 * @param string $outer_element HTML element to use for the outer container.
+	 *
+	 * @return void
+	 */
+	public static function display( $labels = null, $links = true, $outer_element = 'span' ) {
+		if ( empty( $labels ) ) {
+			return;
+		}
+
+		echo wp_kses_post( self::generate_html( $labels, $links, array( 'tag-labels', 'cat-links' ), array( 'tag-label', 'flag' ), $outer_element ) . ' ' );
+	}
+
+	/**
 	 * Initialize hooks.
 	 */
 	public static function init() {

--- a/includes/tag-labels/class-tag-labels.php
+++ b/includes/tag-labels/class-tag-labels.php
@@ -69,11 +69,16 @@ class Tag_Labels {
 	/**
 	 * Given a post ID, grab array of tag labels (if any) for it.
 	 *
-	 * @param int $post_id Post ID.
+	 * @param int|WP_Post|null $post Post to check.
 	 *
-	 * @return array Elements as ['flag' => FLAG_NAME, 'link' => TERM_LINK].
+	 * @return array|null Elements as ['flag' => FLAG_NAME, 'link' => TERM_LINK].
 	 */
-	public static function get_labels_for_post( $post_id ) {
+	public static function get_labels_for_post( $post ) {
+		if ( ! $post ) {
+			return null;
+		}
+
+		$post_id = ( is_a( 'WP_POST', $post ) ? $post->ID : (int) $post );
 		$post_terms = get_the_terms( $post_id, 'post_tag' );
 
 		if ( ! $post_terms ) {

--- a/includes/tag-labels/class-tag-labels.php
+++ b/includes/tag-labels/class-tag-labels.php
@@ -105,8 +105,8 @@ class Tag_Labels {
 		add_action( 'post_tag_add_form_fields', [ __CLASS__, 'add_term' ] );
 		add_action( 'post_tag_edit_form_fields', [ __CLASS__, 'edit_term' ] );
 
-		add_action( 'created_post_tag', [ __CLASS__, 'save_new_term' ] );
-		add_action( 'edited_post_tag', [ __CLASS__, 'save_existing_term' ] );
+		add_action( 'created_post_tag', [ __CLASS__, 'save_term' ] );
+		add_action( 'edited_post_tag', [ __CLASS__, 'save_term' ] );
 	}
 
 	/**
@@ -218,7 +218,7 @@ class Tag_Labels {
 		<?php
 	}
 
-	// phpcs:disable WordPress.Security.NonceVerification.Missing -- nonce verified in accessors
+	// phpcs:disable WordPress.Security.NonceVerification.Missing -- nonce verified upstream
 	/**
 	 * Store custom term meta on save.
 	 *
@@ -242,37 +242,6 @@ class Tag_Labels {
 		}
 	}
 	// phpcs:enable WordPress.Security.NonceVerification.Missing
-
-	/**
-	 * Save label settings for new term.
-	 *
-	 * @param int $term_id Term ID.
-	 */
-	public static function save_new_term( $term_id ) {
-
-		check_admin_referer( 'add-tag', '_wpnonce_add-tag' );
-		if ( ! current_user_can( 'edit_term', $term_id ) ) {
-			return;
-		}
-
-			self::save_term( $term_id );
-	}
-
-	/**
-	 * Save label settings for existing term.
-	 *
-	 * @param int $term_id Term ID.
-	 */
-	public static function save_existing_term( $term_id ) {
-
-		// See wp-admin/edit-tag-form.php for this nonce.
-		check_admin_referer( 'update-tag_' . $term_id );
-		if ( ! current_user_can( 'edit_term', $term_id ) ) {
-			return;
-		}
-
-		self::save_term( $term_id );
-	}
 }
 
 Tag_Labels::init();

--- a/includes/tag-labels/class-tag-labels.php
+++ b/includes/tag-labels/class-tag-labels.php
@@ -7,8 +7,6 @@
 
 namespace Newspack;
 
-// TODO:  Semaphore to only init once.
-
 defined( 'ABSPATH' ) || exit;
 
 /**

--- a/includes/tag-labels/class-tag-labels.php
+++ b/includes/tag-labels/class-tag-labels.php
@@ -36,7 +36,7 @@ class Tag_Labels {
 		if ( ! $term || ! $term->term_id ) {
 			return false;
 		}
-		return (bool) ( true === get_term_meta( $term->term_id, self::TAG_LABEL_META_KEY, true ) );
+		return (bool) ( true == get_term_meta( $term->term_id, self::TAG_LABEL_META_KEY, true ) );  // Meta value is 1 when enabled; use less-strict equivalence here.
 	}
 
 	/**
@@ -185,7 +185,8 @@ class Tag_Labels {
 		check_admin_referer( 'update-tag_' . $term_id );
 
 		if ( ! current_user_can( 'edit_term', $term_id ) ) {
-			return; }
+			return;
+		}
 
 		// Save label data if label is enabled; otherwise kill it.
 		if ( ! empty( $_POST[ self::TAG_LABEL_META_KEY ] ) ) {

--- a/includes/tag-labels/class-tag-labels.php
+++ b/includes/tag-labels/class-tag-labels.php
@@ -17,9 +17,8 @@ class Tag_Labels {
 	/**
 	 * Key names.
 	 */
-	const TAG_LABEL_SLUG = 'label';
-	const TAG_LABEL_META_KEY = '_label_enabled';
-	const TAG_LABEL_FLAG_META_KEY = '_label_flag';
+	const TAG_LABEL_META_KEY = '_np_label_enabled';
+	const TAG_LABEL_FLAG_META_KEY = '_np_label_flag';
 
 
 	// Helper functions for themes to get arrays of labels and flags.
@@ -34,7 +33,7 @@ class Tag_Labels {
 		if ( ! $term || ! $term->term_id ) {
 			return false;
 		}
-		return (bool) ( true == get_term_meta( $term->term_id, self::TAG_LABEL_META_KEY, true ) );  // Meta value is 1 when enabled; use less-strict equivalence here.
+		return ! empty( get_term_meta( $term->term_id, self::TAG_LABEL_META_KEY, true ) );
 	}
 
 	/**

--- a/includes/tag-labels/class-tag-labels.php
+++ b/includes/tag-labels/class-tag-labels.php
@@ -297,7 +297,6 @@ class Tag_Labels {
 			}
 		} else {
 			delete_term_meta( $term_id, self::TAG_LABEL_META_KEY );
-			delete_term_meta( $term_id, self::TAG_LABEL_FLAG_META_KEY );
 		}
 	}
 	// phpcs:enable WordPress.Security.NonceVerification.Missing

--- a/includes/tag-labels/class-tag-labels.php
+++ b/includes/tag-labels/class-tag-labels.php
@@ -229,10 +229,10 @@ class Tag_Labels {
 		$checkbox_id = self::TAG_LABEL_META_KEY;
 		$is_label = self::has_label( $term );
 
-		$label = self::get_tag_label_for_term( $term );
-		$label_flag  = $label ? $label['flag'] : $term->name;
-
-		$input_label_flag = ( $term->name === $label_flag ) ? '' : $label_flag;
+		// Read the stored flag directly so the input value survives disable→re-enable cycles —
+		// get_tag_label_for_term() returns null when has_label() is false, which would hide it.
+		$stored_flag      = get_term_meta( $term->term_id, self::TAG_LABEL_FLAG_META_KEY, true );
+		$input_label_flag = ( '' === $stored_flag || $term->name === $stored_flag ) ? '' : $stored_flag;
 		?>
 		<tr class="form-field newspack-label-enable term-<?php echo esc_attr( self::TAG_LABEL_META_KEY ); ?>-wrap">
 			<th scope="row"><label for="<?php echo esc_attr( $checkbox_id ); ?>"><?php esc_html_e( 'Display as label', 'newspack-plugin' ); ?></label></th>

--- a/includes/tag-labels/class-tag-labels.php
+++ b/includes/tag-labels/class-tag-labels.php
@@ -272,7 +272,7 @@ class Tag_Labels {
 				</p>
 			</td>
 		</tr>
-		<?php wp_nonce_field( 'newspack_tag_labels_save', 'newspack_tag_labels_nonce' ); ?>
+		<tr><td colspan="2"><?php wp_nonce_field( 'newspack_tag_labels_save', 'newspack_tag_labels_nonce' ); ?></td></tr>
 		<?php
 	}
 

--- a/includes/tag-labels/class-tag-labels.php
+++ b/includes/tag-labels/class-tag-labels.php
@@ -29,7 +29,7 @@ class Tag_Labels {
 	 *
 	 * @return bool
 	 */
-	public static function is_tag_label( $term ) {
+	public static function has_label( $term ) {
 		if ( ! $term || ! $term->term_id ) {
 			return false;
 		}
@@ -47,7 +47,7 @@ class Tag_Labels {
 	 * @return array|null As ['flag' => FLAG_NAME, 'link' => TERM_LINK].
 	 */
 	public static function get_tag_label_for_term( $term ) {
-		if ( ! $term || ! $term->term_id || ! self::is_tag_label( $term ) ) {
+		if ( ! $term || ! $term->term_id || ! self::has_label( $term ) ) {
 			return null;
 		}
 
@@ -172,7 +172,7 @@ class Tag_Labels {
 	 */
 	public static function edit_term( $term ) {
 		$checkbox_id = self::TAG_LABEL_META_KEY;
-		$is_label = self::is_tag_label( $term );
+		$is_label = self::has_label( $term );
 
 		$label = self::get_tag_label_for_term( $term );
 		$label_flag  = $label ? $label['flag'] : $term->name;

--- a/includes/tag-labels/class-tag-labels.php
+++ b/includes/tag-labels/class-tag-labels.php
@@ -59,6 +59,9 @@ class Tag_Labels {
 		}
 
 		$term_label_link = get_term_link( $term->term_id );
+		if ( is_wp_error( $term_label_link ) ) {
+			return null;
+		}
 
 		return [
 			'flag' => $term_label_flag,
@@ -81,7 +84,7 @@ class Tag_Labels {
 		$post_id = ( is_a( $post, 'WP_Post' ) ? $post->ID : (int) $post );
 		$post_terms = get_the_terms( $post_id, 'post_tag' );
 
-		if ( ! $post_terms ) {
+		if ( empty( $post_terms ) || is_wp_error( $post_terms ) ) {
 			return [];
 		}
 

--- a/includes/tag-labels/class-tag-labels.php
+++ b/includes/tag-labels/class-tag-labels.php
@@ -224,7 +224,7 @@ class Tag_Labels {
 	 *
 	 * @param int $term_id Term ID.
 	 */
-	private static function save_term( $term_id ) {
+	public static function save_term( $term_id ) {
 
 		// Save label data if label is enabled; otherwise kill it.
 		if ( ! empty( $_POST[ self::TAG_LABEL_META_KEY ] ) ) {

--- a/includes/tag-labels/class-tag-labels.php
+++ b/includes/tag-labels/class-tag-labels.php
@@ -1,0 +1,202 @@
+<?php
+/**
+ * Newspack Tag Labels
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+// TODO:  Semaphore to only init once.
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Newspack Tag Labels
+ */
+class Tag_Labels {
+
+	/**
+	 * Key names.
+	 */
+	const TAG_LABEL_SLUG = 'label';
+	const TAG_LABEL_META_KEY = '_label_enabled';
+	const TAG_LABEL_FLAG_META_KEY = '_label_flag';
+
+
+	// TODO:  Helper functions for themes to get array of labels + flags.
+	/**
+	 * Given a term, check if labels are enabled for it.
+	 *
+	 * @param WP_Term $term Term to check.
+	 *
+	 * @return bool
+	 */
+	public static function is_tag_label( $term ) {
+		if ( ! $term || ! $term->term_id ) {
+			return false;
+		}
+		return (bool) ( true == get_term_meta( $term->term_id, self::TAG_LABEL_META_KEY, true ) );
+	}
+
+	/**
+	 * Given a term, return the flag (text) of its label and
+	 * the link to the term archive.
+	 *
+	 * Will return null if label isn't enabled for the term.
+	 *
+	 * @param WP_Term $term Term to check.
+	 *
+	 * @return array|null As ['flag' => FLAG_NAME, 'link' => TERM_LINK].
+	 */
+	public static function get_tag_label_for_term( $term ) {
+		if ( ! $term || ! $term->term_id || ! self::is_tag_label( $term ) ) {
+			return null;
+		}
+
+		// A little fancy in case someone wants to give a tag a
+		// falsy label flag.  Empty string still gets default value.
+		$term_label_flag = get_term_meta( $term->term_id, self::TAG_LABEL_FLAG_META_KEY, true );
+		$term_label_flag = isset( $term_label_flag ) ? ( ( '' !== $term_label_flag ) ? $term_label_flag : $term->name ) : $term->name;
+
+		$term_label_link = get_term_link( $term->term_id );
+
+		return [
+			'flag' => $term_label_flag,
+			'link' => $term_label_link,
+		];
+	}
+
+	/**
+	 * Given a post ID, grab array of tag labels (if any) for it.
+	 *
+	 * @param int $post_id Post ID.
+	 *
+	 * @return array Elements as ['flag' => FLAG_NAME, 'link' => TERM_LINK].
+	 */
+	public static function get_labels_for_post( $post_id ) {
+		$post_terms = get_the_terms( $post_id, 'post_tag' );
+
+		if ( ! $post_terms ) {
+			return [];
+		}
+
+		return array_filter(
+			array_map(
+				function( $term ) {
+					return self::get_tag_label_for_term( $term );
+				},
+				$post_terms 
+			) 
+		);
+	}
+
+	/**
+	 * Initialize hooks.
+	 */
+	public static function init() {
+		add_action( 'post_tag_term_edit_form_top', array( __CLASS__, 'enqueue_scripts' ) );
+
+		add_action( 'post_tag_edit_form_fields', [ __CLASS__, 'edit_term' ] );
+		add_action( 'edited_post_tag', [ __CLASS__, 'save_term' ] );
+	}
+
+	/**
+	 * Enqueues js script
+	 *
+	 * @return void
+	 */
+	public static function enqueue_scripts() {
+		wp_enqueue_script(
+			'newspack_tag_labels',
+			Newspack::plugin_url() . '/dist/other-scripts/tag-labels.js',
+			[ 'jquery' ],
+			NEWSPACK_PLUGIN_VERSION,
+			true
+		);
+	}
+
+	/**
+	 * Add term edit fields.
+	 *
+	 * Toggle to determine if the term is a label.
+	 * Also, override for flag (text used on label).
+	 *
+	 * @param WP_Term $term The current WP_Term object.
+	 */
+	public static function edit_term( $term ) {
+		$is_label = self::is_tag_label( $term );
+
+		$label = self::get_tag_label_for_term( $term );
+		$label_flag  = $label ? $label['flag'] : $term->name;
+		?>
+		<tr class="form-field newspack-label-enable term-<?php echo esc_attr( self::TAG_LABEL_META_KEY ); ?>-wrap">
+			<th scope="row"><label for="<?php echo esc_attr( $checkbox_id ); ?>"><?php esc_html_e( 'Use as label', 'newspack-plugin' ); ?></label></th>
+			<td>
+				<input
+					type="checkbox"
+					name="<?php echo esc_attr( self::TAG_LABEL_META_KEY ); ?>"
+					value="true"
+					<?php
+						checked( $is_label, true );
+					?>
+				>
+				<p class="description" id="<?php echo esc_attr( self::TAG_LABEL_META_KEY ); ?>-description">
+					<?php echo esc_html__( 'Check to display this tag as a label on posts, similar to how categories are displayed.', 'newspack-plugin' ); ?>
+				</p>
+			</td>
+		</tr>
+		<tr class="form-field newspack-label-setting term-<?php echo esc_attr( self::TAG_LABEL_FLAG_META_KEY ); ?>-wrap">
+			<th scope="row"><label for="<?php echo esc_attr( self::TAG_LABEL_FLAG_META_KEY ); ?>"><?php esc_html_e( 'Label flag', 'newspack-plugin' ); ?></label></th>
+			<td>
+				<input
+					type="text"
+					name="<?php echo esc_attr( self::TAG_LABEL_FLAG_META_KEY ); ?>"
+					placeholder="<?php echo esc_attr( $term->name ); ?>"
+					<?php
+					if ( $term->name === $label_flag ) {
+							echo ' value=""';
+					} else {
+							echo ' value="' . esc_attr( $label_flag ) . '"';
+					}
+
+					if ( ! $is_label ) {
+						echo ' disabled'; }
+					?>
+				>
+				<p class="description" id="<?php echo esc_attr( self::TAG_LABEL_FLAG_META_KEY ); ?>-description">
+					<?php echo esc_html__( 'Enter alternative text to display on this label. By default, the term name will be used.', 'newspack-plugin' ); ?>
+				</p>
+			</td>
+		</tr>
+		<?php
+	}
+
+	/**
+	 * Store our custom term meta when term is saved
+	 *
+	 * @param int $term_id Term ID.
+	 */
+	public static function save_term( $term_id ) {
+
+		// See wp-admin/edit-tag-form.php for where this is set.
+		check_admin_referer( 'update-tag_' . $term_id );
+
+		// Save label data if label is enabled; otherwise kill it.
+		if ( ! empty( $_POST[ self::TAG_LABEL_META_KEY ] ) ) {
+			update_term_meta( $term_id, self::TAG_LABEL_META_KEY, true );
+
+			// Save falsy values other than empty string in case someone wants a flag of '0' or something.
+			if ( isset( $_POST[ self::TAG_LABEL_FLAG_META_KEY ] ) && $_POST[ self::TAG_LABEL_FLAG_META_KEY ] !== '' ) {
+				update_term_meta( $term_id, self::TAG_LABEL_FLAG_META_KEY, sanitize_text_field( wp_unslash( $_POST[ self::TAG_LABEL_FLAG_META_KEY ] ) ) );
+			} else {
+				delete_term_meta( $term_id, self::TAG_LABEL_FLAG_META_KEY );
+			}
+		} else {
+			delete_term_meta( $term_id, self::TAG_LABEL_META_KEY );
+			delete_term_meta( $term_id, self::TAG_LABEL_FLAG_META_KEY );
+		}
+	}
+}
+
+Tag_Labels::init();

--- a/includes/tag-labels/class-tag-labels.php
+++ b/includes/tag-labels/class-tag-labels.php
@@ -24,7 +24,7 @@ class Tag_Labels {
 	const TAG_LABEL_FLAG_META_KEY = '_label_flag';
 
 
-	// TODO:  Helper functions for themes to get array of labels + flags.
+	// Helper functions for themes to get arrays of labels and flags.
 	/**
 	 * Given a term, check if labels are enabled for it.
 	 *
@@ -36,7 +36,7 @@ class Tag_Labels {
 		if ( ! $term || ! $term->term_id ) {
 			return false;
 		}
-		return (bool) ( true == get_term_meta( $term->term_id, self::TAG_LABEL_META_KEY, true ) );
+		return (bool) ( true === get_term_meta( $term->term_id, self::TAG_LABEL_META_KEY, true ) );
 	}
 
 	/**
@@ -57,7 +57,9 @@ class Tag_Labels {
 		// A little fancy in case someone wants to give a tag a
 		// falsy label flag.  Empty string still gets default value.
 		$term_label_flag = get_term_meta( $term->term_id, self::TAG_LABEL_FLAG_META_KEY, true );
-		$term_label_flag = isset( $term_label_flag ) ? ( ( '' !== $term_label_flag ) ? $term_label_flag : $term->name ) : $term->name;
+		if ( ! isset( $term_label_flag ) || '' === $term_label_flag ) {
+			$term_label_flag = $term->name;
+		}
 
 		$term_label_link = get_term_link( $term->term_id );
 
@@ -86,8 +88,8 @@ class Tag_Labels {
 				function( $term ) {
 					return self::get_tag_label_for_term( $term );
 				},
-				$post_terms 
-			) 
+				$post_terms
+			)
 		);
 	}
 

--- a/includes/tag-labels/class-tag-labels.php
+++ b/includes/tag-labels/class-tag-labels.php
@@ -274,6 +274,9 @@ class Tag_Labels {
 	 * @param int $term_id Term ID.
 	 */
 	public static function save_term( $term_id ) {
+		if ( ! current_user_can( 'manage_categories' ) ) {
+			return;
+		}
 
 		// Save label data if label is enabled; otherwise kill it.
 		if ( ! empty( $_POST[ self::TAG_LABEL_META_KEY ] ) ) {

--- a/includes/tag-labels/class-tag-labels.php
+++ b/includes/tag-labels/class-tag-labels.php
@@ -54,7 +54,7 @@ class Tag_Labels {
 		// A little fancy in case someone wants to give a tag a
 		// falsy label flag.  Empty string still gets default value.
 		$term_label_flag = get_term_meta( $term->term_id, self::TAG_LABEL_FLAG_META_KEY, true );
-		if ( ! isset( $term_label_flag ) || '' === $term_label_flag ) {
+		if ( '' === $term_label_flag ) {
 			$term_label_flag = $term->name;
 		}
 

--- a/includes/tag-labels/class-tag-labels.php
+++ b/includes/tag-labels/class-tag-labels.php
@@ -78,7 +78,7 @@ class Tag_Labels {
 			return null;
 		}
 
-		$post_id = ( is_a( 'WP_POST', $post ) ? $post->ID : (int) $post );
+		$post_id = ( is_a( $post, 'WP_Post' ) ? $post->ID : (int) $post );
 		$post_terms = get_the_terms( $post_id, 'post_tag' );
 
 		if ( ! $post_terms ) {

--- a/includes/tag-labels/class-tag-labels.php
+++ b/includes/tag-labels/class-tag-labels.php
@@ -133,7 +133,7 @@ class Tag_Labels {
 		$input_label_flag = ( $term->name === $label_flag ) ? '' : $label_flag;
 		?>
 		<tr class="form-field newspack-label-enable term-<?php echo esc_attr( self::TAG_LABEL_META_KEY ); ?>-wrap">
-			<th scope="row"><label for="<?php echo esc_attr( $checkbox_id ); ?>"><?php esc_html_e( 'Use as label', 'newspack-plugin' ); ?></label></th>
+			<th scope="row"><label for="<?php echo esc_attr( $checkbox_id ); ?>"><?php esc_html_e( 'Display as label', 'newspack-plugin' ); ?></label></th>
 			<td>
 				<input
 					aria-describedby="<?php echo esc_attr( self::TAG_LABEL_META_KEY ); ?>-description"
@@ -145,12 +145,12 @@ class Tag_Labels {
 					?>
 				>
 				<p class="description" id="<?php echo esc_attr( self::TAG_LABEL_META_KEY ); ?>-description">
-					<?php echo esc_html__( 'Check to display this tag as a label on posts, similar to how categories are displayed.', 'newspack-plugin' ); ?>
+					<?php echo esc_html__( 'Show this tag as a highlighted label wherever posts are displayed.', 'newspack-plugin' ); ?>
 				</p>
 			</td>
 		</tr>
-		<tr class="form-field newspack-label-setting term-<?php echo esc_attr( self::TAG_LABEL_FLAG_META_KEY ); ?>-wrap">
-			<th scope="row"><label for="<?php echo esc_attr( self::TAG_LABEL_FLAG_META_KEY ); ?>"><?php esc_html_e( 'Label flag', 'newspack-plugin' ); ?></label></th>
+		<tr class="form-field newspack-label-setting term-<?php echo esc_attr( self::TAG_LABEL_FLAG_META_KEY ); ?>-wrap"<?php echo $is_label ? '' : ' style="display: none;"'; ?>>
+			<th scope="row"><label for="<?php echo esc_attr( self::TAG_LABEL_FLAG_META_KEY ); ?>"><?php esc_html_e( 'Label text', 'newspack-plugin' ); ?></label></th>
 			<td>
 				<input
 					aria-describedby="<?php echo esc_attr( self::TAG_LABEL_FLAG_META_KEY ); ?>-description"
@@ -164,7 +164,7 @@ class Tag_Labels {
 					?>
 				>
 				<p class="description" id="<?php echo esc_attr( self::TAG_LABEL_FLAG_META_KEY ); ?>-description">
-					<?php echo esc_html__( 'Enter alternative text to display on this label. By default, the term name will be used.', 'newspack-plugin' ); ?>
+					<?php echo esc_html__( 'Custom text to display instead of the tag name.', 'newspack-plugin' ); ?>
 				</p>
 			</td>
 		</tr>

--- a/src/other-scripts/tag-labels/index.js
+++ b/src/other-scripts/tag-labels/index.js
@@ -1,11 +1,22 @@
 /* globals jQuery */
 
 ( function ( $ ) {
-	$( '.newspack-label-enable input[type="checkbox"]' ).on( 'change', function () {
-		if ( $( this ).is( ':checked' ) ) {
-			$( '.newspack-label-setting input' ).prop( 'disabled', false );
+	function toggleLabelSetting() {
+		const checkbox = $( '.newspack-label-enable input[type="checkbox"]' );
+		const labelSettingRow = $( '.newspack-label-setting' );
+
+		if ( checkbox.is( ':checked' ) ) {
+			labelSettingRow.show();
+			labelSettingRow.find( 'input' ).prop( 'disabled', false );
 		} else {
-			$( '.newspack-label-setting input' ).prop( 'disabled', true );
+			labelSettingRow.hide();
+			labelSettingRow.find( 'input' ).prop( 'disabled', true );
 		}
-	} );
+	}
+
+	// Set initial state on page load.
+	toggleLabelSetting();
+
+	// Update on checkbox change.
+	$( '.newspack-label-enable input[type="checkbox"]' ).on( 'change', toggleLabelSetting );
 } )( jQuery );

--- a/src/other-scripts/tag-labels/index.js
+++ b/src/other-scripts/tag-labels/index.js
@@ -1,0 +1,11 @@
+/* globals jQuery */
+
+( function ( $ ) {
+	$( '.newspack-label-enable input[type="checkbox"]' ).on( 'change', function () {
+		if ( $( this ).is( ':checked' ) ) {
+			$( '.newspack-label-setting input' ).prop( 'disabled', false );
+		} else {
+			$( '.newspack-label-setting input' ).prop( 'disabled', true );
+		}
+	} );
+} )( jQuery );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR is one of a set that adds the ability to display selected tags as labels.  Changes live in the `feat/tag-labels` topic branch on the *newspack-blocks*, *newspack-plugin*, and *newspack-theme* projects.

See also:  https://github.com/Automattic/newspack-theme/pull/2613
See also:  https://github.com/Automattic/newspack-blocks/pull/2282

1. ~In non-singular context (as part of a Content Loop block, for example), the tag label will show up in front of the headline.~
2. ~In singular context (on the individual post page, for example), the tag label will show up with the category label.~

~By default, the text of the tag label will be the same as the tag name.  Optionally, the label text can be customized (e.g., to something shorter and more suitable for use as a label).~

Labels will appear above the headline, after any category or sponsorship labels.

By default, the text of the tag label will be the same as the tag name.  Optionally, the label text can be customized (e.g., to something shorter and more suitable for use as a label).  Additionally, the label color can be customized in the Newspack Theme customizer.


Addresses [NPPD-383: "Breaking News" or "Developing" Label](https://linear.app/a8c/issue/NPPD-383/breaking-news-or-developing-label).

### How to test the changes in this Pull Request:

#### Basic operation:

1.  Pull [this topic branch](https://github.com/Automattic/newspack-plugin/tree/feat/tag-labels), [the newspack-blocks topic branch](https://github.com/Automattic/newspack-blocks/tree/feat/tag-labels), and [the corresponding newspack-theme topic branch](https://github.com/Automattic/newspack-theme/tree/feat/tag-labels).
2. Create a post tag.  Name and description don't matter.  Confirm that you see a 'Display as label' checkbox below the **Add Tag** form.
3. Check the 'Display as label' checkbox.  Confirm a 'Label text' field appears below the 'Display as Label' checkbox.
4. Save the tag.
5. Tag a post with your new tag.
6. View the post and confirm the post now shows a label with the tag name on it just above the headline.  You should see this on the home page (i.e., Content Loop block) and on the individual post page.
7. Edit the post tag again.  Uncheck the 'Display as label' checkbox.  Confirm the 'Label text' field is disabled and save.
8. Confirm the label is no longer shown on the post.

#### Multiple labels:
1. Enable tag labels on your test tag, as above.
2. Tag your test post with another tag that doesn't have labels enabled.  Confirm only the test tag with labels enabled displays a label on the post.
3. Enable labels on your second test tag.  Confirm it also shows up on the post.

#### Custom label text (flag):
1. Edit one of your test post tags.  Check the 'Display as label' field to enable the 'Label text' field.
2. Add text of your choice (something different from the tag name!) to the 'Label text' field and save.
3. Confirm the test post shows a label with your custom text in all contexts.
4. Edit the post tag and verify your custom text is still shown in the 'Label text' field.
5. Clear the 'Label text' field.  Confirm the original tag name is again shown as a placeholder and save.
6. Confirm the test post shows a label with the original tag name.
7. Edit the post tag, uncheck the 'Display as label' field and save.  Confirm the label's no longer shown.
8. Edit the post tag and add custom text to the 'Label text' field again.  Save.  (Optionally:  check your custom text still shows up!)
9. Edit the post tag and uncheck the 'Display as label' field.  Confirm no label is shown on the test post. 

#### Custom label color:
1. Add a tag with labels enabled to a test post.  
2. Ensure you're using a Newspack theme, and open the theme customizer (**Appearance** > **Customize**).
3. Select **Tag Labels** from the menu.
4. Click on 'Select color' to select a color for the label.  If a post tagged with that label is visible in the preview pane on the right, you should see it change!  The text color may change as well to better contrast with the new label color.
5. Hit the 'Publish' button at the top and check your test post.  It should show the new color scheme.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->