### PR TITLE
fix: remove alignments from the My Account Block button

### DIFF
--- a/src/blocks/my-account-button/block.json
+++ b/src/blocks/my-account-button/block.json
@@ -24,7 +24,7 @@
 	},
 	"supports": {
 		"anchor": true,
-		"align": true,
+		"align": false,
 		"color": {
 			"background": true,
 			"text": true


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR removes the block alignment from the My Account Block:
* It doesn't really make sense to align the block wide or full
* The block's currently marked up like a Buttons block (with a wp-block-buttons and wp-block-button wrapper); we could make the exterior flex, but then I think aligning the block left/right/centre within that wouldn't make any sense
* We can achieve any right/left/centre alignments using the Row block

### How to test the changes in this Pull Request:

1. Apply the PR on a site running the block theme.
2. Add the My Account button block to the page content.
3. Check the block toolbar and confirm you don't have any alignment options.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->