### PR TITLE
fix(my-account): hide payment-method dropdown if only has one child and is disabled

### DIFF
--- a/src/newspack-ui/scss/elements/woocommerce/_my-account.scss
+++ b/src/newspack-ui/scss/elements/woocommerce/_my-account.scss
@@ -138,9 +138,15 @@
 			}
 		}
 	}
-	#payment-methods .newspack-ui__row > .payment-method {
-		min-height: 106px;
+	#payment-methods {
+		.newspack-ui__dropdown:has( ul > li:only-child .disabled ) {
+			display: none;
+		}
+		.newspack-ui__row > .payment-method {
+			min-height: 106px;
+		}
 	}
+
 	#wcpay-upe-element,
 	.wcpay-upe-element {
 		margin-bottom: var(--newspack-ui-spacer-2);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

I noticied this on our testing site

<img width="1296" height="584" alt="Screenshot 2026-02-10 at 13 28 45@2x" src="https://github.com/user-attachments/assets/738e0fd7-6dd2-440c-9c76-88c9a1666f2a" />

If a dropdown only has 1 child and this child is disabled, we should simply hide the dropdown.

### How to test the changes in this Pull Request:

1. Go to my account > payment information
2. Notice the kebab menu next to your payment method (ideally it's disabled, if not, add a `disabled` to the "Delete" button)
3. Switch to this branch
4. Refresh your my account page
5. The kebab menu should be gone (if it wasn't disabled, add the `disabled` class like step 2)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->