### PR TITLE
fix(content-gate): change 'paragraph' to 'block' in settings text

### DIFF
--- a/src/content-gate/editor/editor.js
+++ b/src/content-gate/editor/editor.js
@@ -190,16 +190,16 @@ function GateEdit() {
 					type="number"
 					min="0"
 					value={ meta.visible_paragraphs }
-					label={ __( 'Default paragraph count', 'newspack-plugin' ) }
+					label={ __( 'Default block count', 'newspack-plugin' ) }
 					onChange={ value => editPost( { meta: { visible_paragraphs: value } } ) }
-					help={ __( 'Number of paragraphs that readers can see above the content gate.', 'newspack-plugin' ) }
+					help={ __( 'Number of blocks that readers can see above the content gate.', 'newspack-plugin' ) }
 				/>
 				<hr />
 				<CheckboxControl
 					label={ __( 'Use “More” tag to manually place content gate', 'newspack-plugin' ) }
 					checked={ meta.use_more_tag }
 					onChange={ value => editPost( { meta: { use_more_tag: value } } ) }
-					help={ __( 'Override the default paragraph count on pages where a “More” block has been placed.', 'newspack-plugin' ) }
+					help={ __( 'Override the default block count on pages where a “More” block has been placed.', 'newspack-plugin' ) }
 				/>
 			</PluginDocumentSettingPanel>
 			<PluginDocumentSettingPanel name="content-gate-metering-panel" title={ __( 'Metering', 'newspack-plugin' ) }>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

Updated terminology in the content gate settings panel from "paragraph" to "block" to better align with WordPress block terminology.

Since the Content Gate can be applied to any block type, not just paragraphs, this change makes the UI text more accurate and less confusing for users.

`NPPM-2492`

### How to test the changes in this Pull Request:

1. In wp-admin, go here: Audience > Configuration > Content Gating > Content Gate 
2. Click on Configure 
3. View the Settings in the sidebar to review the copy changes, which are a swap of "paragraph" for "block" on the label: "Default Block Count", and its help: "Number of blocks that readers can see above the content gate.",  plus the help on the More tag checkbox: "Override the default block count on pages where a “More” block has been placed." 


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->