### PR TITLE
Adjust inDesign <li> markup output

### DIFF
--- a/includes/optional-modules/indesign-export/class-indesign-converter.php
+++ b/includes/optional-modules/indesign-export/class-indesign-converter.php
@@ -276,7 +276,7 @@ class InDesign_Converter {
 			'/<(?!pstyle:)(p[^>]*)>/'              => $this->styles['paragraph'],
 
 			// Lists. TODO: Handle numbered and nested lists.
-			'/<li[^>]*>(.*)<\/li>/U'               => "<bnListType:Bullet>$1<bnListType:>",
+			'/<li[^>]*>(.*)<\/li>/U'               => '<bnListType:Bullet>$1<bnListType:>',
 
 			// Line breaks.
 			'/<br[^>]*>/'                          => '<0x000A>',

--- a/includes/optional-modules/indesign-export/class-indesign-converter.php
+++ b/includes/optional-modules/indesign-export/class-indesign-converter.php
@@ -300,7 +300,7 @@ class InDesign_Converter {
 			'/<(?:div|ol|ul|a|img|figure)[^>]*>/'  => '',
 
 			// Replace paragraphs and remaining lists end tags with line breaks.
-			'/<\/(?:p|ul|ol)[^>]*>/'            => "\r\n",
+			'/<\/(?:p|ul|ol)[^>]*>/'               => "\r\n",
 
 			// Remove all remaining closing tags.
 			'/<\/[^>]*>/'                          => '',

--- a/includes/optional-modules/indesign-export/class-indesign-converter.php
+++ b/includes/optional-modules/indesign-export/class-indesign-converter.php
@@ -276,7 +276,7 @@ class InDesign_Converter {
 			'/<(?!pstyle:)(p[^>]*)>/'              => $this->styles['paragraph'],
 
 			// Lists. TODO: Handle numbered and nested lists.
-			'/<li[^>]*>(.*)<\/li>/U'               => "<bnListType:Bullet>$1<bnListType:>\r\n",
+			'/<li[^>]*>(.*)<\/li>/U'               => "<bnListType:Bullet>$1<bnListType:>",
 
 			// Line breaks.
 			'/<br[^>]*>/'                          => '<0x000A>',

--- a/includes/optional-modules/indesign-export/class-indesign-converter.php
+++ b/includes/optional-modules/indesign-export/class-indesign-converter.php
@@ -276,7 +276,7 @@ class InDesign_Converter {
 			'/<(?!pstyle:)(p[^>]*)>/'              => $this->styles['paragraph'],
 
 			// Lists. TODO: Handle numbered and nested lists.
-			'/<li[^>]*>/'                          => '<bnListType:Bullet>',
+			'/<li[^>]*>(.*)<\/li>/U'               => "<bnListType:Bullet>$1<bnListType:>\r\n",
 
 			// Line breaks.
 			'/<br[^>]*>/'                          => '<0x000A>',
@@ -299,8 +299,8 @@ class InDesign_Converter {
 			// Remove unsupported tags while preserving content.
 			'/<(?:div|ol|ul|a|img|figure)[^>]*>/'  => '',
 
-			// Replace paragraphs and lists end tags with line breaks.
-			'/<\/(?:p|li|ul|ol)[^>]*>/'            => "\r\n",
+			// Replace paragraphs and remaining lists end tags with line breaks.
+			'/<\/(?:p|ul|ol)[^>]*>/'            => "\r\n",
 
 			// Remove all remaining closing tags.
 			'/<\/[^>]*>/'                          => '',

--- a/tests/unit-tests/indesign-exporter/indesign-exporter.php
+++ b/tests/unit-tests/indesign-exporter/indesign-exporter.php
@@ -75,8 +75,8 @@ class Newspack_Test_InDesign_Exporter extends WP_UnitTestCase {
 
 		$converter = new InDesign_Converter();
 		$content = $converter->convert_post( $post_id );
-		$this->assertStringContainsString( '<bnListType:Bullet>Item 1.', $content );
-		$this->assertStringContainsString( '<bnListType:Bullet>Item 2.', $content );
+		$this->assertStringContainsString( '<bnListType:Bullet>Item 1.<bnListType:>', $content );
+		$this->assertStringContainsString( '<bnListType:Bullet>Item 2.<bnListType:>', $content );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

**Note: This is a hotfix PR**

Closes NPPM-2530

This PR adjusts the way markup is output for the inDesign export on `<li>` tags. When ingesting the current markup, inDesign complains `<Line No>:- 9 <Error>:- The paragraph level attribute "bnListType" applied again. Inserting a paragraph level attribute termination tag "<bnListType:>` because it doesn't know where the list element ends, and then it tries to fix it, but doesn't quite fix it correctly. This change should solve that by explicitly adding the closing `<bnListType:>` tag at the end of list elements.

### How to test the changes in this Pull Request:

1. Add a bulleted list with multiple bullet points to post content.
2. "Export as InDesign"
3. In the export, observe that the list elements are like `<bnListType:Bullet>Item 1.<bnListType:>`
4. If possible, import the file into InDesign and verify it imports nicely without complaining.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->