### PR TITLE
fix(avatar): resolve guest author avatars in editor

### DIFF
--- a/src/blocks/avatar/class-avatar-block.php
+++ b/src/blocks/avatar/class-avatar-block.php
@@ -36,8 +36,8 @@ final class Avatar_Block {
 			register_block_style(
 				'newspack/avatar',
 				[
-					'name'  => 'stacked',
-					'label' => __( 'Stacked', 'newspack-plugin' ),
+					'name'  => 'overlapped',
+					'label' => __( 'Overlapped', 'newspack-plugin' ),
 				]
 			);
 		}

--- a/src/blocks/avatar/style.scss
+++ b/src/blocks/avatar/style.scss
@@ -3,8 +3,8 @@
 	display: flex;
 	gap: 0.5rem;
 
-	&.is-style-stacked,
-	&[class*="is-style-stacked"] {
+	&.is-style-overlapped,
+	&[class*="is-style-overlapped"] {
 		gap: 0;
 
 		.newspack-avatar-wrapper:not(:last-of-type) {

--- a/src/shared/hooks/use-coauthors.js
+++ b/src/shared/hooks/use-coauthors.js
@@ -25,6 +25,22 @@ export function resetGuestAvatarCacheForTests() {
 }
 
 /**
+ * Extract user_nicename from an author_link URL.
+ * Strips query params and hash fragments, then takes the last path segment.
+ * Returns undefined if the link is missing or yields no valid slug.
+ *
+ * @param {string} link Author archive URL.
+ * @return {string|undefined} The extracted nicename, or undefined.
+ */
+function extractNicenameFromLink( link ) {
+	if ( ! link ) {
+		return undefined;
+	}
+	const slug = link.split( '?' )[ 0 ].split( '#' )[ 0 ].replace( /\/$/, '' ).split( '/' ).pop();
+	return slug || undefined;
+}
+
+/**
  * Hook to get CoAuthors Plus authors from the CAP store or REST API.
  *
  * For the currently-edited post, it uses CAP's JS store for real-time updates.
@@ -87,7 +103,7 @@ export function useCoAuthors( postId, postType = 'post', skip = false ) {
 						id: author.id,
 						display_name: author.display_name,
 						author_link: author.author_link,
-						user_nicename: author.author_link ? author.author_link.replace( /\/$/, '' ).split( '/' ).pop() : undefined,
+						user_nicename: extractNicenameFromLink( author.author_link ),
 					} ) );
 					return { authors: mappedAuthors, isCapAvailable: true };
 				}

--- a/src/shared/hooks/use-coauthors.js
+++ b/src/shared/hooks/use-coauthors.js
@@ -81,10 +81,13 @@ export function useCoAuthors( postId, postType = 'post', skip = false ) {
 
 				if ( restAuthors && Array.isArray( restAuthors ) && restAuthors.length > 0 ) {
 					// Map REST API author objects to our expected format.
+					// Extract user_nicename from author_link so the avatar
+					// effect can fetch from the CAP single-author endpoint.
 					const mappedAuthors = restAuthors.map( author => ( {
 						id: author.id,
 						display_name: author.display_name,
 						author_link: author.author_link,
+						user_nicename: author.author_link ? author.author_link.replace( /\/$/, '' ).split( '/' ).pop() : undefined,
 					} ) );
 					return { authors: mappedAuthors, isCapAvailable: true };
 				}
@@ -96,31 +99,38 @@ export function useCoAuthors( postId, postType = 'post', skip = false ) {
 		[ postId, postType, skip ]
 	);
 
-	// Fetch avatar URLs from the CAP REST API for guest authors only.
+	// Fetch avatar URLs from the CAP REST API for authors that need it.
 	// The CAP store strips avatar data via formatAuthorData(), so we need
 	// to fetch the raw REST response to get the avatar URL (especially for
 	// guest authors whose avatars come from featured images).
 	//
 	// Fetches per-author (by nicename) instead of per-post so that avatars
 	// resolve immediately when a guest author is added — before the post is saved.
+	//
+	// For currently-edited post authors, isGuest is explicitly true/false.
+	// For Query Loop authors, isGuest is undefined (we can't distinguish from
+	// REST data alone), so we fetch for all of them and let the consumer
+	// (hooks.js) prefer WP user data when available.
 	const [ avatarMap, setAvatarMap ] = useState( {} );
 
-	// Build a stable key from guest author nicenames to control effect re-runs.
-	const guestAuthors = authors.filter( author => author.isGuest && author.user_nicename );
-	const guestNicenames = guestAuthors.map( author => author.user_nicename ).join( ',' );
+	// Build a stable key from author nicenames to control effect re-runs.
+	// isGuest !== false: includes guest authors (true) and Query Loop authors (undefined),
+	// but excludes known WP users from the currently-edited post (false).
+	const authorsNeedingAvatars = authors.filter( author => author.isGuest !== false && author.user_nicename );
+	const avatarNicenames = authorsNeedingAvatars.map( author => author.user_nicename ).join( ',' );
 
 	useEffect( () => {
-		if ( skip || ! isCapAvailable || ! guestNicenames ) {
+		if ( skip || ! isCapAvailable || ! avatarNicenames ) {
 			return;
 		}
 
-		// Determine which guest authors still need fetching.
-		const toFetch = guestAuthors.filter( a => ! guestAvatarCache[ a.user_nicename ] );
+		// Determine which authors still need fetching.
+		const toFetch = authorsNeedingAvatars.filter( a => ! guestAvatarCache[ a.user_nicename ] );
 
 		// All cached — sync cache into state and return early.
 		if ( ! toFetch.length ) {
 			const map = {};
-			guestAuthors.forEach( a => {
+			authorsNeedingAvatars.forEach( a => {
 				if ( guestAvatarCache[ a.user_nicename ] ) {
 					map[ a.id ] = guestAvatarCache[ a.user_nicename ];
 				}
@@ -146,7 +156,7 @@ export function useCoAuthors( postId, postType = 'post', skip = false ) {
 				return;
 			}
 			const map = {};
-			guestAuthors.forEach( a => {
+			authorsNeedingAvatars.forEach( a => {
 				if ( guestAvatarCache[ a.user_nicename ] ) {
 					map[ a.id ] = guestAvatarCache[ a.user_nicename ];
 				}
@@ -157,14 +167,14 @@ export function useCoAuthors( postId, postType = 'post', skip = false ) {
 		return () => {
 			cancelled = true;
 		};
-	}, [ skip, isCapAvailable, guestNicenames ] );
+	}, [ skip, isCapAvailable, avatarNicenames ] );
 
 	// Merge avatar URLs into guest authors.
 	// Check both the async avatarMap (populated by the effect) and the
 	// synchronous guestAvatarCache (populated by previous fetches) so that
 	// cached avatars render immediately without waiting for an effect cycle.
 	const authorsWithAvatars = authors.map( author => {
-		if ( ! author.isGuest || ! author.user_nicename ) {
+		if ( author.isGuest === false || ! author.user_nicename ) {
 			return author;
 		}
 		const urls = avatarMap[ author.id ] || guestAvatarCache[ author.user_nicename ];

--- a/src/shared/hooks/use-coauthors.js
+++ b/src/shared/hooks/use-coauthors.js
@@ -17,11 +17,46 @@ const COAUTHORS_ENDPOINT = '/coauthors/v1/coauthors';
 // multiple avatar blocks in a Query Loop share the same guest authors.
 const guestAvatarCache = {};
 
+// In-flight request promises, keyed by user_nicename.
+// Prevents duplicate concurrent requests when multiple block instances
+// mount simultaneously (e.g. Query Loop) and all check the cache before
+// any fetch has completed.
+const inflightRequests = {};
+
+/**
+ * Fetch a single coauthor's avatar URLs, deduplicating concurrent requests.
+ *
+ * @param {string} nicename Author nicename (slug).
+ * @return {Promise} Resolves when the fetch completes (result is stored in guestAvatarCache).
+ */
+function fetchCoauthorAvatar( nicename ) {
+	if ( guestAvatarCache[ nicename ] ) {
+		return Promise.resolve();
+	}
+	if ( inflightRequests[ nicename ] ) {
+		return inflightRequests[ nicename ];
+	}
+	inflightRequests[ nicename ] = apiFetch( {
+		path: `${ COAUTHORS_ENDPOINT }/${ encodeURIComponent( nicename ) }`,
+	} )
+		.then( result => {
+			if ( result?.avatar_urls ) {
+				guestAvatarCache[ nicename ] = result.avatar_urls;
+			}
+		} )
+		.catch( () => {} ) // Silently skip failed fetches.
+		.finally( () => {
+			delete inflightRequests[ nicename ];
+		} );
+	return inflightRequests[ nicename ];
+}
+
 /**
  * Reset the module-level guest avatar cache. Exposed for testing only.
  */
 export function resetGuestAvatarCacheForTests() {
 	Object.keys( guestAvatarCache ).forEach( key => delete guestAvatarCache[ key ] );
+	Object.keys( inflightRequests ).forEach( key => delete inflightRequests[ key ] );
 }
 
 /**
@@ -145,34 +180,8 @@ export function useCoAuthors( postId, postType = 'post', skip = false ) {
 			return;
 		}
 
-		// Determine which authors still need fetching.
-		const toFetch = authorsNeedingAvatars.filter( a => ! guestAvatarCache[ a.user_nicename ] );
-
-		// All cached — sync cache into state and return early.
-		if ( ! toFetch.length ) {
-			const map = {};
-			authorsNeedingAvatars.forEach( a => {
-				if ( guestAvatarCache[ a.user_nicename ] ) {
-					map[ a.id ] = guestAvatarCache[ a.user_nicename ];
-				}
-			} );
-			setAvatarMap( map );
-			return;
-		}
-
 		let cancelled = false;
-		Promise.all(
-			toFetch.map(
-				a =>
-					apiFetch( { path: `${ COAUTHORS_ENDPOINT }/${ encodeURIComponent( a.user_nicename ) }` } )
-						.then( result => {
-							if ( result?.avatar_urls ) {
-								guestAvatarCache[ a.user_nicename ] = result.avatar_urls;
-							}
-						} )
-						.catch( () => {} ) // Silently skip failed fetches.
-			)
-		).then( () => {
+		Promise.all( authorsNeedingAvatars.map( a => fetchCoauthorAvatar( a.user_nicename ) ) ).then( () => {
 			if ( cancelled ) {
 				return;
 			}

--- a/src/shared/hooks/use-coauthors.js
+++ b/src/shared/hooks/use-coauthors.js
@@ -25,19 +25,24 @@ export function resetGuestAvatarCacheForTests() {
 }
 
 /**
- * Extract user_nicename from an author_link URL.
- * Strips query params and hash fragments, then takes the last path segment.
- * Returns undefined if the link is missing or yields no valid slug.
+ * Extract user_nicename from an author archive URL.
  *
- * @param {string} link Author archive URL.
- * @return {string|undefined} The extracted nicename, or undefined.
+ * @param {string} link Author archive URL (e.g. /author/jane/).
+ * @return {string|undefined} Extracted nicename, or undefined.
  */
 function extractNicenameFromLink( link ) {
 	if ( ! link ) {
 		return undefined;
 	}
-	const slug = link.split( '?' )[ 0 ].split( '#' )[ 0 ].replace( /\/$/, '' ).split( '/' ).pop();
-	return slug || undefined;
+	const cleaned = link.split( '?' )[ 0 ].split( '#' )[ 0 ].replace( /\/$/, '' );
+	const segments = cleaned.split( '/' );
+	const slug = segments.pop();
+	// Require a parent path segment so root URLs and plain permalinks are rejected.
+	const parent = segments[ segments.length - 1 ];
+	if ( ! slug || ! parent ) {
+		return undefined;
+	}
+	return slug;
 }
 
 /**

--- a/src/shared/hooks/use-coauthors.js
+++ b/src/shared/hooks/use-coauthors.js
@@ -12,7 +12,7 @@ import apiFetch from '@wordpress/api-fetch';
 const CAP_STORE = 'cap/authors';
 const COAUTHORS_ENDPOINT = '/coauthors/v1/coauthors';
 
-// Module-level cache for guest author avatar URLs, keyed by post ID.
+// Module-level cache for guest author avatar URLs, keyed by user_nicename.
 // Prevents duplicate REST requests when components re-mount or when
 // multiple avatar blocks in a Query Loop share the same guest authors.
 const guestAvatarCache = {};
@@ -93,46 +93,64 @@ export function useCoAuthors( postId, postType = 'post', skip = false ) {
 	// The CAP store strips avatar data via formatAuthorData(), so we need
 	// to fetch the raw REST response to get the avatar URL (especially for
 	// guest authors whose avatars come from featured images).
-	const [ avatarMap, setAvatarMap ] = useState( () => guestAvatarCache[ postId ] || {} );
+	//
+	// Fetches per-author (by nicename) instead of per-post so that avatars
+	// resolve immediately when a guest author is added — before the post is saved.
+	const [ avatarMap, setAvatarMap ] = useState( {} );
 
-	// Build a stable key from guest author IDs to avoid re-fetching on every render.
-	const guestAuthorIds = authors
-		.filter( author => author.isGuest )
-		.map( author => author.id )
-		.join( ',' );
+	// Build a stable key from guest author nicenames to control effect re-runs.
+	const guestAuthors = authors.filter( author => author.isGuest && author.user_nicename );
+	const guestNicenames = guestAuthors.map( author => author.user_nicename ).join( ',' );
 
 	useEffect( () => {
-		if ( skip || ! isCapAvailable || ! guestAuthorIds || ! postId ) {
+		if ( skip || ! isCapAvailable || ! guestNicenames ) {
 			return;
 		}
 
-		// Use cached data if available (avoids duplicate requests on re-mount).
-		if ( guestAvatarCache[ postId ] ) {
-			setAvatarMap( guestAvatarCache[ postId ] );
+		// Determine which guest authors still need fetching.
+		const toFetch = guestAuthors.filter( a => ! guestAvatarCache[ a.user_nicename ] );
+
+		// All cached — sync cache into state and return early.
+		if ( ! toFetch.length ) {
+			const map = {};
+			guestAuthors.forEach( a => {
+				if ( guestAvatarCache[ a.user_nicename ] ) {
+					map[ a.id ] = guestAvatarCache[ a.user_nicename ];
+				}
+			} );
+			setAvatarMap( map );
 			return;
 		}
 
 		let cancelled = false;
-		apiFetch( { path: `${ COAUTHORS_ENDPOINT }?post_id=${ postId }` } ).then( result => {
-			if ( cancelled || ! Array.isArray( result ) ) {
+		Promise.all(
+			toFetch.map(
+				a =>
+					apiFetch( { path: `${ COAUTHORS_ENDPOINT }/${ a.user_nicename }` } )
+						.then( result => {
+							if ( result?.avatar_urls ) {
+								guestAvatarCache[ a.user_nicename ] = result.avatar_urls;
+							}
+						} )
+						.catch( () => {} ) // Silently skip failed fetches.
+			)
+		).then( () => {
+			if ( cancelled ) {
 				return;
 			}
 			const map = {};
-			result.forEach( item => {
-				if ( item.id && item.avatar_urls ) {
-					map[ item.id ] = item.avatar_urls;
+			guestAuthors.forEach( a => {
+				if ( guestAvatarCache[ a.user_nicename ] ) {
+					map[ a.id ] = guestAvatarCache[ a.user_nicename ];
 				}
 			} );
-			if ( Object.keys( map ).length ) {
-				guestAvatarCache[ postId ] = map;
-				setAvatarMap( map );
-			}
+			setAvatarMap( map );
 		} );
 
 		return () => {
 			cancelled = true;
 		};
-	}, [ skip, isCapAvailable, guestAuthorIds, postId ] );
+	}, [ skip, isCapAvailable, guestNicenames ] );
 
 	// Merge avatar URLs into guest authors.
 	const authorsWithAvatars = authors.map( author => {

--- a/src/shared/hooks/use-coauthors.js
+++ b/src/shared/hooks/use-coauthors.js
@@ -18,6 +18,13 @@ const COAUTHORS_ENDPOINT = '/coauthors/v1/coauthors';
 const guestAvatarCache = {};
 
 /**
+ * Reset the module-level guest avatar cache. Exposed for testing only.
+ */
+export function resetGuestAvatarCacheForTests() {
+	Object.keys( guestAvatarCache ).forEach( key => delete guestAvatarCache[ key ] );
+}
+
+/**
  * Hook to get CoAuthors Plus authors from the CAP store or REST API.
  *
  * For the currently-edited post, it uses CAP's JS store for real-time updates.
@@ -126,7 +133,7 @@ export function useCoAuthors( postId, postType = 'post', skip = false ) {
 		Promise.all(
 			toFetch.map(
 				a =>
-					apiFetch( { path: `${ COAUTHORS_ENDPOINT }/${ a.user_nicename }` } )
+					apiFetch( { path: `${ COAUTHORS_ENDPOINT }/${ encodeURIComponent( a.user_nicename ) }` } )
 						.then( result => {
 							if ( result?.avatar_urls ) {
 								guestAvatarCache[ a.user_nicename ] = result.avatar_urls;
@@ -153,11 +160,18 @@ export function useCoAuthors( postId, postType = 'post', skip = false ) {
 	}, [ skip, isCapAvailable, guestNicenames ] );
 
 	// Merge avatar URLs into guest authors.
+	// Check both the async avatarMap (populated by the effect) and the
+	// synchronous guestAvatarCache (populated by previous fetches) so that
+	// cached avatars render immediately without waiting for an effect cycle.
 	const authorsWithAvatars = authors.map( author => {
-		if ( ! author.isGuest || ! avatarMap[ author.id ] ) {
+		if ( ! author.isGuest || ! author.user_nicename ) {
 			return author;
 		}
-		return { ...author, avatar_urls: avatarMap[ author.id ] };
+		const urls = avatarMap[ author.id ] || guestAvatarCache[ author.user_nicename ];
+		if ( ! urls ) {
+			return author;
+		}
+		return { ...author, avatar_urls: urls };
 	} );
 
 	return { authors: authorsWithAvatars, isCapAvailable };

--- a/src/shared/hooks/use-coauthors.test.js
+++ b/src/shared/hooks/use-coauthors.test.js
@@ -277,10 +277,12 @@ describe( 'useCoAuthors', () => {
 			expect( result.current.authors[ 2 ].user_nicename ).toBe( 'jill' );
 		} );
 
-		it( 'should return undefined user_nicename when author_link is missing', () => {
+		it( 'should return undefined user_nicename when author_link is missing or unusable', () => {
 			const restAuthors = [
 				{ id: 1, display_name: 'No Link Author', author_link: null },
 				{ id: 2, display_name: 'Empty Link Author', author_link: '' },
+				{ id: 3, display_name: 'Root URL Author', author_link: 'https://example.com' },
+				{ id: 4, display_name: 'Plain Permalink Author', author_link: '/?author=123' },
 			];
 
 			useSelect.mockImplementation( callback =>
@@ -299,6 +301,8 @@ describe( 'useCoAuthors', () => {
 
 			expect( result.current.authors[ 0 ].user_nicename ).toBeUndefined();
 			expect( result.current.authors[ 1 ].user_nicename ).toBeUndefined();
+			expect( result.current.authors[ 2 ].user_nicename ).toBeUndefined();
+			expect( result.current.authors[ 3 ].user_nicename ).toBeUndefined();
 		} );
 
 		it( 'should fetch avatars for Query Loop authors via CAP endpoint', async () => {

--- a/src/shared/hooks/use-coauthors.test.js
+++ b/src/shared/hooks/use-coauthors.test.js
@@ -251,6 +251,56 @@ describe( 'useCoAuthors', () => {
 			expect( result.current.authors[ 0 ].user_nicename ).toBe( 'external-contributor' );
 		} );
 
+		it( 'should strip query params and hash fragments from author_link', () => {
+			const restAuthors = [
+				{ id: 1, display_name: 'Jane', author_link: '/author/jane/?utm_source=feed' },
+				{ id: 2, display_name: 'John', author_link: '/author/john/#bio' },
+				{ id: 3, display_name: 'Jill', author_link: '/author/jill/?x=1#top' },
+			];
+
+			useSelect.mockImplementation( callback =>
+				callback(
+					createMockSelect( {
+						capStore: { getAuthors: () => [] },
+						currentPostId: 123,
+						entityRecords: {
+							456: { newspack_author_info: restAuthors },
+						},
+					} )
+				)
+			);
+
+			const { result } = renderHook( () => useCoAuthors( 456, 'post' ) );
+
+			expect( result.current.authors[ 0 ].user_nicename ).toBe( 'jane' );
+			expect( result.current.authors[ 1 ].user_nicename ).toBe( 'john' );
+			expect( result.current.authors[ 2 ].user_nicename ).toBe( 'jill' );
+		} );
+
+		it( 'should return undefined user_nicename when author_link is missing', () => {
+			const restAuthors = [
+				{ id: 1, display_name: 'No Link Author', author_link: null },
+				{ id: 2, display_name: 'Empty Link Author', author_link: '' },
+			];
+
+			useSelect.mockImplementation( callback =>
+				callback(
+					createMockSelect( {
+						capStore: { getAuthors: () => [] },
+						currentPostId: 123,
+						entityRecords: {
+							456: { newspack_author_info: restAuthors },
+						},
+					} )
+				)
+			);
+
+			const { result } = renderHook( () => useCoAuthors( 456, 'post' ) );
+
+			expect( result.current.authors[ 0 ].user_nicename ).toBeUndefined();
+			expect( result.current.authors[ 1 ].user_nicename ).toBeUndefined();
+		} );
+
 		it( 'should fetch avatars for Query Loop authors via CAP endpoint', async () => {
 			const avatarUrls = { 96: 'https://example.com/guest-96.jpg' };
 			apiFetch.mockResolvedValue( { avatar_urls: avatarUrls } );

--- a/src/shared/hooks/use-coauthors.test.js
+++ b/src/shared/hooks/use-coauthors.test.js
@@ -12,7 +12,7 @@ import apiFetch from '@wordpress/api-fetch';
 /**
  * Internal dependencies
  */
-import { useCoAuthors } from './use-coauthors';
+import { useCoAuthors, resetGuestAvatarCacheForTests } from './use-coauthors';
 
 jest.mock( '@wordpress/data', () => ( {
 	useSelect: jest.fn(),
@@ -55,6 +55,7 @@ const createMockSelect = ( { capStore = null, currentPostId = 123, entityRecords
 describe( 'useCoAuthors', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
+		resetGuestAvatarCacheForTests();
 		// Default: apiFetch resolves with empty object (no avatar_urls).
 		apiFetch.mockResolvedValue( {} );
 	} );
@@ -320,6 +321,29 @@ describe( 'useCoAuthors', () => {
 			// WP user should not have avatar_urls added by the hook.
 			const wpUser = result.current.authors.find( a => a.id === 1 );
 			expect( wpUser.avatar_urls ).toBeUndefined();
+		} );
+
+		it( 'should not fetch avatar for guest author without user_nicename', async () => {
+			setupWithGuest( [ { id: 1591, display: 'Guest Writer', value: undefined, userType: 'guest-author' } ] );
+
+			renderHook( () => useCoAuthors( 123 ) );
+
+			await act( () => Promise.resolve() );
+
+			expect( apiFetch ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should encode nicename in the REST path', async () => {
+			apiFetch.mockResolvedValue( { avatar_urls: GUEST_AVATAR_URLS } );
+			setupWithGuest( [ { id: 1591, display: 'Guest Writer', value: 'name with spaces', userType: 'guest-author' } ] );
+
+			renderHook( () => useCoAuthors( 123 ) );
+
+			await waitFor( () => {
+				expect( apiFetch ).toHaveBeenCalledWith( {
+					path: '/coauthors/v1/coauthors/name%20with%20spaces',
+				} );
+			} );
 		} );
 
 		it( 'should handle failed fetches gracefully', async () => {

--- a/src/shared/hooks/use-coauthors.test.js
+++ b/src/shared/hooks/use-coauthors.test.js
@@ -1,12 +1,13 @@
 /**
  * External dependencies
  */
-import { renderHook } from '@testing-library/react';
+import { renderHook, act, waitFor } from '@testing-library/react';
 
 /**
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
+import apiFetch from '@wordpress/api-fetch';
 
 /**
  * Internal dependencies
@@ -20,6 +21,8 @@ jest.mock( '@wordpress/data', () => ( {
 jest.mock( '@wordpress/core-data', () => ( {
 	store: 'core',
 } ) );
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
 
 /**
  * Helper to create a mock select function for multiple stores.
@@ -52,6 +55,8 @@ const createMockSelect = ( { capStore = null, currentPostId = 123, entityRecords
 describe( 'useCoAuthors', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
+		// Default: apiFetch resolves with empty object (no avatar_urls).
+		apiFetch.mockResolvedValue( {} );
 	} );
 
 	describe( 'CAP store availability', () => {
@@ -238,6 +243,97 @@ describe( 'useCoAuthors', () => {
 
 			expect( result.current.authors ).toEqual( [] );
 			expect( result.current.isCapAvailable ).toBe( true );
+		} );
+	} );
+
+	describe( 'guest author avatar fetching', () => {
+		const GUEST_AVATAR_URLS = { 24: 'https://example.com/guest-24.jpg', 96: 'https://example.com/guest-96.jpg' };
+
+		const setupWithGuest = capAuthors => {
+			useSelect.mockImplementation( callback =>
+				callback(
+					createMockSelect( {
+						capStore: { getAuthors: () => capAuthors },
+						currentPostId: 123,
+					} )
+				)
+			);
+		};
+
+		it( 'should fetch avatar by nicename for guest authors', async () => {
+			apiFetch.mockResolvedValue( { avatar_urls: GUEST_AVATAR_URLS } );
+			setupWithGuest( [
+				{ id: 1, display: 'Jane', value: 'jane-doe', userType: 'wpuser' },
+				{ id: 1591, display: 'Guest Writer', value: 'guest-writer', userType: 'guest-author' },
+			] );
+
+			const { result } = renderHook( () => useCoAuthors( 123 ) );
+
+			await waitFor( () => {
+				const guest = result.current.authors.find( a => a.id === 1591 );
+				expect( guest.avatar_urls ).toEqual( GUEST_AVATAR_URLS );
+			} );
+
+			expect( apiFetch ).toHaveBeenCalledWith( {
+				path: '/coauthors/v1/coauthors/guest-writer',
+			} );
+		} );
+
+		it( 'should not fetch avatars for WP users', async () => {
+			setupWithGuest( [
+				{ id: 1, display: 'Jane', value: 'jane-doe', userType: 'wpuser' },
+				{ id: 2, display: 'John', value: 'john-smith', userType: 'wpuser' },
+			] );
+
+			renderHook( () => useCoAuthors( 123 ) );
+
+			// Allow any pending effects to flush.
+			await act( () => Promise.resolve() );
+
+			expect( apiFetch ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should not fetch avatars when skip is true', async () => {
+			apiFetch.mockResolvedValue( { avatar_urls: GUEST_AVATAR_URLS } );
+			setupWithGuest( [ { id: 1591, display: 'Guest Writer', value: 'guest-writer', userType: 'guest-author' } ] );
+
+			renderHook( () => useCoAuthors( 123, 'post', true ) );
+
+			await act( () => Promise.resolve() );
+
+			expect( apiFetch ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should not modify WP user authors when merging avatar data', async () => {
+			apiFetch.mockResolvedValue( { avatar_urls: GUEST_AVATAR_URLS } );
+			setupWithGuest( [
+				{ id: 1, display: 'Jane', value: 'jane-doe', userType: 'wpuser' },
+				{ id: 1591, display: 'Guest Writer', value: 'guest-writer', userType: 'guest-author' },
+			] );
+
+			const { result } = renderHook( () => useCoAuthors( 123 ) );
+
+			await waitFor( () => {
+				expect( result.current.authors.find( a => a.id === 1591 ).avatar_urls ).toEqual( GUEST_AVATAR_URLS );
+			} );
+
+			// WP user should not have avatar_urls added by the hook.
+			const wpUser = result.current.authors.find( a => a.id === 1 );
+			expect( wpUser.avatar_urls ).toBeUndefined();
+		} );
+
+		it( 'should handle failed fetches gracefully', async () => {
+			apiFetch.mockRejectedValue( new Error( 'Not found' ) );
+			setupWithGuest( [ { id: 1591, display: 'Guest Writer', value: 'ghost-author', userType: 'guest-author' } ] );
+
+			const { result } = renderHook( () => useCoAuthors( 123 ) );
+
+			// Allow the failed promise to settle.
+			await act( () => Promise.resolve().then( () => Promise.resolve() ) );
+
+			// Guest author should still be in the list, just without avatar_urls.
+			expect( result.current.authors ).toHaveLength( 1 );
+			expect( result.current.authors[ 0 ].display_name ).toBe( 'Guest Writer' );
 		} );
 	} );
 } );

--- a/src/shared/hooks/use-coauthors.test.js
+++ b/src/shared/hooks/use-coauthors.test.js
@@ -466,5 +466,38 @@ describe( 'useCoAuthors', () => {
 			expect( result.current.authors ).toHaveLength( 1 );
 			expect( result.current.authors[ 0 ].display_name ).toBe( 'Guest Writer' );
 		} );
+
+		it( 'should deduplicate concurrent avatar fetches for the same nicename', async () => {
+			apiFetch.mockResolvedValue( { avatar_urls: GUEST_AVATAR_URLS } );
+
+			// Two Query Loop posts sharing the same guest author.
+			const sharedAuthor = { id: 1591, display_name: 'Guest Writer', author_link: '/author/guest-writer/' };
+
+			useSelect.mockImplementation( callback =>
+				callback(
+					createMockSelect( {
+						capStore: { getAuthors: () => [] },
+						currentPostId: 123,
+						entityRecords: {
+							456: { newspack_author_info: [ sharedAuthor ] },
+							789: { newspack_author_info: [ sharedAuthor ] },
+						},
+					} )
+				)
+			);
+
+			// Render two hooks concurrently, simulating two avatar blocks in a Query Loop.
+			const { result: result1 } = renderHook( () => useCoAuthors( 456, 'post' ) );
+			const { result: result2 } = renderHook( () => useCoAuthors( 789, 'post' ) );
+
+			await waitFor( () => {
+				expect( result1.current.authors[ 0 ].avatar_urls ).toEqual( GUEST_AVATAR_URLS );
+				expect( result2.current.authors[ 0 ].avatar_urls ).toEqual( GUEST_AVATAR_URLS );
+			} );
+
+			// Only one apiFetch call should have been made despite two concurrent hooks.
+			const guestWriterCalls = apiFetch.mock.calls.filter( ( [ arg ] ) => arg.path === '/coauthors/v1/coauthors/guest-writer' );
+			expect( guestWriterCalls ).toHaveLength( 1 );
+		} );
 	} );
 } );

--- a/src/shared/hooks/use-coauthors.test.js
+++ b/src/shared/hooks/use-coauthors.test.js
@@ -204,8 +204,8 @@ describe( 'useCoAuthors', () => {
 			const { result } = renderHook( () => useCoAuthors( 456, 'post' ) );
 
 			expect( result.current.authors ).toEqual( [
-				{ id: 1, display_name: 'Jane Doe', author_link: '/author/jane/' },
-				{ id: 2, display_name: 'John Smith', author_link: '/author/john/' },
+				{ id: 1, display_name: 'Jane Doe', author_link: '/author/jane/', user_nicename: 'jane' },
+				{ id: 2, display_name: 'John Smith', author_link: '/author/john/', user_nicename: 'john' },
 			] );
 			expect( result.current.isCapAvailable ).toBe( true );
 		} );
@@ -227,6 +227,59 @@ describe( 'useCoAuthors', () => {
 
 			expect( result.current.authors ).toEqual( [] );
 			expect( result.current.isCapAvailable ).toBe( true );
+		} );
+
+		it( 'should extract user_nicename from author_link', () => {
+			const restAuthors = [
+				{ id: 1591, display_name: 'External Contributor', author_link: 'https://example.com/author/external-contributor/' },
+			];
+
+			useSelect.mockImplementation( callback =>
+				callback(
+					createMockSelect( {
+						capStore: { getAuthors: () => [] },
+						currentPostId: 123,
+						entityRecords: {
+							456: { newspack_author_info: restAuthors },
+						},
+					} )
+				)
+			);
+
+			const { result } = renderHook( () => useCoAuthors( 456, 'post' ) );
+
+			expect( result.current.authors[ 0 ].user_nicename ).toBe( 'external-contributor' );
+		} );
+
+		it( 'should fetch avatars for Query Loop authors via CAP endpoint', async () => {
+			const avatarUrls = { 96: 'https://example.com/guest-96.jpg' };
+			apiFetch.mockResolvedValue( { avatar_urls: avatarUrls } );
+
+			const restAuthors = [
+				{ id: 1591, display_name: 'External Contributor', author_link: 'https://example.com/author/external-contributor/' },
+			];
+
+			useSelect.mockImplementation( callback =>
+				callback(
+					createMockSelect( {
+						capStore: { getAuthors: () => [] },
+						currentPostId: 123,
+						entityRecords: {
+							456: { newspack_author_info: restAuthors },
+						},
+					} )
+				)
+			);
+
+			const { result } = renderHook( () => useCoAuthors( 456, 'post' ) );
+
+			await waitFor( () => {
+				expect( result.current.authors[ 0 ].avatar_urls ).toEqual( avatarUrls );
+			} );
+
+			expect( apiFetch ).toHaveBeenCalledWith( {
+				path: '/coauthors/v1/coauthors/external-contributor',
+			} );
 		} );
 
 		it( 'should return empty authors when post entity is not loaded', () => {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes two issues with guest author avatar resolution in the editor's avatar block:

**1. Guest author avatars not appearing until save + refresh**

When adding a CoAuthors Plus guest author to a post, their avatar didn't render until the post was saved and the page was reloaded. The root cause was that the `useCoAuthors` hook fetched avatar data from the per-post CAP REST endpoint (`/coauthors/v1/coauthors?post_id=X`), which only returns saved coauthors. An unsaved guest author wouldn't be in the response.

The fix switches to per-author fetching using `/coauthors/v1/coauthors/{user_nicename}`, which resolves avatar data for any guest author regardless of save state. A module-level cache keyed by `user_nicename` prevents duplicate requests across re-mounts and Query Loop iterations.

**2. Guest author avatars not appearing in Query Loop context**

In a Query Loop block, guest author avatars never appeared, even after saving and refreshing. The REST data available for Query Loop posts does not include the fields the avatar fetch logic relied on, so those authors were silently skipped.

The fix extracts the author slug from the `author_link` URL and broadens the fetch filters to include Query Loop authors alongside known guest authors.

Closes NPPD-1197.

### How to test the changes in this Pull Request:

1. Open a post with CoAuthors Plus enabled and a WP user as the sole author.
2. In the Authors sidebar, add a guest author (e.g., "External Contributor"). The guest author's avatar should appear immediately in the avatar block, without saving or refreshing.
3. Save the post and reload. The avatar should persist.
4. Remove the guest author and re-add it. The avatar should appear instantly from cache.
5. Create or edit a page with a Query Loop block that includes posts authored by guest contributors.
6. Verify that guest author avatars render correctly in the Query Loop preview.
7. Save and reload. Avatars should still display.
8. Verify that regular WP user avatars continue to work in both single post and Query Loop contexts.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?