### PR TITLE
fix: make sure we get block-supports styles for the overlay gates in time

### DIFF
--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -812,8 +812,8 @@ class Content_Gate {
 		$post  = \get_post( $gate_layout_id ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		setup_postdata( $post );
 
-		// Render blocks to register layout CSS in time for wp_head.
-		\apply_filters( 'newspack_gate_content', \get_the_content( null, null, $gate_layout_id ) );
+		// Render blocks to register layout CSS in time for wp_head without invoking gate content filters.
+		\do_blocks( \get_the_content( null, null, $gate_layout_id ) );
 
 		// Loop through the block-supports rules and get only the new rules added when the gate is rendered.
 		$block_supports_css = '';

--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -830,7 +830,7 @@ class Content_Gate {
 
 		// Print the gate's block-supports CSS inline.
 		if ( '' !== $block_supports_css ) {
-			wp_register_style( 'newspack-content-gate-block-supports', false, [], true );
+			wp_register_style( 'newspack-content-gate-block-supports', false, [], NEWSPACK_PLUGIN_VERSION );
 			wp_add_inline_style( 'newspack-content-gate-block-supports', $block_supports_css );
 			wp_enqueue_style( 'newspack-content-gate-block-supports' );
 		}

--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -783,10 +783,6 @@ class Content_Gate {
 		if ( $styles_prepared ) {
 			return;
 		}
-		// Only run for block themes.
-		if ( function_exists( 'wp_is_block_theme' ) && ! wp_is_block_theme() ) {
-			return;
-		}
 		$gate_layout_id = self::get_overlay_gate_layout_id();
 		if ( ! $gate_layout_id ) {
 			return;

--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -57,6 +57,7 @@ class Content_Gate {
 		add_action( 'init', [ __CLASS__, 'register_post_type' ] );
 		add_action( 'admin_init', [ __CLASS__, 'redirect_cpt' ] );
 		add_action( 'admin_init', [ __CLASS__, 'handle_edit_gate_layout' ] );
+		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'prepare_overlay_gate_styles' ], 21 );
 		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'enqueue_scripts' ] );
 		add_action( 'wp_footer', [ __CLASS__, 'render_overlay_gate' ], 1 );
 		add_filter( 'newspack_popups_assess_has_disabled_popups', [ __CLASS__, 'disable_popups' ] );
@@ -637,33 +638,41 @@ class Content_Gate {
 	}
 
 	/**
-	 * Render the overlay gate.
+	 * Get the overlay gate layout ID when rendering is allowed.
+	 *
+	 * @return int Gate layout ID or 0 when not renderable.
 	 */
-	public static function render_overlay_gate() {
-		if ( ! self::has_gate() ) {
-			return;
+	private static function get_overlay_gate_layout_id() {
+		if ( ! self::has_gate() || ! is_singular() || ! self::is_post_restricted() ) {
+			return 0;
 		}
-		if (
-			/**
-			 * Filters whether the overlay gate can be rendered.
-			 *
-			 * @param bool $can_render Whether the overlay gate can be rendered.
-			 */
-			! apply_filters( 'newspack_can_render_overlay_gate', true )
-		) {
-			return;
-		}
-		// Only render overlay gate for a restricted singular content.
-		if ( ! is_singular() || ! self::is_post_restricted() ) {
-			return;
+		/**
+		 * Filters whether the overlay gate can be rendered.
+		 *
+		 * @param bool $can_render Whether the overlay gate can be rendered.
+		 */
+		if ( ! apply_filters( 'newspack_can_render_overlay_gate', true ) ) {
+			return 0;
 		}
 		// Bail if metering allows rendering the content.
 		if ( ! Metering::is_frontend_metering() && Metering::is_logged_in_metering_allowed() ) {
-			return;
+			return 0;
 		}
 		$gate_layout_id = self::get_gate_layout_id();
 		$style          = \get_post_meta( $gate_layout_id, 'style', true );
 		if ( 'overlay' !== $style ) {
+			return 0;
+		}
+
+		return (int) $gate_layout_id;
+	}
+
+	/**
+	 * Render the overlay gate.
+	 */
+	public static function render_overlay_gate() {
+		$gate_layout_id = self::get_overlay_gate_layout_id();
+		if ( ! $gate_layout_id ) {
 			return;
 		}
 		self::$is_gated = true;
@@ -678,6 +687,74 @@ class Content_Gate {
 		self::mark_gate_as_rendered();
 		wp_reset_postdata();
 		$post = $_post; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+	}
+
+	/**
+	 * Prepare overlay gate styles early so block layout CSS is printed in the head.
+	 *
+	 * Otherwise, certain per-block styles -- like block alignment and spacing -- are missing from the gate content.
+	 */
+	public static function prepare_overlay_gate_styles() {
+		static $styles_prepared = false;
+		if ( $styles_prepared ) {
+			return;
+		}
+		// Only run for block themes.
+		if ( function_exists( 'wp_is_block_theme' ) && ! wp_is_block_theme() ) {
+			return;
+		}
+		$gate_layout_id = self::get_overlay_gate_layout_id();
+		if ( ! $gate_layout_id ) {
+			return;
+		}
+		// Ensure the global styles handle exists before adding inline styles.
+		if ( function_exists( 'wp_enqueue_global_styles' ) ) {
+			wp_enqueue_global_styles();
+		}
+
+		// Get existing block-supports rules so we don't repeat them with the gate's styles.
+		$store              = null;
+		$existing_rule_keys = [];
+		if ( class_exists( '\WP_Style_Engine_CSS_Rules_Store' ) && method_exists( '\WP_Style_Engine_CSS_Rules_Store', 'get_store' ) ) {
+			$store = \WP_Style_Engine_CSS_Rules_Store::get_store( 'block-supports' );
+			if ( $store && method_exists( $store, 'get_all_rules' ) ) {
+				$existing_rule_keys = array_keys( $store->get_all_rules() );
+			}
+		}
+
+		// Temporarily swap the global post with the gate's post ID.
+		global $post;
+		$_post = $post;
+		$post  = \get_post( $gate_layout_id ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		setup_postdata( $post );
+
+		// Render blocks to register layout CSS in time for wp_head.
+		\apply_filters( 'newspack_gate_content', \get_the_content( null, null, $gate_layout_id ) );
+
+		// Loop through the block-supports rules and get only the new rules added when the gate is rendered.
+		$block_supports_css = '';
+		if ( $store && method_exists( $store, 'get_all_rules' ) ) {
+			foreach ( $store->get_all_rules() as $key => $rule ) {
+				if ( in_array( $key, $existing_rule_keys, true ) ) {
+					continue;
+				}
+				if ( is_object( $rule ) && method_exists( $rule, 'get_css' ) ) {
+					$block_supports_css .= $rule->get_css();
+				}
+			}
+		}
+
+		// Print the gate's block-supports CSS inline.
+		if ( '' !== $block_supports_css ) {
+			wp_register_style( 'newspack-content-gate-block-supports', false, [], true );
+			wp_add_inline_style( 'newspack-content-gate-block-supports', $block_supports_css );
+			wp_enqueue_style( 'newspack-content-gate-block-supports' );
+		}
+
+		// Set the global post back to normal.
+		wp_reset_postdata();
+		$post = $_post; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$styles_prepared = true;
 	}
 
 	/**

--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -813,7 +813,10 @@ class Content_Gate {
 		setup_postdata( $post );
 
 		// Render blocks to register layout CSS in time for wp_head without invoking gate content filters.
+		$previous_is_gated = self::$is_gated;
+		self::$is_gated    = true;
 		\do_blocks( \get_the_content( null, null, $gate_layout_id ) );
+		self::$is_gated = $previous_is_gated;
 
 		// Loop through the block-supports rules and get only the new rules added when the gate is rendered.
 		$block_supports_css = '';

--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -801,6 +801,10 @@ class Content_Gate {
 				$existing_rule_keys = array_keys( $store->get_all_rules() );
 			}
 		}
+		// If block-supports storage isn't available, skip rendering blocks just to collect CSS.
+		if ( ! $store || ! method_exists( $store, 'get_all_rules' ) ) {
+			return;
+		}
 
 		// Temporarily swap the global post with the gate's post ID.
 		global $post;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

**Edited** I originally thought this was a block theme issue but I can recreate it on a fresh site running the Classic Theme, too. I've updated the details testing steps accordingly! 

Right now, the overlay content gate is getting inserted at `wp_footer`.

~~When a block theme is used~~ Certain block styles are generated as needed by WordPress, and they're not automatically available ~~like they are with the classic theme~~. By the time the inline gate is injected, it's "too late" for its blocks to be included in those inline styles. This means certain styles -- like block alignments and spacing -- don't work in the gates.

This PR renders the gate's content early so it can get all the styles that are needed, and adds them in their own inline styles separate from the WordPress ones. 

I'm not sure if this is the best approach. The other solution I tried was rendering the overlay earlier. That also seemed to work, but it seems more dependent on how the theme is structured, and it would involve a bit of a rewrite of the overlay styles so they'd still work. It seemed a little messier, and possibly more likely to introduce issues, so just sticking to this for now. Open to feedback on the approach though!

Closes NPPD-1181

### How to test the changes in this Pull Request:

1. Set up a content gate (using Memberships or the new Newspack approach).
2. In the Content gate, insert the Registration Card (compact) pattern (the second one in the list of Content Gate block patterns.
3. Publish.
4. In an incognito window, trigger the gate on a post - note the layout is a little messed up (the button and text should be on opposite sides, and the spacing is wrong between the two lines of text):

<img width="2716" height="1248" alt="CleanShot 2026-02-02 at 16 20 31" src="https://github.com/user-attachments/assets/6df3f315-20ff-4c9c-836c-13f8f637aced" />

5. Apply this PR and run `npm run build`.
6. Repeat step 4; confirm the gate looks better:

<img width="2678" height="918" alt="CleanShot 2026-02-02 at 16 22 13" src="https://github.com/user-attachments/assets/fea0ecdd-4c69-4c5a-a607-da3581c92037" />

7. View source and find `newspack-content-gate-block-supports` (the styles injected for the overlay block) and `core-block-supports-inline-css`. Do a bit of spot checking (mostly making sure the former isn't huge) to confirm that the `newspack-content-gate-block-supports` styles aren't repeating a bunch of stuff from `core-block-supports-inline-css`.
8. Switch to the Block theme (or classic theme if you're already testing with the block theme). 
9. Confirm that the overlay gate also looks good there. 


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->