### PR TITLE
fix(collections): hide indicator for unpublished collections

### DIFF
--- a/includes/collections/class-content-inserter.php
+++ b/includes/collections/class-content-inserter.php
@@ -64,14 +64,9 @@ class Content_Inserter {
 			return;
 		}
 
-		$collections = Query_Helper::get_post_collections( $post );
-		if ( empty( $collections ) ) {
-			return;
-		}
-
 		// Only show indicators for published collections.
 		$collections = array_filter(
-			$collections,
+			Query_Helper::get_post_collections( $post ),
 			function ( $collection_id ) {
 				return 'publish' === get_post_status( $collection_id );
 			}

--- a/includes/collections/class-content-inserter.php
+++ b/includes/collections/class-content-inserter.php
@@ -69,6 +69,17 @@ class Content_Inserter {
 			return;
 		}
 
+		// Only show indicators for published collections.
+		$collections = array_filter(
+			$collections,
+			function ( $collection_id ) {
+				return 'publish' === get_post_status( $collection_id );
+			}
+		);
+		if ( empty( $collections ) ) {
+			return;
+		}
+
 		// Sort by post date descending.
 		usort(
 			$collections,

--- a/tests/unit-tests/collections/class-test-content-inserter.php
+++ b/tests/unit-tests/collections/class-test-content-inserter.php
@@ -319,12 +319,12 @@ class Test_Content_Inserter extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test check_if_post_is_in_collection with mix of published and draft collections.
+	 * Test check_if_post_is_in_collection with mix of published, draft, and scheduled collections.
 	 *
 	 * @covers \Newspack\Collections\Content_Inserter::check_if_post_is_in_collection
 	 */
 	public function test_mixed_status_collections_only_includes_published() {
-		// Create one published and one draft collection.
+		// Create one published, one draft, and one scheduled collection.
 		$published_id = $this->create_test_collection(
 			[
 				'post_title'  => 'Published Collection',
@@ -339,12 +339,21 @@ class Test_Content_Inserter extends \WP_UnitTestCase {
 				'post_status' => 'draft',
 			]
 		);
+		$scheduled_id = $this->create_test_collection(
+			[
+				'post_title'  => 'Scheduled Collection',
+				'post_name'   => 'scheduled-collection',
+				'post_status' => 'future',
+				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '+1 week' ) ),
+			]
+		);
 
-		// Create a post and assign it to both collections.
-		$post_id          = self::factory()->post->create();
-		$published_term   = Sync::get_term_linked_to_collection( $published_id );
-		$draft_term       = Sync::get_term_linked_to_collection( $draft_id );
-		wp_set_object_terms( $post_id, [ $published_term, $draft_term ], Collection_Taxonomy::get_taxonomy() );
+		// Create a post and assign it to all three collections.
+		$post_id        = self::factory()->post->create();
+		$published_term = Sync::get_term_linked_to_collection( $published_id );
+		$draft_term     = Sync::get_term_linked_to_collection( $draft_id );
+		$scheduled_term = Sync::get_term_linked_to_collection( $scheduled_id );
+		wp_set_object_terms( $post_id, [ $published_term, $draft_term, $scheduled_term ], Collection_Taxonomy::get_taxonomy() );
 
 		$this->go_to( get_permalink( $post_id ) );
 		Content_Inserter::check_if_post_is_in_collection();
@@ -355,6 +364,7 @@ class Test_Content_Inserter extends \WP_UnitTestCase {
 
 		$this->assertContains( $published_id, $collections, 'Published collection should be included.' );
 		$this->assertNotContains( $draft_id, $collections, 'Draft collection should be excluded.' );
+		$this->assertNotContains( $scheduled_id, $collections, 'Scheduled collection should be excluded.' );
 
 		// Clean up.
 		$this->reset_enqueuer_data();

--- a/tests/unit-tests/collections/class-test-content-inserter.php
+++ b/tests/unit-tests/collections/class-test-content-inserter.php
@@ -279,6 +279,88 @@ class Test_Content_Inserter extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test check_if_post_is_in_collection excludes draft collections.
+	 *
+	 * @covers \Newspack\Collections\Content_Inserter::check_if_post_is_in_collection
+	 */
+	public function test_draft_collection_excludes_indicator() {
+		$filter_name     = 'the_content';
+		$filter_function = [ Content_Inserter::class, 'maybe_insert_collection_indicators' ];
+
+		// Create a draft collection and assign a post to it.
+		$collection_id = $this->create_test_collection( [ 'post_status' => 'draft' ] );
+		$post_id       = self::factory()->post->create();
+		$term_id       = Sync::get_term_linked_to_collection( $collection_id );
+		wp_set_object_terms( $post_id, $term_id, Collection_Taxonomy::get_taxonomy() );
+
+		$this->go_to( get_permalink( $post_id ) );
+		Content_Inserter::check_if_post_is_in_collection();
+
+		$this->assertFalse( has_filter( $filter_name, $filter_function ), 'Filter should not be added when collection is a draft.' );
+
+		// Reset state.
+		$this->reset_content_inserter_state();
+
+		// Now publish the collection and verify the filter IS added.
+		wp_update_post(
+			[
+				'ID'          => $collection_id,
+				'post_status' => 'publish',
+			]
+		);
+
+		$this->go_to( get_permalink( $post_id ) );
+		Content_Inserter::check_if_post_is_in_collection();
+
+		$this->assertNotFalse( has_filter( $filter_name, $filter_function ), 'Filter should be added when collection is published.' );
+
+		// Clean up.
+		$this->reset_enqueuer_data();
+	}
+
+	/**
+	 * Test check_if_post_is_in_collection with mix of published and draft collections.
+	 *
+	 * @covers \Newspack\Collections\Content_Inserter::check_if_post_is_in_collection
+	 */
+	public function test_mixed_status_collections_only_includes_published() {
+		// Create one published and one draft collection.
+		$published_id = $this->create_test_collection(
+			[
+				'post_title'  => 'Published Collection',
+				'post_name'   => 'published-collection',
+				'post_status' => 'publish',
+			]
+		);
+		$draft_id     = $this->create_test_collection(
+			[
+				'post_title'  => 'Draft Collection',
+				'post_name'   => 'draft-collection',
+				'post_status' => 'draft',
+			]
+		);
+
+		// Create a post and assign it to both collections.
+		$post_id          = self::factory()->post->create();
+		$published_term   = Sync::get_term_linked_to_collection( $published_id );
+		$draft_term       = Sync::get_term_linked_to_collection( $draft_id );
+		wp_set_object_terms( $post_id, [ $published_term, $draft_term ], Collection_Taxonomy::get_taxonomy() );
+
+		$this->go_to( get_permalink( $post_id ) );
+		Content_Inserter::check_if_post_is_in_collection();
+
+		// The stored collections should only include the published one.
+		$reflection  = new \ReflectionClass( Content_Inserter::class );
+		$collections = $reflection->getStaticPropertyValue( 'post_collections' );
+
+		$this->assertContains( $published_id, $collections, 'Published collection should be included.' );
+		$this->assertNotContains( $draft_id, $collections, 'Draft collection should be excluded.' );
+
+		// Clean up.
+		$this->reset_enqueuer_data();
+	}
+
+	/**
 	 * Test build_default_indicator_html with empty collections.
 	 *
 	 * @covers \Newspack\Collections\Content_Inserter::build_default_indicator_html


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

When a published post is assigned to a draft or scheduled Collection, the frontend no longer displays the collection indicator ("This article appears in..." text or "Browse [CollectionName]" card). Previously, the indicator would render regardless of the Collection's publish status, resulting in broken links and premature disclosure of upcoming Collections.

Closes NPPM-2558.

### How to test the changes in this Pull Request:

1. The Collections module should be enabled (Newspack > Settings > Collections).
2. Create a new Collection and leave it as a **draft**.
3. Create and publish a regular post, then assign it to the draft Collection via the Collection Settings panel in the post editor.
4. View the published post on the frontend. Verify **no** collection indicator appears (neither the "This article appears in..." text nor the "Browse" card variant).
5. Now publish the Collection.
6. Reload the post on the frontend. Verify the collection indicator **does** appear with a working link.
7. Create a second Collection (published) and assign the same post to both collections. Verify only the published collection appears in the indicator.
8. PHP tests should pass: `phpunit --filter Test_Content_Inserter`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?