### PR TITLE
fix: lite site updates

### DIFF
--- a/includes/lite-site/class-lite-site.php
+++ b/includes/lite-site/class-lite-site.php
@@ -501,12 +501,12 @@ class Lite_Site {
 		}
 		?>
 		<!-- Global site tag (gtag.js) - Google Analytics -->
-		<script async src="https://www.googletagmanager.com/gtag/js?id=<?php echo esc_js( $settings['measurementID'] ); ?>"></script>
+		<script async src="https://www.googletagmanager.com/gtag/js?id=<?php echo esc_attr( $settings['measurementID'] ); ?>"></script>
 		<script>
 			window.dataLayer = window.dataLayer || [];
 			function gtag(){dataLayer.push(arguments);}
 			gtag('js', new Date());
-			gtag('config', '<?php echo esc_js( $settings['measurementID'] ); ?>');
+			gtag('config', '<?php echo esc_attr( $settings['measurementID'] ); ?>');
 		</script>
 		<?php
 	}

--- a/includes/lite-site/class-lite-site.php
+++ b/includes/lite-site/class-lite-site.php
@@ -487,6 +487,29 @@ class Lite_Site {
 
 		return $content;
 	}
+
+	/**
+	 * Get GA4 snippet if active and settings are present.
+	 */
+	public static function get_ga4_snippet() {
+		if ( ! GoogleSiteKit::is_active() ) {
+			return;
+		}
+		$settings = GoogleSiteKit::get_sitekit_ga4_settings();
+		if ( ! $settings || empty( $settings['measurementID'] ) ) {
+			return;
+		}
+		?>
+		<!-- Global site tag (gtag.js) - Google Analytics -->
+		<script async src="https://www.googletagmanager.com/gtag/js?id=<?php echo esc_js( $settings['measurementID'] ); ?>"></script>
+		<script>
+			window.dataLayer = window.dataLayer || [];
+			function gtag(){dataLayer.push(arguments);}
+			gtag('js', new Date());
+			gtag('config', '<?php echo esc_js( $settings['measurementID'] ); ?>');
+		</script>
+		<?php
+	}
 }
 
 // Initialize the class.

--- a/includes/lite-site/class-lite-site.php
+++ b/includes/lite-site/class-lite-site.php
@@ -41,6 +41,16 @@ class Lite_Site {
 	}
 
 	/**
+	 * Check if the current request is for the lite site.
+	 *
+	 * @return bool True if it's a lite site request, false otherwise.
+	 */
+	public static function is_lite_site_request() {
+		$lite_site = get_query_var( 'lite_site' );
+		return ! empty( $lite_site );
+	}
+
+	/**
 	 * Get the lite site URL base
 	 */
 	public static function get_url_base() {

--- a/includes/lite-site/templates/archive.php
+++ b/includes/lite-site/templates/archive.php
@@ -15,6 +15,7 @@ namespace Newspack;
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title><?php bloginfo( 'name' ); ?></title>
 	<?php require __DIR__ . '/lite-site-styles.php'; ?>
+	<?php Lite_Site::get_ga4_snippet(); ?>
 </head>
 <body>
 	<header class="back">

--- a/includes/lite-site/templates/archive.php
+++ b/includes/lite-site/templates/archive.php
@@ -22,7 +22,7 @@ namespace Newspack;
 	</header>
 	<h1><?php bloginfo( 'name' ); ?></h1>
 	<hr class="separator">
-	<ul>
+	<ul class="post-list">
 	<?php
 	$query_args = [
 		'posts_per_page' => Lite_Site::get_number_of_posts(),

--- a/includes/lite-site/templates/lite-site-styles.php
+++ b/includes/lite-site/templates/lite-site-styles.php
@@ -22,11 +22,11 @@ namespace Newspack;
 		line-height: 1.25;
 		margin: 0 0 2rem;
 	}
-	ul {
+	ul.post-list {
 		list-style: none;
 		padding-left: 0;
 	}
-	li {
+	.post-list li {
 		margin-bottom: 1rem;
 	}
 	a {

--- a/includes/lite-site/templates/single.php
+++ b/includes/lite-site/templates/single.php
@@ -23,6 +23,7 @@ if ( ! $current_post ) {
 	<title><?php echo esc_html( $current_post->post_title ); ?> - <?php bloginfo( 'name' ); ?></title>
 	<link rel="canonical" href="<?php echo esc_url( get_permalink( $current_post ) ); ?>">
 	<?php require __DIR__ . '/lite-site-styles.php'; ?>
+	<?php Lite_Site::get_ga4_snippet(); ?>
 </head>
 <body>
 	<header class="back">

--- a/includes/plugins/class-perfmatters.php
+++ b/includes/plugins/class-perfmatters.php
@@ -21,7 +21,7 @@ class Perfmatters {
 		add_action( 'admin_notices', [ __CLASS__, 'admin_notice' ] );
 		add_filter( 'perfmatters_lazyload_youtube_thumbnail_resolution', [ __CLASS__, 'maybe_serve_high_res_youtube_thumbs' ] );
 		add_filter( 'perfmatters_rucss_excluded_stylesheets', [ __CLASS__, 'add_rucss_excluded_stylesheets' ] );
-		add_filter( 'perfmatters_delay_js', [ __CLASS__, 'should_defer_js' ] );
+		add_filter( 'perfmatters_delay_js', [ __CLASS__, 'should_delay_js' ] );
 	}
 
 	/**
@@ -335,18 +335,18 @@ class Perfmatters {
 	}
 
 	/**
-	 * Whether to defer JS scripts.
+	 * Whether to delay JS scripts.
 	 *
-	 * @param bool $defer_js Existing defer JS value.
+	 * @param bool $delay_js Existing delay JS value.
 	 *
-	 * @return bool Whether to defer JS.
+	 * @return bool Whether to delay JS.
 	 */
-	public static function should_defer_js( $defer_js ) {
-		// Don't defer JS on lite site requests.
+	public static function should_delay_js( $delay_js ) {
+		// Don't delay JS on lite site requests.
 		if ( Lite_Site::is_lite_site_request() ) {
 			return false;
 		}
-		return $defer_js;
+		return $delay_js;
 	}
 }
 Perfmatters::init();

--- a/includes/plugins/class-perfmatters.php
+++ b/includes/plugins/class-perfmatters.php
@@ -21,6 +21,7 @@ class Perfmatters {
 		add_action( 'admin_notices', [ __CLASS__, 'admin_notice' ] );
 		add_filter( 'perfmatters_lazyload_youtube_thumbnail_resolution', [ __CLASS__, 'maybe_serve_high_res_youtube_thumbs' ] );
 		add_filter( 'perfmatters_rucss_excluded_stylesheets', [ __CLASS__, 'add_rucss_excluded_stylesheets' ] );
+		add_filter( 'perfmatters_delay_js', [ __CLASS__, 'should_defer_js' ] );
 	}
 
 	/**
@@ -331,6 +332,21 @@ class Perfmatters {
 			return $stylesheet_exclusions;
 		}
 		return array_unique( array_merge( $stylesheet_exclusions, self::unused_css_excluded_stylesheets() ) );
+	}
+
+	/**
+	 * Whether to defer JS scripts.
+	 *
+	 * @param bool $defer_js Existing defer JS value.
+	 *
+	 * @return bool Whether to defer JS.
+	 */
+	public static function should_defer_js( $defer_js ) {
+		// Don't defer JS on lite site requests.
+		if ( Lite_Site::is_lite_site_request() ) {
+			return false;
+		}
+		return $defer_js;
 	}
 }
 Perfmatters::init();

--- a/includes/plugins/google-site-kit/class-googlesitekit.php
+++ b/includes/plugins/google-site-kit/class-googlesitekit.php
@@ -112,7 +112,7 @@ class GoogleSiteKit {
 	/**
 	 * Get Site Kit's GA4 settings.
 	 */
-	private static function get_sitekit_ga4_settings() {
+	public static function get_sitekit_ga4_settings() {
 		$option_name = self::get_sitekit_ga4_settings_option_name();
 		if ( false === $option_name ) {
 			return false;


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://linear.app/a8c/issue/NPPM-2550/add-ga-to-lite-sites-and-remove-permatters-script and resolves https://a8c.slack.com/archives/C07LB7B14GZ/p1769105774757559

This PR makes a few updates to fix lite site including:

- Add missing list item bullets
![Screenshot 2026-01-22 at 15 49 12](https://github.com/user-attachments/assets/07653731-d615-4034-8257-4c28af70c36e)
- Remove perfmatters delayed scripts
![Screenshot 2026-01-22 at 15 49 39](https://github.com/user-attachments/assets/2c0f7ec9-d177-4f29-8544-c751d5345fbb)
- Adds pageview analytics
![Screenshot 2026-01-22 at 15 50 28](https://github.com/user-attachments/assets/60a03357-e39c-43dd-b82d-f7d95b7ba4f0)

### How to test the changes in this Pull Request:

**More specific list styles**
1. Set up a story with a bulleted list in it.
2. Enable Lite Site.
3. View your story - note your list is gone.
4. Apply this PR.
5. Refresh your story and confirm your list is back.
6. Go to you Lite Site homepage and confirm the list of stories does not have bullets, and is nicely spaced out.

**Remove perfmatters delayed scripts**
1. Ensure perfmatters is enabled and you are using default newspack settings
2. Visit a non-lite site page as a reader
3. Verify the perfmatters script is still present in the page source. (look for `perfmatters-delayed-scripts-js`)
4. Visit the lite site as a reader
5. View page source. On `release` you will see perfmatters related delayed script. On this branch you will not

**Adds GA4 pageview analytics**
1. Ensure site kit is active and setup
2. Visit the lite site as a reader
3. View page source. On `release` there should be no analytics script. On this branch there should be
5. Visit a few lite site pages, wait a few minutes, then verify the pageviews are present in analytics
6. Disconnect Site Kit
7. Verify the analytics snippet is no longer present in lite site

Note: You may need to add the following snippet for the events to send:
```
add_filter(
	'googlesitekit_allowed_tag_environment_types',
	function( $types ) {
		$types[] = 'local'; // or development
		return $types;
	}
);
```

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->