### PR TITLE
fix: iframe editor compatiblity

### DIFF
--- a/includes/class-newspack-ui.php
+++ b/includes/class-newspack-ui.php
@@ -28,7 +28,7 @@ class Newspack_UI {
 	public static function init() {
 		\add_action( 'wp_enqueue_scripts', [ __CLASS__, 'enqueue_assets' ] );
 		\add_action( 'admin_enqueue_scripts', [ __CLASS__, 'enqueue_assets' ] );
-		\add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'enqueue_assets' ] );
+		\add_action( 'enqueue_block_assets', [ __CLASS__, 'enqueue_assets' ] );
 		\add_filter( 'the_content', [ __CLASS__, 'load_demo' ] );
 		\add_action( 'admin_enqueue_scripts', [ __CLASS__, 'theme_colors_css' ] );
 		// Only run if the site is using a block theme.

--- a/includes/class-newspack-ui.php
+++ b/includes/class-newspack-ui.php
@@ -26,7 +26,6 @@ class Newspack_UI {
 	 * Initialize hooks.
 	 */
 	public static function init() {
-		\add_action( 'wp_enqueue_scripts', [ __CLASS__, 'enqueue_assets' ] );
 		\add_action( 'admin_enqueue_scripts', [ __CLASS__, 'enqueue_assets' ] );
 		\add_action( 'enqueue_block_assets', [ __CLASS__, 'enqueue_assets' ] );
 		\add_filter( 'the_content', [ __CLASS__, 'load_demo' ] );

--- a/includes/plugins/co-authors-plus/class-nicename-change.php
+++ b/includes/plugins/co-authors-plus/class-nicename-change.php
@@ -224,7 +224,7 @@ class Nicename_Change {
 	 * @param string $new_nicename  The new nicename.
 	 */
 	public static function handle_old_nicename_meta( $user_id, $old_nicename, $new_nicename ) {
-		$old_nicename_meta = (array) get_user_meta( $user_id, self::OLD_NICENAME_META_KEY );
+		$old_nicename_meta = (array) get_user_meta( $user_id, self::OLD_NICENAME_META_KEY, false );
 
 		// If we haven't added this old nicename before, add it now.
 		if ( ! empty( $old_nicename ) && ! in_array( $old_nicename, $old_nicename_meta, true ) ) {

--- a/includes/revisions-control/class-major-revision.php
+++ b/includes/revisions-control/class-major-revision.php
@@ -60,7 +60,7 @@ class Major_Revision {
 	 * @return array
 	 */
 	public function get_post_revisions() {
-		$ids = get_post_meta( $this->post_id, self::MAJOR_IDS_META_KEY );
+		$ids = get_post_meta( $this->post_id, self::MAJOR_IDS_META_KEY, false );
 		if ( empty( $ids ) ) {
 			return [];
 		}

--- a/src/blocks/avatar/block.json
+++ b/src/blocks/avatar/block.json
@@ -1,4 +1,5 @@
 {
+	"apiVersion": 3,
 	"name": "newspack/avatar",
 	"category": "newspack",
 	"attributes": {

--- a/src/blocks/avatar/block.json
+++ b/src/blocks/avatar/block.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "newspack/avatar",
 	"category": "newspack",

--- a/src/blocks/avatar/edit.jsx
+++ b/src/blocks/avatar/edit.jsx
@@ -159,7 +159,7 @@ const Edit = ( { attributes, context, setAttributes } ) => {
 								alt: author?.name || author?.display_name || '',
 							};
 							return renderAvatar( currentAvatar, author.id || index );
-					} )
+					  } )
 					: renderAvatar( avatar, 'single-author' ) }
 			</div>
 		</>

--- a/src/blocks/avatar/edit.jsx
+++ b/src/blocks/avatar/edit.jsx
@@ -149,7 +149,7 @@ const Edit = ( { attributes, context, setAttributes } ) => {
 		<AvatarWrapper key={ key } avatar={ currentAvatar } size={ attributes.size } attributes={ attributes } />
 	);
 	return (
-		<>
+		<div { ...blockProps }>
 			<AvatarInspectorControls attributes={ attributes } setAttributes={ setAttributes } />
 			{ authors?.length
 				? authors.map( ( author, index ) => {
@@ -160,7 +160,7 @@ const Edit = ( { attributes, context, setAttributes } ) => {
 						return renderAvatar( currentAvatar, author.id || index );
 				  } )
 				: renderAvatar( avatar, 'single-author' ) }
-		</>
+		</div>
 	);
 };
 

--- a/src/blocks/avatar/edit.jsx
+++ b/src/blocks/avatar/edit.jsx
@@ -149,18 +149,20 @@ const Edit = ( { attributes, context, setAttributes } ) => {
 		<AvatarWrapper key={ key } avatar={ currentAvatar } size={ attributes.size } attributes={ attributes } />
 	);
 	return (
-		<div { ...blockProps }>
+		<>
 			<AvatarInspectorControls attributes={ attributes } setAttributes={ setAttributes } />
-			{ authors?.length
-				? authors.map( ( author, index ) => {
-						const currentAvatar = {
-							src: author.avatarSrc,
-							alt: author?.name || author?.display_name || '',
-						};
-						return renderAvatar( currentAvatar, author.id || index );
-				  } )
-				: renderAvatar( avatar, 'single-author' ) }
-		</div>
+			<div { ...blockProps }>
+				{ authors?.length
+					? authors.map( ( author, index ) => {
+							const currentAvatar = {
+								src: author.avatarSrc,
+								alt: author?.name || author?.display_name || '',
+							};
+							return renderAvatar( currentAvatar, author.id || index );
+					} )
+					: renderAvatar( avatar, 'single-author' ) }
+			</div>
+		</>
 	);
 };
 

--- a/src/blocks/correction-box/block.json
+++ b/src/blocks/correction-box/block.json
@@ -1,4 +1,6 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
 	"name": "newspack/correction-box",
 	"category": "newspack",
 	"attributes": {

--- a/src/blocks/correction-box/edit.jsx
+++ b/src/blocks/correction-box/edit.jsx
@@ -77,19 +77,28 @@ export default function Edit( { attributes, setAttributes } ) {
 	}
 
 	return 'wp_template' === postType ? (
-		<div { ...blockProps }>
-			<EmptyPlaceholder />
+		<>
 			<CorrectionSettings />
-		</div>
+			<div { ...blockProps }>
+				<EmptyPlaceholder />
+			</div>
+		</>
 	) : (
-		<div { ...blockProps }>
+		<>
 			<CorrectionSettings />
 			<BlockControls>
 				<ToolbarGroup>
 					<ToolbarButton icon={ update } label={ __( 'Refresh', 'newspack-plugin' ) } onClick={ toggleRefresh } />
 				</ToolbarGroup>
 			</BlockControls>
-			<ServerSideRender block={ meta.name } EmptyResponsePlaceholder={ EmptyPlaceholder } refresh={ isRefreshing } attributes={ attributes } />
-		</div>
+			<div { ...blockProps }>
+				<ServerSideRender
+					block={ meta.name }
+					EmptyResponsePlaceholder={ EmptyPlaceholder }
+					refresh={ isRefreshing }
+					attributes={ attributes }
+				/>
+			</div>
+		</>
 	);
 }

--- a/src/blocks/correction-box/edit.jsx
+++ b/src/blocks/correction-box/edit.jsx
@@ -6,7 +6,7 @@ import { update } from '@wordpress/icons';
 import { useSelect } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 import ServerSideRender from '@wordpress/server-side-render';
-import { BlockControls, InspectorControls } from '@wordpress/block-editor';
+import { BlockControls, InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { ToolbarGroup, ToolbarButton, PanelBody, PanelRow, SelectControl } from '@wordpress/components';
 
 /**
@@ -26,6 +26,7 @@ import meta from './block.json';
 export default function Edit( { attributes, setAttributes } ) {
 	const [ isRefreshing, setIsRefreshing ] = useState( false );
 	const postType = useSelect( select => select( 'core/editor' ).getCurrentPostType(), [] );
+	const blockProps = useBlockProps();
 
 	/**
 	 * Placeholder when no Corrections are available.
@@ -76,12 +77,12 @@ export default function Edit( { attributes, setAttributes } ) {
 	}
 
 	return 'wp_template' === postType ? (
-		<>
+		<div { ...blockProps }>
 			<EmptyPlaceholder />
 			<CorrectionSettings />
-		</>
+		</div>
 	) : (
-		<>
+		<div { ...blockProps }>
 			<CorrectionSettings />
 			<BlockControls>
 				<ToolbarGroup>
@@ -89,6 +90,6 @@ export default function Edit( { attributes, setAttributes } ) {
 				</ToolbarGroup>
 			</BlockControls>
 			<ServerSideRender block={ meta.name } EmptyResponsePlaceholder={ EmptyPlaceholder } refresh={ isRefreshing } attributes={ attributes } />
-		</>
+		</div>
 	);
 }

--- a/src/blocks/correction-item/block.json
+++ b/src/blocks/correction-item/block.json
@@ -1,4 +1,6 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
 	"name": "newspack/correction-item",
 	"category": "newspack",
 	"attributes": {},

--- a/src/blocks/reader-registration/block.json
+++ b/src/blocks/reader-registration/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "newspack/reader-registration",
 	"title": "Reader Registration",
 	"category": "newspack",


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://linear.app/a8c/issue/NPPM-2582/newspack-plugin-iframe-editor-compatibility

This PR ensures all of the custom blocks registered in the main Plugin work in the iframe editor.

### How to test the changes in this Pull Request:

1. Ensure ONLY the main plugin, blocks, newsletters, and popups are the only Newspack extensions active and are all on the `fix/iframe-editor-compatibility` branch.
2. Smoke test blocks in the editor + frontend (You can find a list in the linked linear issue)

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->