### PR TITLE
feat(byline): add byline block with custom byline and CAP support

### DIFF
--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -31,6 +31,7 @@ final class Blocks {
 		}
 		if ( wp_is_block_theme() ) {
 			require_once NEWSPACK_ABSPATH . 'src/blocks/avatar/class-avatar-block.php';
+			require_once NEWSPACK_ABSPATH . 'src/blocks/byline/class-byline-block.php';
 		}
 		if ( Collections::is_module_active() ) {
 			require_once NEWSPACK_ABSPATH . 'src/blocks/collections/index.php';

--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -75,6 +75,7 @@ final class Blocks {
 			'reader_activation_url'            => Reader_Activation::get_setting( 'terms_url' ),
 			'has_recaptcha'                    => Recaptcha::can_use_captcha(),
 			'recaptcha_url'                    => admin_url( 'admin.php?page=newspack-settings' ),
+			'is_block_theme'                   => wp_is_block_theme(),
 			'corrections_enabled'              => wp_is_block_theme() && class_exists( 'Newspack\Corrections' ),
 			'collections_enabled'              => Collections::is_module_active(),
 			'has_memberships'                  => Memberships::is_active(),

--- a/src/blocks/byline/README.md
+++ b/src/blocks/byline/README.md
@@ -1,0 +1,62 @@
+# Byline Block
+
+A Gutenberg block that displays post author attribution with support for multiple authorship systems.
+
+## Overview
+
+The byline block automatically detects and displays the appropriate author information based on what's available for the post. It follows a priority-based approach to determine which byline source to use.
+
+## Byline priority
+
+The block checks for author information in the following order:
+
+1. **Newspack Custom Bylines** - If the custom byline feature is enabled for the post (`_newspack_byline_active` meta), the block displays the custom byline content. Custom bylines support free-text editing with embedded author links using shortcode syntax.
+
+2. **CoAuthors Plus** - If CoAuthors Plus is active and the post has authors assigned through CAP, the block displays all co-authors with proper formatting (e.g., "Author1, Author2, and Author3"). This works with both WordPress users and CAP Guest Authors.
+
+3. **Default WordPress Author** - Falls back to the standard WordPress post author when neither custom bylines nor CoAuthors Plus authors are available.
+
+## Block attributes
+
+| Attribute | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `prefix` | string | `"By "` | Text displayed before author names. Hidden in inspector when custom byline is active. |
+| `linkToAuthorArchive` | boolean | `true` | Whether to link author names to their archive pages. Hidden in inspector when custom byline is active. |
+
+When a custom byline is enabled, both settings are hidden in the block inspector since custom bylines control their own prefix and link behavior.
+
+## Editor behavior
+
+The block reads from the CoAuthors Plus data store (`cap/authors`) for real-time updates in the editor. When authors are added or removed via the Authors panel in the sidebar, the byline block updates immediately without requiring a page refresh.
+
+## Availability
+
+This block is only available for block themes. For classic themes, bylines are handled through the `pre_newspack_posted_by` filter in the Newspack theme.
+
+## Usage with block theme patterns
+
+The block theme post-meta patterns are configured to use this block when available:
+
+```html
+<!-- wp:newspack/byline {"prefix":"By "} /-->
+```
+
+For patterns that include avatars, use the `newspack/avatar` block as a sibling:
+
+```html
+<!-- wp:group {"layout":{"type":"flex"}} -->
+<div class="wp-block-group">
+  <!-- wp:newspack/avatar {"size":48} /-->
+  <!-- wp:newspack/byline /-->
+</div>
+<!-- /wp:group -->
+```
+
+## Developer notes
+
+For CAP authors, the block applies the `coauthors_posts_link` filter for each author link, matching CAP's own `coauthors_posts_links_single()` behavior.
+
+## Related
+
+- **Newspack Avatar Block** (`newspack/avatar`) - Displays author avatar(s) with support for CoAuthors Plus
+- **Newspack Bylines Feature** - The underlying custom bylines system in Newspack (`includes/class-bylines.php`)

--- a/src/blocks/byline/README.md
+++ b/src/blocks/byline/README.md
@@ -31,7 +31,7 @@ The block reads from the CoAuthors Plus data store (`cap/authors`) for real-time
 
 ## Availability
 
-This block is only available for block themes. For classic themes, bylines are handled through the `pre_newspack_posted_by` filter in the Newspack theme.
+This block replaces the Post Author block and is only available in block themes. For Newspack's classic theme, custom bylines are handled through the `pre_newspack_posted_by` filter, and CoAuthors Plus support is added through custom code.
 
 ## Usage with block theme patterns
 

--- a/src/blocks/byline/README.md
+++ b/src/blocks/byline/README.md
@@ -20,7 +20,7 @@ The block checks for author information in the following order:
 
 | Attribute | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `prefix` | string | `"By "` | Text displayed before author names. Hidden in inspector when custom byline is active. |
+| `prefix` | string | `"By"` | Text displayed before author names. A space is added automatically after the prefix. Hidden in inspector when custom byline is active. |
 | `linkToAuthorArchive` | boolean | `true` | Whether to link author names to their archive pages. Hidden in inspector when custom byline is active. |
 
 When a custom byline is enabled, both settings are hidden in the block inspector since custom bylines control their own prefix and link behavior.
@@ -38,7 +38,7 @@ This block is only available for block themes. For classic themes, bylines are h
 The block theme post-meta patterns are configured to use this block when available:
 
 ```html
-<!-- wp:newspack/byline {"prefix":"By "} /-->
+<!-- wp:newspack/byline {"prefix":"By"} /-->
 ```
 
 For patterns that include avatars, use the `newspack/avatar` block as a sibling:

--- a/src/blocks/byline/block.json
+++ b/src/blocks/byline/block.json
@@ -9,7 +9,7 @@
 	"attributes": {
 		"prefix": {
 			"type": "string",
-			"default": "By "
+			"default": "By"
 		},
 		"linkToAuthorArchive": {
 			"type": "boolean",

--- a/src/blocks/byline/block.json
+++ b/src/blocks/byline/block.json
@@ -1,0 +1,68 @@
+{
+	"apiVersion": 3,
+	"name": "newspack/byline",
+	"title": "Byline",
+	"category": "newspack",
+	"description": "Display post author(s) with support for custom bylines and CoAuthors Plus.",
+	"textdomain": "newspack-plugin",
+	"usesContext": [ "postId", "postType" ],
+	"attributes": {
+		"prefix": {
+			"type": "string",
+			"default": "By "
+		},
+		"linkToAuthorArchive": {
+			"type": "boolean",
+			"default": true
+		}
+	},
+	"supports": {
+		"html": false,
+		"color": {
+			"text": true,
+			"background": true,
+			"link": true,
+			"__experimentalDefaultControls": {
+				"text": true,
+				"link": true
+			}
+		},
+		"spacing": {
+			"margin": true,
+			"padding": true,
+			"__experimentalDefaultControls": {
+				"margin": false,
+				"padding": false
+			}
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true,
+				"fontAppearance": true
+			}
+		},
+		"__experimentalBorder": {
+			"radius": true,
+			"width": true,
+			"color": true,
+			"style": true,
+			"__experimentalDefaultControls": {
+				"radius": false,
+				"width": false,
+				"color": false,
+				"style": false
+			}
+		},
+		"interactivity": {
+			"clientNavigation": true
+		}
+	}
+}

--- a/src/blocks/byline/class-byline-block.php
+++ b/src/blocks/byline/class-byline-block.php
@@ -139,7 +139,7 @@ final class Byline_Block {
 		return sprintf(
 			'<div %1$s><span class="byline">%2$s%3$s</span></div>',
 			$wrapper_attributes,
-			esc_html( $prefix ),
+			! empty( $prefix ) ? esc_html( $prefix ) . ' ' : '',
 			$byline_content
 		);
 	}
@@ -230,7 +230,7 @@ final class Byline_Block {
 		return sprintf(
 			'<div %1$s><span class="byline">%2$s%3$s</span></div>',
 			$wrapper_attributes,
-			esc_html( $prefix ),
+			! empty( $prefix ) ? esc_html( $prefix ) . ' ' : '',
 			$author_html
 		);
 	}
@@ -238,7 +238,7 @@ final class Byline_Block {
 	/**
 	 * Get the translated prefix.
 	 *
-	 * The block.json default "By " is not translatable. This method checks if
+	 * The block.json default "By" is not translatable. This method checks if
 	 * the prefix matches the English default and returns the translated version.
 	 * If the user has set a custom prefix, it's returned as-is.
 	 *
@@ -248,8 +248,8 @@ final class Byline_Block {
 	 */
 	private static function get_translated_prefix( string $prefix ) {
 		// If prefix is empty or matches the English default, use translated version.
-		if ( empty( $prefix ) || 'By ' === $prefix ) {
-			return __( 'By ', 'newspack-plugin' );
+		if ( empty( $prefix ) || 'By' === $prefix ) {
+			return __( 'By', 'newspack-plugin' );
 		}
 		return $prefix;
 	}

--- a/src/blocks/byline/class-byline-block.php
+++ b/src/blocks/byline/class-byline-block.php
@@ -108,7 +108,7 @@ final class Byline_Block {
 	 * @return string The block HTML.
 	 */
 	private static function render_coauthors( array $attributes, array $coauthors ) {
-		$prefix             = $attributes['prefix'] ?? __( 'By ', 'newspack-plugin' );
+		$prefix             = self::get_translated_prefix( $attributes['prefix'] ?? '' );
 		$link_to_archive    = $attributes['linkToAuthorArchive'] ?? true;
 		$wrapper_attributes = get_block_wrapper_attributes( [ 'class' => 'wp-block-newspack-byline' ] );
 
@@ -121,14 +121,7 @@ final class Byline_Block {
 			}
 
 			if ( $link_to_archive ) {
-				// Use get_author_posts_url with user_nicename - CAP hooks the author_link filter
-				// via CoAuthors_Guest_Authors::filter_author_link() to construct proper URLs.
-				$author_url     = get_author_posts_url( $coauthor->ID, $coauthor->user_nicename );
-				$author_links[] = sprintf(
-					'<span class="author vcard"><a class="url fn n" href="%1$s">%2$s</a></span>',
-					esc_url( $author_url ),
-					esc_html( $display_name )
-				);
+				$author_links[] = self::get_coauthor_link( $coauthor, $display_name );
 			} else {
 				$author_links[] = sprintf(
 					'<span class="author vcard"><span class="fn n">%1$s</span></span>',
@@ -152,6 +145,53 @@ final class Byline_Block {
 	}
 
 	/**
+	 * Get the author link HTML for a CoAuthors Plus author.
+	 *
+	 * Uses get_author_posts_url() which CAP hooks via the 'author_link' filter
+	 * (CoAuthors_Guest_Authors::filter_author_link) to construct proper URLs for
+	 * both WordPress users and CAP guest authors.
+	 *
+	 * Also applies the 'coauthors_posts_link' filter for compatibility with CAP's
+	 * own coauthors_posts_links_single() function.
+	 *
+	 * @param object $coauthor     The coauthor object.
+	 * @param string $display_name The display name to show.
+	 *
+	 * @return string Author link HTML.
+	 */
+	private static function get_coauthor_link( $coauthor, string $display_name ) {
+		$args = [
+			'before_html' => '',
+			'href'        => get_author_posts_url( $coauthor->ID, $coauthor->user_nicename ),
+			'rel'         => 'author',
+			'class'       => 'url fn n',
+			'text'        => $display_name,
+			'after_html'  => '',
+		];
+
+		/**
+		 * Filter the author link arguments.
+		 *
+		 * This filter is provided by CoAuthors Plus and allows modification of
+		 * author link attributes. We apply it for full CAP compatibility.
+		 *
+		 * @param array  $args     Link arguments: href, rel, class, text, before_html, after_html.
+		 * @param object $coauthor The coauthor object.
+		 */
+		$args = apply_filters( 'coauthors_posts_link', $args, $coauthor );
+
+		return sprintf(
+			'%1$s<span class="author vcard"><a class="%2$s" href="%3$s" rel="%4$s">%5$s</a></span>%6$s',
+			$args['before_html'],
+			esc_attr( $args['class'] ),
+			esc_url( $args['href'] ),
+			esc_attr( $args['rel'] ),
+			esc_html( $args['text'] ),
+			$args['after_html']
+		);
+	}
+
+	/**
 	 * Render default WordPress author.
 	 *
 	 * @param array $attributes The block attributes.
@@ -160,7 +200,7 @@ final class Byline_Block {
 	 * @return string The block HTML.
 	 */
 	private static function render_default_author( array $attributes, int $post_id ) {
-		$prefix             = $attributes['prefix'] ?? __( 'By ', 'newspack-plugin' );
+		$prefix             = self::get_translated_prefix( $attributes['prefix'] ?? '' );
 		$link_to_archive    = $attributes['linkToAuthorArchive'] ?? true;
 		$wrapper_attributes = get_block_wrapper_attributes( [ 'class' => 'wp-block-newspack-byline' ] );
 
@@ -193,6 +233,25 @@ final class Byline_Block {
 			esc_html( $prefix ),
 			$author_html
 		);
+	}
+
+	/**
+	 * Get the translated prefix.
+	 *
+	 * The block.json default "By " is not translatable. This method checks if
+	 * the prefix matches the English default and returns the translated version.
+	 * If the user has set a custom prefix, it's returned as-is.
+	 *
+	 * @param string $prefix The prefix attribute value.
+	 *
+	 * @return string The translated or custom prefix.
+	 */
+	private static function get_translated_prefix( string $prefix ) {
+		// If prefix is empty or matches the English default, use translated version.
+		if ( empty( $prefix ) || 'By ' === $prefix ) {
+			return __( 'By ', 'newspack-plugin' );
+		}
+		return $prefix;
 	}
 
 	/**

--- a/src/blocks/byline/class-byline-block.php
+++ b/src/blocks/byline/class-byline-block.php
@@ -1,0 +1,222 @@
+<?php
+/**
+ * Byline Block.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Blocks\Byline;
+
+use Newspack\Bylines;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Byline_Block Class
+ */
+final class Byline_Block {
+	/**
+	 * Initializes the block.
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		add_action( 'init', [ __CLASS__, 'register_block' ] );
+	}
+
+	/**
+	 * Register the byline block.
+	 *
+	 * @return void
+	 */
+	public static function register_block() {
+		register_block_type_from_metadata(
+			__DIR__ . '/block.json',
+			[
+				'render_callback' => [ __CLASS__, 'render_block' ],
+				'uses_context'    => [ 'postId', 'postType' ],
+			]
+		);
+	}
+
+	/**
+	 * Block render callback.
+	 *
+	 * @param array  $attributes The block attributes.
+	 * @param string $content    The block content.
+	 * @param object $block      The block.
+	 *
+	 * @return string The block HTML.
+	 */
+	public static function render_block( array $attributes, string $content, $block ) {
+		$post_id = $block->context['postId'] ?? get_the_ID();
+
+		if ( empty( $post_id ) ) {
+			return '';
+		}
+
+		// 1. Check for custom byline (use post meta check).
+		if ( class_exists( 'Newspack\Bylines' ) ) {
+			$byline_active = get_post_meta( $post_id, Bylines::META_KEY_ACTIVE, true );
+			if ( $byline_active ) {
+				// Use Bylines::get_post_byline_html() as the authoritative source.
+				// Pass false for include_avatars and byline_wrapper since we handle output ourselves.
+				$custom_byline = Bylines::get_post_byline_html( false, false, $post_id );
+				if ( ! empty( $custom_byline ) ) {
+					return self::render_custom_byline( $attributes, $custom_byline );
+				}
+			}
+		}
+
+		// 2. Check for CoAuthors Plus.
+		if ( function_exists( 'get_coauthors' ) ) {
+			$coauthors = get_coauthors( $post_id );
+			if ( ! empty( $coauthors ) ) {
+				return self::render_coauthors( $attributes, $coauthors );
+			}
+		}
+
+		// 3. Fallback to default author.
+		return self::render_default_author( $attributes, $post_id );
+	}
+
+	/**
+	 * Render custom byline.
+	 *
+	 * @param array  $attributes    The block attributes.
+	 * @param string $custom_byline The custom byline HTML from Bylines class.
+	 *
+	 * @return string The block HTML.
+	 */
+	private static function render_custom_byline( array $attributes, string $custom_byline ) {
+		// Custom bylines already include their prefix text, so we ignore the prefix attribute.
+		$wrapper_attributes = get_block_wrapper_attributes( [ 'class' => 'wp-block-newspack-byline' ] );
+
+		return sprintf(
+			'<div %1$s><span class="byline">%2$s</span></div>',
+			$wrapper_attributes,
+			wp_kses_post( $custom_byline )
+		);
+	}
+
+	/**
+	 * Render CoAuthors Plus authors.
+	 *
+	 * @param array $attributes The block attributes.
+	 * @param array $coauthors  The coauthors array.
+	 *
+	 * @return string The block HTML.
+	 */
+	private static function render_coauthors( array $attributes, array $coauthors ) {
+		$prefix             = $attributes['prefix'] ?? 'By ';
+		$link_to_archive    = $attributes['linkToAuthorArchive'] ?? true;
+		$wrapper_attributes = get_block_wrapper_attributes( [ 'class' => 'wp-block-newspack-byline' ] );
+
+		$author_links = [];
+		foreach ( $coauthors as $coauthor ) {
+			$display_name = isset( $coauthor->display_name ) ? $coauthor->display_name : '';
+
+			if ( empty( $display_name ) ) {
+				continue;
+			}
+
+			if ( $link_to_archive ) {
+				// Use get_author_posts_url with user_nicename - CAP hooks the author_link filter
+				// via CoAuthors_Guest_Authors::filter_author_link() to construct proper URLs.
+				$author_url     = get_author_posts_url( $coauthor->ID, $coauthor->user_nicename );
+				$author_links[] = sprintf(
+					'<span class="author vcard"><a class="url fn n" href="%1$s">%2$s</a></span>',
+					esc_url( $author_url ),
+					esc_html( $display_name )
+				);
+			} else {
+				$author_links[] = sprintf(
+					'<span class="author vcard"><span class="fn n">%1$s</span></span>',
+					esc_html( $display_name )
+				);
+			}
+		}
+
+		if ( empty( $author_links ) ) {
+			return '';
+		}
+
+		$byline_content = self::format_author_list( $author_links );
+
+		return sprintf(
+			'<div %1$s><span class="byline">%2$s%3$s</span></div>',
+			$wrapper_attributes,
+			esc_html( $prefix ),
+			$byline_content
+		);
+	}
+
+	/**
+	 * Render default WordPress author.
+	 *
+	 * @param array $attributes The block attributes.
+	 * @param int   $post_id    The post ID.
+	 *
+	 * @return string The block HTML.
+	 */
+	private static function render_default_author( array $attributes, int $post_id ) {
+		$prefix             = $attributes['prefix'] ?? 'By ';
+		$link_to_archive    = $attributes['linkToAuthorArchive'] ?? true;
+		$wrapper_attributes = get_block_wrapper_attributes( [ 'class' => 'wp-block-newspack-byline' ] );
+
+		$author_id = get_post_field( 'post_author', $post_id );
+		$author    = get_userdata( $author_id );
+
+		if ( ! $author ) {
+			return '';
+		}
+
+		$display_name = $author->display_name;
+
+		if ( $link_to_archive ) {
+			$author_url  = get_author_posts_url( $author_id );
+			$author_html = sprintf(
+				'<span class="author vcard"><a class="url fn n" href="%1$s">%2$s</a></span>',
+				esc_url( $author_url ),
+				esc_html( $display_name )
+			);
+		} else {
+			$author_html = sprintf(
+				'<span class="author vcard"><span class="fn n">%1$s</span></span>',
+				esc_html( $display_name )
+			);
+		}
+
+		return sprintf(
+			'<div %1$s><span class="byline">%2$s%3$s</span></div>',
+			$wrapper_attributes,
+			esc_html( $prefix ),
+			$author_html
+		);
+	}
+
+	/**
+	 * Format a list of author links with proper separators.
+	 *
+	 * Uses wp_sprintf_l for localized list formatting.
+	 *
+	 * @param array $author_links Array of author HTML strings.
+	 *
+	 * @return string Formatted author list.
+	 */
+	private static function format_author_list( array $author_links ) {
+		if ( empty( $author_links ) ) {
+			return '';
+		}
+
+		if ( 1 === count( $author_links ) ) {
+			return $author_links[0];
+		}
+
+		// Use wp_sprintf_l for localized list formatting.
+		// The %l placeholder formats the array as a proper list with commas and "and".
+		return wp_sprintf_l( '%l', $author_links );
+	}
+}
+
+Byline_Block::init();

--- a/src/blocks/byline/class-byline-block.php
+++ b/src/blocks/byline/class-byline-block.php
@@ -108,7 +108,7 @@ final class Byline_Block {
 	 * @return string The block HTML.
 	 */
 	private static function render_coauthors( array $attributes, array $coauthors ) {
-		$prefix             = $attributes['prefix'] ?? 'By ';
+		$prefix             = $attributes['prefix'] ?? __( 'By ', 'newspack-plugin' );
 		$link_to_archive    = $attributes['linkToAuthorArchive'] ?? true;
 		$wrapper_attributes = get_block_wrapper_attributes( [ 'class' => 'wp-block-newspack-byline' ] );
 
@@ -160,7 +160,7 @@ final class Byline_Block {
 	 * @return string The block HTML.
 	 */
 	private static function render_default_author( array $attributes, int $post_id ) {
-		$prefix             = $attributes['prefix'] ?? 'By ';
+		$prefix             = $attributes['prefix'] ?? __( 'By ', 'newspack-plugin' );
 		$link_to_archive    = $attributes['linkToAuthorArchive'] ?? true;
 		$wrapper_attributes = get_block_wrapper_attributes( [ 'class' => 'wp-block-newspack-byline' ] );
 

--- a/src/blocks/byline/class-byline-block.php
+++ b/src/blocks/byline/class-byline-block.php
@@ -90,7 +90,7 @@ final class Byline_Block {
 	 */
 	private static function render_custom_byline( array $attributes, string $custom_byline ) {
 		// Custom bylines already include their prefix text, so we ignore the prefix attribute.
-		$wrapper_attributes = get_block_wrapper_attributes( [ 'class' => 'wp-block-newspack-byline' ] );
+		$wrapper_attributes = get_block_wrapper_attributes();
 
 		return sprintf(
 			'<div %1$s><span class="byline">%2$s</span></div>',
@@ -110,7 +110,7 @@ final class Byline_Block {
 	private static function render_coauthors( array $attributes, array $coauthors ) {
 		$prefix             = self::get_translated_prefix( $attributes['prefix'] ?? '' );
 		$link_to_archive    = $attributes['linkToAuthorArchive'] ?? true;
-		$wrapper_attributes = get_block_wrapper_attributes( [ 'class' => 'wp-block-newspack-byline' ] );
+		$wrapper_attributes = get_block_wrapper_attributes();
 
 		$author_links = [];
 		foreach ( $coauthors as $coauthor ) {
@@ -202,7 +202,7 @@ final class Byline_Block {
 	private static function render_default_author( array $attributes, int $post_id ) {
 		$prefix             = self::get_translated_prefix( $attributes['prefix'] ?? '' );
 		$link_to_archive    = $attributes['linkToAuthorArchive'] ?? true;
-		$wrapper_attributes = get_block_wrapper_attributes( [ 'class' => 'wp-block-newspack-byline' ] );
+		$wrapper_attributes = get_block_wrapper_attributes();
 
 		$author_id = get_post_field( 'post_author', $post_id );
 		$author    = get_userdata( $author_id );

--- a/src/blocks/byline/class-byline-block.php
+++ b/src/blocks/byline/class-byline-block.php
@@ -182,12 +182,12 @@ final class Byline_Block {
 
 		return sprintf(
 			'%1$s<span class="author vcard"><a class="%2$s" href="%3$s" rel="%4$s">%5$s</a></span>%6$s',
-			$args['before_html'],
+			wp_kses_post( $args['before_html'] ),
 			esc_attr( $args['class'] ),
 			esc_url( $args['href'] ),
 			esc_attr( $args['rel'] ),
 			esc_html( $args['text'] ),
-			$args['after_html']
+			wp_kses_post( $args['after_html'] )
 		);
 	}
 

--- a/src/blocks/byline/class-byline-block.php
+++ b/src/blocks/byline/class-byline-block.php
@@ -257,8 +257,6 @@ final class Byline_Block {
 	/**
 	 * Format a list of author links with proper separators.
 	 *
-	 * Uses wp_sprintf_l for localized list formatting.
-	 *
 	 * @param array $author_links Array of author HTML strings.
 	 *
 	 * @return string Formatted author list.
@@ -272,9 +270,8 @@ final class Byline_Block {
 			return $author_links[0];
 		}
 
-		// Use wp_sprintf_l for localized list formatting.
-		// The %l placeholder formats the array as a proper list with commas and "and".
-		return wp_sprintf_l( '%l', $author_links );
+		$last = array_pop( $author_links );
+		return implode( ', ', $author_links ) . _x( ' and ', 'post author separator', 'newspack-plugin' ) . $last;
 	}
 }
 

--- a/src/blocks/byline/edit.jsx
+++ b/src/blocks/byline/edit.jsx
@@ -83,35 +83,24 @@ export default function Edit( { attributes, context, setAttributes } ) {
 		);
 	}
 
-	// Render default WordPress author.
-	if ( defaultAuthor?.name ) {
-		return (
-			<>
-				<BylineInspectorControls attributes={ attributes } setAttributes={ setAttributes } isCustomByline={ false } />
-				<div { ...blockProps }>
-					<span className="byline">
-						{ attributes.prefix?.trim() && `${ attributes.prefix.trim() } ` }
-						<span className="author vcard">
-							{ attributes.linkToAuthorArchive ? (
-								<a href="#author-link" onClick={ e => e.preventDefault() } className="url fn n">
-									{ defaultAuthor.name }
-								</a>
-							) : (
-								<span className="fn n">{ defaultAuthor.name }</span>
-							) }
-						</span>
-					</span>
-				</div>
-			</>
-		);
-	}
-
-	// Fallback - no author found (e.g., in Site Editor without post context).
+	// Render default WordPress author, or placeholder if no author found.
+	const authorName = defaultAuthor?.name || __( '[Author]', 'newspack-plugin' );
 	return (
 		<>
 			<BylineInspectorControls attributes={ attributes } setAttributes={ setAttributes } isCustomByline={ false } />
 			<div { ...blockProps }>
-				<span className="byline">{ __( 'No author', 'newspack-plugin' ) }</span>
+				<span className="byline">
+					{ attributes.prefix?.trim() && `${ attributes.prefix.trim() } ` }
+					<span className="author vcard">
+						{ attributes.linkToAuthorArchive ? (
+							<a href="#author-link" onClick={ e => e.preventDefault() } className="url fn n">
+								{ authorName }
+							</a>
+						) : (
+							<span className="fn n">{ authorName }</span>
+						) }
+					</span>
+				</span>
 			</div>
 		</>
 	);

--- a/src/blocks/byline/edit.jsx
+++ b/src/blocks/byline/edit.jsx
@@ -240,10 +240,13 @@ export default function Edit( { attributes, context, setAttributes } ) {
 		);
 	}
 
-	// Fallback - no author found.
+	// Fallback - no author found (e.g., in Site Editor without post context).
 	return (
-		<div { ...blockProps }>
-			<span className="byline">{ __( 'No author', 'newspack-plugin' ) }</span>
-		</div>
+		<>
+			<BylineInspectorControls attributes={ attributes } setAttributes={ setAttributes } isCustomByline={ false } />
+			<div { ...blockProps }>
+				<span className="byline">{ __( 'No author', 'newspack-plugin' ) }</span>
+			</div>
+		</>
 	);
 }

--- a/src/blocks/byline/edit.jsx
+++ b/src/blocks/byline/edit.jsx
@@ -209,7 +209,7 @@ export default function Edit( { attributes, context, setAttributes } ) {
 				<BylineInspectorControls attributes={ attributes } setAttributes={ setAttributes } isCustomByline={ false } />
 				<div { ...blockProps }>
 					<span className="byline">
-						{ attributes.prefix }
+						{ attributes.prefix && `${ attributes.prefix } ` }
 						{ formatAuthorsList( coAuthors, attributes.linkToAuthorArchive ) }
 					</span>
 				</div>
@@ -224,7 +224,7 @@ export default function Edit( { attributes, context, setAttributes } ) {
 				<BylineInspectorControls attributes={ attributes } setAttributes={ setAttributes } isCustomByline={ false } />
 				<div { ...blockProps }>
 					<span className="byline">
-						{ attributes.prefix }
+						{ attributes.prefix && `${ attributes.prefix } ` }
 						<span className="author vcard">
 							{ attributes.linkToAuthorArchive ? (
 								<a href="#author-link" onClick={ e => e.preventDefault() } className="url fn n">

--- a/src/blocks/byline/edit.jsx
+++ b/src/blocks/byline/edit.jsx
@@ -11,6 +11,7 @@ import { useSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import './style.scss';
+import { parseBylineForDisplay, formatAuthorsList } from './utils';
 
 /**
  * Hook to get custom byline data.
@@ -111,123 +112,6 @@ function useDefaultAuthor( postId, postType ) {
 	);
 
 	return { authorDetails, isLoading };
-}
-
-/**
- * Decode HTML entities in a string.
- *
- * @param {string} text Text with HTML entities.
- * @return {string} Decoded text.
- */
-function decodeHtmlEntities( text ) {
-	const textarea = document.createElement( 'textarea' );
-	textarea.innerHTML = text;
-	return textarea.value;
-}
-
-/**
- * Parse byline shortcodes to extract display names and render as React elements.
- *
- * @param {string} bylineContent Raw byline content with shortcodes.
- * @return {Array} Array of React elements for display.
- */
-function parseBylineForDisplay( bylineContent ) {
-	const elements = [];
-	let lastIndex = 0;
-	const regex = /\[Author id=(\d+)\](.*?)\[\/Author\]/g;
-	let match;
-
-	while ( ( match = regex.exec( bylineContent ) ) !== null ) {
-		// Add text before the match.
-		if ( match.index > lastIndex ) {
-			const textBefore = bylineContent.slice( lastIndex, match.index );
-			elements.push( decodeHtmlEntities( textBefore ) );
-		}
-
-		// Add author link.
-		const authorId = match[ 1 ];
-		const authorName = match[ 2 ];
-		elements.push(
-			<a key={ `author-${ authorId }-${ match.index }` } href="#author-link" onClick={ e => e.preventDefault() } className="url fn n">
-				{ decodeHtmlEntities( authorName ) }
-			</a>
-		);
-
-		lastIndex = match.index + match[ 0 ].length;
-	}
-
-	// Add remaining text after last match.
-	if ( lastIndex < bylineContent.length ) {
-		const textAfter = bylineContent.slice( lastIndex );
-		elements.push( decodeHtmlEntities( textAfter ) );
-	}
-
-	return elements;
-}
-
-/**
- * Format authors list for display using Intl.ListFormat.
- *
- * Uses the browser's Intl.ListFormat API for localized list formatting,
- * which is the JS equivalent of WordPress's wp_sprintf_l().
- *
- * @param {Array}   authors       Array of author objects.
- * @param {boolean} linkToArchive Whether to show as links.
- * @return {Array} Array of React elements.
- */
-function formatAuthorsList( authors, linkToArchive ) {
-	if ( ! authors || authors.length === 0 ) {
-		return [];
-	}
-
-	// For a single author, return directly without list formatting.
-	if ( authors.length === 1 ) {
-		const author = authors[ 0 ];
-		const name = author.display_name || author.name;
-		return [
-			<span key={ `author-wrapper-${ author.id || 0 }` } className="author vcard">
-				{ linkToArchive ? (
-					<a href="#author-link" onClick={ e => e.preventDefault() } className="url fn n">
-						{ name }
-					</a>
-				) : (
-					<span className="fn n">{ name }</span>
-				) }
-			</span>,
-		];
-	}
-
-	// Use Intl.ListFormat for localized list formatting (JS equivalent of wp_sprintf_l).
-	// Get the current locale from WordPress or fall back to browser locale.
-	const locale = document.documentElement.lang || navigator.language || 'en';
-	const listFormatter = new Intl.ListFormat( locale, { style: 'long', type: 'conjunction' } );
-
-	// Create placeholder strings to get the formatted parts.
-	const placeholders = authors.map( ( _, i ) => `__AUTHOR_${ i }__` );
-	const formattedParts = listFormatter.formatToParts( placeholders );
-
-	// Build React elements from the formatted parts.
-	return formattedParts.map( ( part, partIndex ) => {
-		if ( part.type === 'literal' ) {
-			return part.value;
-		}
-		// Extract author index from placeholder.
-		const authorIndex = parseInt( part.value.replace( '__AUTHOR_', '' ).replace( '__', '' ), 10 );
-		const author = authors[ authorIndex ];
-		const name = author.display_name || author.name;
-
-		return (
-			<span key={ `author-wrapper-${ author.id || partIndex }` } className="author vcard">
-				{ linkToArchive ? (
-					<a href="#author-link" onClick={ e => e.preventDefault() } className="url fn n">
-						{ name }
-					</a>
-				) : (
-					<span className="fn n">{ name }</span>
-				) }
-			</span>
-		);
-	} );
 }
 
 /**

--- a/src/blocks/byline/edit.jsx
+++ b/src/blocks/byline/edit.jsx
@@ -75,7 +75,7 @@ export default function Edit( { attributes, context, setAttributes } ) {
 				<BylineInspectorControls attributes={ attributes } setAttributes={ setAttributes } isCustomByline={ false } />
 				<div { ...blockProps }>
 					<span className="byline">
-						{ attributes.prefix && `${ attributes.prefix } ` }
+						{ attributes.prefix?.trim() && `${ attributes.prefix.trim() } ` }
 						{ formatAuthorsList( coAuthors, attributes.linkToAuthorArchive ) }
 					</span>
 				</div>
@@ -90,7 +90,7 @@ export default function Edit( { attributes, context, setAttributes } ) {
 				<BylineInspectorControls attributes={ attributes } setAttributes={ setAttributes } isCustomByline={ false } />
 				<div { ...blockProps }>
 					<span className="byline">
-						{ attributes.prefix && `${ attributes.prefix } ` }
+						{ attributes.prefix?.trim() && `${ attributes.prefix.trim() } ` }
 						<span className="author vcard">
 							{ attributes.linkToAuthorArchive ? (
 								<a href="#author-link" onClick={ e => e.preventDefault() } className="url fn n">

--- a/src/blocks/byline/edit.jsx
+++ b/src/blocks/byline/edit.jsx
@@ -1,158 +1,24 @@
 /**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
-import { PanelBody, TextControl, ToggleControl, Spinner } from '@wordpress/components';
-import { store as coreStore } from '@wordpress/core-data';
-import { useSelect } from '@wordpress/data';
+import { useBlockProps } from '@wordpress/block-editor';
+import { Spinner } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
 import { parseBylineForDisplay, formatAuthorsList } from './utils';
-
-/**
- * Hook to get custom byline data.
- *
- * @param {number} postId   Post ID.
- * @param {string} postType Post type.
- * @return {Object} Custom byline data.
- */
-function useCustomByline( postId, postType ) {
-	const { bylineActive, bylineContent } = useSelect(
-		select => {
-			const { getEditedEntityRecord } = select( coreStore );
-			const postRecord = getEditedEntityRecord( 'postType', postType, postId );
-			return {
-				bylineActive: postRecord?.meta?._newspack_byline_active || false,
-				bylineContent: postRecord?.meta?._newspack_byline || '',
-			};
-		},
-		[ postId, postType ]
-	);
-
-	return { bylineActive, bylineContent };
-}
-
-/**
- * CoAuthors Plus store name.
- */
-const CAP_STORE = 'cap/authors';
-
-/**
- * Hook to get CoAuthors Plus authors from the CAP store.
- * CoAuthors Plus uses its own data store for managing authors in the editor.
- * Note: CAP's store doesn't use standard WP data resolution, so we check
- * for authors directly rather than using hasFinishedResolution.
- *
- * @param {number} postId Post ID to get authors for.
- * @return {Object} Authors array and availability state.
- */
-function useCoAuthors( postId ) {
-	const { authors, isCapAvailable } = useSelect(
-		select => {
-			// Check if CoAuthors Plus store is available.
-			const capStore = select( CAP_STORE );
-			if ( ! capStore || typeof capStore.getAuthors !== 'function' ) {
-				return { authors: [], isCapAvailable: false };
-			}
-
-			// Get authors from the CAP store for the specific post.
-			// The postId is required to get the correct authors for the current post.
-			const capAuthors = postId ? capStore.getAuthors( postId ) : [];
-
-			if ( ! capAuthors || capAuthors.length === 0 ) {
-				return { authors: [], isCapAvailable: true };
-			}
-
-			// Map CAP author objects to our expected format.
-			// CAP stores: { id, label, display, value, userType }
-			const mappedAuthors = capAuthors.map( author => ( {
-				id: author.id,
-				display_name: author.display || author.value || author.label,
-				user_nicename: author.value,
-			} ) );
-
-			return { authors: mappedAuthors, isCapAvailable: true };
-		},
-		[ postId ]
-	);
-
-	return { authors, isCapAvailable };
-}
-
-/**
- * Hook to get default WordPress author.
- *
- * @param {number} postId   Post ID.
- * @param {string} postType Post type.
- * @return {Object} Author details and loading state.
- */
-function useDefaultAuthor( postId, postType ) {
-	const { authorDetails, isLoading } = useSelect(
-		select => {
-			const { getEditedEntityRecord, getUser, hasFinishedResolution } = select( coreStore );
-			const authorId = getEditedEntityRecord( 'postType', postType, postId )?.author;
-
-			if ( ! authorId ) {
-				return { authorDetails: null, isLoading: false };
-			}
-
-			const user = getUser( authorId );
-			const hasResolved = hasFinishedResolution( 'getUser', [ authorId ] );
-
-			return {
-				authorDetails: user,
-				isLoading: ! hasResolved,
-			};
-		},
-		[ postType, postId ]
-	);
-
-	return { authorDetails, isLoading };
-}
-
-/**
- * Inspector controls for the byline block.
- *
- * @param {Object}   props                Component props.
- * @param {Object}   props.attributes     Block attributes.
- * @param {Function} props.setAttributes  Set attributes function.
- * @param {boolean}  props.isCustomByline Whether custom byline is active.
- * @return {JSX.Element} Inspector controls.
- */
-function BylineInspectorControls( { attributes, setAttributes, isCustomByline } ) {
-	return (
-		<InspectorControls>
-			<PanelBody title={ __( 'Settings', 'newspack-plugin' ) }>
-				{ ! isCustomByline && (
-					<>
-						<TextControl
-							__nextHasNoMarginBottom
-							label={ __( 'Prefix', 'newspack-plugin' ) }
-							help={ __( 'Text displayed before the author name(s).', 'newspack-plugin' ) }
-							value={ attributes.prefix }
-							onChange={ prefix => setAttributes( { prefix } ) }
-						/>
-						<ToggleControl
-							__nextHasNoMarginBottom
-							label={ __( 'Link to author archive', 'newspack-plugin' ) }
-							checked={ attributes.linkToAuthorArchive }
-							onChange={ () => setAttributes( { linkToAuthorArchive: ! attributes.linkToAuthorArchive } ) }
-						/>
-					</>
-				) }
-				{ isCustomByline && (
-					<p className="components-base-control__help">
-						{ __( 'Prefix and link settings are controlled by the custom byline and cannot be changed here.', 'newspack-plugin' ) }
-					</p>
-				) }
-			</PanelBody>
-		</InspectorControls>
-	);
-}
+import { useCustomByline } from './hooks/use-custom-byline';
+import { useCoAuthors } from './hooks/use-coauthors';
+import { useDefaultAuthor } from './hooks/use-default-author';
+import { BylineInspectorControls } from './inspector.jsx';
 
 /**
  * Edit component for the byline block.
@@ -250,3 +116,15 @@ export default function Edit( { attributes, context, setAttributes } ) {
 		</>
 	);
 }
+
+Edit.propTypes = {
+	attributes: PropTypes.shape( {
+		prefix: PropTypes.string,
+		linkToAuthorArchive: PropTypes.bool,
+	} ).isRequired,
+	context: PropTypes.shape( {
+		postId: PropTypes.number,
+		postType: PropTypes.string,
+	} ).isRequired,
+	setAttributes: PropTypes.func.isRequired,
+};

--- a/src/blocks/byline/edit.jsx
+++ b/src/blocks/byline/edit.jsx
@@ -37,7 +37,7 @@ export default function Edit( { attributes, context, setAttributes } ) {
 	const { bylineActive, bylineContent } = useCustomByline( postId, postType );
 
 	// Get CoAuthors Plus authors.
-	const { authors: coAuthors, isCapAvailable } = useCoAuthors( postId );
+	const { authors: coAuthors, isCapAvailable } = useCoAuthors( postId, postType );
 
 	// Get default WordPress author.
 	const { authorDetails: defaultAuthor, isLoading: isLoadingAuthor } = useDefaultAuthor( postId, postType );

--- a/src/blocks/byline/edit.jsx
+++ b/src/blocks/byline/edit.jsx
@@ -15,20 +15,21 @@ import './style.scss';
 /**
  * Hook to get custom byline data.
  *
- * @param {number} postId Post ID.
+ * @param {number} postId   Post ID.
+ * @param {string} postType Post type.
  * @return {Object} Custom byline data.
  */
-function useCustomByline( postId ) {
+function useCustomByline( postId, postType ) {
 	const { bylineActive, bylineContent } = useSelect(
 		select => {
 			const { getEditedEntityRecord } = select( coreStore );
-			const postRecord = getEditedEntityRecord( 'postType', 'post', postId );
+			const postRecord = getEditedEntityRecord( 'postType', postType, postId );
 			return {
 				bylineActive: postRecord?.meta?._newspack_byline_active || false,
 				bylineContent: postRecord?.meta?._newspack_byline || '',
 			};
 		},
-		[ postId ]
+		[ postId, postType ]
 	);
 
 	return { bylineActive, bylineContent };
@@ -243,30 +244,27 @@ function BylineInspectorControls( { attributes, setAttributes, isCustomByline } 
 		<InspectorControls>
 			<PanelBody title={ __( 'Settings', 'newspack-plugin' ) }>
 				{ ! isCustomByline && (
-					<TextControl
-						__nextHasNoMarginBottom
-						label={ __( 'Prefix', 'newspack-plugin' ) }
-						help={ __( 'Text displayed before the author name(s).', 'newspack-plugin' ) }
-						value={ attributes.prefix }
-						onChange={ prefix => setAttributes( { prefix } ) }
-					/>
+					<>
+						<TextControl
+							__nextHasNoMarginBottom
+							label={ __( 'Prefix', 'newspack-plugin' ) }
+							help={ __( 'Text displayed before the author name(s).', 'newspack-plugin' ) }
+							value={ attributes.prefix }
+							onChange={ prefix => setAttributes( { prefix } ) }
+						/>
+						<ToggleControl
+							__nextHasNoMarginBottom
+							label={ __( 'Link to author archive', 'newspack-plugin' ) }
+							checked={ attributes.linkToAuthorArchive }
+							onChange={ () => setAttributes( { linkToAuthorArchive: ! attributes.linkToAuthorArchive } ) }
+						/>
+					</>
 				) }
 				{ isCustomByline && (
 					<p className="components-base-control__help">
-						{ __( 'Prefix is not shown for custom bylines as they include their own prefix text.', 'newspack-plugin' ) }
+						{ __( 'Prefix and link settings are controlled by the custom byline and cannot be changed here.', 'newspack-plugin' ) }
 					</p>
 				) }
-				<ToggleControl
-					__nextHasNoMarginBottom
-					label={ __( 'Link to author archive', 'newspack-plugin' ) }
-					checked={ attributes.linkToAuthorArchive }
-					onChange={ () => setAttributes( { linkToAuthorArchive: ! attributes.linkToAuthorArchive } ) }
-					help={
-						isCustomByline
-							? __( 'This setting does not apply to custom bylines, which have their own link settings.', 'newspack-plugin' )
-							: undefined
-					}
-				/>
 			</PanelBody>
 		</InspectorControls>
 	);
@@ -282,11 +280,11 @@ function BylineInspectorControls( { attributes, setAttributes, isCustomByline } 
  * @return {JSX.Element} Edit component.
  */
 export default function Edit( { attributes, context, setAttributes } ) {
-	const { postId, postType } = context;
+	const { postId, postType = 'post' } = context;
 	const blockProps = useBlockProps( { className: 'wp-block-newspack-byline' } );
 
 	// Get custom byline data.
-	const { bylineActive, bylineContent } = useCustomByline( postId );
+	const { bylineActive, bylineContent } = useCustomByline( postId, postType );
 
 	// Get CoAuthors Plus authors.
 	const { authors: coAuthors, isCapAvailable } = useCoAuthors( postId );

--- a/src/blocks/byline/edit.jsx
+++ b/src/blocks/byline/edit.jsx
@@ -1,0 +1,363 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import { PanelBody, TextControl, ToggleControl, Spinner } from '@wordpress/components';
+import { store as coreStore } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+/**
+ * Hook to get custom byline data.
+ *
+ * @param {number} postId Post ID.
+ * @return {Object} Custom byline data.
+ */
+function useCustomByline( postId ) {
+	const { bylineActive, bylineContent } = useSelect(
+		select => {
+			const { getEditedEntityRecord } = select( coreStore );
+			const postRecord = getEditedEntityRecord( 'postType', 'post', postId );
+			return {
+				bylineActive: postRecord?.meta?._newspack_byline_active || false,
+				bylineContent: postRecord?.meta?._newspack_byline || '',
+			};
+		},
+		[ postId ]
+	);
+
+	return { bylineActive, bylineContent };
+}
+
+/**
+ * CoAuthors Plus store name.
+ */
+const CAP_STORE = 'cap/authors';
+
+/**
+ * Hook to get CoAuthors Plus authors from the CAP store.
+ * CoAuthors Plus uses its own data store for managing authors in the editor.
+ * Note: CAP's store doesn't use standard WP data resolution, so we check
+ * for authors directly rather than using hasFinishedResolution.
+ *
+ * @return {Object} Authors array and availability state.
+ */
+function useCoAuthors() {
+	const { authors, isCapAvailable } = useSelect( select => {
+		// Check if CoAuthors Plus store is available.
+		const capStore = select( CAP_STORE );
+		if ( ! capStore || typeof capStore.getAuthors !== 'function' ) {
+			return { authors: [], isCapAvailable: false };
+		}
+
+		// Get authors from the CAP store.
+		// This returns the current editing state, updating in real-time.
+		const capAuthors = capStore.getAuthors();
+
+		if ( ! capAuthors || capAuthors.length === 0 ) {
+			return { authors: [], isCapAvailable: true };
+		}
+
+		// Map CAP author objects to our expected format.
+		// CAP stores: { id, label, display, value, userType }
+		const mappedAuthors = capAuthors.map( author => ( {
+			id: author.id,
+			display_name: author.display || author.value || author.label,
+			user_nicename: author.value,
+		} ) );
+
+		return { authors: mappedAuthors, isCapAvailable: true };
+	}, [] );
+
+	return { authors, isCapAvailable };
+}
+
+/**
+ * Hook to get default WordPress author.
+ *
+ * @param {number} postId   Post ID.
+ * @param {string} postType Post type.
+ * @return {Object} Author details and loading state.
+ */
+function useDefaultAuthor( postId, postType ) {
+	const { authorDetails, isLoading } = useSelect(
+		select => {
+			const { getEditedEntityRecord, getUser, hasFinishedResolution } = select( coreStore );
+			const authorId = getEditedEntityRecord( 'postType', postType, postId )?.author;
+
+			if ( ! authorId ) {
+				return { authorDetails: null, isLoading: false };
+			}
+
+			const user = getUser( authorId );
+			const hasResolved = hasFinishedResolution( 'getUser', [ authorId ] );
+
+			return {
+				authorDetails: user,
+				isLoading: ! hasResolved,
+			};
+		},
+		[ postType, postId ]
+	);
+
+	return { authorDetails, isLoading };
+}
+
+/**
+ * Decode HTML entities in a string.
+ *
+ * @param {string} text Text with HTML entities.
+ * @return {string} Decoded text.
+ */
+function decodeHtmlEntities( text ) {
+	const textarea = document.createElement( 'textarea' );
+	textarea.innerHTML = text;
+	return textarea.value;
+}
+
+/**
+ * Parse byline shortcodes to extract display names and render as React elements.
+ *
+ * @param {string} bylineContent Raw byline content with shortcodes.
+ * @return {Array} Array of React elements for display.
+ */
+function parseBylineForDisplay( bylineContent ) {
+	const elements = [];
+	let lastIndex = 0;
+	const regex = /\[Author id=(\d+)\](.*?)\[\/Author\]/g;
+	let match;
+
+	while ( ( match = regex.exec( bylineContent ) ) !== null ) {
+		// Add text before the match.
+		if ( match.index > lastIndex ) {
+			const textBefore = bylineContent.slice( lastIndex, match.index );
+			elements.push( decodeHtmlEntities( textBefore ) );
+		}
+
+		// Add author link.
+		const authorId = match[ 1 ];
+		const authorName = match[ 2 ];
+		elements.push(
+			<a key={ `author-${ authorId }-${ match.index }` } href="#author-link" onClick={ e => e.preventDefault() } className="url fn n">
+				{ decodeHtmlEntities( authorName ) }
+			</a>
+		);
+
+		lastIndex = match.index + match[ 0 ].length;
+	}
+
+	// Add remaining text after last match.
+	if ( lastIndex < bylineContent.length ) {
+		const textAfter = bylineContent.slice( lastIndex );
+		elements.push( decodeHtmlEntities( textAfter ) );
+	}
+
+	return elements;
+}
+
+/**
+ * Format authors list for display using Intl.ListFormat.
+ *
+ * Uses the browser's Intl.ListFormat API for localized list formatting,
+ * which is the JS equivalent of WordPress's wp_sprintf_l().
+ *
+ * @param {Array}   authors       Array of author objects.
+ * @param {boolean} linkToArchive Whether to show as links.
+ * @return {Array} Array of React elements.
+ */
+function formatAuthorsList( authors, linkToArchive ) {
+	if ( ! authors || authors.length === 0 ) {
+		return [];
+	}
+
+	// For a single author, return directly without list formatting.
+	if ( authors.length === 1 ) {
+		const author = authors[ 0 ];
+		const name = author.display_name || author.name;
+		return [
+			<span key={ `author-wrapper-${ author.id || 0 }` } className="author vcard">
+				{ linkToArchive ? (
+					<a href="#author-link" onClick={ e => e.preventDefault() } className="url fn n">
+						{ name }
+					</a>
+				) : (
+					<span className="fn n">{ name }</span>
+				) }
+			</span>,
+		];
+	}
+
+	// Use Intl.ListFormat for localized list formatting (JS equivalent of wp_sprintf_l).
+	// Get the current locale from WordPress or fall back to browser locale.
+	const locale = document.documentElement.lang || navigator.language || 'en';
+	const listFormatter = new Intl.ListFormat( locale, { style: 'long', type: 'conjunction' } );
+
+	// Create placeholder strings to get the formatted parts.
+	const placeholders = authors.map( ( _, i ) => `__AUTHOR_${ i }__` );
+	const formattedParts = listFormatter.formatToParts( placeholders );
+
+	// Build React elements from the formatted parts.
+	return formattedParts.map( ( part, partIndex ) => {
+		if ( part.type === 'literal' ) {
+			return part.value;
+		}
+		// Extract author index from placeholder.
+		const authorIndex = parseInt( part.value.replace( '__AUTHOR_', '' ).replace( '__', '' ), 10 );
+		const author = authors[ authorIndex ];
+		const name = author.display_name || author.name;
+
+		return (
+			<span key={ `author-wrapper-${ author.id || partIndex }` } className="author vcard">
+				{ linkToArchive ? (
+					<a href="#author-link" onClick={ e => e.preventDefault() } className="url fn n">
+						{ name }
+					</a>
+				) : (
+					<span className="fn n">{ name }</span>
+				) }
+			</span>
+		);
+	} );
+}
+
+/**
+ * Inspector controls for the byline block.
+ *
+ * @param {Object}   props                Component props.
+ * @param {Object}   props.attributes     Block attributes.
+ * @param {Function} props.setAttributes  Set attributes function.
+ * @param {boolean}  props.isCustomByline Whether custom byline is active.
+ * @return {JSX.Element} Inspector controls.
+ */
+function BylineInspectorControls( { attributes, setAttributes, isCustomByline } ) {
+	return (
+		<InspectorControls>
+			<PanelBody title={ __( 'Settings', 'newspack-plugin' ) }>
+				{ ! isCustomByline && (
+					<TextControl
+						__nextHasNoMarginBottom
+						label={ __( 'Prefix', 'newspack-plugin' ) }
+						help={ __( 'Text displayed before the author name(s).', 'newspack-plugin' ) }
+						value={ attributes.prefix }
+						onChange={ prefix => setAttributes( { prefix } ) }
+					/>
+				) }
+				{ isCustomByline && (
+					<p className="components-base-control__help">
+						{ __( 'Prefix is not shown for custom bylines as they include their own prefix text.', 'newspack-plugin' ) }
+					</p>
+				) }
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ __( 'Link to author archive', 'newspack-plugin' ) }
+					checked={ attributes.linkToAuthorArchive }
+					onChange={ () => setAttributes( { linkToAuthorArchive: ! attributes.linkToAuthorArchive } ) }
+					help={
+						isCustomByline
+							? __( 'This setting does not apply to custom bylines, which have their own link settings.', 'newspack-plugin' )
+							: undefined
+					}
+				/>
+			</PanelBody>
+		</InspectorControls>
+	);
+}
+
+/**
+ * Edit component for the byline block.
+ *
+ * @param {Object}   props               Component props.
+ * @param {Object}   props.attributes    Block attributes.
+ * @param {Object}   props.context       Block context.
+ * @param {Function} props.setAttributes Set attributes function.
+ * @return {JSX.Element} Edit component.
+ */
+export default function Edit( { attributes, context, setAttributes } ) {
+	const { postId, postType } = context;
+	const blockProps = useBlockProps( { className: 'wp-block-newspack-byline' } );
+
+	// Get custom byline data.
+	const { bylineActive, bylineContent } = useCustomByline( postId );
+
+	// Get CoAuthors Plus authors.
+	const { authors: coAuthors, isCapAvailable } = useCoAuthors();
+
+	// Get default WordPress author.
+	const { authorDetails: defaultAuthor, isLoading: isLoadingAuthor } = useDefaultAuthor( postId, postType );
+
+	// Determine which byline to show.
+	const isCustomByline = bylineActive && bylineContent;
+	const hasCoAuthors = isCapAvailable && coAuthors?.length > 0;
+
+	// Loading state - show spinner while fetching default author (only when CAP has no authors).
+	if ( ! isCustomByline && ! hasCoAuthors && isLoadingAuthor ) {
+		return (
+			<div { ...blockProps }>
+				<Spinner />
+			</div>
+		);
+	}
+
+	// Render custom byline.
+	if ( isCustomByline ) {
+		const parsedByline = parseBylineForDisplay( bylineContent );
+		return (
+			<>
+				<BylineInspectorControls attributes={ attributes } setAttributes={ setAttributes } isCustomByline={ true } />
+				<div { ...blockProps }>
+					<span className="byline">{ parsedByline }</span>
+				</div>
+			</>
+		);
+	}
+
+	// Render CoAuthors Plus byline.
+	if ( hasCoAuthors ) {
+		return (
+			<>
+				<BylineInspectorControls attributes={ attributes } setAttributes={ setAttributes } isCustomByline={ false } />
+				<div { ...blockProps }>
+					<span className="byline">
+						{ attributes.prefix }
+						{ formatAuthorsList( coAuthors, attributes.linkToAuthorArchive ) }
+					</span>
+				</div>
+			</>
+		);
+	}
+
+	// Render default WordPress author.
+	if ( defaultAuthor?.name ) {
+		return (
+			<>
+				<BylineInspectorControls attributes={ attributes } setAttributes={ setAttributes } isCustomByline={ false } />
+				<div { ...blockProps }>
+					<span className="byline">
+						{ attributes.prefix }
+						<span className="author vcard">
+							{ attributes.linkToAuthorArchive ? (
+								<a href="#author-link" onClick={ e => e.preventDefault() } className="url fn n">
+									{ defaultAuthor.name }
+								</a>
+							) : (
+								<span className="fn n">{ defaultAuthor.name }</span>
+							) }
+						</span>
+					</span>
+				</div>
+			</>
+		);
+	}
+
+	// Fallback - no author found.
+	return (
+		<div { ...blockProps }>
+			<span className="byline">{ __( 'No author', 'newspack-plugin' ) }</span>
+		</div>
+	);
+}

--- a/src/blocks/byline/edit.jsx
+++ b/src/blocks/byline/edit.jsx
@@ -45,34 +45,38 @@ const CAP_STORE = 'cap/authors';
  * Note: CAP's store doesn't use standard WP data resolution, so we check
  * for authors directly rather than using hasFinishedResolution.
  *
+ * @param {number} postId Post ID to get authors for.
  * @return {Object} Authors array and availability state.
  */
-function useCoAuthors() {
-	const { authors, isCapAvailable } = useSelect( select => {
-		// Check if CoAuthors Plus store is available.
-		const capStore = select( CAP_STORE );
-		if ( ! capStore || typeof capStore.getAuthors !== 'function' ) {
-			return { authors: [], isCapAvailable: false };
-		}
+function useCoAuthors( postId ) {
+	const { authors, isCapAvailable } = useSelect(
+		select => {
+			// Check if CoAuthors Plus store is available.
+			const capStore = select( CAP_STORE );
+			if ( ! capStore || typeof capStore.getAuthors !== 'function' ) {
+				return { authors: [], isCapAvailable: false };
+			}
 
-		// Get authors from the CAP store.
-		// This returns the current editing state, updating in real-time.
-		const capAuthors = capStore.getAuthors();
+			// Get authors from the CAP store for the specific post.
+			// The postId is required to get the correct authors for the current post.
+			const capAuthors = postId ? capStore.getAuthors( postId ) : [];
 
-		if ( ! capAuthors || capAuthors.length === 0 ) {
-			return { authors: [], isCapAvailable: true };
-		}
+			if ( ! capAuthors || capAuthors.length === 0 ) {
+				return { authors: [], isCapAvailable: true };
+			}
 
-		// Map CAP author objects to our expected format.
-		// CAP stores: { id, label, display, value, userType }
-		const mappedAuthors = capAuthors.map( author => ( {
-			id: author.id,
-			display_name: author.display || author.value || author.label,
-			user_nicename: author.value,
-		} ) );
+			// Map CAP author objects to our expected format.
+			// CAP stores: { id, label, display, value, userType }
+			const mappedAuthors = capAuthors.map( author => ( {
+				id: author.id,
+				display_name: author.display || author.value || author.label,
+				user_nicename: author.value,
+			} ) );
 
-		return { authors: mappedAuthors, isCapAvailable: true };
-	}, [] );
+			return { authors: mappedAuthors, isCapAvailable: true };
+		},
+		[ postId ]
+	);
 
 	return { authors, isCapAvailable };
 }
@@ -285,7 +289,7 @@ export default function Edit( { attributes, context, setAttributes } ) {
 	const { bylineActive, bylineContent } = useCustomByline( postId );
 
 	// Get CoAuthors Plus authors.
-	const { authors: coAuthors, isCapAvailable } = useCoAuthors();
+	const { authors: coAuthors, isCapAvailable } = useCoAuthors( postId );
 
 	// Get default WordPress author.
 	const { authorDetails: defaultAuthor, isLoading: isLoadingAuthor } = useDefaultAuthor( postId, postType );

--- a/src/blocks/byline/edit.jsx
+++ b/src/blocks/byline/edit.jsx
@@ -31,7 +31,7 @@ import { BylineInspectorControls } from './inspector.jsx';
  */
 export default function Edit( { attributes, context, setAttributes } ) {
 	const { postId, postType = 'post' } = context;
-	const blockProps = useBlockProps( { className: 'wp-block-newspack-byline' } );
+	const blockProps = useBlockProps();
 
 	// Get custom byline data.
 	const { bylineActive, bylineContent } = useCustomByline( postId, postType );

--- a/src/blocks/byline/hooks/use-coauthors.js
+++ b/src/blocks/byline/hooks/use-coauthors.js
@@ -1,0 +1,51 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+
+/**
+ * CoAuthors Plus store name.
+ */
+const CAP_STORE = 'cap/authors';
+
+/**
+ * Hook to get CoAuthors Plus authors from the CAP store.
+ * CoAuthors Plus uses its own data store for managing authors in the editor.
+ * Note: CAP's store doesn't use standard WP data resolution, so we check
+ * for authors directly rather than using hasFinishedResolution.
+ *
+ * @param {number} postId Post ID to get authors for.
+ * @return {Object} Authors array and availability state.
+ */
+export function useCoAuthors( postId ) {
+	const { authors, isCapAvailable } = useSelect(
+		select => {
+			// Check if CoAuthors Plus store is available.
+			const capStore = select( CAP_STORE );
+			if ( ! capStore || typeof capStore.getAuthors !== 'function' ) {
+				return { authors: [], isCapAvailable: false };
+			}
+
+			// Get authors from the CAP store for the specific post.
+			// The postId is required to get the correct authors for the current post.
+			const capAuthors = postId ? capStore.getAuthors( postId ) : [];
+
+			if ( ! capAuthors || capAuthors.length === 0 ) {
+				return { authors: [], isCapAvailable: true };
+			}
+
+			// Map CAP author objects to our expected format.
+			// CAP stores: { id, label, display, value, userType }
+			const mappedAuthors = capAuthors.map( author => ( {
+				id: author.id,
+				display_name: author.display || author.value || author.label,
+				user_nicename: author.value,
+			} ) );
+
+			return { authors: mappedAuthors, isCapAvailable: true };
+		},
+		[ postId ]
+	);
+
+	return { authors, isCapAvailable };
+}

--- a/src/blocks/byline/hooks/use-coauthors.js
+++ b/src/blocks/byline/hooks/use-coauthors.js
@@ -25,7 +25,7 @@ export function useCoAuthors( postId, postType = 'post' ) {
 		select => {
 			// Check if CoAuthors Plus store is available.
 			const capStore = select( CAP_STORE );
-			const isCapStoreAvailable = capStore && typeof capStore.getAuthors === 'function';
+			const isCapStoreAvailable = Boolean( capStore && typeof capStore.getAuthors === 'function' );
 
 			// Get the currently-edited post ID to detect Query Loop context.
 			const editorStore = select( 'core/editor' );

--- a/src/blocks/byline/hooks/use-coauthors.js
+++ b/src/blocks/byline/hooks/use-coauthors.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * CoAuthors Plus store name.
@@ -9,42 +10,70 @@ import { useSelect } from '@wordpress/data';
 const CAP_STORE = 'cap/authors';
 
 /**
- * Hook to get CoAuthors Plus authors from the CAP store.
- * CoAuthors Plus uses its own data store for managing authors in the editor.
- * Note: CAP's store doesn't use standard WP data resolution, so we check
- * for authors directly rather than using hasFinishedResolution.
+ * Hook to get CoAuthors Plus authors from the CAP store or REST API.
  *
- * @param {number} postId Post ID to get authors for.
+ * For the currently-edited post, it uses CAP's JS store for real-time updates.
+ * For Query Loop posts, it uses REST API data since CAP's store only works for the
+ * currently-edited post.
+ *
+ * @param {number} postId   Post ID to get authors for.
+ * @param {string} postType Post type (default: 'post').
  * @return {Object} Authors array and availability state.
  */
-export function useCoAuthors( postId ) {
+export function useCoAuthors( postId, postType = 'post' ) {
 	const { authors, isCapAvailable } = useSelect(
 		select => {
 			// Check if CoAuthors Plus store is available.
 			const capStore = select( CAP_STORE );
-			if ( ! capStore || typeof capStore.getAuthors !== 'function' ) {
-				return { authors: [], isCapAvailable: false };
-			}
+			const isCapStoreAvailable = capStore && typeof capStore.getAuthors === 'function';
 
-			// Get authors from the CAP store for the specific post.
-			// The postId is required to get the correct authors for the current post.
-			const capAuthors = postId ? capStore.getAuthors( postId ) : [];
+			// Get the currently-edited post ID to detect Query Loop context.
+			const editorStore = select( 'core/editor' );
+			const currentPostId = editorStore?.getCurrentPostId?.();
+			const isQueryLoopContext = postId && currentPostId && postId !== currentPostId;
 
-			if ( ! capAuthors || capAuthors.length === 0 ) {
+			// For the currently-edited post, use CAP's store for real-time updates.
+			if ( isCapStoreAvailable && ! isQueryLoopContext ) {
+				const capAuthors = postId ? capStore.getAuthors( postId ) : [];
+
+				if ( capAuthors && capAuthors.length > 0 ) {
+					// Map CAP store author objects to our expected format.
+					// CAP stores: { id, label, display, value, userType }
+					const mappedAuthors = capAuthors.map( author => ( {
+						id: author.id,
+						display_name: author.display || author.value || author.label,
+						user_nicename: author.value,
+					} ) );
+					return { authors: mappedAuthors, isCapAvailable: true };
+				}
+
 				return { authors: [], isCapAvailable: true };
 			}
 
-			// Map CAP author objects to our expected format.
-			// CAP stores: { id, label, display, value, userType }
-			const mappedAuthors = capAuthors.map( author => ( {
-				id: author.id,
-				display_name: author.display || author.value || author.label,
-				user_nicename: author.value,
-			} ) );
+			// For Query Loop context, try to get coauthors from REST API.
+			// Newspack adds 'newspack_author_info' with full author data.
+			if ( isQueryLoopContext && postId ) {
+				const { getEntityRecord } = select( coreStore );
+				const post = getEntityRecord( 'postType', postType, postId );
 
-			return { authors: mappedAuthors, isCapAvailable: true };
+				// Use newspack_author_info which has full author objects.
+				const restAuthors = post?.newspack_author_info;
+
+				if ( restAuthors && Array.isArray( restAuthors ) && restAuthors.length > 0 ) {
+					// Map REST API author objects to our expected format.
+					const mappedAuthors = restAuthors.map( author => ( {
+						id: author.id,
+						display_name: author.display_name,
+						author_link: author.author_link,
+					} ) );
+					return { authors: mappedAuthors, isCapAvailable: true };
+				}
+			}
+
+			// CAP not available or no authors found.
+			return { authors: [], isCapAvailable: isCapStoreAvailable };
 		},
-		[ postId ]
+		[ postId, postType ]
 	);
 
 	return { authors, isCapAvailable };

--- a/src/blocks/byline/hooks/use-coauthors.test.js
+++ b/src/blocks/byline/hooks/use-coauthors.test.js
@@ -17,92 +17,206 @@ jest.mock( '@wordpress/data', () => ( {
 	useSelect: jest.fn(),
 } ) );
 
+jest.mock( '@wordpress/core-data', () => ( {
+	store: 'core',
+} ) );
+
+/**
+ * Helper to create a mock select function for multiple stores.
+ *
+ * @param {Object} options               Mock options.
+ * @param {Object} options.capStore      CAP store mock (null if unavailable).
+ * @param {number} options.currentPostId Currently-edited post ID.
+ * @param {Object} options.entityRecords Map of postId -> post entity record.
+ * @return {Function} Mock select function.
+ */
+const createMockSelect = ( { capStore = null, currentPostId = 123, entityRecords = {} } = {} ) => {
+	return storeName => {
+		if ( storeName === 'cap/authors' ) {
+			return capStore;
+		}
+		if ( storeName === 'core/editor' ) {
+			return {
+				getCurrentPostId: () => currentPostId,
+			};
+		}
+		if ( storeName === 'core' ) {
+			return {
+				getEntityRecord: ( kind, type, id ) => entityRecords[ id ] || null,
+			};
+		}
+		return null;
+	};
+};
+
 describe( 'useCoAuthors', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
 	} );
 
-	it( 'should return isCapAvailable false when CAP store is not available', () => {
-		useSelect.mockImplementation( callback => callback( () => null ) );
+	describe( 'CAP store availability', () => {
+		it( 'should return isCapAvailable false when CAP store is not available', () => {
+			useSelect.mockImplementation( callback => callback( createMockSelect( { capStore: null } ) ) );
 
-		const { result } = renderHook( () => useCoAuthors( 123 ) );
+			const { result } = renderHook( () => useCoAuthors( 123 ) );
 
-		expect( result.current.authors ).toEqual( [] );
-		expect( result.current.isCapAvailable ).toBe( false );
+			expect( result.current.authors ).toEqual( [] );
+			expect( result.current.isCapAvailable ).toBe( false );
+		} );
+
+		it( 'should return isCapAvailable false when getAuthors is not a function', () => {
+			useSelect.mockImplementation( callback => callback( createMockSelect( { capStore: {} } ) ) );
+
+			const { result } = renderHook( () => useCoAuthors( 123 ) );
+
+			expect( result.current.authors ).toEqual( [] );
+			expect( result.current.isCapAvailable ).toBe( false );
+		} );
 	} );
 
-	it( 'should return isCapAvailable false when getAuthors is not a function', () => {
-		useSelect.mockImplementation( callback => callback( () => ( {} ) ) );
+	describe( 'currently-edited post (uses CAP store)', () => {
+		it( 'should return empty authors when CAP is available but no authors assigned', () => {
+			useSelect.mockImplementation( callback =>
+				callback(
+					createMockSelect( {
+						capStore: { getAuthors: () => [] },
+						currentPostId: 123,
+					} )
+				)
+			);
 
-		const { result } = renderHook( () => useCoAuthors( 123 ) );
+			const { result } = renderHook( () => useCoAuthors( 123 ) );
 
-		expect( result.current.authors ).toEqual( [] );
-		expect( result.current.isCapAvailable ).toBe( false );
+			expect( result.current.authors ).toEqual( [] );
+			expect( result.current.isCapAvailable ).toBe( true );
+		} );
+
+		it( 'should return empty authors when postId is falsy', () => {
+			const getAuthorsMock = jest.fn( () => [] );
+			useSelect.mockImplementation( callback =>
+				callback(
+					createMockSelect( {
+						capStore: { getAuthors: getAuthorsMock },
+						currentPostId: 123,
+					} )
+				)
+			);
+
+			const { result } = renderHook( () => useCoAuthors( null ) );
+
+			expect( result.current.authors ).toEqual( [] );
+			expect( result.current.isCapAvailable ).toBe( true );
+		} );
+
+		it( 'should map CAP authors to expected format', () => {
+			const capAuthors = [
+				{ id: 1, display: 'Jane Doe', value: 'jane-doe', label: 'Jane' },
+				{ id: 2, display: 'John Smith', value: 'john-smith', label: 'John' },
+			];
+
+			useSelect.mockImplementation( callback =>
+				callback(
+					createMockSelect( {
+						capStore: { getAuthors: () => capAuthors },
+						currentPostId: 123,
+					} )
+				)
+			);
+
+			const { result } = renderHook( () => useCoAuthors( 123 ) );
+
+			expect( result.current.authors ).toEqual( [
+				{ id: 1, display_name: 'Jane Doe', user_nicename: 'jane-doe' },
+				{ id: 2, display_name: 'John Smith', user_nicename: 'john-smith' },
+			] );
+			expect( result.current.isCapAvailable ).toBe( true );
+		} );
+
+		it( 'should fallback to value then label for display_name', () => {
+			const capAuthors = [
+				{ id: 1, value: 'from-value', label: 'From Label' }, // no display
+				{ id: 2, label: 'Only Label' }, // no display or value
+			];
+
+			useSelect.mockImplementation( callback =>
+				callback(
+					createMockSelect( {
+						capStore: { getAuthors: () => capAuthors },
+						currentPostId: 123,
+					} )
+				)
+			);
+
+			const { result } = renderHook( () => useCoAuthors( 123 ) );
+
+			expect( result.current.authors[ 0 ].display_name ).toBe( 'from-value' );
+			expect( result.current.authors[ 1 ].display_name ).toBe( 'Only Label' );
+		} );
 	} );
 
-	it( 'should return empty authors when CAP is available but no authors assigned', () => {
-		useSelect.mockImplementation( callback =>
-			callback( () => ( {
-				getAuthors: () => [],
-			} ) )
-		);
+	describe( 'Query Loop context (uses REST API)', () => {
+		it( 'should use REST API when postId differs from currently-edited post', () => {
+			const restAuthors = [
+				{ id: 1, display_name: 'Jane Doe', author_link: '/author/jane/' },
+				{ id: 2, display_name: 'John Smith', author_link: '/author/john/' },
+			];
 
-		const { result } = renderHook( () => useCoAuthors( 123 ) );
+			useSelect.mockImplementation( callback =>
+				callback(
+					createMockSelect( {
+						capStore: { getAuthors: () => [] },
+						currentPostId: 123, // Editing post 123
+						entityRecords: {
+							456: { newspack_author_info: restAuthors }, // Query Loop post 456
+						},
+					} )
+				)
+			);
 
-		expect( result.current.authors ).toEqual( [] );
-		expect( result.current.isCapAvailable ).toBe( true );
-	} );
+			// Request authors for post 456 (different from current 123)
+			const { result } = renderHook( () => useCoAuthors( 456, 'post' ) );
 
-	it( 'should return empty authors when postId is falsy', () => {
-		const getAuthorsMock = jest.fn( () => [] );
-		useSelect.mockImplementation( callback =>
-			callback( () => ( {
-				getAuthors: getAuthorsMock,
-			} ) )
-		);
+			expect( result.current.authors ).toEqual( [
+				{ id: 1, display_name: 'Jane Doe', author_link: '/author/jane/' },
+				{ id: 2, display_name: 'John Smith', author_link: '/author/john/' },
+			] );
+			expect( result.current.isCapAvailable ).toBe( true );
+		} );
 
-		const { result } = renderHook( () => useCoAuthors( null ) );
+		it( 'should return empty authors when REST API has no author info', () => {
+			useSelect.mockImplementation( callback =>
+				callback(
+					createMockSelect( {
+						capStore: { getAuthors: () => [] },
+						currentPostId: 123,
+						entityRecords: {
+							456: { newspack_author_info: null },
+						},
+					} )
+				)
+			);
 
-		expect( result.current.authors ).toEqual( [] );
-		expect( result.current.isCapAvailable ).toBe( true );
-	} );
+			const { result } = renderHook( () => useCoAuthors( 456, 'post' ) );
 
-	it( 'should map CAP authors to expected format', () => {
-		const capAuthors = [
-			{ id: 1, display: 'Jane Doe', value: 'jane-doe', label: 'Jane' },
-			{ id: 2, display: 'John Smith', value: 'john-smith', label: 'John' },
-		];
+			expect( result.current.authors ).toEqual( [] );
+			expect( result.current.isCapAvailable ).toBe( true );
+		} );
 
-		useSelect.mockImplementation( callback =>
-			callback( () => ( {
-				getAuthors: () => capAuthors,
-			} ) )
-		);
+		it( 'should return empty authors when post entity is not loaded', () => {
+			useSelect.mockImplementation( callback =>
+				callback(
+					createMockSelect( {
+						capStore: { getAuthors: () => [] },
+						currentPostId: 123,
+						entityRecords: {}, // No entity records
+					} )
+				)
+			);
 
-		const { result } = renderHook( () => useCoAuthors( 123 ) );
+			const { result } = renderHook( () => useCoAuthors( 456, 'post' ) );
 
-		expect( result.current.authors ).toEqual( [
-			{ id: 1, display_name: 'Jane Doe', user_nicename: 'jane-doe' },
-			{ id: 2, display_name: 'John Smith', user_nicename: 'john-smith' },
-		] );
-		expect( result.current.isCapAvailable ).toBe( true );
-	} );
-
-	it( 'should fallback to value then label for display_name', () => {
-		const capAuthors = [
-			{ id: 1, value: 'from-value', label: 'From Label' }, // no display
-			{ id: 2, label: 'Only Label' }, // no display or value
-		];
-
-		useSelect.mockImplementation( callback =>
-			callback( () => ( {
-				getAuthors: () => capAuthors,
-			} ) )
-		);
-
-		const { result } = renderHook( () => useCoAuthors( 123 ) );
-
-		expect( result.current.authors[ 0 ].display_name ).toBe( 'from-value' );
-		expect( result.current.authors[ 1 ].display_name ).toBe( 'Only Label' );
+			expect( result.current.authors ).toEqual( [] );
+			expect( result.current.isCapAvailable ).toBe( true );
+		} );
 	} );
 } );

--- a/src/blocks/byline/hooks/use-coauthors.test.js
+++ b/src/blocks/byline/hooks/use-coauthors.test.js
@@ -1,0 +1,108 @@
+/**
+ * External dependencies
+ */
+import { renderHook } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { useCoAuthors } from './use-coauthors';
+
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: jest.fn(),
+} ) );
+
+describe( 'useCoAuthors', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'should return isCapAvailable false when CAP store is not available', () => {
+		useSelect.mockImplementation( callback => callback( () => null ) );
+
+		const { result } = renderHook( () => useCoAuthors( 123 ) );
+
+		expect( result.current.authors ).toEqual( [] );
+		expect( result.current.isCapAvailable ).toBe( false );
+	} );
+
+	it( 'should return isCapAvailable false when getAuthors is not a function', () => {
+		useSelect.mockImplementation( callback => callback( () => ( {} ) ) );
+
+		const { result } = renderHook( () => useCoAuthors( 123 ) );
+
+		expect( result.current.authors ).toEqual( [] );
+		expect( result.current.isCapAvailable ).toBe( false );
+	} );
+
+	it( 'should return empty authors when CAP is available but no authors assigned', () => {
+		useSelect.mockImplementation( callback =>
+			callback( () => ( {
+				getAuthors: () => [],
+			} ) )
+		);
+
+		const { result } = renderHook( () => useCoAuthors( 123 ) );
+
+		expect( result.current.authors ).toEqual( [] );
+		expect( result.current.isCapAvailable ).toBe( true );
+	} );
+
+	it( 'should return empty authors when postId is falsy', () => {
+		const getAuthorsMock = jest.fn( () => [] );
+		useSelect.mockImplementation( callback =>
+			callback( () => ( {
+				getAuthors: getAuthorsMock,
+			} ) )
+		);
+
+		const { result } = renderHook( () => useCoAuthors( null ) );
+
+		expect( result.current.authors ).toEqual( [] );
+		expect( result.current.isCapAvailable ).toBe( true );
+	} );
+
+	it( 'should map CAP authors to expected format', () => {
+		const capAuthors = [
+			{ id: 1, display: 'Jane Doe', value: 'jane-doe', label: 'Jane' },
+			{ id: 2, display: 'John Smith', value: 'john-smith', label: 'John' },
+		];
+
+		useSelect.mockImplementation( callback =>
+			callback( () => ( {
+				getAuthors: () => capAuthors,
+			} ) )
+		);
+
+		const { result } = renderHook( () => useCoAuthors( 123 ) );
+
+		expect( result.current.authors ).toEqual( [
+			{ id: 1, display_name: 'Jane Doe', user_nicename: 'jane-doe' },
+			{ id: 2, display_name: 'John Smith', user_nicename: 'john-smith' },
+		] );
+		expect( result.current.isCapAvailable ).toBe( true );
+	} );
+
+	it( 'should fallback to value then label for display_name', () => {
+		const capAuthors = [
+			{ id: 1, value: 'from-value', label: 'From Label' }, // no display
+			{ id: 2, label: 'Only Label' }, // no display or value
+		];
+
+		useSelect.mockImplementation( callback =>
+			callback( () => ( {
+				getAuthors: () => capAuthors,
+			} ) )
+		);
+
+		const { result } = renderHook( () => useCoAuthors( 123 ) );
+
+		expect( result.current.authors[ 0 ].display_name ).toBe( 'from-value' );
+		expect( result.current.authors[ 1 ].display_name ).toBe( 'Only Label' );
+	} );
+} );

--- a/src/blocks/byline/hooks/use-custom-byline.js
+++ b/src/blocks/byline/hooks/use-custom-byline.js
@@ -1,0 +1,28 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Hook to get custom byline data.
+ *
+ * @param {number} postId   Post ID.
+ * @param {string} postType Post type.
+ * @return {Object} Custom byline data.
+ */
+export function useCustomByline( postId, postType ) {
+	const { bylineActive, bylineContent } = useSelect(
+		select => {
+			const { getEditedEntityRecord } = select( coreStore );
+			const postRecord = getEditedEntityRecord( 'postType', postType, postId );
+			return {
+				bylineActive: postRecord?.meta?._newspack_byline_active || false,
+				bylineContent: postRecord?.meta?._newspack_byline || '',
+			};
+		},
+		[ postId, postType ]
+	);
+
+	return { bylineActive, bylineContent };
+}

--- a/src/blocks/byline/hooks/use-custom-byline.test.js
+++ b/src/blocks/byline/hooks/use-custom-byline.test.js
@@ -1,0 +1,92 @@
+/**
+ * External dependencies
+ */
+import { renderHook } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { useCustomByline } from './use-custom-byline';
+
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/core-data', () => ( {
+	store: 'core',
+} ) );
+
+describe( 'useCustomByline', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'should return inactive byline when meta is not set', () => {
+		useSelect.mockImplementation( callback =>
+			callback( () => ( {
+				getEditedEntityRecord: () => ( {} ),
+			} ) )
+		);
+
+		const { result } = renderHook( () => useCustomByline( 123, 'post' ) );
+
+		expect( result.current.bylineActive ).toBe( false );
+		expect( result.current.bylineContent ).toBe( '' );
+	} );
+
+	it( 'should return inactive byline when meta exists but byline is inactive', () => {
+		useSelect.mockImplementation( callback =>
+			callback( () => ( {
+				getEditedEntityRecord: () => ( {
+					meta: {
+						_newspack_byline_active: false,
+						_newspack_byline: 'Some content',
+					},
+				} ),
+			} ) )
+		);
+
+		const { result } = renderHook( () => useCustomByline( 123, 'post' ) );
+
+		expect( result.current.bylineActive ).toBe( false );
+		expect( result.current.bylineContent ).toBe( 'Some content' );
+	} );
+
+	it( 'should return active byline with content', () => {
+		const bylineContent = 'By [Author id=5]Jane Doe[/Author]';
+
+		useSelect.mockImplementation( callback =>
+			callback( () => ( {
+				getEditedEntityRecord: () => ( {
+					meta: {
+						_newspack_byline_active: true,
+						_newspack_byline: bylineContent,
+					},
+				} ),
+			} ) )
+		);
+
+		const { result } = renderHook( () => useCustomByline( 123, 'post' ) );
+
+		expect( result.current.bylineActive ).toBe( true );
+		expect( result.current.bylineContent ).toBe( bylineContent );
+	} );
+
+	it( 'should handle null post record gracefully', () => {
+		useSelect.mockImplementation( callback =>
+			callback( () => ( {
+				getEditedEntityRecord: () => null,
+			} ) )
+		);
+
+		const { result } = renderHook( () => useCustomByline( 123, 'post' ) );
+
+		expect( result.current.bylineActive ).toBe( false );
+		expect( result.current.bylineContent ).toBe( '' );
+	} );
+} );

--- a/src/blocks/byline/hooks/use-default-author.js
+++ b/src/blocks/byline/hooks/use-default-author.js
@@ -1,0 +1,36 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Hook to get default WordPress author.
+ *
+ * @param {number} postId   Post ID.
+ * @param {string} postType Post type.
+ * @return {Object} Author details and loading state.
+ */
+export function useDefaultAuthor( postId, postType ) {
+	const { authorDetails, isLoading } = useSelect(
+		select => {
+			const { getEditedEntityRecord, getUser, hasFinishedResolution } = select( coreStore );
+			const authorId = getEditedEntityRecord( 'postType', postType, postId )?.author;
+
+			if ( ! authorId ) {
+				return { authorDetails: null, isLoading: false };
+			}
+
+			const user = getUser( authorId );
+			const hasResolved = hasFinishedResolution( 'getUser', [ authorId ] );
+
+			return {
+				authorDetails: user,
+				isLoading: ! hasResolved,
+			};
+		},
+		[ postType, postId ]
+	);
+
+	return { authorDetails, isLoading };
+}

--- a/src/blocks/byline/hooks/use-default-author.test.js
+++ b/src/blocks/byline/hooks/use-default-author.test.js
@@ -1,0 +1,131 @@
+/**
+ * External dependencies
+ */
+import { renderHook } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { useDefaultAuthor } from './use-default-author';
+
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/core-data', () => ( {
+	store: 'core',
+} ) );
+
+describe( 'useDefaultAuthor', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'should return null author when post has no author ID', () => {
+		useSelect.mockImplementation( callback =>
+			callback( () => ( {
+				getEditedEntityRecord: () => ( { author: null } ),
+				getUser: jest.fn(),
+				hasFinishedResolution: jest.fn(),
+			} ) )
+		);
+
+		const { result } = renderHook( () => useDefaultAuthor( 123, 'post' ) );
+
+		expect( result.current.authorDetails ).toBeNull();
+		expect( result.current.isLoading ).toBe( false );
+	} );
+
+	it( 'should return loading true while fetching user', () => {
+		useSelect.mockImplementation( callback =>
+			callback( () => ( {
+				getEditedEntityRecord: () => ( { author: 5 } ),
+				getUser: () => null,
+				hasFinishedResolution: () => false,
+			} ) )
+		);
+
+		const { result } = renderHook( () => useDefaultAuthor( 123, 'post' ) );
+
+		expect( result.current.authorDetails ).toBeNull();
+		expect( result.current.isLoading ).toBe( true );
+	} );
+
+	it( 'should return author details when resolved', () => {
+		const mockUser = { id: 5, name: 'Jane Doe', slug: 'jane-doe' };
+
+		useSelect.mockImplementation( callback =>
+			callback( () => ( {
+				getEditedEntityRecord: () => ( { author: 5 } ),
+				getUser: () => mockUser,
+				hasFinishedResolution: () => true,
+			} ) )
+		);
+
+		const { result } = renderHook( () => useDefaultAuthor( 123, 'post' ) );
+
+		expect( result.current.authorDetails ).toEqual( mockUser );
+		expect( result.current.isLoading ).toBe( false );
+	} );
+
+	it( 'should pass postType and postId to getEditedEntityRecord', () => {
+		const getEditedEntityRecord = jest.fn( () => ( { author: 10 } ) );
+
+		useSelect.mockImplementation( callback =>
+			callback( () => ( {
+				getEditedEntityRecord,
+				getUser: () => ( { id: 10, name: 'Author' } ),
+				hasFinishedResolution: () => true,
+			} ) )
+		);
+
+		renderHook( () => useDefaultAuthor( 456, 'page' ) );
+
+		expect( getEditedEntityRecord ).toHaveBeenCalledWith( 'postType', 'page', 456 );
+	} );
+
+	it( 'should handle null entity record gracefully', () => {
+		const getUser = jest.fn();
+		const hasFinishedResolution = jest.fn();
+
+		useSelect.mockImplementation( callback =>
+			callback( () => ( {
+				getEditedEntityRecord: () => null,
+				getUser,
+				hasFinishedResolution,
+			} ) )
+		);
+
+		const { result } = renderHook( () => useDefaultAuthor( 123, 'post' ) );
+
+		expect( result.current.authorDetails ).toBeNull();
+		expect( result.current.isLoading ).toBe( false );
+		expect( getUser ).not.toHaveBeenCalled();
+		expect( hasFinishedResolution ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should handle undefined entity record gracefully', () => {
+		const getUser = jest.fn();
+		const hasFinishedResolution = jest.fn();
+
+		useSelect.mockImplementation( callback =>
+			callback( () => ( {
+				getEditedEntityRecord: () => undefined,
+				getUser,
+				hasFinishedResolution,
+			} ) )
+		);
+
+		const { result } = renderHook( () => useDefaultAuthor( 123, 'post' ) );
+
+		expect( result.current.authorDetails ).toBeNull();
+		expect( result.current.isLoading ).toBe( false );
+		expect( getUser ).not.toHaveBeenCalled();
+		expect( hasFinishedResolution ).not.toHaveBeenCalled();
+	} );
+} );

--- a/src/blocks/byline/index.js
+++ b/src/blocks/byline/index.js
@@ -1,0 +1,36 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { postAuthor as icon } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import Edit from './edit';
+import colors from '../../../packages/colors/colors.module.scss';
+import './style.scss';
+
+export const title = __( 'Byline', 'newspack-plugin' );
+
+const { name } = metadata;
+
+export { metadata, name };
+
+export const settings = {
+	title,
+	icon: {
+		src: icon,
+		foreground: colors[ 'primary-400' ],
+	},
+	keywords: [
+		__( 'author', 'newspack-plugin' ),
+		__( 'byline', 'newspack-plugin' ),
+		__( 'writer', 'newspack-plugin' ),
+		__( 'newspack', 'newspack-plugin' ),
+	],
+	description: __( 'Display post author(s) with support for custom bylines and CoAuthors Plus.', 'newspack-plugin' ),
+	usesContext: [ 'postId', 'postType' ],
+	edit: Edit,
+};

--- a/src/blocks/byline/inspector.jsx
+++ b/src/blocks/byline/inspector.jsx
@@ -1,0 +1,60 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { InspectorControls } from '@wordpress/block-editor';
+import { PanelBody, TextControl, ToggleControl } from '@wordpress/components';
+
+/**
+ * Inspector controls for the byline block.
+ *
+ * @param {Object}   props                Component props.
+ * @param {Object}   props.attributes     Block attributes.
+ * @param {Function} props.setAttributes  Set attributes function.
+ * @param {boolean}  props.isCustomByline Whether custom byline is active.
+ * @return {JSX.Element} Inspector controls.
+ */
+export function BylineInspectorControls( { attributes, setAttributes, isCustomByline } ) {
+	return (
+		<InspectorControls>
+			<PanelBody title={ __( 'Settings', 'newspack-plugin' ) }>
+				{ ! isCustomByline && (
+					<>
+						<TextControl
+							__nextHasNoMarginBottom
+							label={ __( 'Prefix', 'newspack-plugin' ) }
+							help={ __( 'Text displayed before the author name(s).', 'newspack-plugin' ) }
+							value={ attributes.prefix }
+							onChange={ prefix => setAttributes( { prefix } ) }
+						/>
+						<ToggleControl
+							__nextHasNoMarginBottom
+							label={ __( 'Link to author archive', 'newspack-plugin' ) }
+							checked={ attributes.linkToAuthorArchive }
+							onChange={ () => setAttributes( { linkToAuthorArchive: ! attributes.linkToAuthorArchive } ) }
+						/>
+					</>
+				) }
+				{ isCustomByline && (
+					<p className="components-base-control__help">
+						{ __( 'Prefix and link settings are controlled by the custom byline and cannot be changed here.', 'newspack-plugin' ) }
+					</p>
+				) }
+			</PanelBody>
+		</InspectorControls>
+	);
+}
+
+BylineInspectorControls.propTypes = {
+	attributes: PropTypes.shape( {
+		prefix: PropTypes.string,
+		linkToAuthorArchive: PropTypes.bool,
+	} ).isRequired,
+	setAttributes: PropTypes.func.isRequired,
+	isCustomByline: PropTypes.bool.isRequired,
+};

--- a/src/blocks/byline/inspector.test.jsx
+++ b/src/blocks/byline/inspector.test.jsx
@@ -1,0 +1,64 @@
+/**
+ * External dependencies
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { BylineInspectorControls } from './inspector.jsx';
+
+// Mock InspectorControls to render children directly.
+jest.mock( '@wordpress/block-editor', () => ( {
+	InspectorControls: ( { children } ) => <div data-testid="inspector">{ children }</div>,
+} ) );
+
+describe( 'BylineInspectorControls', () => {
+	const defaultProps = {
+		attributes: {
+			prefix: 'By',
+			linkToAuthorArchive: true,
+		},
+		setAttributes: jest.fn(),
+		isCustomByline: false,
+	};
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'should render prefix and link controls when not custom byline', () => {
+		render( <BylineInspectorControls { ...defaultProps } /> );
+
+		expect( screen.getByLabelText( /prefix/i ) ).toBeInTheDocument();
+		expect( screen.getByLabelText( /link to author archive/i ) ).toBeInTheDocument();
+	} );
+
+	it( 'should hide controls and show message when custom byline is active', () => {
+		render( <BylineInspectorControls { ...defaultProps } isCustomByline={ true } /> );
+
+		expect( screen.queryByLabelText( /prefix/i ) ).not.toBeInTheDocument();
+		expect( screen.queryByLabelText( /link to author archive/i ) ).not.toBeInTheDocument();
+		expect( screen.getByText( /prefix and link settings are controlled/i ) ).toBeInTheDocument();
+	} );
+
+	it( 'should call setAttributes when prefix changes', () => {
+		const setAttributes = jest.fn();
+		render( <BylineInspectorControls { ...defaultProps } setAttributes={ setAttributes } /> );
+
+		const input = screen.getByLabelText( /prefix/i );
+		fireEvent.change( input, { target: { value: 'Written by' } } );
+
+		expect( setAttributes ).toHaveBeenCalledWith( { prefix: 'Written by' } );
+	} );
+
+	it( 'should call setAttributes when link toggle changes', () => {
+		const setAttributes = jest.fn();
+		render( <BylineInspectorControls { ...defaultProps } setAttributes={ setAttributes } /> );
+
+		const toggle = screen.getByLabelText( /link to author archive/i );
+		fireEvent.click( toggle );
+
+		expect( setAttributes ).toHaveBeenCalledWith( { linkToAuthorArchive: false } );
+	} );
+} );

--- a/src/blocks/byline/style.scss
+++ b/src/blocks/byline/style.scss
@@ -1,0 +1,18 @@
+.wp-block-newspack-byline {
+	.byline {
+		display: inline;
+
+		.author {
+			display: inline;
+
+			a {
+				text-decoration: inherit;
+
+				&:hover,
+				&:focus {
+					text-decoration: underline;
+				}
+			}
+		}
+	}
+}

--- a/src/blocks/byline/style.scss
+++ b/src/blocks/byline/style.scss
@@ -4,15 +4,6 @@
 
 		.author {
 			display: inline;
-
-			a {
-				text-decoration: inherit;
-
-				&:hover,
-				&:focus {
-					text-decoration: underline;
-				}
-			}
 		}
 	}
 }

--- a/src/blocks/byline/utils.js
+++ b/src/blocks/byline/utils.js
@@ -1,0 +1,122 @@
+/**
+ * WordPress dependencies
+ */
+import { createElement } from '@wordpress/element';
+
+/**
+ * Decode HTML entities in a string.
+ *
+ * @param {string} text Text with HTML entities.
+ * @return {string} Decoded text.
+ */
+export function decodeHtmlEntities( text ) {
+	const textarea = document.createElement( 'textarea' );
+	textarea.innerHTML = text;
+	return textarea.value;
+}
+
+/**
+ * Parse byline shortcodes to extract display names and render as React elements.
+ *
+ * @param {string} bylineContent Raw byline content with shortcodes.
+ * @return {Array} Array of React elements for display.
+ */
+export function parseBylineForDisplay( bylineContent ) {
+	const elements = [];
+	let lastIndex = 0;
+	const regex = /\[Author id=(\d+)\](.*?)\[\/Author\]/g;
+	let match;
+
+	while ( ( match = regex.exec( bylineContent ) ) !== null ) {
+		// Add text before the match.
+		if ( match.index > lastIndex ) {
+			const textBefore = bylineContent.slice( lastIndex, match.index );
+			elements.push( decodeHtmlEntities( textBefore ) );
+		}
+
+		// Add author link.
+		const authorId = match[ 1 ];
+		const authorName = match[ 2 ];
+		elements.push(
+			createElement(
+				'a',
+				{
+					key: `author-${ authorId }-${ match.index }`,
+					href: '#author-link',
+					onClick: e => e.preventDefault(),
+					className: 'url fn n',
+				},
+				decodeHtmlEntities( authorName )
+			)
+		);
+
+		lastIndex = match.index + match[ 0 ].length;
+	}
+
+	// Add remaining text after last match.
+	if ( lastIndex < bylineContent.length ) {
+		const textAfter = bylineContent.slice( lastIndex );
+		elements.push( decodeHtmlEntities( textAfter ) );
+	}
+
+	return elements;
+}
+
+/**
+ * Format authors list for display using Intl.ListFormat.
+ *
+ * Uses the browser's Intl.ListFormat API for localized list formatting,
+ * which is the JS equivalent of WordPress's wp_sprintf_l().
+ *
+ * @param {Array}   authors       Array of author objects.
+ * @param {boolean} linkToArchive Whether to show as links.
+ * @return {Array} Array of React elements.
+ */
+export function formatAuthorsList( authors, linkToArchive ) {
+	if ( ! authors || authors.length === 0 ) {
+		return [];
+	}
+
+	// For a single author, return directly without list formatting.
+	if ( authors.length === 1 ) {
+		const author = authors[ 0 ];
+		const name = author.display_name || author.name;
+		return [
+			createElement(
+				'span',
+				{ key: `author-wrapper-${ author.id || 0 }`, className: 'author vcard' },
+				linkToArchive
+					? createElement( 'a', { href: '#author-link', onClick: e => e.preventDefault(), className: 'url fn n' }, name )
+					: createElement( 'span', { className: 'fn n' }, name )
+			),
+		];
+	}
+
+	// Use Intl.ListFormat for localized list formatting (JS equivalent of wp_sprintf_l).
+	// Get the current locale from WordPress or fall back to browser locale.
+	const locale = document.documentElement.lang || navigator.language || 'en';
+	const listFormatter = new Intl.ListFormat( locale, { style: 'long', type: 'conjunction' } );
+
+	// Create placeholder strings to get the formatted parts.
+	const placeholders = authors.map( ( _, i ) => `__AUTHOR_${ i }__` );
+	const formattedParts = listFormatter.formatToParts( placeholders );
+
+	// Build React elements from the formatted parts.
+	return formattedParts.map( ( part, partIndex ) => {
+		if ( part.type === 'literal' ) {
+			return part.value;
+		}
+		// Extract author index from placeholder.
+		const authorIndex = parseInt( part.value.replace( '__AUTHOR_', '' ).replace( '__', '' ), 10 );
+		const author = authors[ authorIndex ];
+		const name = author.display_name || author.name;
+
+		return createElement(
+			'span',
+			{ key: `author-wrapper-${ author.id || partIndex }`, className: 'author vcard' },
+			linkToArchive
+				? createElement( 'a', { href: '#author-link', onClick: e => e.preventDefault(), className: 'url fn n' }, name )
+				: createElement( 'span', { className: 'fn n' }, name )
+		);
+	} );
+}

--- a/src/blocks/byline/utils.js
+++ b/src/blocks/byline/utils.js
@@ -6,10 +6,16 @@ import { createElement } from '@wordpress/element';
 /**
  * Decode HTML entities in a string.
  *
+ * Uses a textarea element to safely decode entities without executing scripts.
+ * DOMParser is not used because it normalizes whitespace per HTML parsing rules.
+ *
  * @param {string} text Text with HTML entities.
  * @return {string} Decoded text.
  */
 export function decodeHtmlEntities( text ) {
+	if ( ! text ) {
+		return '';
+	}
 	const textarea = document.createElement( 'textarea' );
 	textarea.innerHTML = text;
 	return textarea.value;

--- a/src/blocks/byline/utils.js
+++ b/src/blocks/byline/utils.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { createElement } from '@wordpress/element';
+import { _x } from '@wordpress/i18n';
 
 /**
  * Decode HTML entities in a string.
@@ -73,10 +74,26 @@ export function parseBylineForDisplay( bylineContent ) {
 }
 
 /**
- * Format authors list for display using Intl.ListFormat.
+ * Create an author element for display.
  *
- * Uses the browser's Intl.ListFormat API for localized list formatting,
- * which is the JS equivalent of WordPress's wp_sprintf_l().
+ * @param {Object}  author        Author object.
+ * @param {number}  index         Author index for key generation.
+ * @param {boolean} linkToArchive Whether to show as a link.
+ * @return {Object} React element.
+ */
+function createAuthorElement( author, index, linkToArchive ) {
+	const name = author.display_name || author.name;
+	return createElement(
+		'span',
+		{ key: `author-wrapper-${ author.id || index }`, className: 'author vcard' },
+		linkToArchive
+			? createElement( 'a', { href: '#author-link', onClick: e => e.preventDefault(), className: 'url fn n' }, name )
+			: createElement( 'span', { className: 'fn n' }, name )
+	);
+}
+
+/**
+ * Format authors list for display.
  *
  * @param {Array}   authors       Array of author objects.
  * @param {boolean} linkToArchive Whether to show as links.
@@ -87,46 +104,19 @@ export function formatAuthorsList( authors, linkToArchive ) {
 		return [];
 	}
 
-	// For a single author, return directly without list formatting.
 	if ( authors.length === 1 ) {
-		const author = authors[ 0 ];
-		const name = author.display_name || author.name;
-		return [
-			createElement(
-				'span',
-				{ key: `author-wrapper-${ author.id || 0 }`, className: 'author vcard' },
-				linkToArchive
-					? createElement( 'a', { href: '#author-link', onClick: e => e.preventDefault(), className: 'url fn n' }, name )
-					: createElement( 'span', { className: 'fn n' }, name )
-			),
-		];
+		return [ createAuthorElement( authors[ 0 ], 0, linkToArchive ) ];
 	}
 
-	// Use Intl.ListFormat for localized list formatting (JS equivalent of wp_sprintf_l).
-	// Get the current locale from WordPress or fall back to browser locale.
-	const locale = document.documentElement.lang || navigator.language || 'en';
-	const listFormatter = new Intl.ListFormat( locale, { style: 'long', type: 'conjunction' } );
-
-	// Create placeholder strings to get the formatted parts.
-	const placeholders = authors.map( ( _, i ) => `__AUTHOR_${ i }__` );
-	const formattedParts = listFormatter.formatToParts( placeholders );
-
-	// Build React elements from the formatted parts.
-	return formattedParts.map( ( part, partIndex ) => {
-		if ( part.type === 'literal' ) {
-			return part.value;
+	const result = [];
+	authors.forEach( ( author, index ) => {
+		result.push( createAuthorElement( author, index, linkToArchive ) );
+		if ( index < authors.length - 2 ) {
+			result.push( ', ' );
+		} else if ( index === authors.length - 2 ) {
+			result.push( _x( ' and ', 'post author separator', 'newspack-plugin' ) );
 		}
-		// Extract author index from placeholder.
-		const authorIndex = parseInt( part.value.replace( '__AUTHOR_', '' ).replace( '__', '' ), 10 );
-		const author = authors[ authorIndex ];
-		const name = author.display_name || author.name;
-
-		return createElement(
-			'span',
-			{ key: `author-wrapper-${ author.id || partIndex }`, className: 'author vcard' },
-			linkToArchive
-				? createElement( 'a', { href: '#author-link', onClick: e => e.preventDefault(), className: 'url fn n' }, name )
-				: createElement( 'span', { className: 'fn n' }, name )
-		);
 	} );
+
+	return result;
 }

--- a/src/blocks/byline/utils.js
+++ b/src/blocks/byline/utils.js
@@ -22,6 +22,10 @@ export function decodeHtmlEntities( text ) {
  * @return {Array} Array of React elements for display.
  */
 export function parseBylineForDisplay( bylineContent ) {
+	if ( ! bylineContent ) {
+		return [];
+	}
+
 	const elements = [];
 	let lastIndex = 0;
 	const regex = /\[Author id=(\d+)\](.*?)\[\/Author\]/g;

--- a/src/blocks/byline/utils.test.js
+++ b/src/blocks/byline/utils.test.js
@@ -1,0 +1,75 @@
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+import { createElement, Fragment } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { decodeHtmlEntities, parseBylineForDisplay, formatAuthorsList } from './utils';
+
+describe( 'decodeHtmlEntities', () => {
+	it( 'should decode HTML entities', () => {
+		expect( decodeHtmlEntities( '&amp;' ) ).toBe( '&' );
+		expect( decodeHtmlEntities( '&lt;&gt;' ) ).toBe( '<>' );
+		expect( decodeHtmlEntities( 'John &amp; Jane' ) ).toBe( 'John & Jane' );
+		expect( decodeHtmlEntities( '' ) ).toBe( '' );
+	} );
+} );
+
+describe( 'parseBylineForDisplay', () => {
+	it( 'should parse byline shortcodes into text and author links', () => {
+		const result = parseBylineForDisplay( 'By [Author id=5]Jane Doe[/Author] and [Author id=7]John Smith[/Author]' );
+
+		expect( result ).toHaveLength( 4 );
+		expect( result[ 0 ] ).toBe( 'By ' );
+		expect( result[ 2 ] ).toBe( ' and ' );
+
+		const { container: c1 } = render( result[ 1 ] );
+		expect( c1.querySelector( 'a.url.fn.n' ) ).toHaveTextContent( 'Jane Doe' );
+
+		const { container: c2 } = render( result[ 3 ] );
+		expect( c2.querySelector( 'a' ) ).toHaveTextContent( 'John Smith' );
+	} );
+
+	it( 'should decode HTML entities and handle plain text', () => {
+		expect( parseBylineForDisplay( '' ) ).toHaveLength( 0 );
+		expect( parseBylineForDisplay( 'By Staff' )[ 0 ] ).toBe( 'By Staff' );
+
+		const result = parseBylineForDisplay( '[Author id=1]John &amp; Jane[/Author]' );
+		const { container } = render( result[ 0 ] );
+		expect( container ).toHaveTextContent( 'John & Jane' );
+	} );
+} );
+
+describe( 'formatAuthorsList', () => {
+	it( 'should return empty array for no authors', () => {
+		expect( formatAuthorsList( [], true ) ).toEqual( [] );
+		expect( formatAuthorsList( null, true ) ).toEqual( [] );
+	} );
+
+	it( 'should format single author with and without link', () => {
+		const authors = [ { id: 1, display_name: 'Jane Doe' } ];
+
+		const { container: linked } = render( formatAuthorsList( authors, true )[ 0 ] );
+		expect( linked.querySelector( 'a.url.fn.n' ) ).toHaveTextContent( 'Jane Doe' );
+
+		const { container: unlinked } = render( formatAuthorsList( authors, false )[ 0 ] );
+		expect( unlinked.querySelector( 'span.fn.n' ) ).toHaveTextContent( 'Jane Doe' );
+		expect( unlinked.querySelector( 'a' ) ).toBeNull();
+	} );
+
+	it( 'should format multiple authors with conjunction', () => {
+		const authors = [
+			{ id: 1, display_name: 'Jane' },
+			{ id: 2, display_name: 'John' },
+			{ id: 3, name: 'Bob' }, // Tests name fallback.
+		];
+		const { container } = render( createElement( Fragment, null, ...formatAuthorsList( authors, true ) ) );
+
+		expect( container ).toHaveTextContent( 'Jane' );
+		expect( container ).toHaveTextContent( 'John' );
+		expect( container ).toHaveTextContent( 'Bob' );
+	} );
+} );

--- a/src/blocks/index.js
+++ b/src/blocks/index.js
@@ -37,6 +37,7 @@ const readerActivationBlocks = [ 'newspack/reader-registration' ];
 const correctionBlocks = [ 'newspack/correction-box', 'newspack/correction-item' ];
 const collectionsBlocks = [ 'newspack/collections' ];
 const contentGateBlocks = [ 'newspack/content-gate-countdown', 'newspack/content-gate-countdown-box' ];
+const blockThemeBlocks = [ 'newspack/avatar', 'newspack/byline' ];
 
 /**
  * Function to register an individual block.
@@ -64,6 +65,10 @@ const registerBlock = block => {
 	}
 	/** Do not register content gate blocks if the feature or Memberships is not active. */
 	if ( contentGateBlocks.includes( name ) && ( ! newspack_blocks.has_memberships || ! newspack_blocks.is_content_gate_countdown_active ) ) {
+		return;
+	}
+	/** Do not register block theme blocks if not using a block theme. */
+	if ( blockThemeBlocks.includes( name ) && ! newspack_blocks.is_block_theme ) {
 		return;
 	}
 

--- a/src/blocks/index.js
+++ b/src/blocks/index.js
@@ -12,6 +12,7 @@ import * as readerRegistration from './reader-registration';
 import * as correctionBox from './correction-box';
 import * as correctionItem from './correction-item';
 import * as avatar from './avatar';
+import * as byline from './byline';
 import * as collections from './collections';
 import * as contentGateCountdown from './content-gate/countdown';
 import * as contentGateCountdownBox from './content-gate/countdown-box';
@@ -21,7 +22,16 @@ import * as contentGateCountdownBox from './content-gate/countdown-box';
  */
 import './core-image';
 
-export const blocks = [ readerRegistration, correctionBox, correctionItem, avatar, collections, contentGateCountdown, contentGateCountdownBox ];
+export const blocks = [
+	readerRegistration,
+	correctionBox,
+	correctionItem,
+	avatar,
+	byline,
+	collections,
+	contentGateCountdown,
+	contentGateCountdownBox,
+];
 
 const readerActivationBlocks = [ 'newspack/reader-registration' ];
 const correctionBlocks = [ 'newspack/correction-box', 'newspack/correction-item' ];

--- a/tests/unit-tests/bylines/class-test-byline-block.php
+++ b/tests/unit-tests/bylines/class-test-byline-block.php
@@ -1,0 +1,378 @@
+<?php
+/**
+ * Test Byline Block functionality.
+ *
+ * @package Newspack\Tests
+ * @covers \Newspack\Blocks\Byline\Byline_Block
+ */
+
+namespace Newspack\Tests\Unit\Bylines;
+
+use Newspack\Bylines;
+use Newspack\Blocks\Byline\Byline_Block;
+
+/**
+ * Test class for the Byline Block.
+ *
+ * @todo Add tests for CoAuthors Plus integration (requires CAP mocks).
+ *
+ * @group byline-block
+ */
+class Test_Byline_Block extends \WP_UnitTestCase {
+
+	/**
+	 * Test post ID.
+	 *
+	 * @var int
+	 */
+	protected static $post_id;
+
+	/**
+	 * Test author ID.
+	 *
+	 * @var int
+	 */
+	protected static $author_id;
+
+	/**
+	 * Set up test environment.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		require_once NEWSPACK_ABSPATH . 'src/blocks/byline/class-byline-block.php';
+
+		self::$author_id = static::factory()->user->create(
+			[
+				'user_login'   => 'testauthor',
+				'user_email'   => 'testauthor@example.com',
+				'display_name' => 'Test Author',
+				'role'         => 'author',
+			]
+		);
+
+		self::$post_id = static::factory()->post->create(
+			[
+				'post_author' => self::$author_id,
+				'post_status' => 'publish',
+			]
+		);
+
+		Bylines::register_post_meta();
+
+		if ( ! \WP_Block_Type_Registry::get_instance()->is_registered( 'newspack/byline' ) ) {
+			Byline_Block::register_block();
+		}
+	}
+
+	/**
+	 * Clean up after each test.
+	 */
+	public function tear_down(): void {
+		delete_post_meta( self::$post_id, Bylines::META_KEY_ACTIVE );
+		delete_post_meta( self::$post_id, Bylines::META_KEY_BYLINE );
+
+		if ( \WP_Block_Type_Registry::get_instance()->is_registered( 'newspack/byline' ) ) {
+			unregister_block_type( 'newspack/byline' );
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Helper method to render block with proper WordPress context.
+	 *
+	 * @param array $attributes Block attributes.
+	 * @param int   $post_id    Post ID for context.
+	 * @return string Rendered HTML.
+	 */
+	private function render_byline_block( $attributes = [], $post_id = null ) {
+		if ( null === $post_id ) {
+			$post_id = self::$post_id;
+		}
+
+		\WP_Block_Supports::$block_to_render = [
+			'blockName' => 'newspack/byline',
+			'attrs'     => $attributes,
+		];
+
+		$block          = new \stdClass();
+		$block->context = [ 'postId' => $post_id ];
+
+		$output = Byline_Block::render_block( $attributes, '', $block );
+
+		\WP_Block_Supports::$block_to_render = null;
+
+		return $output;
+	}
+
+	/**
+	 * Test render_block returns empty string for invalid post ID.
+	 *
+	 * @covers \Newspack\Blocks\Byline\Byline_Block::render_block
+	 */
+	public function test_render_block_empty_for_invalid_post() {
+		$output = $this->render_byline_block( [], 0 );
+
+		$this->assertEmpty( $output, 'Should return empty string for invalid post ID.' );
+	}
+
+	/**
+	 * Test render_block returns default author when no custom byline or CAP.
+	 *
+	 * @covers \Newspack\Blocks\Byline\Byline_Block::render_block
+	 * @covers \Newspack\Blocks\Byline\Byline_Block::render_default_author
+	 * @covers \Newspack\Blocks\Byline\Byline_Block::get_translated_prefix
+	 */
+	public function test_render_block_default_author() {
+		$attributes = [
+			'prefix'              => 'By ',
+			'linkToAuthorArchive' => true,
+		];
+
+		$output = $this->render_byline_block( $attributes );
+
+		$this->assertStringContainsString( 'Test Author', $output, 'Should contain author name.' );
+		$this->assertStringContainsString( 'wp-block-newspack-byline', $output, 'Should have byline block class.' );
+		$this->assertStringContainsString( 'class="byline"', $output, 'Should have byline class.' );
+		$this->assertStringContainsString( 'By ', $output, 'Should contain prefix.' );
+		$this->assertStringContainsString( '<a', $output, 'Should contain link when linkToAuthorArchive is true.' );
+	}
+
+	/**
+	 * Test render_block respects linkToAuthorArchive = false.
+	 *
+	 * @covers \Newspack\Blocks\Byline\Byline_Block::render_block
+	 * @covers \Newspack\Blocks\Byline\Byline_Block::render_default_author
+	 */
+	public function test_render_block_default_author_no_link() {
+		$attributes = [
+			'prefix'              => 'By ',
+			'linkToAuthorArchive' => false,
+		];
+
+		$output = $this->render_byline_block( $attributes );
+
+		$this->assertStringContainsString( 'Test Author', $output, 'Should contain author name.' );
+		$this->assertStringNotContainsString( '<a', $output, 'Should not contain link when linkToAuthorArchive is false.' );
+		$this->assertStringContainsString( '<span class="fn n">', $output, 'Should have span instead of link.' );
+	}
+
+	/**
+	 * Test render_block uses custom byline when active.
+	 *
+	 * @covers \Newspack\Blocks\Byline\Byline_Block::render_block
+	 * @covers \Newspack\Blocks\Byline\Byline_Block::render_custom_byline
+	 */
+	public function test_render_block_custom_byline() {
+		// Activate custom byline with non-existent author ID.
+		// When author ID doesn't exist, the shortcode text is used as fallback.
+		update_post_meta( self::$post_id, Bylines::META_KEY_ACTIVE, true );
+		update_post_meta( self::$post_id, Bylines::META_KEY_BYLINE, 'By [Author id=999]Jane Doe[/Author]' );
+
+		$attributes = [
+			'prefix'              => 'Published by ',
+			'linkToAuthorArchive' => true,
+		];
+
+		$output = $this->render_byline_block( $attributes );
+
+		// Custom bylines include their own prefix, so block prefix should be ignored.
+		$this->assertStringContainsString( 'Jane Doe', $output, 'Should contain custom byline author name.' );
+		$this->assertStringContainsString( 'wp-block-newspack-byline', $output, 'Should have byline block class.' );
+		// The prefix from attributes should NOT appear because custom bylines have their own.
+		$this->assertStringNotContainsString( 'Published by ', $output, 'Should not contain block prefix for custom byline.' );
+	}
+
+	/**
+	 * Test render_block priority: custom byline takes precedence over default author.
+	 *
+	 * @covers \Newspack\Blocks\Byline\Byline_Block::render_block
+	 * @covers \Newspack\Blocks\Byline\Byline_Block::render_custom_byline
+	 */
+	public function test_render_block_custom_byline_priority() {
+		// Activate custom byline with different name than default author.
+		update_post_meta( self::$post_id, Bylines::META_KEY_ACTIVE, true );
+		update_post_meta( self::$post_id, Bylines::META_KEY_BYLINE, 'By [Author id=999]Custom Author[/Author]' );
+
+		$output = $this->render_byline_block( [] );
+
+		// Should show custom byline, not the default author "Test Author".
+		$this->assertStringContainsString( 'Custom Author', $output, 'Should show custom byline author.' );
+		$this->assertStringNotContainsString( 'Test Author', $output, 'Should not show default author when custom byline is active.' );
+	}
+
+	/**
+	 * Test render_block falls back to default when custom byline is inactive.
+	 *
+	 * @covers \Newspack\Blocks\Byline\Byline_Block::render_block
+	 * @covers \Newspack\Blocks\Byline\Byline_Block::render_default_author
+	 */
+	public function test_render_block_fallback_when_custom_byline_inactive() {
+		// Set byline content but don't activate it.
+		update_post_meta( self::$post_id, Bylines::META_KEY_ACTIVE, false );
+		update_post_meta( self::$post_id, Bylines::META_KEY_BYLINE, 'By [Author id=999]Custom Author[/Author]' );
+
+		$output = $this->render_byline_block( [] );
+
+		// Should show default author since custom byline is not active.
+		$this->assertStringContainsString( 'Test Author', $output, 'Should fall back to default author when custom byline is inactive.' );
+	}
+
+	/**
+	 * Test render_block falls back to default when custom byline is empty.
+	 *
+	 * @covers \Newspack\Blocks\Byline\Byline_Block::render_block
+	 * @covers \Newspack\Blocks\Byline\Byline_Block::render_default_author
+	 */
+	public function test_render_block_fallback_when_custom_byline_empty() {
+		// Activate custom byline but leave content empty.
+		update_post_meta( self::$post_id, Bylines::META_KEY_ACTIVE, true );
+		update_post_meta( self::$post_id, Bylines::META_KEY_BYLINE, '' );
+
+		$output = $this->render_byline_block( [] );
+
+		// Should show default author since custom byline is empty.
+		$this->assertStringContainsString( 'Test Author', $output, 'Should fall back to default author when custom byline is empty.' );
+	}
+
+	/**
+	 * Test render_block with custom prefix.
+	 *
+	 * @covers \Newspack\Blocks\Byline\Byline_Block::render_block
+	 * @covers \Newspack\Blocks\Byline\Byline_Block::render_default_author
+	 * @covers \Newspack\Blocks\Byline\Byline_Block::get_translated_prefix
+	 */
+	public function test_render_block_custom_prefix() {
+		$attributes = [
+			'prefix'              => 'Written by ',
+			'linkToAuthorArchive' => true,
+		];
+
+		$output = $this->render_byline_block( $attributes );
+
+		$this->assertStringContainsString( 'Written by ', $output, 'Should contain custom prefix.' );
+	}
+
+	/**
+	 * Test render_block uses postId from context.
+	 *
+	 * @covers \Newspack\Blocks\Byline\Byline_Block::render_block
+	 * @covers \Newspack\Blocks\Byline\Byline_Block::render_default_author
+	 */
+	public function test_render_block_uses_context_post_id() {
+		// Create another post with a different author.
+		$another_author_id = static::factory()->user->create(
+			[
+				'display_name' => 'Another Author',
+			]
+		);
+		$another_post_id   = static::factory()->post->create(
+			[
+				'post_author' => $another_author_id,
+			]
+		);
+
+		$output = $this->render_byline_block( [], $another_post_id );
+
+		$this->assertStringContainsString( 'Another Author', $output, 'Should use author from context postId.' );
+		$this->assertStringNotContainsString( 'Test Author', $output, 'Should not show author from different post.' );
+
+		// Clean up.
+		wp_delete_post( $another_post_id, true );
+		wp_delete_user( $another_author_id );
+	}
+
+	/**
+	 * Test render_block returns empty for post with no author.
+	 *
+	 * @covers \Newspack\Blocks\Byline\Byline_Block::render_block
+	 * @covers \Newspack\Blocks\Byline\Byline_Block::render_default_author
+	 */
+	public function test_render_block_no_author() {
+		// Create a post with author 0.
+		$no_author_post_id = static::factory()->post->create(
+			[
+				'post_author' => 0,
+			]
+		);
+
+		$output = $this->render_byline_block( [], $no_author_post_id );
+
+		$this->assertEmpty( $output, 'Should return empty string for post with no author.' );
+
+		// Clean up.
+		wp_delete_post( $no_author_post_id, true );
+	}
+
+	/**
+	 * Test default attributes are applied.
+	 *
+	 * @covers \Newspack\Blocks\Byline\Byline_Block::render_block
+	 * @covers \Newspack\Blocks\Byline\Byline_Block::render_default_author
+	 * @covers \Newspack\Blocks\Byline\Byline_Block::get_translated_prefix
+	 */
+	public function test_render_block_default_attributes() {
+		// Pass empty attributes to use defaults.
+		$output = $this->render_byline_block( [] );
+
+		// Default prefix is "By ".
+		$this->assertStringContainsString( 'By ', $output, 'Should use default prefix.' );
+		// Default linkToAuthorArchive is true.
+		$this->assertStringContainsString( '<a', $output, 'Should link to archive by default.' );
+	}
+
+	/**
+	 * Test format_author_list with single author.
+	 *
+	 * @covers \Newspack\Blocks\Byline\Byline_Block::format_author_list
+	 */
+	public function test_format_author_list_single_author() {
+		$author_links = [ '<span class="author">John Doe</span>' ];
+
+		$result = ( new \ReflectionMethod( Byline_Block::class, 'format_author_list' ) )->invoke( null, $author_links );
+
+		$this->assertEquals( '<span class="author">John Doe</span>', $result, 'Single author should be returned as-is.' );
+	}
+
+	/**
+	 * Test format_author_list with multiple authors.
+	 *
+	 * @covers \Newspack\Blocks\Byline\Byline_Block::format_author_list
+	 */
+	public function test_format_author_list_multiple_authors() {
+		$method = new \ReflectionMethod( Byline_Block::class, 'format_author_list' );
+
+		// Two authors.
+		$two_authors = [
+			'<span class="author">John Doe</span>',
+			'<span class="author">Jane Smith</span>',
+		];
+		$result      = $method->invoke( null, $two_authors );
+		$this->assertStringContainsString( 'John Doe', $result );
+		$this->assertStringContainsString( 'Jane Smith', $result );
+		$this->assertStringContainsString( ' and ', $result );
+
+		// Three authors.
+		$three_authors = [
+			'<span class="author">John Doe</span>',
+			'<span class="author">Jane Smith</span>',
+			'<span class="author">Bob Wilson</span>',
+		];
+		$result        = $method->invoke( null, $three_authors );
+		$this->assertStringContainsString( 'John Doe', $result );
+		$this->assertStringContainsString( 'Jane Smith', $result );
+		$this->assertStringContainsString( 'Bob Wilson', $result );
+	}
+
+	/**
+	 * Test format_author_list with empty array.
+	 *
+	 * @covers \Newspack\Blocks\Byline\Byline_Block::format_author_list
+	 */
+	public function test_format_author_list_empty() {
+		$result = ( new \ReflectionMethod( Byline_Block::class, 'format_author_list' ) )->invoke( null, [] );
+
+		$this->assertEmpty( $result, 'Empty array should return empty string.' );
+	}
+}

--- a/tests/unit-tests/bylines/class-test-byline-block.php
+++ b/tests/unit-tests/bylines/class-test-byline-block.php
@@ -126,7 +126,7 @@ class Test_Byline_Block extends \WP_UnitTestCase {
 	 */
 	public function test_render_block_default_author() {
 		$attributes = [
-			'prefix'              => 'By ',
+			'prefix'              => 'By',
 			'linkToAuthorArchive' => true,
 		];
 
@@ -147,7 +147,7 @@ class Test_Byline_Block extends \WP_UnitTestCase {
 	 */
 	public function test_render_block_default_author_no_link() {
 		$attributes = [
-			'prefix'              => 'By ',
+			'prefix'              => 'By',
 			'linkToAuthorArchive' => false,
 		];
 
@@ -316,8 +316,8 @@ class Test_Byline_Block extends \WP_UnitTestCase {
 		// Pass empty attributes to use defaults.
 		$output = $this->render_byline_block( [] );
 
-		// Default prefix is "By ".
-		$this->assertStringContainsString( 'By ', $output, 'Should use default prefix.' );
+		// Default prefix is "By" (space is added during assembly).
+		$this->assertStringContainsString( 'By ', $output, 'Should use default prefix with space.' );
 		// Default linkToAuthorArchive is true.
 		$this->assertStringContainsString( '<a', $output, 'Should link to archive by default.' );
 	}

--- a/tests/unit-tests/data-events.php
+++ b/tests/unit-tests/data-events.php
@@ -98,8 +98,14 @@ class Newspack_Test_Data_Events extends WP_UnitTestCase {
 
 		$this->assertIsArray( $hook_request );
 		$this->assertIsArray( $hook_queued_dispatches );
-		$this->assertEquals( $action_name, $hook_queued_dispatches[0]['action_name'] );
-		$this->assertEquals( $data, $hook_queued_dispatches[0]['data'] );
+
+		// Find our test action (other events may be queued from other tests).
+		$matching = array_filter(
+			$hook_queued_dispatches,
+			fn( $d ) => $d['action_name'] === $action_name
+		);
+		$this->assertNotEmpty( $matching, 'Test action should be in queued dispatches.' );
+		$this->assertEquals( $data, array_values( $matching )[0]['data'] );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds a Byline block for block themes that displays post author attribution.

The block supports three authorship systems in priority order:
1. Newspack Custom Bylines
2. CoAuthors Plus (including guest contributors)
3. Default WordPress author

Block settings include prefix text and author archive linking. When custom bylines are active, these settings are hidden since custom bylines control their own formatting.

Only available for block themes. Classic themes continue using the `pre_newspack_posted_by` filter.

See the [README](https://github.com/Automattic/newspack-plugin/blob/feat/byline-block/src/blocks/byline/README.md) for additional info.

Related PR: https://github.com/Automattic/newspack-block-theme/pull/399

Closes NPPD-1122.

_**Note:** There's a known mismatch between the `newspack/avatar` and `newspack/byline` blocks when custom bylines are active. The avatar block currently shows the post author or CAP authors, but isn't aware of custom bylines. This means the avatar may display a different author than the byline text. This will be addressed in a follow-up PR by adding custom byline support to the avatar block._

### How to test the changes in this Pull Request:

1. Activate the [block theme](https://github.com/Automattic/newspack-block-theme).
2. Create a new post and add the new "Byline" block.
3. Verify it displays the post author name with "By " prefix and with a link to the author archive.
5. In the block settings test:
     - Toggling "Link to author archive" off.
     - Changing the prefix.

**Custom Bylines:**

6. Open the Bylines sidebar panel and enable custom bylines.
7. Add one or more authors to the custom byline.
8. Verify the byline block displays the custom byline content.
9. Verify prefix and link settings are hidden in the block inspector.
10. Disable custom bylines. Block should fall back to the default author.

**CoAuthors Plus (requires [plugin](https://github.com/Automattic/co-authors-plus)):**

11. Disable custom bylines if active.
12. In the "Authors" sidebar panel, add a second WP user as a co-author.
13. Verify byline displays both authors with "and" conjunction (e.g., "By Jane and John")
14. Add a third co-author. Verify the Oxford comma formatting (e.g., "By Jane, John, and Bob")
15. Create a guest contributor in CAP and assign to the post.
16. Verify that the guest also displays correctly and links to their archive page.

**Edge cases:**

17. Create a post with no author (author ID = 0). Block should render empty.
18. Insert block in a Query Loop. Verify it uses each post's author, not the current post.

**Unit tests:**

19. Run JS tests and PHP tests and verify that all pass.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?