### PR TITLE
fix(my-account): activate first payment method on load

### DIFF
--- a/src/my-account/v1/payment-information.js
+++ b/src/my-account/v1/payment-information.js
@@ -68,4 +68,10 @@ domReady( function () {
 
 	// Prevent multiple form submissions and show loading state for all modals.
 	document.addEventListener( 'submit', handleFormSubmission );
+
+	// Force display first payment method.
+	const firstPaymentMethod = document.querySelector( '.woocommerce-PaymentMethod:first-child' );
+	if ( firstPaymentMethod ) {
+		firstPaymentMethod.classList.add( 'active' );
+	}
 } );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

NPPM-2600

If the site has multiple payment gateways, the modal renders the available options. The first item is selected, but the content remains hidden. It only appears after selecting another option and then back.

This PR ensures the first option of the accordion is active.

### How to test the changes in this Pull Request:

1. While on release, configure 2 payment gateways and visit My Account -> Payment Information 
2. Click to "Add Payment Method" and confirm the issue
3. Checkout this branch, refresh the page, and click the button
4. Confirm the first option is selected, and its content is visible
5. Click the other payment gateway and confirm it behaves as expected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->