### PR TITLE
fix: remove newspack-ui CSS class from my account when not logged in

### DIFF
--- a/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php
+++ b/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php
@@ -81,7 +81,9 @@ class My_Account_UI_V1 {
 			return $classes;
 		}
 
-		$classes[] = 'newspack-ui';
+		if ( is_user_logged_in() ) {
+			$classes[] = 'newspack-ui';
+		}
 		$classes[] = 'newspack-my-account';
 		$classes[] = 'newspack-my-account--v1';
 		if ( ! \is_user_logged_in() ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR fixes a super-minor issue I keep running into:

The My Account updates started adding the `newspack-ui` CSS class to the body for any of the My Account pages. This works great except when you're not logged in, then you see the regular header and footer, but with a smaller font size. The theme's relative font sizing is normally based on 20px, not 16px.

### How to test the changes in this Pull Request:

1. In an incognito window, go to /my-account and note the smaller header/footer.
2. Apply this PR.
3. Refresh the incognito window and confirm the header/footer fonts look okay.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->