### PR TITLE
fix: return block markup when outputting corrections

### DIFF
--- a/includes/corrections/class-corrections.php
+++ b/includes/corrections/class-corrections.php
@@ -46,7 +46,7 @@ class Corrections {
 	 */
 	public static function init() {
 		add_action( 'init', [ __CLASS__, 'register_post_type' ] );
-		add_filter( 'the_content', [ __CLASS__, 'output_corrections_on_post' ], 2 );
+		add_filter( 'the_content', [ __CLASS__, 'output_corrections_on_post' ], 1 );
 		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'wp_enqueue_scripts' ] );
 		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'wp_enqueue_scripts' ] );
 		add_action( 'rest_api_init', [ __CLASS__, 'register_rest_routes' ] );
@@ -467,7 +467,7 @@ class Corrections {
 
 		ob_start();
 		?>
-		<!-- wp:group {"className":"correction-module","backgroundColor":"light-gray"} -->
+		<!-- wp:newspack/correction-box {"className":"correction-module","backgroundColor":"light-gray"} -->
 		<div class="wp-block-group newspack-corrections-module corrections-<?php echo esc_attr( $corrections_priority ); ?>-module">
 			<?php foreach ( $corrections as $correction ) : ?>
 				<?php
@@ -488,9 +488,9 @@ class Corrections {
 				</p>
 			<?php endforeach; ?>
 		</div>
-		<!-- /wp:group -->
+		<!-- /wp:newspack/correction-box -->
 		<?php
-		return do_blocks( ob_get_clean() );
+		return ob_get_clean();
 	}
 
 	/**

--- a/includes/corrections/class-corrections.php
+++ b/includes/corrections/class-corrections.php
@@ -46,7 +46,7 @@ class Corrections {
 	 */
 	public static function init() {
 		add_action( 'init', [ __CLASS__, 'register_post_type' ] );
-		add_filter( 'the_content', [ __CLASS__, 'output_corrections_on_post' ], 1 );
+		add_filter( 'the_content', [ __CLASS__, 'output_corrections_on_post' ], 2 );
 		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'wp_enqueue_scripts' ] );
 		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'wp_enqueue_scripts' ] );
 		add_action( 'rest_api_init', [ __CLASS__, 'register_rest_routes' ] );


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://linear.app/a8c/issue/NPPM-2507/high-priority-corrections-hide-inline-campaign-prompts

See https://github.com/Automattic/newspack-popups/pull/1511

### How to test the changes in this Pull Request:

See https://github.com/Automattic/newspack-popups/pull/1511 for testing instructions

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->