### PR TITLE
fix(memberships): allow free trial members to comment

### DIFF
--- a/includes/optional-modules/class-woo-member-commenting.php
+++ b/includes/optional-modules/class-woo-member-commenting.php
@@ -134,7 +134,7 @@ class Woo_Member_Commenting {
 				wc_memberships_get_user_memberships(
 					get_current_user_id(),
 					[
-						'status' => [ 'active', 'complimentary', 'free_trial', 'pending' ],
+						'status' => Memberships::$active_statuses,
 					]
 				),
 				fn( $membership ) => in_array( $membership->get_plan()->get_slug(), self::get_plan_slugs() )

--- a/includes/optional-modules/class-woo-member-commenting.php
+++ b/includes/optional-modules/class-woo-member-commenting.php
@@ -134,7 +134,7 @@ class Woo_Member_Commenting {
 				wc_memberships_get_user_memberships(
 					get_current_user_id(),
 					[
-						'status' => Memberships::$active_statuses,
+						'status' => [ 'active', 'complimentary', 'free_trial', 'pending' ],
 					]
 				),
 				fn( $membership ) => in_array( $membership->get_plan()->get_slug(), self::get_plan_slugs() )

--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -27,7 +27,7 @@ class Memberships {
 	 *
 	 * @var array
 	 */
-	public static $active_statuses = [ 'active', 'complimentary', 'free-trial', 'pending' ];
+	public static $active_statuses = [ 'active', 'complimentary', 'free_trial', 'pending' ];
 
 	/**
 	 * Initialize hooks and filters.


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://linear.app/a8c/issue/NPPM-2553/newsroom-nz-comments-not-working-for-free-trial-members-on-live-site

This PR addresses an issue where we were incorrectly filtering memberships with an "active" status, omitting free trial memberships. The [`Memberships::$active_statuses`](https://github.com/Automattic/newspack-plugin/blob/c58fd3211ebf0894b87866529b37e93159f869e5/includes/plugins/wc-memberships/class-memberships.php#L32) array uses a hyphen rather than an underscore, which the `wc_memberships_get_user_memberships` methods requires. 

~~Since I'm not familiar with the memberships implementation here or whether there are varying cases of `free-trial` and/or `free_trial` used, I am simply declaring a new array of statuses and passing that to `wc_memberships_get_user_memberships`.~~

### How to test the changes in this Pull Request:

1. Set up the woo memberships commenting module by adding the constant to `wp-config.php` (see below)
2. Set up a membership tied to a subscription with a free trial
3. As a reader, purchase the subscription with free trial. On `release` you won't be able to comment on any posts. On this branch you will.

```
const NP_WC_MEMBER_COMMENT_SETTINGS = [
  'membership_plan_slug'        => ['membership_slug'], // Slug(s) of membership plans. 
  'membership_purchase_post_id'     => 2, // Post id to a page/post with membershipt tease
  'membership_required_message' => "Become a member, why don't cha?",
];
```

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->