### PR TITLE
fix(my-account): missing padding on labels

### DIFF
--- a/src/newspack-ui/scss/elements/woocommerce/_my-account.scss
+++ b/src/newspack-ui/scss/elements/woocommerce/_my-account.scss
@@ -156,7 +156,7 @@
 	}
 	.woocommerce form .form-row label,
 	.woocommerce-page form .form-row label {
-		display: inline;
+		display: inline-flex;
 	}
 	label:has(input[type="checkbox"]):not(.newspack-ui__input-card),
 	label:has(input[type="radio"]):not(.newspack-ui__input-card) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

There's a gap missing between the label and an input. This PR changes the label display to `inline-flex` instead of `inline` which brings back the margin-bottom.

Before:
<img width="1690" height="764" alt="bfr" src="https://github.com/user-attachments/assets/24a5b16d-7eb1-46ea-a1ac-37188186fe9c" />

After:
<img width="1686" height="810" alt="aftr" src="https://github.com/user-attachments/assets/b558b306-e085-4813-a56b-5a994edc52a3" />

### How to test the changes in this Pull Request:

1. Navigate to my account
2. Notice the gap is missing
3. Switch to this branch and refresh page
4. Check if any other labels have been affected by this change (should be all good)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->