### PR TITLE
fix: remove redundant 24h cron retry for ESP email change sync

### DIFF
--- a/includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php
+++ b/includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php
@@ -33,11 +33,6 @@ class WooCommerce_My_Account {
 	];
 
 	/**
-	 * Cron hook for syncing email change with ESP.
-	 */
-	const SYNC_ESP_EMAIL_CHANGE_CRON_HOOK = 'newspack_esp_sync_email_change';
-
-	/**
 	 * Memoized nonce for account deletion.
 	 *
 	 * @var string
@@ -81,8 +76,6 @@ class WooCommerce_My_Account {
 			\add_filter( 'wc_memberships_members_area_my-memberships_actions', [ __CLASS__, 'hide_cancel_button_from_memberships_table' ] );
 			\add_filter( 'wc_memberships_my_memberships_column_names', [ __CLASS__, 'remove_next_bill_on' ], 21 );
 			\add_action( 'profile_update', [ __CLASS__, 'handle_admin_email_change_request' ], 10, 3 );
-			\add_action( self::SYNC_ESP_EMAIL_CHANGE_CRON_HOOK, [ __CLASS__, 'sync_email_change_with_esp' ], 10, 3 );
-
 			\add_action(
 				'init',
 				function() {
@@ -1266,12 +1259,7 @@ class WooCommerce_My_Account {
 		if ( ! $contact || is_wp_error( $contact ) ) {
 			return;
 		}
-		$update = Contact_Sync::sync( $contact, 'Email_Change', array_merge( $contact, [ 'email' => $old_email ] ) );
-		if ( is_wp_error( $update ) ) {
-			// If the update failed, retry in 24 hours.
-			\wp_schedule_single_event( time() + DAY_IN_SECONDS, self::SYNC_ESP_EMAIL_CHANGE_CRON_HOOK, [ $user_id, $new_email, $old_email ] );
-			Logger::error( 'Error syncing email change with ESP: ' . $update->get_error_message() . '. Retrying in 24 hours.' );
-		}
+		Contact_Sync::sync( $contact, 'Email_Change', array_merge( $contact, [ 'email' => $old_email ] ) );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Removes the redundant WP-Cron 24h retry in `sync_email_change_with_esp()`. When a reader changes their email and the ESP sync fails, `Contact_Sync::push_to_integrations()` already schedules per-integration retries via ActionScheduler (added in #4469).

Specifically removes:
- The `SYNC_ESP_EMAIL_CHANGE_CRON_HOOK` constant and its `add_action` registration.
- The `is_wp_error` check + `wp_schedule_single_event` fallback after `Contact_Sync::sync()`.

The `sync_email_change_with_esp()` method itself is preserved — it builds the `$existing_contact` payload with the old email address, which integrations need to locate and update the existing ESP record.

Related to NPPD-1073.

### How to test the changes in this Pull Request:

1. Connect an ESP integration (e.g., Mailchimp) with **invalid credentials** so that syncs will fail.
2. Enable Reader Activation and register a new reader, then change their email via My Account or wp-admin.
3. Verify that **no** `newspack_esp_sync_email_change` WP-Cron events are scheduled: `wp cron event list --search=newspack_esp_sync_email_change` should return empty.
4. Verify that ActionScheduler per-integration retries **are** scheduled: check for pending actions in `wp action-scheduler action list --status=pending --group=newspack` with hook `newspack_contact_sync_retry`.
5. Fix the ESP credentials and let the AS retry succeed. Confirm the contact syncs with the correct (new) email.
6. Repeat step 2 with **valid** credentials and confirm the sync succeeds immediately with no retry actions scheduled.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?