### PR TITLE
fix: add block theme check before switching templates to prevent warnings

### DIFF
--- a/includes/plugins/woocommerce/class-woocommerce-connection.php
+++ b/includes/plugins/woocommerce/class-woocommerce-connection.php
@@ -707,6 +707,9 @@ class WooCommerce_Connection {
 		if ( ! function_exists( 'WC' ) ) {
 			return false;
 		}
+		if ( wp_is_block_theme() ) {
+			return false;
+		}
 		return is_checkout() || is_cart() || is_account_page();
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This change just gets rid of some annoying notices when you're using the Block theme:

`[21-Jan-2026 21:15:22 UTC] PHP Warning:  include(): Failed opening '/var/www/additional-sites-html/blocktheme2/wp-content/themes/newspack-block-theme/single-wide.php' for inclusion (include_path='.:/usr/share/php') in /var/www/additional-sites-html/blocktheme2/wp-includes/template-loader.php on line 125`

### How to test the changes in this Pull Request:

1. Apply the PR.
2. Using the Classic Theme, edit your /cart page and make sure it's set to use the Default or One-Column (not wide) template.
3. Ensure it's still using the One-Column wide template on the front-end.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->