### PR TITLE
fix(my-account): resubscription validation in order-again template

### DIFF
--- a/includes/plugins/woocommerce/my-account/templates/v1/order-again.php
+++ b/includes/plugins/woocommerce/my-account/templates/v1/order-again.php
@@ -10,7 +10,19 @@
 defined( 'ABSPATH' ) || exit;
 
 $wp_button_class = 'newspack-ui__button newspack-ui__button--secondary';
-$button_text     = wcs_order_contains_subscription( $order, 'parent' ) ? __( 'Renew subscription', 'newspack-plugin' ) : __( 'Order again', 'newspack-plugin' );
+$contains_subscription = wcs_order_contains_subscription( $order, 'parent' );
+$button_text     = $contains_subscription ? __( 'Renew subscription', 'newspack-plugin' ) : __( 'Order again', 'newspack-plugin' );
+if ( $contains_subscription ) {
+	$subscriptions = wcs_get_subscriptions_for_order( $order->get_id() );
+	if ( empty( $subscriptions ) ) {
+		return;
+	}
+	foreach ( $subscriptions as $subscription ) {
+		if ( ! wcs_can_user_resubscribe_to( $subscription, get_current_user_id() ) ) {
+			return;
+		}
+	}
+}
 ?>
 
 <p class="order-again">

--- a/includes/plugins/woocommerce/my-account/templates/v1/order-again.php
+++ b/includes/plugins/woocommerce/my-account/templates/v1/order-again.php
@@ -11,7 +11,7 @@ defined( 'ABSPATH' ) || exit;
 
 $wp_button_class = 'newspack-ui__button newspack-ui__button--secondary';
 $contains_subscription = wcs_order_contains_subscription( $order, 'parent' );
-$button_text     = $contains_subscription ? __( 'Renew subscription', 'newspack-plugin' ) : __( 'Order again', 'newspack-plugin' );
+$button_text = $contains_subscription ? __( 'Renew subscription', 'newspack-plugin' ) : __( 'Order again', 'newspack-plugin' );
 if ( $contains_subscription ) {
 	$subscriptions = wcs_get_subscriptions_for_order( $order->get_id() );
 	if ( empty( $subscriptions ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

NPPM-2625

When a subscription expires, and its product is no longer purchasable (set to private), the subscription page still renders "Renew subscription" for the re-order button. Clicking on it opens a broken modal checkout, since Woo doesn't allow for the cart to be generated.

### How to test the changes in this Pull Request:

1. While on trunk, purchase a subscription as a reader
2. As an admin, edit the subscription from the admin dashboard and change it's status to expired
3. Edit the subscription product and set it to private
4. Back as the reader, visit the subscription page and click "Renew subscription"
5. Confirm you get a broken modal checkout
6. Checkout this branch, refresh the reader subscription page and confirm the button is now gone
7. Edit the product and remove the private flag
8. Refresh the reader subscription page and confirm the button is back and you are able to resubscribe

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->