### PR TITLE
fix(sso): change Jetpack configuration notice from error to warning

### DIFF
--- a/src/wizards/newspack/views/settings/connections/jetpack-sso.tsx
+++ b/src/wizards/newspack/views/settings/connections/jetpack-sso.tsx
@@ -93,7 +93,7 @@ const JetpackSSO = () => {
 						{ settings.jetpack_sso_force_2fa && (
 							<>
 								<Notice
-									isError
+									isWarning
 									noticeText={ __(
 										'Two-factor authentication is currently enforced for all users via Jetpack configuration.',
 										'newspack-plugin'
@@ -101,7 +101,7 @@ const JetpackSSO = () => {
 								/>
 								<p>
 									{ __(
-										'Customize which capabilties to enforce 2FA by untoggling the “Require accounts to use WordPress.com Two-Step Authentication” option in Jetpack settings.',
+										'Customize which capabilities to enforce 2FA by untoggling the “Require accounts to use WordPress.com Two-Step Authentication” option in Jetpack settings.',
 										'newspack-plugin'
 									) }
 								</p>

--- a/src/wizards/newspack/views/settings/connections/jetpack-sso.tsx
+++ b/src/wizards/newspack/views/settings/connections/jetpack-sso.tsx
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { BaseControl, CheckboxControl } from '@wordpress/components';
+import { BaseControl, CheckboxControl, ExternalLink } from '@wordpress/components';
 import { useEffect, useState } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 
@@ -63,13 +63,9 @@ const JetpackSSO = () => {
 			<ActionCard
 				isMedium
 				title={ __( 'Force two-factor authentication', 'newspack-plugin' ) }
-				description={ () => (
-					<>
-						{ __(
-							'Improve security by requiring two-factor authentication via WordPress.com for users with higher capabilities.',
-							'newspack-plugin'
-						) }
-					</>
+				description={ __(
+					'Improve security by requiring two-factor authentication via WordPress.com for users with higher capabilities.',
+					'newspack-plugin'
 				) }
 				hasGreyHeader={ !! settings.force_2fa }
 				toggleChecked={ !! settings.force_2fa }
@@ -92,13 +88,15 @@ const JetpackSSO = () => {
 						{ error && <Notice isError noticeText={ error } /> }
 						{ settings.jetpack_sso_force_2fa && (
 							<>
-								<Notice
-									isWarning
-									noticeText={ __(
+								<Notice isWarning>
+									{ __(
 										'Two-factor authentication is currently enforced for all users via Jetpack configuration.',
 										'newspack-plugin'
-									) }
-								/>
+									) }{ ' ' }
+									<ExternalLink href="/wp-admin/admin.php?page=jetpack#/settings">
+										{ __( 'Jetpack Settings', 'newspack-plugin' ) }
+									</ExternalLink>
+								</Notice>
 								<p>
 									{ __(
 										'Customize which capabilities to enforce 2FA by untoggling the “Require accounts to use WordPress.com Two-Step Authentication” option in Jetpack settings.',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

NPPM-2491

The notice about Jetpack enforcing 2FA for every user should be a warning rather than an error.

### How to test the changes in this Pull Request:

1. Go to Newspack -> Settings -> Connections and enable "Force two-factor authentication"
2. Go to Jetpack -> Settings -> Security and toggle all options from the  "WordPress.com login" section

<img width="1089" height="293" alt="image" src="https://github.com/user-attachments/assets/65ed60e9-97f2-4792-a53c-b861087b0194" />

3. Back to the Newspack -> Settings -> Connections page, confirm you get the following notice:

<img width="1115" height="468" alt="image" src="https://github.com/user-attachments/assets/49a25ae8-38e0-4449-85ab-5ad3f6d741b3" />

Mind that if you first update the settings in Jetpack and later in Newspack, you'll not get the notice because activating our strategy will toggle off "Require accounts to use WordPress.com Two-Step Authentication"

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->