### PR TITLE
fix: skip redirect from login modal

### DIFF
--- a/src/reader-activation-auth/index.js
+++ b/src/reader-activation-auth/index.js
@@ -47,6 +47,14 @@ window.newspackRAS.push( readerActivation => {
 			ev.preventDefault();
 			const modalTrigger = ev.target;
 			let callback, redirect;
+
+			// If reader sees this form as a modal, it's likely they'll want
+			// to dismiss the modal and stay on the underlying page when
+			// sign-in flow is complete.
+			// Detect a modal container in ancestors and flag so we can skip
+			// the redirect later.
+			const isInsideOverlay = modalTrigger.closest( '.newspack-popup, .newspack-lightbox, [class*="lightbox"], [class*="popup"]' );
+
 			if ( ev.target.getAttribute( 'data-redirect' ) ) {
 				redirect = ev.target.getAttribute( 'data-redirect' );
 			} else {
@@ -62,7 +70,9 @@ window.newspackRAS.push( readerActivation => {
 					}
 				}
 			}
-			if ( redirect && redirect !== '#' ) {
+
+			// If we're in a modal, ignore redirect so 'Continue' dismisses it and reader can continue on the current page.
+			if ( redirect && redirect !== '#' && ! isInsideOverlay ) {
 				callback = () => {
 					window.location.href = redirect;
 				};

--- a/src/reader-activation-auth/index.js
+++ b/src/reader-activation-auth/index.js
@@ -53,7 +53,9 @@ window.newspackRAS.push( readerActivation => {
 			// sign-in flow is complete.
 			// Detect a modal container in ancestors and flag so we can skip
 			// the redirect later.
-			const isInsideOverlay = modalTrigger.closest( '.newspack-popup, .newspack-lightbox, [class*="lightbox"], [class*="popup"]' );
+			const isInsideOverlay = Boolean(
+				modalTrigger.closest( '.newspack-popup, .newspack-lightbox, [class*="lightbox"], [class*="popup"]' )
+			);
 
 			if ( ev.target.getAttribute( 'data-redirect' ) ) {
 				redirect = ev.target.getAttribute( 'data-redirect' );

--- a/src/reader-activation-auth/index.js
+++ b/src/reader-activation-auth/index.js
@@ -48,14 +48,8 @@ window.newspackRAS.push( readerActivation => {
 			const modalTrigger = ev.target;
 			let callback, redirect;
 
-			// If reader sees this form as a modal, it's likely they'll want
-			// to dismiss the modal and stay on the underlying page when
-			// sign-in flow is complete.
-			// Detect a modal container in ancestors and flag so we can skip
-			// the redirect later.
-			const isInsideOverlay = Boolean(
-				modalTrigger.closest( '.newspack-popup, .newspack-lightbox, [class*="lightbox"], [class*="popup"]' )
-			);
+			// Check ancestors to see if we're signing in to an existing account.
+			const isExistingAccountFlow = Boolean( modalTrigger.closest( '.newspack-registration__have-account' ) );
 
 			if ( ev.target.getAttribute( 'data-redirect' ) ) {
 				redirect = ev.target.getAttribute( 'data-redirect' );
@@ -74,7 +68,7 @@ window.newspackRAS.push( readerActivation => {
 			}
 
 			// If we're in a modal, ignore redirect so 'Continue' dismisses it and reader can continue on the current page.
-			if ( redirect && redirect !== '#' && ! isInsideOverlay ) {
+			if ( redirect && redirect !== '#' && ! isExistingAccountFlow ) {
 				callback = () => {
 					window.location.href = redirect;
 				};


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
Login flow for existing users from Reader Registration block happens in a modal.  And end of successful login, reader has the option to either hit the 'Continue' button or the 'X' to exit the flow. 'Continue' redirects to a signup page; 'X' closes the modal and leaves the user on the page they started the flow.

This PR detects whether the form is being shown in a modal; if so, it skips the redirect step so that 'Continue' will close the modal just like the 'X' button.

Note that the block may appear on a standalone page (like `/my-account/` when not logged in).  In those cases, the existing behavior--the redirect--is left unchanged so that the reader exits at a useful location.

Addresses [NPPM-2542: Bug: Reader Registration block redirects off the current page after using the Magic Link OTP](https://linear.app/a8c/issue/NPPM-2542/bug-reader-registration-block-redirects-off-the-current-page-after).

### How to test the changes in this Pull Request:

#### Original modal flow as documented in the Linear issue
1. Pull `fix/modal-skip-login-redirect` topic branch.
2. Add the Reader Registration block to any page, such as the Home Page
4. Create a reader account on the site (if one doesn't exist).
5. Either log out or open a fresh browser session.
6. Navigate to the Reader Registration block and select "Sign into an existing account".
7. Enter the email address of the existing reader account and select "Continue".
8. Enter the OTP and hit continue.
9. On the success page, select 'Continue'. Verify it closes the modal and leaves you where you started.

#### Standalone page test
1. As 1-3 above; make sure you're logged out before proceeding.
2. Navigate to a page that will show a standalone login form, like `/my-account/`.
3. Complete the login flow.
4. On success, select 'Continue'.  Verify it redirects you off the login page.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->