### PR TITLE
fix: show_if_newspack_group_subsription_enabled misspelling

### DIFF
--- a/src/other-scripts/custom-product-options/index.js
+++ b/src/other-scripts/custom-product-options/index.js
@@ -30,7 +30,7 @@
 
 	function showOrHideAllOptions( e ) {
 		const $checkbox = $( '.show_if_subscription' );
-		const $fields = $( '.show_if_newspack_group_subsription_enabled' );
+		const $fields = $( '.show_if_newspack_group_subscription_enabled' );
 
 		if ( e.currentTarget.value === 'subscription' || e.currentTarget.value === 'variable-subscription' ) {
 			$checkbox.show();


### PR DESCRIPTION
Fixes a misspelled class name that was mostly fixed in #4397, but looks like we missed one instance.