### PR TITLE
fix(guest-contributors): preserve special characters in guest contributor display names

### DIFF
--- a/includes/plugins/co-authors-plus/class-guest-contributor-role.php
+++ b/includes/plugins/co-authors-plus/class-guest-contributor-role.php
@@ -318,10 +318,15 @@ class Guest_Contributor_Role {
 
 		if ( ! $update ) {
 			// For guest authors, the form is modified via JS and we get the display name in the username field.
-			$user->display_name = $user->user_login;
+			// Get the original display name from POST data (before WordPress sanitizes it).
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verification happens in wp-admin/user-new.php before this hook.
+			$original_display_name = isset( $_POST['user_login'] ) ? sanitize_text_field( wp_unslash( $_POST['user_login'] ) ) : '';
 
-			// Create user name from Display name.
-			$user->user_login = self::generate_username( $user->display_name );
+			// Generate sanitized username from the original display name.
+			$user->user_login = self::generate_username( $original_display_name );
+
+			// Set display name to the sanitized value (preserves accents but removes HTML/scripts).
+			$user->display_name = $original_display_name;
 		}
 
 		if ( empty( $user->user_email ) ) {

--- a/includes/plugins/co-authors-plus/class-guest-contributor-role.php
+++ b/includes/plugins/co-authors-plus/class-guest-contributor-role.php
@@ -320,7 +320,7 @@ class Guest_Contributor_Role {
 			// For guest authors, the form is modified via JS and we get the display name in the username field.
 			// Get the original display name from POST data (before WordPress sanitizes it).
 			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verification happens in wp-admin/user-new.php before this hook.
-			$original_display_name = isset( $_POST['user_login'] ) ? sanitize_text_field( wp_unslash( $_POST['user_login'] ) ) : '';
+			$original_display_name = isset( $_POST['user_login'] ) ? sanitize_text_field( wp_unslash( $_POST['user_login'] ) ) : $user->user_login;
 
 			// Generate sanitized username from the original display name.
 			$user->user_login = self::generate_username( $original_display_name );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes a bug where special characters (accented letters, diacritics, punctuation, etc.) were being stripped from Guest Contributor display names during user creation. `NPPM-2360`

**The root cause**
When creating a Guest Contributor, the **Display name** value shares the **username** field. Because the username is passed through `sanitize_user()`, accented characters and other special characters are stripped from the Display name as well.



**The proposed solution**
- Capture the original Display name value from `$_POST['user_login']` **before** WordPress applies `sanitize_user()`
- Sanitize the Display name using `sanitize_text_field()` with `wp_unslash()`, which preserves international characters while still preventing XSS/HTML injection
- Continue using `sanitize_user()` for the generated username — no change here
- Explicitly set the Display name to the accent-preserving, safely-sanitized value

### How to test the changes in this Pull Request:

**Before applying this PR (to reproduce the issue):**

1. In the admin dashboard, go to **Users → Guest Authors → Create a new Guest Contributor**
2. Enter a **Display name** containing accented characters (e.g., `Iñigo Montoya`)
3. Add the user
4. Search for the user and click **Edit**
5. Observe that the “**Display name publicly as**” field shows a name **without accents**
6. Note that the username is URL-safe (e.g., `inigo-montoya`)

**After applying this PR:**

1. In the admin dashboard, go to **Users → Guest Authors → Create a new Guest Contributor**
2. Enter a **Display name** containing accented characters (e.g., `Pepé Le Pew`)
3. Add the user
4. Search for the user and click **Edit**
5. Observe that the “**Display name publicly as**” field now preserves accents
6. Confirm that the username remains URL-safe (e.g., `pepe-le-pew`)

Please also test with additional names and characters. For example: `Sévêrüs Snāpê, Ph.D.`

**Security Considerations:**
This fix uses `wp_unslash()` and `sanitize_text_field()` to safely process user input while preserving accented characters. This approach prevents XSS and HTML injection while allowing legitimate display names with accents, diacritics, and punctuation.

**Note on `phpcs:ignore`**
A `phpcs:ignore WordPress.Security.NonceVerification.Missing` comment was added for this change.

This logic runs on the `user_profile_update_errors` hook, which is triggered from `wp-admin/user-new.php` after WordPress has already verified the nonce. Since this hook does not have direct access to the earlier nonce verification, the ignore comment seems appropriate here, but I wanted to explicitly call it out for review.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?



