### PR TITLE
hotfix: make lite site list styles more specific

### DIFF
--- a/includes/lite-site/templates/archive.php
+++ b/includes/lite-site/templates/archive.php
@@ -22,7 +22,7 @@ namespace Newspack;
 	</header>
 	<h1><?php bloginfo( 'name' ); ?></h1>
 	<hr class="separator">
-	<ul>
+	<ul class="post-list">
 	<?php
 	$query_args = [
 		'posts_per_page' => Lite_Site::get_number_of_posts(),

--- a/includes/lite-site/templates/lite-site-styles.php
+++ b/includes/lite-site/templates/lite-site-styles.php
@@ -22,11 +22,11 @@ namespace Newspack;
 		line-height: 1.25;
 		margin: 0 0 2rem;
 	}
-	ul {
+	ul.post-list {
 		list-style: none;
 		padding-left: 0;
 	}
-	li {
+	.post-list li {
 		margin-bottom: 1rem;
 	}
 	a {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Our Lite Site feature includes some styles for lists, but it's actually meant to style the post list on the landing page. Instead, it's accidentally making lists in stories not-lists.

This hotfix makes those styles more specific.

### How to test the changes in this Pull Request:

1. Set up a story with a bulleted list in it.
2. Enable Lite Site.
3. View your story - note your list is gone.
4. Apply this PR.
5. Refresh your story and confirm your list is back.
6. Go to you Lite Site homepage and confirm the list of stories does not have bullets, and is nicely spaced out.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->