### PR TITLE
chore: resolve lint issue for get_post_meta and get_user_meta

### DIFF
--- a/includes/plugins/co-authors-plus/class-nicename-change.php
+++ b/includes/plugins/co-authors-plus/class-nicename-change.php
@@ -224,7 +224,7 @@ class Nicename_Change {
 	 * @param string $new_nicename  The new nicename.
 	 */
 	public static function handle_old_nicename_meta( $user_id, $old_nicename, $new_nicename ) {
-		$old_nicename_meta = (array) get_user_meta( $user_id, self::OLD_NICENAME_META_KEY );
+		$old_nicename_meta = (array) get_user_meta( $user_id, self::OLD_NICENAME_META_KEY, false );
 
 		// If we haven't added this old nicename before, add it now.
 		if ( ! empty( $old_nicename ) && ! in_array( $old_nicename, $old_nicename_meta, true ) ) {

--- a/includes/revisions-control/class-major-revision.php
+++ b/includes/revisions-control/class-major-revision.php
@@ -60,7 +60,7 @@ class Major_Revision {
 	 * @return array
 	 */
 	public function get_post_revisions() {
-		$ids = get_post_meta( $this->post_id, self::MAJOR_IDS_META_KEY );
+		$ids = get_post_meta( $this->post_id, self::MAJOR_IDS_META_KEY, false );
 		if ( empty( $ids ) ) {
 			return [];
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes the lint issue that are currently in trunk: https://github.com/Automattic/newspack-plugin/actions/runs/21871164961/job/63126520151

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->