### PR TITLE
fix: add check for my account before switching error notice

### DIFF
--- a/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php
+++ b/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php
@@ -184,7 +184,8 @@ class My_Account_UI_V1 {
 				return __DIR__ . '/templates/v1/order-again.php';
 			case 'notices/error.php':
 				// Only override error notices on My Account pages to avoid breaking checkout validation.
-				if ( function_exists( 'is_account_page' ) && \is_account_page() ) {
+				// Guard is_account_page() to avoid running before the main query.
+				if ( \did_action( 'wp' ) && function_exists( 'is_account_page' ) && \is_account_page() ) {
 					return __DIR__ . '/templates/v1/notices/error.php';
 				}
 				return $template;

--- a/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php
+++ b/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php
@@ -185,7 +185,7 @@ class My_Account_UI_V1 {
 			case 'notices/error.php':
 				// Only override error notices on My Account pages to avoid breaking checkout validation.
 				// Guard is_account_page() to avoid running before the main query.
-				if ( \did_action( 'wp' ) && function_exists( 'is_account_page' ) && \is_account_page() ) {
+				if ( function_exists( 'is_account_page' ) && function_exists( 'did_action' ) && \did_action( 'wp' ) && \is_account_page() ) {
 					return __DIR__ . '/templates/v1/notices/error.php';
 				}
 				return $template;

--- a/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php
+++ b/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php
@@ -183,7 +183,11 @@ class My_Account_UI_V1 {
 			case 'order/order-again.php':
 				return __DIR__ . '/templates/v1/order-again.php';
 			case 'notices/error.php':
-				return __DIR__ . '/templates/v1/notices/error.php';
+				// Only override error notices on My Account pages to avoid breaking checkout validation.
+				if ( function_exists( 'is_account_page' ) && \is_account_page() ) {
+					return __DIR__ . '/templates/v1/notices/error.php';
+				}
+				return $template;
 			case 'notices/notice.php':
 				return __DIR__ . '/templates/v1/notices/notice.php';
 			case 'notices/success.php':


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Right now there's an issue in trunk where the 'Billing Information' screen is being skipped in the modal checkout.

This appears to be something to do with swapping the error.php -- at least so sez AI: 

> It’s because notices/error.php doesn’t output any HTML. It calls Newspack_UI::add_notice() (snackbar) and returns nothing. On normal My Account pages that’s fine, but during modal checkout the first‑step validation relies on Woo’s notice HTML to come back in the AJAX response (update_order_review). When the error template outputs nothing, the response has no messages, so the JS thinks validation succeeded and skips to the next screen.

This PR adds a check to only swap out the error.php when using My Account -- there might be a better way to do this so I'm open to suggestions!

### How to test the changes in this Pull Request:

1. Set up your site to have a Checkout button block, and disable requiring signing in when making a purchase.
2. In an incognito window, run through the checkout; note you get bumped immediately to the second step without being asked for billing info:

<img width="1064" height="1644" alt="CleanShot 2026-02-12 at 10 37 20@2x" src="https://github.com/user-attachments/assets/59b4fe12-a0cf-42cf-9d27-d4ca7ac93aca" />

3. Apply this PR.
4. Repeat step 2 and make sure you get asked for your Billing details:

<img width="1360" height="1010" alt="CleanShot 2026-02-12 at 10 36 45@2x" src="https://github.com/user-attachments/assets/ff6bb16c-354d-4924-a749-0989d6d9c440" />

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->