### PR TITLE
fix(phpcs): add explicit $single param to meta calls

### DIFF
--- a/includes/plugins/co-authors-plus/class-nicename-change.php
+++ b/includes/plugins/co-authors-plus/class-nicename-change.php
@@ -224,7 +224,7 @@ class Nicename_Change {
 	 * @param string $new_nicename  The new nicename.
 	 */
 	public static function handle_old_nicename_meta( $user_id, $old_nicename, $new_nicename ) {
-		$old_nicename_meta = (array) get_user_meta( $user_id, self::OLD_NICENAME_META_KEY );
+		$old_nicename_meta = (array) get_user_meta( $user_id, self::OLD_NICENAME_META_KEY, false );
 
 		// If we haven't added this old nicename before, add it now.
 		if ( ! empty( $old_nicename ) && ! in_array( $old_nicename, $old_nicename_meta, true ) ) {

--- a/includes/revisions-control/class-major-revision.php
+++ b/includes/revisions-control/class-major-revision.php
@@ -60,7 +60,7 @@ class Major_Revision {
 	 * @return array
 	 */
 	public function get_post_revisions() {
-		$ids = get_post_meta( $this->post_id, self::MAJOR_IDS_META_KEY );
+		$ids = get_post_meta( $this->post_id, self::MAJOR_IDS_META_KEY, false );
 		if ( empty( $ids ) ) {
 			return [];
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds the explicit `$single` parameter (`false`) to `get_post_meta()` and `get_user_meta()` calls that were triggering the `WordPress.WP.GetMetaSingle.Missing` PHPCS warning. Both calls intentionally return arrays of meta values, so `false` is the correct value.

```
FILE: ...plugin/newspack-plugin/includes/revisions-control/class-major-revision.php
--------------------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
--------------------------------------------------------------------------------
 63 | WARNING | When passing the $key parameter to get_post_meta(), it is
    |         | recommended to also pass the $single parameter to explicitly
    |         | indicate whether a single value or multiple values are expected
    |         | to be returned. (WordPress.WP.GetMetaSingle.Missing)
--------------------------------------------------------------------------------


FILE: ...newspack-plugin/includes/plugins/co-authors-plus/class-nicename-change.php
--------------------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
--------------------------------------------------------------------------------
 227 | WARNING | When passing the $key parameter to get_user_meta(), it is
     |         | recommended to also pass the $single parameter to explicitly
     |         | indicate whether a single value or multiple values are
     |         | expected to be returned. (WordPress.WP.GetMetaSingle.Missing)
--------------------------------------------------------------------------------
```

Closes NPPM-2606.

### How to test the changes in this Pull Request:

1. Run PHPCS and confirm no `GetMetaSingle.Missing` warnings on the changed files.
2. Verify that revisions control and Co-Authors Plus nicename change functionality still work as expected (the behavior is unchanged since `false` is the default).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?