### PR TITLE
fix(my-account): "order again" checkout redirect

### DIFF
--- a/src/my-account/v1/modal-checkout.js
+++ b/src/my-account/v1/modal-checkout.js
@@ -55,10 +55,17 @@ domReady( () => {
 	 */
 	const orderAgain = document.querySelectorAll( 'p.order-again a' );
 	orderAgain.forEach( button => {
-		registerModalCheckoutButton( button, null, 'order_again', data => {
-			// Track the reorder.
-			window.newspackRAS.push( [ 'product_reordered', { order_id: data.order_id, product_id: data.product_id } ] );
-		} );
+		registerModalCheckoutButton(
+			button,
+			null,
+			'order_again',
+			data => {
+				// Track the reorder.
+				window.newspackRAS.push( [ 'product_reordered', { order_id: data.order_id, product_id: data.product_id } ] );
+			},
+			null,
+			false
+		);
 	} );
 
 	/**

--- a/src/my-account/v1/utils.js
+++ b/src/my-account/v1/utils.js
@@ -44,13 +44,14 @@ function handleClose() {
  * Must receive a link element with a `href` attribute that points to a cart
  * generation URL.
  *
- * @param {HTMLElement} element            The element to register.
- * @param {string}      title              The modal title.
- * @param {string}      actionType         The action type.
- * @param {Function}    onCheckoutComplete The function to call when the checkout is complete.
- * @param {Function}    onClose            The function to call when the modal is closed. Default is `handleClose`.
+ * @param {HTMLElement} element               The element to register.
+ * @param {string}      title                 The modal title.
+ * @param {string}      actionType            The action type.
+ * @param {Function}    onCheckoutComplete    The function to call when the checkout is complete.
+ * @param {Function}    onClose               The function to call when the modal is closed. Default is `handleClose`.
+ * @param {boolean}     redirectToResponseUrl Whether to redirect to the response URL. Default is `true`.
  */
-export function registerModalCheckoutButton( element, title, actionType, onCheckoutComplete, onClose ) {
+export function registerModalCheckoutButton( element, title, actionType, onCheckoutComplete, onClose, redirectToResponseUrl = true ) {
 	const spinner = document.createElement( 'div' );
 	spinner.classList.add( 'newspack-ui' );
 	spinner.innerHTML = '<div class="newspack-ui__spinner"><span></span></div>';
@@ -58,7 +59,7 @@ export function registerModalCheckoutButton( element, title, actionType, onCheck
 	const openCheckout = async url => {
 		const response = await fetch( url );
 		window.newspackOpenModalCheckout( {
-			url: response.url,
+			url: redirectToResponseUrl ? response.url : null,
 			title,
 			actionType,
 			onCheckoutComplete: data => {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

NPPM-2561

Since https://github.com/Automattic/newspack-blocks/pull/2141, the `newspackOpenModalCheckout()` function allows the incoming URL to set the modal destination. This is to support different checkout endpoints, like when changing the payment method.

This breaks the modal for the "Order again" button because it redirects to the cart page, which is not supported in the modal.

This PR fixes the issue by introducing a `redirectToResponseUrl` bool to the button registration, allowing the "Order again" button to not set the redirect URL. In this case, it'll resort to the default checkout URL.

### How to test the changes in this Pull Request:

1. As a reader, do a one-time donation
2. Visit the order page and click "Order again"
3. Confirm you get an error:

<img width="1696" height="750" alt="image" src="https://github.com/user-attachments/assets/f2a271ca-340a-4ef4-bbee-a22875537329" />

4. Checkout this branch, refresh the order page, and click the "Order again" button
5. Confirm the modal renders without error,s and you are able to complete the order

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->