### PR TITLE
feat(sync): add batch queue for contact syncing

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -103,6 +103,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/reader-activation/sync/class-woocommerce.php';
 		include_once NEWSPACK_ABSPATH . 'includes/reader-activation/sync/class-contact-sync.php';
 		include_once NEWSPACK_ABSPATH . 'includes/reader-activation/sync/class-contact-sync-admin.php';
+		include_once NEWSPACK_ABSPATH . 'includes/reader-activation/sync/class-contact-sync-batch.php';
 		include_once NEWSPACK_ABSPATH . 'includes/reader-activation/class-integrations.php';
 		\Newspack\Reader_Activation\Integrations::init();
 		include_once NEWSPACK_ABSPATH . 'includes/data-events/class-utils.php';

--- a/includes/cli/class-ras-contact-sync.php
+++ b/includes/cli/class-ras-contact-sync.php
@@ -10,6 +10,7 @@ namespace Newspack\CLI;
 use WP_CLI;
 use Newspack\Reader_Activation;
 use Newspack\Reader_Activation\Contact_Sync;
+use Newspack\Reader_Activation\Contact_Sync_Batch;
 use Newspack_Subscription_Migrations\CSV_Importers\CSV_Importer;
 use Newspack_Subscription_Migrations\Stripe_Sync;
 
@@ -26,15 +27,6 @@ class RAS_Contact_Sync {
 	 * @var string
 	 */
 	protected static $context = 'Contact sync manually triggered via CLI';
-
-	/**
-	 * The final results object.
-	 *
-	 * @var array
-	 */
-	protected static $results = [
-		'processed' => 0,
-	];
 
 	/**
 	 * Log to WP CLI.
@@ -54,6 +46,9 @@ class RAS_Contact_Sync {
 	/**
 	 * Sync reader contact data to the connected integrations.
 	 *
+	 * Collects user IDs based on config, enqueues them via Contact_Sync_Batch,
+	 * and polls progress until complete.
+	 *
 	 * @param array $config {
 	 *   Configuration options.
 	 *
@@ -63,7 +58,7 @@ class RAS_Contact_Sync {
 	 *   @type array|bool  $config['subscription_ids'] If set, only sync the given subscription IDs.
 	 *   @type array|bool  $config['user_ids'] If set, only sync the given user IDs.
 	 *   @type array|bool  $config['order_ids'] If set, only sync the given order IDs.
-	 *   @type int         $config['batch_size'] Number of contacts to sync per batch.
+	 *   @type int         $config['batch_size'] Number of contacts to sync per batch chunk.
 	 *   @type int         $config['offset'] Number of contacts to skip.
 	 *   @type int         $config['max_batches'] Maximum number of batches to process.
 	 *   @type bool        $config['is_dry_run'] True if a dry run.
@@ -96,67 +91,62 @@ class RAS_Contact_Sync {
 			return $can_sync;
 		}
 
-		// If syncing only migrated subscriptions.
-		if ( $config['migrated_only'] ) {
-			$config['subscription_ids'] = self::get_migrated_subscriptions( $config['migrated_only'], $config['batch_size'], $config['offset'], $config['active_only'] );
-			if ( \is_wp_error( $config['subscription_ids'] ) ) {
-				return $config['subscription_ids'];
-			}
-			$batches = 0;
+		$user_ids = self::collect_user_ids( $config );
+		if ( \is_wp_error( $user_ids ) ) {
+			return $user_ids;
 		}
 
-		if ( ! empty( $config['subscription_ids'] ) ) {
-			static::log( __( 'Syncing by subscription ID...', 'newspack-plugin' ) );
-
-			while ( ! empty( $config['subscription_ids'] ) ) {
-				$subscription_id = array_shift( $config['subscription_ids'] );
-				$subscription    = \wcs_get_subscription( $subscription_id );
-
-				if ( \is_wp_error( $subscription ) ) {
-					static::log(
-						sprintf(
-							// Translators: %d is the subscription ID arg passed to the script.
-							__( 'No subscription with ID %d. Skipping.', 'newspack-plugin' ),
-							$subscription_id
-						)
-					);
-
-					continue;
-				}
-
-				$result = Contact_Sync::sync_contact( $subscription, self::$context, $config['is_dry_run'] );
-				if ( \is_wp_error( $result ) ) {
-					static::log(
-						sprintf(
-							// Translators: %1$d is the subscription ID arg passed to the script. %2$s is the error message.
-							__( 'Error syncing contact info for subscription ID %1$d. %2$s', 'newspack-plugin' ),
-							$subscription_id,
-							$result->get_error_message()
-						)
-					);
-				}
-
-				// Get the next batch.
-				if ( $config['migrated_only'] && empty( $config['subscription_ids'] ) ) {
-					$batches++;
-
-					if ( $config['max_batches'] && $batches >= $config['max_batches'] ) {
-						break;
-					}
-
-					$next_batch_offset = $config['offset'] + ( $batches * $config['batch_size'] );
-					$config['subscription_ids'] = self::get_migrated_subscriptions( $config['migrated_only'], $config['batch_size'], $next_batch_offset, $config['active_only'] );
-				}
-			}
+		if ( empty( $user_ids ) ) {
+			static::log( __( 'No contacts found to sync.', 'newspack-plugin' ) );
+			return 0;
 		}
 
-		// If order-ids flag is passed, sync contacts for those orders.
+		static::log(
+			sprintf(
+				// Translators: %d is the number of contacts collected.
+				__( 'Collected %d contacts for syncing.', 'newspack-plugin' ),
+				count( $user_ids )
+			)
+		);
+
+		if ( $config['is_dry_run'] ) {
+			return count( $user_ids );
+		}
+
+		$batch_id = Contact_Sync_Batch::enqueue( $user_ids, [ 'batch_size' => $config['batch_size'] ] );
+
+		return self::poll_progress( $batch_id );
+	}
+
+	/**
+	 * Collect user IDs to sync based on the provided configuration.
+	 *
+	 * @param array $config Configuration options (see sync_contacts).
+	 *
+	 * @return array|\WP_Error Array of user IDs or WP_Error.
+	 */
+	private static function collect_user_ids( $config ) {
+		// If user-ids flag is passed, use those directly.
+		if ( ! empty( $config['user_ids'] ) ) {
+			static::log( __( 'Collecting user IDs from --user-ids...', 'newspack-plugin' ) );
+			if ( $config['active_only'] ) {
+				return array_values(
+					array_filter(
+						$config['user_ids'],
+						[ __CLASS__, 'user_has_active_subscriptions' ]
+					)
+				);
+			}
+			return $config['user_ids'];
+		}
+
+		// If order-ids flag is passed, convert orders to user IDs.
 		if ( ! empty( $config['order_ids'] ) ) {
-			static::log( __( 'Syncing by order ID...', 'newspack-plugin' ) );
+			static::log( __( 'Collecting user IDs from --order-ids...', 'newspack-plugin' ) );
+			$user_ids = [];
 			foreach ( $config['order_ids'] as $order_id ) {
-				$order = new \WC_Order( $order_id );
-
-				if ( \is_wp_error( $order ) ) {
+				$order = \wc_get_order( $order_id );
+				if ( ! $order ) {
 					static::log(
 						sprintf(
 							// Translators: %d is the order ID.
@@ -164,91 +154,170 @@ class RAS_Contact_Sync {
 							$order_id
 						)
 					);
-
 					continue;
 				}
+				$user_id = $order->get_customer_id();
+				if ( $user_id ) {
+					$user_ids[] = $user_id;
+				}
+			}
+			return array_values( array_unique( $user_ids ) );
+		}
 
-				$result = Contact_Sync::sync_contact( $order, self::$context, $config['is_dry_run'] );
-				if ( \is_wp_error( $result ) ) {
+		// If migrated-only or subscription-ids flag is passed, convert subscriptions to user IDs.
+		if ( $config['migrated_only'] || ! empty( $config['subscription_ids'] ) ) {
+			$subscription_ids = ! empty( $config['subscription_ids'] )
+				? $config['subscription_ids']
+				: self::get_all_migrated_subscriptions( $config );
+
+			if ( \is_wp_error( $subscription_ids ) ) {
+				return $subscription_ids;
+			}
+
+			static::log(
+				sprintf(
+					// Translators: %d is the number of subscriptions found.
+					__( 'Collecting user IDs from %d subscriptions...', 'newspack-plugin' ),
+					count( $subscription_ids )
+				)
+			);
+
+			$user_ids = [];
+			foreach ( $subscription_ids as $subscription_id ) {
+				$subscription = \wcs_get_subscription( $subscription_id );
+				if ( \is_wp_error( $subscription ) || ! $subscription ) {
 					static::log(
 						sprintf(
-							// Translators: %1$d is the order ID arg passed to the script. %2$s is the error message.
-							__( 'Error syncing contact info for order ID %1$d. %2$s', 'newspack-plugin' ),
-							$order_id,
-							$result->get_error_message()
+							// Translators: %d is the subscription ID.
+							__( 'No subscription with ID %d. Skipping.', 'newspack-plugin' ),
+							$subscription_id
 						)
 					);
-				} elseif ( ! empty( static::$results ) ) {
-					static::$results['processed']++;
+					continue;
+				}
+				$user_id = $subscription->get_customer_id();
+				if ( $user_id ) {
+					$user_ids[] = $user_id;
 				}
 			}
+			return array_values( array_unique( $user_ids ) );
 		}
 
-		// If user-ids flag is passed, sync those users.
-		if ( ! empty( $config['user_ids'] ) ) {
-			static::log( __( 'Syncing by customer user ID...', 'newspack-plugin' ) );
-			foreach ( $config['user_ids'] as $user_id ) {
+		// Default: collect all readers.
+		if ( $config['active_only'] ) {
+			static::log( __( 'Collecting all readers with active subscriptions...', 'newspack-plugin' ) );
+		} else {
+			static::log( __( 'Collecting all reader IDs...', 'newspack-plugin' ) );
+		}
+
+		$all_user_ids = [];
+		$batch_ids    = self::get_batch_of_readers( $config['batch_size'], $config['offset'] );
+		$batches      = 0;
+
+		while ( $batch_ids ) {
+			foreach ( $batch_ids as $user_id ) {
 				if ( ! $config['active_only'] || self::user_has_active_subscriptions( $user_id ) ) {
-					$result = Contact_Sync::sync_contact( $user_id, self::$context, $config['is_dry_run'] );
-					if ( \is_wp_error( $result ) ) {
-						static::log(
-							sprintf(
-								// Translators: %1$d is the user ID arg passed to the script. %2$s is the error message.
-								__( 'Error syncing contact info for user ID %1$d. %2$s', 'newspack-plugin' ),
-								$user_id,
-								$result->get_error_message()
-							)
-						);
-					}
+					$all_user_ids[] = $user_id;
 				}
 			}
+
+			$batches++;
+			if ( $config['max_batches'] && $batches >= $config['max_batches'] ) {
+				break;
+			}
+
+			$batch_ids = self::get_batch_of_readers( $config['batch_size'], $config['offset'] + ( $batches * $config['batch_size'] ) );
 		}
 
-		// Default behavior: sync all readers.
-		if (
-			false === $config['user_ids'] &&
-			false === $config['order_ids'] &&
-			false === $config['subscription_ids'] &&
-			false === $config['migrated_only']
-		) {
-			if ( $config['active_only'] ) {
-				static::log( __( 'Syncing all readers with active subscriptions...', 'newspack-plugin' ) );
-			} else {
-				static::log( __( 'Syncing all readers...', 'newspack-plugin' ) );
+		return $all_user_ids;
+	}
+
+	/**
+	 * Collect all migrated subscription IDs across batches.
+	 *
+	 * @param array $config Configuration options (see sync_contacts).
+	 *
+	 * @return array|\WP_Error Array of subscription IDs or WP_Error.
+	 */
+	private static function get_all_migrated_subscriptions( $config ) {
+		static::log( __( 'Collecting migrated subscription IDs...', 'newspack-plugin' ) );
+
+		$all_subscription_ids = [];
+		$batches              = 0;
+		$offset               = $config['offset'];
+
+		while ( true ) {
+			$batch = self::get_migrated_subscriptions( $config['migrated_only'], $config['batch_size'], $offset, $config['active_only'] );
+			if ( \is_wp_error( $batch ) ) {
+				return $batch;
 			}
-			$user_ids = self::get_batch_of_readers( $config['batch_size'], $config['offset'] );
-			$batches  = 0;
 
-			while ( $user_ids ) {
-				$user_id = array_shift( $user_ids );
-				if ( ! $config['active_only'] || self::user_has_active_subscriptions( $user_id ) ) {
-					$result = Contact_Sync::sync_contact( $user_id, self::$context, $config['is_dry_run'] );
-					if ( \is_wp_error( $result ) ) {
-						static::log(
-							sprintf(
-								// Translators: $1$s is the contact's user ID. %2$s is the error message.
-								__( 'Error syncing contact info for user ID %1$d. %2$s' ),
-								$user_id,
-								$result->get_error_message()
-							)
-						);
-					}
-				}
-
-				// Get the next batch.
-				if ( empty( $user_ids ) ) {
-					$batches++;
-
-					if ( $config['max_batches'] && $batches >= $config['max_batches'] ) {
-						break;
-					}
-
-					$user_ids = self::get_batch_of_readers( $config['batch_size'], $config['offset'] + ( $batches * $config['batch_size'] ) );
-				}
+			if ( empty( $batch ) ) {
+				break;
 			}
+
+			$all_subscription_ids = array_merge( $all_subscription_ids, $batch );
+			$batches++;
+
+			if ( $config['max_batches'] && $batches >= $config['max_batches'] ) {
+				break;
+			}
+
+			$offset = $config['offset'] + ( $batches * $config['batch_size'] );
 		}
 
-		return static::$results['processed'];
+		return $all_subscription_ids;
+	}
+
+	/**
+	 * Poll the progress of a Contact_Sync_Batch until complete.
+	 *
+	 * @param string $batch_id The batch ID to poll.
+	 *
+	 * @return int The number of completed contacts.
+	 */
+	private static function poll_progress( $batch_id ) {
+		$progress = Contact_Sync_Batch::get_progress( $batch_id );
+		if ( ! $progress ) {
+			return 0;
+		}
+
+		$progress_bar  = \WP_CLI\Utils\make_progress_bar( __( 'Syncing contacts', 'newspack-plugin' ), $progress['total'] );
+		$last_finished = 0;
+
+		while ( true ) {
+			$progress = Contact_Sync_Batch::get_progress( $batch_id );
+			if ( ! $progress ) {
+				break;
+			}
+
+			$finished = $progress['completed'] + $progress['failed'];
+			$new      = $finished - $last_finished;
+			for ( $i = 0; $i < $new; $i++ ) {
+				$progress_bar->tick();
+			}
+			$last_finished = $finished;
+
+			if ( 'running' !== $progress['status'] ) {
+				break;
+			}
+
+			sleep( 2 );
+		}
+
+		$progress_bar->finish();
+
+		if ( $progress && $progress['failed'] > 0 ) {
+			WP_CLI::warning(
+				sprintf(
+					// Translators: %d is the number of failed contacts.
+					__( '%d contacts failed to sync.', 'newspack-plugin' ),
+					$progress['failed']
+				)
+			);
+		}
+
+		return $progress ? $progress['completed'] : 0;
 	}
 
 	/**

--- a/includes/cli/class-ras-contact-sync.php
+++ b/includes/cli/class-ras-contact-sync.php
@@ -113,7 +113,13 @@ class RAS_Contact_Sync {
 			return count( $user_ids );
 		}
 
-		$batch_id = Contact_Sync_Batch::enqueue( $user_ids, [ 'batch_size' => $config['batch_size'] ] );
+		$batch_id = Contact_Sync_Batch::enqueue(
+			$user_ids,
+			[
+				'batch_size' => $config['batch_size'],
+				'context'    => $config['context'],
+			]
+		);
 
 		return self::poll_progress( $batch_id );
 	}
@@ -286,6 +292,8 @@ class RAS_Contact_Sync {
 		$last_finished = 0;
 
 		while ( true ) {
+			// Clear the object cache so we get fresh progress from the database.
+			wp_cache_delete( Contact_Sync_Batch::PROGRESS_OPTION_PREFIX . $batch_id, 'options' );
 			$progress = Contact_Sync_Batch::get_progress( $batch_id );
 			if ( ! $progress ) {
 				break;

--- a/includes/cli/class-ras-contact-sync.php
+++ b/includes/cli/class-ras-contact-sync.php
@@ -293,7 +293,7 @@ class RAS_Contact_Sync {
 
 		while ( true ) {
 			// Clear the object cache so we get fresh progress from the database.
-			wp_cache_delete( Contact_Sync_Batch::PROGRESS_OPTION_PREFIX . $batch_id, 'options' );
+			wp_cache_delete( Contact_Sync_Batch::PROGRESS_OPTION, 'options' );
 			$progress = Contact_Sync_Batch::get_progress( $batch_id );
 			if ( ! $progress ) {
 				break;

--- a/includes/reader-activation/sync/class-contact-sync-admin.php
+++ b/includes/reader-activation/sync/class-contact-sync-admin.php
@@ -204,7 +204,7 @@ class Contact_Sync_Admin {
 			$scheduled_syncs = absint( wp_unslash( $_GET['scheduled-sync-contacts'] ) );
 			$message         = sprintf(
 				// translators: %d: number of contacts resynced.
-				__( '%d contacts scheculed for resync to the ESP and should complete in a couple of minutes.', 'newspack-plugin' ),
+				__( '%d contacts scheduled for resync to the ESP and should complete in a couple of minutes.', 'newspack-plugin' ),
 				$scheduled_syncs
 			);
 		}

--- a/includes/reader-activation/sync/class-contact-sync-admin.php
+++ b/includes/reader-activation/sync/class-contact-sync-admin.php
@@ -46,7 +46,6 @@ class Contact_Sync_Admin {
 		add_filter( 'bulk_actions-users', [ __CLASS__, 'bulk_actions' ] );
 		add_filter( 'handle_bulk_actions-users', [ __CLASS__, 'handle_bulk_actions' ], 10, 3 );
 		add_action( 'admin_notices', [ __CLASS__, 'admin_notices' ] );
-		add_action( 'newspack_sync_admin_batch', [ 'Newspack\Reader_Activation\Contact_Sync', 'sync_contact' ], 10, 1 ); // ActionScheduler hook.
 	}
 
 	/**
@@ -135,9 +134,7 @@ class Contact_Sync_Admin {
 		if ( ! \current_user_can( 'edit_users' ) ) {
 			\wp_die( \esc_html__( 'You do not have permission to do that.', 'newspack-plugin' ) );
 		}
-		foreach ( $items as $user_id ) {
-			as_schedule_single_action( time(), 'newspack_sync_admin_batch', [ 'user_id' => $user_id ] );
-		}
+		Contact_Sync_Batch::enqueue( $items, [ 'context' => self::$context ] );
 		$sendback = \add_query_arg(
 			[
 				'update'                  => self::ADMIN_ACTION,
@@ -216,7 +213,7 @@ class Contact_Sync_Admin {
 			<p>
 				<?php echo esc_html( $message ); ?>
 				<?php if ( isset( $_GET['scheduled-sync-contacts'] ) ) : ?>
-					<a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-status&tab=action-scheduler&s=newspack_sync_admin_batch&orderby=schedule&order=desc' ) ); ?>">
+					<a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-status&tab=action-scheduler&s=newspack_contact_sync_batch&orderby=schedule&order=desc' ) ); ?>">
 						<?php echo esc_html__( 'Click here to monitor progress.', 'newspack-plugin' ); ?>
 					</a>
 				<?php endif; ?>

--- a/includes/reader-activation/sync/class-contact-sync-admin.php
+++ b/includes/reader-activation/sync/class-contact-sync-admin.php
@@ -123,6 +123,12 @@ class Contact_Sync_Admin {
 		if ( self::ADMIN_ACTION !== $doaction ) {
 			return $sendback;
 		}
+		// Prevent duplicate processing across redirected requests.
+		$guard_key = 'newspack_esp_sync_' . md5( wp_json_encode( $items ) );
+		if ( \get_transient( $guard_key ) ) {
+			return $sendback;
+		}
+		\set_transient( $guard_key, true, 30 );
 		// Bulk action requires ActionScheduler, so we don't show it if it's not available.
 		if ( ! class_exists( 'ActionScheduler' ) ) {
 			\wp_die( \esc_html__( 'ActionScheduler is not available to perform the bulk action.', 'newspack-plugin' ) );
@@ -135,6 +141,7 @@ class Contact_Sync_Admin {
 			\wp_die( \esc_html__( 'You do not have permission to do that.', 'newspack-plugin' ) );
 		}
 		Contact_Sync_Batch::enqueue( $items, [ 'context' => self::$context ] );
+		$sendback = \remove_query_arg( [ 'action', 'action2', 'users', '_wpnonce', '_wp_http_referer' ], $sendback );
 		$sendback = \add_query_arg(
 			[
 				'update'                  => self::ADMIN_ACTION,

--- a/includes/reader-activation/sync/class-contact-sync-batch.php
+++ b/includes/reader-activation/sync/class-contact-sync-batch.php
@@ -54,15 +54,21 @@ class Contact_Sync_Batch {
 	 * @param array $user_ids Array of user IDs to sync.
 	 * @param array $config   Optional. Configuration options.
 	 *                        - batch_size (int): Number of users per chunk. Default DEFAULT_BATCH_SIZE.
+	 *                        - context (string): Context string for sync logging. Default 'Batch sync'.
 	 *
-	 * @return string The batch ID.
+	 * @return string The batch ID, or empty string if no user IDs provided.
 	 */
 	public static function enqueue( array $user_ids, array $config = [] ) {
+		if ( empty( $user_ids ) ) {
+			return '';
+		}
+
 		$batch_size = isset( $config['batch_size'] ) ? absint( $config['batch_size'] ) : self::DEFAULT_BATCH_SIZE;
 		if ( $batch_size < 1 ) {
 			$batch_size = self::DEFAULT_BATCH_SIZE;
 		}
 
+		$context  = isset( $config['context'] ) ? $config['context'] : 'Batch sync';
 		$batch_id = 'batch_' . uniqid();
 		$chunks   = array_chunk( $user_ids, $batch_size );
 
@@ -71,6 +77,7 @@ class Contact_Sync_Batch {
 			'completed'  => 0,
 			'failed'     => 0,
 			'status'     => 'running',
+			'context'    => $context,
 			'created_at' => time(),
 		];
 		self::save_progress( $batch_id, $progress );
@@ -121,7 +128,7 @@ class Contact_Sync_Batch {
 			return;
 		}
 
-		$context = 'Batch sync';
+		$context = isset( $progress['context'] ) ? $progress['context'] : 'Batch sync';
 
 		foreach ( $user_ids as $user_id ) {
 			try {
@@ -173,8 +180,20 @@ class Contact_Sync_Batch {
 			return;
 		}
 
-		if ( function_exists( 'as_unschedule_all_actions' ) ) {
-			as_unschedule_all_actions( self::BATCH_HOOK, null, 'newspack' );
+		if ( function_exists( 'as_get_scheduled_actions' ) ) {
+			$actions = as_get_scheduled_actions(
+				[
+					'hook'   => self::BATCH_HOOK,
+					'group'  => 'newspack',
+					'status' => \ActionScheduler_Store::STATUS_PENDING,
+				]
+			);
+			foreach ( $actions as $action_id => $action ) {
+				$args = $action->get_args();
+				if ( isset( $args[0] ) && $args[0] === $batch_id ) {
+					\ActionScheduler::store()->cancel_action( $action_id );
+				}
+			}
 		}
 
 		$progress['status'] = 'cancelled';

--- a/includes/reader-activation/sync/class-contact-sync-batch.php
+++ b/includes/reader-activation/sync/class-contact-sync-batch.php
@@ -101,13 +101,53 @@ class Contact_Sync_Batch {
 	}
 
 	/**
-	 * Process a batch chunk. Placeholder for Task 2.
+	 * Process a batch chunk of user IDs for contact syncing.
+	 *
+	 * Called by ActionScheduler for each chunk. Syncs each user via Contact_Sync::sync_contact(),
+	 * increments completed/failed counters, and sets status to 'complete' when all contacts
+	 * have been processed.
 	 *
 	 * @param string $batch_id The batch ID.
 	 * @param array  $user_ids The user IDs in this chunk.
 	 */
 	public static function process_batch( $batch_id, $user_ids ) {
-		// To be implemented in Task 2.
+		if ( empty( $batch_id ) || ! is_array( $user_ids ) ) {
+			Logger::log( 'Invalid batch data received from Action Scheduler.', 'NEWSPACK-SYNC', 'error' );
+			return;
+		}
+
+		$progress = self::get_progress( $batch_id );
+		if ( ! $progress || 'running' !== $progress['status'] ) {
+			return;
+		}
+
+		$context = 'Batch sync';
+
+		foreach ( $user_ids as $user_id ) {
+			$result = Contact_Sync::sync_contact( $user_id, $context );
+			if ( \is_wp_error( $result ) ) {
+				$progress['failed']++;
+			} else {
+				$progress['completed']++;
+			}
+		}
+
+		// Check if all contacts have been processed.
+		if ( ( $progress['completed'] + $progress['failed'] ) >= $progress['total'] ) {
+			$progress['status'] = 'complete';
+			Logger::log(
+				sprintf(
+					'Batch %s complete: %d succeeded, %d failed out of %d.',
+					$batch_id,
+					$progress['completed'],
+					$progress['failed'],
+					$progress['total']
+				),
+				'NEWSPACK-SYNC'
+			);
+		}
+
+		self::save_progress( $batch_id, $progress );
 	}
 
 	/**

--- a/includes/reader-activation/sync/class-contact-sync-batch.php
+++ b/includes/reader-activation/sync/class-contact-sync-batch.php
@@ -124,11 +124,20 @@ class Contact_Sync_Batch {
 		$context = 'Batch sync';
 
 		foreach ( $user_ids as $user_id ) {
-			$result = Contact_Sync::sync_contact( $user_id, $context );
-			if ( \is_wp_error( $result ) ) {
+			try {
+				$result = Contact_Sync::sync_contact( $user_id, $context );
+				if ( \is_wp_error( $result ) ) {
+					$progress['failed']++;
+				} else {
+					$progress['completed']++;
+				}
+			} catch ( \Throwable $e ) {
 				$progress['failed']++;
-			} else {
-				$progress['completed']++;
+				Logger::log(
+					sprintf( 'Batch %s: error syncing user %d: %s', $batch_id, $user_id, $e->getMessage() ),
+					'NEWSPACK-SYNC',
+					'error'
+				);
 			}
 		}
 
@@ -148,6 +157,38 @@ class Contact_Sync_Batch {
 		}
 
 		self::save_progress( $batch_id, $progress );
+	}
+
+	/**
+	 * Cancel a running batch.
+	 *
+	 * Unschedules all pending ActionScheduler actions for the batch hook
+	 * and marks the batch progress as cancelled.
+	 *
+	 * @param string $batch_id The batch ID.
+	 */
+	public static function cancel( $batch_id ) {
+		$progress = self::get_progress( $batch_id );
+		if ( ! $progress ) {
+			return;
+		}
+
+		if ( function_exists( 'as_unschedule_all_actions' ) ) {
+			as_unschedule_all_actions( self::BATCH_HOOK, null, 'newspack' );
+		}
+
+		$progress['status'] = 'cancelled';
+		self::save_progress( $batch_id, $progress );
+
+		Logger::log(
+			sprintf(
+				'Batch %s cancelled. %d/%d completed before cancellation.',
+				$batch_id,
+				$progress['completed'],
+				$progress['total']
+			),
+			'NEWSPACK-SYNC'
+		);
 	}
 
 	/**

--- a/includes/reader-activation/sync/class-contact-sync-batch.php
+++ b/includes/reader-activation/sync/class-contact-sync-batch.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * Batch queue for contact data syncing.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Reader_Activation;
+
+use Newspack\Logger;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Contact Sync Batch Class.
+ *
+ * Manages chunked batches of user IDs for async contact syncing via ActionScheduler.
+ */
+class Contact_Sync_Batch {
+
+	/**
+	 * ActionScheduler hook for processing a batch chunk.
+	 */
+	const BATCH_HOOK = 'newspack_contact_sync_batch';
+
+	/**
+	 * Option name prefix for batch progress records.
+	 */
+	const PROGRESS_OPTION_PREFIX = 'newspack_contact_sync_batch_';
+
+	/**
+	 * Default number of user IDs per batch chunk.
+	 */
+	const DEFAULT_BATCH_SIZE = 10;
+
+	/**
+	 * Time-to-live for progress records in seconds.
+	 */
+	const PROGRESS_TTL = DAY_IN_SECONDS;
+
+	/**
+	 * Initialize hooks.
+	 */
+	public static function init_hooks() {
+		add_action( self::BATCH_HOOK, [ __CLASS__, 'process_batch' ], 10, 2 );
+	}
+
+	/**
+	 * Enqueue a batch of user IDs for async contact syncing.
+	 *
+	 * Splits the user IDs into chunks and schedules an ActionScheduler action for each chunk.
+	 * Creates a progress record in wp_options to track batch status.
+	 *
+	 * @param array $user_ids Array of user IDs to sync.
+	 * @param array $config   Optional. Configuration options.
+	 *                        - batch_size (int): Number of users per chunk. Default DEFAULT_BATCH_SIZE.
+	 *
+	 * @return string The batch ID.
+	 */
+	public static function enqueue( array $user_ids, array $config = [] ) {
+		$batch_size = isset( $config['batch_size'] ) ? absint( $config['batch_size'] ) : self::DEFAULT_BATCH_SIZE;
+		if ( $batch_size < 1 ) {
+			$batch_size = self::DEFAULT_BATCH_SIZE;
+		}
+
+		$batch_id = 'batch_' . uniqid();
+		$chunks   = array_chunk( $user_ids, $batch_size );
+
+		$progress = [
+			'total'      => count( $user_ids ),
+			'completed'  => 0,
+			'failed'     => 0,
+			'status'     => 'running',
+			'created_at' => time(),
+		];
+		self::save_progress( $batch_id, $progress );
+
+		foreach ( $chunks as $chunk ) {
+			\as_schedule_single_action(
+				time(),
+				self::BATCH_HOOK,
+				[ $batch_id, $chunk ],
+				'newspack'
+			);
+		}
+
+		Logger::log(
+			sprintf(
+				'Batch %s enqueued: %d users in %d chunks (batch_size=%d).',
+				$batch_id,
+				count( $user_ids ),
+				count( $chunks ),
+				$batch_size
+			),
+			'NEWSPACK-SYNC'
+		);
+
+		self::cleanup_stale_progress();
+
+		return $batch_id;
+	}
+
+	/**
+	 * Process a batch chunk. Placeholder for Task 2.
+	 *
+	 * @param string $batch_id The batch ID.
+	 * @param array  $user_ids The user IDs in this chunk.
+	 */
+	public static function process_batch( $batch_id, $user_ids ) {
+		// To be implemented in Task 2.
+	}
+
+	/**
+	 * Get the progress of a batch.
+	 *
+	 * @param string $batch_id The batch ID.
+	 *
+	 * @return array|false The progress array, or false if the batch ID is not found.
+	 */
+	public static function get_progress( $batch_id ) {
+		$progress = get_option( self::PROGRESS_OPTION_PREFIX . $batch_id, false );
+		return $progress;
+	}
+
+	/**
+	 * Save the progress record for a batch.
+	 *
+	 * @param string $batch_id The batch ID.
+	 * @param array  $progress The progress data.
+	 */
+	private static function save_progress( $batch_id, $progress ) {
+		update_option( self::PROGRESS_OPTION_PREFIX . $batch_id, $progress, false );
+	}
+
+	/**
+	 * Delete stale progress records older than PROGRESS_TTL.
+	 */
+	private static function cleanup_stale_progress() {
+		global $wpdb;
+		$prefix  = self::PROGRESS_OPTION_PREFIX;
+		$results = $wpdb->get_results( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->prepare(
+				"SELECT option_name, option_value FROM {$wpdb->options} WHERE option_name LIKE %s",
+				$wpdb->esc_like( $prefix ) . '%'
+			)
+		);
+		if ( empty( $results ) ) {
+			return;
+		}
+		$now = time();
+		foreach ( $results as $row ) {
+			$progress = maybe_unserialize( $row->option_value );
+			if ( is_array( $progress ) && isset( $progress['created_at'] ) && ( $now - $progress['created_at'] ) > self::PROGRESS_TTL ) {
+				delete_option( $row->option_name );
+			}
+		}
+	}
+}
+Contact_Sync_Batch::init_hooks();

--- a/includes/reader-activation/sync/class-contact-sync-batch.php
+++ b/includes/reader-activation/sync/class-contact-sync-batch.php
@@ -24,9 +24,9 @@ class Contact_Sync_Batch {
 	const BATCH_HOOK = 'newspack_contact_sync_batch';
 
 	/**
-	 * Option name prefix for batch progress records.
+	 * Option name for batch progress records.
 	 */
-	const PROGRESS_OPTION_PREFIX = 'newspack_contact_sync_batch_';
+	const PROGRESS_OPTION = 'newspack_contact_sync_batch_progress';
 
 	/**
 	 * Default number of user IDs per batch chunk.
@@ -218,8 +218,8 @@ class Contact_Sync_Batch {
 	 * @return array|false The progress array, or false if the batch ID is not found.
 	 */
 	public static function get_progress( $batch_id ) {
-		$progress = get_option( self::PROGRESS_OPTION_PREFIX . $batch_id, false );
-		return $progress;
+		$all_progress = get_option( self::PROGRESS_OPTION, [] );
+		return isset( $all_progress[ $batch_id ] ) ? $all_progress[ $batch_id ] : false;
 	}
 
 	/**
@@ -229,30 +229,29 @@ class Contact_Sync_Batch {
 	 * @param array  $progress The progress data.
 	 */
 	private static function save_progress( $batch_id, $progress ) {
-		update_option( self::PROGRESS_OPTION_PREFIX . $batch_id, $progress, false );
+		$all_progress              = get_option( self::PROGRESS_OPTION, [] );
+		$all_progress[ $batch_id ] = $progress;
+		update_option( self::PROGRESS_OPTION, $all_progress, false );
 	}
 
 	/**
 	 * Delete stale progress records older than PROGRESS_TTL.
 	 */
 	private static function cleanup_stale_progress() {
-		global $wpdb;
-		$prefix  = self::PROGRESS_OPTION_PREFIX;
-		$results = $wpdb->get_results( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-			$wpdb->prepare(
-				"SELECT option_name, option_value FROM {$wpdb->options} WHERE option_name LIKE %s",
-				$wpdb->esc_like( $prefix ) . '%'
-			)
-		);
-		if ( empty( $results ) ) {
+		$all_progress = get_option( self::PROGRESS_OPTION, [] );
+		if ( empty( $all_progress ) ) {
 			return;
 		}
-		$now = time();
-		foreach ( $results as $row ) {
-			$progress = maybe_unserialize( $row->option_value );
+		$now     = time();
+		$cleaned = false;
+		foreach ( $all_progress as $batch_id => $progress ) {
 			if ( is_array( $progress ) && isset( $progress['created_at'] ) && ( $now - $progress['created_at'] ) > self::PROGRESS_TTL ) {
-				delete_option( $row->option_name );
+				unset( $all_progress[ $batch_id ] );
+				$cleaned = true;
 			}
+		}
+		if ( $cleaned ) {
+			update_option( self::PROGRESS_OPTION, $all_progress, false );
 		}
 	}
 }

--- a/includes/reader-activation/sync/class-sync.php
+++ b/includes/reader-activation/sync/class-sync.php
@@ -52,7 +52,11 @@ class Sync {
 			);
 		}
 
-		if ( class_exists( 'WCS_Staging' ) && \WCS_Staging::is_duplicate_site() ) {
+		if (
+			! ( defined( 'WP_CLI' ) && WP_CLI ) &&
+			class_exists( 'WCS_Staging' ) &&
+			\WCS_Staging::is_duplicate_site()
+		) {
 			$errors->add(
 				'wcs_duplicate_site',
 				__( 'Audience Management contact data syncing is disabled for cloned sites.', 'newspack-plugin' )

--- a/tests/unit-tests/contact-sync-batch.php
+++ b/tests/unit-tests/contact-sync-batch.php
@@ -57,4 +57,48 @@ class Newspack_Test_Contact_Sync_Batch extends WP_UnitTestCase {
 		$result = Contact_Sync_Batch::get_progress( 'nonexistent_batch_id' );
 		$this->assertFalse( $result, 'get_progress() should return false for an unknown batch ID.' );
 	}
+
+	/**
+	 * Test that process_batch syncs contacts and updates progress.
+	 */
+	public function test_process_batch_syncs_contacts() {
+		if ( ! function_exists( 'as_schedule_single_action' ) ) {
+			$this->markTestSkipped( 'ActionScheduler not available.' );
+		}
+
+		as_unschedule_all_actions( Contact_Sync_Batch::BATCH_HOOK );
+
+		$user_ids = [ 1, 2, 3 ];
+		$batch_id = Contact_Sync_Batch::enqueue( $user_ids, [ 'batch_size' => 3 ] );
+
+		// Process the single chunk directly.
+		Contact_Sync_Batch::process_batch( $batch_id, $user_ids );
+
+		$progress = Contact_Sync_Batch::get_progress( $batch_id );
+		$this->assertEquals( 3, $progress['completed'] + $progress['failed'], 'All 3 contacts should be accounted for (completed + failed).' );
+	}
+
+	/**
+	 * Test that batch completion is detected after all chunks are processed.
+	 */
+	public function test_batch_completion() {
+		if ( ! function_exists( 'as_schedule_single_action' ) ) {
+			$this->markTestSkipped( 'ActionScheduler not available.' );
+		}
+
+		as_unschedule_all_actions( Contact_Sync_Batch::BATCH_HOOK );
+
+		$user_ids = [ 1, 2, 3, 4 ];
+		$batch_id = Contact_Sync_Batch::enqueue( $user_ids, [ 'batch_size' => 2 ] );
+
+		// Process chunk 1: users [1, 2].
+		Contact_Sync_Batch::process_batch( $batch_id, [ 1, 2 ] );
+		$progress = Contact_Sync_Batch::get_progress( $batch_id );
+		$this->assertEquals( 'running', $progress['status'], 'Status should still be running after first chunk.' );
+
+		// Process chunk 2: users [3, 4].
+		Contact_Sync_Batch::process_batch( $batch_id, [ 3, 4 ] );
+		$progress = Contact_Sync_Batch::get_progress( $batch_id );
+		$this->assertEquals( 'complete', $progress['status'], 'Status should be complete after all chunks processed.' );
+	}
 }

--- a/tests/unit-tests/contact-sync-batch.php
+++ b/tests/unit-tests/contact-sync-batch.php
@@ -6,6 +6,9 @@
  */
 
 use Newspack\Reader_Activation\Contact_Sync_Batch;
+use Newspack\Reader_Activation\Integrations;
+
+require_once __DIR__ . '/integrations/class-failing-sample-integration.php';
 
 /**
  * Test the Contact_Sync_Batch class.
@@ -100,5 +103,120 @@ class Newspack_Test_Contact_Sync_Batch extends WP_UnitTestCase {
 		Contact_Sync_Batch::process_batch( $batch_id, [ 3, 4 ] );
 		$progress = Contact_Sync_Batch::get_progress( $batch_id );
 		$this->assertEquals( 'complete', $progress['status'], 'Status should be complete after all chunks processed.' );
+	}
+
+	/**
+	 * Test that process_batch handles failures from integrations.
+	 */
+	public function test_process_batch_handles_failures() {
+		if ( ! function_exists( 'as_schedule_single_action' ) ) {
+			$this->markTestSkipped( 'ActionScheduler not available.' );
+		}
+
+		// Register a failing integration.
+		Failing_Sample_Integration::reset();
+		Failing_Sample_Integration::$should_fail = true;
+		$integration = new Failing_Sample_Integration( 'batch_fail_mock', 'Batch Fail Mock' );
+		Integrations::register( $integration );
+		Integrations::enable( 'batch_fail_mock' );
+
+		// Allow sync in test environment.
+		if ( ! defined( 'NEWSPACK_ALLOW_READER_SYNC' ) ) {
+			define( 'NEWSPACK_ALLOW_READER_SYNC', true );
+		}
+
+		as_unschedule_all_actions( Contact_Sync_Batch::BATCH_HOOK );
+
+		// Create real WordPress users.
+		$user_id_1 = self::factory()->user->create();
+		$user_id_2 = self::factory()->user->create();
+		$user_ids  = [ $user_id_1, $user_id_2 ];
+
+		$batch_id = Contact_Sync_Batch::enqueue( $user_ids, [ 'batch_size' => 2 ] );
+
+		// Process the batch directly.
+		Contact_Sync_Batch::process_batch( $batch_id, $user_ids );
+
+		$progress = Contact_Sync_Batch::get_progress( $batch_id );
+		$this->assertGreaterThan( 0, $progress['failed'], 'Some contacts should have failed.' );
+		$this->assertEquals( 'complete', $progress['status'], 'Batch should complete even with failures.' );
+	}
+
+	/**
+	 * Test that cancel() stops a batch and marks it as cancelled.
+	 */
+	public function test_cancel_batch() {
+		if ( ! function_exists( 'as_schedule_single_action' ) ) {
+			$this->markTestSkipped( 'ActionScheduler not available.' );
+		}
+
+		as_unschedule_all_actions( Contact_Sync_Batch::BATCH_HOOK );
+
+		$user_ids = [ 1, 2, 3, 4, 5, 6 ];
+		$batch_id = Contact_Sync_Batch::enqueue( $user_ids, [ 'batch_size' => 2 ] );
+
+		// Verify AS actions are pending.
+		$pending = as_get_scheduled_actions(
+			[
+				'hook'   => Contact_Sync_Batch::BATCH_HOOK,
+				'group'  => 'newspack',
+				'status' => \ActionScheduler_Store::STATUS_PENDING,
+			],
+			'ARRAY_A'
+		);
+		$this->assertNotEmpty( $pending, 'There should be pending AS actions before cancel.' );
+
+		// Cancel the batch.
+		Contact_Sync_Batch::cancel( $batch_id );
+
+		// Verify progress is cancelled.
+		$progress = Contact_Sync_Batch::get_progress( $batch_id );
+		$this->assertEquals( 'cancelled', $progress['status'], 'Status should be cancelled after cancel().' );
+
+		// Verify no pending AS actions remain.
+		$pending_after = as_get_scheduled_actions(
+			[
+				'hook'   => Contact_Sync_Batch::BATCH_HOOK,
+				'group'  => 'newspack',
+				'status' => \ActionScheduler_Store::STATUS_PENDING,
+			],
+			'ARRAY_A'
+		);
+		$this->assertEmpty( $pending_after, 'No pending AS actions should remain after cancel.' );
+	}
+
+	/**
+	 * Test that stale progress records are cleaned up on enqueue.
+	 */
+	public function test_progress_cleanup() {
+		if ( ! function_exists( 'as_schedule_single_action' ) ) {
+			$this->markTestSkipped( 'ActionScheduler not available.' );
+		}
+
+		as_unschedule_all_actions( Contact_Sync_Batch::BATCH_HOOK );
+
+		// Manually insert a stale progress record.
+		$stale_batch_id = 'batch_stale_test';
+		$option_name    = Contact_Sync_Batch::PROGRESS_OPTION_PREFIX . $stale_batch_id;
+		update_option(
+			$option_name,
+			[
+				'total'      => 10,
+				'completed'  => 5,
+				'failed'     => 0,
+				'status'     => 'running',
+				'created_at' => time() - ( DAY_IN_SECONDS + 1 ),
+			],
+			false
+		);
+
+		// Verify the option exists.
+		$this->assertNotFalse( get_option( $option_name ), 'Stale progress record should exist before cleanup.' );
+
+		// Enqueue triggers cleanup.
+		Contact_Sync_Batch::enqueue( [ 1 ] );
+
+		// Verify the stale option was cleaned up.
+		$this->assertFalse( get_option( $option_name ), 'Stale progress record should be deleted after cleanup.' );
 	}
 }

--- a/tests/unit-tests/contact-sync-batch.php
+++ b/tests/unit-tests/contact-sync-batch.php
@@ -120,11 +120,6 @@ class Newspack_Test_Contact_Sync_Batch extends WP_UnitTestCase {
 		Integrations::register( $integration );
 		Integrations::enable( 'batch_fail_mock' );
 
-		// Allow sync in test environment.
-		if ( ! defined( 'NEWSPACK_ALLOW_READER_SYNC' ) ) {
-			define( 'NEWSPACK_ALLOW_READER_SYNC', true );
-		}
-
 		as_unschedule_all_actions( Contact_Sync_Batch::BATCH_HOOK );
 
 		// Create real WordPress users.

--- a/tests/unit-tests/contact-sync-batch.php
+++ b/tests/unit-tests/contact-sync-batch.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Tests the Contact_Sync_Batch class.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Reader_Activation\Contact_Sync_Batch;
+
+/**
+ * Test the Contact_Sync_Batch class.
+ */
+class Newspack_Test_Contact_Sync_Batch extends WP_UnitTestCase {
+
+	/**
+	 * Test that enqueue creates a progress record and schedules AS actions.
+	 */
+	public function test_enqueue_creates_progress_and_schedules_actions() {
+		if ( ! function_exists( 'as_schedule_single_action' ) ) {
+			$this->markTestSkipped( 'ActionScheduler not available.' );
+		}
+
+		// Clean up any pending actions from previous runs.
+		as_unschedule_all_actions( Contact_Sync_Batch::BATCH_HOOK );
+
+		$user_ids   = [ 1, 2, 3, 4, 5 ];
+		$batch_size = 2;
+		$batch_id   = Contact_Sync_Batch::enqueue( $user_ids, [ 'batch_size' => $batch_size ] );
+
+		$this->assertIsString( $batch_id, 'enqueue() should return a string batch ID.' );
+		$this->assertStringStartsWith( 'batch_', $batch_id, 'Batch ID should start with batch_ prefix.' );
+
+		// Verify progress record.
+		$progress = Contact_Sync_Batch::get_progress( $batch_id );
+		$this->assertIsArray( $progress, 'get_progress() should return an array.' );
+		$this->assertEquals( 5, $progress['total'], 'Total should equal the number of user IDs.' );
+		$this->assertEquals( 0, $progress['completed'], 'Completed should be 0 initially.' );
+		$this->assertEquals( 0, $progress['failed'], 'Failed should be 0 initially.' );
+		$this->assertEquals( 'running', $progress['status'], 'Status should be running.' );
+
+		// Verify scheduled actions: 5 users / batch_size 2 = 3 chunks (2, 2, 1).
+		$pending = as_get_scheduled_actions(
+			[
+				'hook'   => Contact_Sync_Batch::BATCH_HOOK,
+				'group'  => 'newspack',
+				'status' => \ActionScheduler_Store::STATUS_PENDING,
+			],
+			'ARRAY_A'
+		);
+		$this->assertCount( 3, $pending, 'Should schedule 3 AS actions for 5 users with batch_size 2.' );
+	}
+
+	/**
+	 * Test that get_progress returns false for an invalid batch ID.
+	 */
+	public function test_get_progress_invalid_id() {
+		$result = Contact_Sync_Batch::get_progress( 'nonexistent_batch_id' );
+		$this->assertFalse( $result, 'get_progress() should return false for an unknown batch ID.' );
+	}
+}

--- a/tests/unit-tests/contact-sync-batch.php
+++ b/tests/unit-tests/contact-sync-batch.php
@@ -190,28 +190,25 @@ class Newspack_Test_Contact_Sync_Batch extends WP_UnitTestCase {
 
 		as_unschedule_all_actions( Contact_Sync_Batch::BATCH_HOOK );
 
-		// Manually insert a stale progress record.
+		// Manually insert a stale progress record into the single option.
 		$stale_batch_id = 'batch_stale_test';
-		$option_name    = Contact_Sync_Batch::PROGRESS_OPTION_PREFIX . $stale_batch_id;
-		update_option(
-			$option_name,
-			[
-				'total'      => 10,
-				'completed'  => 5,
-				'failed'     => 0,
-				'status'     => 'running',
-				'created_at' => time() - ( DAY_IN_SECONDS + 1 ),
-			],
-			false
-		);
+		$all_progress   = get_option( Contact_Sync_Batch::PROGRESS_OPTION, [] );
+		$all_progress[ $stale_batch_id ] = [
+			'total'      => 10,
+			'completed'  => 5,
+			'failed'     => 0,
+			'status'     => 'running',
+			'created_at' => time() - ( DAY_IN_SECONDS + 1 ),
+		];
+		update_option( Contact_Sync_Batch::PROGRESS_OPTION, $all_progress, false );
 
-		// Verify the option exists.
-		$this->assertNotFalse( get_option( $option_name ), 'Stale progress record should exist before cleanup.' );
+		// Verify the stale record exists.
+		$this->assertNotFalse( Contact_Sync_Batch::get_progress( $stale_batch_id ), 'Stale progress record should exist before cleanup.' );
 
 		// Enqueue triggers cleanup.
 		Contact_Sync_Batch::enqueue( [ 1 ] );
 
-		// Verify the stale option was cleaned up.
-		$this->assertFalse( get_option( $option_name ), 'Stale progress record should be deleted after cleanup.' );
+		// Verify the stale record was cleaned up.
+		$this->assertFalse( Contact_Sync_Batch::get_progress( $stale_batch_id ), 'Stale progress record should be deleted after cleanup.' );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Introduces a new `Contact_Sync_Batch` class that provides batch handling for contact data syncing via ActionScheduler. Instead of scheduling one AS action per user (admin) or running a synchronous loop (CLI), bulk sync operations are now chunked and processed asynchronously with progress tracking.

- **Admin bulk action updated** to use the batch queue instead of per-user AS scheduling
- **CLI sync updated** from a synchronous loop to collect → enqueue → poll with a WP-CLI progress bar
- Progress records stored in `wp_options` with automatic 24h cleanup
- Batch cancellation only affects the target batch's pending actions

### How to test the changes in this Pull Request:

1. Enable ESP sync admin tools: `define( 'NEWSPACK_ESP_SYNC_ADMIN', true );` and ensure at least one ESP integration is connected and enabled.
2. Go to Users, select multiple users, choose "Resync to the ESP" from Bulk Actions, and apply. Verify the success notice says "X contacts scheduled for resync" and the monitoring link points to `newspack_contact_sync_batch` actions.
3. Run `wp newspack esp sync --batch-size=5` and verify a progress bar displays and completes.
4. Run `wp newspack esp sync --dry-run` to verify it counts contacts without syncing.
5. Run `wp newspack esp sync --user-ids=1,2,3` to verify specific user sync via the batch queue.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?