### PR TITLE
fix: decrease image size for Collections in certain cases

### DIFF
--- a/src/blocks/collections/class-collections-block.php
+++ b/src/blocks/collections/class-collections-block.php
@@ -69,7 +69,7 @@ final class Collections_Block {
 	}
 
 	/**
-	 * Register custom image sizes for collections block when displayed as a grid.
+	 * Register custom image sizes for collections block.
 	 *
 	 * @return void
 	 */
@@ -276,11 +276,11 @@ final class Collections_Block {
 	 * @return string Image size name.
 	 */
 	public static function get_image_size_from_attributes( $attributes ) {
-		if ( 'grid' === $attributes['layout'] && 4 <= $attributes['columns'] ) {
+		if ( isset( $attributes['layout'], $attributes['columns'] ) && 'grid' === $attributes['layout'] && 4 <= $attributes['columns'] ) {
 			return 'newspack_collection_small';
 		}
 
-		if ( 'grid' === $attributes['layout'] && 3 === $attributes['columns'] ) {
+		if ( isset( $attributes['layout'], $attributes['columns'] ) && 'grid' === $attributes['layout'] && 3 === $attributes['columns'] ) {
 			return 'newspack_collection_medium';
 		}
 

--- a/src/blocks/collections/class-collections-block.php
+++ b/src/blocks/collections/class-collections-block.php
@@ -65,6 +65,18 @@ final class Collections_Block {
 	 */
 	public static function init() {
 		add_action( 'init', [ __CLASS__, 'register_block' ] );
+		add_action( 'after_setup_theme', [ __CLASS__, 'register_image_sizes' ] );
+	}
+
+	/**
+	 * Register custom image sizes for collections block when displayed as a grid.
+	 *
+	 * @return void
+	 */
+	public static function register_image_sizes() {
+		add_image_size( 'newspack_collection_small', 550, 9999 );
+		add_image_size( 'newspack_collection_medium', 800, 9999 );
+		add_image_size( 'newspack_collection_large', 1200, 9999 );
 	}
 
 	/**
@@ -264,23 +276,27 @@ final class Collections_Block {
 	 * @return string Image size name.
 	 */
 	public static function get_image_size_from_attributes( $attributes ) {
-		if ( 'grid' === $attributes['layout'] && 5 <= $attributes['columns'] ) {
-			return 'medium';
+		if ( 'grid' === $attributes['layout'] && 4 <= $attributes['columns'] ) {
+			return 'newspack_collection_small';
+		}
+
+		if ( 'grid' === $attributes['layout'] && 3 === $attributes['columns'] ) {
+			return 'newspack_collection_medium';
 		}
 
 		if ( ! isset( $attributes['layout'] ) || 'grid' === $attributes['layout'] ) {
-			return 'post-thumbnail';
+			return 'newspack_collection_large';
 		}
 
 		$size = isset( $attributes['imageSize'] ) ? $attributes['imageSize'] : 'small';
 		switch ( $size ) {
 			case 'large':
-				return 'full';
+				return 'newspack_collection_large';
 			case 'medium':
-				return 'medium_large';
+				return 'newspack_collection_medium';
 			case 'small':
 			default:
-				return 'medium';
+				return 'newspack_collection_small';
 		}
 	}
 

--- a/src/blocks/collections/class-collections-block.php
+++ b/src/blocks/collections/class-collections-block.php
@@ -65,6 +65,16 @@ final class Collections_Block {
 	 */
 	public static function init() {
 		add_action( 'init', [ __CLASS__, 'register_block' ] );
+		add_action( 'after_setup_theme', [ __CLASS__, 'register_image_sizes' ] );
+	}
+
+	/**
+	 * Register custom image sizes for collections block when displayed as a grid.
+	 *
+	 * @return void
+	 */
+	public static function register_image_sizes() {
+		add_image_size( 'newspack_collection_grid', 550, 9999 );
 	}
 
 	/**
@@ -257,6 +267,8 @@ final class Collections_Block {
 		<?php
 	}
 
+
+
 	/**
 	 * Map editor image size attribute to an image size name used on the frontend.
 	 *
@@ -264,6 +276,10 @@ final class Collections_Block {
 	 * @return string Image size name.
 	 */
 	public static function get_image_size_from_attributes( $attributes ) {
+		if ( 'grid' === $attributes['layout'] && 5 <= $attributes['columns'] ) {
+			return 'newspack_collection_grid';
+		}
+
 		if ( ! isset( $attributes['layout'] ) || 'grid' === $attributes['layout'] ) {
 			return 'post-thumbnail';
 		}

--- a/src/blocks/collections/class-collections-block.php
+++ b/src/blocks/collections/class-collections-block.php
@@ -65,16 +65,6 @@ final class Collections_Block {
 	 */
 	public static function init() {
 		add_action( 'init', [ __CLASS__, 'register_block' ] );
-		add_action( 'after_setup_theme', [ __CLASS__, 'register_image_sizes' ] );
-	}
-
-	/**
-	 * Register custom image sizes for collections block when displayed as a grid.
-	 *
-	 * @return void
-	 */
-	public static function register_image_sizes() {
-		add_image_size( 'newspack_collection_grid', 550, 9999 );
 	}
 
 	/**
@@ -277,7 +267,7 @@ final class Collections_Block {
 	 */
 	public static function get_image_size_from_attributes( $attributes ) {
 		if ( 'grid' === $attributes['layout'] && 5 <= $attributes['columns'] ) {
-			return 'newspack_collection_grid';
+			return 'medium';
 		}
 
 		if ( ! isset( $attributes['layout'] ) || 'grid' === $attributes['layout'] ) {

--- a/src/blocks/collections/class-collections-block.php
+++ b/src/blocks/collections/class-collections-block.php
@@ -257,8 +257,6 @@ final class Collections_Block {
 		<?php
 	}
 
-
-
 	/**
 	 * Map editor image size attribute to an image size name used on the frontend.
 	 *

--- a/tests/unit-tests/collections/class-test-collections-block.php
+++ b/tests/unit-tests/collections/class-test-collections-block.php
@@ -199,7 +199,7 @@ class Test_Collections_Block extends \WP_UnitTestCase {
 			'imageSize' => 'small',
 		];
 		$size       = Collections_Block::get_image_size_from_attributes( $attributes );
-		$this->assertEquals( 'medium', $size, 'Small should map to medium' );
+		$this->assertEquals( 'newspack_collection_small', $size, 'Small should map to newspack_collection_small' );
 
 		// Test medium size.
 		$attributes = [
@@ -207,7 +207,7 @@ class Test_Collections_Block extends \WP_UnitTestCase {
 			'imageSize' => 'medium',
 		];
 		$size       = Collections_Block::get_image_size_from_attributes( $attributes );
-		$this->assertEquals( 'medium_large', $size, 'Medium should map to medium_large' );
+		$this->assertEquals( 'newspack_collection_medium', $size, 'Medium should map to newspack_collection_medium' );
 
 		// Test large size.
 		$attributes = [
@@ -215,31 +215,39 @@ class Test_Collections_Block extends \WP_UnitTestCase {
 			'imageSize' => 'large',
 		];
 		$size       = Collections_Block::get_image_size_from_attributes( $attributes );
-		$this->assertEquals( 'full', $size, 'Large should map to full' );
+		$this->assertEquals( 'newspack_collection_large', $size, 'Large should map to newspack_collection_large' );
 
 		// Test default.
 		$attributes = [ 'layout' => 'list' ];
 		$size       = Collections_Block::get_image_size_from_attributes( $attributes );
-		$this->assertEquals( 'medium', $size, 'Default should be medium' );
+		$this->assertEquals( 'newspack_collection_small', $size, 'Default should be newspack_collection_small' );
 
-		// Test grid layout with columns < 5 (should return post-thumbnail).
-		foreach ( [ 1, 2, 3, 4 ] as $columns ) {
+		// Test grid layout with columns < 3 (should return newspack_collection_large).
+		foreach ( [ 1, 2 ] as $columns ) {
 			$attributes = [
 				'layout'  => 'grid',
 				'columns' => $columns,
 			];
 			$size       = Collections_Block::get_image_size_from_attributes( $attributes );
-			$this->assertEquals( 'post-thumbnail', $size, "Grid layout with {$columns} columns should map to post-thumbnail" );
+			$this->assertEquals( 'newspack_collection_large', $size, 'Grid layout with {$columns} columns should map to newspack_collection_large' );
 		}
 
-		// Test grid layout with columns >= 5 (should return medium).
-		foreach ( [ 5, 6 ] as $columns ) {
+		// Test grid layout with columns = 3 (should return newspack_collection_medium).
+		$attributes = [
+			'layout'  => 'grid',
+			'columns' => 3,
+		];
+		$size       = Collections_Block::get_image_size_from_attributes( $attributes );
+		$this->assertEquals( 'newspack_collection_medium', $size, 'Grid layout with 3 columns should map to newspack_collection_medium' );
+
+		// Test grid layout with columns >= 4 (should return newspack_collection_medium).
+		foreach ( [ 4, 5, 6 ] as $columns ) {
 			$attributes = [
 				'layout'  => 'grid',
 				'columns' => $columns,
 			];
 			$size       = Collections_Block::get_image_size_from_attributes( $attributes );
-			$this->assertEquals( 'medium', $size, "Grid layout with {$columns} columns should map to medium" );
+			$this->assertEquals( 'newspack_collection_small', $size, 'Grid layout with {$columns} columns should map to newspack_collection_small' );
 		}
 	}
 

--- a/tests/unit-tests/collections/class-test-collections-block.php
+++ b/tests/unit-tests/collections/class-test-collections-block.php
@@ -232,14 +232,14 @@ class Test_Collections_Block extends \WP_UnitTestCase {
 			$this->assertEquals( 'post-thumbnail', $size, "Grid layout with {$columns} columns should map to post-thumbnail" );
 		}
 
-		// Test grid layout with columns >= 5 (should return newspack_collection_grid).
+		// Test grid layout with columns >= 5 (should return medium).
 		foreach ( [ 5, 6 ] as $columns ) {
 			$attributes = [
 				'layout'  => 'grid',
 				'columns' => $columns,
 			];
 			$size       = Collections_Block::get_image_size_from_attributes( $attributes );
-			$this->assertEquals( 'newspack_collection_grid', $size, "Grid layout with {$columns} columns should map to newspack_collection_grid" );
+			$this->assertEquals( 'medium', $size, "Grid layout with {$columns} columns should map to medium" );
 		}
 	}
 

--- a/tests/unit-tests/collections/class-test-collections-block.php
+++ b/tests/unit-tests/collections/class-test-collections-block.php
@@ -222,10 +222,25 @@ class Test_Collections_Block extends \WP_UnitTestCase {
 		$size       = Collections_Block::get_image_size_from_attributes( $attributes );
 		$this->assertEquals( 'medium', $size, 'Default should be medium' );
 
-		// Test grid layout.
-		$attributes = [ 'layout' => 'grid' ];
-		$size       = Collections_Block::get_image_size_from_attributes( $attributes );
-		$this->assertEquals( 'post-thumbnail', $size, 'Grid layout should map to post-thumbnail' );
+		// Test grid layout with columns < 5 (should return post-thumbnail).
+		foreach ( [ 1, 2, 3, 4 ] as $columns ) {
+			$attributes = [
+				'layout'  => 'grid',
+				'columns' => $columns,
+			];
+			$size       = Collections_Block::get_image_size_from_attributes( $attributes );
+			$this->assertEquals( 'post-thumbnail', $size, "Grid layout with {$columns} columns should map to post-thumbnail" );
+		}
+
+		// Test grid layout with columns >= 5 (should return newspack_collection_grid).
+		foreach ( [ 5, 6 ] as $columns ) {
+			$attributes = [
+				'layout'  => 'grid',
+				'columns' => $columns,
+			];
+			$size       = Collections_Block::get_image_size_from_attributes( $attributes );
+			$this->assertEquals( 'newspack_collection_grid', $size, "Grid layout with {$columns} columns should map to newspack_collection_grid" );
+		}
 	}
 
 	/**

--- a/tests/unit-tests/collections/class-test-collections-block.php
+++ b/tests/unit-tests/collections/class-test-collections-block.php
@@ -229,7 +229,7 @@ class Test_Collections_Block extends \WP_UnitTestCase {
 				'columns' => $columns,
 			];
 			$size       = Collections_Block::get_image_size_from_attributes( $attributes );
-			$this->assertEquals( 'newspack_collection_large', $size, 'Grid layout with {$columns} columns should map to newspack_collection_large' );
+			$this->assertEquals( 'newspack_collection_large', $size, "Grid layout with {$columns} columns should map to newspack_collection_large" );
 		}
 
 		// Test grid layout with columns = 3 (should return newspack_collection_medium).
@@ -247,7 +247,7 @@ class Test_Collections_Block extends \WP_UnitTestCase {
 				'columns' => $columns,
 			];
 			$size       = Collections_Block::get_image_size_from_attributes( $attributes );
-			$this->assertEquals( 'newspack_collection_small', $size, 'Grid layout with {$columns} columns should map to newspack_collection_small' );
+			$this->assertEquals( 'newspack_collection_small', $size, "Grid layout with {$columns} columns should map to newspack_collection_small" );
 		}
 	}
 

--- a/tests/unit-tests/collections/class-test-collections-block.php
+++ b/tests/unit-tests/collections/class-test-collections-block.php
@@ -240,7 +240,7 @@ class Test_Collections_Block extends \WP_UnitTestCase {
 		$size       = Collections_Block::get_image_size_from_attributes( $attributes );
 		$this->assertEquals( 'newspack_collection_medium', $size, 'Grid layout with 3 columns should map to newspack_collection_medium' );
 
-		// Test grid layout with columns >= 4 (should return newspack_collection_medium).
+		// Test grid layout with columns >= 4 (should return newspack_collection_small).
 		foreach ( [ 4, 5, 6 ] as $columns ) {
 			$attributes = [
 				'layout'  => 'grid',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds some image sizes to the Collections code so we can reduce the image size that's used in some cases.

Originally, the code used `medium` (defined in the Media Library, but defaulted to 300px), `post-thumbnail` (which is set to 1200px in our theme), and full size.

This PR adds a small (550px), medium (800px), and large (1200px) image size, and tries to use them in a way that we're loading retina-sized images when we can, but also not loading anything beyond 1200px wide. This means a single collection taking up the full width of a one-column wide template will not be perfectly sharp on retina screens, but I think it's a sort of fine line we have to walk with not loading absolutely huge images. 

See: NPPM-2520

### How to test the changes in this Pull Request:

1. Apply this PR.
2. Regenerate the thumbnails (`wp media regenerate` or use the Regenerate Thumbnails plugin). 
3. View the /collections landing page and confirm that the main grid of images is using the new "small" size, 550px wide (it's kind of a random number, but it is double the size that these Collections can display at when they wrap to a three column grid for tablet-sized screens).
4. Create a page and add 9 Collection blocks of different settings:
   * For the first six blocks, set them to use the grid layout and set them to one column, two columns, three columns... until you have a set that show the range from 1-6 columns.
   * For the final three blocks, set them to use the list layout and set the image sizes to small, medium, and large.
5. Go through the images and open each in a new tab:
    * For the grid layout, the one and two column blocks should use a 1200px wide image; the 3 column block should use a 800px wide image, and the four to six column blocks should use a 550px wide image
    * For the list layout, the small image should be 550px, the medium image should be 800px, and the large image should be 1200px
6. Do a general review of image quality using a retina screen. It will be most helpful if you use a graphic with text, like a true Collections cover from our of our publishers -- text and sharp edges will show image quality issues much readier than a regular photograph. It's expected that some will be a little softer than they were, but if any seem to be of a noticeable low quality, please flag here!

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->