### PR TITLE
fix(content-gate): persist restricted content

### DIFF
--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -165,7 +165,7 @@ class Content_Gate {
 
 		$content = self::get_restricted_post_excerpt( $post );
 
-		$post->post_content   = $content . self::get_inline_gate_content();
+		$post->post_content   = $content . self::get_inline_gate_html();
 		$post->post_excerpt   = $content;
 		$post->comment_status = 'closed';
 		$post->comment_count  = 0;

--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -44,6 +44,13 @@ class Content_Gate {
 	public static $valid_gate_post_statuses = [ 'publish', 'draft', 'pending', 'future', 'private', 'trash' ];
 
 	/**
+	 * Restricted content per post ID.
+	 *
+	 * @var string[]
+	 */
+	private static $restricted_content = [];
+
+	/**
 	 * Initialize hooks and filters.
 	 */
 	public static function init() {
@@ -56,6 +63,7 @@ class Content_Gate {
 		add_filter( 'newspack_reader_activity_article_view', [ __CLASS__, 'suppress_article_view_activity' ], 100 );
 
 		add_action( 'the_post', [ __CLASS__, 'restrict_post' ], 10, 2 );
+		add_filter( 'the_content', [ __CLASS__, 'handle_restricted_post_content_filtering' ], PHP_INT_MAX );
 
 		/** Add gate content filters to mimic 'the_content'. See 'wp-includes/default-filters.php' for reference. */
 		add_filter( 'newspack_gate_content', 'capital_P_dangit', 11 );
@@ -161,7 +169,24 @@ class Content_Gate {
 		$post->post_excerpt   = $content;
 		$post->comment_status = 'closed';
 		$post->comment_count  = 0;
+
+		self::$restricted_content[ $post->ID ] = $post->post_content;
+
 		self::mark_gate_as_rendered();
+	}
+
+	/**
+	 * Handle restricted post content filtering.
+	 *
+	 * @param string $content Content.
+	 *
+	 * @return string
+	 */
+	public static function handle_restricted_post_content_filtering( $content ) {
+		if ( ! isset( self::$restricted_content[ get_the_ID() ] ) ) {
+			return $content;
+		}
+		return self::$restricted_content[ get_the_ID() ];
 	}
 
 	/**

--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -63,7 +63,7 @@ class Content_Gate {
 		add_filter( 'newspack_reader_activity_article_view', [ __CLASS__, 'suppress_article_view_activity' ], 100 );
 
 		add_action( 'the_post', [ __CLASS__, 'restrict_post' ], 10, 2 );
-		add_filter( 'the_content', [ __CLASS__, 'handle_restricted_post_content_filtering' ], PHP_INT_MAX );
+		add_filter( 'the_content', [ __CLASS__, 'handle_restricted_content' ], PHP_INT_MAX );
 
 		/** Add gate content filters to mimic 'the_content'. See 'wp-includes/default-filters.php' for reference. */
 		add_filter( 'newspack_gate_content', 'capital_P_dangit', 11 );
@@ -182,7 +182,7 @@ class Content_Gate {
 	 *
 	 * @return string
 	 */
-	public static function handle_restricted_post_content_filtering( $content ) {
+	public static function handle_restricted_content( $content ) {
 		if ( ! isset( self::$restricted_content[ get_the_ID() ] ) ) {
 			return $content;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Filters applied to `the_content` may restore the original content to a restricted post. This ensures the restricted content persists.

### How to test the changes in this Pull Request:

1. Without Woo Memberships, configure a content gate (Audience -> Content Gates) with inline layout
2. While in trunk, visit a restricted post and confirm the gate never renders, and the original post is displayed
3. Checkout this branch, run `wp cache flush`, and refresh the page
4. Confirm the content is restricted, and the gate now renders in the expected position
5. Change the gate layout to overlay and confirm it renders as expected and the content is also restricted

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->