### PR TITLE
fix(content-gate): support zero paragraph excerpt

### DIFF
--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -591,12 +591,19 @@ class Content_Gate {
 		if ( $use_more_tag && strpos( $content, '<!--more-->' ) ) {
 			$content = apply_filters( 'newspack_gate_content', explode( '<!--more-->', $content )[0] );
 		} else {
+			$visible_paragraphs = get_post_meta( $gate_post_id, 'visible_paragraphs', true );
+			// If visible paragraphs is explicitly 0, return no content.
+			// Also align with the registered meta default (2) when the meta is unset.
+			$count = '' === $visible_paragraphs ? 2 : max( 0, (int) $visible_paragraphs );
+			if ( 0 === $count ) {
+				return '';
+			}
+
 			$content = apply_filters( 'newspack_gate_content', $content );
-			$count   = max( 1, (int) get_post_meta( $gate_post_id, 'visible_paragraphs', true ) );
 			// Split into paragraphs.
 			$content = explode( '</p>', $content );
 			// Extract the first $x paragraphs only.
-			$content = array_slice( $content, 0, $count ?? 2 );
+			$content = array_slice( $content, 0, $count );
 			if ( 'overlay' === $style ) {
 				// Append ellipsis to the last paragraph.
 				$content[ count( $content ) - 1 ] .= ' [&hellip;]';

--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -552,7 +552,8 @@ class Content_Gate {
 		$gate = '<div style=\'content:"";clear:both;display:table;\'></div>' . $gate;
 
 		// Apply inline fade.
-		if ( \get_post_meta( $gate_post_id, 'inline_fade', true ) ) {
+		$visible_paragraphs = self::get_visible_paragraphs( $gate_post_id );
+		if ( $visible_paragraphs > 0 && \get_post_meta( $gate_post_id, 'inline_fade', true ) ) {
 			$gate = '<div style="pointer-events: none; height: 10em; margin-top: -10em; width: 100%; position: absolute; background: linear-gradient(180deg, rgba(255,255,255,0) 14%, rgba(255,255,255,1) 76%);"></div>' . $gate;
 		}
 
@@ -568,6 +569,18 @@ class Content_Gate {
 	 */
 	public static function get_inline_gate_html() {
 		return apply_filters( 'newspack_gate_content', self::get_inline_gate_content() );
+	}
+
+	/**
+	 * Get the number of visible paragraphs for the gate.
+	 *
+	 * @param int $gate_post_id Gate post ID.
+	 *
+	 * @return int
+	 */
+	protected static function get_visible_paragraphs( $gate_post_id ) {
+		$visible_paragraphs = \get_post_meta( $gate_post_id, 'visible_paragraphs', true );
+		return '' === $visible_paragraphs ? 2 : max( 0, (int) $visible_paragraphs );
 	}
 
 	/**
@@ -591,10 +604,7 @@ class Content_Gate {
 		if ( $use_more_tag && strpos( $content, '<!--more-->' ) ) {
 			$content = apply_filters( 'newspack_gate_content', explode( '<!--more-->', $content )[0] );
 		} else {
-			$visible_paragraphs = get_post_meta( $gate_post_id, 'visible_paragraphs', true );
-			// If visible paragraphs is explicitly 0, return no content.
-			// Also align with the registered meta default (2) when the meta is unset.
-			$count = '' === $visible_paragraphs ? 2 : max( 0, (int) $visible_paragraphs );
+			$count = self::get_visible_paragraphs( $gate_post_id );
 			if ( 0 === $count ) {
 				return '';
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

NPPM-2531

Support setting visible paragraphs to zero when configuring the content gate. This means no content should render, and the gate should display immediately.

### How to test the changes in this Pull Request:

1. Make sure you have Woo Memberships and content gate configured
2. While on `release`, navigate to Audience -> Configuration -> Content Gating, and edit your gate
3. Set the gate's "visible paragraphs" to zero
4. Visit a gated article and confirm the first paragraph renders
5. Checkout this branch, refresh, and confirm the gate renders without any content

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->