### PR TITLE
feat(integrations): make sure contact data is read from persistent data

### DIFF
--- a/includes/data-events/class-woo-user-registration.php
+++ b/includes/data-events/class-woo-user-registration.php
@@ -7,6 +7,8 @@
 
 namespace Newspack\Data_Events;
 
+use Newspack\Reader_Activation;
+
 /**
  * Class that triggers a registration event with Newspack metadata for users registered during the Woocommerce checkout process.
  */
@@ -94,6 +96,14 @@ final class Woo_User_Registration {
 		// For modal checkout, the referer is actually what we want to capture as the registration page.
 		if ( ! empty( self::$metadata['referer'] ) && method_exists( 'Newspack_Blocks\Modal_Checkout', 'is_modal_checkout' ) && \Newspack_Blocks\Modal_Checkout::is_modal_checkout() ) {
 			self::$metadata['current_page_url'] = self::$metadata['referer'];
+		}
+
+		if ( isset( self::$metadata['registration_method'] ) ) {
+			\update_user_meta( $user_id, Reader_Activation::REGISTRATION_METHOD, self::$metadata['registration_method'] );
+		}
+
+		if ( isset( self::$metadata['current_page_url'] ) ) {
+			\update_user_meta( $user_id, Reader_Activation::REGISTRATION_PAGE, self::$metadata['current_page_url'] );
 		}
 
 		/**

--- a/includes/data-events/connectors/class-contact-sync-connector.php
+++ b/includes/data-events/connectors/class-contact-sync-connector.php
@@ -87,21 +87,13 @@ class Contact_Sync_Connector {
 	 * @param int   $client_id ID of the client that triggered the event.
 	 */
 	public static function reader_registered( $timestamp, $data, $client_id ) {
-		$metadata = [
-			'account'           => $data['user_id'],
-			'registration_date' => gmdate( Sync_Metadata::DATE_FORMAT, $timestamp ),
-		];
-		if ( isset( $data['metadata']['current_page_url'] ) ) {
-			$metadata['registration_page'] = $data['metadata']['current_page_url'];
-		}
-		if ( isset( $data['metadata']['registration_method'] ) ) {
-			$metadata['registration_method'] = $data['metadata']['registration_method'];
+		if ( empty( $data['user_id'] ) ) {
+			return;
 		}
 
-		$contact = [
-			'email'    => $data['email'],
-			'metadata' => $metadata,
-		];
+		$customer = new \WC_Customer( $data['user_id'] );
+
+		$contact = Sync_WooCommerce::get_contact_from_customer( $customer );
 
 		Contact_Sync::sync( $contact, 'RAS Reader registration' );
 	}
@@ -328,18 +320,6 @@ class Contact_Sync_Connector {
 		if ( ! $contact ) {
 			return;
 		}
-
-		// Ensure email is set as the user probably won't have a billing email.
-		if ( empty( $contact['email'] ) ) {
-			$user = get_userdata( $user_id );
-			$contact['email'] = $user->user_email;
-		}
-
-		if ( empty( $contact['metadata'] ) ) {
-			$contact['metadata'] = [];
-		}
-
-		$contact['metadata']['network_registration_site'] = $registration_site;
 
 		$site_url = get_site_url();
 		Contact_Sync::sync( $contact, sprintf( 'RAS Newspack Network: User propagated from another site in the network. Propagated from %s to %s.', $registration_site, $site_url ) );

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -34,6 +34,7 @@ final class Reader_Activation {
 	const EMAIL_VERIFIED                    = 'np_reader_email_verified';
 	const WITHOUT_PASSWORD                  = 'np_reader_without_password';
 	const REGISTRATION_METHOD               = 'np_reader_registration_method';
+	const REGISTRATION_PAGE                 = 'np_reader_registration_page';
 	const CONNECTED_ACCOUNT                 = 'np_reader_connected_account';
 	const READER_SAVED_GENERIC_DISPLAY_NAME = 'np_reader_saved_generic_display_name';
 
@@ -2330,6 +2331,10 @@ final class Reader_Activation {
 			if ( in_array( $metadata['registration_method'], self::SSO_REGISTRATION_METHODS, true ) ) {
 				self::set_reader_verified( $user_id );
 			}
+		}
+
+		if ( isset( $metadata['current_page_url'] ) ) {
+			\update_user_meta( $user_id, self::REGISTRATION_PAGE, $metadata['current_page_url'] );
 		}
 
 		/**

--- a/includes/reader-activation/sync/class-metadata.php
+++ b/includes/reader-activation/sync/class-metadata.php
@@ -339,6 +339,11 @@ class Metadata {
 			$metadata['registration_method'] = $registration_method;
 		}
 
+		$registration_page = self::has_key( 'registration_page', $metadata ) ? self::get_key_value( 'registration_page', $metadata ) : \get_user_meta( $user->ID, Reader_Activation::REGISTRATION_PAGE, true );
+		if ( ! empty( $registration_page ) ) {
+			$metadata['registration_page'] = $registration_page;
+		}
+
 		$connected_account = self::has_key( 'connected_account', $metadata ) ? self::get_key_value( 'connected_account', $metadata ) : \get_user_meta( $user->ID, Reader_Activation::CONNECTED_ACCOUNT, true );
 		if ( ! empty( $connected_account ) && in_array( $connected_account, Reader_Activation::SSO_REGISTRATION_METHODS ) ) {
 			$metadata['connected_account'] = $connected_account;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Make sure all metadata about a contact is persisted in the DB so the contact sync data is always fetched on the fly from persisted data, and never rely on data that only exists during the life cycle of an event.

### How to test the changes in this Pull Request:

1. Register to a site in different ways and make sure the same metadata fields are synced, including registration page
2. Change your ESP configuration to a wrong API key
3. Register to the site and see the sync fail
4. Fix the API Key
5. Watch the retry be executed and see it includes all metadata including payment_page
6. Register on a site in a Network and watch the sync on another site in the network. Confirm the "Network Registration Site" correctly
7. Access a page with UTM headers like `?utm_source=website&utm_medium=homepage&utm_campaign=header`
8. Make a donation and confirm the sync includes those
9. Trigger another sync for the same user and make sure UTM fields are still there


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->