### PR TITLE
fix(memberships): restrict commenting to relevant statuses

### DIFF
--- a/includes/optional-modules/class-woo-member-commenting.php
+++ b/includes/optional-modules/class-woo-member-commenting.php
@@ -131,7 +131,12 @@ class Woo_Member_Commenting {
 			$require_membership_to_comment = false;
 		} else {
 			$memberships_required_plans    = array_filter(
-				wc_memberships_get_user_memberships(),
+				wc_memberships_get_user_memberships(
+					get_current_user_id(),
+					[
+						'status' => [ 'active', 'complimentary', 'pending', 'free_trial' ],
+					]
+				),
 				fn( $membership ) => in_array( $membership->get_plan()->get_slug(), self::get_plan_slugs() )
 			);
 			$require_membership_to_comment = empty( $memberships_required_plans );

--- a/includes/optional-modules/class-woo-member-commenting.php
+++ b/includes/optional-modules/class-woo-member-commenting.php
@@ -134,7 +134,7 @@ class Woo_Member_Commenting {
 				wc_memberships_get_user_memberships(
 					get_current_user_id(),
 					[
-						'status' => [ 'active', 'complimentary', 'pending', 'free_trial' ],
+						'status' => Memberships::$active_statuses,
 					]
 				),
 				fn( $membership ) => in_array( $membership->get_plan()->get_slug(), self::get_plan_slugs() )


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://linear.app/a8c/issue/NPPM-2524/bug-woo-member-commenting-module-allows-cancelled-memberships-to

This PR fixes an issue where readers with cancelled subscriptions are able to comment when the `woo-member-commenting` module is active and enabled.

We do this by filtering by status when checking a given readers subscriptions (Proposed by Adam Leone in the Linear task).

### How to test the changes in this Pull Request:

1. Set up the `woo-member-commenting` module (See instructions on that below
2. Ensure commenting is enabled in WordPress settings
3. As a non-subscribed reader, visit a restricted post associated with a membership plan and verify you are not able to comment on the post
4. Subscribe to the relevant subscription to gain access
5. Verify you can now comment
6. Cancel the subscription as the reader so it is in `pending-cancel` state
7. Verify you can still comment
8. As admin, fully cancel the subscription
9. As reader, verify you can no longer comment

**Setting up woo member commenting:**
1. Run the following command: `wp newspack optional-module activate woo-member-commenting`
2. Add the following snippet to `wp-config.php`:
```
const NP_WC_MEMBER_COMMENT_SETTINGS = [
  'membership_plan_slug'        => [''], // Slug(s) of membership plans. 
  'membership_purchase_post_id'     => 6, // Post id to a page/post with membershipt tease
  'membership_required_message' => "Become a member, why don't cha?",
];
```

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->