### PR TITLE
feat(content-gate): create layout and improve asset management

### DIFF
--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -484,7 +484,7 @@ class Content_Gate {
 		if ( $gate_mode ) {
 			$url = add_query_arg( 'gate_mode', $gate_mode, $url );
 		}
-		return str_replace( site_url(), '', $url );
+		return \wp_make_link_relative( $url );
 	}
 
 	/**

--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -49,8 +49,8 @@ class Content_Gate {
 	public static function init() {
 		add_action( 'init', [ __CLASS__, 'register_post_type' ] );
 		add_action( 'admin_init', [ __CLASS__, 'redirect_cpt' ] );
+		add_action( 'admin_init', [ __CLASS__, 'handle_edit_gate_layout' ] );
 		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'enqueue_scripts' ] );
-		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'enqueue_block_editor_assets' ] );
 		add_action( 'wp_footer', [ __CLASS__, 'render_overlay_gate' ], 1 );
 		add_filter( 'newspack_popups_assess_has_disabled_popups', [ __CLASS__, 'disable_popups' ] );
 		add_filter( 'newspack_reader_activity_article_view', [ __CLASS__, 'suppress_article_view_activity' ], 100 );
@@ -325,36 +325,6 @@ class Content_Gate {
 	}
 
 	/**
-	 * Enqueue block editor assets.
-	 */
-	public static function enqueue_block_editor_assets() {
-		if ( ! in_array( get_post_type(), self::get_gate_post_types(), true ) ) {
-			return;
-		}
-		\wp_enqueue_script(
-			'newspack-content-gate',
-			Newspack::plugin_url() . '/dist/content-gate-editor.js',
-			[],
-			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/dist/content-gate-editor.js' ),
-			true
-		);
-		\wp_localize_script(
-			'newspack-content-gate',
-			'newspack_content_gate',
-			[
-				'has_campaigns' => class_exists( 'Newspack_Popups' ),
-			]
-		);
-
-		\wp_enqueue_style(
-			'newspack-content-gate',
-			Newspack::plugin_url() . '/dist/content-gate-editor.css',
-			[],
-			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/dist/content-gate-editor.css' )
-		);
-	}
-
-	/**
 	 * Get the post ID of the custom gate.
 	 *
 	 * @param int $post_id Post ID to find gate for.
@@ -495,6 +465,85 @@ class Content_Gate {
 			return new \WP_Error( 'newspack_content_gate_create_gate_error', $id->get_error_message() );
 		}
 		return $id;
+	}
+
+	/**
+	 * Get edit gate layout URL.
+	 *
+	 * @param int|false    $gate_id   Gate ID or false if not set.
+	 * @param string|false $gate_mode Gate mode or false if not set.
+	 *
+	 * @return string Edit gate layout URL.
+	 */
+	public static function get_edit_gate_layout_url( $gate_id = false, $gate_mode = false ) {
+		$action = 'newspack_edit_gate_layout';
+		$url    = add_query_arg( '_wpnonce', \wp_create_nonce( $action ), \admin_url( 'admin.php?action=' . $action ) );
+		if ( $gate_id ) {
+			$url = add_query_arg( 'gate_id', $gate_id, $url );
+		}
+		if ( $gate_mode ) {
+			$url = add_query_arg( 'gate_mode', $gate_mode, $url );
+		}
+		return str_replace( site_url(), '', $url );
+	}
+
+	/**
+	 * Handle edit gate layout.
+	 */
+	public static function handle_edit_gate_layout() {
+		if ( ! isset( $_GET['action'] ) || 'newspack_edit_gate_layout' !== $_GET['action'] ) {
+			return;
+		}
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+		check_admin_referer( 'newspack_edit_gate_layout' );
+
+		$gate_id = isset( $_GET['gate_id'] ) ? \absint( $_GET['gate_id'] ) : false;
+		if ( ! $gate_id ) {
+			\wp_die( esc_html( __( 'Gate ID is required.', 'newspack' ) ) );
+		}
+
+		$gate_mode = isset( $_GET['gate_mode'] ) ? \sanitize_text_field( $_GET['gate_mode'] ) : false;
+		if ( ! $gate_mode ) {
+			\wp_die( esc_html( __( 'Gate mode is required.', 'newspack' ) ) );
+		}
+
+		$gate = self::get_gate( $gate_id );
+		if ( ! $gate ) {
+			\wp_die( esc_html( __( 'Gate not found.', 'newspack' ) ) );
+		}
+
+		$gate_layout_id            = 0;
+		$gate_layout_default_title = __( 'Content Gate Layout', 'newspack' );
+
+		if ( 'registration' === $gate_mode ) {
+			$gate_layout_id = $gate['registration']['gate_layout_id'];
+			$gate_layout_default_title = __( 'Registration Access Layout', 'newspack' );
+		} elseif ( 'custom_access' === $gate_mode ) {
+			$gate_layout_id = $gate['custom_access']['gate_layout_id'];
+			$gate_layout_default_title = __( 'Paid Access Layout', 'newspack' );
+		} else {
+			\wp_die( esc_html( __( 'Invalid gate mode.', 'newspack' ) ) );
+		}
+
+		$gate_layout = get_post( $gate_layout_id );
+		if ( $gate_layout ) {
+			if ( 'trash' === get_post_status( $gate_layout_id ) ) {
+				\wp_untrash_post( $gate_layout_id );
+			}
+			\wp_safe_redirect( \admin_url( 'post.php?post=' . $gate_layout_id . '&action=edit' ) );
+			exit;
+		} else {
+			$gate_layout_id = self::create_gate( $gate_layout_default_title, self::GATE_LAYOUT_CPT );
+			if ( is_wp_error( $gate_layout_id ) ) {
+				\wp_die( esc_html( $gate_layout_id->get_error_message() ) );
+			}
+			$gate[ $gate_mode ]['gate_layout_id'] = $gate_layout_id;
+			self::update_gate_settings( $gate_id, $gate );
+			\wp_safe_redirect( \admin_url( 'post.php?post=' . $gate_layout_id . '&action=edit' ) );
+			exit;
+		}
 	}
 
 	/**

--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -532,7 +532,7 @@ class Content_Gate {
 			if ( 'trash' === get_post_status( $gate_layout_id ) ) {
 				\wp_untrash_post( $gate_layout_id );
 			}
-			\wp_safe_redirect( \admin_url( 'post.php?post=' . $gate_layout_id . '&action=edit' ) );
+			\wp_safe_redirect( \get_edit_post_link( $gate_layout_id, 'edit' ) );
 			exit;
 		} else {
 			$gate_layout_id = self::create_gate( $gate_layout_default_title, self::GATE_LAYOUT_CPT );

--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -254,7 +254,7 @@ class Content_Gate {
 			]
 		);
 		// Register the layout post type.
-		self::register_layout_post_type( self::GATE_LAYOUT_CPT, __( 'Content Gate Layout', 'newspack' ) );
+		self::register_layout_post_type( self::GATE_LAYOUT_CPT, __( 'Content Gate Layout', 'newspack' ), '', false );
 	}
 
 	/**
@@ -447,10 +447,12 @@ class Content_Gate {
 	 *
 	 * @param string $title     Optional gate title. Defaults to 'Content Gate'.
 	 * @param string $post_type Optional post type. Defaults to self::GATE_CPT.
+	 *
+	 * @return int|\WP_Error The gate post ID or error if not created.
 	 */
 	public static function create_gate( $title = '', $post_type = self::GATE_CPT ) {
 		$all_gates = self::get_gates();
-		$id        = \wp_insert_post(
+		return \wp_insert_post(
 			[
 				'post_title'   => $title,
 				'post_type'    => $post_type,
@@ -461,10 +463,20 @@ class Content_Gate {
 				],
 			]
 		);
-		if ( is_wp_error( $id ) ) {
-			return new \WP_Error( 'newspack_content_gate_create_gate_error', $id->get_error_message() );
-		}
-		return $id;
+	}
+
+	/**
+	 * Create a new gate layout post.
+	 *
+	 * @return int|\WP_Error The gate layout post ID or error if not created.
+	 */
+	public static function create_gate_layout() {
+		return \wp_insert_post(
+			[
+				'post_type'    => self::GATE_LAYOUT_CPT,
+				'post_content' => '<!-- wp:paragraph --><p>' . __( 'This post is only available to members.', 'newspack' ) . '</p><!-- /wp:paragraph -->',
+			]
+		);
 	}
 
 	/**
@@ -535,7 +547,7 @@ class Content_Gate {
 			\wp_safe_redirect( \get_edit_post_link( $gate_layout_id, 'edit' ) );
 			exit;
 		} else {
-			$gate_layout_id = self::create_gate( $gate_layout_default_title, self::GATE_LAYOUT_CPT );
+			$gate_layout_id = self::create_gate_layout();
 			if ( is_wp_error( $gate_layout_id ) ) {
 				\wp_die( esc_html( $gate_layout_id->get_error_message() ) );
 			}

--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -682,6 +682,10 @@ class Content_Gate {
 	 * @return void
 	 */
 	public static function update_registration_settings( $gate_id, $settings ) {
+		$registration = get_post_meta( $gate_id, 'registration', true );
+		if ( $registration ) {
+			$settings = wp_parse_args( $settings, $registration );
+		}
 		\update_post_meta( $gate_id, 'registration', $settings );
 	}
 
@@ -715,6 +719,10 @@ class Content_Gate {
 	 * @return void
 	 */
 	public static function update_custom_access_settings( $gate_id, $settings ) {
+		$custom_access = get_post_meta( $gate_id, 'custom_access', true );
+		if ( $custom_access ) {
+			$settings = wp_parse_args( $settings, $custom_access );
+		}
 		\update_post_meta( $gate_id, 'custom_access', $settings );
 	}
 

--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -541,7 +541,7 @@ class Content_Gate {
 			}
 			$gate[ $gate_mode ]['gate_layout_id'] = $gate_layout_id;
 			self::update_gate_settings( $gate_id, $gate );
-			\wp_safe_redirect( \admin_url( 'post.php?post=' . $gate_layout_id . '&action=edit' ) );
+			\wp_safe_redirect( \get_edit_post_link( $gate_layout_id, 'edit' ) );
 			exit;
 		}
 	}

--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -254,7 +254,7 @@ class Content_Gate {
 			]
 		);
 		// Register the layout post type.
-		self::register_layout_post_type( self::GATE_LAYOUT_CPT, __( 'Content Gate Layout', 'newspack' ), '', false );
+		self::register_layout_post_type( self::GATE_LAYOUT_CPT, __( 'Content Gate Layout', 'newspack' ) );
 	}
 
 	/**
@@ -468,11 +468,17 @@ class Content_Gate {
 	/**
 	 * Create a new gate layout post.
 	 *
+	 * @param string $title Optional gate layout title. Defaults to 'Content Gate Layout'.
+	 *
 	 * @return int|\WP_Error The gate layout post ID or error if not created.
 	 */
-	public static function create_gate_layout() {
+	public static function create_gate_layout( $title = '' ) {
+		if ( empty( $title ) ) {
+			$title = __( 'Content Gate Layout', 'newspack' );
+		}
 		return \wp_insert_post(
 			[
+				'post_title'   => $title,
 				'post_type'    => self::GATE_LAYOUT_CPT,
 				'post_content' => '<!-- wp:paragraph --><p>' . __( 'This post is only available to members.', 'newspack' ) . '</p><!-- /wp:paragraph -->',
 			]
@@ -547,7 +553,7 @@ class Content_Gate {
 			\wp_safe_redirect( \get_edit_post_link( $gate_layout_id, 'edit' ) );
 			exit;
 		} else {
-			$gate_layout_id = self::create_gate_layout();
+			$gate_layout_id = self::create_gate_layout( $gate_layout_default_title );
 			if ( is_wp_error( $gate_layout_id ) ) {
 				\wp_die( esc_html( $gate_layout_id->get_error_message() ) );
 			}

--- a/includes/content-gate/class-metering.php
+++ b/includes/content-gate/class-metering.php
@@ -33,6 +33,7 @@ class Metering {
 	 */
 	public static function init() {
 		add_filter( 'newspack_content_gate_restrict_post', [ __CLASS__, 'restrict_post' ] );
+		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'enqueue_block_editor_assets' ], 11 ); // Render after gate layout editor.
 		add_action( 'init', [ __CLASS__, 'register_meta' ] );
 		add_action( 'wp_footer', [ __CLASS__, 'enqueue_scripts' ] );
 		add_action( 'wp_footer', [ __CLASS__, 'render_frontend_metering_gate' ] );
@@ -51,6 +52,17 @@ class Metering {
 			return false;
 		}
 		return $restrict;
+	}
+
+	/**
+	 * Block editor assets for metering settings.
+	 */
+	public static function enqueue_block_editor_assets() {
+		if ( ! in_array( get_post_type(), Content_Gate::get_gate_post_types(), true ) ) {
+			return;
+		}
+		$asset = require dirname( NEWSPACK_PLUGIN_FILE ) . '/dist/content-gate-editor-metering.asset.php';
+		wp_enqueue_script( 'newspack-content-gate-editor-metering', Newspack::plugin_url() . '/dist/content-gate-editor-metering.js', $asset['dependencies'], $asset['version'], true );
 	}
 
 	/**

--- a/includes/content-gate/trait-content-gate-layout.php
+++ b/includes/content-gate/trait-content-gate-layout.php
@@ -113,6 +113,28 @@ trait Content_Gate_Layout {
 		);
 
 		self::register_layout_meta( $post_type );
+
+		add_action(
+			'enqueue_block_editor_assets',
+			function() use ( $post_type ) {
+				self::enqueue_block_editor_layout_assets( $post_type );
+			}
+		);
+	}
+
+	/**
+	 * Enqueue block editor assets.
+	 *
+	 * @param string $post_type The post type to enqueue assets for.
+	 */
+	protected static function enqueue_block_editor_layout_assets( $post_type ) {
+		if ( $post_type !== get_post_type() ) {
+			return;
+		}
+		$asset = require dirname( NEWSPACK_PLUGIN_FILE ) . '/dist/content-gate-editor.asset.php';
+		wp_enqueue_script( 'newspack-content-gate', Newspack::plugin_url() . '/dist/content-gate-editor.js', $asset['dependencies'], $asset['version'], true );
+		wp_localize_script( 'newspack-content-gate', 'newspack_content_gate', [ 'has_campaigns' => class_exists( 'Newspack_Popups' ) ] );
+		wp_enqueue_style( 'newspack-content-gate', Newspack::plugin_url() . '/dist/content-gate-editor.css', [], $asset['version'] );
 	}
 
 	/**

--- a/includes/content-gate/trait-content-gate-layout.php
+++ b/includes/content-gate/trait-content-gate-layout.php
@@ -77,13 +77,19 @@ trait Content_Gate_Layout {
 	/**
 	 * Register a gate custom post type with common configuration.
 	 *
-	 * @param string $post_type    The post type slug.
-	 * @param string $label        The singular label for the post type.
-	 * @param string $label_plural Optional plural label. Defaults to singular + 's'.
+	 * @param string  $post_type     The post type slug.
+	 * @param string  $label         The singular label for the post type.
+	 * @param string  $label_plural  Optional plural label. Defaults to singular + 's'.
+	 * @param boolean $supports_title Whether to support title. Defaults to true.
 	 */
-	public static function register_layout_post_type( $post_type, $label, $label_plural = '' ) {
+	public static function register_layout_post_type( $post_type, $label, $label_plural = '', $supports_title = true ) {
 		if ( empty( $label_plural ) ) {
 			$label_plural = $label . 's';
+		}
+
+		$supports = [ 'editor', 'custom-fields', 'revisions' ];
+		if ( $supports_title ) {
+			$supports[] = 'title';
 		}
 
 		\register_post_type(
@@ -108,7 +114,7 @@ trait Content_Gate_Layout {
 				'show_ui'      => true,
 				'show_in_menu' => false,
 				'show_in_rest' => true,
-				'supports'     => [ 'editor', 'custom-fields', 'revisions', 'title' ],
+				'supports'     => $supports,
 			]
 		);
 

--- a/includes/content-gate/trait-content-gate-layout.php
+++ b/includes/content-gate/trait-content-gate-layout.php
@@ -77,19 +77,13 @@ trait Content_Gate_Layout {
 	/**
 	 * Register a gate custom post type with common configuration.
 	 *
-	 * @param string  $post_type     The post type slug.
-	 * @param string  $label         The singular label for the post type.
-	 * @param string  $label_plural  Optional plural label. Defaults to singular + 's'.
-	 * @param boolean $supports_title Whether to support title. Defaults to true.
+	 * @param string $post_type    The post type slug.
+	 * @param string $label        The singular label for the post type.
+	 * @param string $label_plural Optional plural label. Defaults to singular + 's'.
 	 */
-	public static function register_layout_post_type( $post_type, $label, $label_plural = '', $supports_title = true ) {
+	public static function register_layout_post_type( $post_type, $label, $label_plural = '' ) {
 		if ( empty( $label_plural ) ) {
 			$label_plural = $label . 's';
-		}
-
-		$supports = [ 'editor', 'custom-fields', 'revisions' ];
-		if ( $supports_title ) {
-			$supports[] = 'title';
 		}
 
 		\register_post_type(
@@ -114,7 +108,7 @@ trait Content_Gate_Layout {
 				'show_ui'      => true,
 				'show_in_menu' => false,
 				'show_in_rest' => true,
-				'supports'     => $supports,
+				'supports'     => [ 'editor', 'custom-fields', 'revisions', 'title' ],
 			]
 		);
 

--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -39,7 +39,7 @@ class Memberships {
 		add_action( 'init', [ __CLASS__, 'register_post_type' ] );
 		add_action( 'admin_init', [ __CLASS__, 'handle_edit_plan_gate' ] );
 		add_action( 'admin_init', [ __CLASS__, 'handle_edit_gate' ] );
-		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'enqueue_block_editor_assets' ] );
+		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'enqueue_block_editor_assets' ], 9 ); // Render before gate layout editor.
 		add_filter( 'newspack_post_has_restrictions', [ __CLASS__, 'post_has_restrictions' ], 10, 2 );
 		add_filter( 'newspack_is_post_restricted', [ __CLASS__, 'is_post_restricted' ], 10, 2 );
 
@@ -165,8 +165,15 @@ class Memberships {
 		if ( get_post_type() !== self::GATE_CPT ) {
 			return;
 		}
+		wp_enqueue_script(
+			'newspack-content-gate-memberships',
+			Newspack::plugin_url() . '/dist/content-gate-editor-memberships.js',
+			[],
+			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/dist/content-gate-editor-memberships.js' ),
+			true
+		);
 		\wp_localize_script(
-			'newspack-content-gate',
+			'newspack-content-gate-memberships',
 			'newspack_memberships_gate',
 			[
 				'edit_gate_url'      => self::get_edit_gate_url(),

--- a/includes/wizards/audience/class-audience-content-gates.php
+++ b/includes/wizards/audience/class-audience-content-gates.php
@@ -336,7 +336,10 @@ class Audience_Content_Gates extends Wizard {
 								'properties' => [
 									'active'               => [ 'type' => 'boolean' ],
 									'require_verification' => [ 'type' => 'boolean' ],
-									'gate_layout_id'       => [ 'type' => 'integer' ],
+									'gate_layout_id'       => [
+										'type'     => 'integer',
+										'required' => false,
+									],
 									'metering'             => [
 										'type'       => 'object',
 										'properties' => [
@@ -359,7 +362,10 @@ class Audience_Content_Gates extends Wizard {
 											'period'  => [ 'type' => 'string' ],
 										],
 									],
-									'gate_layout_id' => [ 'type' => 'integer' ],
+									'gate_layout_id' => [
+										'type'     => 'integer',
+										'required' => false,
+									],
 									'access_rules'   => [
 										'type'  => 'array',
 										'items' => [
@@ -407,12 +413,15 @@ class Audience_Content_Gates extends Wizard {
 	 * @return array The sanitized registration.
 	 */
 	public function sanitize_registration( $registration ) {
-		return [
+		$registration = [
 			'active'               => boolval( $registration['active'] ),
-			'gate_layout_id'       => absint( $registration['gate_layout_id'] ),
 			'metering'             => $this->sanitize_metering( $registration['metering'] ),
 			'require_verification' => boolval( $registration['require_verification'] ),
 		];
+		if ( isset( $registration['gate_layout_id'] ) ) {
+			$registration['gate_layout_id'] = absint( $registration['gate_layout_id'] );
+		}
+		return $registration;
 	}
 
 	/**
@@ -423,12 +432,15 @@ class Audience_Content_Gates extends Wizard {
 	 * @return array The sanitized custom access.
 	 */
 	public function sanitize_custom_access( $custom_access ) {
-		return [
-			'active'         => boolval( $custom_access['active'] ),
-			'gate_layout_id' => absint( $custom_access['gate_layout_id'] ),
-			'metering'       => $this->sanitize_metering( $custom_access['metering'] ),
-			'access_rules'   => $this->sanitize_rules( $custom_access['access_rules'], 'access' ),
+		$custom_access = [
+			'active'       => boolval( $custom_access['active'] ),
+			'metering'     => $this->sanitize_metering( $custom_access['metering'] ),
+			'access_rules' => $this->sanitize_rules( $custom_access['access_rules'], 'access' ),
 		];
+		if ( isset( $custom_access['gate_layout_id'] ) ) {
+			$custom_access['gate_layout_id'] = absint( $custom_access['gate_layout_id'] );
+		}
+		return $custom_access;
 	}
 
 	/**

--- a/includes/wizards/audience/class-audience-content-gates.php
+++ b/includes/wizards/audience/class-audience-content-gates.php
@@ -96,6 +96,7 @@ class Audience_Content_Gates extends Wizard {
 				'api'                     => '/' . NEWSPACK_API_NAMESPACE . '/wizard/' . $this->slug,
 				'available_access_rules'  => Access_Rules::get_access_rules(),
 				'available_content_rules' => Content_Gate::get_content_rules(),
+				'edit_gate_layout_url'    => Content_Gate::get_edit_gate_layout_url(),
 			]
 		);
 

--- a/includes/wizards/audience/class-audience-content-gates.php
+++ b/includes/wizards/audience/class-audience-content-gates.php
@@ -336,7 +336,7 @@ class Audience_Content_Gates extends Wizard {
 								'properties' => [
 									'active'               => [ 'type' => 'boolean' ],
 									'require_verification' => [ 'type' => 'boolean' ],
-									'gate_id'              => [ 'type' => 'integer' ],
+									'gate_layout_id'       => [ 'type' => 'integer' ],
 									'metering'             => [
 										'type'       => 'object',
 										'properties' => [
@@ -350,8 +350,8 @@ class Audience_Content_Gates extends Wizard {
 							'custom_access' => [
 								'type'       => 'object',
 								'properties' => [
-									'active'       => [ 'type' => 'boolean' ],
-									'metering'     => [
+									'active'         => [ 'type' => 'boolean' ],
+									'metering'       => [
 										'type'       => 'object',
 										'properties' => [
 											'enabled' => [ 'type' => 'boolean' ],
@@ -359,8 +359,8 @@ class Audience_Content_Gates extends Wizard {
 											'period'  => [ 'type' => 'string' ],
 										],
 									],
-									'gate_id'      => [ 'type' => 'integer' ],
-									'access_rules' => [
+									'gate_layout_id' => [ 'type' => 'integer' ],
+									'access_rules'   => [
 										'type'  => 'array',
 										'items' => [
 											'type'       => 'object',
@@ -409,7 +409,7 @@ class Audience_Content_Gates extends Wizard {
 	public function sanitize_registration( $registration ) {
 		return [
 			'active'               => boolval( $registration['active'] ),
-			'gate_id'              => intval( $registration['gate_id'] ),
+			'gate_layout_id'       => absint( $registration['gate_layout_id'] ),
 			'metering'             => $this->sanitize_metering( $registration['metering'] ),
 			'require_verification' => boolval( $registration['require_verification'] ),
 		];
@@ -424,10 +424,10 @@ class Audience_Content_Gates extends Wizard {
 	 */
 	public function sanitize_custom_access( $custom_access ) {
 		return [
-			'active'       => boolval( $custom_access['active'] ),
-			'gate_id'      => intval( $custom_access['gate_id'] ),
-			'metering'     => $this->sanitize_metering( $custom_access['metering'] ),
-			'access_rules' => $this->sanitize_rules( $custom_access['access_rules'], 'access' ),
+			'active'         => boolval( $custom_access['active'] ),
+			'gate_layout_id' => absint( $custom_access['gate_layout_id'] ),
+			'metering'       => $this->sanitize_metering( $custom_access['metering'] ),
+			'access_rules'   => $this->sanitize_rules( $custom_access['access_rules'], 'access' ),
 		];
 	}
 

--- a/src/content-gate/editor/editor.js
+++ b/src/content-gate/editor/editor.js
@@ -13,7 +13,6 @@ import { registerPlugin } from '@wordpress/plugins';
 /**
  * Internal dependencies
  */
-import MeteringSettings from './metering-settings';
 import PositionControl from '../../../packages/components/src/position-control';
 import './editor.scss';
 
@@ -36,7 +35,6 @@ const overlaySizes = [
 ];
 
 function GateEdit() {
-	const newspack_memberships_gate = window.newspack_memberships_gate || {};
 	const { meta } = useSelect( select => {
 		const { getEditedPostAttribute } = select( 'core/editor' );
 		return {
@@ -55,90 +53,12 @@ function GateEdit() {
 			wrapper.removeAttribute( 'data-overlay-size' );
 		}
 	}, [ meta.style, meta.overlay_size ] );
-	const { createNotice } = useDispatch( 'core/notices' );
-	useEffect( () => {
-		if ( newspack_memberships_gate?.gate_plans && Object.keys( newspack_memberships_gate.gate_plans ).length ) {
-			createNotice(
-				'info',
-				sprintf(
-					// translators: %s is the list of plans.
-					__( "You're currently editing a gate for content restricted by: %s", 'newspack-plugin' ),
-					Object.values( newspack_memberships_gate?.gate_plans ).join( ', ' )
-				)
-			);
-		}
-	}, [] );
-	const getPlansToEdit = () => {
-		if ( ! newspack_memberships_gate ) {
-			return [];
-		}
-		const currentGatePlans = Object.keys( newspack_memberships_gate?.gate_plans ) || [];
-		const plans = newspack_memberships_gate?.plans.filter( plan => {
-			return ! currentGatePlans.includes( plan.id.toString() );
-		} );
-		return plans;
-	};
 	return (
 		<Fragment>
 			{ newspack_content_gate.has_campaigns && (
 				<PluginPostStatusInfo>
 					<p>{ __( "Newspack Campaign prompts won't be displayed when rendering gated content.", 'newspack-plugin' ) }</p>
 				</PluginPostStatusInfo>
-			) }
-			{ newspack_memberships_gate?.plans?.length > 1 && (
-				<PluginDocumentSettingPanel name="content-gate-plans" title={ __( 'WooCommerce Memberships', 'newspack-plugin' ) }>
-					{ ! Object.keys( newspack_memberships_gate?.gate_plans ).length ? (
-						<Fragment>
-							<p>
-								{ __(
-									'This gate will be rendered for all membership plans. Manage custom gates for when the content is locked behind a specific plan:',
-									'newspack-plugin'
-								) }
-							</p>
-						</Fragment>
-					) : (
-						<Fragment>
-							<p>
-								{ sprintf(
-									// translators: %s is the list of plans.
-									__( 'This gate will be rendered for the following membership plans: %s', 'newspack-plugin' ),
-									Object.values( newspack_memberships_gate.gate_plans ).join( ', ' )
-								) }
-							</p>
-							<hr />
-							<p
-								dangerouslySetInnerHTML={ {
-									__html: sprintf(
-										// translators: %s is the link to the primary gate.
-										__( 'Edit the <a href="%s">primary gate</a>, or:', 'newspack-plugin' ),
-										newspack_memberships_gate.edit_gate_url
-									),
-								} }
-							/>
-						</Fragment>
-					) }
-					<ul>
-						{ getPlansToEdit().map( plan => (
-							<li key={ plan.id }>
-								{ plan.name } (
-								{ plan.gate_id !== false && (
-									<Fragment>
-										<strong>
-											{ plan.gate_status === 'publish'
-												? __( 'published', 'newspack-plugin' )
-												: __( 'draft', 'newspack-plugin' ) }
-										</strong>{ ' ' }
-										-{ ' ' }
-									</Fragment>
-								) }
-								<a href={ newspack_memberships_gate.edit_plan_gate_url + '&plan_id=' + plan.id }>
-									{ plan.gate_id ? __( 'edit gate', 'newspack-plugin' ) : __( 'create gate', 'newspack-plugin' ) }
-								</a>
-								)
-							</li>
-						) ) }
-					</ul>
-				</PluginDocumentSettingPanel>
 			) }
 			<PluginDocumentSettingPanel name="content-gate-styles-panel" title={ __( 'Styles', 'newspack-plugin' ) }>
 				<div className="newspack-content-gate-style-selector">
@@ -201,9 +121,6 @@ function GateEdit() {
 					onChange={ value => editPost( { meta: { use_more_tag: value } } ) }
 					help={ __( 'Override the default paragraph count on pages where a “More” block has been placed.', 'newspack-plugin' ) }
 				/>
-			</PluginDocumentSettingPanel>
-			<PluginDocumentSettingPanel name="content-gate-metering-panel" title={ __( 'Metering', 'newspack-plugin' ) }>
-				<MeteringSettings />
 			</PluginDocumentSettingPanel>
 		</Fragment>
 	);

--- a/src/content-gate/editor/editor.scss
+++ b/src/content-gate/editor/editor.scss
@@ -49,3 +49,10 @@
 		margin: 0;
 	}
 }
+
+/**
+ * Hide the title input for the gate layout post type.
+ */
+.post-type-np_gate_layout .editor-post-title {
+	display: none;
+}

--- a/src/content-gate/editor/memberships.js
+++ b/src/content-gate/editor/memberships.js
@@ -1,0 +1,97 @@
+/**
+ * WordPress dependencies
+ */
+import { sprintf, __ } from '@wordpress/i18n';
+import { useDispatch } from '@wordpress/data';
+import { Fragment, useEffect, useMemo } from '@wordpress/element';
+import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
+import { registerPlugin } from '@wordpress/plugins';
+
+function MembershipsGate() {
+	const newspack_memberships_gate = window.newspack_memberships_gate || {};
+	const { gate_plans, plans } = newspack_memberships_gate;
+	const { createNotice } = useDispatch( 'core/notices' );
+	useEffect( () => {
+		if ( gate_plans && Object.keys( gate_plans ).length ) {
+			createNotice(
+				'info',
+				sprintf(
+					// translators: %s is the list of plans.
+					__( "You're currently editing a gate for content restricted by: %s", 'newspack-plugin' ),
+					Object.values( gate_plans ).join( ', ' )
+				)
+			);
+		}
+	}, [] );
+	const plansToEdit = useMemo( () => {
+		if ( ! plans?.length || ! gate_plans ) {
+			return [];
+		}
+		const currentGatePlans = Object.keys( gate_plans ) || [];
+		return plans.filter( plan => {
+			return ! currentGatePlans.includes( plan.id.toString() );
+		} );
+	}, [ gate_plans, plans ] );
+
+	if ( ! plans?.length ) {
+		return null;
+	}
+	return (
+		<PluginDocumentSettingPanel name="content-gate-plans" title={ __( 'WooCommerce Memberships', 'newspack-plugin' ) }>
+			{ ! Object.keys( newspack_memberships_gate?.gate_plans ).length ? (
+				<Fragment>
+					<p>
+						{ __(
+							'This gate will be rendered for all membership plans. Manage custom gates for when the content is locked behind a specific plan:',
+							'newspack-plugin'
+						) }
+					</p>
+				</Fragment>
+			) : (
+				<Fragment>
+					<p>
+						{ sprintf(
+							// translators: %s is the list of plans.
+							__( 'This gate will be rendered for the following membership plans: %s', 'newspack-plugin' ),
+							Object.values( newspack_memberships_gate.gate_plans ).join( ', ' )
+						) }
+					</p>
+					<hr />
+					<p
+						dangerouslySetInnerHTML={ {
+							__html: sprintf(
+								// translators: %s is the link to the primary gate.
+								__( 'Edit the <a href="%s">primary gate</a>, or:', 'newspack-plugin' ),
+								newspack_memberships_gate.edit_gate_url
+							),
+						} }
+					/>
+				</Fragment>
+			) }
+			<ul>
+				{ plansToEdit.map( plan => (
+					<li key={ plan.id }>
+						{ plan.name } (
+						{ plan.gate_id !== false && (
+							<Fragment>
+								<strong>
+									{ plan.gate_status === 'publish' ? __( 'published', 'newspack-plugin' ) : __( 'draft', 'newspack-plugin' ) }
+								</strong>{ ' ' }
+								-{ ' ' }
+							</Fragment>
+						) }
+						<a href={ newspack_memberships_gate.edit_plan_gate_url + '&plan_id=' + plan.id }>
+							{ plan.gate_id ? __( 'edit gate', 'newspack-plugin' ) : __( 'create gate', 'newspack-plugin' ) }
+						</a>
+						)
+					</li>
+				) ) }
+			</ul>
+		</PluginDocumentSettingPanel>
+	);
+}
+
+registerPlugin( 'newspack-memberships-gate', {
+	render: MembershipsGate,
+	icon: null,
+} );

--- a/src/content-gate/editor/metering-settings.js
+++ b/src/content-gate/editor/metering-settings.js
@@ -4,6 +4,8 @@
 import { __ } from '@wordpress/i18n';
 import { CheckboxControl, SelectControl, TextControl } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
+import { registerPlugin } from '@wordpress/plugins';
 
 function MeteringSettings() {
 	const { meta } = useSelect( select => {
@@ -14,7 +16,7 @@ function MeteringSettings() {
 	} );
 	const { editPost } = useDispatch( 'core/editor' );
 	return (
-		<>
+		<PluginDocumentSettingPanel name="content-gate-metering-panel" title={ __( 'Metering', 'newspack-plugin' ) }>
 			<CheckboxControl
 				label={ __( 'Enable metering', 'newspack-plugin' ) }
 				checked={ meta.metering }
@@ -61,8 +63,11 @@ function MeteringSettings() {
 					/>
 				</>
 			) }
-		</>
+		</PluginDocumentSettingPanel>
 	);
 }
 
-export default MeteringSettings;
+registerPlugin( 'newspack-content-gate-metering', {
+	render: MeteringSettings,
+	icon: null,
+} );

--- a/src/wizards/audience/views/content-gates/content-gate-settings.tsx
+++ b/src/wizards/audience/views/content-gates/content-gate-settings.tsx
@@ -86,8 +86,8 @@ export default function ContentGateSettings( { gate, onDelete, onSave }: Content
 	return (
 		<>
 			<ContentRules rules={ contentRules } onChange={ setContentRules } />
-			<Registration registration={ registration } onChange={ setRegistration } />
-			<CustomAccess customAccess={ customAccess } onChange={ setCustomAccess } />
+			<Registration gateId={ gate.id } registration={ registration } onChange={ setRegistration } />
+			<CustomAccess gateId={ gate.id } customAccess={ customAccess } onChange={ setCustomAccess } />
 			<div className="newspack-buttons-card">
 				{ gate.status === 'draft' && (
 					<Button disabled={ ! isReady } variant="primary" onClick={ handlePublish }>

--- a/src/wizards/audience/views/content-gates/custom-access.tsx
+++ b/src/wizards/audience/views/content-gates/custom-access.tsx
@@ -2,6 +2,7 @@
  * WordPress dependencies.
  */
 import { __ } from '@wordpress/i18n';
+import { useCallback } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -14,17 +15,28 @@ import AccessRules from './access-rules';
 interface CustomAccessProps {
 	gateId?: number;
 	customAccess: CustomAccess;
-	onChange: ( customAccess: CustomAccess ) => void;
+	onChange: ( customAccess: Partial< CustomAccess > ) => void;
 	cardProps?: Partial< React.ComponentPropsWithoutRef< typeof ActionCard > >;
 }
 
 export default function CustomAccess( { gateId, customAccess, onChange, cardProps = {} }: CustomAccessProps ) {
+	const handleChange = useCallback(
+		( value: Partial< CustomAccess > ) => {
+			onChange( {
+				active: customAccess.active,
+				metering: customAccess.metering,
+				access_rules: customAccess.access_rules,
+				...value,
+			} );
+		},
+		[ customAccess, onChange ]
+	);
 	return (
 		<ActionCard
 			title={ __( 'Paid Access', 'newspack-plugin' ) }
 			description={ __( 'Readers must pay to view this content.', 'newspack-plugin' ) }
 			toggleChecked={ customAccess.active }
-			toggleOnChange={ ( active: boolean ) => onChange( { ...customAccess, active } ) }
+			toggleOnChange={ ( active: boolean ) => handleChange( { active } ) }
 			actionText={ gateId ? __( 'Edit Layout', 'newspack-plugin' ) : undefined }
 			href={ gateId ? getEditGateLayoutUrl( gateId, 'custom_access' ) : undefined }
 			{ ...cardProps }
@@ -33,10 +45,10 @@ export default function CustomAccess( { gateId, customAccess, onChange, cardProp
 				<Card noBorder>
 					<AccessRules
 						rules={ customAccess.access_rules }
-						onChange={ ( rules: GateAccessRule[] ) => onChange( { ...customAccess, access_rules: rules } ) }
+						onChange={ ( rules: GateAccessRule[] ) => handleChange( { access_rules: rules } ) }
 					/>
 					<hr />
-					<Metering metering={ customAccess.metering } onChange={ ( metering: Metering ) => onChange( { ...customAccess, metering } ) } />
+					<Metering metering={ customAccess.metering } onChange={ ( metering: Metering ) => handleChange( { metering } ) } />
 				</Card>
 			) }
 		</ActionCard>

--- a/src/wizards/audience/views/content-gates/custom-access.tsx
+++ b/src/wizards/audience/views/content-gates/custom-access.tsx
@@ -7,22 +7,26 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { ActionCard, Card } from '../../../../../packages/components/src';
+import { getEditGateLayoutUrl } from './utils';
 import Metering from './metering';
 import AccessRules from './access-rules';
 
 interface CustomAccessProps {
+	gateId?: number;
 	customAccess: CustomAccess;
 	onChange: ( customAccess: CustomAccess ) => void;
 	cardProps?: Partial< React.ComponentPropsWithoutRef< typeof ActionCard > >;
 }
 
-export default function CustomAccess( { customAccess, onChange, cardProps = {} }: CustomAccessProps ) {
+export default function CustomAccess( { gateId, customAccess, onChange, cardProps = {} }: CustomAccessProps ) {
 	return (
 		<ActionCard
 			title={ __( 'Paid Access', 'newspack-plugin' ) }
 			description={ __( 'Readers must pay to view this content.', 'newspack-plugin' ) }
 			toggleChecked={ customAccess.active }
 			toggleOnChange={ ( active: boolean ) => onChange( { ...customAccess, active } ) }
+			actionText={ gateId ? __( 'Edit Layout', 'newspack-plugin' ) : undefined }
+			href={ gateId ? getEditGateLayoutUrl( gateId, 'custom_access' ) : undefined }
 			{ ...cardProps }
 		>
 			{ customAccess.active && (

--- a/src/wizards/audience/views/content-gates/registration.tsx
+++ b/src/wizards/audience/views/content-gates/registration.tsx
@@ -8,22 +8,25 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { ActionCard, Card } from '../../../../../packages/components/src';
-
+import { getEditGateLayoutUrl } from './utils';
 import Metering from './metering';
 
 interface RegistrationProps {
+	gateId?: number;
 	registration: Registration;
 	onChange: ( registration: Registration ) => void;
 	cardProps?: Partial< React.ComponentPropsWithoutRef< typeof ActionCard > >;
 }
 
-export default function Registration( { registration, onChange, cardProps = {} }: RegistrationProps ) {
+export default function Registration( { gateId, registration, onChange, cardProps = {} }: RegistrationProps ) {
 	return (
 		<ActionCard
 			title={ __( 'Registered Access', 'newspack-plugin' ) }
 			description={ __( 'Readers must log in to view this content.', 'newspack-plugin' ) }
 			toggleChecked={ registration.active }
 			toggleOnChange={ ( active: boolean ) => onChange( { ...registration, active } ) }
+			actionText={ gateId ? __( 'Edit Layout', 'newspack-plugin' ) : undefined }
+			href={ gateId ? getEditGateLayoutUrl( gateId, 'registration' ) : undefined }
 			{ ...cardProps }
 		>
 			{ registration.active && (

--- a/src/wizards/audience/views/content-gates/registration.tsx
+++ b/src/wizards/audience/views/content-gates/registration.tsx
@@ -2,6 +2,7 @@
  * WordPress dependencies.
  */
 import { CheckboxControl } from '@wordpress/components';
+import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -14,17 +15,28 @@ import Metering from './metering';
 interface RegistrationProps {
 	gateId?: number;
 	registration: Registration;
-	onChange: ( registration: Registration ) => void;
+	onChange: ( registration: Partial< Registration > ) => void;
 	cardProps?: Partial< React.ComponentPropsWithoutRef< typeof ActionCard > >;
 }
 
 export default function Registration( { gateId, registration, onChange, cardProps = {} }: RegistrationProps ) {
+	const handleChange = useCallback(
+		( value: Partial< Registration > ) => {
+			onChange( {
+				active: registration.active,
+				metering: registration.metering,
+				require_verification: registration.require_verification,
+				...value,
+			} );
+		},
+		[ registration, onChange ]
+	);
 	return (
 		<ActionCard
 			title={ __( 'Registered Access', 'newspack-plugin' ) }
 			description={ __( 'Readers must log in to view this content.', 'newspack-plugin' ) }
 			toggleChecked={ registration.active }
-			toggleOnChange={ ( active: boolean ) => onChange( { ...registration, active } ) }
+			toggleOnChange={ ( active: boolean ) => handleChange( { active } ) }
 			actionText={ gateId ? __( 'Edit Layout', 'newspack-plugin' ) : undefined }
 			href={ gateId ? getEditGateLayoutUrl( gateId, 'registration' ) : undefined }
 			{ ...cardProps }
@@ -34,10 +46,10 @@ export default function Registration( { gateId, registration, onChange, cardProp
 					<CheckboxControl
 						label={ __( 'Require readers to verify their email address.', 'newspack-plugin' ) }
 						checked={ registration.require_verification }
-						onChange={ () => onChange( { ...registration, require_verification: ! registration.require_verification } ) }
+						onChange={ () => handleChange( { require_verification: ! registration.require_verification } ) }
 					/>
 					<hr />
-					<Metering metering={ registration.metering } onChange={ ( metering: Metering ) => onChange( { ...registration, metering } ) } />
+					<Metering metering={ registration.metering } onChange={ ( metering: Metering ) => handleChange( { metering } ) } />
 				</Card>
 			) }
 		</ActionCard>

--- a/src/wizards/audience/views/content-gates/types/index.d.ts
+++ b/src/wizards/audience/views/content-gates/types/index.d.ts
@@ -77,13 +77,13 @@ type Registration = {
 	active: boolean;
 	metering: Metering;
 	require_verification: boolean;
-	gate_id: number;
+	gate_layout_id: number;
 };
 
 type CustomAccess = {
 	active: boolean;
 	metering: Metering;
-	gate_id: number;
+	gate_layout_id: number;
 	access_rules: GateAccessRule[];
 };
 

--- a/src/wizards/audience/views/content-gates/utils.tsx
+++ b/src/wizards/audience/views/content-gates/utils.tsx
@@ -3,7 +3,22 @@ import { addQueryArgs } from '@wordpress/url';
  * Get edit gate layout URL.
  */
 export function getEditGateLayoutUrl( gateId: number, gateMode: string ) {
-	let url = window.newspackAudienceContentGates.edit_gate_layout_url;
+	const audienceGates = ( window as any ).newspackAudienceContentGates;
+
+	if (
+		! audienceGates ||
+		typeof audienceGates.edit_gate_layout_url !== 'string' ||
+		! audienceGates.edit_gate_layout_url
+	) {
+		// Fallback to avoid runtime errors if the global config is not available.
+		// eslint-disable-next-line no-console
+		console.error(
+			'newspackAudienceContentGates.edit_gate_layout_url is not defined on window.'
+		);
+		return '';
+	}
+
+	let url = audienceGates.edit_gate_layout_url;
 	if ( gateId ) {
 		url = addQueryArgs( url, { gate_id: gateId } );
 	}

--- a/src/wizards/audience/views/content-gates/utils.tsx
+++ b/src/wizards/audience/views/content-gates/utils.tsx
@@ -5,16 +5,10 @@ import { addQueryArgs } from '@wordpress/url';
 export function getEditGateLayoutUrl( gateId: number, gateMode: string ) {
 	const audienceGates = ( window as any ).newspackAudienceContentGates;
 
-	if (
-		! audienceGates ||
-		typeof audienceGates.edit_gate_layout_url !== 'string' ||
-		! audienceGates.edit_gate_layout_url
-	) {
+	if ( ! audienceGates || typeof audienceGates.edit_gate_layout_url !== 'string' || ! audienceGates.edit_gate_layout_url ) {
 		// Fallback to avoid runtime errors if the global config is not available.
 		// eslint-disable-next-line no-console
-		console.error(
-			'newspackAudienceContentGates.edit_gate_layout_url is not defined on window.'
-		);
+		console.error( 'newspackAudienceContentGates.edit_gate_layout_url is not defined on window.' );
 		return '';
 	}
 

--- a/src/wizards/audience/views/content-gates/utils.tsx
+++ b/src/wizards/audience/views/content-gates/utils.tsx
@@ -1,0 +1,14 @@
+import { addQueryArgs } from '@wordpress/url';
+/**
+ * Get edit gate layout URL.
+ */
+export function getEditGateLayoutUrl( gateId: number, gateMode: string ) {
+	let url = window.newspackAudienceContentGates.edit_gate_layout_url;
+	if ( gateId ) {
+		url = addQueryArgs( url, { gate_id: gateId } );
+	}
+	if ( gateMode ) {
+		url = addQueryArgs( url, { gate_mode: gateMode } );
+	}
+	return url;
+}

--- a/src/wizards/types/window.d.ts
+++ b/src/wizards/types/window.d.ts
@@ -61,6 +61,7 @@ declare global {
 			api: string;
 			available_access_rules: AccessRules;
 			available_content_rules: ContentRules;
+			edit_gate_layout_url: string;
 		};
 	}
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -63,6 +63,8 @@ const entry = {
 	...wizardsScriptFiles,
 	blocks: path.join( __dirname, 'src', 'blocks', 'index.js' ),
 	'content-gate-editor': path.join( __dirname, 'src', 'content-gate', 'editor', 'editor.js' ),
+	'content-gate-editor-memberships': path.join( __dirname, 'src', 'content-gate', 'editor', 'memberships.js' ),
+	'content-gate-editor-metering': path.join( __dirname, 'src', 'content-gate', 'editor', 'metering-settings.js' ),
 	'content-gate-block-patterns': path.join( __dirname, 'src', 'content-gate', 'editor', 'block-patterns.js' ),
 	'content-banner': path.join( __dirname, 'src', 'content-gate', 'content-banner.js' ),
 	wizards: path.join( __dirname, 'src', 'wizards', 'index.tsx' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR implements a few things:

 - Allow the creation of gate layout posts for each gate mode (registration and custom access)
 - Move the layout block editor asset enqueueing strategy to the trait
 - Isolate the Memberships block editor asset so its own class enqueues it
 - Isolate the Metering block editor asset so its own class also enqueues it

### How to test the changes in this Pull Request:

1. Make sure you have Woo Memberships enabled and multiple plans configured
2. Edit the Memberships gate (Audience -> Configuration -> Content Gate)
3. Confirm every panel continues to work as expected
   1. Edit gates for differents plan and save
   2. Customize layout settings
   3. Customize metering settings
5. Create/edit a regular content gate (Audience -> Content Gates)
6. Enable both Registration and Paid access
7. Click "Edit layout" for each mode
8. Confirm each creates a draft with layout panels
9. Edit both layouts and confirm the values persist
10. Back in the "Content Gates" page, confirm that clicking "Edit layout" redirects to the created posts (and not new ones)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->