### PR TITLE
Adjust lazy loading logic

### DIFF
--- a/includes/plugins/class-perfmatters.php
+++ b/includes/plugins/class-perfmatters.php
@@ -227,8 +227,9 @@ class Perfmatters {
 		if ( ! isset( $options['lazyload'] ) ) {
 			$options['lazyload'] = [];
 		}
-		$options['lazyload']['lazy_loading_iframes']       = true;
-		$options['lazyload']['youtube_preview_thumbnails'] = true;
+		$options['lazyload']['lazy_loading']               = false;
+		$options['lazyload']['lazy_loading_iframes']       = false;
+		$options['lazyload']['youtube_preview_thumbnails'] = false;
 		$options['lazyload']['image_dimensions']           = true;
 
 		$parent_exclusions = empty( $options['lazyload']['lazy_loading_parent_exclusions'] ) ? [] : $options['lazyload']['lazy_loading_parent_exclusions'];


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

**Note: This is a hotfix**

Closes NPPM-2590

This PR adjusts our default lazy load logic to use WP core's lazy loading for everything. This solves an issue where images were not having the lazy load attribute applied to them. WP core [already has lazy loading on by default for iframes and images.](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/media.php#L1849)

### How to test the changes in this Pull Request:

1. You'll probably want to adjust the lazy load threshold to 0, either [directly here or via the available filter.](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/media.php#L6221) Otherwise you'll need a post with at least 3 images and an iframe (like the YouTube embed block). You'll also want to have Perfmatters enabled and using the default Newspack configuration.
2. Before applying this PR, inspect the images and iframe. Observe they do not have the `loading="lazy"` attribute as part of their markup.
3. Apply this PR. Refresh the page. Observe the images and iframe have the attribute:

<img width="1399" height="616" alt="Screenshot 2026-02-12 at 1 14 53 PM" src="https://github.com/user-attachments/assets/d2f30df2-58a5-4467-8721-776b1d6bec05" />

<img width="1422" height="580" alt="Screenshot 2026-02-12 at 1 14 32 PM" src="https://github.com/user-attachments/assets/b70cc84d-a954-4d2c-86ac-193dfe074520" />

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->