### PR TITLE
fix(content-gating): evaluate registration requirement before paid access

### DIFF
--- a/includes/content-gate/class-content-restriction-control.php
+++ b/includes/content-gate/class-content-restriction-control.php
@@ -185,22 +185,8 @@ class Content_Restriction_Control {
 			$gate_layout_id = null;
 			$is_restricted  = false;
 
-			// Check custom_access mode first (higher priority).
-			if ( ! empty( $gate['custom_access']['active'] ) ) {
-				$access_rules = $gate['custom_access']['access_rules'] ?? [];
-				if ( ! empty( $access_rules ) ) {
-					foreach ( $access_rules as $rule ) {
-						if ( ! Access_Rules::evaluate_rule( $rule['slug'], $rule['value'] ?? null ) ) {
-							$is_restricted  = true;
-							$gate_layout_id = $gate['custom_access']['gate_layout_id'] ?? $gate['id'];
-							break;
-						}
-					}
-				}
-			}
-
-			// If custom_access didn't restrict and registration mode is active.
-			if ( ! $is_restricted && ! empty( $gate['registration']['active'] ) ) {
+			// If registration mode is active.
+			if ( ! empty( $gate['registration']['active'] ) ) {
 				// Check if user is logged in.
 				if ( ! \is_user_logged_in() ) {
 					$is_restricted  = true;
@@ -211,6 +197,20 @@ class Content_Restriction_Control {
 					if ( ! \get_user_meta( $user->ID, Reader_Activation::EMAIL_VERIFIED, true ) ) {
 						$is_restricted  = true;
 						$gate_layout_id = $gate['registration']['gate_layout_id'] ?? $gate['id'];
+					}
+				}
+			}
+
+			// If custom_access mode is active.
+			if ( ! $is_restricted && ! empty( $gate['custom_access']['active'] ) ) {
+				$access_rules = $gate['custom_access']['access_rules'] ?? [];
+				if ( ! empty( $access_rules ) ) {
+					foreach ( $access_rules as $rule ) {
+						if ( ! Access_Rules::evaluate_rule( $rule['slug'], $rule['value'] ?? null ) ) {
+							$is_restricted  = true;
+							$gate_layout_id = $gate['custom_access']['gate_layout_id'] ?? $gate['id'];
+							break;
+						}
 					}
 				}
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Redo of #4421 but without applying the extra content filter, as discussed in #4420. Evaluates Registration gate layout requirements and renders it before Paid Access.

### How to test the changes in this Pull Request:

1. Check out this branch and make sure Woo Memberships is deactivated and `define( 'NEWSPACK_CONTENT_GATES', true );` is defined in wp-config.php.
2. In **Audience > Content Gates** publish a content gate and enable both Registration and Paid Access options, with a subscription product access rule enabled for the latter. Edit and publish gate layouts for both sections.
3. In a new reader session, visit a post restricted by the content gate and confirm that you see the Registration gate layout first.
4. Register a new reader account , and confirm after refresh that you now see the Paid Access gate layout.
5. Purchase the required subscription product for paid access and confirm that you now have access to the restricted content.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->