### PR TITLE
fix(subscriptions): skip free trial tweak during switches

### DIFF
--- a/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
+++ b/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
@@ -247,6 +247,21 @@ class WooCommerce_Subscriptions {
 	 * @return int The trial length.
 	 */
 	public static function limit_free_trials_to_one_per_user( $trial_length, $product ) {
+		/**
+		 * Bail if this is a subscription switch.
+		 *
+		 * Subscription switches mock a free trial on the cart item to make sure
+		 * the switch total doesn't include any recurring amount.
+		 *
+		 * With this method, if the product being switched to is a subscription
+		 * already owned, it'll charge the full subscription amount + proration.
+		 *
+		 * @see https://github.com/woocommerce/woocommerce-subscriptions/blob/8a3cd300786218d76eb51d28b8d2d9ff5eee3ef6/includes/switching/class-wc-subscriptions-switcher.php#L134
+		 */
+		if ( class_exists( 'WC_Subscriptions_Switcher' ) && \WC_Subscriptions_Switcher::cart_contains_switches() ) {
+			return $trial_length;
+		}
+
 		$user_id = get_current_user_id();
 
 		// If not logged in, try to get the user ID from the billing email.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Subscription switches [mock a free trial](https://github.com/woocommerce/woocommerce-subscriptions/blob/8a3cd300786218d76eb51d28b8d2d9ff5eee3ef6/includes/switching/class-wc-subscriptions-switcher.php#L134) to exclude recurring amounts from the switch checkout.

This conflicts with our free trial limiter if the subscription product the customer is switching to is already owned (😄). It'll override the mock and charge the full subscription amount + calculated proration.

### How to test the changes in this Pull Request:

1. While in trunk, setup a variable subscription product and, as a reader, purchase 2 variations
2. In My Account, visit one of the subscription and click "Change subscription"
3. Select a variation you already own
4. Confirm the upgrade is being charged the full subscription amount + the calculated proration
5. Switch to this branch, click "Change subscription" again, and confirm the upgrade charge is correct
6. Follow the steps from #4287 and confirm there's no regression

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->