### PR TITLE
Add dynamic copyright date block

### DIFF
--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -35,6 +35,7 @@ final class Blocks {
 			require_once NEWSPACK_ABSPATH . 'src/blocks/byline/class-byline-block.php';
 			require_once NEWSPACK_ABSPATH . 'src/blocks/author-profile-social/class-author-profile-social-block.php';
 			require_once NEWSPACK_ABSPATH . 'src/blocks/author-social-link/class-author-social-link-block.php';
+			require_once NEWSPACK_ABSPATH . 'src/blocks/copyright-date/class-copyright-date-block.php';
 			Social_Icons::init();
 		}
 		if ( Collections::is_module_active() ) {

--- a/src/blocks/copyright-date/README.md
+++ b/src/blocks/copyright-date/README.md
@@ -1,0 +1,42 @@
+# Copyright Date Block
+
+A Gutenberg block that displays the current year with configurable prefix and suffix text.
+
+## Overview
+
+The Copyright Date block dynamically renders the current year based on the site's timezone setting. It's designed for use in footer templates and patterns, removing the need to manually update the copyright year. The year updates automatically for all visitors based on the site's configured timezone, not the visitor's local time.
+
+## Block attributes
+
+| Attribute | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `prefix` | string | `"©"` | Plain text displayed before the year. Edited inline via a RichText field with formatting disabled. |
+| `suffix` | string | `""` | Plain text displayed after the year. Edited inline via a RichText field with formatting disabled. |
+
+## Editor behavior
+
+The prefix and suffix are edited directly in the block content area using inline RichText fields with formatting disabled. There are no custom sidebar controls. The year is derived from `dateI18n('Y')` (`@wordpress/date`), which respects the site's timezone setting.
+
+## Rendering
+
+The block is server-rendered (dynamic block with no `save` function). The PHP render callback uses `wp_date('Y')` for the year, matching the editor's `dateI18n('Y')`. The output consists of up to three `<span>` elements (prefix, year, suffix) separated by spaces, wrapped in a `<div>` with block wrapper attributes.
+
+Both prefix and suffix values are escaped with `esc_html()` in the render output. Empty prefix or suffix values are omitted from the markup entirely.
+
+## Usage with block theme patterns
+
+All footer patterns in the Newspack Block Theme include this block:
+
+```html
+<!-- wp:newspack/copyright-date /-->
+```
+
+The block uses the default © prefix, so no attributes need to be specified in patterns.
+
+## Styling
+
+The block has no stylesheet. All visual styling is controlled through the block's supported styles (typography, colors, spacing, borders) or inherited from the parent block.
+
+## Related
+
+- [Newspack Block Theme footer patterns](https://github.com/Automattic/newspack-block-theme/tree/trunk/patterns/footer) - Footer patterns that use this block.

--- a/src/blocks/copyright-date/block.json
+++ b/src/blocks/copyright-date/block.json
@@ -1,0 +1,65 @@
+{
+	"apiVersion": 3,
+	"name": "newspack/copyright-date",
+	"title": "Copyright Date",
+	"category": "newspack",
+	"description": "Display the current year with configurable prefix and suffix text.",
+	"textdomain": "newspack-plugin",
+	"attributes": {
+		"prefix": {
+			"type": "string",
+			"default": "\u00a9"
+		},
+		"suffix": {
+			"type": "string",
+			"default": ""
+		}
+	},
+	"supports": {
+		"html": false,
+		"color": {
+			"text": true,
+			"background": true,
+			"__experimentalDefaultControls": {
+				"text": true
+			}
+		},
+		"spacing": {
+			"margin": true,
+			"padding": true,
+			"__experimentalDefaultControls": {
+				"margin": false,
+				"padding": false
+			}
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true,
+				"fontAppearance": true
+			}
+		},
+		"__experimentalBorder": {
+			"radius": true,
+			"width": true,
+			"color": true,
+			"style": true,
+			"__experimentalDefaultControls": {
+				"radius": false,
+				"width": false,
+				"color": false,
+				"style": false
+			}
+		},
+		"interactivity": {
+			"clientNavigation": true
+		}
+	}
+}

--- a/src/blocks/copyright-date/block.json
+++ b/src/blocks/copyright-date/block.json
@@ -8,7 +8,7 @@
 	"attributes": {
 		"prefix": {
 			"type": "string",
-			"default": "\u00a9"
+			"default": "\u00a9 "
 		},
 		"suffix": {
 			"type": "string",

--- a/src/blocks/copyright-date/class-copyright-date-block.php
+++ b/src/blocks/copyright-date/class-copyright-date-block.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Copyright Date Block.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Blocks\CopyrightDate;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Copyright_Date_Block Class
+ */
+final class Copyright_Date_Block {
+
+	/**
+	 * Block name.
+	 */
+	public const BLOCK_NAME = 'newspack/copyright-date';
+
+	/**
+	 * Initializes the block.
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		add_action( 'init', [ __CLASS__, 'register_block' ] );
+	}
+
+	/**
+	 * Register the copyright date block.
+	 *
+	 * @return void
+	 */
+	public static function register_block() {
+		register_block_type_from_metadata(
+			__DIR__ . '/block.json',
+			[
+				'render_callback' => [ __CLASS__, 'render_block' ],
+			]
+		);
+	}
+
+	/**
+	 * Block render callback.
+	 *
+	 * @param array $attributes The block attributes.
+	 *
+	 * @return string The block HTML.
+	 */
+	public static function render_block( array $attributes ) {
+		$prefix      = $attributes['prefix'] ?? '';
+		$suffix      = $attributes['suffix'] ?? '';
+		$year        = wp_date( 'Y' );
+		$block_class = wp_get_block_default_classname( self::BLOCK_NAME );
+
+		$parts = [];
+
+		if ( '' !== $prefix ) {
+			$parts[] = sprintf(
+				'<span class="%s__prefix">%s</span>',
+				$block_class,
+				esc_html( $prefix )
+			);
+		}
+
+		$parts[] = sprintf(
+			'<span class="%s__year">%s</span>',
+			$block_class,
+			esc_html( $year )
+		);
+
+		if ( '' !== $suffix ) {
+			$parts[] = sprintf(
+				'<span class="%s__suffix">%s</span>',
+				$block_class,
+				esc_html( $suffix )
+			);
+		}
+
+		$wrapper_attributes = get_block_wrapper_attributes();
+
+		return sprintf(
+			'<div %1$s>%2$s</div>',
+			$wrapper_attributes,
+			implode( ' ', $parts )
+		);
+	}
+}
+
+Copyright_Date_Block::init();

--- a/src/blocks/copyright-date/class-copyright-date-block.php
+++ b/src/blocks/copyright-date/class-copyright-date-block.php
@@ -61,7 +61,7 @@ final class Copyright_Date_Block {
 			$parts[] = sprintf(
 				'<span class="%s__prefix">%s</span>',
 				$block_class,
-				esc_html( $prefix )
+				wp_kses_post( $prefix )
 			);
 		}
 
@@ -75,7 +75,7 @@ final class Copyright_Date_Block {
 			$parts[] = sprintf(
 				'<span class="%s__suffix">%s</span>',
 				$block_class,
-				esc_html( $suffix )
+				wp_kses_post( $suffix )
 			);
 		}
 

--- a/src/blocks/copyright-date/class-copyright-date-block.php
+++ b/src/blocks/copyright-date/class-copyright-date-block.php
@@ -43,6 +43,18 @@ final class Copyright_Date_Block {
 	}
 
 	/**
+	 * Allowed HTML for prefix and suffix fields (links only).
+	 */
+	public const ALLOWED_HTML = [
+		'a' => [
+			'href'   => true,
+			'class'  => true,
+			'target' => true,
+			'rel'    => true,
+		],
+	];
+
+	/**
 	 * Block render callback.
 	 *
 	 * @param array $attributes The block attributes.
@@ -61,7 +73,7 @@ final class Copyright_Date_Block {
 			$inner .= sprintf(
 				'<span class="%s__prefix">%s</span>',
 				$block_class,
-				wp_kses_post( $prefix )
+				wp_kses( $prefix, self::ALLOWED_HTML )
 			);
 		}
 
@@ -75,7 +87,7 @@ final class Copyright_Date_Block {
 			$inner .= sprintf(
 				' <span class="%s__suffix">%s</span>',
 				$block_class,
-				wp_kses_post( $suffix )
+				wp_kses( $suffix, self::ALLOWED_HTML )
 			);
 		}
 

--- a/src/blocks/copyright-date/class-copyright-date-block.php
+++ b/src/blocks/copyright-date/class-copyright-date-block.php
@@ -55,25 +55,25 @@ final class Copyright_Date_Block {
 		$year        = wp_date( 'Y' );
 		$block_class = wp_get_block_default_classname( self::BLOCK_NAME );
 
-		$parts = [];
+		$inner = '';
 
 		if ( '' !== $prefix ) {
-			$parts[] = sprintf(
+			$inner .= sprintf(
 				'<span class="%s__prefix">%s</span>',
 				$block_class,
 				wp_kses_post( $prefix )
 			);
 		}
 
-		$parts[] = sprintf(
+		$inner .= sprintf(
 			'<span class="%s__year">%s</span>',
 			$block_class,
 			esc_html( $year )
 		);
 
 		if ( '' !== $suffix ) {
-			$parts[] = sprintf(
-				'<span class="%s__suffix">%s</span>',
+			$inner .= sprintf(
+				' <span class="%s__suffix">%s</span>',
 				$block_class,
 				wp_kses_post( $suffix )
 			);
@@ -84,7 +84,7 @@ final class Copyright_Date_Block {
 		return sprintf(
 			'<div %1$s>%2$s</div>',
 			$wrapper_attributes,
-			implode( ' ', $parts )
+			$inner
 		);
 	}
 }

--- a/src/blocks/copyright-date/edit.jsx
+++ b/src/blocks/copyright-date/edit.jsx
@@ -1,0 +1,50 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { dateI18n } from '@wordpress/date';
+import { getBlockDefaultClassName } from '@wordpress/blocks';
+import { useBlockProps, RichText } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+
+const blockClass = getBlockDefaultClassName( metadata.name );
+
+/**
+ * Edit component for the copyright date block.
+ *
+ * @param {Object}   props               Component props.
+ * @param {Object}   props.attributes    Block attributes.
+ * @param {Function} props.setAttributes Set attributes function.
+ * @return {JSX.Element} Edit component.
+ */
+export default function Edit( { attributes, setAttributes } ) {
+	const { prefix, suffix } = attributes;
+	const blockProps = useBlockProps();
+	const year = dateI18n( 'Y' );
+
+	return (
+		<div { ...blockProps }>
+			<RichText
+				className={ `${ blockClass }__prefix` }
+				tagName="span"
+				placeholder={ __( 'Prefix…', 'newspack-plugin' ) }
+				value={ prefix }
+				onChange={ value => setAttributes( { prefix: value } ) }
+				allowedFormats={ [] }
+			/>{ ' ' }
+			<span className={ `${ blockClass }__year` }>{ year }</span>{ ' ' }
+			<RichText
+				className={ `${ blockClass }__suffix` }
+				tagName="span"
+				placeholder={ __( 'Suffix…', 'newspack-plugin' ) }
+				value={ suffix }
+				onChange={ value => setAttributes( { suffix: value } ) }
+				allowedFormats={ [] }
+			/>
+		</div>
+	);
+}

--- a/src/blocks/copyright-date/edit.jsx
+++ b/src/blocks/copyright-date/edit.jsx
@@ -35,7 +35,7 @@ export default function Edit( { attributes, setAttributes } ) {
 				value={ prefix }
 				onChange={ value => setAttributes( { prefix: value } ) }
 				allowedFormats={ [ 'core/link' ] }
-			/>{ ' ' }
+			/>
 			<span className={ `${ blockClass }__year` }>{ year }</span>{ ' ' }
 			<RichText
 				className={ `${ blockClass }__suffix` }

--- a/src/blocks/copyright-date/edit.jsx
+++ b/src/blocks/copyright-date/edit.jsx
@@ -34,7 +34,7 @@ export default function Edit( { attributes, setAttributes } ) {
 				placeholder={ __( 'Prefix…', 'newspack-plugin' ) }
 				value={ prefix }
 				onChange={ value => setAttributes( { prefix: value } ) }
-				allowedFormats={ [] }
+				allowedFormats={ [ 'core/link' ] }
 			/>{ ' ' }
 			<span className={ `${ blockClass }__year` }>{ year }</span>{ ' ' }
 			<RichText
@@ -43,7 +43,7 @@ export default function Edit( { attributes, setAttributes } ) {
 				placeholder={ __( 'Suffix…', 'newspack-plugin' ) }
 				value={ suffix }
 				onChange={ value => setAttributes( { suffix: value } ) }
-				allowedFormats={ [] }
+				allowedFormats={ [ 'core/link' ] }
 			/>
 		</div>
 	);

--- a/src/blocks/copyright-date/edit.test.jsx
+++ b/src/blocks/copyright-date/edit.test.jsx
@@ -79,13 +79,13 @@ describe( 'Copyright Date Edit', () => {
 		expect( screen.getByText( '2099' ) ).toHaveClass( `${ blockClass }__year` );
 	} );
 
-	it( 'should disable formatting on prefix and suffix RichText fields', () => {
+	it( 'should only allow link formatting on prefix and suffix RichText fields', () => {
 		render( <Edit { ...{ ...defaultProps, attributes: { prefix: '\u00a9', suffix: 'Acme' } } } /> );
 
 		const prefix = screen.getByText( '\u00a9' );
 		const suffix = screen.getByText( 'Acme' );
 
-		expect( prefix ).toHaveAttribute( 'data-allowed-formats', '[]' );
-		expect( suffix ).toHaveAttribute( 'data-allowed-formats', '[]' );
+		expect( prefix ).toHaveAttribute( 'data-allowed-formats', '["core/link"]' );
+		expect( suffix ).toHaveAttribute( 'data-allowed-formats', '["core/link"]' );
 	} );
 } );

--- a/src/blocks/copyright-date/edit.test.jsx
+++ b/src/blocks/copyright-date/edit.test.jsx
@@ -1,0 +1,91 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import Edit from './edit';
+import metadata from './block.json';
+import { getBlockDefaultClassName } from '@wordpress/blocks';
+
+jest.mock( '@wordpress/block-editor', () => ( {
+	useBlockProps: () => ( { 'data-testid': 'block-wrapper' } ),
+	RichText: ( { value, className, placeholder, tagName: Tag = 'span', allowedFormats } ) => (
+		<Tag className={ className } data-placeholder={ placeholder } data-allowed-formats={ JSON.stringify( allowedFormats ) }>
+			{ value }
+		</Tag>
+	),
+} ) );
+
+jest.mock( '@wordpress/blocks', () => ( {
+	getBlockDefaultClassName: name => 'wp-block-' + name.replace( '/', '-' ),
+} ) );
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: str => str,
+} ) );
+
+jest.mock( '@wordpress/date', () => ( {
+	dateI18n: jest.fn( () => '2099' ),
+} ) );
+
+const blockClass = getBlockDefaultClassName( metadata.name );
+
+const defaultProps = {
+	attributes: { prefix: '\u00a9', suffix: '' },
+	setAttributes: jest.fn(),
+};
+
+describe( 'Copyright Date Edit', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'should use dateI18n for the year to respect site timezone', () => {
+		const { dateI18n } = require( '@wordpress/date' );
+		render( <Edit { ...defaultProps } /> );
+
+		expect( dateI18n ).toHaveBeenCalledWith( 'Y' );
+		expect( screen.getByText( '2099' ) ).toBeInTheDocument();
+	} );
+
+	it( 'should render the default copyright symbol prefix', () => {
+		render( <Edit { ...defaultProps } /> );
+
+		const prefix = screen.getByText( '\u00a9' );
+		expect( prefix ).toBeInTheDocument();
+		expect( prefix ).toHaveClass( `${ blockClass }__prefix` );
+	} );
+
+	it( 'should render a custom prefix', () => {
+		render( <Edit { ...{ ...defaultProps, attributes: { prefix: 'Copyright', suffix: '' } } } /> );
+
+		expect( screen.getByText( 'Copyright' ) ).toBeInTheDocument();
+	} );
+
+	it( 'should render suffix when provided', () => {
+		render( <Edit { ...{ ...defaultProps, attributes: { prefix: '\u00a9', suffix: 'Acme Inc' } } } /> );
+
+		const suffix = screen.getByText( 'Acme Inc' );
+		expect( suffix ).toBeInTheDocument();
+		expect( suffix ).toHaveClass( `${ blockClass }__suffix` );
+	} );
+
+	it( 'should have correct BEM class on year element', () => {
+		render( <Edit { ...defaultProps } /> );
+
+		expect( screen.getByText( '2099' ) ).toHaveClass( `${ blockClass }__year` );
+	} );
+
+	it( 'should disable formatting on prefix and suffix RichText fields', () => {
+		render( <Edit { ...{ ...defaultProps, attributes: { prefix: '\u00a9', suffix: 'Acme' } } } /> );
+
+		const prefix = screen.getByText( '\u00a9' );
+		const suffix = screen.getByText( 'Acme' );
+
+		expect( prefix ).toHaveAttribute( 'data-allowed-formats', '[]' );
+		expect( suffix ).toHaveAttribute( 'data-allowed-formats', '[]' );
+	} );
+} );

--- a/src/blocks/copyright-date/index.js
+++ b/src/blocks/copyright-date/index.js
@@ -1,0 +1,34 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { postDate as icon } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import Edit from './edit';
+import colors from '../../../packages/colors/colors.module.scss';
+
+export const title = __( 'Copyright Date', 'newspack-plugin' );
+
+const { name } = metadata;
+
+export { metadata, name };
+
+export const settings = {
+	title,
+	icon: {
+		src: icon,
+		foreground: colors[ 'primary-400' ],
+	},
+	keywords: [
+		__( 'copyright', 'newspack-plugin' ),
+		__( 'date', 'newspack-plugin' ),
+		__( 'year', 'newspack-plugin' ),
+		__( 'newspack', 'newspack-plugin' ),
+	],
+	description: __( 'Display the current year with configurable prefix and suffix text.', 'newspack-plugin' ),
+	edit: Edit,
+};

--- a/src/blocks/index.js
+++ b/src/blocks/index.js
@@ -19,6 +19,7 @@ import * as authorSocialLink from './author-social-link';
 import * as collections from './collections';
 import * as contentGateCountdown from './content-gate/countdown';
 import * as contentGateCountdownBox from './content-gate/countdown-box';
+import * as copyrightDate from './copyright-date';
 
 /**
  * Block Scripts
@@ -37,6 +38,7 @@ export const blocks = [
 	collections,
 	contentGateCountdown,
 	contentGateCountdownBox,
+	copyrightDate,
 ];
 
 const readerActivationBlocks = [ 'newspack/reader-registration', 'newspack/my-account-button' ];
@@ -48,6 +50,7 @@ const blockThemeBlocks = [
 	'newspack/author-social-link',
 	'newspack/avatar',
 	'newspack/byline',
+	'newspack/copyright-date',
 	'newspack/my-account-button',
 ];
 

--- a/tests/unit-tests/class-test-copyright-date-block.php
+++ b/tests/unit-tests/class-test-copyright-date-block.php
@@ -165,15 +165,15 @@ class Newspack_Test_Copyright_Date_Block extends WP_UnitTestCase {
 			]
 		);
 
+		$this->assertStringContainsString( '</span> <span class="' . $this->block_class . '__year">', $output, 'Space should separate prefix and year.' );
+		$this->assertStringContainsString( '</span> <span class="' . $this->block_class . '__suffix">', $output, 'Space should separate year and suffix.' );
+
 		$prefix_pos = strpos( $output, $this->block_class . '__prefix' );
 		$year_pos   = strpos( $output, $this->block_class . '__year' );
 		$suffix_pos = strpos( $output, $this->block_class . '__suffix' );
 
 		$this->assertGreaterThan( $prefix_pos, $year_pos, 'Year should appear after prefix.' );
 		$this->assertGreaterThan( $year_pos, $suffix_pos, 'Suffix should appear after year.' );
-
-		$this->assertStringContainsString( '</span> <span class="' . $this->block_class . '__year">', $output, 'Space should separate prefix and year.' );
-		$this->assertStringContainsString( '</span> <span class="' . $this->block_class . '__suffix">', $output, 'Space should separate year and suffix.' );
 	}
 
 	/**

--- a/tests/unit-tests/class-test-copyright-date-block.php
+++ b/tests/unit-tests/class-test-copyright-date-block.php
@@ -179,7 +179,7 @@ class Newspack_Test_Copyright_Date_Block extends WP_UnitTestCase {
 			]
 		);
 
-		$this->assertStringContainsString( '</span> <span class="' . $this->block_class . '__year">', $output, 'Space should separate prefix and year.' );
+		$this->assertStringContainsString( '</span><span class="' . $this->block_class . '__year">', $output, 'Prefix and year should be adjacent (spacing controlled by prefix content).' );
 		$this->assertStringContainsString( '</span> <span class="' . $this->block_class . '__suffix">', $output, 'Space should separate year and suffix.' );
 
 		$prefix_pos = strpos( $output, $this->block_class . '__prefix' );

--- a/tests/unit-tests/class-test-copyright-date-block.php
+++ b/tests/unit-tests/class-test-copyright-date-block.php
@@ -126,24 +126,9 @@ class Newspack_Test_Copyright_Date_Block extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test prefix and suffix strip unsafe HTML to prevent XSS.
+	 * Test only link tags are allowed; all other HTML is stripped.
 	 */
-	public function test_unsafe_html_is_stripped() {
-		$xss    = '<script>alert(1)</script>';
-		$output = $this->render_block(
-			[
-				'prefix' => $xss,
-				'suffix' => $xss,
-			]
-		);
-
-		$this->assertStringNotContainsString( '<script>', $output, 'Script tags should be stripped from output.' );
-	}
-
-	/**
-	 * Test prefix and suffix preserve safe HTML like links.
-	 */
-	public function test_links_are_preserved() {
+	public function test_only_links_are_allowed() {
 		$link   = '<a href="https://example.com">Acme Inc</a>';
 		$output = $this->render_block(
 			[
@@ -151,8 +136,18 @@ class Newspack_Test_Copyright_Date_Block extends WP_UnitTestCase {
 				'suffix' => $link,
 			]
 		);
+		$this->assertSame( 2, substr_count( $output, $link ), 'Links should be preserved in both prefix and suffix.' );
 
-		$this->assertSame( 2, substr_count( $output, '<a href="https://example.com">Acme Inc</a>' ), 'Links should be preserved in both prefix and suffix.' );
+		$other_html = '<strong>bold</strong> <em>italic</em> <script>alert(1)</script>';
+		$output     = $this->render_block(
+			[
+				'prefix' => $other_html,
+				'suffix' => $other_html,
+			]
+		);
+		$this->assertStringNotContainsString( '<strong>', $output, 'Strong tags should be stripped.' );
+		$this->assertStringNotContainsString( '<em>', $output, 'Em tags should be stripped.' );
+		$this->assertStringNotContainsString( '<script>', $output, 'Script tags should be stripped.' );
 	}
 
 	/**

--- a/tests/unit-tests/class-test-copyright-date-block.php
+++ b/tests/unit-tests/class-test-copyright-date-block.php
@@ -126,9 +126,9 @@ class Newspack_Test_Copyright_Date_Block extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test prefix and suffix are escaped with esc_html to prevent XSS.
+	 * Test prefix and suffix strip unsafe HTML to prevent XSS.
 	 */
-	public function test_html_is_escaped() {
+	public function test_unsafe_html_is_stripped() {
 		$xss    = '<script>alert(1)</script>';
 		$output = $this->render_block(
 			[
@@ -137,8 +137,22 @@ class Newspack_Test_Copyright_Date_Block extends WP_UnitTestCase {
 			]
 		);
 
-		$this->assertStringNotContainsString( '<script>', $output, 'Script tags should not appear in output.' );
-		$this->assertSame( 2, substr_count( $output, '&lt;script&gt;' ), 'Both prefix and suffix should be HTML-escaped.' );
+		$this->assertStringNotContainsString( '<script>', $output, 'Script tags should be stripped from output.' );
+	}
+
+	/**
+	 * Test prefix and suffix preserve safe HTML like links.
+	 */
+	public function test_links_are_preserved() {
+		$link   = '<a href="https://example.com">Acme Inc</a>';
+		$output = $this->render_block(
+			[
+				'prefix' => $link,
+				'suffix' => $link,
+			]
+		);
+
+		$this->assertSame( 2, substr_count( $output, '<a href="https://example.com">Acme Inc</a>' ), 'Links should be preserved in both prefix and suffix.' );
 	}
 
 	/**

--- a/tests/unit-tests/class-test-copyright-date-block.php
+++ b/tests/unit-tests/class-test-copyright-date-block.php
@@ -1,0 +1,195 @@
+<?php
+/**
+ * Tests for Copyright Date block.
+ *
+ * @package Newspack\Tests
+ * @covers \Newspack\Blocks\CopyrightDate\Copyright_Date_Block
+ */
+
+use Newspack\Blocks\CopyrightDate\Copyright_Date_Block;
+
+/**
+ * Test class for the Copyright Date Block.
+ *
+ * @group copyright-date-block
+ */
+class Newspack_Test_Copyright_Date_Block extends WP_UnitTestCase {
+
+	/**
+	 * Block CSS class derived from block name.
+	 *
+	 * @var string
+	 */
+	private $block_class;
+
+	/**
+	 * Setup.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		require_once NEWSPACK_ABSPATH . 'src/blocks/copyright-date/class-copyright-date-block.php';
+		$this->block_class = wp_get_block_default_classname( Copyright_Date_Block::BLOCK_NAME );
+
+		if ( ! \WP_Block_Type_Registry::get_instance()->is_registered( Copyright_Date_Block::BLOCK_NAME ) ) {
+			Copyright_Date_Block::register_block();
+		}
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tear_down(): void {
+		if ( \WP_Block_Type_Registry::get_instance()->is_registered( Copyright_Date_Block::BLOCK_NAME ) ) {
+			unregister_block_type( Copyright_Date_Block::BLOCK_NAME );
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Build block markup for do_blocks().
+	 *
+	 * @param array $attributes Optional block attributes.
+	 * @return string Rendered block HTML.
+	 */
+	private function render_block( array $attributes = [] ) {
+		$attrs = $attributes ? ' ' . wp_json_encode( $attributes ) : '';
+		return do_blocks( '<!-- wp:' . Copyright_Date_Block::BLOCK_NAME . $attrs . ' /-->' );
+	}
+
+	/**
+	 * Test default render includes current year and copyright symbol prefix.
+	 */
+	public function test_render_default_attributes() {
+		$output = $this->render_block();
+
+		$this->assertNotEmpty( $output, 'Block should produce output.' );
+		$this->assertStringContainsString( $this->block_class, $output, 'Output should contain the block class.' );
+		$this->assertStringContainsString( wp_date( 'Y' ), $output, 'Output should contain the current year.' );
+		$this->assertStringContainsString( '©', $output, 'Default prefix should be the copyright symbol.' );
+	}
+
+	/**
+	 * Test year is rendered in its own span.
+	 */
+	public function test_render_year_span() {
+		$output = $this->render_block();
+		$year   = wp_date( 'Y' );
+
+		$this->assertStringContainsString(
+			'<span class="' . $this->block_class . '__year">' . $year . '</span>',
+			$output,
+			'Year should be wrapped in a span with the __year BEM class.'
+		);
+	}
+
+	/**
+	 * Test prefix rendering: BEM span, custom text, and omitted when empty.
+	 */
+	public function test_render_prefix() {
+		$default = $this->render_block( [ 'prefix' => "\u{00a9}" ] );
+		$this->assertStringContainsString(
+			'<span class="' . $this->block_class . '__prefix">©</span>',
+			$default,
+			'Default prefix should render © in a __prefix span.'
+		);
+
+		$custom = $this->render_block( [ 'prefix' => 'Copyright' ] );
+		$this->assertStringContainsString( '<span class="' . $this->block_class . '__prefix">Copyright</span>', $custom, 'Custom prefix text should render in a __prefix span.' );
+		$this->assertStringNotContainsString( '©', $custom, 'Custom prefix should not contain the copyright symbol.' );
+
+		$empty = $this->render_block( [ 'prefix' => '' ] );
+		$this->assertStringNotContainsString( $this->block_class . '__prefix', $empty, 'Empty prefix should omit the __prefix span.' );
+		$this->assertStringContainsString( $this->block_class . '__year', $empty, 'Year should still render when prefix is empty.' );
+	}
+
+	/**
+	 * Test suffix rendering: BEM span when provided, omitted when empty.
+	 */
+	public function test_render_suffix() {
+		$with_suffix = $this->render_block(
+			[
+				'prefix' => "\u{00a9}",
+				'suffix' => 'My Publication',
+			]
+		);
+		$this->assertStringContainsString( '<span class="' . $this->block_class . '__suffix">My Publication</span>', $with_suffix, 'Suffix should render in a __suffix span.' );
+
+		$empty = $this->render_block(
+			[
+				'prefix' => "\u{00a9}",
+				'suffix' => '',
+			]
+		);
+		$this->assertStringNotContainsString( '<span class="' . $this->block_class . '__suffix">', $empty, 'Empty suffix should omit the __suffix span.' );
+	}
+
+	/**
+	 * Test prefix and suffix are escaped with esc_html to prevent XSS.
+	 */
+	public function test_html_is_escaped() {
+		$xss    = '<script>alert(1)</script>';
+		$output = $this->render_block(
+			[
+				'prefix' => $xss,
+				'suffix' => $xss,
+			]
+		);
+
+		$this->assertStringNotContainsString( '<script>', $output, 'Script tags should not appear in output.' );
+		$this->assertSame( 2, substr_count( $output, '&lt;script&gt;' ), 'Both prefix and suffix should be HTML-escaped.' );
+	}
+
+	/**
+	 * Test output wraps in div with block wrapper attributes.
+	 */
+	public function test_render_wrapper_element() {
+		$output = $this->render_block();
+
+		$this->assertMatchesRegularExpression(
+			'/<div\s[^>]*class="[^"]*' . $this->block_class . '[^"]*"/',
+			$output,
+			'Output should be wrapped in a div with the block class.'
+		);
+	}
+
+	/**
+	 * Test parts render in correct order with space separation.
+	 */
+	public function test_render_parts_order() {
+		$output = $this->render_block(
+			[
+				'prefix' => "\u{00a9}",
+				'suffix' => 'Acme Inc',
+			]
+		);
+
+		$prefix_pos = strpos( $output, $this->block_class . '__prefix' );
+		$year_pos   = strpos( $output, $this->block_class . '__year' );
+		$suffix_pos = strpos( $output, $this->block_class . '__suffix' );
+
+		$this->assertGreaterThan( $prefix_pos, $year_pos, 'Year should appear after prefix.' );
+		$this->assertGreaterThan( $year_pos, $suffix_pos, 'Suffix should appear after year.' );
+
+		$this->assertStringContainsString( '</span> <span class="' . $this->block_class . '__year">', $output, 'Space should separate prefix and year.' );
+		$this->assertStringContainsString( '</span> <span class="' . $this->block_class . '__suffix">', $output, 'Space should separate year and suffix.' );
+	}
+
+	/**
+	 * Test render with only year (no prefix, no suffix).
+	 */
+	public function test_render_year_only() {
+		$output = $this->render_block(
+			[
+				'prefix' => '',
+				'suffix' => '',
+			]
+		);
+		$year   = wp_date( 'Y' );
+
+		$this->assertStringContainsString( $year, $output, 'Year should render even without prefix and suffix.' );
+		$this->assertStringNotContainsString( $this->block_class . '__prefix', $output, 'Prefix span should be omitted.' );
+		$this->assertStringNotContainsString( $this->block_class . '__suffix', $output, 'Suffix span should be omitted.' );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds a new `newspack/copyright-date` dynamic block that renders the current year with configurable prefix and suffix text. The year is derived from the site's timezone (via `wp_date` in PHP and `dateI18n` in JS), so it stays accurate regardless of the visitor's location.

The block ships with sensible defaults (© prefix, empty suffix) and disables rich text formatting on both fields in favor of inheriting the block's typography styles.

Closes NPPD-1186.

Related PR: https://github.com/Automattic/newspack-block-theme/pull/414

### How to test the changes in this Pull Request:

1. Insert the "Copyright Date" block in the block editor.
2. Verify the default rendering shows `© <current year>` in both the editor and frontend.
3. Edit the prefix (e.g., change to "Copyright") and add a suffix (e.g., "My Publication"). Confirm both render correctly on the frontend as separate `<span>` elements with spaces between parts.
4. Clear the prefix entirely and verify only the year renders (no empty span in the markup).
5. Clear the suffix and verify no suffix span appears.
6. Confirm the year matches the site's configured timezone (Settings > General > Timezone), not the browser's local time.
7. Try entering HTML in the prefix/suffix fields and verify it is escaped in the frontend output.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?