### PR TITLE
fix(byline): update placeholder text to "Author Name"

### DIFF
--- a/src/blocks/byline/edit.jsx
+++ b/src/blocks/byline/edit.jsx
@@ -84,7 +84,7 @@ export default function Edit( { attributes, context, setAttributes } ) {
 	}
 
 	// Render default WordPress author, or placeholder if no author found.
-	const authorName = defaultAuthor?.name || __( '[Author]', 'newspack-plugin' );
+	const authorName = defaultAuthor?.name || __( 'Author Name', 'newspack-plugin' );
 	return (
 		<>
 			<BylineInspectorControls attributes={ attributes } setAttributes={ setAttributes } isCustomByline={ false } />


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Updates the byline block placeholder from "By [Author]" to "By Author Name".

Reference: https://github.com/Automattic/newspack-blocks/pull/2286#issuecomment-3938651512

Closes NPPD-1268.

### How to test the changes in this Pull Request:

1. Open the Site Editor and navigate to a template that includes the Byline block.
2. Verify the placeholder text reads "By Author Name" instead of "By [Author]".

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?