### PR TITLE
fix(content-gate): create gate layout with 'publish' status

### DIFF
--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -581,6 +581,7 @@ class Content_Gate {
 				'post_title'   => $title,
 				'post_type'    => self::GATE_LAYOUT_CPT,
 				'post_content' => $content,
+				'post_status'  => 'publish',
 			],
 			true // Return WP_Error on failure.
 		);

--- a/tests/unit-tests/content-gate/content-gates.php
+++ b/tests/unit-tests/content-gate/content-gates.php
@@ -273,6 +273,8 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 		$this->assertNotNull( $custom_access_layout, 'Custom access layout post should exist' );
 		$this->assertEquals( Content_Gate::GATE_LAYOUT_CPT, $registration_layout->post_type, 'Registration layout should be correct post type' );
 		$this->assertEquals( Content_Gate::GATE_LAYOUT_CPT, $custom_access_layout->post_type, 'Custom access layout should be correct post type' );
+		$this->assertEquals( 'publish', $registration_layout->post_status, 'Registration layout should be published' );
+		$this->assertEquals( 'publish', $custom_access_layout->post_status, 'Custom access layout should be published' );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Gate layouts should be created with the status set to 'publish'.

### How to test the changes in this Pull Request:

1. While in trunk, create a new content gate and edit a layout
2. Confirm the created layout is initially a draft
3. Checkout this branch, create a new gate, and confirm the layout status is publish

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->