### PR TITLE
fix(countdown-banner): cache result of `is_enabled()` check

### DIFF
--- a/includes/content-gate/class-metering-countdown.php
+++ b/includes/content-gate/class-metering-countdown.php
@@ -141,7 +141,6 @@ class Metering_Countdown {
 
 		// In customizer preview.
 		if ( self::$is_enabled && is_customize_preview() ) {
-			self::$is_enabled = true;
 			return self::$is_enabled;
 		}
 

--- a/includes/content-gate/class-metering-countdown.php
+++ b/includes/content-gate/class-metering-countdown.php
@@ -15,6 +15,13 @@ class Metering_Countdown {
 	const OPTION_PREFIX = 'np_countdown_banner_';
 
 	/**
+	 * Whether the countdown banner is enabled.
+	 *
+	 * @var bool
+	 */
+	private static $is_enabled = null;
+
+	/**
 	 * Initialize hooks.
 	 */
 	public static function init() {
@@ -126,20 +133,25 @@ class Metering_Countdown {
 	 * @return bool
 	 */
 	public static function is_enabled() {
+		if ( is_bool( self::$is_enabled ) ) {
+			return self::$is_enabled;
+		}
 		// Only when singular and if enabled in the settings.
-		$enabled = ! is_admin() && is_singular() && self::get_settings( 'enabled' );
+		self::$is_enabled = ! is_admin() && is_singular() && self::get_settings( 'enabled' );
 
 		// In customizer preview.
-		if ( $enabled && is_customize_preview() ) {
-			return true;
+		if ( self::$is_enabled && is_customize_preview() ) {
+			self::$is_enabled = true;
+			return self::$is_enabled;
 		}
 
 		// In the frontend only when the post is metered.
 		if ( ! Metering::is_metering() || ! Content_Gate::is_post_restricted() ) {
-			return false;
+			self::$is_enabled = false;
+			return self::$is_enabled;
 		}
 
-		return $enabled;
+		return self::$is_enabled;
 	}
 
 	/**

--- a/includes/content-gate/class-metering-countdown.php
+++ b/includes/content-gate/class-metering-countdown.php
@@ -138,6 +138,9 @@ class Metering_Countdown {
 		}
 		// Only when singular and if enabled in the settings.
 		self::$is_enabled = ! is_admin() && is_singular() && self::get_settings( 'enabled' );
+		if ( false === self::$is_enabled ) {
+			return self::$is_enabled;
+		}
 
 		// In customizer preview.
 		if ( self::$is_enabled && is_customize_preview() ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Plugs a performance hole by memoizing the result of `Metering_Countdown::is_enabled()` to avoid redundant checks that can cause extra calculations and site slowdowns. 

#2243 proposes some additional improvements that are worth making for content gating logic, but this PR should hotfix a known performance issue for live sites already using metered content gates.

Closes NPPM-2543.

### How to test the changes in this Pull Request:

1. On `release`, add an `error_log( 'post is not metered or restricted' );` after [line 138](https://github.com/Automattic/newspack-plugin/blob/release/includes/content-gate/class-metering-countdown.php#L138) and visit a post that's NOT affected by content gating rules. Observe that your test error log is logged many times for the single page request, demonstrating that this method is running a lot more often than needed.
2. Check out this branch and repeat, and confirm that the error log appears only once per page request.
3. Smoke test countdown banner functionality to make sure it still works as described in #4366.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->