### PR TITLE
fix(snackbar): autohide progress bar not always appearing

### DIFF
--- a/src/newspack-ui/scss/elements/_notices.scss
+++ b/src/newspack-ui/scss/elements/_notices.scss
@@ -139,7 +139,7 @@
 					&[data-autohide="true"] {
 						.newspack-ui__snackbar__content::after {
 							opacity: 1;
-							transition: transform 8000ms linear;
+							transition: background-color 125ms ease-out, transform 8000ms linear;
 							transform: translateX(-100%);
 						}
 					}
@@ -176,8 +176,8 @@
 					left: 0;
 					height: 3px;
 					position: absolute;
-					transform: background-color 125ms ease-out;
-					transition: none;
+					transform: none;
+					transition: background-color 125ms ease-out;
 					width: 100%;
 				}
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a minor CSS error that results in the "progress bar" bottom colored border to occasionally not appear on snackbar elements with a `data-autohide` attribute. I believe this happens because the CSS doesn't explicitly reset the `transform` on the colored border when the element is first rendered—the values for `transform` and `transition` values seem to be accidentally swapped.

### How to test the changes in this Pull Request:

1. Log into My Account and start the progress to change your account email address. After the page refreshes, observe that the snackbar appears without any colored bottom border, but still autohides itself after 8 seconds. (Note that this doesn't always happen, but it happened fairly often for me)
2. Check out this branch and repeat, and confirm that the autohiding snackbars always appear with the colored bottom border.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->