### PR TITLE
feat(my-account): improve navigation on small screens

### DIFF
--- a/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php
+++ b/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php
@@ -215,12 +215,18 @@ class My_Account_UI_V1 {
 		// Remove logout menu item (to be replaced in our custom template).
 		unset( $items['customer-logout'] );
 
-		// Rename "Payment Methods" to "Payment Information".
+		// Rename "Payment Methods" to "Payment information".
 		if ( isset( $items['payment-methods'] ) ) {
 			$items['payment-methods'] = __( 'Payment information', 'newspack-plugin' );
 		}
 
-		// Remove "Addresses" (replaced by custom "Payment Information" page).
+		// Rename singular "My Subscription" to "Subscription" while keeping plural "Subscriptions" as-is.
+		// Compare against WooCommerce Subscriptions' translated string so this also works in non-English sites.
+		if ( isset( $items['subscriptions'] ) && __( 'My Subscription', 'woocommerce-subscriptions' ) === $items['subscriptions'] ) {
+			$items['subscriptions'] = __( 'Subscription', 'newspack-plugin' );
+		}
+
+		// Remove "Addresses" (replaced by custom "Payment information" page).
 		unset( $items['edit-address'] );
 
 		return $items;

--- a/includes/plugins/woocommerce/my-account/templates/v1/navigation.php
+++ b/includes/plugins/woocommerce/my-account/templates/v1/navigation.php
@@ -42,7 +42,7 @@ if ( function_exists( 'wc_memberships_for_teams' ) ) {
 	<h1 class="newspack-ui__font--s newspack-ui__spacing-top--0 newspack-ui__spacing-bottom--0"><?php echo esc_html( $current_page_name ); ?></h1>
 
 	<div class="newspack-my-account__navigation-topbar__button">
-		<button class="newspack-ui__button newspack-ui__button--x-small newspack-ui__button--ghost newspack-ui__button--icon" aria-expanded="false" aria-label="<?php esc_attr_e( 'Open navigation', 'newspack-plugin' ); ?>" data-label-close="<?php esc_attr_e( 'Close navigation', 'newspack-plugin' ); ?>" data-label-open="<?php esc_attr_e( 'Open navigation', 'newspack-plugin' ); ?>">
+		<button class="newspack-ui__button newspack-ui__button--medium newspack-ui__button--ghost newspack-ui__button--icon" aria-expanded="false" aria-label="<?php esc_attr_e( 'Open navigation', 'newspack-plugin' ); ?>" data-label-close="<?php esc_attr_e( 'Close navigation', 'newspack-plugin' ); ?>" data-label-open="<?php esc_attr_e( 'Open navigation', 'newspack-plugin' ); ?>">
 			<?php Newspack_UI_Icons::print_svg( 'menu' ); ?>
 			<?php Newspack_UI_Icons::print_svg( 'close' ); ?>
 		</button>

--- a/src/my-account/v1/_content.scss
+++ b/src/my-account/v1/_content.scss
@@ -4,7 +4,7 @@
 
 .newspack-my-account {
 	.woocommerce-MyAccount-content {
-		transition: transform 0.25s ease-in-out;
+		transition: transform 125ms ease-in-out;
 		@media ( min-width: 768px ) {
 			border: none;
 			margin-left: auto;

--- a/src/my-account/v1/_content.scss
+++ b/src/my-account/v1/_content.scss
@@ -9,9 +9,9 @@
 			border: none;
 			margin-left: auto;
 			margin-right: auto;
-			max-width: calc(1082px + var(--newspack-ui-spacer-5) * 2);
+			max-width: calc(301px + 768px);
 			padding-bottom: 0;
-			padding-left: calc(300px + var(--newspack-ui-spacer-5));
+			padding-left: 301px;
 			padding-top: 0;
 			transition: none;
 			width: 100%;

--- a/src/my-account/v1/_forms.scss
+++ b/src/my-account/v1/_forms.scss
@@ -20,6 +20,35 @@
 			font-size: inherit;
 		}
 	}
+	.edit-profile {
+		display: grid;
+		gap: var(--newspack-ui-spacer-5);
+
+		@media ( min-width: 768px ) {
+			grid-template-columns: repeat(2, 1fr);
+
+			.form-row-wide {
+				grid-column: span 2;
+			}
+		}
+
+		> * {
+			margin: 0 !important;
+			width: 100% !important;
+		}
+
+		label {
+			display: block !important;
+		}
+
+		.legend {
+			margin-bottom: 0 !important;
+		}
+
+		.clear {
+			display: none;
+		}
+	}
 	/* stylelint-disable selector-id-pattern */
 	#billing_city_field,
 	#shipping_city_field,

--- a/src/my-account/v1/_navigation.scss
+++ b/src/my-account/v1/_navigation.scss
@@ -8,6 +8,8 @@
 		transition: transform 125ms ease-in-out;
 	}
 	&.navigation-open {
+		overflow: hidden;
+
 		.woocommerce-MyAccount-navigation,
 		.woocommerce-MyAccount-content {
 			transform: translateX(-100vw);
@@ -19,12 +21,23 @@
 	}
 	&__navigation-topbar {
 		align-items: center;
-		background-color: var(--newspack-ui-color-neutral-0);
-		border-bottom: 1px solid var(--newspack-ui-color-border);
+		background-color: var(--newspack-ui-color-primary);
+		color: var(--newspack-ui-color-against-primary);
 		display: flex;
 		justify-content: space-between;
-		margin: calc(var(--newspack-ui-spacer-10) * -1) calc(var(--newspack-ui-spacer-3) * -1) var(--newspack-ui-spacer-5);
+		margin: 0 calc(var(--newspack-ui-spacer-3) * -1) var(--newspack-ui-spacer-6);
+		padding: 0;
+		position: sticky;
+		top: 0;
 		width: calc(100% + var(--newspack-ui-spacer-3) * 2);
+		z-index: 99998;
+
+		@media ( min-width: 601px ) {
+			.admin-bar & {
+				top: var(--wp-admin--admin-bar--height);
+			}
+		}
+
 		@media ( min-width: 768px ) {
 			display: none;
 		}
@@ -36,10 +49,9 @@
 
 		&__button {
 			display: grid;
-			height: var(--newspack-ui-spacer-9);
-			outline: 1px solid var(--newspack-ui-color-border);
+			height: var(--newspack-ui-spacer-11);
 			place-items: center;
-			width: var(--newspack-ui-spacer-9);
+			width: var(--newspack-ui-spacer-11);
 
 			svg + svg {
 				display: none;
@@ -79,9 +91,9 @@
 		left: 100vw;
 		line-height: var(--newspack-ui-line-height-s);
 		overflow-y: auto;
-		padding: var(--newspack-ui-spacer-5);
+		padding: calc(var(--newspack-ui-spacer-3) + var(--newspack-ui-spacer-11)) var(--newspack-ui-spacer-3) var(--newspack-ui-spacer-3);
 		position: fixed;
-		top: calc(var(--newspack-ui-spacer-9) + 1px);
+		top: 0;
 		z-index: 2;
 		@media ( min-width: 768px ) {
 			border-right: 1px solid var(--newspack-ui-color-border);
@@ -89,12 +101,15 @@
 			left: 0;
 			top: 0;
 			line-height: var(--newspack-ui-line-height-xs);
-			padding-bottom: var(--newspack-ui-spacer-6);
-			padding-top: 0;
+			padding: 0 var(--newspack-ui-spacer-5) var(--newspack-ui-spacer-6);
 			width: 301px;
 		}
 		@at-root .admin-bar#{&} {
-			top: calc(var(--wp-admin--admin-bar--height) + var(--newspack-ui-spacer-9) + 1px);
+			top: calc(var(--wp-admin--admin-bar--height) - var(--wp-admin--admin-bar--scroll, var(--wp-admin--admin-bar--height)));
+
+			@media ( min-width: 601px ) {
+				top: var(--wp-admin--admin-bar--height);
+			}
 			@media ( min-width: 768px ) {
 				padding-top: var(--wp-admin--admin-bar--height);
 				top: 0;
@@ -125,8 +140,12 @@
 			}
 		}
 		.newspack-my-account__home-link {
-			margin-bottom: var(--newspack-ui-spacer-2);
-			margin-top: var(--newspack-ui-spacer-6);
+			margin-bottom: var(--newspack-ui-spacer-5);
+
+			@media ( min-width: 768px ) {
+				margin-bottom: var(--newspack-ui-spacer-2);
+				margin-top: var(--newspack-ui-spacer-6);
+			}
 
 			svg {
 				margin-left: -8px;

--- a/src/my-account/v1/_navigation.scss
+++ b/src/my-account/v1/_navigation.scss
@@ -20,6 +20,15 @@
 			}
 		}
 	}
+	&:not(.is-block-theme) {
+		.site-content {
+			overflow: visible;
+
+			@media ( min-width: 768px ) {
+				overflow: hidden;
+			}
+		}
+	}
 	.woocommerce-MyAccount-navigation,
 	.woocommerce-MyAccount-content {
 		transition: transform 125ms ease-in-out;
@@ -51,7 +60,7 @@
 		position: sticky;
 		top: 0;
 		width: calc(100% + var(--newspack-ui-spacer-3) * 2);
-		z-index: 99998;
+		z-index: 99996;
 
 		@media ( min-width: 601px ) {
 			.admin-bar & {

--- a/src/my-account/v1/_navigation.scss
+++ b/src/my-account/v1/_navigation.scss
@@ -3,12 +3,33 @@
  */
 
 .newspack-my-account {
+	&--logged-in.admin-bar {
+		html:has(&) {
+			margin-top: 0 !important;
+
+			@media ( min-width: 601px ) {
+				margin-top: var(--wp-admin--admin-bar--height) !important;
+			}
+		}
+
+		#wpadminbar {
+			display: none;
+
+			@media ( min-width: 601px ) {
+				display: block;
+			}
+		}
+	}
 	.woocommerce-MyAccount-navigation,
 	.woocommerce-MyAccount-content {
 		transition: transform 125ms ease-in-out;
 	}
 	&.navigation-open {
 		overflow: hidden;
+
+		@media ( min-width: 768px ) {
+			overflow: visible;
+		}
 
 		.woocommerce-MyAccount-navigation,
 		.woocommerce-MyAccount-content {
@@ -105,7 +126,7 @@
 			width: 301px;
 		}
 		@at-root .admin-bar#{&} {
-			top: calc(var(--wp-admin--admin-bar--height) - var(--wp-admin--admin-bar--scroll, var(--wp-admin--admin-bar--height)));
+			top: 0;
 
 			@media ( min-width: 601px ) {
 				top: var(--wp-admin--admin-bar--height);

--- a/src/my-account/v1/navigation.js
+++ b/src/my-account/v1/navigation.js
@@ -8,32 +8,6 @@
 import { domReady } from '../../utils';
 
 domReady( () => {
-	const adminBar = document.getElementById( 'wpadminbar' );
-
-	const updateAdminBarScrolled = () => {
-		const hasAdminBar = !! adminBar;
-		const isSmallScreen = window.innerWidth < 601;
-		const adminBarHeight = hasAdminBar ? adminBar.offsetHeight : 0;
-		const scrollTop = Math.max( window.scrollY, document.documentElement.scrollTop );
-		const adminBarScroll = hasAdminBar && isSmallScreen ? Math.min( scrollTop, adminBarHeight ) : 0;
-
-		document.body.style.setProperty( '--wp-admin--admin-bar--scroll', `${ adminBarScroll }px` );
-	};
-
-	const debounce = ( callback, wait = 100 ) => {
-		let timeoutId;
-
-		return ( ...args ) => {
-			window.clearTimeout( timeoutId );
-			timeoutId = window.setTimeout( () => callback( ...args ), wait );
-		};
-	};
-
-	const handleScrollOrResize = debounce( updateAdminBarScrolled, 100 );
-
-	window.addEventListener( 'scroll', handleScrollOrResize );
-	window.addEventListener( 'resize', handleScrollOrResize );
-
 	// Open and close navigation menu.
 	const openNavigationButton = document.querySelector( '.newspack-my-account__navigation-topbar__button .newspack-ui__button' );
 	let setButtonState;
@@ -51,7 +25,6 @@ domReady( () => {
 		openNavigationButton.addEventListener( 'click', () => {
 			const isOpen = document.body.classList.toggle( 'navigation-open' );
 			setButtonState( isOpen );
-			updateAdminBarScrolled();
 		} );
 	}
 
@@ -62,9 +35,6 @@ domReady( () => {
 			if ( setButtonState ) {
 				setButtonState( false );
 			}
-			updateAdminBarScrolled();
 		}
 	} );
-
-	updateAdminBarScrolled();
 } );

--- a/src/my-account/v1/navigation.js
+++ b/src/my-account/v1/navigation.js
@@ -8,6 +8,32 @@
 import { domReady } from '../../utils';
 
 domReady( () => {
+	const adminBar = document.getElementById( 'wpadminbar' );
+
+	const updateAdminBarScrolled = () => {
+		const hasAdminBar = !! adminBar;
+		const isSmallScreen = window.innerWidth < 601;
+		const adminBarHeight = hasAdminBar ? adminBar.offsetHeight : 0;
+		const scrollTop = Math.max( window.scrollY, document.documentElement.scrollTop );
+		const adminBarScroll = hasAdminBar && isSmallScreen ? Math.min( scrollTop, adminBarHeight ) : 0;
+
+		document.body.style.setProperty( '--wp-admin--admin-bar--scroll', `${ adminBarScroll }px` );
+	};
+
+	const debounce = ( callback, wait = 100 ) => {
+		let timeoutId;
+
+		return ( ...args ) => {
+			window.clearTimeout( timeoutId );
+			timeoutId = window.setTimeout( () => callback( ...args ), wait );
+		};
+	};
+
+	const handleScrollOrResize = debounce( updateAdminBarScrolled, 100 );
+
+	window.addEventListener( 'scroll', handleScrollOrResize );
+	window.addEventListener( 'resize', handleScrollOrResize );
+
 	// Open and close navigation menu.
 	const openNavigationButton = document.querySelector( '.newspack-my-account__navigation-topbar__button .newspack-ui__button' );
 	let setButtonState;
@@ -25,6 +51,7 @@ domReady( () => {
 		openNavigationButton.addEventListener( 'click', () => {
 			const isOpen = document.body.classList.toggle( 'navigation-open' );
 			setButtonState( isOpen );
+			updateAdminBarScrolled();
 		} );
 	}
 
@@ -35,6 +62,9 @@ domReady( () => {
 			if ( setButtonState ) {
 				setButtonState( false );
 			}
+			updateAdminBarScrolled();
 		}
 	} );
+
+	updateAdminBarScrolled();
 } );

--- a/src/my-account/v1/style.scss
+++ b/src/my-account/v1/style.scss
@@ -21,12 +21,11 @@
 			width: auto;
 		}
 		.woocommerce {
-			padding: var(--newspack-ui-spacer-11) var(--newspack-ui-spacer-3);
+			padding: 0 var(--newspack-ui-spacer-3) var(--newspack-ui-spacer-3);
 
 			/* WooCommerce breakpoint is 768px. */
 			@media ( min-width: 768px ) {
-				padding-left: var(--newspack-ui-spacer-5);
-				padding-right: var(--newspack-ui-spacer-5);
+				padding: var(--newspack-ui-spacer-11) var(--newspack-ui-spacer-5);
 			}
 		}
 		.woocommerce-MyAccount-navigation,

--- a/src/newspack-ui/scss/elements/woocommerce/_my-account.scss
+++ b/src/newspack-ui/scss/elements/woocommerce/_my-account.scss
@@ -93,7 +93,7 @@
 				margin-top: 0;
 			}
 		}
-		& + *:not(.newspack-ui__modal-container) {
+		& + *:not(.newspack-ui__modal-container):not(.clear) {
 			margin-top: var(--newspack-ui-spacer-5);
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR modifies the appearance of the navigation on small screens.

The header is now branded with the primary colour to clearly differentiate it from the front end and make it obvious that users are in a different part of the site. This is especially helpful on mobile, where things can get confusing more easily. Using the primary colour also ties in nicely with the menu when it’s open, since the current page is highlighted with the same colour.

I’ve tweaked the behaviour and padding of the navigation when it’s opened. There was an issue on very small screens (under 601px) where the menu’s top position was based on the admin bar. If the user scrolled, this caused a large gap because the admin bar isn’t fixed at that breakpoint.

I also made the header sticky so users can always access the navigation.

### How to test the changes in this Pull Request:

1. Test my account, on small screens
2. Switch to this branch
3. Notice the changes I mentioned above

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->