### PR TITLE
fix(my-account): don't show subscription payment notice in modal checkout

### DIFF
--- a/includes/plugins/woocommerce/class-woocommerce-update-payment-notice.php
+++ b/includes/plugins/woocommerce/class-woocommerce-update-payment-notice.php
@@ -145,6 +145,9 @@ class WooCommerce_Update_Payment_Notice {
 			}
 
 			$line_items = $subscription->get_items();
+			if ( empty( $line_items ) ) {
+				continue;
+			}
 			$line_item  = reset( $line_items );
 			$product    = wc_get_product( $line_item->get_product_id() );
 			// If the product has a parent, use the parent product.

--- a/includes/plugins/woocommerce/class-woocommerce-update-payment-notice.php
+++ b/includes/plugins/woocommerce/class-woocommerce-update-payment-notice.php
@@ -85,6 +85,11 @@ class WooCommerce_Update_Payment_Notice {
 			return;
 		}
 
+		// Don't show in modal checkout frame.
+		if ( method_exists( 'Newspack_Blocks\Modal_Checkout', 'is_modal_checkout' ) && \Newspack_Blocks\Modal_Checkout::is_modal_checkout() ) {
+			return;
+		}
+
 		$notices = self::get_notices();
 		if ( empty( $notices ) ) {
 			return;
@@ -139,8 +144,9 @@ class WooCommerce_Update_Payment_Notice {
 				continue;
 			}
 
-			$line_item = reset( $subscription->get_items() );
-			$product   = wc_get_product( $line_item->get_product_id() );
+			$line_items = $subscription->get_items();
+			$line_item  = reset( $line_items );
+			$product    = wc_get_product( $line_item->get_product_id() );
 			// If the product has a parent, use the parent product.
 			if ( $product->get_parent_id() ) {
 				$product = wc_get_product( $product->get_parent_id() );
@@ -174,7 +180,7 @@ class WooCommerce_Update_Payment_Notice {
 				];
 			}
 
-			$notices[] = self::get_message( $subscription ) . ' ' . sprintf(
+			$notice = self::get_message( $subscription ) . ' ' . sprintf(
 					/* translators: %1$s: action URL, %2$s: link attributes */
 				__( 'Please <a href="%1$s" %2$s>update your payment method</a>.', 'newspack-plugin' ),
 				esc_url( $url ),
@@ -188,6 +194,18 @@ class WooCommerce_Update_Payment_Notice {
 						array_values( $link_attrs )
 					)
 				)
+			);
+			$notices[] = $notice;
+			add_filter(
+				'newspack_ui_notice_is_urgent',
+				function( $is_urgent, $printed_notice ) use ( $notice ) {
+					if ( $printed_notice === $notice ) {
+						$is_urgent = true;
+					}
+					return $is_urgent;
+				},
+				10,
+				2
 			);
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a minor error notice rendering bug found while testing #4498. Also fixes a PHP warning, and makes the subscription payment snackbar notice "urgent" so it requires manual dismissal instead of auto-hiding after 5 seconds.

### How to test the changes in this Pull Request:

1. If #4498 hasn't been merged to trunk yet, follow steps 1-5 of testing instructions for that PR to trigger the broken modal checkout window. If it has been merged, then you can force an error by temporarily undoing the changes in that PR and following steps 1-5 to trigger the broken modal checkout window.
2. Observe that the broken modal checkout renders with both a snackbar notice and an error message:

<img width="678" height="309" alt="Screenshot 2026-02-19 at 4 48 48 PM" src="https://github.com/user-attachments/assets/13745075-1a6d-461b-a3bb-26da11375bbc" />

3. Also observe a PHP notice in debug.log: `PHP Notice:  Only variables should be passed by reference in /newspack-repos/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-update-payment-notice.php on line 142`
4. Check out this branch and trigger the broken modal window again.
5. This time, confirm that the modal appears without the snackbar notice. Also confirm no PHP notice.

<img width="738" height="337" alt="Screenshot 2026-02-19 at 4 46 20 PM" src="https://github.com/user-attachments/assets/cb9391ad-742f-4440-94e5-922ed57e95d3" />

6. After clicking "Go back" to close the broken checkout modal, confirm that the subscription payment message appears as a snackbar in My Account pages and does not auto-hide (should close only after you click the × button in the notice). 

<img width="1122" height="607" alt="Screenshot 2026-02-19 at 4 57 37 PM" src="https://github.com/user-attachments/assets/05bda9a1-418b-46ae-a409-f35b925b4bbe" />

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->