### PR TITLE
fix: tweak inline gate styles for block theme

### DIFF
--- a/includes/content-gate/trait-content-gate-layout.php
+++ b/includes/content-gate/trait-content-gate-layout.php
@@ -150,6 +150,16 @@ trait Content_Gate_Layout {
 	}
 
 	/**
+	 * Check if the current theme is a block theme.
+	 *
+	 * @return boolean True if the current theme is a block theme.
+	 */
+	private static function is_block_theme() {
+		return function_exists( 'wp_is_block_theme' ) && wp_is_block_theme();
+	}
+
+
+	/**
 	 * Get the number of visible paragraphs for the gate.
 	 *
 	 * @param int $gate_post_id Gate post ID.
@@ -208,8 +218,14 @@ trait Content_Gate_Layout {
 			$gate_content = '<div style="pointer-events: none; height: 10em; margin-top: -10em; width: 100%; position: absolute; background: linear-gradient(180deg, rgba(255,255,255,0) 14%, rgba(255,255,255,1) 76%); max-width: 100%;"></div>' . $gate_content;
 		}
 
+		$gate_content_classes = [ 'newspack-content-gate__gate', 'newspack-content-gate__inline-gate' ];
+		// Add a class if the current theme is a block theme.
+		if ( self::is_block_theme() ) {
+			$gate_content_classes[] = 'is-layout-constrained';
+		}
+
 		// Wrap gate in a div for styling.
-		$gate_content = '<div class="newspack-content-gate__gate newspack-content-gate__inline-gate is-layout-constrained">' . $gate_content . '</div>';
+		$gate_content = '<div class="' . esc_attr( implode( ' ', $gate_content_classes ) ) . '">' . $gate_content . '</div>';
 		return $gate_content;
 	}
 

--- a/includes/content-gate/trait-content-gate-layout.php
+++ b/includes/content-gate/trait-content-gate-layout.php
@@ -169,11 +169,11 @@ trait Content_Gate_Layout {
 		// Apply inline fade.
 		$visible_paragraphs = self::get_visible_paragraphs( $gate_post_id );
 		if ( $visible_paragraphs > 0 && \get_post_meta( $gate_post_id, 'inline_fade', true ) ) {
-			$gate = '<div style="pointer-events: none; height: 10em; margin-top: -10em; width: 100%; position: absolute; background: linear-gradient(180deg, rgba(255,255,255,0) 14%, rgba(255,255,255,1) 76%);"></div>' . $gate;
+			$gate = '<div style="pointer-events: none; height: 10em; margin-top: -10em; width: 100%; position: absolute; background: linear-gradient(180deg, rgba(255,255,255,0) 14%, rgba(255,255,255,1) 76%); max-width: 100%;"></div>' . $gate;
 		}
 
 		// Wrap gate in a div for styling.
-		$gate = '<div class="newspack-content-gate__gate newspack-content-gate__inline-gate">' . $gate . '</div>';
+		$gate = '<div class="newspack-content-gate__gate newspack-content-gate__inline-gate is-layout-constrained">' . $gate . '</div>';
 		return $gate;
 	}
 

--- a/src/content-gate/gate.scss
+++ b/src/content-gate/gate.scss
@@ -86,6 +86,9 @@
 		width: 100%;
 		overflow: clip;
 	}
+	&__inline-gate {
+		max-width: 100%;
+	}
 	&__inline-fade {
 		position: absolute;
 		bottom: 0;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR makes some tweaks to the inline Content Gate so it respects block widths. 

It needs to be tested with the Classic Theme with this PR: https://github.com/Automattic/newspack-theme/pull/2625

And it needs to be tested with the Block theme with this PR: https://github.com/Automattic/newspack-block-theme/pull/407

Closes NPPD-1180

### How to test the changes in this Pull Request:

1. Apply this PR to the plugin, https://github.com/Automattic/newspack-theme/pull/2625 to the classic theme, and https://github.com/Automattic/newspack-block-theme/pull/407 to the block theme.
2. Set the site to use the Block Theme. 
3. Reset any Single templates you've may have edited in the Site Editor.
4. Set up a Content Gate using either Memberships or the new Newspack approach; make it inline.
5. In the Gate content, use one of the Content Gate patterns with a wide block. 
6. In an incognito window, view a post on the front end and confirm the gate uses the wide width):

<img width="2796" height="1320" alt="CleanShot 2026-02-02 at 13 05 33@2x" src="https://github.com/user-attachments/assets/124db1e5-a89d-442a-aed4-191c6bc5ecd4" />

9. Try editing your post and changing the template to "Single - Sidebar Layout"; Save.
10. View the front-end in an incognito window and confirm that the gate doesn't go outside of the content area: 

<img width="2670" height="1426" alt="CleanShot 2026-02-02 at 13 07 07" src="https://github.com/user-attachments/assets/eff9b04c-ea98-4bf2-99ac-7b42cde44437" />

11. Try rotating through a few other single post templates and make sure things look okay.
12. Try editing the gate and confirm that full-width and regular width blocks also display as expected.
13. Switch to the Classic theme.
14. Repeat the steps 6-12 with the Classic theme, switching between the Default, One Column and One Column Wide templates. Ensure the gate displays the expected block width. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->