### PR TITLE
feat: reinstate the Appearance > Editor link for block themes

### DIFF
--- a/includes/class-patches.php
+++ b/includes/class-patches.php
@@ -123,7 +123,7 @@ class Patches {
 	}
 
 	/**
-	 * Remove the Design from the Appearance menu for the Classic theme:
+	 * Remove the Design link from the Appearance menu for the Classic theme.
 	 */
 	public static function remove_core_appearance_menu_links() {
 		if ( wp_is_block_theme() ) {

--- a/includes/class-patches.php
+++ b/includes/class-patches.php
@@ -123,14 +123,12 @@ class Patches {
 	}
 
 	/**
-	 * Remove some site editor links from the Appearance menu:
-	 * - The Appearance > Patterns link added in WordPress 6.6.
-	 * - The Appearance > Design link added in WordPress 6.8.
-	 *
-	 * Once WordPress 6.8 is released, the code to remove the Patterns link can be removed.
+	 * Remove the Design from the Appearance menu for the Classic theme:
 	 */
 	public static function remove_core_appearance_menu_links() {
-		remove_submenu_page( 'themes.php', 'site-editor.php?path=/patterns' );
+		if ( wp_is_block_theme() ) {
+			return;
+		}
 		remove_submenu_page( 'themes.php', 'site-editor.php' );
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

We've customized the Appearance menu for our Classic Theme over time; those customizations are affecting the Block theme too, though, making it kind of tough to edit 😅 

This PR:
* Adds a check for a block theme before hiding anything
* Updates the menu items we're hiding: the Appearance > Patterns link is no longer a top level link as of WP 6.8, being replaced (for Classic themes) with Appearance > Design.

### How to test the changes in this Pull Request:

1. Apply this PR.
2. On a site running the Classic theme, go to WP Admin and check the Appearance menu - confirm you do NOT have a link to Design:

<img width="165" height="192" alt="CleanShot 2026-01-19 at 10 40 24" src="https://github.com/user-attachments/assets/9a610813-d037-4476-9eeb-62c2a2640ff6" />

3. Switch to a Block theme; confirm you do have a link to Editor:

<img width="159" height="129" alt="CleanShot 2026-01-19 at 10 40 54" src="https://github.com/user-attachments/assets/fbc7cdce-9ab7-4838-8774-4356e5f9d5a3" />

(You may or may not have a link to Customize, depending what other plugins you're running - WordPress won't add it out of the box for block themes, but will add it if any plugins are using it).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->