### PR TITLE
fix(my-acount): navigation margin without favicon

### DIFF
--- a/src/my-account/v1/_navigation.scss
+++ b/src/my-account/v1/_navigation.scss
@@ -106,7 +106,7 @@
 			background-color: var(--newspack-ui-color-neutral-0);
 			display: none;
 			height: var(--newspack-ui-spacer-9);
-			margin: var(--newspack-ui-spacer-6) var(--newspack-ui-spacer-3);
+			margin: var(--newspack-ui-spacer-6) var(--newspack-ui-spacer-3) 0;
 			padding: calc(var(--newspack-ui-spacer-base) * 0.5);
 			place-items: center;
 			transition: border-color 125ms ease-in-out;
@@ -126,7 +126,7 @@
 		}
 		.newspack-my-account__home-link {
 			margin-bottom: var(--newspack-ui-spacer-2);
-			margin-top: 0;
+			margin-top: var(--newspack-ui-spacer-6);
 
 			svg {
 				margin-left: -8px;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

NPPD-1060

Without a favicon, the new My Account navigation menu is rendered attached to the top. This PR tweaks the CSS to set an appropriate margin.

### How to test the changes in this Pull Request:

1. Make sure you have `define( 'NEWSPACK_MY_ACCOUNT_VERSION', '1.0.0' );` in your `wp-config.php`
2. While in trunk, navigate to Appearence -> Customize -> Site Identity
3. Make sure you don't have a **Site Icon** set
4. As a reader, visit "My Account" 
5. Confirm the navigation is attached to the top of the page
6. Checkout this branch and refresh
7. Confirm there's now a margin
8. Set a Site Icon and refresh the My Account page
9. Confirm you get the same margin with the image

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->