### PR TITLE
feat(corrections): append corrections to Republication Tracker Tool content

### DIFF
--- a/includes/corrections/class-corrections.php
+++ b/includes/corrections/class-corrections.php
@@ -531,12 +531,11 @@ class Corrections {
 	 * Uses only basic HTML elements (<p>, <strong>) that render
 	 * distinctly without CSS, since republished content is stripped of styles.
 	 *
-	 * @param array  $corrections Array of correction post objects.
-	 * @param string $priority    The priority level ('high' or 'low').
+	 * @param array $corrections Array of correction post objects.
 	 *
 	 * @return string The simplified corrections markup.
 	 */
-	private static function get_republish_corrections_markup( $corrections, $priority = 'low' ) {
+	private static function get_republish_corrections_markup( $corrections ) {
 		if ( empty( $corrections ) ) {
 			return '';
 		}

--- a/includes/corrections/class-corrections.php
+++ b/includes/corrections/class-corrections.php
@@ -53,6 +53,7 @@ class Corrections {
 		add_action( 'admin_init', [ __CLASS__, 'register_corrections_block_patterns' ] );
 		add_action( 'init', [ __CLASS__, 'register_corrections_template' ] );
 		add_action( 'transition_post_status', [ __CLASS__, 'update_corrections_status' ], 10, 3 );
+		add_filter( 'republication_tracker_tool_republish_content', [ __CLASS__, 'append_corrections_to_republished_content' ], 10, 2 );
 	}
 
 	/**
@@ -490,6 +491,72 @@ class Corrections {
 		<!-- /wp:newspack/correction-box -->
 		<?php
 		return ob_get_clean();
+	}
+
+	/**
+	 * Appends corrections to republished content via the Republication Tracker Tool.
+	 *
+	 * @param string  $content The republished content.
+	 * @param WP_Post $post    The post being republished.
+	 *
+	 * @return string The content with corrections appended.
+	 */
+	public static function append_corrections_to_republished_content( $content, $post ) {
+		$corrections = self::get_corrections( $post->ID );
+		if ( empty( $corrections ) ) {
+			return $content;
+		}
+
+		// Separate corrections by priority.
+		$high_priority_corrections = [];
+		$low_priority_corrections  = [];
+
+		foreach ( $corrections as $correction ) {
+			if ( 'high' === $correction->correction_priority ) {
+				$high_priority_corrections[] = $correction;
+			} else {
+				$low_priority_corrections[] = $correction;
+			}
+		}
+
+		$top_markup    = ! empty( $high_priority_corrections ) ? self::get_republish_corrections_markup( $high_priority_corrections, 'high' ) : '';
+		$bottom_markup = ! empty( $low_priority_corrections ) ? self::get_republish_corrections_markup( $low_priority_corrections, 'low' ) : '';
+
+		return $top_markup . $content . $bottom_markup;
+	}
+
+	/**
+	 * Generates simplified corrections markup for republished content.
+	 *
+	 * Uses only basic HTML elements (<p>, <strong>) that render
+	 * distinctly without CSS, since republished content is stripped of styles.
+	 *
+	 * @param array  $corrections Array of correction post objects.
+	 * @param string $priority    The priority level ('high' or 'low').
+	 *
+	 * @return string The simplified corrections markup.
+	 */
+	private static function get_republish_corrections_markup( $corrections, $priority = 'low' ) {
+		if ( empty( $corrections ) ) {
+			return '';
+		}
+
+		$markup = '';
+
+		foreach ( $corrections as $correction ) {
+			$correction_date = \get_the_date( get_option( 'date_format' ), $correction->ID );
+			$correction_time = \get_the_time( get_option( 'time_format' ), $correction->ID );
+			$heading         = sprintf(
+				'%s added on %s%s:',
+				self::get_correction_type( $correction->ID ),
+				$correction_date,
+				$correction_time ? ' ' . $correction_time : ''
+			);
+
+			$markup .= '<p><strong>' . esc_html( $heading ) . '</strong> ' . esc_html( $correction->post_content ) . '</p>';
+		}
+
+		return $markup;
 	}
 
 	/**

--- a/includes/corrections/class-corrections.php
+++ b/includes/corrections/class-corrections.php
@@ -546,7 +546,7 @@ class Corrections {
 			$correction_date = \get_the_date( get_option( 'date_format' ), $correction->ID );
 			$correction_time = \get_the_time( get_option( 'time_format' ), $correction->ID );
 			$heading         = sprintf(
-				'%s added on %s%s:',
+				'%s, %s%s:',
 				self::get_correction_type( $correction->ID ),
 				$correction_date,
 				$correction_time ? ' ' . $correction_time : ''


### PR DESCRIPTION
## Summary

Corrections and clarifications attached to articles lose their visual distinction when content is republished via the Republication Tracker Tool  (RTT). RTT strips CSS and simplifies markup, so the current corrections output (which relies on styled <div>, <a>, and <span> elements) blends  into the article body. We need to hook into RTT's content filters to inject corrections in a style-independent format that stands out using only basic HTML.

- Hooks into the Republication Tracker Tool's `republication_tracker_tool_republish_content` filter to include corrections and clarifications in republished article content
- Uses simplified markup (`<p>`, `<strong>`) that renders distinctly without CSS, since RTT strips styles from republished content
- Preserves priority placement: high-priority corrections prepended, low-priority corrections appended

## Test plan

- [ ] Create a test post with corrections (both high and low priority, both correction and clarification types)
- [ ] Activate the Republication Tracker Tool plugin
- [ ] View the republication widget/modal on the post and verify corrections appear in the republished content
- [ ] Confirm high-priority corrections appear above the article content
- [ ] Confirm low-priority corrections appear below the article content
- [ ] Verify the output uses only `<p>` and `<strong>` elements — no styled elements or links
- [ ] Copy the republished content and paste into another site to confirm it renders correctly without stylesheets
