### PR TITLE
fix: add fallback selector for the content gate in block theme

### DIFF
--- a/src/content-gate/gate.js
+++ b/src/content-gate/gate.js
@@ -245,7 +245,7 @@ function handleFormSubmission( evt, gate ) {
 function initOverlay( gate ) {
 	let entry = document.querySelector( '.entry-content' );
 	if ( ! entry ) {
-		entry = document.querySelector( '#content' );
+		entry = document.querySelector( '#content, #wp--skip-link--target' );
 	}
 	gate.style.removeProperty( 'display' );
 	let seen = false;

--- a/src/content-gate/gate.js
+++ b/src/content-gate/gate.js
@@ -245,7 +245,7 @@ function handleFormSubmission( evt, gate ) {
 function initOverlay( gate ) {
 	let entry = document.querySelector( '.entry-content' );
 	if ( ! entry ) {
-		entry = document.querySelector( '#content, #wp--skip-link--target' );
+		entry = document.querySelector( '#content' ) || document.querySelector( 'main' );
 	}
 	gate.style.removeProperty( 'display' );
 	let seen = false;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Both styles of content gate seem to work well out of the box with the block theme. So far, the only thing I've noticed is missing is some kind of fallback for the `entry` selector.

The Post Content block (part of the Query Block) [also uses `.entry-content` as a CSS class](https://github.com/WordPress/gutenberg/blob/ba0dc9a7c83078609de5b6e51f10263d8ba11ae8/packages/block-library/src/post-content/index.php#L63), so the main selector is available.

The `#content` ID that's used as a fallback isn't part of the block theme. Instead of trying to add it, I added a second fallback using `#wp--skip-link--target`, which is added to the `<main>` element by [some JS in WordPress](https://github.com/WordPress/wordpress-develop/blob/0b50baa5d164bedd17d3ae9e2eafc6286d6255b6/src/wp-includes/theme-templates.php#L172-L210), at roughly the same level as `#content`. 

See NPPD-1126

### How to test the changes in this Pull Request:

1. Apply this PR & run `npm run build`.
2. Test on a site running our block theme.
3. Set up a Content Gate (either using Memberships or Newspack gates), and set the gate to be an overlay.
4. Test in an incognito window, and confirm the gate is triggered.
5. Edit line 246 in the src/content-gate/gate.js file to modify the initial `let entry` definition, to make sure it doesn't match any CSS classes, so the fallback will need to be used (eg. `let entry = document.querySelector( '.entry-content-not-a-real-class' );`
6. Rerun `npm run build`, and retest the gate in the incognito window. The skip link ID is fairly high so the gate will trigger before scolling, but this is also the case with the Classic theme and `#content` (it contains the post header, whereas `.entry-content` only contains the post body).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->