### PR TITLE
feat(content-gate): support new metering schema

### DIFF
--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -369,6 +369,25 @@ class Content_Gate {
 	}
 
 	/**
+	 * Get the gate layout ID for the post.
+	 *
+	 * @param int $post_id Post ID. If not given, uses the current post ID.
+	 *
+	 * @return int|false
+	 */
+	public static function get_gate_layout_id( $post_id = null ) {
+		$gate_layout_id = Memberships::is_active() ? Memberships::get_gate_post_id( $post_id ) : Content_Restriction_Control::get_gate_layout_id( $post_id );
+
+		/**
+		 * Filters the gate layout ID.
+		 *
+		 * @param int $gate_layout_id Gate layout ID.
+		 * @param int $post_id      Post ID.
+		 */
+		return apply_filters( 'newspack_content_gate_layout_id', $gate_layout_id, $post_id );
+	}
+
+	/**
 	 * Get gate metadata to be used for analytics purposes.
 	 *
 	 * @return array {
@@ -593,8 +612,7 @@ class Content_Gate {
 	 * Get the inline gate content.
 	 */
 	public static function get_inline_gate_content() {
-		$gate_post_id = self::get_gate_post_id();
-		return self::get_inline_gate_content_for_post( $gate_post_id );
+		return self::get_inline_gate_content_for_post( self::get_gate_layout_id() );
 	}
 
 	/**
@@ -615,9 +633,7 @@ class Content_Gate {
 	 */
 	public static function get_restricted_post_excerpt( $post ) {
 		self::$is_gated = true;
-
-		$gate_post_id = self::get_gate_post_id();
-		return self::get_restricted_post_excerpt_for_gate( $post, $gate_post_id );
+		return self::get_restricted_post_excerpt_for_gate( $post, self::get_gate_layout_id() );
 	}
 
 	/**
@@ -645,8 +661,8 @@ class Content_Gate {
 		if ( ! Metering::is_frontend_metering() && Metering::is_logged_in_metering_allowed() ) {
 			return;
 		}
-		$gate_post_id = self::get_gate_post_id();
-		$style        = \get_post_meta( $gate_post_id, 'style', true );
+		$gate_layout_id = self::get_gate_layout_id();
+		$style          = \get_post_meta( $gate_layout_id, 'style', true );
 		if ( 'overlay' !== $style ) {
 			return;
 		}
@@ -654,10 +670,10 @@ class Content_Gate {
 
 		global $post;
 		$_post = $post;
-		$post  = \get_post( $gate_post_id ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$post  = \get_post( $gate_layout_id ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		setup_postdata( $post );
 
-		self::render_overlay_gate_html( $gate_post_id );
+		self::render_overlay_gate_html( $gate_layout_id );
 
 		self::mark_gate_as_rendered();
 		wp_reset_postdata();

--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -683,9 +683,15 @@ class Content_Gate {
 			$registration = [];
 		}
 
+		$default_metering = [
+			'enabled' => false,
+			'count'   => 0,
+			'period'  => 'month',
+		];
+
 		return [
 			'active'               => isset( $registration['active'] ) ? (bool) $registration['active'] : false,
-			'metering'             => isset( $registration['metering'] ) ? $registration['metering'] : Metering::get_metering_settings( $gate_id ),
+			'metering'             => isset( $registration['metering'] ) ? $registration['metering'] : $default_metering,
 			'require_verification' => isset( $registration['require_verification'] ) ? (bool) $registration['require_verification'] : false,
 			'gate_layout_id'       => isset( $registration['gate_layout_id'] ) ? (int) $registration['gate_layout_id'] : 0,
 		];
@@ -720,9 +726,15 @@ class Content_Gate {
 			$custom_access = [];
 		}
 
+		$default_metering = [
+			'enabled' => false,
+			'count'   => 0,
+			'period'  => 'month',
+		];
+
 		return [
 			'active'         => isset( $custom_access['active'] ) ? (bool) $custom_access['active'] : false,
-			'metering'       => isset( $custom_access['metering'] ) ? $custom_access['metering'] : Metering::get_metering_settings( $gate_id ),
+			'metering'       => isset( $custom_access['metering'] ) ? $custom_access['metering'] : $default_metering,
 			'access_rules'   => isset( $custom_access['access_rules'] ) ? $custom_access['access_rules'] : [],
 			'gate_layout_id' => isset( $custom_access['gate_layout_id'] ) ? (int) $custom_access['gate_layout_id'] : 0,
 		];

--- a/includes/content-gate/class-content-restriction-control.php
+++ b/includes/content-gate/class-content-restriction-control.php
@@ -14,11 +14,18 @@ use Newspack\Access_Rules;
  */
 class Content_Restriction_Control {
 	/**
-	 * Map of post IDs to gate IDs.
+	 * Map of post IDs to gate layout IDs.
 	 *
-	 * @var array
+	 * @var int[]
 	 */
 	private static $post_gate_id_map = [];
+
+	/**
+	 * Map of post IDs to gate IDs.
+	 *
+	 * @var int[]
+	 */
+	private static $post_gate_layout_id_map = [];
 
 	/**
 	 * Initialize hooks and filters.
@@ -216,7 +223,8 @@ class Content_Restriction_Control {
 			}
 
 			if ( $is_restricted && $gate_layout_id ) {
-				self::$post_gate_id_map[ $post_id ] = $gate_layout_id;
+				self::$post_gate_id_map[ $post_id ] = $gate['id'];
+				self::$post_gate_layout_id_map[ $post_id ] = $gate_layout_id;
 				return true;
 			}
 		}
@@ -242,6 +250,23 @@ class Content_Restriction_Control {
 		}
 		if ( ! empty( self::$post_gate_id_map[ $post_id ] ) ) {
 			return self::$post_gate_id_map[ $post_id ];
+		}
+		return false;
+	}
+
+	/**
+	 * Get the current gate layout ID.
+	 *
+	 * @param int $post_id Post ID. If not given, uses the current post ID.
+	 *
+	 * @return int|false
+	 */
+	public static function get_gate_layout_id( $post_id = null ) {
+		if ( ! self::get_gate_post_id( $post_id ) ) {
+			return false;
+		}
+		if ( ! empty( self::$post_gate_layout_id_map[ $post_id ] ) ) {
+			return self::$post_gate_layout_id_map[ $post_id ];
 		}
 		return false;
 	}

--- a/includes/content-gate/class-content-restriction-control.php
+++ b/includes/content-gate/class-content-restriction-control.php
@@ -14,14 +14,14 @@ use Newspack\Access_Rules;
  */
 class Content_Restriction_Control {
 	/**
-	 * Map of post IDs to gate layout IDs.
+	 * Map of post IDs to gate IDs.
 	 *
 	 * @var int[]
 	 */
 	private static $post_gate_id_map = [];
 
 	/**
-	 * Map of post IDs to gate IDs.
+	 * Map of post IDs to gate layout IDs.
 	 *
 	 * @var int[]
 	 */

--- a/includes/content-gate/class-content-restriction-control.php
+++ b/includes/content-gate/class-content-restriction-control.php
@@ -262,7 +262,13 @@ class Content_Restriction_Control {
 	 * @return int|false
 	 */
 	public static function get_gate_layout_id( $post_id = null ) {
-		if ( ! self::get_gate_post_id( $post_id ) ) {
+		if ( ! Content_Gate::is_newspack_feature_enabled() ) {
+			return false;
+		}
+		if ( is_singular() ) {
+			$post_id = $post_id ? $post_id : get_queried_object_id();
+		}
+		if ( ! $post_id ) {
 			return false;
 		}
 		if ( ! empty( self::$post_gate_layout_id_map[ $post_id ] ) ) {

--- a/includes/content-gate/class-metering-countdown.php
+++ b/includes/content-gate/class-metering-countdown.php
@@ -207,7 +207,7 @@ class Metering_Countdown {
 		if ( $views === 0 || Metering::is_frontend_metering() ) {
 			$classes[] = 'newspack-countdown-banner__cta--hidden';
 		}
-		$metering_settings = Metering::get_registration_metering_settings( Content_Gate::get_gate_post_id() );
+		$metering_settings = Metering::get_anonymous_settings( Content_Gate::get_gate_post_id() );
 		$registered_count  = $metering_settings['count'];
 		?>
 		<div class="newspack-ui">

--- a/includes/content-gate/class-metering-countdown.php
+++ b/includes/content-gate/class-metering-countdown.php
@@ -221,7 +221,7 @@ class Metering_Countdown {
 		if ( $views === 0 || Metering::is_frontend_metering() ) {
 			$classes[] = 'newspack-countdown-banner__cta--hidden';
 		}
-		$metering_settings = Metering::get_anonymous_settings( Content_Gate::get_gate_post_id() );
+		$metering_settings = Metering::get_registered_settings( Content_Gate::get_gate_post_id() );
 		$registered_count  = $metering_settings['count'];
 		?>
 		<div class="newspack-ui">

--- a/includes/content-gate/class-metering-countdown.php
+++ b/includes/content-gate/class-metering-countdown.php
@@ -207,8 +207,8 @@ class Metering_Countdown {
 		if ( $views === 0 || Metering::is_frontend_metering() ) {
 			$classes[] = 'newspack-countdown-banner__cta--hidden';
 		}
-		$metering_settings = Metering::get_metering_settings( Content_Gate::get_gate_post_id() );
-		$registered_count  = $metering_settings['registered_count'];
+		$metering_settings = Metering::get_registration_metering_settings( Content_Gate::get_gate_post_id() );
+		$registered_count  = $metering_settings['count'];
 		?>
 		<div class="newspack-ui">
 			<div class="banner newspack-countdown-banner__cta <?php echo esc_attr( implode( ' ', $classes ) ); ?>">

--- a/includes/content-gate/class-metering.php
+++ b/includes/content-gate/class-metering.php
@@ -381,8 +381,7 @@ class Metering {
 		}
 
 		// Aggregate metering by gate priority, if available.
-		$suffix = Content_Gate::is_newspack_feature_enabled() && ! Memberships::is_active() && $priority ? $priority : $gate_post_id;
-		$user_meta_key = self::METERING_META_KEY . '_' . $suffix;
+		$user_meta_key = self::METERING_META_KEY . '_' . $gate_post_id;
 
 		$updated_user_data  = false;
 		$user_metering_data = \get_user_meta( get_current_user_id(), $user_meta_key, true );

--- a/includes/content-gate/class-metering.php
+++ b/includes/content-gate/class-metering.php
@@ -256,10 +256,15 @@ class Metering {
 	/**
 	 * Get the metering expiration time for the given date.
 	 *
+	 * @param string|null $period Metering period. Default is null, which will use the gate's metering period.
+	 *
 	 * @return int Timestamp of the expiration time.
 	 */
-	private static function get_expiration_time() {
-		$period = \get_post_meta( Content_Gate::get_gate_post_id(), 'metering_period', true );
+	private static function get_expiration_time( $period = null ) {
+		if ( ! $period ) {
+			$settings = self::get_metering_settings( Content_Gate::get_gate_post_id() );
+			$period = $settings['period'];
+		}
 		switch ( $period ) {
 			case 'day':
 				return strtotime( 'tomorrow' );
@@ -385,7 +390,7 @@ class Metering {
 
 		$user_expiration = isset( $user_metering_data['expiration'] ) ? $user_metering_data['expiration'] : 0;
 
-		$current_expiration = self::get_expiration_time();
+		$current_expiration = self::get_expiration_time( $settings['period'] );
 		if ( $user_expiration !== $current_expiration ) {
 			// Clear content if expired.
 			if ( $user_expiration < $current_expiration ) {
@@ -505,14 +510,15 @@ class Metering {
 	 * @return int|boolean Total number of metered views if metering is enabled, otherwise false.
 	 */
 	public static function get_total_metered_views( $is_logged_in = false ) {
-		$gate_post_id = Content_Gate::get_gate_post_id( get_the_ID() );
+		$gate_post_id = Content_Gate::get_gate_post_id();
 		if ( ! $gate_post_id ) {
 			return false;
 		}
+		$metering_settings = self::get_metering_settings( $gate_post_id );
 		if ( ! $is_logged_in ) {
-			return (int) \get_post_meta( $gate_post_id, 'metering_anonymous_count', true );
+			return $metering_settings['anonymous_count'];
 		}
-		return (int) \get_post_meta( $gate_post_id, 'metering_registered_count', true );
+		return $metering_settings['registered_count'];
 	}
 }
 Metering::init();

--- a/includes/content-gate/class-metering.php
+++ b/includes/content-gate/class-metering.php
@@ -123,11 +123,81 @@ class Metering {
 	 * @return array Metering settings.
 	 */
 	public static function get_metering_settings( $gate_id ) {
+		$anonymous_settings  = self::get_anonymous_settings( $gate_id );
+		$registered_settings = self::get_registered_settings( $gate_id );
+		return [
+			'enabled'           => $anonymous_settings['enabled'] || $registered_settings['enabled'],
+			'period'            => $anonymous_settings['period'], // Legacy property, equivalent to anonymous_period.
+			'anonymous_count'   => $anonymous_settings['count'],
+			'anonymous_period'  => $anonymous_settings['period'],
+			'registered_count'  => $registered_settings['count'],
+			'registered_period' => $registered_settings['period'],
+		];
+	}
+
+	/**
+	 * Get legacy metering settings for a gate.
+	 *
+	 * @param int $gate_id Gate ID.
+	 *
+	 * @return array Metering settings.
+	 */
+	protected static function get_legacy_metering_settings( $gate_id ) {
 		return [
 			'enabled'          => (bool) \get_post_meta( $gate_id, 'metering', true ),
-			'anonymous_count'  => \get_post_meta( $gate_id, 'metering_anonymous_count', true ),
-			'registered_count' => \get_post_meta( $gate_id, 'metering_registered_count', true ),
+			'anonymous_count'  => absint( \get_post_meta( $gate_id, 'metering_anonymous_count', true ) ),
+			'registered_count' => absint( \get_post_meta( $gate_id, 'metering_registered_count', true ) ),
 			'period'           => \get_post_meta( $gate_id, 'metering_period', true ),
+		];
+	}
+
+	/**
+	 * Get anonymous metering settings for a gate.
+	 *
+	 * @param int $gate_id Gate ID.
+	 *
+	 * @return array Anonymous metering settings.
+	 */
+	public static function get_anonymous_settings( $gate_id ) {
+		$registration = Content_Gate::get_registration_settings( $gate_id );
+		if ( empty( $registration ) ) {
+			// Fetch from legacy metering settings.
+			$metering = self::get_legacy_metering_settings( $gate_id );
+			return [
+				'enabled' => $metering['enabled'],
+				'count'   => $metering['anonymous_count'],
+				'period'  => $metering['period'],
+			];
+		}
+		return [
+			'enabled' => $registration['metering']['enabled'],
+			'count'   => absint( $registration['metering']['count'] ),
+			'period'  => $registration['metering']['period'],
+		];
+	}
+
+	/**
+	 * Get registered metering settings for a gate.
+	 *
+	 * @param int $gate_id Gate ID.
+	 *
+	 * @return array Registered metering settings.
+	 */
+	public static function get_registered_settings( $gate_id ) {
+		$custom_access = Content_Gate::get_custom_access_settings( $gate_id );
+		if ( empty( $custom_access ) ) {
+			// Fetch from legacy metering settings.
+			$metering = self::get_legacy_metering_settings( $gate_id );
+			return [
+				'enabled' => $metering['enabled'],
+				'count'   => $metering['registered_count'],
+				'period'  => $metering['period'],
+			];
+		}
+		return [
+			'enabled' => $custom_access['metering']['enabled'],
+			'count'   => absint( $custom_access['metering']['count'] ),
+			'period'  => $custom_access['metering']['period'],
 		];
 	}
 
@@ -165,14 +235,15 @@ class Metering {
 			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/dist/content-gate-metering.js' ),
 			true
 		);
+		$settings = self::get_metering_settings( $gate_post_id );
 		\wp_localize_script(
 			$handle,
 			'newspack_metering_settings',
 			[
 				'visible_paragraphs' => \get_post_meta( $gate_post_id, 'visible_paragraphs', true ),
 				'use_more_tag'       => \get_post_meta( $gate_post_id, 'use_more_tag', true ),
-				'count'              => \get_post_meta( $gate_post_id, 'metering_anonymous_count', true ),
-				'period'             => \get_post_meta( $gate_post_id, 'metering_period', true ),
+				'count'              => $settings['anonymous_count'],
+				'period'             => $settings['anonymous_period'],
 				'gate_id'            => $gate_post_id,
 				'post_id'            => get_the_ID(),
 				'article_view'       => self::$article_view,
@@ -212,16 +283,13 @@ class Metering {
 			$post_id = get_the_ID();
 		}
 		$gate_post_id = Content_Gate::get_gate_post_id( $post_id );
-		$metering     = \get_post_meta( $gate_post_id, 'metering', true );
-		if ( ! $metering ) {
-			return false;
+
+		$settings = self::get_metering_settings( $gate_post_id );
+		if ( $settings['enabled'] && ( $settings['anonymous_count'] > 0 || $settings['registered_count'] > 0 ) ) {
+			return true;
 		}
-		$anonymous_count  = \get_post_meta( $gate_post_id, 'metering_anonymous_count', true );
-		$registered_count = \get_post_meta( $gate_post_id, 'metering_registered_count', true );
-		if ( ! $anonymous_count && ! $registered_count ) {
-			return false;
-		}
-		return true;
+
+		return false;
 	}
 
 	/**
@@ -248,11 +316,9 @@ class Metering {
 			return false;
 		}
 
-		$gate_post_id    = Content_Gate::get_gate_post_id();
-		$metering        = \get_post_meta( $gate_post_id, 'metering', true );
-		$anonymous_count = \get_post_meta( $gate_post_id, 'metering_anonymous_count', true );
-
-		$is_frontend_metering = $metering && ! empty( $anonymous_count );
+		$gate_post_id         = Content_Gate::get_gate_post_id();
+		$settings             = self::get_anonymous_settings( $gate_post_id );
+		$is_frontend_metering = $settings['enabled'] && $settings['count'] > 0;
 
 		/**
 		 * Filters whether to use the frontend metering strategy.
@@ -293,11 +359,11 @@ class Metering {
 		}
 
 		$gate_post_id = Content_Gate::get_gate_post_id();
-		$metering     = \get_post_meta( $gate_post_id, 'metering', true );
+		$settings     = self::get_registered_settings( $gate_post_id );
 		$priority     = \get_post_meta( $gate_post_id, 'gate_priority', true );
 
 		// Bail if metering is not enabled.
-		if ( ! $metering ) {
+		if ( ! $settings['enabled'] || $settings['count'] <= 0 ) {
 			return false;
 		}
 
@@ -329,9 +395,7 @@ class Metering {
 			$updated_user_data                = true;
 		}
 
-		$count = (int) \get_post_meta( $gate_post_id, 'metering_registered_count', true );
-
-		$limited          = count( $user_metering_data['content'] ) >= $count;
+		$limited          = count( $user_metering_data['content'] ) >= $settings['count'];
 		$accessed_content = in_array( $post_id, $user_metering_data['content'], true );
 		if ( ! $limited && ! $accessed_content ) {
 			$user_metering_data['content'][] = $post_id;
@@ -409,7 +473,8 @@ class Metering {
 			$post_id = get_the_ID();
 		}
 		$gate_post_id = Content_Gate::get_gate_post_id( $post_id );
-		return \get_post_meta( $gate_post_id, 'metering_period', true );
+		$settings     = self::get_metering_settings( $gate_post_id );
+		return $settings['period'];
 	}
 
 	/**

--- a/includes/content-gate/class-metering.php
+++ b/includes/content-gate/class-metering.php
@@ -159,8 +159,7 @@ class Metering {
 	 * @return array Anonymous metering settings.
 	 */
 	public static function get_anonymous_settings( $gate_id ) {
-		$registration = Content_Gate::get_registration_settings( $gate_id );
-		if ( empty( $registration ) ) {
+		if ( Memberships::is_active() ) {
 			// Fetch from legacy metering settings.
 			$metering = self::get_legacy_metering_settings( $gate_id );
 			return [
@@ -169,6 +168,8 @@ class Metering {
 				'period'  => $metering['period'],
 			];
 		}
+
+		$registration = Content_Gate::get_registration_settings( $gate_id );
 		return [
 			'enabled' => $registration['metering']['enabled'],
 			'count'   => absint( $registration['metering']['count'] ),
@@ -184,8 +185,7 @@ class Metering {
 	 * @return array Registered metering settings.
 	 */
 	public static function get_registered_settings( $gate_id ) {
-		$custom_access = Content_Gate::get_custom_access_settings( $gate_id );
-		if ( empty( $custom_access ) ) {
+		if ( Memberships::is_active() ) {
 			// Fetch from legacy metering settings.
 			$metering = self::get_legacy_metering_settings( $gate_id );
 			return [
@@ -194,6 +194,8 @@ class Metering {
 				'period'  => $metering['period'],
 			];
 		}
+
+		$custom_access = Content_Gate::get_custom_access_settings( $gate_id );
 		return [
 			'enabled' => $custom_access['metering']['enabled'],
 			'count'   => absint( $custom_access['metering']['count'] ),

--- a/includes/content-gate/class-metering.php
+++ b/includes/content-gate/class-metering.php
@@ -226,7 +226,8 @@ class Metering {
 		if ( ! \is_singular() || ! Content_Gate::is_post_restricted() || ! self::is_frontend_metering() ) {
 			return;
 		}
-		$gate_post_id = Content_Gate::get_gate_post_id();
+		$gate_layout_id = Content_Gate::get_gate_layout_id();
+		$gate_post_id   = Content_Gate::get_gate_post_id();
 		$handle       = 'newspack-content-gate-metering';
 		\wp_enqueue_script(
 			$handle,
@@ -240,8 +241,8 @@ class Metering {
 			$handle,
 			'newspack_metering_settings',
 			[
-				'visible_paragraphs' => \get_post_meta( $gate_post_id, 'visible_paragraphs', true ),
-				'use_more_tag'       => \get_post_meta( $gate_post_id, 'use_more_tag', true ),
+				'visible_paragraphs' => \get_post_meta( $gate_layout_id, 'visible_paragraphs', true ),
+				'use_more_tag'       => \get_post_meta( $gate_layout_id, 'use_more_tag', true ),
 				'count'              => $settings['anonymous_count'],
 				'period'             => $settings['anonymous_period'],
 				'gate_id'            => $gate_post_id,

--- a/includes/content-gate/trait-content-gate-layout.php
+++ b/includes/content-gate/trait-content-gate-layout.php
@@ -181,21 +181,21 @@ trait Content_Gate_Layout {
 	 * Get the restricted post excerpt based on gate settings.
 	 *
 	 * @param \WP_Post $post         The post object to get excerpt from.
-	 * @param int      $gate_post_id The gate post ID containing layout settings.
+	 * @param int      $gate_layout_id The gate layout ID.
 	 *
 	 * @return string The restricted post excerpt HTML.
 	 */
-	public static function get_restricted_post_excerpt_for_gate( $post, $gate_post_id ) {
+	public static function get_restricted_post_excerpt_for_gate( $post, $gate_layout_id ) {
 		$content = $post->post_content;
 
-		$style = \get_post_meta( $gate_post_id, 'style', true );
+		$style = \get_post_meta( $gate_layout_id, 'style', true );
 
-		$use_more_tag = get_post_meta( $gate_post_id, 'use_more_tag', true );
+		$use_more_tag = get_post_meta( $gate_layout_id, 'use_more_tag', true );
 		// Use <!--more--> as threshold if it exists.
 		if ( $use_more_tag && strpos( $content, '<!--more-->' ) ) {
 			$content = apply_filters( 'newspack_gate_content', explode( '<!--more-->', $content )[0] );
 		} else {
-			$count = self::get_visible_paragraphs( $gate_post_id );
+			$count = self::get_visible_paragraphs( $gate_layout_id );
 			if ( 0 === $count ) {
 				return '';
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

NPPD-1023

Implements the necessary changes to metering to integrate with the new content gate schema from #4370.

The `get_metering_settings()` method was modified to fetch from `get_anonymous_settings()` and `get_registered_settings()`, each configured in the registration and paid access modes, respectively. Both new methods fallback to the values from `get_legacy_metering_settings()`. This should keep compatibility with the existing approach using Memberships.

Several hardcoded `get_post_meta()` for metering settings were also updated to use the appropriate getter method.

A new `get_gate_layout_id()` method was introduced, also compatible with the Memberships strategy, to fetch layout-specific settings, such as paragraph count, styles, etc.

### How to test the changes in this Pull Request:

1. Without the new content gate strategy, make sure a gate configured with Memberships works without regression toggling:
   1. anonymous metering
   2. registered metering
   3. metering countdown banner
4. Deactivate Memberships and enable the new content gate (`define( 'NEWSPACK_CONTENT_GATES', true );`)
5. Create a gate with just "Registered Access" and configure metering
6. Enable the Countdown banner
7. Using an anonymous session, confirm anonymous metering and that the countdown banner behaves as expected
8. Edit the gate and enable "Paid Access" with metering
9. Authenticate as a reader without paid access and confirm metering and that the countdown banner behaves as expected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->