### PR TITLE
feat(content-gating): i3 designs for content gates list view

### DIFF
--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -512,7 +512,7 @@ class Content_Gate {
 			[
 				'post_title'   => $gate['title'],
 				'post_type'    => $post_type,
-				'post_status'  => $gate['status'] ?? 'draft',
+				'post_status'  => 'publish',
 				'post_content' => '',
 				'meta_input'   => [
 					'gate_priority' => count( $all_gates ),

--- a/languages/newspack-plugin.pot
+++ b/languages/newspack-plugin.pot
@@ -7534,7 +7534,7 @@ msgid "Please select a Constant Contact Master List."
 msgstr ""
 
 #: dist/audience-wizards.f3e1118ff4c1e097b5a1.js:40
-msgid "You have unsaved changes. Discard changes?"
+msgid "You have unsaved changes that will be lost. Discard changes?"
 msgstr ""
 
 #: dist/audience-wizards.f3e1118ff4c1e097b5a1.js:43

--- a/packages/components/src/action-card/index.js
+++ b/packages/components/src/action-card/index.js
@@ -302,7 +302,7 @@ const ActionCard = ( {
 						<Card className={ classes } onClick={ simple && onClick } id={ id ?? null } noBorder={ noBorder }>
 							<div className="newspack-action-card__draggable-controls">
 								<div className="drag-handle" draggable onDragStart={ onDraggableStart } onDragEnd={ onDraggableEnd }>
-									<Icon icon={ dragHandle } height={ 18 } width={ 18 } />
+									<Icon icon={ dragHandle } />
 								</div>
 								<div className="movers">
 									<Button

--- a/packages/components/src/button/index.tsx
+++ b/packages/components/src/button/index.tsx
@@ -19,10 +19,11 @@ const { useHistory } = Router;
 type OriginalButtonProps = typeof BaseComponent.defaultProps;
 type Props = OriginalButtonProps & {
 	href?: string;
+	loading?: boolean;
 	onClick?: () => void;
 };
 
-const Button = ( { href, onClick, ...otherProps }: Props ) => {
+const Button = ( { href, loading = undefined, onClick, ...otherProps }: Props ) => {
 	const history = useHistory();
 	const [ isAwaitingOnClick, setIsAwaitingOnClick ] = useState( false );
 
@@ -42,7 +43,7 @@ const Button = ( { href, onClick, ...otherProps }: Props ) => {
 		otherProps.disabled = true;
 	}
 	// @ts-expect-error - @wordpress/components' Button can only have either href or onClick, not both.
-	return <BaseComponent { ...otherProps } />;
+	return <BaseComponent loading={ loading ? true : undefined } { ...otherProps } />;
 };
 
 export default Button;

--- a/packages/components/src/card-settings-group/index.tsx
+++ b/packages/components/src/card-settings-group/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Content Gates edit - settings group component.
+ * Card - Settings group component.
  */
 
 /**

--- a/packages/components/src/card-sortable-list/index.tsx
+++ b/packages/components/src/card-sortable-list/index.tsx
@@ -5,7 +5,7 @@
 /**
  * WordPress dependencies.
  */
-import { Draggable, __experimentalVStack as VStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import { Disabled, Draggable, __experimentalVStack as VStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { useEffect, useLayoutEffect, useRef, useState } from '@wordpress/element';
 
 /**
@@ -38,11 +38,11 @@ type DragMeasurements = {
 };
 
 const CardSortableList = ( {
-	isActive = false,
+	disabled = false,
 	items = [],
 	onDragCallback = () => {},
 }: {
-	isActive?: boolean;
+	disabled?: boolean;
 	items?: DraggableItem[];
 	onDragCallback?: ( index: number, targetIndex: number ) => void;
 } ) => {
@@ -333,7 +333,7 @@ const CardSortableList = ( {
 			ref={ listRef }
 			className={ classNames(
 				'newspack-card--core--sortable-list',
-				isActive && 'newspack-card--core--sortable-list__is-active',
+				disabled && 'newspack-card--core--sortable-list__is-disabled',
 				isDragging && 'newspack-card--core--sortable-list__is-dragging'
 			) }
 			style={ measurements ? { height: measurements.lockedHeight } : undefined }
@@ -342,51 +342,52 @@ const CardSortableList = ( {
 			{ sortedItems.map( ( item, index ) => {
 				const translateY = getTranslateY( index );
 				return (
-					<div
-						key={ index }
-						ref={ el => {
-							itemRefs.current[ index ] = el;
-						} }
-						className={ classNames( 'newspack-card--core--sortable-list__item', {
-							'is-source': draggingIndex === index,
-							'is-dropped': droppedIndex === index,
-						} ) }
-						style={ translateY ? { transform: `translateY(${ translateY }px)` } : { transition: ! isDragging ? 'none' : undefined } }
-						id={ `draggable-card-${ index }` }
-						onDragOver={ e => handleDragOver( e, index ) }
-					>
-						<Draggable
-							transferData={ {} }
-							cloneClassname="newspack-card--core--sortable-list__item__clone"
-							elementId={ `draggable-card-${ index }` }
-							onDragStart={ () => handleDragStart( index ) }
-							onDragEnd={ handleDragEnd }
-							appendToOwnerDocument
+					<Disabled key={ index } isDisabled={ disabled }>
+						<div
+							ref={ el => {
+								itemRefs.current[ index ] = el;
+							} }
+							className={ classNames( 'newspack-card--core--sortable-list__item', {
+								'is-source': draggingIndex === index,
+								'is-dropped': droppedIndex === index,
+							} ) }
+							style={ translateY ? { transform: `translateY(${ translateY }px)` } : { transition: ! isDragging ? 'none' : undefined } }
+							id={ `draggable-card-${ index }` }
+							onDragOver={ e => handleDragOver( e, index ) }
 						>
-							{ ( { onDraggableStart, onDraggableEnd } ) => (
-								<Card
-									isSmall
-									draggable
-									onDragStart={ onDraggableStart }
-									onDragEnd={ onDraggableEnd }
-									__experimentalCoreCard
-									__experimentalCoreProps={ {
-										header: (
-											<h3>
-												{ item.title }
-												<Badge level={ item.badgeLevel } text={ item.badgeText } />
-											</h3>
-										),
-										isDraggable: true,
-										isFirstTarget: index === 0,
-										isLastTarget: index === sortedItems.length - 1,
-										dragIndex: index,
-										onDragCallback: handleButtonMove,
-									} }
-								/>
-							) }
-						</Draggable>
-					</div>
+							<Draggable
+								transferData={ {} }
+								cloneClassname="newspack-card--core--sortable-list__item__clone"
+								elementId={ `draggable-card-${ index }` }
+								onDragStart={ () => handleDragStart( index ) }
+								onDragEnd={ handleDragEnd }
+								appendToOwnerDocument
+							>
+								{ ( { onDraggableStart, onDraggableEnd } ) => (
+									<Card
+										isSmall
+										draggable
+										onDragStart={ onDraggableStart }
+										onDragEnd={ onDraggableEnd }
+										__experimentalCoreCard
+										__experimentalCoreProps={ {
+											header: (
+												<h3>
+													{ item.title }
+													<Badge level={ item.badgeLevel } text={ item.badgeText } />
+												</h3>
+											),
+											isDraggable: true,
+											isFirstTarget: index === 0,
+											isLastTarget: index === sortedItems.length - 1,
+											dragIndex: index,
+											onDragCallback: handleButtonMove,
+										} }
+									/>
+								) }
+							</Draggable>
+						</div>
+					</Disabled>
 				);
 			} ) }
 		</VStack>

--- a/packages/components/src/card-sortable-list/index.tsx
+++ b/packages/components/src/card-sortable-list/index.tsx
@@ -6,7 +6,7 @@
  * WordPress dependencies.
  */
 import { Draggable, __experimentalVStack as VStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
-import { useEffect, useRef, useState } from '@wordpress/element';
+import { useEffect, useLayoutEffect, useRef, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -20,6 +20,7 @@ import './style.scss';
 import classNames from 'classnames';
 
 const DROP_ANIMATION_DURATION = 400; // ms — must match $drop-duration in style.scss
+const BUTTON_MOVE_DURATION = 200; // ms — must match $button-move-duration in style.scss
 
 type DraggableItem = {
 	title: string;
@@ -53,6 +54,14 @@ const CardSortableList = ( {
 	const listRef = useRef< HTMLDivElement | null >( null );
 	const itemRefs = useRef< ( HTMLDivElement | null )[] >( [] );
 	const dropAnimationTimer = useRef< ReturnType< typeof setTimeout > | null >( null );
+	const buttonMoveTimer = useRef< ReturnType< typeof setTimeout > | null >( null );
+	const buttonFlipRef = useRef< {
+		fromIndex: number;
+		toIndex: number;
+		stride: number;
+		direction: number;
+	} | null >( null );
+	const [ buttonMoveId, setButtonMoveId ] = useState( 0 );
 
 	// Keep sortedItems in sync when the items prop changes externally (e.g. after a save).
 	useEffect( () => {
@@ -65,10 +74,107 @@ const CardSortableList = ( {
 			if ( dropAnimationTimer.current ) {
 				clearTimeout( dropAnimationTimer.current );
 			}
+			if ( buttonMoveTimer.current ) {
+				clearTimeout( buttonMoveTimer.current );
+			}
 		};
 	}, [] );
 
+	/**
+	 * Handle a chevron-button move. Records item positions before the reorder so
+	 * the FLIP animation can play after React commits the new DOM order.
+	 */
+	const handleButtonMove = ( fromIndex: number, toIndex: number ) => {
+		if ( toIndex < 0 || toIndex >= sortedItems.length ) {
+			return;
+		}
+
+		const fromEl = itemRefs.current[ fromIndex ];
+		const toEl = itemRefs.current[ toIndex ];
+		if ( ! fromEl || ! toEl ) {
+			return;
+		}
+
+		const stride = Math.abs( toEl.getBoundingClientRect().top - fromEl.getBoundingClientRect().top );
+		const direction = toIndex > fromIndex ? 1 : -1;
+		buttonFlipRef.current = { fromIndex, toIndex, stride, direction };
+
+		const reordered = [ ...sortedItems ];
+		const [ moved ] = reordered.splice( fromIndex, 1 );
+		reordered.splice( toIndex, 0, moved );
+		setSortedItems( reordered );
+		setButtonMoveId( id => id + 1 );
+	};
+
+	/**
+	 * FLIP Invert+Play step: runs synchronously after React commits the reordered
+	 * DOM. Animate each swapped item from its previous position to its new one
+	 * using inline CSS transitions (no CSS classes, to avoid creating a new
+	 * containing block that would break position:fixed on the Draggable clone).
+	 */
+	useLayoutEffect( () => {
+		const flipData = buttonFlipRef.current;
+		if ( ! flipData ) {
+			return;
+		}
+		buttonFlipRef.current = null;
+
+		const { fromIndex, toIndex, stride, direction } = flipData;
+
+		const startAnimation = ( el: HTMLDivElement | null, startY: number ) => {
+			if ( ! el ) {
+				return;
+			}
+			// Snap to the starting position with no transition.
+			el.style.transition = 'none';
+			el.style.transform = `translateY(${ startY }px)`;
+			// Force a reflow so the browser registers the starting position
+			// before we switch to the animated transition.
+			el.getBoundingClientRect();
+			// Animate from startY back to 0 (its new natural position).
+			el.style.transition = `transform ${ BUTTON_MOVE_DURATION }ms ease-out`;
+			el.style.transform = '';
+		};
+
+		// Moved item is now at toIndex: animate it in from its old position.
+		startAnimation( itemRefs.current[ toIndex ], -direction * stride );
+		// Displaced item is now at fromIndex: animate it in from its old position.
+		startAnimation( itemRefs.current[ fromIndex ], direction * stride );
+
+		if ( buttonMoveTimer.current ) {
+			clearTimeout( buttonMoveTimer.current );
+		}
+		buttonMoveTimer.current = setTimeout( () => {
+			// Clear inline animation styles before calling the external callback so
+			// the subsequent React re-render doesn't fight a live animation.
+			[ fromIndex, toIndex ].forEach( i => {
+				const el = itemRefs.current[ i ];
+				if ( el ) {
+					el.style.transition = '';
+					el.style.transform = '';
+				}
+			} );
+			onDragCallback( fromIndex, toIndex );
+			buttonMoveTimer.current = null;
+		}, BUTTON_MOVE_DURATION );
+	}, [ buttonMoveId ] ); // eslint-disable-line react-hooks/exhaustive-deps
+
 	const handleDragStart = ( index: number ) => {
+		// Cancel any in-progress button-move animation so no item wrapper keeps
+		// an inline transform. A transformed ancestor breaks position:fixed on
+		// the Draggable clone (CSS spec: fixed positioning is relative to the
+		// nearest ancestor with a transform/filter/perspective).
+		if ( buttonMoveTimer.current ) {
+			clearTimeout( buttonMoveTimer.current );
+			buttonMoveTimer.current = null;
+			itemRefs.current.forEach( el => {
+				if ( el ) {
+					el.style.transition = '';
+					el.style.transform = '';
+				}
+			} );
+		}
+
 		const listEl = listRef.current;
 		if ( listEl ) {
 			const itemEls = itemRefs.current;
@@ -237,6 +343,7 @@ const CardSortableList = ( {
 							elementId={ `draggable-card-${ index }` }
 							onDragStart={ () => handleDragStart( index ) }
 							onDragEnd={ handleDragEnd }
+							appendToOwnerDocument
 						>
 							{ ( { onDraggableStart, onDraggableEnd } ) => (
 								<Card
@@ -256,9 +363,8 @@ const CardSortableList = ( {
 										isFirstTarget: index === 0,
 										isLastTarget: index === sortedItems.length - 1,
 										dragIndex: index,
-										onDragStart: () => handleDragStart( index ),
-										onDragEnd: handleDragEnd,
-										onDragOver: handleDragOver,
+										dragTargetIndex: hoverIndex,
+										onDragCallback: handleButtonMove,
 									} }
 								/>
 							) }

--- a/packages/components/src/card-sortable-list/index.tsx
+++ b/packages/components/src/card-sortable-list/index.tsx
@@ -154,6 +154,25 @@ const CardSortableList = ( {
 					el.style.transform = '';
 				}
 			} );
+
+			// Move focus to the matching chevron button on the card at toIndex.
+			// Focus before onDragCallback so a parent rerender can't steal focus.
+			const targetEl = itemRefs.current[ toIndex ];
+			if ( targetEl ) {
+				const moveButtons = targetEl.querySelectorAll< HTMLButtonElement >(
+					'.newspack-card--core__header__draggable-controls__move-buttons button'
+				);
+				// direction > 0 = moved down → prefer the down button (index 1).
+				// direction < 0 = moved up   → prefer the up   button (index 0).
+				const preferred = direction > 0 ? moveButtons[ 1 ] : moveButtons[ 0 ];
+				const fallback = direction > 0 ? moveButtons[ 0 ] : moveButtons[ 1 ];
+				if ( preferred && ! preferred.disabled ) {
+					preferred.focus();
+				} else if ( fallback && ! fallback.disabled ) {
+					fallback.focus();
+				}
+			}
+
 			onDragCallback( fromIndex, toIndex );
 			buttonMoveTimer.current = null;
 		}, BUTTON_MOVE_DURATION );

--- a/packages/components/src/card-sortable-list/index.tsx
+++ b/packages/components/src/card-sortable-list/index.tsx
@@ -335,7 +335,6 @@ const CardSortableList = ( {
 						style={ translateY ? { transform: `translateY(${ translateY }px)` } : { transition: ! isDragging ? 'none' : undefined } }
 						id={ `draggable-card-${ index }` }
 						onDragOver={ e => handleDragOver( e, index ) }
-						// onDragLeave={ handleDragLeave }
 					>
 						<Draggable
 							transferData={ {} }

--- a/packages/components/src/card-sortable-list/index.tsx
+++ b/packages/components/src/card-sortable-list/index.tsx
@@ -20,7 +20,7 @@ import './style.scss';
 import classNames from 'classnames';
 
 const DROP_ANIMATION_DURATION = 400; // ms — must match $drop-duration in style.scss
-const BUTTON_MOVE_DURATION = 200; // ms — must match $button-move-duration in style.scss
+const BUTTON_MOVE_DURATION = 200; // ms — must match $shift-duration in style.scss
 
 type DraggableItem = {
 	title: string;

--- a/packages/components/src/card-sortable-list/index.tsx
+++ b/packages/components/src/card-sortable-list/index.tsx
@@ -363,7 +363,6 @@ const CardSortableList = ( {
 										isFirstTarget: index === 0,
 										isLastTarget: index === sortedItems.length - 1,
 										dragIndex: index,
-										dragTargetIndex: hoverIndex,
 										onDragCallback: handleButtonMove,
 									} }
 								/>

--- a/packages/components/src/card-sortable-list/index.tsx
+++ b/packages/components/src/card-sortable-list/index.tsx
@@ -23,6 +23,7 @@ const DROP_ANIMATION_DURATION = 400; // ms — must match $drop-duration in styl
 const BUTTON_MOVE_DURATION = 200; // ms — must match $shift-duration in style.scss
 
 type DraggableItem = {
+	id: string | number;
 	title: string;
 	badgeLevel: 'default' | 'success' | 'info' | 'warning' | 'error';
 	badgeText: string;
@@ -62,6 +63,7 @@ const CardSortableList = ( {
 		direction: number;
 	} | null >( null );
 	const [ buttonMoveId, setButtonMoveId ] = useState( 0 );
+	const documentDragOverRef = useRef< ( ( e: Event ) => void ) | null >( null );
 
 	// Keep sortedItems in sync when the items prop changes externally (e.g. after a save).
 	useEffect( () => {
@@ -76,6 +78,9 @@ const CardSortableList = ( {
 			}
 			if ( buttonMoveTimer.current ) {
 				clearTimeout( buttonMoveTimer.current );
+			}
+			if ( documentDragOverRef.current ) {
+				document.removeEventListener( 'dragover', documentDragOverRef.current );
 			}
 		};
 	}, [] );
@@ -215,11 +220,21 @@ const CardSortableList = ( {
 				itemTops: rects.map( rect => rect?.top ?? 0 ),
 			} );
 		}
+		// Make the entire document a valid drop target so the browser skips
+		// its snap-back animation when the cursor is released outside the list.
+		const preventSnapback = ( e: Event ) => e.preventDefault();
+		document.addEventListener( 'dragover', preventSnapback );
+		documentDragOverRef.current = preventSnapback;
+
 		setDraggingIndex( index );
 		setDroppedIndex( null );
 	};
 
 	const clearDragState = () => {
+		if ( documentDragOverRef.current ) {
+			document.removeEventListener( 'dragover', documentDragOverRef.current );
+			documentDragOverRef.current = null;
+		}
 		setDraggingIndex( null );
 		setHoverIndex( null );
 		setMeasurements( null );
@@ -342,7 +357,7 @@ const CardSortableList = ( {
 			{ sortedItems.map( ( item, index ) => {
 				const translateY = getTranslateY( index );
 				return (
-					<Disabled key={ index } isDisabled={ disabled }>
+					<Disabled key={ item.id } isDisabled={ disabled }>
 						<div
 							ref={ el => {
 								itemRefs.current[ index ] = el;

--- a/packages/components/src/card-sortable-list/index.tsx
+++ b/packages/components/src/card-sortable-list/index.tsx
@@ -24,7 +24,7 @@ const BUTTON_MOVE_DURATION = 200; // ms — must match $shift-duration in style.
 
 type DraggableItem = {
 	title: string;
-	badgeLevel: 'success' | 'info' | 'warning' | 'error';
+	badgeLevel: 'default' | 'success' | 'info' | 'warning' | 'error';
 	badgeText: string;
 };
 

--- a/packages/components/src/card-sortable-list/index.tsx
+++ b/packages/components/src/card-sortable-list/index.tsx
@@ -1,0 +1,273 @@
+/**
+ * Card - Sortable list component.
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { Draggable, __experimentalVStack as VStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import { useEffect, useRef, useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { Badge, Card } from '../';
+import './style.scss';
+
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+
+const DROP_ANIMATION_DURATION = 400; // ms — must match $drop-duration in style.scss
+
+type DraggableItem = {
+	title: string;
+	badgeLevel: 'success' | 'info' | 'warning' | 'error';
+	badgeText: string;
+};
+
+type DragMeasurements = {
+	lockedHeight: number;
+	sourceHeight: number;
+	// Height of each item (including the VStack gap after it, except the last).
+	itemStrides: number[];
+	// Top edge of each item, used for drop position hit-testing in onDragEnd.
+	itemTops: number[];
+};
+
+const CardSortableList = ( {
+	isActive = false,
+	items = [],
+	onDragCallback = () => {},
+}: {
+	isActive?: boolean;
+	items?: DraggableItem[];
+	onDragCallback?: ( index: number, targetIndex: number ) => void;
+} ) => {
+	const [ sortedItems, setSortedItems ] = useState( items );
+	const [ draggingIndex, setDraggingIndex ] = useState< number | null >( null );
+	const [ hoverIndex, setHoverIndex ] = useState< number | null >( null );
+	const [ droppedIndex, setDroppedIndex ] = useState< number | null >( null );
+	const [ measurements, setMeasurements ] = useState< DragMeasurements | null >( null );
+	const listRef = useRef< HTMLDivElement | null >( null );
+	const itemRefs = useRef< ( HTMLDivElement | null )[] >( [] );
+	const dropAnimationTimer = useRef< ReturnType< typeof setTimeout > | null >( null );
+
+	// Keep sortedItems in sync when the items prop changes externally (e.g. after a save).
+	useEffect( () => {
+		setSortedItems( items );
+	}, [ items ] );
+
+	// Clean up any pending animation timer on unmount.
+	useEffect( () => {
+		return () => {
+			if ( dropAnimationTimer.current ) {
+				clearTimeout( dropAnimationTimer.current );
+			}
+		};
+	}, [] );
+
+	const handleDragStart = ( index: number ) => {
+		const listEl = listRef.current;
+		if ( listEl ) {
+			const itemEls = itemRefs.current;
+			const rects = itemEls.map( el => el?.getBoundingClientRect() );
+
+			// Stride = item height + gap to next item (difference between consecutive tops).
+			const itemStrides = rects.map( ( rect, i ) => {
+				if ( ! rect ) {
+					return 0;
+				}
+				const nextRect = rects[ i + 1 ];
+				return nextRect ? nextRect.top - rect.top : rect.height;
+			} );
+
+			setMeasurements( {
+				lockedHeight: listEl.getBoundingClientRect().height,
+				sourceHeight: rects[ index ]?.height ?? 0,
+				itemStrides,
+				itemTops: rects.map( rect => rect?.top ?? 0 ),
+			} );
+		}
+		setDraggingIndex( index );
+		setDroppedIndex( null );
+	};
+
+	const clearDragState = () => {
+		setDraggingIndex( null );
+		setHoverIndex( null );
+		setMeasurements( null );
+	};
+
+	/**
+	 * Determine the drop target index from cursor coordinates and the item
+	 * top positions snapshotted at drag start. Mirrors the midpoint logic
+	 * previously used in getDropIndex but works without a live event target.
+	 */
+	const getDropIndexFromCursor = ( clientY: number, m: DragMeasurements, sourceIndex: number ): number => {
+		const { itemTops, itemStrides, sourceHeight } = m;
+		for ( let i = 0; i < itemTops.length; i++ ) {
+			const movingDown = sourceIndex > i;
+			const midpoint = itemTops[ i ] + ( movingDown ? itemStrides[ i ] : itemStrides[ i ] - sourceHeight );
+			if ( clientY < midpoint ) {
+				return i;
+			}
+		}
+		return itemTops.length; // below all items
+	};
+
+	const handleDragEnd = ( event: DragEvent ) => {
+		// Take a local copy of measurements before clearDragState nulls it.
+		const m = measurements;
+		const sourceIndex = draggingIndex;
+
+		clearDragState();
+
+		if ( m === null || sourceIndex === null ) {
+			return;
+		}
+
+		const dropIndex = getDropIndexFromCursor( event.clientY, m, sourceIndex );
+
+		// Compute the destination index in the post-removal array.
+		// After splicing out the dragged item, indices above it shift down by one.
+		const insertIndex = dropIndex > sourceIndex ? dropIndex - 1 : dropIndex;
+		if ( insertIndex === sourceIndex ) {
+			return;
+		}
+
+		const reordered = [ ...sortedItems ];
+		const [ moved ] = reordered.splice( sourceIndex, 1 );
+		reordered.splice( insertIndex, 0, moved );
+
+		// First render: show items in their new order with no animation.
+		// The dragging CSS classes are already cleared by clearDragState() above,
+		// so no transitions will fire on this paint.
+		setSortedItems( reordered );
+
+		// Next frame: trigger the drop animation on the newly-positioned item,
+		// then call onDragCallback after the animation completes.
+		requestAnimationFrame( () => {
+			setDroppedIndex( insertIndex );
+			dropAnimationTimer.current = setTimeout( () => {
+				setDroppedIndex( null );
+				onDragCallback( sourceIndex, insertIndex );
+			}, DROP_ANIMATION_DURATION );
+		} );
+	};
+
+	const handleDragOver = ( event: React.DragEvent< HTMLDivElement >, index: number ) => {
+		event.preventDefault();
+		if ( ! measurements ) {
+			return;
+		}
+		const rect = event.currentTarget.getBoundingClientRect();
+		const midpoint = rect.top + rect.height / 2;
+		setHoverIndex( event.clientY < midpoint ? index : index + 1 );
+	};
+
+	/**
+	 * Compute the translateY for a non-source item at `index` given the current
+	 * draggingIndex and hoverIndex, so that items visually shift to show the gap
+	 * while the container's layout height stays fixed.
+	 *
+	 * The source item has been visually hidden but still occupies its layout slot.
+	 * Items between the source and the hover position need to slide by the source
+	 * item's stride (height + gap) to either fill the vacated source slot or make
+	 * room for the incoming gap at the hover position.
+	 */
+	const getTranslateY = ( index: number ): number => {
+		if ( draggingIndex === null || hoverIndex === null || ! measurements ) {
+			return 0;
+		}
+		if ( index === draggingIndex ) {
+			return 0;
+		}
+
+		const { itemStrides, sourceHeight } = measurements;
+		const sourceStride = itemStrides[ draggingIndex ] ?? sourceHeight;
+
+		if ( hoverIndex > draggingIndex ) {
+			// Dragging downward: items strictly between source and hover position slide up.
+			if ( index > draggingIndex && index < hoverIndex ) {
+				return -sourceStride;
+			}
+		} else if ( index >= hoverIndex && index < draggingIndex ) {
+			// Dragging upward: items between hover position and source slide down.
+			return sourceStride;
+		}
+
+		return 0;
+	};
+
+	const isDragging = draggingIndex !== null;
+
+	return (
+		<VStack
+			ref={ listRef }
+			className={ classNames(
+				'newspack-card--core--sortable-list',
+				isActive && 'newspack-card--core--sortable-list__is-active',
+				isDragging && 'newspack-card--core--sortable-list__is-dragging'
+			) }
+			style={ measurements ? { height: measurements.lockedHeight } : undefined }
+			spacing="16px"
+		>
+			{ sortedItems.map( ( item, index ) => {
+				const translateY = getTranslateY( index );
+				return (
+					<div
+						key={ index }
+						ref={ el => {
+							itemRefs.current[ index ] = el;
+						} }
+						className={ classNames( 'newspack-card--core--sortable-list__item', {
+							'is-source': draggingIndex === index,
+							'is-dropped': droppedIndex === index,
+						} ) }
+						style={ translateY ? { transform: `translateY(${ translateY }px)` } : { transition: ! isDragging ? 'none' : undefined } }
+						id={ `draggable-card-${ index }` }
+						onDragOver={ e => handleDragOver( e, index ) }
+						// onDragLeave={ handleDragLeave }
+					>
+						<Draggable
+							transferData={ {} }
+							cloneClassname="newspack-card--core--sortable-list__item__clone"
+							elementId={ `draggable-card-${ index }` }
+							onDragStart={ () => handleDragStart( index ) }
+							onDragEnd={ handleDragEnd }
+						>
+							{ ( { onDraggableStart, onDraggableEnd } ) => (
+								<Card
+									isSmall
+									draggable
+									onDragStart={ onDraggableStart }
+									onDragEnd={ onDraggableEnd }
+									__experimentalCoreCard
+									__experimentalCoreProps={ {
+										header: (
+											<h3>
+												{ item.title }
+												<Badge level={ item.badgeLevel } text={ item.badgeText } />
+											</h3>
+										),
+										isDraggable: true,
+										isFirstTarget: index === 0,
+										isLastTarget: index === sortedItems.length - 1,
+										dragIndex: index,
+										onDragStart: () => handleDragStart( index ),
+										onDragEnd: handleDragEnd,
+										onDragOver: handleDragOver,
+									} }
+								/>
+							) }
+						</Draggable>
+					</div>
+				);
+			} ) }
+		</VStack>
+	);
+};
+
+export default CardSortableList;

--- a/packages/components/src/card-sortable-list/index.tsx
+++ b/packages/components/src/card-sortable-list/index.tsx
@@ -318,7 +318,7 @@ const CardSortableList = ( {
 				isDragging && 'newspack-card--core--sortable-list__is-dragging'
 			) }
 			style={ measurements ? { height: measurements.lockedHeight } : undefined }
-			spacing="16px"
+			spacing={ 4 }
 		>
 			{ sortedItems.map( ( item, index ) => {
 				const translateY = getTranslateY( index );

--- a/packages/components/src/card-sortable-list/style.scss
+++ b/packages/components/src/card-sortable-list/style.scss
@@ -1,0 +1,49 @@
+$collapse-duration: 200ms;
+$shift-duration: 150ms;
+$drop-duration: 400ms; // must match DROP_ANIMATION_DURATION in index.tsx
+
+.newspack-card--core--sortable-list {
+	margin: 16px 0;
+
+	&__item {
+		cursor: grab;
+
+		/*
+		 * Animate items sliding to fill/make space around the dragged item.
+		 */
+		transition: transform $shift-duration ease;
+
+		/*
+		 * Collapse the source item's content — the wrapper stays in layout as the
+		 * anchor point, and the container height is locked via inline style in JS.
+		 */
+		&.is-source {
+			cursor: grabbing;
+			opacity: 0;
+			transition: opacity $collapse-duration ease;
+		}
+
+		/*
+		 * Drop landing animation: brief fade-in and scale on the newly placed item.
+		 */
+		&.is-dropped {
+			animation: newspack-sortable-drop $drop-duration ease forwards;
+			opacity: 0;
+		}
+	}
+}
+
+@keyframes newspack-sortable-drop {
+	0% {
+		opacity: 0;
+		transform: scale(0.98);
+	}
+	60% {
+		opacity: 1;
+		transform: scale(1.01);
+	}
+	100% {
+		opacity: 1;
+		transform: scale(1);
+	}
+}

--- a/packages/components/src/card-sortable-list/style.scss
+++ b/packages/components/src/card-sortable-list/style.scss
@@ -3,8 +3,6 @@ $shift-duration: 150ms;
 $drop-duration: 400ms; /* must match DROP_ANIMATION_DURATION in index.tsx */
 
 .newspack-card--core--sortable-list {
-	margin: 16px 0;
-
 	&__item {
 		cursor: grab;
 

--- a/packages/components/src/card-sortable-list/style.scss
+++ b/packages/components/src/card-sortable-list/style.scss
@@ -1,6 +1,6 @@
 $collapse-duration: 200ms;
 $shift-duration: 150ms;
-$drop-duration: 400ms; // must match DROP_ANIMATION_DURATION in index.tsx
+$drop-duration: 400ms; /* must match DROP_ANIMATION_DURATION in index.tsx */
 
 .newspack-card--core--sortable-list {
 	margin: 16px 0;
@@ -30,6 +30,7 @@ $drop-duration: 400ms; // must match DROP_ANIMATION_DURATION in index.tsx
 			animation: newspack-sortable-drop $drop-duration ease forwards;
 			opacity: 0;
 		}
+
 	}
 }
 

--- a/packages/components/src/card/core-card.js
+++ b/packages/components/src/card/core-card.js
@@ -78,10 +78,10 @@ const CoreCard = ( {
 						</div>
 					) }
 					{ header && <div className="newspack-card--core__header-content">{ header }</div> }
-					{ ! actions && actionType === 'chevron' && (
+					{ ! actions?.length > 0 && actionType === 'chevron' && (
 						<Icon className="newspack-card--core__action" icon={ chevronRight } height={ 24 } width={ 24 } />
 					) }
-					{ ! actions && actionType === 'toggle' && (
+					{ ! actions?.length > 0 && actionType === 'toggle' && (
 						<ToggleControl
 							className="newspack-card--core__action"
 							label={ otherProps.title }

--- a/packages/components/src/card/core-card.js
+++ b/packages/components/src/card/core-card.js
@@ -7,8 +7,8 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Card as CardWrapper, CardHeader, CardFooter, DropdownMenu, MenuItem, ToggleControl } from '@wordpress/components';
-import { Icon, chevronRight, moreVertical } from '@wordpress/icons';
+import { Button, Card as CardWrapper, CardHeader, CardFooter, DropdownMenu, MenuItem, ToggleControl } from '@wordpress/components';
+import { Icon, chevronDown, chevronRight, chevronUp, dragHandle, moreVertical } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -31,18 +31,24 @@ const CoreCard = ( {
 	icon,
 	iconBackgroundColor,
 	isActive,
+	isDraggable,
+	isFirstTarget,
+	isLastTarget,
 	isNarrow,
 	isSmall,
+	dragIndex,
+	onDragCallback = () => {},
 	onHeaderClick,
 	noBorder,
 	noMargin,
-	children,
+	children = null,
 	...otherProps
 } ) => {
 	const classes = classNames(
 		'newspack-card--core',
 		className,
 		( buttonsCard || as === 'a' ) && 'newspack-card--core__buttons-card',
+		isDraggable && 'newspack-card--core__is-draggable',
 		isNarrow && 'newspack-card--core__is-narrow',
 		isSmall && 'newspack-card--core__is-small',
 		icon && 'newspack-card--core__has-icon',
@@ -68,10 +74,33 @@ const CoreCard = ( {
 			{ ( header || icon ) && (
 				<CardHeader
 					as={ onHeaderClick ? 'button' : undefined }
-					className="newspack-card--core__header"
+					className={ classNames( 'newspack-card--core__header', isDraggable && 'newspack-card--core__header--is-draggable' ) }
 					size={ sizeProps }
 					onClick={ onHeaderClick }
 				>
+					{ isDraggable && (
+						<div className="newspack-card--core__header__draggable-controls">
+							<div className="newspack-card--core__header__draggable-controls__drag-handle">
+								<Icon icon={ dragHandle } height={ 18 } width={ 18 } />
+							</div>
+							<div className="newspack-card--core__header__draggable-controls__move-buttons">
+								<Button
+									icon={ chevronUp }
+									onClick={ () => onDragCallback( dragIndex - 1 ) }
+									disabled={ isFirstTarget }
+									label={ __( 'Move one position up', 'newspack-plugin' ) }
+									size="small"
+								/>
+								<Button
+									icon={ chevronDown }
+									onClick={ () => onDragCallback( dragIndex + 1 ) }
+									disabled={ isLastTarget }
+									label={ __( 'Move one position down', 'newspack-plugin' ) }
+									size="small"
+								/>
+							</div>
+						</div>
+					) }
 					{ icon && (
 						<div className="newspack-card--core__icon">
 							<Icon icon={ icon } height={ isSmall ? 24 : 48 } width={ isSmall ? 24 : 48 } />

--- a/packages/components/src/card/core-card.js
+++ b/packages/components/src/card/core-card.js
@@ -35,6 +35,7 @@ const CoreCard = ( {
 	isSmall,
 	onHeaderClick,
 	noBorder,
+	noMargin,
 	children,
 	...otherProps
 } ) => {
@@ -47,7 +48,8 @@ const CoreCard = ( {
 		icon && 'newspack-card--core__has-icon',
 		iconBackgroundColor && 'newspack-card--core__has-icon-background-color',
 		isActive && 'newspack-card--core__is-active',
-		children && 'newspack-card--core__has-children'
+		children && 'newspack-card--core__has-children',
+		noMargin && 'newspack-card--core__no-margin'
 	);
 	let sizeProps = isSmall ? 'small' : otherProps.size;
 	if ( buttonsCard || as === 'a' ) {

--- a/packages/components/src/card/core-card.js
+++ b/packages/components/src/card/core-card.js
@@ -6,8 +6,9 @@
 /**
  * WordPress dependencies
  */
-import { Card as CardWrapper, CardHeader, CardFooter, ToggleControl } from '@wordpress/components';
-import { Icon, chevronRight } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
+import { Card as CardWrapper, CardHeader, CardFooter, DropdownMenu, MenuItem, ToggleControl } from '@wordpress/components';
+import { Icon, chevronRight, moreVertical } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -20,6 +21,7 @@ import './style-core.scss';
 import classNames from 'classnames';
 
 const CoreCard = ( {
+	actions,
 	actionType,
 	as,
 	buttonsCard,
@@ -74,8 +76,10 @@ const CoreCard = ( {
 						</div>
 					) }
 					{ header && <div className="newspack-card--core__header-content">{ header }</div> }
-					{ actionType === 'chevron' && <Icon className="newspack-card--core__action" icon={ chevronRight } height={ 24 } width={ 24 } /> }
-					{ actionType === 'toggle' && (
+					{ ! actions && actionType === 'chevron' && (
+						<Icon className="newspack-card--core__action" icon={ chevronRight } height={ 24 } width={ 24 } />
+					) }
+					{ ! actions && actionType === 'toggle' && (
 						<ToggleControl
 							className="newspack-card--core__action"
 							label={ otherProps.title }
@@ -83,6 +87,23 @@ const CoreCard = ( {
 							checked={ isActive }
 							onChange={ () => {} }
 						/>
+					) }
+					{ actions?.length > 0 && (
+						<DropdownMenu icon={ moreVertical } label={ __( 'More', 'newspack-plugin' ) }>
+							{ () =>
+								actions.map( ( action, index ) => (
+									<MenuItem
+										key={ index }
+										icon={ action.icon }
+										onClick={ action.action }
+										disabled={ action.disabled || false }
+										isDestructive={ action.destructive || false }
+									>
+										{ action.label }
+									</MenuItem>
+								) )
+							}
+						</DropdownMenu>
 					) }
 				</CardHeader>
 			) }

--- a/packages/components/src/card/core-card.js
+++ b/packages/components/src/card/core-card.js
@@ -86,14 +86,14 @@ const CoreCard = ( {
 							<div className="newspack-card--core__header__draggable-controls__move-buttons">
 								<Button
 									icon={ chevronUp }
-									onClick={ () => onDragCallback( dragIndex - 1 ) }
+									onClick={ () => onDragCallback( dragIndex, dragIndex - 1 ) }
 									disabled={ isFirstTarget }
 									label={ __( 'Move one position up', 'newspack-plugin' ) }
 									size="small"
 								/>
 								<Button
 									icon={ chevronDown }
-									onClick={ () => onDragCallback( dragIndex + 1 ) }
+									onClick={ () => onDragCallback( dragIndex, dragIndex + 1 ) }
 									disabled={ isLastTarget }
 									label={ __( 'Move one position down', 'newspack-plugin' ) }
 									size="small"

--- a/packages/components/src/card/core-card.js
+++ b/packages/components/src/card/core-card.js
@@ -81,7 +81,7 @@ const CoreCard = ( {
 					{ isDraggable && (
 						<div className="newspack-card--core__header__draggable-controls">
 							<div className="newspack-card--core__header__draggable-controls__drag-handle">
-								<Icon icon={ dragHandle } height={ 18 } width={ 18 } />
+								<Icon icon={ dragHandle } />
 							</div>
 							<div className="newspack-card--core__header__draggable-controls__move-buttons">
 								<Button

--- a/packages/components/src/card/index.js
+++ b/packages/components/src/card/index.js
@@ -42,6 +42,8 @@ class Card extends Component {
 				footer: null, // Pass a React component to render in a CardFooter component.
 				noMargin: false,
 				isDraggable: false,
+				dragIndex: null,
+				onDragCallback: () => {},
 			},
 			...otherProps
 		} = this.props;

--- a/packages/components/src/card/index.js
+++ b/packages/components/src/card/index.js
@@ -41,6 +41,7 @@ class Card extends Component {
 				icon: null,
 				footer: null, // Pass a React component to render in a CardFooter component.
 				noMargin: false,
+				isDraggable: false,
 			},
 			...otherProps
 		} = this.props;

--- a/packages/components/src/card/index.js
+++ b/packages/components/src/card/index.js
@@ -40,6 +40,7 @@ class Card extends Component {
 				header: null, // Pass a React component to render in a CardHeader component.
 				icon: null,
 				footer: null, // Pass a React component to render in a CardFooter component.
+				noMargin: false,
 			},
 			...otherProps
 		} = this.props;

--- a/packages/components/src/card/style-core.scss
+++ b/packages/components/src/card/style-core.scss
@@ -82,7 +82,7 @@
 	}
 	&__header--is-draggable {
 		.newspack-card--core__header-content {
-			padding-left: 60px;
+			padding-left: 65px;
 		}
 		.newspack-card--core__header__draggable-controls {
 			align-items: center;

--- a/packages/components/src/card/style-core.scss
+++ b/packages/components/src/card/style-core.scss
@@ -80,6 +80,42 @@
 			top: 0;
 		}
 	}
+	&__header--is-draggable {
+		.newspack-card--core__header-content {
+			padding-left: 60px;
+		}
+		.newspack-card--core__header__draggable-controls {
+			align-items: center;
+			border-right: 1px solid wp-colors.$gray-200;
+			display: flex;
+			height: 100%;
+			justify-content: space-between;
+			left: 0;
+			padding: 0 8px;
+			position: absolute;
+			top: 0;
+		}
+		.newspack-card--core__header__draggable-controls__drag-handle {
+			cursor: grab;
+			height: 18px;
+		}
+		.newspack-card--core__header__draggable-controls__move-buttons {
+			display: flex;
+			flex-direction: column;
+			.components-button.has-icon {
+				height: 16px;
+				padding: 0;
+				width: 100%;
+			}
+		}
+	}
+	&__header--is-draggable__drag-handle {
+		cursor: grab;
+	}
+	&__header--is-draggable__move-buttons {
+		display: flex;
+		flex-direction: column;
+	}
 	button.newspack-card--core__header {
 		appearance: none;
 		background-color: white;

--- a/packages/components/src/card/style-core.scss
+++ b/packages/components/src/card/style-core.scss
@@ -109,13 +109,6 @@
 			}
 		}
 	}
-	&__header--is-draggable__drag-handle {
-		cursor: grab;
-	}
-	&__header--is-draggable__move-buttons {
-		display: flex;
-		flex-direction: column;
-	}
 	button.newspack-card--core__header {
 		appearance: none;
 		background-color: white;

--- a/packages/components/src/card/style-core.scss
+++ b/packages/components/src/card/style-core.scss
@@ -97,7 +97,8 @@
 		}
 		.newspack-card--core__header__draggable-controls__drag-handle {
 			cursor: grab;
-			height: 18px;
+			display: grid;
+			place-items: center;
 		}
 		.newspack-card--core__header__draggable-controls__move-buttons {
 			display: flex;

--- a/packages/components/src/card/style-core.scss
+++ b/packages/components/src/card/style-core.scss
@@ -69,11 +69,12 @@
 			}
 		}
 		.components-dropdown-menu {
-			align-items: center;
+			aspect-ratio: 1;
 			border-left: 1px solid wp-colors.$gray-200;
-			display: flex;
+			display: grid;
 			height: 100%;
 			padding: 4px;
+			place-items: center;
 			position: absolute;
 			right: 0;
 			top: 0;

--- a/packages/components/src/card/style-core.scss
+++ b/packages/components/src/card/style-core.scss
@@ -8,6 +8,7 @@
 .newspack-card--core,
 .newspack-wizard .newspack-card--core {
 	background: white;
+	position: relative;
 	transition: background-color 125ms ease-in-out, box-shadow 125ms ease-in-out, color 125ms ease-in-out;
 	svg {
 		transition: fill 125ms ease-in-out;
@@ -49,9 +50,9 @@
 	&__header {
 		color: wp-colors.$gray-700;
 		column-gap: 16px;
+		position: relative;
 		.newspack-card--core__action {
 			margin: 0;
-
 			label {
 				border: 0;
 				clip-path: inset(50%);
@@ -63,6 +64,16 @@
 				width: 1px;
 				word-wrap: normal !important;
 			}
+		}
+		.components-dropdown-menu {
+			align-items: center;
+			border-left: 1px solid wp-colors.$gray-200;
+			display: flex;
+			height: 100%;
+			padding: 4px;
+			position: absolute;
+			right: 0;
+			top: 0;
 		}
 	}
 	button.newspack-card--core__header {
@@ -93,7 +104,14 @@
 		h4,
 		h5,
 		h6 {
+			align-items: center;
 			color: wp-colors.$gray-900;
+			font-weight: 500;
+			display: flex;
+			gap: 8px;
+			.newspack-badge {
+				font-weight: 400;
+			}
 		}
 	}
 	&__is-active {

--- a/packages/components/src/card/style-core.scss
+++ b/packages/components/src/card/style-core.scss
@@ -47,6 +47,9 @@
 			}
 		}
 	}
+	&__no-margin .components-card__body {
+		padding: 0 !important;
+	}
 	&__header {
 		color: wp-colors.$gray-700;
 		column-gap: 16px;
@@ -184,6 +187,9 @@
 			padding: 16px 24px;
 			.newspack-card--core__is-small & {
 				padding: 16px;
+			}
+			.newspack-card--core__no-margin & {
+				padding: 0;
 			}
 		}
 	}

--- a/packages/components/src/confirm-dialog/index.tsx
+++ b/packages/components/src/confirm-dialog/index.tsx
@@ -19,8 +19,7 @@ import classnames from 'classnames';
  */
 type ConfirmDialogProps = {
 	className?: string;
-	isWide?: boolean;
-	isNarrow?: boolean;
+	size?: 'small' | 'medium' | 'large' | 'x-large' | 'full';
 	hideTitle?: boolean;
 	title?: string;
 	isDestructive?: boolean;
@@ -31,14 +30,21 @@ type ConfirmDialogProps = {
 	children?: React.ReactNode;
 };
 
+const sizeClassMap = {
+	small: 'newspack-modal--size-small',
+	medium: 'newspack-modal--size-medium',
+	large: 'newspack-modal--size-large',
+	'x-large': 'newspack-modal--size-x-large',
+	full: 'newspack-modal--size-full',
+};
+
 function ConfirmDialog(
-	{ className, isWide, isNarrow = true, hideTitle, isDestructive, onConfirm, onCancel, ...otherProps }: ConfirmDialogProps,
+	{ className, size = 'small', hideTitle, isDestructive, onConfirm, onCancel, ...otherProps }: ConfirmDialogProps,
 	ref: React.Ref< HTMLDivElement >
 ) {
 	const classes = classnames(
 		'newspack-modal',
-		isWide && 'newspack-modal--wide',
-		isNarrow && 'newspack-modal--narrow',
+		sizeClassMap[ size ],
 		hideTitle && 'newspack-modal--hide-title', // Note: also hides the X close button.
 		isDestructive && 'newspack-modal--destructive',
 		className

--- a/packages/components/src/confirm-dialog/index.tsx
+++ b/packages/components/src/confirm-dialog/index.tsx
@@ -1,0 +1,58 @@
+/**
+ * Modal
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { forwardRef } from '@wordpress/element';
+import { __experimentalConfirmDialog as BaseComponent } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+
+/**
+ * External dependencies.
+ */
+import classnames from 'classnames';
+
+/*
+ * See both https://wordpress.github.io/gutenberg/?path=/docs/components-confirmdialog--docs and
+ * https://wordpress.github.io/gutenberg/?path=/docs/components-modal--docs for all supported props.
+ */
+type ConfirmDialogProps = {
+	className?: string;
+	isWide?: boolean;
+	isNarrow?: boolean;
+	hideTitle?: boolean;
+	title?: string;
+	isDestructive?: boolean;
+	cancelButtonText?: string;
+	confirmButtonText?: string;
+	onConfirm: () => void;
+	onCancel: () => void;
+	children?: React.ReactNode;
+};
+
+function ConfirmDialog(
+	{ className, isWide, isNarrow = true, hideTitle, isDestructive, onConfirm, onCancel, ...otherProps }: ConfirmDialogProps,
+	ref: React.Ref< HTMLDivElement >
+) {
+	const classes = classnames(
+		'newspack-modal',
+		isWide && 'newspack-modal--wide',
+		isNarrow && 'newspack-modal--narrow',
+		hideTitle && 'newspack-modal--hide-title', // Note: also hides the X close button.
+		isDestructive && 'newspack-modal--destructive',
+		className
+	);
+
+	return (
+		<BaseComponent
+			className={ classes }
+			{ ...otherProps }
+			ref={ ref }
+			onConfirm={ onConfirm }
+			onCancel={ onCancel }
+			__experimentalHideHeader={ false }
+		/>
+	);
+}
+export default forwardRef( ConfirmDialog );

--- a/packages/components/src/grid/index.tsx
+++ b/packages/components/src/grid/index.tsx
@@ -12,9 +12,10 @@ import './style.scss';
  */
 import classnames from 'classnames';
 
-const Grid = ( { className = '', columns = 2, gutter = 32, noMargin = false, rowGap = 0, ...otherProps } ) => {
+const Grid = ( { className = '', borders = false, columns = 2, gutter = 32, noMargin = false, rowGap = 0, ...otherProps } ) => {
 	const classes = classnames(
 		'newspack-grid',
+		borders && 'newspack-grid__borders',
 		noMargin && 'newspack-grid--no-margin',
 		columns && 'newspack-grid__columns-' + columns,
 		gutter && 'newspack-grid__gutter-' + gutter,

--- a/packages/components/src/grid/style.scss
+++ b/packages/components/src/grid/style.scss
@@ -41,6 +41,11 @@
 		grid-gap: 32px;
 	}
 
+	// Gutter 64
+	&__gutter-64 {
+		grid-gap: 64px;
+	}
+
 	// Row Gap 0
 	&__row-gap-0 {
 		grid-row-gap: 0;
@@ -59,11 +64,6 @@
 	// Row Gap 32
 	&__row-gap-32 {
 		grid-row-gap: 32px;
-	}
-
-	// Gutter 64
-	&__gutter-64 {
-		grid-gap: 64px;
 	}
 
 	// Columns 6
@@ -132,6 +132,44 @@
 	> * {
 		margin-bottom: 0 !important;
 		margin-top: 0 !important;
+		> h1:first-child,
+		> h2:first-child,
+		> h3:first-child,
+		> h4:first-child,
+		> h5:first-child,
+		> h6:first-child {
+			margin-top: 0;
+		}
+	}
+
+	// Borders
+	&__borders {
+		grid-gap: 0 !important;
+		> * {
+			border-bottom: 1px solid wp-colors.$gray-300;
+			&:last-child {
+				border-bottom: none;
+			}
+			@media screen and ( min-width: 744px ) {
+				border-bottom: none;
+				border-right: 1px solid wp-colors.$gray-300;
+				&:last-child {
+					border-right: none;
+				}
+			}
+		}
+		&.newspack-grid__gutter-8 > * {
+			padding: 8px;
+		}
+		&.newspack-grid__gutter-16 > * {
+			padding: 16px;
+		}
+		&.newspack-grid__gutter-32 > * {
+			padding: 32px;
+		}
+		&.newspack-grid__gutter-64 > * {
+			padding: 64px;
+		}
 	}
 
 	.components-base-control {

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -11,6 +11,7 @@ export { default as Card } from './card';
 export { default as CardSettingsGroup } from './card-settings-group';
 export { default as CategoryAutocomplete } from './category-autocomplete';
 export { default as ColorPicker } from './color-picker';
+export { default as ConfirmDialog } from './confirm-dialog';
 export { default as CustomSelectControl } from './custom-select-control';
 export { default as Divider } from './divider';
 export { default as FormTokenField } from './form-token-field';

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -9,6 +9,7 @@ export { default as ButtonCard } from './button-card';
 export { default as BoxContrast } from './box-contrast';
 export { default as Card } from './card';
 export { default as CardSettingsGroup } from './card-settings-group';
+export { default as CardSortableList } from './card-sortable-list';
 export { default as CategoryAutocomplete } from './category-autocomplete';
 export { default as ColorPicker } from './color-picker';
 export { default as ConfirmDialog } from './confirm-dialog';

--- a/packages/components/src/modal/index.js
+++ b/packages/components/src/modal/index.js
@@ -18,12 +18,21 @@ import './style.scss';
  */
 import classnames from 'classnames';
 
-function Modal( { className, isWide, isNarrow, hideTitle, ...otherProps }, ref ) {
+const sizeClassMap = {
+	small: 'newspack-modal--size-small',
+	medium: 'newspack-modal--size-medium',
+	large: 'newspack-modal--size-large',
+	'x-large': 'newspack-modal--size-x-large',
+	full: 'newspack-modal--size-full',
+};
+
+const getSizeClassName = size => sizeClassMap[ size ] || sizeClassMap.medium;
+
+function Modal( { className, size = 'medium', hideTitle, ...otherProps }, ref ) {
 	const classes = classnames(
 		'newspack-modal',
-		isWide && 'newspack-modal--wide',
-		isNarrow && 'newspack-modal--narrow',
 		hideTitle && 'newspack-modal--hide-title', // Note: also hides the X close button.
+		getSizeClassName( size ),
 		className
 	);
 

--- a/packages/components/src/modal/index.js
+++ b/packages/components/src/modal/index.js
@@ -18,10 +18,11 @@ import './style.scss';
  */
 import classnames from 'classnames';
 
-function Modal( { className, isWide, isNarrow, hideTitle, ...otherProps }, ref ) {
+function Modal( { className, isWide, isMedium, isNarrow, hideTitle, ...otherProps }, ref ) {
 	const classes = classnames(
 		'newspack-modal',
 		isWide && 'newspack-modal--wide',
+		isMedium && 'newspack-modal--medium',
 		isNarrow && 'newspack-modal--narrow',
 		hideTitle && 'newspack-modal--hide-title', // Note: also hides the X close button.
 		className

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -17,9 +17,9 @@
 
 	border-radius: 8px;
 	margin: auto;
-	max-height: calc(100% - var(--newspack-wizard-section-space));
+	max-height: calc(100% - 64px);
 	max-width: 512px;
-	width: calc(100% - var(--newspack-wizard-section-space));
+	width: calc(100% - 64px);
 
 	&--size-small {
 		max-width: 384px;
@@ -65,10 +65,6 @@
 				background-color: colors.$error-600;
 			}
 		}
-	}
-
-	@media screen and ( min-width: 960px ) {
-		max-height: calc(100% - 128px);
 	}
 
 	// Links

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -41,6 +41,17 @@
 		}
 	}
 
+	&--destructive {
+		.components-button.is-primary {
+			background-color: colors.$error-500;
+			color: colors.$neutral-000;
+			&:hover,
+			&:focus {
+				background-color: colors.$error-600;
+			}
+		}
+	}
+
 	@media screen and ( min-width: 960px ) {
 		max-height: calc(100% - 128px);
 	}

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -25,6 +25,10 @@
 		}
 	}
 
+	&--medium {
+		max-width: 512px;
+	}
+
 	&--narrow {
 		max-width: 360px;
 		width: 360px;

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -15,19 +15,34 @@
 	--wp-admin-theme-color-lighter-10: #{colors.$primary-000};
 	--wp-admin-theme-color-lighter-10--rgb: #{colors.$primary-000--rgb};
 
-	@media screen and ( min-width: 744px ) {
-		max-width: 680px;
-		width: 680px;
+	border-radius: 8px;
+	margin: auto;
+	max-height: calc(100% - var(--newspack-wizard-section-space));
+	max-width: 512px;
+	width: calc(100% - var(--newspack-wizard-section-space));
 
-		&--wide {
-			max-width: 1168px;
-			width: 1168px;
+	&--size-small {
+		max-width: 384px;
+
+		&.newspack-modal--hide-title {
+			max-width: 350px;
 		}
 	}
 
-	&--narrow {
-		max-width: 360px;
-		width: 360px;
+	&--size-medium {
+		max-width: 512px;
+	}
+
+	&--size-large {
+		max-width: 840px;
+	}
+
+	&--size-x-large {
+		max-width: 1168px;
+	}
+
+	&--size-full {
+		max-width: 100%;
 	}
 
 	&--hide-title {
@@ -73,8 +88,14 @@
 	}
 
 	.components-modal__content {
-		> *:last-child {
-			margin-bottom: 0;
+		> * {
+			&:first-child {
+				margin-top: 0;
+			}
+
+			&:last-child {
+				margin-bottom: 0;
+			}
 		}
 	}
 }

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -38,7 +38,7 @@
 	}
 
 	&--size-x-large {
-		max-width: 1168px;
+		max-width: calc(var(--newspack-wizard-section-width) + 64px)
 	}
 
 	&--size-full {

--- a/packages/components/src/section-header/index.js
+++ b/packages/components/src/section-header/index.js
@@ -59,6 +59,8 @@ const SectionHeader = ( {
 	pageHeader = false,
 	title,
 	id = null,
+	primaryAction,
+	secondaryAction,
 	children = null,
 } ) => {
 	// If id is in the URL as a scrollTo param, scroll to it on render.
@@ -88,7 +90,11 @@ const SectionHeader = ( {
 	return (
 		<div
 			id={ id }
-			className={ classnames( 'newspack-section-header__container', backNav && 'newspack-section-header--has-back-nav' ) }
+			className={ classnames(
+				'newspack-section-header__container',
+				backNav && 'newspack-section-header--has-back-nav',
+				primaryAction && 'newspack-section-header--has-primary-action'
+			) }
 			ref={ ref }
 		>
 			<Grid columns={ 1 } gutter={ 8 } className={ classes }>
@@ -110,6 +116,13 @@ const SectionHeader = ( {
 						{ badges?.length
 							? badges.map( ( badge, i ) => <Badge key={ i } text={ badge.label } level={ badge.level || 'default' } /> )
 							: null }
+						{ secondaryAction && (
+							<div className="newspack-section-header__secondary-action">
+								<Button variant="link" href={ secondaryAction.href } onClick={ secondaryAction.action }>
+									{ secondaryAction.label }
+								</Button>
+							</div>
+						) }
 					</div>
 				) }
 				{ typeof title === 'function' && <HeadingTag>{ title() }</HeadingTag> }
@@ -118,6 +131,13 @@ const SectionHeader = ( {
 				{ description && typeof description !== 'string' && typeof description !== 'function' && <p>{ description }</p> }
 				{ children && <div className="newspack-section-header__children">{ children }</div> }
 			</Grid>
+			{ primaryAction && (
+				<div className="newspack-section-header__primary-action">
+					<Button href={ primaryAction.href } variant="primary" onClick={ primaryAction.action }>
+						{ primaryAction.label }
+					</Button>
+				</div>
+			) }
 		</div>
 	);
 };

--- a/packages/components/src/section-header/index.js
+++ b/packages/components/src/section-header/index.js
@@ -81,8 +81,7 @@ const SectionHeader = ( {
 		centered && 'newspack-section-header--is-centered',
 		isWhite && 'newspack-section-header--is-white',
 		noMargin && 'newspack-section-header--no-margin',
-		pageHeader && 'newspack-section-header--page-header',
-		className
+		pageHeader && 'newspack-section-header--page-header'
 	);
 
 	const HeadingTag = pageHeader ? 'h1' : `h${ heading }`;
@@ -93,7 +92,8 @@ const SectionHeader = ( {
 			className={ classnames(
 				'newspack-section-header__container',
 				backNav && 'newspack-section-header--has-back-nav',
-				primaryAction && 'newspack-section-header--has-primary-action'
+				primaryAction && 'newspack-section-header--has-primary-action',
+				className
 			) }
 			ref={ ref }
 		>

--- a/packages/components/src/section-header/style.scss
+++ b/packages/components/src/section-header/style.scss
@@ -6,12 +6,22 @@
 @use "../../../colors/colors.module" as colors;
 
 .newspack-section-header {
+	flex: 1;
 	margin: 64px 0 32px;
 
 	&__container {
 		position: relative;
 		&:not(:first-child) {
 			margin-top: 48px;
+		}
+		&.newspack-section-header--has-primary-action {
+			display: flex;
+			flex-direction: column;
+			gap: 16px;
+			@media (min-width: 782px) {
+				align-items: flex-start;
+				flex-direction: row;
+			}
 		}
 		&.newspack-section-header--has-back-nav {
 			--back-nav-button-size: 36px;
@@ -32,7 +42,6 @@
 		}
 	}
 
-	&--no-margin,
 	h1,
 	h2,
 	h3,
@@ -42,6 +51,10 @@
 		align-items: center;
 		display: flex;
 		gap: 8px;
+		margin: 0 !important;
+	}
+
+	&--no-margin {
 		margin: 0 !important;
 	}
 
@@ -70,6 +83,24 @@
 
 		.newspack-badge {
 			margin-top: 4px;
+		}
+	}
+
+	&__primary-action {
+		@media (min-width: 782px) {
+			display: flex;
+			flex: 1;
+			justify-content: flex-end;
+		}
+	}
+
+	&__secondary-action {
+		align-items: flex-end;
+		display: flex;
+		height: 100%;
+		margin-left: 8px;
+		.components-button {
+			line-height: 36px;
 		}
 	}
 

--- a/packages/components/src/section-header/style.scss
+++ b/packages/components/src/section-header/style.scss
@@ -62,7 +62,7 @@
 		text-align: center;
 	}
 
-	&:not( #{&}--no-margin ) + *:not( #{&} ) {
+	&:not( #{&}--no-margin ) + *:not( #{&} ):not(.newspack-wizard__section-header):not(.newspack-section-header__primary-action) {
 		margin-top: -16px !important;
 	}
 

--- a/packages/components/src/section-header/style.scss
+++ b/packages/components/src/section-header/style.scss
@@ -17,7 +17,7 @@
 		&.newspack-section-header--has-primary-action {
 			display: flex;
 			flex-direction: column;
-			gap: 16px;
+			gap: 32px;
 			@media (min-width: 782px) {
 				align-items: flex-start;
 				flex-direction: row;

--- a/packages/components/src/section-header/style.scss
+++ b/packages/components/src/section-header/style.scss
@@ -77,12 +77,12 @@
 	}
 
 	&__title-container {
-		align-items: center;
+		align-items: baseline;
 		display: flex;
 		gap: 8px;
 
 		.newspack-badge {
-			margin-top: 4px;
+			transform: translateY(-4px);
 		}
 	}
 
@@ -95,13 +95,8 @@
 	}
 
 	&__secondary-action {
-		align-items: flex-end;
 		display: flex;
-		height: 100%;
 		margin-left: 8px;
-		.components-button {
-			line-height: 36px;
-		}
 	}
 
 	&__children {

--- a/packages/components/src/waiting/index.js
+++ b/packages/components/src/waiting/index.js
@@ -23,11 +23,12 @@ class Waiting extends Component {
 	 * Render
 	 */
 	render() {
-		const { className, isRight, isLeft, isCenter, ...otherProps } = this.props;
+		const { className, isRight, isLeft, isCenter, noMargin, ...otherProps } = this.props;
 		const classes = classnames( 'newspack-waiting', className, {
 			'is-right': isRight,
 			'is-left': isLeft,
 			'is-center': isCenter,
+			'no-margin': noMargin,
 		} );
 		return <Spinner className={ classes } { ...otherProps } />;
 	}

--- a/packages/components/src/waiting/style.scss
+++ b/packages/components/src/waiting/style.scss
@@ -24,4 +24,8 @@
 	&.is-center {
 		margin: auto;
 	}
+
+	&.no-margin {
+		margin: 0;
+	}
 }

--- a/packages/components/src/web-preview/style.scss
+++ b/packages/components/src/web-preview/style.scss
@@ -16,7 +16,7 @@
 	--wp-admin-theme-color-lighter-10: #{colors.$primary-000};
 	--wp-admin-theme-color-lighter-10--rgb: #{colors.$primary-000--rgb};
 
-	background: colors.$neutral-700;
+	background: color-mix(in srgb, colors.$neutral-1000, transparent 65%);
 	box-sizing: border-box;
 	height: 100%;
 	left: 0;

--- a/packages/components/src/with-wizard-screen/style.scss
+++ b/packages/components/src/with-wizard-screen/style.scss
@@ -148,6 +148,10 @@
 		}
 	}
 
+	&__section-header {
+		margin-bottom: 32px;
+	}
+
 	&__content {
 		margin: 0 auto;
 		max-width: calc(calc(var(--newspack-wizard-section-space) * 2) + var(--newspack-wizard-section-width));

--- a/packages/components/src/with-wizard/index.js
+++ b/packages/components/src/with-wizard/index.js
@@ -279,7 +279,7 @@ export default function withWizard( WrappedComponent, requiredPlugins ) {
 			return (
 				message &&
 				callback && (
-					<Modal isNarrow hideTitle={ ! title } title={ title } onRequestClose={ () => this.setState( { confirmation: null } ) }>
+					<Modal size="small" hideTitle={ ! title } title={ title } onRequestClose={ () => this.setState( { confirmation: null } ) }>
 						<p>{ message }</p>
 						<Card buttonsCard noBorder className="justify-end">
 							<Button variant="secondary" onClick={ () => this.setState( { confirmation: null } ) }>

--- a/packages/components/src/wizard/components/WizardSnackbar.js
+++ b/packages/components/src/wizard/components/WizardSnackbar.js
@@ -11,6 +11,7 @@ import { useDispatch } from '@wordpress/data';
 /**
  * Internal dependencies.
  */
+import { Button } from '../../';
 import { WIZARD_STORE_NAMESPACE } from '../store';
 import './style.scss';
 
@@ -22,14 +23,17 @@ import classnames from 'classnames';
 /**
  * WizardSnackbar component.
  *
- * @param {Object}      props          - The component props.
- * @param {JSX.Element} props.children - The component children.
- * @param {Object}      props.props    - The component props. See: https://wordpress.github.io/gutenberg/?path=/docs/components-snackbar--docs
- * @param {string}      props.position - The snackbar position.
- * @param {string}      props.type     - The snackbar type: 'info', 'success', 'warning', or 'error'.
+ * @param {Object}      props             - The component props.
+ * @param {string}      props.buttonLabel - The label of the button to navigate to when the button is clicked.
+ * @param {JSX.Element} props.children    - The component children.
+ * @param {string}      props.href        - The href to navigate to when the button is clicked.
+ * @param {Function}    props.onClick     - The function to call when the button is clicked.
+ * @param {Object}      props.props       - The component props. See: https://wordpress.github.io/gutenberg/?path=/docs/components-snackbar--docs
+ * @param {string}      props.position    - The snackbar position.
+ * @param {string}      props.type        - The snackbar type: 'info', 'success', 'warning', or 'error'.
  * @return {JSX.Element} The component.
  */
-const WizardSnackbar = ( { children, position = 'bottom-left', type = 'info', ...props } ) => {
+const WizardSnackbar = ( { children, position = 'bottom-left', type = 'info', buttonLabel, href, onClick, ...props } ) => {
 	const className = classnames(
 		'newspack-wizard__snackbar',
 		props.className,
@@ -50,6 +54,11 @@ const WizardSnackbar = ( { children, position = 'bottom-left', type = 'info', ..
 	return (
 		<BaseComponent className={ className } { ...props } onRemove={ onRemove }>
 			{ children }
+			{ buttonLabel && (
+				<Button variant="link" href={ href } onClick={ onClick }>
+					{ buttonLabel }
+				</Button>
+			) }
 		</BaseComponent>
 	);
 };

--- a/packages/components/src/wizard/components/WizardSnackbar.js
+++ b/packages/components/src/wizard/components/WizardSnackbar.js
@@ -1,0 +1,57 @@
+/**
+ * Snackbar.
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { Snackbar as BaseComponent } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies.
+ */
+import { WIZARD_STORE_NAMESPACE } from '../store';
+import './style.scss';
+
+/**
+ * External dependencies.
+ */
+import classnames from 'classnames';
+
+/**
+ * WizardSnackbar component.
+ *
+ * @param {Object}      props          - The component props.
+ * @param {JSX.Element} props.children - The component children.
+ * @param {Object}      props.props    - The component props. See: https://wordpress.github.io/gutenberg/?path=/docs/components-snackbar--docs
+ * @param {string}      props.position - The snackbar position.
+ * @param {string}      props.type     - The snackbar type: 'info', 'success', 'warning', or 'error'.
+ * @return {JSX.Element} The component.
+ */
+const WizardSnackbar = ( { children, position = 'bottom-left', type = 'info', ...props } ) => {
+	const className = classnames(
+		'newspack-wizard__snackbar',
+		props.className,
+		`newspack-wizard__snackbar--${ position }`,
+		`newspack-wizard__snackbar--${ type }`
+	);
+	const { removeNotice, resetNotices } = useDispatch( WIZARD_STORE_NAMESPACE );
+	const onRemove = () => {
+		if ( props.onRemove ) {
+			props.onRemove();
+		}
+		if ( props.id ) {
+			removeNotice( props.id );
+		} else {
+			resetNotices();
+		}
+	};
+	return (
+		<BaseComponent className={ className } { ...props } onRemove={ onRemove }>
+			{ children }
+		</BaseComponent>
+	);
+};
+
+export default WizardSnackbar;

--- a/packages/components/src/wizard/components/WizardSnackbar.js
+++ b/packages/components/src/wizard/components/WizardSnackbar.js
@@ -11,7 +11,6 @@ import { useDispatch } from '@wordpress/data';
 /**
  * Internal dependencies.
  */
-import { Button } from '../../';
 import { WIZARD_STORE_NAMESPACE } from '../store';
 import './style.scss';
 
@@ -23,17 +22,15 @@ import classnames from 'classnames';
 /**
  * WizardSnackbar component.
  *
- * @param {Object}      props             - The component props.
- * @param {string}      props.buttonLabel - The label of the button to navigate to when the button is clicked.
- * @param {JSX.Element} props.children    - The component children.
- * @param {string}      props.href        - The href to navigate to when the button is clicked.
- * @param {Function}    props.onClick     - The function to call when the button is clicked.
- * @param {Object}      props.props       - The component props. See: https://wordpress.github.io/gutenberg/?path=/docs/components-snackbar--docs
- * @param {string}      props.position    - The snackbar position.
- * @param {string}      props.type        - The snackbar type: 'info', 'success', 'warning', or 'error'.
+ * @param {Object}      props          - The component props.
+ * @param {Object[]}    props.actions  - The actions to display in the snackbar.
+ * @param {JSX.Element} props.children - The component children.
+ * @param {Object}      props.props    - The component props. See: https://wordpress.github.io/gutenberg/?path=/docs/components-snackbar--docs
+ * @param {string}      props.position - The snackbar position.
+ * @param {string}      props.type     - The snackbar type: 'info', 'success', 'warning', or 'error'.
  * @return {JSX.Element} The component.
  */
-const WizardSnackbar = ( { children, position = 'bottom-left', type = 'info', buttonLabel, href, onClick, ...props } ) => {
+const WizardSnackbar = ( { children, position = 'bottom-left', type = 'info', actions = [], ...props } ) => {
 	const className = classnames(
 		'newspack-wizard__snackbar',
 		props.className,
@@ -52,13 +49,8 @@ const WizardSnackbar = ( { children, position = 'bottom-left', type = 'info', bu
 		}
 	};
 	return (
-		<BaseComponent className={ className } { ...props } onRemove={ onRemove }>
+		<BaseComponent className={ className } { ...props } onRemove={ onRemove } actions={ actions }>
 			{ children }
-			{ buttonLabel && (
-				<Button variant="link" href={ href } onClick={ onClick }>
-					{ buttonLabel }
-				</Button>
-			) }
 		</BaseComponent>
 	);
 };

--- a/packages/components/src/wizard/components/style.scss
+++ b/packages/components/src/wizard/components/style.scss
@@ -1,5 +1,3 @@
-@use "../../../colors/colors.module" as colors;
-
 .newspack-wizard {
 	&__snackbar {
 		border-bottom: 2px solid transparent;
@@ -34,6 +32,16 @@
 			top: calc(16px + 46px); /* 46px for admin bar */
 			@media screen and ( min-width: 783px ) {
 				top: calc(16px + 32px); /* 32px for admin bar */
+			}
+		}
+		a,
+		.components-button.is-link {
+			color: var(--newspack-ui-color-neutral-0);
+			cursor: pointer;
+			margin-left: 16px;
+			&:hover,
+			&:focus {
+				color: var(--newspack-ui-color-neutral-10);
 			}
 		}
 	}

--- a/packages/components/src/wizard/components/style.scss
+++ b/packages/components/src/wizard/components/style.scss
@@ -1,0 +1,40 @@
+@use "../../../colors/colors.module" as colors;
+
+.newspack-wizard {
+	&__snackbar {
+		border-bottom: 2px solid transparent;
+		bottom: 16px;
+		left: 16px;
+		max-width: calc(100vw - 32px);
+		position: fixed;
+		z-index: 99999;
+		&--success {
+			border-color: var(--newspack-ui-color-success-60);
+		}
+		&--error {
+			border-color: var(--newspack-ui-color-error-60);
+		}
+		&--warning {
+			border-color: var(--newspack-ui-color-warning-40);
+		}
+		@media screen and ( min-width: 783px ) {
+			left: calc(36px + 16px); /* 36px for admin menu bar */
+		}
+		@media screen and ( min-width: 960px ) {
+			left: calc(160px + 16px); /* 160px for admin menu bar */
+		}
+		&.newspack-wizard__snackbar--bottom-right,
+		&.newspack-wizard__snackbar--top-right {
+			left: auto;
+			right: calc(16px);
+		}
+		&.newspack-wizard__snackbar--top-left,
+		&.newspack-wizard__snackbar--top-right {
+			bottom: auto;
+			top: calc(16px + 46px); /* 46px for admin bar */
+			@media screen and ( min-width: 783px ) {
+				top: calc(16px + 32px); /* 32px for admin bar */
+			}
+		}
+	}
+}

--- a/packages/components/src/wizard/index.js
+++ b/packages/components/src/wizard/index.js
@@ -18,6 +18,7 @@ import { category, moreVertical } from '@wordpress/icons';
 import { Footer, Notice, Button, NewspackIcon, TabbedNavigation, PluginInstaller, SectionHeader, HandoffMessage } from '../';
 import Router from '../proxied-imports/router';
 import registerStore, { WIZARD_STORE_NAMESPACE } from './store';
+import WizardSnackbar from './components/WizardSnackbar';
 import WizardError from './components/WizardError';
 
 registerStore();
@@ -78,6 +79,7 @@ const Wizard = (
 	const isLoading = useSelect( select => select( WIZARD_STORE_NAMESPACE ).isLoading() );
 	const isQuietLoading = useSelect( select => select( WIZARD_STORE_NAMESPACE ).isQuietLoading() );
 	const headerData = useSelect( select => select( WIZARD_STORE_NAMESPACE ).getHeaderData() );
+	const notices = useSelect( select => select( WIZARD_STORE_NAMESPACE ).getNotices() );
 	const { actions, backNav, badges, sectionDescription, sectionName, sectionTitle, sectionPrimaryAction, sectionSecondaryAction } = headerData;
 
 	const mainActions = actions?.filter( action => action.type === 'primary' || action.type === 'secondary' );
@@ -224,6 +226,12 @@ const Wizard = (
 						<Redirect to={ displayedSections[ 0 ].path } />
 					</Switch>
 				</HashRouter>
+				{ notices?.length > 0 &&
+					notices.map( ( notice, index ) => (
+						<WizardSnackbar key={ index } type={ notice.type } id={ notice.id }>
+							{ notice.message }
+						</WizardSnackbar>
+					) ) }
 			</div>
 			{ ! isLoading && <Footer simple={ hasSimpleFooter } /> }
 		</div>

--- a/packages/components/src/wizard/index.js
+++ b/packages/components/src/wizard/index.js
@@ -228,7 +228,14 @@ const Wizard = (
 				</HashRouter>
 				{ notices?.length > 0 &&
 					notices.map( ( notice, index ) => (
-						<WizardSnackbar key={ index } type={ notice.type } id={ notice.id }>
+						<WizardSnackbar
+							key={ index }
+							type={ notice.type }
+							id={ notice.id }
+							buttonLabel={ notice.buttonLabel }
+							href={ notice.href }
+							onClick={ notice.onClick }
+						>
 							{ notice.message }
 						</WizardSnackbar>
 					) ) }

--- a/packages/components/src/wizard/index.js
+++ b/packages/components/src/wizard/index.js
@@ -29,12 +29,11 @@ const { HashRouter, Redirect, Route, Switch, useLocation } = Router;
  */
 const ResetHeaderData = () => {
 	const location = useLocation();
-	const { resetHeaderData, setError } = useDispatch( WIZARD_STORE_NAMESPACE );
+	const { resetHeaderData } = useDispatch( WIZARD_STORE_NAMESPACE );
 
 	useEffect( () => {
 		resetHeaderData();
-		setError( null );
-	}, [ location.pathname, setError, resetHeaderData ] );
+	}, [ location.pathname, resetHeaderData ] );
 
 	return null;
 };
@@ -79,7 +78,7 @@ const Wizard = (
 	const isLoading = useSelect( select => select( WIZARD_STORE_NAMESPACE ).isLoading() );
 	const isQuietLoading = useSelect( select => select( WIZARD_STORE_NAMESPACE ).isQuietLoading() );
 	const headerData = useSelect( select => select( WIZARD_STORE_NAMESPACE ).getHeaderData() );
-	const { actions, backNav, badges, sectionName, sectionTitle } = headerData;
+	const { actions, backNav, badges, sectionDescription, sectionName, sectionTitle, sectionPrimaryAction, sectionSecondaryAction } = headerData;
 
 	const mainActions = actions?.filter( action => action.type === 'primary' || action.type === 'secondary' );
 	const moreActions = actions?.filter( action => action.type === 'more' );
@@ -203,8 +202,17 @@ const Wizard = (
 									render={ routerProps => (
 										<div className={ classnames( 'newspack-wizard__content', className ) }>
 											{ 'function' === typeof renderAboveSections ? renderAboveSections() : null }
-											{ sectionTitle && (
-												<SectionHeader backNav={ backNav } heading={ 1 } title={ sectionTitle } badges={ badges } noMargin />
+											{ ( sectionTitle || section.title ) && (
+												<SectionHeader
+													backNav={ backNav || section.backNav }
+													title={ sectionTitle || section.title }
+													description={ sectionDescription || section.description }
+													badges={ badges || section.badges }
+													primaryAction={ sectionPrimaryAction || section.primaryAction }
+													secondaryAction={ sectionSecondaryAction || section.secondaryAction }
+													heading={ 1 }
+													noMargin
+												/>
 											) }
 											<SectionComponent { ...routerProps } { ...sectionProps } { ...sharedProps } />
 										</div>

--- a/packages/components/src/wizard/index.js
+++ b/packages/components/src/wizard/index.js
@@ -228,7 +228,7 @@ const Wizard = (
 				</HashRouter>
 				{ notices?.length > 0 &&
 					notices.map( ( notice, index ) => (
-						<WizardSnackbar key={ index } type={ notice.type } id={ notice.id } actions={ notice.actions }>
+						<WizardSnackbar key={ notice.id || index } type={ notice.type } id={ notice.id } actions={ notice.actions }>
 							{ notice.message }
 						</WizardSnackbar>
 					) ) }

--- a/packages/components/src/wizard/index.js
+++ b/packages/components/src/wizard/index.js
@@ -204,6 +204,7 @@ const Wizard = (
 											{ 'function' === typeof renderAboveSections ? renderAboveSections() : null }
 											{ ( sectionTitle || section.title ) && (
 												<SectionHeader
+													className="newspack-wizard__section-header"
 													backNav={ backNav || section.backNav }
 													title={ sectionTitle || section.title }
 													description={ sectionDescription || section.description }

--- a/packages/components/src/wizard/index.js
+++ b/packages/components/src/wizard/index.js
@@ -228,14 +228,7 @@ const Wizard = (
 				</HashRouter>
 				{ notices?.length > 0 &&
 					notices.map( ( notice, index ) => (
-						<WizardSnackbar
-							key={ index }
-							type={ notice.type }
-							id={ notice.id }
-							buttonLabel={ notice.buttonLabel }
-							href={ notice.href }
-							onClick={ notice.onClick }
-						>
+						<WizardSnackbar key={ index } type={ notice.type } id={ notice.id } actions={ notice.actions }>
 							{ notice.message }
 						</WizardSnackbar>
 					) ) }

--- a/packages/components/src/wizard/store/index.js
+++ b/packages/components/src/wizard/store/index.js
@@ -27,6 +27,7 @@ const DEFAULT_STATE = {
 	isLoading: false,
 	isQuietLoading: false,
 	apiData: {},
+	notices: [],
 	error: null,
 };
 
@@ -54,8 +55,14 @@ const reducer = ( state = DEFAULT_STATE, { type, payload = {} } ) => {
 			return set( clone( state ), [ 'apiData', payload.slug ], payload.data );
 		case 'UPDATE_WIZARD_SETTINGS':
 			return set( clone( state ), [ 'apiData', payload.slug, ...payload.path ], payload.value );
+		case 'ADD_NOTICE':
+			return { ...state, notices: [ ...state.notices, payload ] };
+		case 'REMOVE_NOTICE':
+			return { ...state, notices: state.notices.filter( notice => notice.id !== payload ) };
 		case 'SET_ERROR':
 			return { ...state, error: payload };
+		case 'RESET_NOTICES':
+			return { ...state, notices: DEFAULT_STATE.notices };
 		default:
 			return state;
 	}
@@ -70,6 +77,9 @@ const actions = {
 	fetchFromAPI: createAction( 'FETCH_FROM_API' ),
 	setAPIDataForWizard: createAction( 'SET_API_DATA' ),
 	updateWizardSettings: createAction( 'UPDATE_WIZARD_SETTINGS' ),
+	addNotice: createAction( 'ADD_NOTICE' ),
+	removeNotice: createAction( 'REMOVE_NOTICE' ),
+	resetNotices: createAction( 'RESET_NOTICES' ),
 	setError: createAction( 'SET_ERROR' ),
 
 	// Async actions. These will not show up in Redux devtools.
@@ -104,6 +114,7 @@ const selectors = {
 	isQuietLoading: state => state.isQuietLoading,
 	getWizardAPIData: ( state, slug ) => state.apiData[ slug ] || {},
 	getWizardData: ( state, slug ) => state.apiData[ slug ] ?? {},
+	getNotices: state => state.notices,
 	getError: state => state.error,
 };
 

--- a/packages/components/src/wizard/store/index.js
+++ b/packages/components/src/wizard/store/index.js
@@ -20,6 +20,7 @@ const DEFAULT_STATE = {
 		actions: [],
 		backNav: '',
 		badges: [],
+		sectionDescription: '',
 		sectionName: '',
 		sectionTitle: '',
 	},

--- a/src/admin/style.scss
+++ b/src/admin/style.scss
@@ -164,22 +164,11 @@ h1 {
 }
 .newspack-wizard {
 	.newspack-wizard__loader {
+		display: grid;
 		height: 100%;
+		place-items: center;
 		position: absolute;
 		width: 100%;
-		display: flex;
-
-		> div {
-			position: relative;
-			margin: auto;
-			text-align: center;
-		}
-
-		span {
-			display: block;
-			color: #757575;
-			animation: opacity-pulse 1.4s infinite ease-in-out;
-		}
 	}
 
 	&.newspack-dashboard {

--- a/src/wizards/audience/components/prompt.tsx
+++ b/src/wizards/audience/components/prompt.tsx
@@ -89,7 +89,7 @@ export default function Prompt( { inFlight, prompt, setInFlight, setPrompts }: P
 		return `${ previewURL }?${ stringify( { ...abbreviatedKeys } ) }`;
 	};
 
-	const unblock = hooks.usePrompt( isDirty, __( 'You have unsaved changes. Discard changes?', 'newspack-plugin' ) );
+	const unblock = hooks.usePrompt( isDirty, __( 'You have unsaved changes that will be lost. Discard changes?', 'newspack-plugin' ) );
 
 	const savePrompt = ( slug: string, data: InputValues ) => {
 		return new Promise< void >( ( res, rej ) => {

--- a/src/wizards/audience/components/segment-group/index.js
+++ b/src/wizards/audience/components/segment-group/index.js
@@ -102,9 +102,9 @@ const SegmentGroup = props => {
 									onRequestClose={ () => setModalVisible( false ) }
 									shouldCloseOnEsc={ false }
 									shouldCloseOnClickOutside={ false }
-									isWide
+									size="x-large"
 								>
-									<Grid gutter={ 32 } columns={ 3 }>
+									<Grid columns={ 3 } noMargin>
 										<ButtonCard
 											href={ addNewURL( 'overlay-center', campaignId, id ) }
 											title={ __( 'Center Overlay', 'newspack-plugin' ) }

--- a/src/wizards/audience/components/settings-modal/index.js
+++ b/src/wizards/audience/components/settings-modal/index.js
@@ -22,7 +22,7 @@ const PromptSettingsModal = ( { prompt, disabled, onClose, updatePopup } ) => {
 	};
 
 	return (
-		<Modal title={ prompt.title } onRequestClose={ onClose } isWide>
+		<Modal title={ prompt.title } onRequestClose={ onClose } size="x-large">
 			<Button onClick={ () => onClose() } className="screen-reader-text">
 				{ __( 'Close Modal', 'newspack-plugin' ) }
 			</Button>

--- a/src/wizards/audience/views/content-gates/content-gate-settings.tsx
+++ b/src/wizards/audience/views/content-gates/content-gate-settings.tsx
@@ -1,118 +1,109 @@
 /**
  * WordPress dependencies.
  */
-import { useEffect, useMemo, useState, useCallback } from '@wordpress/element';
-import { Button } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import { AUDIENCE_CONTENT_GATES_WIZARD_SLUG } from './consts';
-import { useWizardApiFetch } from '../../../hooks/use-wizard-api-fetch';
-import ContentRules from './edit/content-rules';
-import Registration from './edit/registration';
-import CustomAccess from './edit/custom-access';
+import { Button, Grid } from '../../../../../packages/components/src';
+import ContentRuleControl from './edit/content-rule-control';
+import { getEditGateLayoutUrl } from './utils';
 
 type ContentGateSettingsProps = {
 	gate: Gate;
-	onDelete: ( id: number ) => void;
-	onSave: ( gate: Gate ) => void;
 };
 
-export default function ContentGateSettings( { gate, onDelete, onSave }: ContentGateSettingsProps ) {
-	const { wizardApiFetch, resetError } = useWizardApiFetch( AUDIENCE_CONTENT_GATES_WIZARD_SLUG );
-	const [ contentRules, setContentRules ] = useState< GateContentRule[] >( gate.content_rules );
-	const [ registration, setRegistration ] = useState< Registration >( gate.registration );
-	const [ customAccess, setCustomAccess ] = useState< CustomAccess >( gate.custom_access );
-	const [ status, setStatus ] = useState< GateStatus >( gate.status );
-	const [ isEditingStatus, setIsEditingStatus ] = useState( false );
+const availableAccessRules = window.newspackAudienceContentGates.available_access_rules || {};
 
-	const isReady = useMemo( () => {
-		return contentRules.length > 0 && ( registration.active || ( customAccess.active && customAccess.access_rules.length > 0 ) );
-	}, [ contentRules, registration, customAccess ] );
+const noOp = () => {};
 
-	const handleSave = useCallback( () => {
-		const _gate = {
-			...gate,
-			content_rules: contentRules,
-			registration,
-			custom_access: customAccess,
-			status,
-		};
-		resetError();
-		wizardApiFetch< Gate >(
-			{
-				path: `/newspack/v1/wizard/${ AUDIENCE_CONTENT_GATES_WIZARD_SLUG }/${ gate.id }`,
-				method: 'POST',
-				data: { gate: _gate },
-			},
-			{
-				onSuccess( data ) {
-					onSave( data );
-				},
-				onFinally() {
-					setIsEditingStatus( false );
-				},
-			}
-		);
-	}, [ contentRules, registration, customAccess, status ] );
-
-	// Update status and trigger save.
-	useEffect( () => {
-		if ( ! isEditingStatus ) {
-			return;
-		}
-		handleSave();
-	}, [ isEditingStatus, status, handleSave ] );
-
-	const handleDelete = () => onDelete( gate.id );
-	const handleRestore = () => {
-		setIsEditingStatus( true );
-		setStatus( 'draft' );
-	};
-
-	const handlePublish = () => {
-		// eslint-disable-next-line no-alert
-		if ( ! confirm( __( 'Are you sure you want to publish this content gate?', 'newspack-plugin' ) ) ) {
-			return;
-		}
-		setIsEditingStatus( true );
-		setStatus( 'publish' );
-	};
-
+export default function ContentGateSettings( { gate }: ContentGateSettingsProps ) {
 	return (
-		<>
-			<ContentRules rules={ contentRules } onChange={ setContentRules } />
-			<Registration gateId={ gate.id } registration={ registration } onChange={ setRegistration } />
-			<CustomAccess gateId={ gate.id } customAccess={ customAccess } onChange={ setCustomAccess } />
-			<div className="newspack-buttons-card">
-				{ gate.status === 'draft' && (
-					<Button disabled={ ! isReady } variant="primary" onClick={ handlePublish }>
-						{ __( 'Publish', 'newspack-plugin' ) }
-					</Button>
+		<Grid className="newspack-content-gates__gate__settings" columns={ 3 } gutter={ 16 } borders noMargin>
+			<div>
+				<h4>{ __( 'Content rules', 'newspack-plugin' ) }</h4>
+				{ gate.content_rules.length > 0 ? (
+					gate.content_rules.map( rule => (
+						<ContentRuleControl
+							key={ rule.slug }
+							slug={ rule.slug }
+							value={ rule.value }
+							exclusion={ rule.exclusion }
+							onChange={ noOp }
+							onChangeExclusion={ noOp }
+							isStatic
+						/>
+					) )
+				) : (
+					<p>{ __( 'N/A', 'newspack-plugin' ) }</p>
 				) }
-				{ gate.status !== 'trash' && (
-					<Button variant={ gate.status === 'publish' ? 'primary' : 'secondary' } onClick={ handleSave }>
-						{ gate.status === 'publish' ? __( 'Update', 'newspack-plugin' ) : __( 'Save draft', 'newspack-plugin' ) }
-					</Button>
+			</div>
+			<div>
+				<h4>{ __( 'Registered access', 'newspack-plugin' ) }</h4>
+				{ gate.registration?.active && (
+					<p>
+						<strong>{ __( 'Require verification:', 'newspack-plugin' ) } </strong>{ ' ' }
+						{ gate.registration.require_verification ? __( 'Yes', 'newspack-plugin' ) : __( 'No', 'newspack-plugin' ) }
+					</p>
 				) }
-				{ gate.status === 'publish' && (
-					<Button isDestructive variant="secondary" onClick={ handleRestore }>
-						{ __( 'Unpublish', 'newspack-plugin' ) }
-					</Button>
+				{ gate.registration?.active && gate.registration.metering.enabled && (
+					<p>
+						<strong>{ __( 'Metered:', 'newspack-plugin' ) } </strong>{ ' ' }
+						{ sprintf(
+							// translators: 1: metering count, 2: metering period
+							__( '%1$d free views per %2$s', 'newspack-plugin' ),
+							gate.registration.metering.count,
+							gate.registration.metering.period
+						) }
+					</p>
 				) }
-				{ 'trash' === gate.status && (
-					<Button variant="secondary" onClick={ handleRestore }>
-						{ __( 'Restore', 'newspack-plugin' ) }
-					</Button>
-				) }
-				{ gate.status !== 'publish' && (
-					<Button variant="tertiary" isDestructive onClick={ handleDelete }>
-						{ 'trash' === gate.status ? __( 'Delete permanently', 'newspack-plugin' ) : __( 'Delete', 'newspack-plugin' ) }
+				{ ! gate.registration?.active && <p>{ __( 'N/A', 'newspack-plugin' ) }</p> }
+				{ gate.registration?.active && gate.registration.gate_layout_id && (
+					<Button variant="secondary" href={ getEditGateLayoutUrl( gate.id, 'registration' ) }>
+						{ __( 'Customize registered access layout', 'newspack-plugin' ) }
 					</Button>
 				) }
 			</div>
-		</>
+			<div>
+				<h4>{ __( 'Paid access', 'newspack-plugin' ) }</h4>
+				{ gate.custom_access?.active &&
+					gate.custom_access.access_rules.length > 0 &&
+					gate.custom_access.access_rules.map( ruleGroup =>
+						ruleGroup.map( rule =>
+							availableAccessRules[ rule.slug ]?.name ? (
+								<p key={ rule.slug }>
+									<strong>{ availableAccessRules[ rule.slug ].name }:</strong>{ ' ' }
+									{ Array.isArray( rule.value ) && availableAccessRules[ rule.slug ]?.options
+										? rule.value
+												.map(
+													value =>
+														availableAccessRules[ rule.slug ].options?.find( option => option.value === value )?.label
+												)
+												.join( ', ' )
+										: rule.value }
+								</p>
+							) : null
+						)
+					) }
+				{ gate.custom_access?.active && gate.custom_access.metering.enabled && (
+					<p>
+						<strong>{ __( 'Metered:', 'newspack-plugin' ) } </strong>{ ' ' }
+						{ sprintf(
+							// translators: 1: metering count, 2: metering period
+							__( '%1$d free views per %2$s', 'newspack-plugin' ),
+							gate.custom_access.metering.count,
+							gate.custom_access.metering.period
+						) }
+					</p>
+				) }
+				{ ( ! gate.custom_access?.active || gate.custom_access.access_rules?.length === 0 ) && <p>{ __( 'N/A', 'newspack-plugin' ) }</p> }
+				{ gate.custom_access?.active && gate.custom_access.access_rules?.length > 0 && gate.custom_access.gate_layout_id && (
+					<Button variant="secondary" href={ getEditGateLayoutUrl( gate.id, 'custom_access' ) }>
+						{ __( 'Customize paid access layout', 'newspack-plugin' ) }
+					</Button>
+				) }
+			</div>
+		</Grid>
 	);
 }

--- a/src/wizards/audience/views/content-gates/content-gate-settings.tsx
+++ b/src/wizards/audience/views/content-gates/content-gate-settings.tsx
@@ -2,108 +2,228 @@
  * WordPress dependencies.
  */
 import { __, sprintf } from '@wordpress/i18n';
+import { CardBody } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
-import { Button, Grid } from '../../../../../packages/components/src';
+import { Badge, Button, Card, Grid, Router } from '../../../../../packages/components/src';
+import { useWizardData } from '../../../../../packages/components/src/wizard/store/utils';
+import { useWizardApiFetch } from '../../../hooks/use-wizard-api-fetch';
+import { WIZARD_STORE_NAMESPACE } from '../../../../../packages/components/src/wizard/store';
 import ContentRuleControl from './edit/content-rule-control';
-import { getEditGateLayoutUrl } from './utils';
-
-type ContentGateSettingsProps = {
-	gate: Gate;
-};
+import { getEditGateLayoutUrl, getGateStatus, getGateStatusBadgeLevel } from './utils';
+import { AUDIENCE_CONTENT_GATES_WIZARD_SLUG } from './consts';
 
 const availableAccessRules = window.newspackAudienceContentGates.available_access_rules || {};
 
 const noOp = () => {};
 
-export default function ContentGateSettings( { gate }: ContentGateSettingsProps ) {
+const { useHistory } = Router;
+
+export default function ContentGateSettings( { gate, updateGatesData }: { gate: Gate; updateGatesData: ( gates: Gate[] ) => void } ) {
+	const history = useHistory();
+	const { gates = null as unknown as Gate[] } = useWizardData( AUDIENCE_CONTENT_GATES_WIZARD_SLUG ) as WizardData;
+	const { wizardApiFetch, isFetching, resetError } = useWizardApiFetch( AUDIENCE_CONTENT_GATES_WIZARD_SLUG );
+	const { addNotice, resetNotices } = useDispatch( WIZARD_STORE_NAMESPACE );
+
+	const handleStatusChange = ( status: GateStatus, showNotice = true ) => {
+		if ( isFetching ) {
+			return;
+		}
+		resetError();
+		resetNotices();
+		const _gate = {
+			...gate,
+			status,
+		};
+		wizardApiFetch< Gate >(
+			{
+				path: `/newspack/v1/wizard/${ AUDIENCE_CONTENT_GATES_WIZARD_SLUG }/${ gate.id }`,
+				method: 'POST',
+				data: { gate: _gate },
+			},
+			{
+				onSuccess( data: Gate ) {
+					updateGatesData( gates.map( g => ( g.id === data.id ? data : g ) ) );
+					if ( showNotice ) {
+						addNotice( {
+							message: sprintf(
+								// translators: 1: the gate title, or "Content" if we can't determine the gate title. 2: the gate status. __(
+								'%1$s gate %2$s.',
+								gate.title ? `“${ gate.title }”` : __( 'Content', 'newspack-plugin' ),
+								gate.status === 'publish' ? __( 'enabled', 'newspack-plugin' ) : __( 'disabled', 'newspack-plugin' )
+							),
+							type: 'success',
+							id: 'content-gate-updated',
+							buttonLabel: __( 'Undo', 'newspack-plugin' ),
+							onClick: () => handleStatusChange( gate.status, false ),
+						} );
+					}
+				},
+			}
+		);
+	};
+
+	const handleDelete = () => {
+		// eslint-disable-next-line no-alert
+		if ( ! confirm( __( 'Are you sure you want to permanently delete this content gate?', 'newspack-plugin' ) ) ) {
+			return;
+		}
+		resetError();
+		resetNotices();
+		wizardApiFetch(
+			{
+				path: `/newspack/v1/wizard/${ AUDIENCE_CONTENT_GATES_WIZARD_SLUG }/${ gate.id }`,
+				method: 'DELETE',
+			},
+			{
+				onSuccess() {
+					const deletedGate = gates.find( g => g.id === gate.id );
+					const newGates = gates.filter( g => g.id !== gate.id );
+					updateGatesData( newGates );
+					addNotice( {
+						message: sprintf(
+							// translators: %s is the gate title, or "Content" if we can't determine the deleted gate title.
+							__( '%s gate deleted.', 'newspack-plugin' ),
+							deletedGate?.title ? `“${ deletedGate.title }”` : __( 'Content', 'newspack-plugin' )
+						),
+						type: 'success',
+						id: 'content-gate-deleted',
+					} );
+				},
+			}
+		);
+	};
+
 	return (
-		<Grid className="newspack-content-gates__gate__settings" columns={ 3 } gutter={ 16 } borders noMargin>
-			<div>
-				<h4>{ __( 'Content rules', 'newspack-plugin' ) }</h4>
-				{ gate.content_rules.length > 0 ? (
-					gate.content_rules.map( rule => (
-						<ContentRuleControl
-							key={ rule.slug }
-							slug={ rule.slug }
-							value={ rule.value }
-							exclusion={ rule.exclusion }
-							onChange={ noOp }
-							onChangeExclusion={ noOp }
-							isStatic
-						/>
-					) )
-				) : (
-					<p>{ __( 'N/A', 'newspack-plugin' ) }</p>
-				) }
-			</div>
-			<div>
-				<h4>{ __( 'Registered access', 'newspack-plugin' ) }</h4>
-				{ gate.registration?.active && (
-					<p>
-						<strong>{ __( 'Require verification:', 'newspack-plugin' ) } </strong>{ ' ' }
-						{ gate.registration.require_verification ? __( 'Yes', 'newspack-plugin' ) : __( 'No', 'newspack-plugin' ) }
-					</p>
-				) }
-				{ gate.registration?.active && gate.registration.metering.enabled && (
-					<p>
-						<strong>{ __( 'Metered:', 'newspack-plugin' ) } </strong>{ ' ' }
-						{ sprintf(
-							// translators: 1: metering count, 2: metering period
-							__( '%1$d free views per %2$s', 'newspack-plugin' ),
-							gate.registration.metering.count,
-							gate.registration.metering.period
+		<Card
+			className="newspack-content-gates__gate"
+			id={ gate.id }
+			key={ gate.id }
+			isSmall
+			__experimentalCoreCard
+			__experimentalCoreProps={ {
+				noMargin: true,
+				header: (
+					<>
+						<h3>
+							{ gate.title }
+							<Badge level={ getGateStatusBadgeLevel( gate.status ) } text={ getGateStatus( gate.status ) } />
+						</h3>
+					</>
+				),
+				actions: [
+					{
+						label: __( 'Edit', 'newspack-plugin' ),
+						action: () => history.push( `/edit/${ gate.id }` ),
+						disabled: isFetching,
+					},
+					{
+						label: gate.status !== 'publish' ? __( 'Activate', 'newspack-plugin' ) : __( 'Deactivate', 'newspack-plugin' ),
+						action: () => handleStatusChange( gate.status === 'publish' ? 'draft' : 'publish' ),
+						disabled: isFetching,
+					},
+					{
+						label: __( 'Delete', 'newspack-plugin' ),
+						action: () => handleDelete(),
+						disabled: isFetching,
+						destructive: true,
+					},
+				],
+			} }
+		>
+			<CardBody>
+				<Grid className="newspack-content-gates__gate__settings" columns={ 3 } gutter={ 16 } borders noMargin>
+					<div>
+						<h4>{ __( 'Content rules', 'newspack-plugin' ) }</h4>
+						{ gate.content_rules.length > 0 ? (
+							gate.content_rules.map( rule => (
+								<ContentRuleControl
+									key={ rule.slug }
+									slug={ rule.slug }
+									value={ rule.value }
+									exclusion={ rule.exclusion }
+									onChange={ noOp }
+									onChangeExclusion={ noOp }
+									isStatic
+								/>
+							) )
+						) : (
+							<p>{ __( 'N/A', 'newspack-plugin' ) }</p>
 						) }
-					</p>
-				) }
-				{ ! gate.registration?.active && <p>{ __( 'N/A', 'newspack-plugin' ) }</p> }
-				{ gate.registration?.active && gate.registration.gate_layout_id && (
-					<Button variant="secondary" href={ getEditGateLayoutUrl( gate.id, 'registration' ) }>
-						{ __( 'Customize registered access layout', 'newspack-plugin' ) }
-					</Button>
-				) }
-			</div>
-			<div>
-				<h4>{ __( 'Paid access', 'newspack-plugin' ) }</h4>
-				{ gate.custom_access?.active &&
-					gate.custom_access.access_rules.length > 0 &&
-					gate.custom_access.access_rules.map( ruleGroup =>
-						ruleGroup.map( rule =>
-							availableAccessRules[ rule.slug ]?.name ? (
-								<p key={ rule.slug }>
-									<strong>{ availableAccessRules[ rule.slug ].name }:</strong>{ ' ' }
-									{ Array.isArray( rule.value ) && availableAccessRules[ rule.slug ]?.options
-										? rule.value
-												.map(
-													value =>
-														availableAccessRules[ rule.slug ].options?.find( option => option.value === value )?.label
-												)
-												.join( ', ' )
-										: rule.value }
-								</p>
-							) : null
-						)
-					) }
-				{ gate.custom_access?.active && gate.custom_access.metering.enabled && (
-					<p>
-						<strong>{ __( 'Metered:', 'newspack-plugin' ) } </strong>{ ' ' }
-						{ sprintf(
-							// translators: 1: metering count, 2: metering period
-							__( '%1$d free views per %2$s', 'newspack-plugin' ),
-							gate.custom_access.metering.count,
-							gate.custom_access.metering.period
+					</div>
+					<div>
+						<h4>{ __( 'Registered access', 'newspack-plugin' ) }</h4>
+						{ gate.registration?.active && (
+							<p>
+								<strong>{ __( 'Require verification:', 'newspack-plugin' ) } </strong>{ ' ' }
+								{ gate.registration.require_verification ? __( 'Yes', 'newspack-plugin' ) : __( 'No', 'newspack-plugin' ) }
+							</p>
 						) }
-					</p>
-				) }
-				{ ( ! gate.custom_access?.active || gate.custom_access.access_rules?.length === 0 ) && <p>{ __( 'N/A', 'newspack-plugin' ) }</p> }
-				{ gate.custom_access?.active && gate.custom_access.access_rules?.length > 0 && gate.custom_access.gate_layout_id && (
-					<Button variant="secondary" href={ getEditGateLayoutUrl( gate.id, 'custom_access' ) }>
-						{ __( 'Customize paid access layout', 'newspack-plugin' ) }
-					</Button>
-				) }
-			</div>
-		</Grid>
+						{ gate.registration?.active && gate.registration.metering.enabled && (
+							<p>
+								<strong>{ __( 'Metered:', 'newspack-plugin' ) } </strong>{ ' ' }
+								{ sprintf(
+									// translators: 1: metering count, 2: metering period
+									__( '%1$d free views per %2$s', 'newspack-plugin' ),
+									gate.registration.metering.count,
+									gate.registration.metering.period
+								) }
+							</p>
+						) }
+						{ ! gate.registration?.active && <p>{ __( 'N/A', 'newspack-plugin' ) }</p> }
+						{ gate.registration?.active && gate.registration.gate_layout_id && (
+							<Button variant="secondary" href={ getEditGateLayoutUrl( gate.id, 'registration' ) }>
+								{ __( 'Customize registered access layout', 'newspack-plugin' ) }
+							</Button>
+						) }
+					</div>
+					<div>
+						<h4>{ __( 'Paid access', 'newspack-plugin' ) }</h4>
+						{ gate.custom_access?.active &&
+							gate.custom_access.access_rules.length > 0 &&
+							gate.custom_access.access_rules.map( ruleGroup =>
+								ruleGroup.map( rule =>
+									availableAccessRules[ rule.slug ]?.name ? (
+										<p key={ rule.slug }>
+											<strong>{ availableAccessRules[ rule.slug ].name }:</strong>{ ' ' }
+											{ Array.isArray( rule.value ) && availableAccessRules[ rule.slug ]?.options
+												? rule.value
+														.map(
+															value =>
+																availableAccessRules[ rule.slug ].options?.find( option => option.value === value )
+																	?.label
+														)
+														.join( ', ' )
+												: rule.value }
+										</p>
+									) : null
+								)
+							) }
+						{ gate.custom_access?.active && gate.custom_access.metering.enabled && (
+							<p>
+								<strong>{ __( 'Metered:', 'newspack-plugin' ) } </strong>{ ' ' }
+								{ sprintf(
+									// translators: 1: metering count, 2: metering period
+									__( '%1$d free views per %2$s', 'newspack-plugin' ),
+									gate.custom_access.metering.count,
+									gate.custom_access.metering.period
+								) }
+							</p>
+						) }
+						{ ( ! gate.custom_access?.active || gate.custom_access.access_rules?.length === 0 ) && (
+							<p>{ __( 'N/A', 'newspack-plugin' ) }</p>
+						) }
+						{ gate.custom_access?.active && gate.custom_access.access_rules?.length > 0 && gate.custom_access.gate_layout_id && (
+							<Button variant="secondary" href={ getEditGateLayoutUrl( gate.id, 'custom_access' ) }>
+								{ __( 'Customize paid access layout', 'newspack-plugin' ) }
+							</Button>
+						) }
+					</div>
+				</Grid>
+			</CardBody>
+		</Card>
 	);
 }

--- a/src/wizards/audience/views/content-gates/content-gate-settings.tsx
+++ b/src/wizards/audience/views/content-gates/content-gate-settings.tsx
@@ -53,7 +53,7 @@ export default function ContentGateSettings( { gate, updateGatesData }: { gate: 
 								// translators: 1: the gate title, or "Content" if we can't determine the gate title. 2: the gate status. __(
 								'%1$s gate %2$s.',
 								gate.title ? `“${ gate.title }”` : __( 'Content', 'newspack-plugin' ),
-								gate.status === 'publish' ? __( 'enabled', 'newspack-plugin' ) : __( 'disabled', 'newspack-plugin' )
+								gate.status === 'publish' ? __( 'disabled', 'newspack-plugin' ) : __( 'enabled', 'newspack-plugin' )
 							),
 							type: 'success',
 							id: 'content-gate-updated',

--- a/src/wizards/audience/views/content-gates/content-gate-settings.tsx
+++ b/src/wizards/audience/views/content-gates/content-gate-settings.tsx
@@ -21,7 +21,7 @@ type ContentGateSettingsProps = {
 };
 
 export default function ContentGateSettings( { gate, onDelete, onSave }: ContentGateSettingsProps ) {
-	const { wizardApiFetch } = useWizardApiFetch( AUDIENCE_CONTENT_GATES_WIZARD_SLUG );
+	const { wizardApiFetch, resetError } = useWizardApiFetch( AUDIENCE_CONTENT_GATES_WIZARD_SLUG );
 	const [ contentRules, setContentRules ] = useState< GateContentRule[] >( gate.content_rules );
 	const [ registration, setRegistration ] = useState< Registration >( gate.registration );
 	const [ customAccess, setCustomAccess ] = useState< CustomAccess >( gate.custom_access );
@@ -40,6 +40,7 @@ export default function ContentGateSettings( { gate, onDelete, onSave }: Content
 			custom_access: customAccess,
 			status,
 		};
+		resetError();
 		wizardApiFetch< Gate >(
 			{
 				path: `/newspack/v1/wizard/${ AUDIENCE_CONTENT_GATES_WIZARD_SLUG }/${ gate.id }`,
@@ -49,9 +50,6 @@ export default function ContentGateSettings( { gate, onDelete, onSave }: Content
 			{
 				onSuccess( data ) {
 					onSave( data );
-				},
-				onError( error ) {
-					console.error( error ); // eslint-disable-line no-console
 				},
 				onFinally() {
 					setIsEditingStatus( false );

--- a/src/wizards/audience/views/content-gates/content-gate-settings.tsx
+++ b/src/wizards/audience/views/content-gates/content-gate-settings.tsx
@@ -55,7 +55,7 @@ export default function ContentGateSettings( { gate, updateGatesData }: { gate: 
 					addNotice( {
 						message: sprintf(
 							// translators: 1: the gate title, or "Content" if we can't determine the gate title. 2: the gate status.
-							'%1$s gate %2$s.',
+							__( '%1$s gate %2$s.', 'newspack-plugin' ),
 							gateTitle ? `"${ gateTitle }"` : __( 'Content', 'newspack-plugin' ),
 							prevStatus === 'publish' ? __( 'disabled', 'newspack-plugin' ) : __( 'enabled', 'newspack-plugin' )
 						),

--- a/src/wizards/audience/views/content-gates/content-gate-settings.tsx
+++ b/src/wizards/audience/views/content-gates/content-gate-settings.tsx
@@ -4,12 +4,12 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { CardBody } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
-import { useRef } from '@wordpress/element';
+import { useRef, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-import { Badge, Button, Card, Grid, Router } from '../../../../../packages/components/src';
+import { Badge, Button, Card, ConfirmDialog, Grid, Router } from '../../../../../packages/components/src';
 import { useWizardData } from '../../../../../packages/components/src/wizard/store/utils';
 import { useWizardApiFetch } from '../../../hooks/use-wizard-api-fetch';
 import { WIZARD_STORE_NAMESPACE } from '../../../../../packages/components/src/wizard/store';
@@ -28,6 +28,7 @@ export default function ContentGateSettings( { gate, updateGatesData }: { gate: 
 	const { gates = null as unknown as Gate[] } = useWizardData( AUDIENCE_CONTENT_GATES_WIZARD_SLUG ) as WizardData;
 	const { wizardApiFetch, isFetching, resetError } = useWizardApiFetch( AUDIENCE_CONTENT_GATES_WIZARD_SLUG );
 	const { addNotice, resetNotices } = useDispatch( WIZARD_STORE_NAMESPACE );
+	const [ showDeleteDialog, setShowDeleteDialog ] = useState( false );
 
 	const updateStatus = useRef< ( status: GateStatus ) => void >();
 	const handleStatusChange = ( status: GateStatus ) => {
@@ -69,10 +70,6 @@ export default function ContentGateSettings( { gate, updateGatesData }: { gate: 
 	updateStatus.current = handleStatusChange;
 
 	const handleDelete = () => {
-		// eslint-disable-next-line no-alert
-		if ( ! confirm( __( 'Are you sure you want to permanently delete this content gate?', 'newspack-plugin' ) ) ) {
-			return;
-		}
 		resetError();
 		resetNotices();
 		wizardApiFetch(
@@ -100,132 +97,154 @@ export default function ContentGateSettings( { gate, updateGatesData }: { gate: 
 	};
 
 	return (
-		<Card
-			className="newspack-content-gates__gate"
-			id={ gate.id }
-			key={ gate.id }
-			isSmall
-			__experimentalCoreCard
-			__experimentalCoreProps={ {
-				noMargin: true,
-				header: (
-					<>
-						<h3>
-							{ gate.title }
-							<Badge level={ getGateStatusBadgeLevel( gate.status ) } text={ getGateStatus( gate.status ) } />
-						</h3>
-					</>
-				),
-				actions: [
-					{
-						label: __( 'Edit', 'newspack-plugin' ),
-						action: () => history.push( `/edit/${ gate.id }` ),
-						disabled: isFetching,
-					},
-					{
-						label: gate.status !== 'publish' ? __( 'Activate', 'newspack-plugin' ) : __( 'Deactivate', 'newspack-plugin' ),
-						action: () => updateStatus.current?.( gate.status === 'publish' ? 'draft' : 'publish' ),
-						disabled: isFetching,
-					},
-					{
-						label: __( 'Delete', 'newspack-plugin' ),
-						action: () => handleDelete(),
-						disabled: isFetching,
-						destructive: true,
-					},
-				],
-			} }
-		>
-			<CardBody>
-				<Grid className="newspack-content-gates__gate__settings" columns={ 3 } gutter={ 16 } borders noMargin>
-					<div>
-						<h4>{ __( 'Content rules', 'newspack-plugin' ) }</h4>
-						{ gate.content_rules.length > 0 ? (
-							gate.content_rules.map( rule => (
-								<ContentRuleControl
-									key={ rule.slug }
-									slug={ rule.slug }
-									value={ rule.value }
-									exclusion={ rule.exclusion }
-									onChange={ noOp }
-									onChangeExclusion={ noOp }
-									isStatic
-								/>
-							) )
-						) : (
-							<p>{ __( 'N/A', 'newspack-plugin' ) }</p>
-						) }
-					</div>
-					<div>
-						<h4>{ __( 'Registered access', 'newspack-plugin' ) }</h4>
-						{ gate.registration?.active && (
-							<p>
-								<strong>{ __( 'Require verification:', 'newspack-plugin' ) } </strong>{ ' ' }
-								{ gate.registration.require_verification ? __( 'Yes', 'newspack-plugin' ) : __( 'No', 'newspack-plugin' ) }
-							</p>
-						) }
-						{ gate.registration?.active && gate.registration.metering.enabled && (
-							<p>
-								<strong>{ __( 'Metered:', 'newspack-plugin' ) } </strong>{ ' ' }
-								{ sprintf(
-									// translators: 1: metering count, 2: metering period
-									__( '%1$d free views per %2$s', 'newspack-plugin' ),
-									gate.registration.metering.count,
-									gate.registration.metering.period
-								) }
-							</p>
-						) }
-						{ ! gate.registration?.active && <p>{ __( 'N/A', 'newspack-plugin' ) }</p> }
-						{ gate.registration?.active && gate.registration.gate_layout_id && (
-							<Button variant="secondary" href={ getEditGateLayoutUrl( gate.id, 'registration' ) }>
-								{ __( 'Customize registered access layout', 'newspack-plugin' ) }
-							</Button>
-						) }
-					</div>
-					<div>
-						<h4>{ __( 'Paid access', 'newspack-plugin' ) }</h4>
-						{ gate.custom_access?.active &&
-							gate.custom_access.access_rules.length > 0 &&
-							gate.custom_access.access_rules.map( ruleGroup =>
-								ruleGroup.map( rule =>
-									availableAccessRules[ rule.slug ]?.name ? (
-										<p key={ rule.slug }>
-											<strong>{ availableAccessRules[ rule.slug ].name }:</strong>{ ' ' }
-											{ Array.isArray( rule.value ) && availableAccessRules[ rule.slug ]?.options
-												? rule.value
-														.map(
-															value =>
-																availableAccessRules[ rule.slug ].options?.find( option => option.value === value )
-																	?.label
-														)
-														.join( ', ' )
-												: rule.value }
-										</p>
-									) : null
-								)
+		<>
+			{ showDeleteDialog && (
+				<ConfirmDialog
+					title={ __( 'Are you sure?', 'newspack-plugin' ) }
+					onConfirm={ handleDelete }
+					onCancel={ () => setShowDeleteDialog( false ) }
+					confirmButtonText={ __( 'Delete', 'newspack-plugin' ) }
+					isDestructive={ true }
+				>
+					<p
+						dangerouslySetInnerHTML={ {
+							__html: sprintf(
+								// translators: %s is the gate title.
+								__( 'This will <strong>permanently delete</strong> “%s” and cannot be undone.', 'newspack-plugin' ),
+								`“${ gate.title }”`
+							),
+						} }
+					/>
+				</ConfirmDialog>
+			) }
+			<Card
+				className="newspack-content-gates__gate"
+				id={ gate.id }
+				key={ gate.id }
+				isSmall
+				__experimentalCoreCard
+				__experimentalCoreProps={ {
+					noMargin: true,
+					header: (
+						<>
+							<h3>
+								{ gate.title }
+								<Badge level={ getGateStatusBadgeLevel( gate.status ) } text={ getGateStatus( gate.status ) } />
+							</h3>
+						</>
+					),
+					actions: [
+						{
+							label: __( 'Edit', 'newspack-plugin' ),
+							action: () => history.push( `/edit/${ gate.id }` ),
+							disabled: isFetching,
+						},
+						{
+							label: gate.status !== 'publish' ? __( 'Activate', 'newspack-plugin' ) : __( 'Deactivate', 'newspack-plugin' ),
+							action: () => updateStatus.current?.( gate.status === 'publish' ? 'draft' : 'publish' ),
+							disabled: isFetching,
+						},
+						{
+							label: __( 'Delete', 'newspack-plugin' ),
+							action: () => setShowDeleteDialog( true ),
+							disabled: isFetching,
+							destructive: true,
+						},
+					],
+				} }
+			>
+				<CardBody>
+					<Grid className="newspack-content-gates__gate__settings" columns={ 3 } gutter={ 16 } borders noMargin>
+						<div>
+							<h4>{ __( 'Content rules', 'newspack-plugin' ) }</h4>
+							{ gate.content_rules.length > 0 ? (
+								gate.content_rules.map( rule => (
+									<ContentRuleControl
+										key={ rule.slug }
+										slug={ rule.slug }
+										value={ rule.value }
+										exclusion={ rule.exclusion }
+										onChange={ noOp }
+										onChangeExclusion={ noOp }
+										isStatic
+									/>
+								) )
+							) : (
+								<p>{ __( 'N/A', 'newspack-plugin' ) }</p>
 							) }
-						{ gate.custom_access?.active && gate.custom_access.metering.enabled && (
-							<p>
-								<strong>{ __( 'Metered:', 'newspack-plugin' ) } </strong>{ ' ' }
-								{ sprintf(
-									// translators: 1: metering count, 2: metering period
-									__( '%1$d free views per %2$s', 'newspack-plugin' ),
-									gate.custom_access.metering.count,
-									gate.custom_access.metering.period
+						</div>
+						<div>
+							<h4>{ __( 'Registered access', 'newspack-plugin' ) }</h4>
+							{ gate.registration?.active && (
+								<p>
+									<strong>{ __( 'Require verification:', 'newspack-plugin' ) } </strong>{ ' ' }
+									{ gate.registration.require_verification ? __( 'Yes', 'newspack-plugin' ) : __( 'No', 'newspack-plugin' ) }
+								</p>
+							) }
+							{ gate.registration?.active && gate.registration.metering.enabled && (
+								<p>
+									<strong>{ __( 'Metered:', 'newspack-plugin' ) } </strong>{ ' ' }
+									{ sprintf(
+										// translators: 1: metering count, 2: metering period
+										__( '%1$d free views per %2$s', 'newspack-plugin' ),
+										gate.registration.metering.count,
+										gate.registration.metering.period
+									) }
+								</p>
+							) }
+							{ ! gate.registration?.active && <p>{ __( 'N/A', 'newspack-plugin' ) }</p> }
+							{ gate.registration?.active && gate.registration.gate_layout_id && (
+								<Button variant="secondary" href={ getEditGateLayoutUrl( gate.id, 'registration' ) }>
+									{ __( 'Customize registered access layout', 'newspack-plugin' ) }
+								</Button>
+							) }
+						</div>
+						<div>
+							<h4>{ __( 'Paid access', 'newspack-plugin' ) }</h4>
+							{ gate.custom_access?.active &&
+								gate.custom_access.access_rules.length > 0 &&
+								gate.custom_access.access_rules.map( ruleGroup =>
+									ruleGroup.map( rule =>
+										availableAccessRules[ rule.slug ]?.name ? (
+											<p key={ rule.slug }>
+												<strong>{ availableAccessRules[ rule.slug ].name }:</strong>{ ' ' }
+												{ Array.isArray( rule.value ) && availableAccessRules[ rule.slug ]?.options
+													? rule.value
+															.map(
+																value =>
+																	availableAccessRules[ rule.slug ].options?.find(
+																		option => option.value === value
+																	)?.label
+															)
+															.join( ', ' )
+													: rule.value }
+											</p>
+										) : null
+									)
 								) }
-							</p>
-						) }
-						{ ( ! gate.custom_access?.active || gate.custom_access.access_rules?.length === 0 ) && (
-							<p>{ __( 'N/A', 'newspack-plugin' ) }</p>
-						) }
-						{ gate.custom_access?.active && gate.custom_access.access_rules?.length > 0 && gate.custom_access.gate_layout_id && (
-							<Button variant="secondary" href={ getEditGateLayoutUrl( gate.id, 'custom_access' ) }>
-								{ __( 'Customize paid access layout', 'newspack-plugin' ) }
-							</Button>
-						) }
-					</div>
-				</Grid>
-			</CardBody>
-		</Card>
+							{ gate.custom_access?.active && gate.custom_access.metering.enabled && (
+								<p>
+									<strong>{ __( 'Metered:', 'newspack-plugin' ) } </strong>{ ' ' }
+									{ sprintf(
+										// translators: 1: metering count, 2: metering period
+										__( '%1$d free views per %2$s', 'newspack-plugin' ),
+										gate.custom_access.metering.count,
+										gate.custom_access.metering.period
+									) }
+								</p>
+							) }
+							{ ( ! gate.custom_access?.active || gate.custom_access.access_rules?.length === 0 ) && (
+								<p>{ __( 'N/A', 'newspack-plugin' ) }</p>
+							) }
+							{ gate.custom_access?.active && gate.custom_access.access_rules?.length > 0 && gate.custom_access.gate_layout_id && (
+								<Button variant="secondary" href={ getEditGateLayoutUrl( gate.id, 'custom_access' ) }>
+									{ __( 'Customize paid access layout', 'newspack-plugin' ) }
+								</Button>
+							) }
+						</div>
+					</Grid>
+				</CardBody>
+			</Card>
+		</>
 	);
 }

--- a/src/wizards/audience/views/content-gates/content-gate-settings.tsx
+++ b/src/wizards/audience/views/content-gates/content-gate-settings.tsx
@@ -4,7 +4,7 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { CardBody } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
-import { useRef, useState } from '@wordpress/element';
+import { createInterpolateElement, useRef, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -106,15 +106,14 @@ export default function ContentGateSettings( { gate, updateGatesData }: { gate: 
 					confirmButtonText={ __( 'Delete', 'newspack-plugin' ) }
 					isDestructive={ true }
 				>
-					<p
-						dangerouslySetInnerHTML={ {
-							__html: sprintf(
-								// translators: %s is the gate title.
-								__( 'This will <strong>permanently delete</strong> “%s” and cannot be undone.', 'newspack-plugin' ),
-								gate.title
-							),
-						} }
-					/>
+					{ createInterpolateElement(
+						sprintf(
+							// translators: %s is the gate title.
+							__( 'This will <strong>permanently delete</strong> “%s” and cannot be undone.', 'newspack-plugin' ),
+							gate.title
+						),
+						{ strong: <strong /> }
+					) }
 				</ConfirmDialog>
 			) }
 			<Card

--- a/src/wizards/audience/views/content-gates/content-gate-settings.tsx
+++ b/src/wizards/audience/views/content-gates/content-gate-settings.tsx
@@ -111,7 +111,7 @@ export default function ContentGateSettings( { gate, updateGatesData }: { gate: 
 							__html: sprintf(
 								// translators: %s is the gate title.
 								__( 'This will <strong>permanently delete</strong> “%s” and cannot be undone.', 'newspack-plugin' ),
-								`“${ gate.title }”`
+								gate.title
 							),
 						} }
 					/>

--- a/src/wizards/audience/views/content-gates/content-gate-settings.tsx
+++ b/src/wizards/audience/views/content-gates/content-gate-settings.tsx
@@ -4,6 +4,7 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { CardBody } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
+import { useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -28,12 +29,15 @@ export default function ContentGateSettings( { gate, updateGatesData }: { gate: 
 	const { wizardApiFetch, isFetching, resetError } = useWizardApiFetch( AUDIENCE_CONTENT_GATES_WIZARD_SLUG );
 	const { addNotice, resetNotices } = useDispatch( WIZARD_STORE_NAMESPACE );
 
-	const handleStatusChange = ( status: GateStatus, showNotice = true ) => {
+	const updateStatus = useRef< ( status: GateStatus ) => void >();
+	const handleStatusChange = ( status: GateStatus ) => {
 		if ( isFetching ) {
 			return;
 		}
 		resetError();
 		resetNotices();
+		const prevStatus = gate.status;
+		const gateTitle = gate.title;
 		const _gate = {
 			...gate,
 			status,
@@ -47,24 +51,22 @@ export default function ContentGateSettings( { gate, updateGatesData }: { gate: 
 			{
 				onSuccess( data: Gate ) {
 					updateGatesData( gates.map( g => ( g.id === data.id ? data : g ) ) );
-					if ( showNotice ) {
-						addNotice( {
-							message: sprintf(
-								// translators: 1: the gate title, or "Content" if we can't determine the gate title. 2: the gate status. __(
-								'%1$s gate %2$s.',
-								gate.title ? `“${ gate.title }”` : __( 'Content', 'newspack-plugin' ),
-								gate.status === 'publish' ? __( 'disabled', 'newspack-plugin' ) : __( 'enabled', 'newspack-plugin' )
-							),
-							type: 'success',
-							id: 'content-gate-updated',
-							buttonLabel: __( 'Undo', 'newspack-plugin' ),
-							onClick: () => handleStatusChange( gate.status, false ),
-						} );
-					}
+					addNotice( {
+						message: sprintf(
+							// translators: 1: the gate title, or "Content" if we can't determine the gate title. 2: the gate status.
+							'%1$s gate %2$s.',
+							gateTitle ? `"${ gateTitle }"` : __( 'Content', 'newspack-plugin' ),
+							prevStatus === 'publish' ? __( 'disabled', 'newspack-plugin' ) : __( 'enabled', 'newspack-plugin' )
+						),
+						type: 'success',
+						id: 'content-gate-status-changed',
+						actions: [ { label: __( 'Undo', 'newspack-plugin' ), onClick: () => updateStatus.current?.( prevStatus ) } ],
+					} );
 				},
 			}
 		);
 	};
+	updateStatus.current = handleStatusChange;
 
 	const handleDelete = () => {
 		// eslint-disable-next-line no-alert
@@ -122,7 +124,7 @@ export default function ContentGateSettings( { gate, updateGatesData }: { gate: 
 					},
 					{
 						label: gate.status !== 'publish' ? __( 'Activate', 'newspack-plugin' ) : __( 'Deactivate', 'newspack-plugin' ),
-						action: () => handleStatusChange( gate.status === 'publish' ? 'draft' : 'publish' ),
+						action: () => updateStatus.current?.( gate.status === 'publish' ? 'draft' : 'publish' ),
 						disabled: isFetching,
 					},
 					{

--- a/src/wizards/audience/views/content-gates/content-gates-priority.tsx
+++ b/src/wizards/audience/views/content-gates/content-gates-priority.tsx
@@ -36,6 +36,7 @@ const ContentGatesPriority = ( {
 	const gateItems = useMemo(
 		() =>
 			sortedGates.map( gate => ( {
+				id: gate.id,
 				title: gate.title,
 				badgeLevel: getGateStatusBadgeLevel( gate.status ) as 'default' | 'success' | 'info' | 'warning' | 'error',
 				badgeText: getGateStatus( gate.status ) as string,

--- a/src/wizards/audience/views/content-gates/content-gates-priority.tsx
+++ b/src/wizards/audience/views/content-gates/content-gates-priority.tsx
@@ -7,7 +7,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useDispatch } from '@wordpress/data';
-import { useEffect, useMemo, useState } from '@wordpress/element';
+import { useMemo, useRef, useState } from '@wordpress/element';
 import { __experimentalHStack as HStack, __experimentalVStack as VStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 
 /**
@@ -20,9 +20,17 @@ import { useWizardApiFetch } from '../../../hooks/use-wizard-api-fetch';
 import { getGateStatus, getGateStatusBadgeLevel } from './utils';
 import { AUDIENCE_CONTENT_GATES_WIZARD_SLUG } from './consts';
 
-const ContentGatesPriority = ( { closeModal, updateGatesData }: { closeModal: () => void; updateGatesData: ( gates: Gate[] ) => void } ) => {
+const ContentGatesPriority = ( {
+	closeModal,
+	showModal,
+	updateGatesData,
+}: {
+	closeModal: () => void;
+	showModal: boolean;
+	updateGatesData: ( gates: Gate[] ) => void;
+} ) => {
 	const { gates = [] as Gate[] } = useWizardData( AUDIENCE_CONTENT_GATES_WIZARD_SLUG ) as WizardData;
-	const { wizardApiFetch, isFetching, errorMessage, setError } = useWizardApiFetch( AUDIENCE_CONTENT_GATES_WIZARD_SLUG );
+	const { wizardApiFetch, isFetching, setError } = useWizardApiFetch( AUDIENCE_CONTENT_GATES_WIZARD_SLUG );
 	const { addNotice, resetNotices } = useDispatch( WIZARD_STORE_NAMESPACE );
 	const [ sortedGates, setSortedGates ] = useState< Gate[] >( gates );
 	const gateItems = useMemo(
@@ -35,12 +43,7 @@ const ContentGatesPriority = ( { closeModal, updateGatesData }: { closeModal: ()
 		[ sortedGates ]
 	);
 
-	useEffect( () => {
-		if ( errorMessage ) {
-			closeModal();
-		}
-	}, [ errorMessage ] );
-
+	const updatePriorities = useRef< ( updates: Gate[] ) => void >();
 	const handleUpdateGatePriorities = ( updates: Gate[] ) => {
 		if ( isFetching ) {
 			return;
@@ -58,20 +61,24 @@ const ContentGatesPriority = ( { closeModal, updateGatesData }: { closeModal: ()
 			{
 				onSuccess: () => {
 					updateGatesData( updates );
-					closeModal();
 					addNotice( {
 						message: __( 'Gate priority updated.', 'newspack-plugin' ),
 						type: 'success',
 						id: 'content-gates-priority-updated',
+						actions: [ { label: __( 'Undo', 'newspack-plugin' ), onClick: () => updatePriorities.current?.( oldGates ) } ],
 					} );
 				},
 				onError: ( fetchError: WpFetchError ) => {
 					setError( fetchError );
 					updateGatesData( oldGates );
 				},
+				onFinally: () => {
+					closeModal();
+				},
 			}
 		);
 	};
+	updatePriorities.current = handleUpdateGatePriorities;
 
 	const sortGates = ( index: number, targetIndex: number ) => {
 		if ( isFetching ) {
@@ -94,30 +101,32 @@ const ContentGatesPriority = ( { closeModal, updateGatesData }: { closeModal: ()
 	};
 
 	return (
-		<Modal title={ __( 'Gate priority', 'newspack-plugin' ) } onRequestClose={ closeModal }>
-			<VStack spacing={ 6 }>
-				<span>
-					{ __(
-						'Gates are checked in this order. If content matches more than one gate, only the first matching gate will apply.',
-						'newspack-plugin'
-					) }
-				</span>
-				<CardSortableList disabled={ isFetching } items={ gateItems } onDragCallback={ sortGates } />
-				<HStack justify="end">
-					<Button variant="tertiary" disabled={ isFetching } onClick={ closeModal }>
-						{ __( 'Cancel', 'newspack-plugin' ) }
-					</Button>
-					<Button
-						variant="primary"
-						disabled={ isFetching || JSON.stringify( sortedGates ) === JSON.stringify( gates ) }
-						loading={ isFetching }
-						onClick={ () => handleUpdateGatePriorities( sortedGates ) }
-					>
-						{ __( 'Save', 'newspack-plugin' ) }
-					</Button>
-				</HStack>
-			</VStack>
-		</Modal>
+		showModal && (
+			<Modal title={ __( 'Gate priority', 'newspack-plugin' ) } onRequestClose={ closeModal }>
+				<VStack spacing={ 6 }>
+					<span>
+						{ __(
+							'Gates are checked in this order. If content matches more than one gate, only the first matching gate will apply.',
+							'newspack-plugin'
+						) }
+					</span>
+					<CardSortableList disabled={ isFetching } items={ gateItems } onDragCallback={ sortGates } />
+					<HStack justify="end">
+						<Button variant="tertiary" disabled={ isFetching } onClick={ closeModal }>
+							{ __( 'Cancel', 'newspack-plugin' ) }
+						</Button>
+						<Button
+							variant="primary"
+							disabled={ isFetching || JSON.stringify( sortedGates ) === JSON.stringify( gates ) }
+							loading={ isFetching }
+							onClick={ () => updatePriorities.current?.( sortedGates ) }
+						>
+							{ __( 'Save', 'newspack-plugin' ) }
+						</Button>
+					</HStack>
+				</VStack>
+			</Modal>
+		)
 	);
 };
 

--- a/src/wizards/audience/views/content-gates/content-gates-priority.tsx
+++ b/src/wizards/audience/views/content-gates/content-gates-priority.tsx
@@ -7,11 +7,12 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useMemo, useState } from '@wordpress/element';
+import { __experimentalHStack as HStack, __experimentalVStack as VStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 
 /**
  * Internal dependencies
  */
-import { Button, Card, CardSortableList, Modal } from '../../../../../packages/components/src';
+import { Button, CardSortableList, Modal } from '../../../../../packages/components/src';
 import { useWizardData } from '../../../../../packages/components/src/wizard/store/utils';
 import { useWizardApiFetch } from '../../../hooks/use-wizard-api-fetch';
 import { getGateStatus, getGateStatusBadgeLevel } from './utils';
@@ -78,26 +79,28 @@ const ContentGatesPriority = ( { closeModal, updateGatesData }: { closeModal: ()
 	};
 
 	return (
-		<Modal isMedium title={ __( 'Gate priority', 'newspack-plugin' ) } onRequestClose={ closeModal }>
-			<p>
-				{ __(
-					'Gates are checked in this order. If content matches more than one gate, only the first matching gate will apply.',
-					'newspack-plugin'
-				) }
-			</p>
-			<CardSortableList isActive={ isFetching } items={ gateItems } onDragCallback={ sortGates } />
-			<Card buttonsCard noBorder className="justify-end">
-				<Button variant="tertiary" disabled={ isFetching } onClick={ closeModal }>
-					{ __( 'Cancel', 'newspack-plugin' ) }
-				</Button>
-				<Button
-					variant="primary"
-					disabled={ isFetching || JSON.stringify( sortedGates ) === JSON.stringify( gates ) }
-					onClick={ () => handleUpdateGatePriorities( sortedGates ) }
-				>
-					{ __( 'Save', 'newspack-plugin' ) }
-				</Button>
-			</Card>
+		<Modal title={ __( 'Gate priority', 'newspack-plugin' ) } onRequestClose={ closeModal }>
+			<VStack spacing={ 6 }>
+				<span>
+					{ __(
+						'Gates are checked in this order. If content matches more than one gate, only the first matching gate will apply.',
+						'newspack-plugin'
+					) }
+				</span>
+				<CardSortableList isActive={ isFetching } items={ gateItems } onDragCallback={ sortGates } />
+				<HStack justify="end">
+					<Button variant="tertiary" disabled={ isFetching } onClick={ closeModal }>
+						{ __( 'Cancel', 'newspack-plugin' ) }
+					</Button>
+					<Button
+						variant="primary"
+						disabled={ isFetching || JSON.stringify( sortedGates ) === JSON.stringify( gates ) }
+						onClick={ () => handleUpdateGatePriorities( sortedGates ) }
+					>
+						{ __( 'Save', 'newspack-plugin' ) }
+					</Button>
+				</HStack>
+			</VStack>
 		</Modal>
 	);
 };

--- a/src/wizards/audience/views/content-gates/content-gates-priority.tsx
+++ b/src/wizards/audience/views/content-gates/content-gates-priority.tsx
@@ -7,7 +7,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useDispatch } from '@wordpress/data';
-import { useMemo, useState } from '@wordpress/element';
+import { useEffect, useMemo, useState } from '@wordpress/element';
 import { __experimentalHStack as HStack, __experimentalVStack as VStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 
 /**
@@ -22,7 +22,7 @@ import { AUDIENCE_CONTENT_GATES_WIZARD_SLUG } from './consts';
 
 const ContentGatesPriority = ( { closeModal, updateGatesData }: { closeModal: () => void; updateGatesData: ( gates: Gate[] ) => void } ) => {
 	const { gates = [] as Gate[] } = useWizardData( AUDIENCE_CONTENT_GATES_WIZARD_SLUG ) as WizardData;
-	const { wizardApiFetch, isFetching, setError } = useWizardApiFetch( AUDIENCE_CONTENT_GATES_WIZARD_SLUG );
+	const { wizardApiFetch, isFetching, errorMessage, setError } = useWizardApiFetch( AUDIENCE_CONTENT_GATES_WIZARD_SLUG );
 	const { addNotice, resetNotices } = useDispatch( WIZARD_STORE_NAMESPACE );
 	const [ sortedGates, setSortedGates ] = useState< Gate[] >( gates );
 	const gateItems = useMemo(
@@ -34,6 +34,12 @@ const ContentGatesPriority = ( { closeModal, updateGatesData }: { closeModal: ()
 			} ) ),
 		[ sortedGates ]
 	);
+
+	useEffect( () => {
+		if ( errorMessage ) {
+			closeModal();
+		}
+	}, [ errorMessage ] );
 
 	const handleUpdateGatePriorities = ( updates: Gate[] ) => {
 		if ( isFetching ) {

--- a/src/wizards/audience/views/content-gates/content-gates-priority.tsx
+++ b/src/wizards/audience/views/content-gates/content-gates-priority.tsx
@@ -95,6 +95,7 @@ const ContentGatesPriority = ( { closeModal, updateGatesData }: { closeModal: ()
 					<Button
 						variant="primary"
 						disabled={ isFetching || JSON.stringify( sortedGates ) === JSON.stringify( gates ) }
+						loading={ isFetching }
 						onClick={ () => handleUpdateGatePriorities( sortedGates ) }
 					>
 						{ __( 'Save', 'newspack-plugin' ) }

--- a/src/wizards/audience/views/content-gates/content-gates-priority.tsx
+++ b/src/wizards/audience/views/content-gates/content-gates-priority.tsx
@@ -1,0 +1,102 @@
+/**
+ * Content Gate component.
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { __ } from '@wordpress/i18n';
+import { useMemo, useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { Button, Card, CardSortableList, Modal } from '../../../../../packages/components/src';
+import { useWizardData } from '../../../../../packages/components/src/wizard/store/utils';
+import { useWizardApiFetch } from '../../../hooks/use-wizard-api-fetch';
+import { getGateStatus, getGateStatusBadgeLevel } from './utils';
+import { AUDIENCE_CONTENT_GATES_WIZARD_SLUG } from './consts';
+
+const ContentGatesPriority = ( { closeModal, updateGatesData }: { closeModal: () => void; updateGatesData: ( gates: Gate[] ) => void } ) => {
+	const { gates = [] as Gate[] } = useWizardData( AUDIENCE_CONTENT_GATES_WIZARD_SLUG ) as WizardData;
+	const { wizardApiFetch, isFetching, setError } = useWizardApiFetch( AUDIENCE_CONTENT_GATES_WIZARD_SLUG );
+	const [ sortedGates, setSortedGates ] = useState< Gate[] >( gates );
+	const gateItems = useMemo(
+		() =>
+			gates.map( gate => ( {
+				title: gate.title,
+				badgeLevel: getGateStatusBadgeLevel( gate.status ) as 'success' | 'info' | 'warning' | 'error',
+				badgeText: getGateStatus( gate.status ) as string,
+			} ) ),
+		[ gates ]
+	);
+
+	const handleUpdateGatePriorities = ( updates: Gate[] ) => {
+		if ( isFetching ) {
+			return;
+		}
+		const oldGates = [ ...gates ];
+		updateGatesData( updates );
+		wizardApiFetch< Gate >(
+			{
+				path: `/newspack/v1/wizard/${ AUDIENCE_CONTENT_GATES_WIZARD_SLUG }/priority`,
+				method: 'POST',
+				data: {
+					gates: updates.map( g => ( { id: g.id, priority: g.priority } ) ),
+				},
+			},
+			{
+				onSuccess: () => {
+					closeModal();
+				},
+				onError: ( fetchError: WpFetchError ) => {
+					setError( fetchError );
+					updateGatesData( oldGates );
+				},
+			}
+		);
+	};
+
+	const sortGates = ( index: number, targetIndex: number ) => {
+		if ( isFetching ) {
+			return;
+		}
+
+		const gate = gates[ index as keyof typeof gates ];
+		const _sortedGates = [ ...gates ];
+
+		// Remove the gate and drop it back into the array at the target index.
+		_sortedGates.splice( index, 1 );
+		_sortedGates.splice( targetIndex, 0, gate );
+
+		// Reindex priorities to avoid gaps and dupes.
+		_sortedGates.forEach( ( _gate, _index ) => ( _gate.priority = _index ) );
+		setSortedGates( _sortedGates );
+	};
+
+	return (
+		<Modal isNarrow title={ __( 'Gate priority', 'newspack-plugin' ) } onRequestClose={ closeModal }>
+			<p>
+				{ __(
+					'Gates are checked in this order. If content matches more than one gate, only the first matching gate will apply.',
+					'newspack-plugin'
+				) }
+			</p>
+			<CardSortableList isActive={ isFetching } items={ gateItems } onDragCallback={ sortGates } />
+			<Card buttonsCard noBorder className="justify-end">
+				<Button variant="tertiary" disabled={ isFetching } onClick={ closeModal }>
+					{ __( 'Cancel', 'newspack-plugin' ) }
+				</Button>
+				<Button
+					variant="primary"
+					disabled={ isFetching || JSON.stringify( sortedGates ) === JSON.stringify( gates ) }
+					onClick={ () => handleUpdateGatePriorities( sortedGates ) }
+				>
+					{ __( 'Save', 'newspack-plugin' ) }
+				</Button>
+			</Card>
+		</Modal>
+	);
+};
+
+export default ContentGatesPriority;

--- a/src/wizards/audience/views/content-gates/content-gates-priority.tsx
+++ b/src/wizards/audience/views/content-gates/content-gates-priority.tsx
@@ -23,12 +23,12 @@ const ContentGatesPriority = ( { closeModal, updateGatesData }: { closeModal: ()
 	const [ sortedGates, setSortedGates ] = useState< Gate[] >( gates );
 	const gateItems = useMemo(
 		() =>
-			gates.map( gate => ( {
+			sortedGates.map( gate => ( {
 				title: gate.title,
 				badgeLevel: getGateStatusBadgeLevel( gate.status ) as 'success' | 'info' | 'warning' | 'error',
 				badgeText: getGateStatus( gate.status ) as string,
 			} ) ),
-		[ gates ]
+		[ sortedGates ]
 	);
 
 	const handleUpdateGatePriorities = ( updates: Gate[] ) => {
@@ -36,7 +36,6 @@ const ContentGatesPriority = ( { closeModal, updateGatesData }: { closeModal: ()
 			return;
 		}
 		const oldGates = [ ...gates ];
-		updateGatesData( updates );
 		wizardApiFetch< Gate >(
 			{
 				path: `/newspack/v1/wizard/${ AUDIENCE_CONTENT_GATES_WIZARD_SLUG }/priority`,
@@ -47,6 +46,7 @@ const ContentGatesPriority = ( { closeModal, updateGatesData }: { closeModal: ()
 			},
 			{
 				onSuccess: () => {
+					updateGatesData( updates );
 					closeModal();
 				},
 				onError: ( fetchError: WpFetchError ) => {
@@ -62,8 +62,8 @@ const ContentGatesPriority = ( { closeModal, updateGatesData }: { closeModal: ()
 			return;
 		}
 
-		const gate = gates[ index as keyof typeof gates ];
-		const _sortedGates = [ ...gates ];
+		const gate = sortedGates[ index as keyof typeof gates ];
+		const _sortedGates = [ ...sortedGates ];
 
 		// Remove the gate and drop it back into the array at the target index.
 		_sortedGates.splice( index, 1 );
@@ -75,7 +75,7 @@ const ContentGatesPriority = ( { closeModal, updateGatesData }: { closeModal: ()
 	};
 
 	return (
-		<Modal isNarrow title={ __( 'Gate priority', 'newspack-plugin' ) } onRequestClose={ closeModal }>
+		<Modal isMedium title={ __( 'Gate priority', 'newspack-plugin' ) } onRequestClose={ closeModal }>
 			<p>
 				{ __(
 					'Gates are checked in this order. If content matches more than one gate, only the first matching gate will apply.',

--- a/src/wizards/audience/views/content-gates/content-gates-priority.tsx
+++ b/src/wizards/audience/views/content-gates/content-gates-priority.tsx
@@ -62,7 +62,7 @@ const ContentGatesPriority = ( { closeModal, updateGatesData }: { closeModal: ()
 			return;
 		}
 
-		const gate = sortedGates[ index as keyof typeof gates ];
+		const gate = sortedGates[ index ];
 		const _sortedGates = [ ...sortedGates ];
 
 		// Remove the gate and drop it back into the array at the target index.

--- a/src/wizards/audience/views/content-gates/content-gates-priority.tsx
+++ b/src/wizards/audience/views/content-gates/content-gates-priority.tsx
@@ -25,7 +25,7 @@ const ContentGatesPriority = ( { closeModal, updateGatesData }: { closeModal: ()
 		() =>
 			sortedGates.map( gate => ( {
 				title: gate.title,
-				badgeLevel: getGateStatusBadgeLevel( gate.status ) as 'success' | 'info' | 'warning' | 'error',
+				badgeLevel: getGateStatusBadgeLevel( gate.status ) as 'default' | 'success' | 'info' | 'warning' | 'error',
 				badgeText: getGateStatus( gate.status ) as string,
 			} ) ),
 		[ sortedGates ]

--- a/src/wizards/audience/views/content-gates/content-gates-priority.tsx
+++ b/src/wizards/audience/views/content-gates/content-gates-priority.tsx
@@ -1,5 +1,5 @@
 /**
- * Content Gate component.
+ * Content Gate Priority component.
  */
 
 /**

--- a/src/wizards/audience/views/content-gates/content-gates-priority.tsx
+++ b/src/wizards/audience/views/content-gates/content-gates-priority.tsx
@@ -70,8 +70,11 @@ const ContentGatesPriority = ( { closeModal, updateGatesData }: { closeModal: ()
 		_sortedGates.splice( targetIndex, 0, gate );
 
 		// Reindex priorities to avoid gaps and dupes.
-		_sortedGates.forEach( ( _gate, _index ) => ( _gate.priority = _index ) );
-		setSortedGates( _sortedGates );
+		const reindexedGates = _sortedGates.map( ( _gate, _index ) => ( {
+			..._gate,
+			priority: _index,
+		} ) );
+		setSortedGates( reindexedGates );
 	};
 
 	return (

--- a/src/wizards/audience/views/content-gates/content-gates-priority.tsx
+++ b/src/wizards/audience/views/content-gates/content-gates-priority.tsx
@@ -6,6 +6,7 @@
  * WordPress dependencies.
  */
 import { __ } from '@wordpress/i18n';
+import { useDispatch } from '@wordpress/data';
 import { useMemo, useState } from '@wordpress/element';
 import { __experimentalHStack as HStack, __experimentalVStack as VStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 
@@ -14,6 +15,7 @@ import { __experimentalHStack as HStack, __experimentalVStack as VStack } from '
  */
 import { Button, CardSortableList, Modal } from '../../../../../packages/components/src';
 import { useWizardData } from '../../../../../packages/components/src/wizard/store/utils';
+import { WIZARD_STORE_NAMESPACE } from '../../../../../packages/components/src/wizard/store';
 import { useWizardApiFetch } from '../../../hooks/use-wizard-api-fetch';
 import { getGateStatus, getGateStatusBadgeLevel } from './utils';
 import { AUDIENCE_CONTENT_GATES_WIZARD_SLUG } from './consts';
@@ -21,6 +23,7 @@ import { AUDIENCE_CONTENT_GATES_WIZARD_SLUG } from './consts';
 const ContentGatesPriority = ( { closeModal, updateGatesData }: { closeModal: () => void; updateGatesData: ( gates: Gate[] ) => void } ) => {
 	const { gates = [] as Gate[] } = useWizardData( AUDIENCE_CONTENT_GATES_WIZARD_SLUG ) as WizardData;
 	const { wizardApiFetch, isFetching, setError } = useWizardApiFetch( AUDIENCE_CONTENT_GATES_WIZARD_SLUG );
+	const { addNotice, resetNotices } = useDispatch( WIZARD_STORE_NAMESPACE );
 	const [ sortedGates, setSortedGates ] = useState< Gate[] >( gates );
 	const gateItems = useMemo(
 		() =>
@@ -37,6 +40,7 @@ const ContentGatesPriority = ( { closeModal, updateGatesData }: { closeModal: ()
 			return;
 		}
 		const oldGates = [ ...gates ];
+		resetNotices();
 		wizardApiFetch< Gate >(
 			{
 				path: `/newspack/v1/wizard/${ AUDIENCE_CONTENT_GATES_WIZARD_SLUG }/priority`,
@@ -49,6 +53,11 @@ const ContentGatesPriority = ( { closeModal, updateGatesData }: { closeModal: ()
 				onSuccess: () => {
 					updateGatesData( updates );
 					closeModal();
+					addNotice( {
+						message: __( 'Gate priority updated.', 'newspack-plugin' ),
+						type: 'success',
+						id: 'content-gates-priority-updated',
+					} );
 				},
 				onError: ( fetchError: WpFetchError ) => {
 					setError( fetchError );

--- a/src/wizards/audience/views/content-gates/content-gates-priority.tsx
+++ b/src/wizards/audience/views/content-gates/content-gates-priority.tsx
@@ -87,7 +87,7 @@ const ContentGatesPriority = ( { closeModal, updateGatesData }: { closeModal: ()
 						'newspack-plugin'
 					) }
 				</span>
-				<CardSortableList isActive={ isFetching } items={ gateItems } onDragCallback={ sortGates } />
+				<CardSortableList disabled={ isFetching } items={ gateItems } onDragCallback={ sortGates } />
 				<HStack justify="end">
 					<Button variant="tertiary" disabled={ isFetching } onClick={ closeModal }>
 						{ __( 'Cancel', 'newspack-plugin' ) }

--- a/src/wizards/audience/views/content-gates/content-gates-priority.tsx
+++ b/src/wizards/audience/views/content-gates/content-gates-priority.tsx
@@ -31,7 +31,7 @@ const ContentGatesPriority = ( {
 } ) => {
 	const { gates = [] as Gate[] } = useWizardData( AUDIENCE_CONTENT_GATES_WIZARD_SLUG ) as WizardData;
 	const { wizardApiFetch, isFetching, setError } = useWizardApiFetch( AUDIENCE_CONTENT_GATES_WIZARD_SLUG );
-	const { addNotice, resetNotices } = useDispatch( WIZARD_STORE_NAMESPACE );
+	const { addNotice, resetError, resetNotices } = useDispatch( WIZARD_STORE_NAMESPACE );
 	const [ sortedGates, setSortedGates ] = useState< Gate[] >( gates );
 	const gateItems = useMemo(
 		() =>
@@ -49,6 +49,7 @@ const ContentGatesPriority = ( {
 			return;
 		}
 		const oldGates = [ ...gates ];
+		resetError();
 		resetNotices();
 		wizardApiFetch< Gate >(
 			{

--- a/src/wizards/audience/views/content-gates/content-gates-priority.tsx
+++ b/src/wizards/audience/views/content-gates/content-gates-priority.tsx
@@ -30,8 +30,8 @@ const ContentGatesPriority = ( {
 	updateGatesData: ( gates: Gate[] ) => void;
 } ) => {
 	const { gates = [] as Gate[] } = useWizardData( AUDIENCE_CONTENT_GATES_WIZARD_SLUG ) as WizardData;
-	const { wizardApiFetch, isFetching, setError } = useWizardApiFetch( AUDIENCE_CONTENT_GATES_WIZARD_SLUG );
-	const { addNotice, resetError, resetNotices } = useDispatch( WIZARD_STORE_NAMESPACE );
+	const { wizardApiFetch, isFetching, resetError, setError } = useWizardApiFetch( AUDIENCE_CONTENT_GATES_WIZARD_SLUG );
+	const { addNotice, resetNotices } = useDispatch( WIZARD_STORE_NAMESPACE );
 	const [ sortedGates, setSortedGates ] = useState< Gate[] >( gates );
 	const gateItems = useMemo(
 		() =>

--- a/src/wizards/audience/views/content-gates/content-gates.tsx
+++ b/src/wizards/audience/views/content-gates/content-gates.tsx
@@ -5,12 +5,12 @@
 /**
  * WordPress dependencies.
  */
+import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import { CardBody, __experimentalVStack as VStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { useDispatch } from '@wordpress/data';
 import { useEffect, useRef, useState } from '@wordpress/element';
 import { ENTER } from '@wordpress/keycodes';
-import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies

--- a/src/wizards/audience/views/content-gates/content-gates.tsx
+++ b/src/wizards/audience/views/content-gates/content-gates.tsx
@@ -66,13 +66,11 @@ const ContentGates = ( { updateGatesData }: { updateGatesData: ( gates: Gate[] )
 	return (
 		<>
 			{ error && <Notice isError noticeText={ errorMessage } /> }
-			{
-				<ContentGatesPriority
-					showModal={ showPriorityModal }
-					closeModal={ () => setShowPriorityModal( false ) }
-					updateGatesData={ updateGatesData }
-				/>
-			}
+			<ContentGatesPriority
+				showModal={ showPriorityModal }
+				closeModal={ () => setShowPriorityModal( false ) }
+				updateGatesData={ updateGatesData }
+			/>
 			<VStack className="newspack-content-gates__gates" spacing="16px" ref={ ref }>
 				{ gates.map( gate => {
 					return <ContentGateSettings key={ gate.id } gate={ gate } updateGatesData={ updateGatesData } />;

--- a/src/wizards/audience/views/content-gates/content-gates.tsx
+++ b/src/wizards/audience/views/content-gates/content-gates.tsx
@@ -75,43 +75,6 @@ const ContentGates = ( { updateGatesData }: { updateGatesData: ( gates: Gate[] )
 		} );
 	}, [ isInFlight, gates ] );
 
-	const handleCreateGate = () => {
-		if ( isInFlight ) {
-			return;
-		}
-		resetError();
-		setIsInFlight( true );
-		wizardApiFetch< Gate >(
-			{
-				path: `/newspack/v1/wizard/${ AUDIENCE_CONTENT_GATES_WIZARD_SLUG }`,
-				method: 'POST',
-				data: {
-					gate: {
-						title: newGateName,
-						status: 'draft',
-					},
-				},
-			},
-			{
-				onSuccess( data ) {
-					const newGates = [
-						...gates.map( g => {
-							g.isExpanded = false;
-							return g;
-						} ),
-						{ ...data, isExpanded: true },
-					];
-					updateGatesData( newGates );
-					setShowModal( false );
-					setNewGateName( '' );
-				},
-				onFinally() {
-					setIsInFlight( false );
-				},
-			}
-		);
-	};
-
 	const toggleStatus = ( id: number ) => {
 		if ( isFetching ) {
 			return;
@@ -194,7 +157,7 @@ const ContentGates = ( { updateGatesData }: { updateGatesData: ( gates: Gate[] )
 	}
 
 	return (
-		<VStack className="newspack-content-gates__gates" spacing="16px">
+		<>
 			{ error && <Notice isError noticeText={ errorMessage } /> }
 			{ showModal && (
 				<Modal isNarrow title={ __( 'Add Content Gate', 'newspack-plugin' ) } onRequestClose={ () => setShowModal( false ) }>
@@ -206,12 +169,11 @@ const ContentGates = ( { updateGatesData }: { updateGatesData: ( gates: Gate[] )
 						onKeyUp={ ( event: KeyboardEvent ) => {
 							if ( ENTER === event.keyCode && '' !== newGateName ) {
 								event.preventDefault();
-								handleCreateGate();
 							}
 						} }
 					/>
 					<Card buttonsCard noBorder className="justify-end">
-						<Button variant="primary" onClick={ handleCreateGate } disabled={ isInFlight }>
+						<Button variant="primary" onClick={ () => {} } disabled={ isInFlight }>
 							{ __( 'Add Content Gate', 'newspack-plugin' ) }
 						</Button>
 						<Button disabled={ isInFlight } isDestructive variant="secondary" onClick={ () => setShowModal( false ) }>
@@ -220,7 +182,7 @@ const ContentGates = ( { updateGatesData }: { updateGatesData: ( gates: Gate[] )
 					</Card>
 				</Modal>
 			) }
-			<div ref={ ref }>
+			<VStack className="newspack-content-gates__gates" spacing="16px" ref={ ref }>
 				{ gates.map( ( gate, index ) => {
 					const reorderGates = ( targetIndex: number ) => {
 						const sortedGates = [ ...gates ];
@@ -244,6 +206,7 @@ const ContentGates = ( { updateGatesData }: { updateGatesData: ( gates: Gate[] )
 							isSmall
 							__experimentalCoreCard
 							__experimentalCoreProps={ {
+								noMargin: true,
 								header: (
 									<>
 										<h3>
@@ -279,8 +242,8 @@ const ContentGates = ( { updateGatesData }: { updateGatesData: ( gates: Gate[] )
 						</Card>
 					);
 				} ) }
-			</div>
-		</VStack>
+			</VStack>
+		</>
 	);
 };
 export default ContentGates;

--- a/src/wizards/audience/views/content-gates/content-gates.tsx
+++ b/src/wizards/audience/views/content-gates/content-gates.tsx
@@ -6,6 +6,7 @@
  * WordPress dependencies.
  */
 import apiFetch from '@wordpress/api-fetch';
+import { useDispatch } from '@wordpress/data';
 import { useEffect, useRef, useState } from '@wordpress/element';
 import { ENTER } from '@wordpress/keycodes';
 import { __ } from '@wordpress/i18n';
@@ -13,9 +14,10 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { Button, Card, Modal, Notice, SectionHeader, TextControl } from '../../../../../packages/components/src';
+import { Button, Card, Modal, Notice, TextControl } from '../../../../../packages/components/src';
 import { useWizardData } from '../../../../../packages/components/src/wizard/store/utils';
 import { useWizardApiFetch } from '../../../hooks/use-wizard-api-fetch';
+import { WIZARD_STORE_NAMESPACE } from '../../../../../packages/components/src/wizard/store';
 import WizardsActionCard from '../../../wizards-action-card';
 import ContentGatesOnboarding from './content-gates-onboarding';
 import ContentGateSettings from './content-gate-settings';
@@ -25,23 +27,14 @@ import './style.scss';
 
 const ContentGates = ( { updateGatesData }: { updateGatesData: ( gates: Gate[] ) => void } ) => {
 	const wizardData = useWizardData( AUDIENCE_CONTENT_GATES_WIZARD_SLUG ) as WizardData;
-	const { wizardApiFetch, isFetching, errorMessage, resetError } = useWizardApiFetch( AUDIENCE_CONTENT_GATES_WIZARD_SLUG );
+	const { wizardApiFetch, isFetching, error, errorMessage, resetError, setError } = useWizardApiFetch( AUDIENCE_CONTENT_GATES_WIZARD_SLUG );
+	const { setHeaderData } = useDispatch( WIZARD_STORE_NAMESPACE );
 	const [ showModal, setShowModal ] = useState( false );
 	const [ newGateName, setNewGateName ] = useState( '' );
 	const [ isInFlight, setIsInFlight ] = useState( false );
-	const [ error, setError ] = useState< string | null >( null );
 	const ref = useRef( null );
 
 	const gates = ( wizardData?.gates || [] ) as Gate[];
-
-	const resetErrors = () => {
-		setError( null );
-		resetError();
-	};
-
-	useEffect( () => {
-		resetErrors();
-	}, [] );
 
 	useEffect( () => {
 		if ( isFetching ) {
@@ -52,16 +45,26 @@ const ContentGates = ( { updateGatesData }: { updateGatesData: ( gates: Gate[] )
 	}, [ isFetching ] );
 
 	useEffect( () => {
-		if ( errorMessage ) {
-			setError( errorMessage );
+		if ( isInFlight || ! gates?.length ) {
+			return;
 		}
-	}, [ errorMessage ] );
+		setHeaderData( {
+			sectionPrimaryAction: {
+				label: __( 'Add new content gate', 'newspack-plugin' ),
+				href: '#/edit/new/all',
+			},
+			sectionSecondaryAction: {
+				label: __( 'Gate priority', 'newspack-plugin' ),
+				action: () => setShowModal( true ),
+			},
+		} );
+	}, [ isInFlight, gates ] );
 
 	const handleCreateGate = () => {
 		if ( isInFlight ) {
 			return;
 		}
-		resetErrors();
+		resetError();
 		setIsInFlight( true );
 		wizardApiFetch< Gate >(
 			{
@@ -102,7 +105,7 @@ const ContentGates = ( { updateGatesData }: { updateGatesData: ( gates: Gate[] )
 				return;
 			}
 		}
-		resetErrors();
+		resetError();
 		wizardApiFetch(
 			{
 				path: `/newspack/v1/wizard/${ AUDIENCE_CONTENT_GATES_WIZARD_SLUG }/${ id }`,
@@ -134,7 +137,7 @@ const ContentGates = ( { updateGatesData }: { updateGatesData: ( gates: Gate[] )
 		const oldGates = [ ...gates ];
 		updateGatesData( updates );
 		setIsInFlight( true );
-		resetErrors();
+		resetError();
 		apiFetch< Gate >( {
 			path: `/newspack/v1/wizard/${ AUDIENCE_CONTENT_GATES_WIZARD_SLUG }/priority`,
 			method: 'POST',
@@ -143,7 +146,7 @@ const ContentGates = ( { updateGatesData }: { updateGatesData: ( gates: Gate[] )
 			},
 		} )
 			.catch( ( fetchError: WpFetchError ) => {
-				setError( fetchError.message );
+				setError( fetchError );
 				updateGatesData( oldGates );
 			} )
 			.finally( () => setIsInFlight( false ) );
@@ -163,12 +166,8 @@ const ContentGates = ( { updateGatesData }: { updateGatesData: ( gates: Gate[] )
 
 	return (
 		<div className="newspack-content-gates__gates">
-			{ error && <Notice isError noticeText={ error } /> }
+			{ error && <Notice isError noticeText={ errorMessage } /> }
 			<Card noBorder headerActions>
-				<SectionHeader heading={ 1 } title={ __( 'Content Gates', 'newspack-plugin' ) } noMargin />
-				<Button variant="secondary" onClick={ () => setShowModal( true ) }>
-					{ __( 'Add Content Gate', 'newspack-plugin' ) }
-				</Button>
 				{ showModal && (
 					<Modal isNarrow title={ __( 'Add Content Gate', 'newspack-plugin' ) } onRequestClose={ () => setShowModal( false ) }>
 						<TextControl

--- a/src/wizards/audience/views/content-gates/content-gates.tsx
+++ b/src/wizards/audience/views/content-gates/content-gates.tsx
@@ -66,7 +66,13 @@ const ContentGates = ( { updateGatesData }: { updateGatesData: ( gates: Gate[] )
 	return (
 		<>
 			{ error && <Notice isError noticeText={ errorMessage } /> }
-			{ showPriorityModal && <ContentGatesPriority closeModal={ () => setShowPriorityModal( false ) } updateGatesData={ updateGatesData } /> }
+			{
+				<ContentGatesPriority
+					showModal={ showPriorityModal }
+					closeModal={ () => setShowPriorityModal( false ) }
+					updateGatesData={ updateGatesData }
+				/>
+			}
 			<VStack className="newspack-content-gates__gates" spacing="16px" ref={ ref }>
 				{ gates.map( gate => {
 					return <ContentGateSettings key={ gate.id } gate={ gate } updateGatesData={ updateGatesData } />;

--- a/src/wizards/audience/views/content-gates/content-gates.tsx
+++ b/src/wizards/audience/views/content-gates/content-gates.tsx
@@ -6,6 +6,7 @@
  * WordPress dependencies.
  */
 import apiFetch from '@wordpress/api-fetch';
+import { CardBody, __experimentalVStack as VStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { useDispatch } from '@wordpress/data';
 import { useEffect, useRef, useState } from '@wordpress/element';
 import { ENTER } from '@wordpress/keycodes';
@@ -14,18 +15,20 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { Button, Card, Modal, Notice, TextControl } from '../../../../../packages/components/src';
+import { Badge, Button, Card, Modal, Notice, Router, TextControl } from '../../../../../packages/components/src';
 import { useWizardData } from '../../../../../packages/components/src/wizard/store/utils';
 import { useWizardApiFetch } from '../../../hooks/use-wizard-api-fetch';
 import { WIZARD_STORE_NAMESPACE } from '../../../../../packages/components/src/wizard/store';
-import WizardsActionCard from '../../../wizards-action-card';
 import ContentGatesOnboarding from './content-gates-onboarding';
 import ContentGateSettings from './content-gate-settings';
 import { AUDIENCE_CONTENT_GATES_WIZARD_SLUG } from './consts';
 import { getGateStatus, getGateStatusBadgeLevel } from './utils';
 import './style.scss';
 
+const { useHistory } = Router;
+
 const ContentGates = ( { updateGatesData }: { updateGatesData: ( gates: Gate[] ) => void } ) => {
+	const history = useHistory();
 	const wizardData = useWizardData( AUDIENCE_CONTENT_GATES_WIZARD_SLUG ) as WizardData;
 	const { wizardApiFetch, isFetching, error, errorMessage, resetError, setError } = useWizardApiFetch( AUDIENCE_CONTENT_GATES_WIZARD_SLUG );
 	const { setHeaderData } = useDispatch( WIZARD_STORE_NAMESPACE );
@@ -165,38 +168,31 @@ const ContentGates = ( { updateGatesData }: { updateGatesData: ( gates: Gate[] )
 	}
 
 	return (
-		<div className="newspack-content-gates__gates">
+		<VStack className="newspack-content-gates__gates" spacing="16px">
 			{ error && <Notice isError noticeText={ errorMessage } /> }
-			<Card noBorder headerActions>
-				{ showModal && (
-					<Modal isNarrow title={ __( 'Add Content Gate', 'newspack-plugin' ) } onRequestClose={ () => setShowModal( false ) }>
-						<TextControl
-							disabled={ isInFlight }
-							label={ __( 'Name', 'newspack-plugin' ) }
-							placeholder={ __( 'Enter a name for the content gate', 'newspack-plugin' ) }
-							onChange={ ( value: string ) => setNewGateName( value ) }
-							onKeyUp={ ( event: KeyboardEvent ) => {
-								if ( ENTER === event.keyCode && '' !== newGateName ) {
-									event.preventDefault();
-									handleCreateGate();
-								}
-							} }
-						/>
-						<Card buttonsCard noBorder className="justify-end">
-							<Button variant="primary" onClick={ handleCreateGate } disabled={ isInFlight }>
-								{ __( 'Add Content Gate', 'newspack-plugin' ) }
-							</Button>
-							<Button disabled={ isInFlight } isDestructive variant="secondary" onClick={ () => setShowModal( false ) }>
-								{ __( 'Cancel', 'newspack-plugin' ) }
-							</Button>
-						</Card>
-					</Modal>
-				) }
-			</Card>
-			{ gates.length === 0 && (
-				<Card noBorder>
-					<p>{ __( 'No content gates configured. Add a content gate to configure access rules.', 'newspack-plugin' ) }</p>
-				</Card>
+			{ showModal && (
+				<Modal isNarrow title={ __( 'Add Content Gate', 'newspack-plugin' ) } onRequestClose={ () => setShowModal( false ) }>
+					<TextControl
+						disabled={ isInFlight }
+						label={ __( 'Name', 'newspack-plugin' ) }
+						placeholder={ __( 'Enter a name for the content gate', 'newspack-plugin' ) }
+						onChange={ ( value: string ) => setNewGateName( value ) }
+						onKeyUp={ ( event: KeyboardEvent ) => {
+							if ( ENTER === event.keyCode && '' !== newGateName ) {
+								event.preventDefault();
+								handleCreateGate();
+							}
+						} }
+					/>
+					<Card buttonsCard noBorder className="justify-end">
+						<Button variant="primary" onClick={ handleCreateGate } disabled={ isInFlight }>
+							{ __( 'Add Content Gate', 'newspack-plugin' ) }
+						</Button>
+						<Button disabled={ isInFlight } isDestructive variant="secondary" onClick={ () => setShowModal( false ) }>
+							{ __( 'Cancel', 'newspack-plugin' ) }
+						</Button>
+					</Card>
+				</Modal>
 			) }
 			<div ref={ ref }>
 				{ gates.map( ( gate, index ) => {
@@ -215,30 +211,50 @@ const ContentGates = ( { updateGatesData }: { updateGatesData: ( gates: Gate[] )
 						}
 					};
 					return (
-						<WizardsActionCard
+						<Card
 							className="newspack-content-gates__gate"
-							draggable={ gates.length > 1 }
-							expandable
-							isExpanded={ gate.isExpanded || gates.length === 1 }
 							id={ gate.id }
 							key={ gate.id }
-							title={ gate.title }
-							titleLink={ `#/edit/${ gate.id }` }
-							isMedium={ gates.length > 1 }
-							toggleChecked={ true }
-							dragIndex={ index }
-							dragWrapperRef={ ref }
-							onDragCallback={ reorderGates }
-							disabled={ isInFlight }
-							badge={ getGateStatus( gate.status ) }
-							badgeLevel={ getGateStatusBadgeLevel( gate.status ) }
+							isSmall
+							__experimentalCoreCard
+							__experimentalCoreProps={ {
+								header: (
+									<>
+										<h3>
+											{ gate.title }
+											<Badge level={ getGateStatusBadgeLevel( gate.status ) } text={ getGateStatus( gate.status ) } />
+										</h3>
+									</>
+								),
+								actions: [
+									{
+										label: __( 'Edit', 'newspack-plugin' ),
+										action: () => history.push( `/edit/${ gate.id }` ),
+										disabled: isFetching,
+									},
+									{
+										label:
+											gate.status !== 'publish' ? __( 'Activate', 'newspack-plugin' ) : __( 'Deactivate', 'newspack-plugin' ),
+										action: () => console.log( gate.status ),
+										disabled: isFetching,
+									},
+									{
+										label: __( 'Delete', 'newspack-plugin' ),
+										action: () => handleDeleteGate( gate.id ),
+										disabled: isFetching,
+										destructive: true,
+									},
+								],
+							} }
 						>
-							<ContentGateSettings gate={ gate } onDelete={ handleDeleteGate } onSave={ handleSaveGate } />
-						</WizardsActionCard>
+							<CardBody>
+								<ContentGateSettings gate={ gate } onDelete={ handleDeleteGate } onSave={ handleSaveGate } />
+							</CardBody>
+						</Card>
 					);
 				} ) }
 			</div>
-		</div>
+		</VStack>
 	);
 };
 export default ContentGates;

--- a/src/wizards/audience/views/content-gates/content-gates.tsx
+++ b/src/wizards/audience/views/content-gates/content-gates.tsx
@@ -6,7 +6,6 @@
  * WordPress dependencies.
  */
 import { __ } from '@wordpress/i18n';
-import apiFetch from '@wordpress/api-fetch';
 import { __experimentalVStack as VStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { useDispatch } from '@wordpress/data';
 import { useEffect, useRef, useState } from '@wordpress/element';
@@ -26,11 +25,10 @@ import './style.scss';
 
 const ContentGates = ( { updateGatesData }: { updateGatesData: ( gates: Gate[] ) => void } ) => {
 	const wizardData = useWizardData( AUDIENCE_CONTENT_GATES_WIZARD_SLUG ) as WizardData;
-	const { isFetching, error, errorMessage, resetError, setError } = useWizardApiFetch( AUDIENCE_CONTENT_GATES_WIZARD_SLUG );
+	const { isFetching, error, errorMessage } = useWizardApiFetch( AUDIENCE_CONTENT_GATES_WIZARD_SLUG );
 	const { resetHeaderData, setHeaderData } = useDispatch( WIZARD_STORE_NAMESPACE );
 	const [ showModal, setShowModal ] = useState( false );
 	const [ newGateName, setNewGateName ] = useState( '' );
-	const [ isInFlight, setIsInFlight ] = useState( false );
 	const ref = useRef( null );
 	const gates = ( wizardData?.gates || [] ) as Gate[];
 
@@ -62,26 +60,6 @@ const ContentGates = ( { updateGatesData }: { updateGatesData: ( gates: Gate[] )
 		} );
 	}, [ isFetching, gates ] );
 
-	const handleUpdateGatePriorities = ( updates: Gate[] ) => {
-		if ( isFetching ) {
-			return;
-		}
-		const oldGates = [ ...gates ];
-		updateGatesData( updates );
-		setIsInFlight( true );
-		resetError();
-		apiFetch< Gate >( {
-			path: `/newspack/v1/wizard/${ AUDIENCE_CONTENT_GATES_WIZARD_SLUG }/priority`,
-			method: 'POST',
-			data: {
-				gates: updates.map( g => ( { id: g.id, priority: g.priority } ) ),
-			},
-		} ).catch( ( fetchError: WpFetchError ) => {
-			setError( fetchError );
-			updateGatesData( oldGates );
-		} );
-	};
-
 	if ( ! gates?.length ) {
 		return <ContentGatesOnboarding />;
 	}
@@ -92,7 +70,7 @@ const ContentGates = ( { updateGatesData }: { updateGatesData: ( gates: Gate[] )
 			{ showModal && (
 				<Modal isNarrow title={ __( 'Add Content Gate', 'newspack-plugin' ) } onRequestClose={ () => setShowModal( false ) }>
 					<TextControl
-						disabled={ isInFlight }
+						disabled={ isFetching }
 						label={ __( 'Name', 'newspack-plugin' ) }
 						placeholder={ __( 'Enter a name for the content gate', 'newspack-plugin' ) }
 						onChange={ ( value: string ) => setNewGateName( value ) }
@@ -103,31 +81,17 @@ const ContentGates = ( { updateGatesData }: { updateGatesData: ( gates: Gate[] )
 						} }
 					/>
 					<Card buttonsCard noBorder className="justify-end">
-						<Button variant="primary" onClick={ () => {} } disabled={ isInFlight }>
+						<Button variant="primary" onClick={ () => {} } disabled={ isFetching }>
 							{ __( 'Add Content Gate', 'newspack-plugin' ) }
 						</Button>
-						<Button disabled={ isInFlight } isDestructive variant="secondary" onClick={ () => setShowModal( false ) }>
+						<Button disabled={ isFetching } isDestructive variant="secondary" onClick={ () => setShowModal( false ) }>
 							{ __( 'Cancel', 'newspack-plugin' ) }
 						</Button>
 					</Card>
 				</Modal>
 			) }
 			<VStack className="newspack-content-gates__gates" spacing="16px" ref={ ref }>
-				{ gates.map( ( gate, index ) => {
-					const reorderGates = ( targetIndex: number ) => {
-						const sortedGates = [ ...gates ];
-
-						sortedGates.splice( index, 1 );
-						sortedGates.splice( targetIndex, 0, gate );
-
-						// Reindex priorities to avoid gaps and dupes.
-						sortedGates.forEach( ( g, i ) => ( g.priority = i ) );
-
-						// Only trigger the API request if the order has changed.
-						if ( JSON.stringify( sortedGates ) !== JSON.stringify( gates ) ) {
-							handleUpdateGatePriorities( sortedGates );
-						}
-					};
+				{ gates.map( gate => {
 					return <ContentGateSettings key={ gate.id } gate={ gate } updateGatesData={ updateGatesData } />;
 				} ) }
 			</VStack>

--- a/src/wizards/audience/views/content-gates/content-gates.tsx
+++ b/src/wizards/audience/views/content-gates/content-gates.tsx
@@ -7,7 +7,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
-import { CardBody, __experimentalVStack as VStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import { __experimentalVStack as VStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { useDispatch } from '@wordpress/data';
 import { useEffect, useRef, useState } from '@wordpress/element';
 import { ENTER } from '@wordpress/keycodes';
@@ -15,40 +15,27 @@ import { ENTER } from '@wordpress/keycodes';
 /**
  * Internal dependencies
  */
-import { Badge, Button, Card, Modal, Notice, Router, TextControl } from '../../../../../packages/components/src';
+import { Button, Card, Modal, Notice, TextControl } from '../../../../../packages/components/src';
 import { useWizardData } from '../../../../../packages/components/src/wizard/store/utils';
 import { useWizardApiFetch } from '../../../hooks/use-wizard-api-fetch';
 import { WIZARD_STORE_NAMESPACE } from '../../../../../packages/components/src/wizard/store';
 import ContentGatesOnboarding from './content-gates-onboarding';
 import ContentGateSettings from './content-gate-settings';
 import { AUDIENCE_CONTENT_GATES_WIZARD_SLUG } from './consts';
-import { getGateStatus, getGateStatusBadgeLevel } from './utils';
 import './style.scss';
 
-const { useHistory } = Router;
-
 const ContentGates = ( { updateGatesData }: { updateGatesData: ( gates: Gate[] ) => void } ) => {
-	const history = useHistory();
 	const wizardData = useWizardData( AUDIENCE_CONTENT_GATES_WIZARD_SLUG ) as WizardData;
-	const { wizardApiFetch, isFetching, error, errorMessage, resetError, setError } = useWizardApiFetch( AUDIENCE_CONTENT_GATES_WIZARD_SLUG );
+	const { isFetching, error, errorMessage, resetError, setError } = useWizardApiFetch( AUDIENCE_CONTENT_GATES_WIZARD_SLUG );
 	const { resetHeaderData, setHeaderData } = useDispatch( WIZARD_STORE_NAMESPACE );
 	const [ showModal, setShowModal ] = useState( false );
 	const [ newGateName, setNewGateName ] = useState( '' );
 	const [ isInFlight, setIsInFlight ] = useState( false );
 	const ref = useRef( null );
-
 	const gates = ( wizardData?.gates || [] ) as Gate[];
 
 	useEffect( () => {
 		if ( isFetching ) {
-			setIsInFlight( true );
-		} else {
-			setIsInFlight( false );
-		}
-	}, [ isFetching ] );
-
-	useEffect( () => {
-		if ( isInFlight ) {
 			return;
 		}
 		if ( ! gates?.length ) {
@@ -73,57 +60,10 @@ const ContentGates = ( { updateGatesData }: { updateGatesData: ( gates: Gate[] )
 					  }
 					: undefined,
 		} );
-	}, [ isInFlight, gates ] );
-
-	const toggleStatus = ( id: number ) => {
-		if ( isFetching ) {
-			return;
-		}
-		resetError();
-		const gate = gates.find( g => g.id === id );
-		if ( ! gate ) {
-			return;
-		}
-		const _gate = {
-			...gate,
-			status: gate.status === 'publish' ? 'draft' : 'publish',
-		};
-		wizardApiFetch< Gate >(
-			{
-				path: `/newspack/v1/wizard/${ AUDIENCE_CONTENT_GATES_WIZARD_SLUG }/${ gate.id }`,
-				method: 'POST',
-				data: { gate: _gate },
-			},
-			{
-				onSuccess( data: Gate ) {
-					updateGatesData( gates.map( g => ( g.id === data.id ? data : g ) ) );
-				},
-			}
-		);
-	};
-
-	const handleDelete = ( id: number ) => {
-		// eslint-disable-next-line no-alert
-		if ( ! confirm( __( 'Are you sure you want to permanently delete this content gate?', 'newspack-plugin' ) ) ) {
-			return;
-		}
-		resetError();
-		wizardApiFetch(
-			{
-				path: `/newspack/v1/wizard/${ AUDIENCE_CONTENT_GATES_WIZARD_SLUG }/${ id }`,
-				method: 'DELETE',
-			},
-			{
-				onSuccess() {
-					const newGates = gates.filter( g => g.id !== id );
-					updateGatesData( newGates );
-				},
-			}
-		);
-	};
+	}, [ isFetching, gates ] );
 
 	const handleUpdateGatePriorities = ( updates: Gate[] ) => {
-		if ( isInFlight ) {
+		if ( isFetching ) {
 			return;
 		}
 		const oldGates = [ ...gates ];
@@ -136,20 +76,10 @@ const ContentGates = ( { updateGatesData }: { updateGatesData: ( gates: Gate[] )
 			data: {
 				gates: updates.map( g => ( { id: g.id, priority: g.priority } ) ),
 			},
-		} )
-			.catch( ( fetchError: WpFetchError ) => {
-				setError( fetchError );
-				updateGatesData( oldGates );
-			} )
-			.finally( () => setIsInFlight( false ) );
-	};
-
-	const handleSaveGate = ( gate: Gate ) => {
-		if ( isInFlight ) {
-			return;
-		}
-		const newGates = gates.map( g => ( g.id === gate.id ? gate : g ) );
-		updateGatesData( newGates );
+		} ).catch( ( fetchError: WpFetchError ) => {
+			setError( fetchError );
+			updateGatesData( oldGates );
+		} );
 	};
 
 	if ( ! gates?.length ) {
@@ -198,49 +128,7 @@ const ContentGates = ( { updateGatesData }: { updateGatesData: ( gates: Gate[] )
 							handleUpdateGatePriorities( sortedGates );
 						}
 					};
-					return (
-						<Card
-							className="newspack-content-gates__gate"
-							id={ gate.id }
-							key={ gate.id }
-							isSmall
-							__experimentalCoreCard
-							__experimentalCoreProps={ {
-								noMargin: true,
-								header: (
-									<>
-										<h3>
-											{ gate.title }
-											<Badge level={ getGateStatusBadgeLevel( gate.status ) } text={ getGateStatus( gate.status ) } />
-										</h3>
-									</>
-								),
-								actions: [
-									{
-										label: __( 'Edit', 'newspack-plugin' ),
-										action: () => history.push( `/edit/${ gate.id }` ),
-										disabled: isFetching,
-									},
-									{
-										label:
-											gate.status !== 'publish' ? __( 'Activate', 'newspack-plugin' ) : __( 'Deactivate', 'newspack-plugin' ),
-										action: () => toggleStatus( gate.id ),
-										disabled: isFetching,
-									},
-									{
-										label: __( 'Delete', 'newspack-plugin' ),
-										action: () => handleDelete( gate.id ),
-										disabled: isFetching,
-										destructive: true,
-									},
-								],
-							} }
-						>
-							<CardBody>
-								<ContentGateSettings gate={ gate } onDelete={ handleDelete } onSave={ handleSaveGate } />
-							</CardBody>
-						</Card>
-					);
+					return <ContentGateSettings key={ gate.id } gate={ gate } updateGatesData={ updateGatesData } />;
 				} ) }
 			</VStack>
 		</>

--- a/src/wizards/audience/views/content-gates/content-gates.tsx
+++ b/src/wizards/audience/views/content-gates/content-gates.tsx
@@ -68,7 +68,7 @@ const ContentGates = ( { updateGatesData }: { updateGatesData: ( gates: Gate[] )
 		<>
 			{ error && <Notice isError noticeText={ errorMessage } /> }
 			{ showModal && (
-				<Modal isNarrow title={ __( 'Add Content Gate', 'newspack-plugin' ) } onRequestClose={ () => setShowModal( false ) }>
+				<Modal size="small" title={ __( 'Add Content Gate', 'newspack-plugin' ) } onRequestClose={ () => setShowModal( false ) }>
 					<TextControl
 						disabled={ isFetching }
 						label={ __( 'Name', 'newspack-plugin' ) }

--- a/src/wizards/audience/views/content-gates/content-gates.tsx
+++ b/src/wizards/audience/views/content-gates/content-gates.tsx
@@ -31,7 +31,7 @@ const ContentGates = ( { updateGatesData }: { updateGatesData: ( gates: Gate[] )
 	const history = useHistory();
 	const wizardData = useWizardData( AUDIENCE_CONTENT_GATES_WIZARD_SLUG ) as WizardData;
 	const { wizardApiFetch, isFetching, error, errorMessage, resetError, setError } = useWizardApiFetch( AUDIENCE_CONTENT_GATES_WIZARD_SLUG );
-	const { setHeaderData } = useDispatch( WIZARD_STORE_NAMESPACE );
+	const { resetHeaderData, setHeaderData } = useDispatch( WIZARD_STORE_NAMESPACE );
 	const [ showModal, setShowModal ] = useState( false );
 	const [ newGateName, setNewGateName ] = useState( '' );
 	const [ isInFlight, setIsInFlight ] = useState( false );
@@ -48,18 +48,30 @@ const ContentGates = ( { updateGatesData }: { updateGatesData: ( gates: Gate[] )
 	}, [ isFetching ] );
 
 	useEffect( () => {
-		if ( isInFlight || ! gates?.length ) {
+		if ( isInFlight ) {
+			return;
+		}
+		if ( ! gates?.length ) {
+			resetHeaderData();
 			return;
 		}
 		setHeaderData( {
+			sectionTitle: __( 'Access control', 'newspack-plugin' ),
+			sectionDescription: __(
+				'Set up gates to manage what content readers can access across your site. Start by selecting which content to restrict, then configure access through registered and/or paid options (including metered rules).',
+				'newspack-plugin'
+			),
 			sectionPrimaryAction: {
 				label: __( 'Add new content gate', 'newspack-plugin' ),
 				href: '#/edit/new/all',
 			},
-			sectionSecondaryAction: {
-				label: __( 'Gate priority', 'newspack-plugin' ),
-				action: () => setShowModal( true ),
-			},
+			sectionSecondaryAction:
+				gates.length > 1
+					? {
+							label: __( 'Gate priority', 'newspack-plugin' ),
+							action: () => setShowModal( true ),
+					  }
+					: undefined,
 		} );
 	}, [ isInFlight, gates ] );
 
@@ -100,13 +112,37 @@ const ContentGates = ( { updateGatesData }: { updateGatesData: ( gates: Gate[] )
 		);
 	};
 
-	const handleDeleteGate = ( id: number ) => {
-		const currentStatus = gates.find( g => g.id === id )?.status;
-		if ( currentStatus === 'trash' ) {
-			// eslint-disable-next-line no-alert
-			if ( ! confirm( __( 'Are you sure you want to permanently delete this content gate?', 'newspack-plugin' ) ) ) {
-				return;
+	const toggleStatus = ( id: number ) => {
+		if ( isFetching ) {
+			return;
+		}
+		resetError();
+		const gate = gates.find( g => g.id === id );
+		if ( ! gate ) {
+			return;
+		}
+		const _gate = {
+			...gate,
+			status: gate.status === 'publish' ? 'draft' : 'publish',
+		};
+		wizardApiFetch< Gate >(
+			{
+				path: `/newspack/v1/wizard/${ AUDIENCE_CONTENT_GATES_WIZARD_SLUG }/${ gate.id }`,
+				method: 'POST',
+				data: { gate: _gate },
+			},
+			{
+				onSuccess( data: Gate ) {
+					updateGatesData( gates.map( g => ( g.id === data.id ? data : g ) ) );
+				},
 			}
+		);
+	};
+
+	const handleDelete = ( id: number ) => {
+		// eslint-disable-next-line no-alert
+		if ( ! confirm( __( 'Are you sure you want to permanently delete this content gate?', 'newspack-plugin' ) ) ) {
+			return;
 		}
 		resetError();
 		wizardApiFetch(
@@ -116,18 +152,8 @@ const ContentGates = ( { updateGatesData }: { updateGatesData: ( gates: Gate[] )
 			},
 			{
 				onSuccess() {
-					if ( currentStatus === 'trash' ) {
-						const newGates = gates.filter( g => g.id !== id );
-						updateGatesData( newGates );
-					} else {
-						const newGates = gates.map( g => {
-							if ( g.id === id ) {
-								g.status = 'trash';
-							}
-							return g;
-						} );
-						updateGatesData( newGates );
-					}
+					const newGates = gates.filter( g => g.id !== id );
+					updateGatesData( newGates );
 				},
 			}
 		);
@@ -235,12 +261,12 @@ const ContentGates = ( { updateGatesData }: { updateGatesData: ( gates: Gate[] )
 									{
 										label:
 											gate.status !== 'publish' ? __( 'Activate', 'newspack-plugin' ) : __( 'Deactivate', 'newspack-plugin' ),
-										action: () => console.log( gate.status ),
+										action: () => toggleStatus( gate.id ),
 										disabled: isFetching,
 									},
 									{
 										label: __( 'Delete', 'newspack-plugin' ),
-										action: () => handleDeleteGate( gate.id ),
+										action: () => handleDelete( gate.id ),
 										disabled: isFetching,
 										destructive: true,
 									},
@@ -248,7 +274,7 @@ const ContentGates = ( { updateGatesData }: { updateGatesData: ( gates: Gate[] )
 							} }
 						>
 							<CardBody>
-								<ContentGateSettings gate={ gate } onDelete={ handleDeleteGate } onSave={ handleSaveGate } />
+								<ContentGateSettings gate={ gate } onDelete={ handleDelete } onSave={ handleSaveGate } />
 							</CardBody>
 						</Card>
 					);

--- a/src/wizards/audience/views/content-gates/content-gates.tsx
+++ b/src/wizards/audience/views/content-gates/content-gates.tsx
@@ -9,16 +9,16 @@ import { __ } from '@wordpress/i18n';
 import { __experimentalVStack as VStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { useDispatch } from '@wordpress/data';
 import { useEffect, useRef, useState } from '@wordpress/element';
-import { ENTER } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
  */
-import { Button, Card, Modal, Notice, TextControl } from '../../../../../packages/components/src';
+import { Notice } from '../../../../../packages/components/src';
 import { useWizardData } from '../../../../../packages/components/src/wizard/store/utils';
 import { useWizardApiFetch } from '../../../hooks/use-wizard-api-fetch';
 import { WIZARD_STORE_NAMESPACE } from '../../../../../packages/components/src/wizard/store';
 import ContentGatesOnboarding from './content-gates-onboarding';
+import ContentGatesPriority from './content-gates-priority';
 import ContentGateSettings from './content-gate-settings';
 import { AUDIENCE_CONTENT_GATES_WIZARD_SLUG } from './consts';
 import './style.scss';
@@ -27,8 +27,7 @@ const ContentGates = ( { updateGatesData }: { updateGatesData: ( gates: Gate[] )
 	const wizardData = useWizardData( AUDIENCE_CONTENT_GATES_WIZARD_SLUG ) as WizardData;
 	const { isFetching, error, errorMessage } = useWizardApiFetch( AUDIENCE_CONTENT_GATES_WIZARD_SLUG );
 	const { resetHeaderData, setHeaderData } = useDispatch( WIZARD_STORE_NAMESPACE );
-	const [ showModal, setShowModal ] = useState( false );
-	const [ newGateName, setNewGateName ] = useState( '' );
+	const [ showPriorityModal, setShowPriorityModal ] = useState( false );
 	const ref = useRef( null );
 	const gates = ( wizardData?.gates || [] ) as Gate[];
 
@@ -54,7 +53,7 @@ const ContentGates = ( { updateGatesData }: { updateGatesData: ( gates: Gate[] )
 				gates.length > 1
 					? {
 							label: __( 'Gate priority', 'newspack-plugin' ),
-							action: () => setShowModal( true ),
+							action: () => setShowPriorityModal( true ),
 					  }
 					: undefined,
 		} );
@@ -67,29 +66,7 @@ const ContentGates = ( { updateGatesData }: { updateGatesData: ( gates: Gate[] )
 	return (
 		<>
 			{ error && <Notice isError noticeText={ errorMessage } /> }
-			{ showModal && (
-				<Modal isNarrow title={ __( 'Add Content Gate', 'newspack-plugin' ) } onRequestClose={ () => setShowModal( false ) }>
-					<TextControl
-						disabled={ isFetching }
-						label={ __( 'Name', 'newspack-plugin' ) }
-						placeholder={ __( 'Enter a name for the content gate', 'newspack-plugin' ) }
-						onChange={ ( value: string ) => setNewGateName( value ) }
-						onKeyUp={ ( event: KeyboardEvent ) => {
-							if ( ENTER === event.keyCode && '' !== newGateName ) {
-								event.preventDefault();
-							}
-						} }
-					/>
-					<Card buttonsCard noBorder className="justify-end">
-						<Button variant="primary" onClick={ () => {} } disabled={ isFetching }>
-							{ __( 'Add Content Gate', 'newspack-plugin' ) }
-						</Button>
-						<Button disabled={ isFetching } isDestructive variant="secondary" onClick={ () => setShowModal( false ) }>
-							{ __( 'Cancel', 'newspack-plugin' ) }
-						</Button>
-					</Card>
-				</Modal>
-			) }
+			{ showPriorityModal && <ContentGatesPriority closeModal={ () => setShowPriorityModal( false ) } updateGatesData={ updateGatesData } /> }
 			<VStack className="newspack-content-gates__gates" spacing="16px" ref={ ref }>
 				{ gates.map( gate => {
 					return <ContentGateSettings key={ gate.id } gate={ gate } updateGatesData={ updateGatesData } />;

--- a/src/wizards/audience/views/content-gates/edit/access-rule.tsx
+++ b/src/wizards/audience/views/content-gates/edit/access-rule.tsx
@@ -12,7 +12,7 @@ import { CardBody, ToggleControl } from '@wordpress/components';
  */
 import AccessRuleControl from './access-rule-control';
 
-export default function AccessRule( { config, enabled, onToggle = () => {}, rule, slug, onChange }: GateRuleProps ) {
+export default function AccessRule( { config, enabled, onToggle = () => {}, rule, slug, onChange }: GateAccessRuleProps ) {
 	return (
 		<CardBody size="small">
 			<ToggleControl label={ config.name } help={ config.description } checked={ enabled } onChange={ () => onToggle( slug ) } />

--- a/src/wizards/audience/views/content-gates/edit/content-rule-control-taxonomy.tsx
+++ b/src/wizards/audience/views/content-gates/edit/content-rule-control-taxonomy.tsx
@@ -5,7 +5,7 @@
 /**
  * WordPress dependencies.
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { FormTokenField } from '@wordpress/components';
 import type { TokenItem } from '@wordpress/components/build-types/form-token-field/types.d.ts';
 import apiFetch from '@wordpress/api-fetch';
@@ -21,7 +21,7 @@ const debounce = ( func: ( search?: string ) => void, wait: number ) => {
 	};
 };
 
-export default function ContentRuleControlTaxonomy( { slug, value, onChange }: GateRuleControlProps ) {
+export default function ContentRuleControlTaxonomy( { slug, value, exclusion, onChange, isStatic = false }: GateRuleControlProps ) {
 	const rule = useMemo( () => window.newspackAudienceContentGates.available_content_rules[ slug ], [ slug ] );
 
 	const [ savedItems, setSavedItems ] = useState< { value: string; label: string }[] >( [] );
@@ -107,6 +107,15 @@ export default function ContentRuleControlTaxonomy( { slug, value, onChange }: G
 		return [ ...new Set( result ) ];
 	}, [ value, savedItems, suggestions ] );
 
+	const staticLabels = useMemo( () => {
+		return tokens.length === 0
+			? '-'
+			: tokens
+					.map( token => token.split( ':' ).slice( 1 ).join( ':' ).trim() )
+					.filter( label => label.length > 0 )
+					.join( ', ' );
+	}, [ tokens ] );
+
 	const handleChange = useCallback(
 		( newTokens: ( string | TokenItem )[] ) => {
 			const items = [ ...savedItems, ...suggestions ];
@@ -128,15 +137,33 @@ export default function ContentRuleControlTaxonomy( { slug, value, onChange }: G
 		return null;
 	}
 
+	if ( isStatic ) {
+		return (
+			<p>
+				<strong>
+					{ sprintf(
+						// translators: 1: rule name, 2: includes or excludes
+						__( '%1$s %2$s:', 'newspack-plugin' ),
+						rule.name,
+						exclusion ? __( 'exclude', 'newspack-plugin' ) : __( 'include', 'newspack-plugin' )
+					) }
+				</strong>{ ' ' }
+				{ staticLabels }
+			</p>
+		);
+	}
+
 	return (
-		<FormTokenField
-			label={ '' }
-			suggestions={ suggestions.map( s => `${ s.value }: ${ s.label }` ) }
-			onInputChange={ handleInputChange }
-			value={ tokens }
-			onChange={ handleChange }
-			__experimentalExpandOnFocus
-			__next40pxDefaultSize
-		/>
+		<>
+			<FormTokenField
+				label={ '' }
+				suggestions={ suggestions.map( s => `${ s.value }: ${ s.label }` ) }
+				onInputChange={ handleInputChange }
+				value={ tokens }
+				onChange={ handleChange }
+				__experimentalExpandOnFocus
+				__next40pxDefaultSize
+			/>
+		</>
 	);
 }

--- a/src/wizards/audience/views/content-gates/edit/content-rule-control.tsx
+++ b/src/wizards/audience/views/content-gates/edit/content-rule-control.tsx
@@ -5,7 +5,7 @@
 /**
  * WordPress dependencies.
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import {
 	CheckboxControl,
 	__experimentalToggleGroupControl as ToggleGroupControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
@@ -18,11 +18,28 @@ import {
 import ContentRuleControlTaxonomy from './content-rule-control-taxonomy';
 import { Grid } from '../../../../../../packages/components/src';
 
-export default function ContentRuleControl( { slug, value, exclusion, onChange, onChangeExclusion }: GateRuleControlProps ) {
+export default function ContentRuleControl( { slug, value, exclusion, onChange, onChangeExclusion, isStatic = false }: GateRuleControlProps ) {
 	const rule = window.newspackAudienceContentGates.available_content_rules[ slug ];
 
 	if ( ! rule || ! Array.isArray( value ) ) {
 		return null;
+	}
+	if ( isStatic ) {
+		return rule.options && rule.options.length > 0 ? (
+			<p>
+				<strong>
+					{ sprintf(
+						// translators: 1: rule name, 2: includes or excludes
+						__( '%1$s %2$s:', 'newspack-plugin' ),
+						rule.name,
+						exclusion ? __( 'exclude', 'newspack-plugin' ) : __( 'include', 'newspack-plugin' )
+					) }
+				</strong>{ ' ' }
+				{ value.map( v => rule.options?.find( option => option.value === v )?.label ).join( ', ' ) }
+			</p>
+		) : (
+			<ContentRuleControlTaxonomy slug={ slug } value={ value } exclusion={ exclusion } onChange={ onChange } isStatic={ true } />
+		);
 	}
 	return (
 		<div className="newspack-content-gates__content-rule-control">
@@ -51,7 +68,7 @@ export default function ContentRuleControl( { slug, value, exclusion, onChange, 
 					) ) }
 				</Grid>
 			) : (
-				<ContentRuleControlTaxonomy slug={ slug } value={ value } onChange={ onChange } />
+				<ContentRuleControlTaxonomy slug={ slug } value={ value } onChange={ onChange } exclusion={ exclusion } />
 			) }
 		</div>
 	);

--- a/src/wizards/audience/views/content-gates/edit/content-rule.tsx
+++ b/src/wizards/audience/views/content-gates/edit/content-rule.tsx
@@ -12,13 +12,14 @@ import { CardBody, ToggleControl } from '@wordpress/components';
  */
 import ContentRuleControl from './content-rule-control';
 
-export default function ContentRule( { config, enabled, onToggle = () => {}, rule, slug, onChange, onChangeExclusion }: GateRuleProps ) {
+export default function ContentRule( { config, enabled, onToggle = () => {}, rule, slug, onChange, onChangeExclusion }: GateContentRuleProps ) {
 	return (
 		<CardBody size="small">
 			<ToggleControl label={ config.name } help={ config.description } checked={ enabled } onChange={ () => onToggle( slug ) } />
 			{ enabled && (
 				<ContentRuleControl
 					slug={ slug }
+					exclusion={ rule?.exclusion ?? false }
 					value={ rule?.value ?? config.default }
 					onChange={ onChange }
 					onChangeExclusion={ onChangeExclusion }

--- a/src/wizards/audience/views/content-gates/edit/custom-access.tsx
+++ b/src/wizards/audience/views/content-gates/edit/custom-access.tsx
@@ -1,25 +1,21 @@
 /**
  * WordPress dependencies.
  */
-import { __ } from '@wordpress/i18n';
-import { CardBody, CardDivider } from '@wordpress/components';
+import { CardBody } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-import { Button } from '../../../../../../packages/components/src';
-import { getEditGateLayoutUrl } from '../utils';
 import Metering from './metering';
 import AccessRules from './access-rules';
 
 interface CustomAccessProps {
-	gateId?: number;
 	customAccess: CustomAccess;
 	onChange: ( customAccess: Partial< CustomAccess > ) => void;
 }
 
-export default function CustomAccess( { gateId, customAccess, onChange }: CustomAccessProps ) {
+export default function CustomAccess( { customAccess, onChange }: CustomAccessProps ) {
 	// Get the first group of rules (UI currently only supports a single group).
 	const currentRules = customAccess.access_rules[ 0 ] || [];
 
@@ -46,16 +42,6 @@ export default function CustomAccess( { gateId, customAccess, onChange }: Custom
 
 	return (
 		<>
-			{ gateId ? (
-				<>
-					<CardBody size="small">
-						<Button variant="secondary" href={ getEditGateLayoutUrl( gateId, 'custom_access' ) }>
-							{ __( 'Edit Layout', 'newspack-plugin' ) }
-						</Button>
-					</CardBody>
-					<CardDivider />
-				</>
-			) : null }
 			<AccessRules rules={ currentRules } onChange={ handleRulesChange } />
 			<CardBody size="small">
 				<Metering metering={ customAccess.metering } onChange={ ( metering: Metering ) => handleChange( { metering } ) } />

--- a/src/wizards/audience/views/content-gates/edit/index.tsx
+++ b/src/wizards/audience/views/content-gates/edit/index.tsx
@@ -78,6 +78,7 @@ const Edit = ( { match, updateGatesData }: ContentGateEditProps ) => {
 	const [ status, setStatus ] = useState< GateStatus >( gate.status );
 
 	const isNew = _id === 'new' || ! id;
+	const isSaving = useRef( false );
 
 	const isDirty =
 		isNew ||
@@ -108,6 +109,7 @@ const Edit = ( { match, updateGatesData }: ContentGateEditProps ) => {
 			{
 				onSuccess( data ) {
 					updateGatesData( [ ...gates, { ...data } ] );
+					isSaving.current = true;
 					history.push( `/content-gates` );
 					addNotice( {
 						// translators: %s is the gate title.
@@ -127,7 +129,6 @@ const Edit = ( { match, updateGatesData }: ContentGateEditProps ) => {
 		}
 		resetError();
 		resetNotices();
-		const prevStatus = gate.status;
 		const gateTitle = title || gate.title;
 		const _gate = {
 			...gate,
@@ -146,16 +147,16 @@ const Edit = ( { match, updateGatesData }: ContentGateEditProps ) => {
 			{
 				onSuccess( data: Gate ) {
 					updateGatesData( gates.map( g => ( g.id === data.id ? data : g ) ) );
+					isSaving.current = true;
+					history.push( `/content-gates` );
 					addNotice( {
 						message: sprintf(
-							// translators: 1: the gate title, or "Content" if we can't determine the gate title. 2: the gate status.
-							'%1$s gate %2$s.',
-							gateTitle ? `"${ gateTitle }"` : __( 'Content', 'newspack-plugin' ),
-							prevStatus === 'publish' ? __( 'disabled', 'newspack-plugin' ) : __( 'enabled', 'newspack-plugin' )
+							// translators: %s is the gate title.
+							__( '%s gate updated.', 'newspack-plugin' ),
+							gateTitle ? `"${ gateTitle }"` : __( 'Content', 'newspack-plugin' )
 						),
 						type: 'success',
-						id: 'content-gate-status-changed',
-						actions: [ { label: __( 'Undo', 'newspack-plugin' ), onClick: () => updateStatus.current?.( prevStatus ) } ],
+						id: 'content-gate-updated',
 					} );
 				},
 			}
@@ -357,7 +358,10 @@ const Edit = ( { match, updateGatesData }: ContentGateEditProps ) => {
 
 	return (
 		<div className="newspack-content-gate__edit">
-			<Prompt when={ isDirty } message={ __( 'This gate has unsaved changes. Discard changes?', 'newspack-plugin' ) } />
+			<Prompt
+				when={ isDirty }
+				message={ () => isSaving.current || __( 'This gate has unsaved changes. Discard changes?', 'newspack-plugin' ) }
+			/>
 			{ errorMessage && <Notice isError noticeText={ errorMessage } /> }
 			{ ( isNew || isRenaming ) && (
 				<>

--- a/src/wizards/audience/views/content-gates/edit/index.tsx
+++ b/src/wizards/audience/views/content-gates/edit/index.tsx
@@ -84,7 +84,7 @@ const Edit = ( { history, match, updateGatesData }: ContentGateEditProps ) => {
 		const _gate = {
 			...gate,
 			title,
-			status: 'draft',
+			status: 'publish',
 			content_rules: contentRules,
 			registration,
 			custom_access: customAccess,
@@ -98,7 +98,7 @@ const Edit = ( { history, match, updateGatesData }: ContentGateEditProps ) => {
 			{
 				onSuccess( data ) {
 					updateGatesData( [ ...gates, { ...data } ] );
-					history.push( `/edit/${ data.id }` );
+					history.push( `/content-gates` );
 				},
 			}
 		);
@@ -127,6 +127,7 @@ const Edit = ( { history, match, updateGatesData }: ContentGateEditProps ) => {
 				onSuccess( data: Gate ) {
 					updateGatesData( gates.map( g => ( g.id === data.id ? data : g ) ) );
 					setIsRenaming( false );
+					history.push( `/content-gates` );
 				},
 			}
 		);

--- a/src/wizards/audience/views/content-gates/edit/index.tsx
+++ b/src/wizards/audience/views/content-gates/edit/index.tsx
@@ -199,7 +199,7 @@ const Edit = ( { match, updateGatesData }: ContentGateEditProps ) => {
 					addNotice( {
 						message: sprintf(
 							// translators: 1: the gate title, or "Content" if we can't determine the gate title. 2: the gate status.
-							'%1$s gate %2$s.',
+							__( '%1$s gate %2$s.', 'newspack-plugin' ),
 							gateTitle ? `"${ gateTitle }"` : __( 'Content', 'newspack-plugin' ),
 							prevStatus === 'publish' ? __( 'disabled', 'newspack-plugin' ) : __( 'enabled', 'newspack-plugin' )
 						),

--- a/src/wizards/audience/views/content-gates/edit/index.tsx
+++ b/src/wizards/audience/views/content-gates/edit/index.tsx
@@ -25,7 +25,7 @@ import CustomAccess from './custom-access';
 import { getGateStatus, getGateStatusBadgeLevel } from '../utils';
 import './style.scss';
 
-const { useHistory } = Router;
+const { useHistory, Prompt } = Router;
 
 type ContentGateEditProps = {
 	history: { push: ( path: string ) => void };
@@ -78,6 +78,13 @@ const Edit = ( { match, updateGatesData }: ContentGateEditProps ) => {
 	const [ status, setStatus ] = useState< GateStatus >( gate.status );
 
 	const isNew = _id === 'new' || ! id;
+
+	const isDirty =
+		isNew ||
+		title !== gate.title ||
+		JSON.stringify( contentRules ) !== JSON.stringify( gate.content_rules ) ||
+		JSON.stringify( registration ) !== JSON.stringify( gate.registration ) ||
+		JSON.stringify( customAccess ) !== JSON.stringify( gate.custom_access );
 
 	const handleCreate = useCallback( () => {
 		if ( isFetching ) {
@@ -350,6 +357,7 @@ const Edit = ( { match, updateGatesData }: ContentGateEditProps ) => {
 
 	return (
 		<div className="newspack-content-gate__edit">
+			<Prompt when={ isDirty } message={ __( 'This gate has unsaved changes. Discard changes?', 'newspack-plugin' ) } />
 			{ errorMessage && <Notice isError noticeText={ errorMessage } /> }
 			{ ( isNew || isRenaming ) && (
 				<>

--- a/src/wizards/audience/views/content-gates/edit/index.tsx
+++ b/src/wizards/audience/views/content-gates/edit/index.tsx
@@ -15,7 +15,7 @@ import { commentAuthorAvatar, currencyDollar, postList, settings } from '@wordpr
  * Internal dependencies
  */
 import { AUDIENCE_CONTENT_GATES_WIZARD_SLUG } from '../consts';
-import { CardSettingsGroup, Divider, Grid, Notice, SectionHeader, TextControl } from '../../../../../../packages/components/src';
+import { CardSettingsGroup, Divider, Grid, Notice, Router, SectionHeader, TextControl } from '../../../../../../packages/components/src';
 import { WIZARD_STORE_NAMESPACE } from '../../../../../../packages/components/src/wizard/store';
 import { useWizardData } from '../../../../../../packages/components/src/wizard/store/utils';
 import { useWizardApiFetch } from '../../../../hooks/use-wizard-api-fetch';
@@ -24,6 +24,8 @@ import Registration from './registration';
 import CustomAccess from './custom-access';
 import { getGateStatus, getGateStatusBadgeLevel } from '../utils';
 import './style.scss';
+
+const { useHistory } = Router;
 
 type ContentGateEditProps = {
 	history: { push: ( path: string ) => void };
@@ -58,12 +60,13 @@ const getContentTypeFromRules = ( rules: GateContentRule[] ): 'all' | 'custom' |
 	return 'all';
 };
 
-const Edit = ( { history, match, updateGatesData }: ContentGateEditProps ) => {
+const Edit = ( { match, updateGatesData }: ContentGateEditProps ) => {
+	const history = useHistory();
 	const { id: _id, type } = match.params;
 	const id = _id ? parseInt( _id ) : 0;
 	const { gates = null as unknown as Gate[] } = useWizardData( AUDIENCE_CONTENT_GATES_WIZARD_SLUG ) as WizardData;
 	const { wizardApiFetch, isFetching, errorMessage, resetError, setError } = useWizardApiFetch( AUDIENCE_CONTENT_GATES_WIZARD_SLUG );
-	const { setHeaderData, addNotice } = useDispatch( WIZARD_STORE_NAMESPACE );
+	const { addNotice, resetNotices, setHeaderData } = useDispatch( WIZARD_STORE_NAMESPACE );
 	const [ gate, setGate ] = useState< Gate >( ( gates && gates.find( g => g.id === id ) ) || DEFAULT_GATE ); // eslint-disable-line @typescript-eslint/no-unused-vars
 	const [ title, setTitle ] = useState< string >( gate.title );
 	const [ isRenaming, setIsRenaming ] = useState< boolean >( false );
@@ -80,6 +83,7 @@ const Edit = ( { history, match, updateGatesData }: ContentGateEditProps ) => {
 		if ( isFetching ) {
 			return;
 		}
+		resetNotices();
 		resetError();
 		const _gate = {
 			...gate,
@@ -98,6 +102,12 @@ const Edit = ( { history, match, updateGatesData }: ContentGateEditProps ) => {
 				onSuccess( data ) {
 					updateGatesData( [ ...gates, { ...data } ] );
 					history.push( `/content-gates` );
+					addNotice( {
+						// translators: %s is the gate title.
+						message: sprintf( __( '“%s” gate created.', 'newspack-plugin' ), title ),
+						type: 'success',
+						id: 'content-gate-created',
+					} );
 				},
 			}
 		);
@@ -108,6 +118,7 @@ const Edit = ( { history, match, updateGatesData }: ContentGateEditProps ) => {
 			return;
 		}
 		resetError();
+		resetNotices();
 		const _gate = {
 			...gate,
 			title,
@@ -164,6 +175,12 @@ const Edit = ( { history, match, updateGatesData }: ContentGateEditProps ) => {
 						updateGatesData( newGates );
 						history.push( `/content-gates` );
 						setIsDeleting( false );
+						addNotice( {
+							// translators: %s is the gate title.
+							message: sprintf( __( '“%s” gate deleted.', 'newspack-plugin' ), title ),
+							type: 'success',
+							id: 'content-gate-deleted',
+						} );
 					},
 					onFinally() {
 						setIsDeleting( false );

--- a/src/wizards/audience/views/content-gates/edit/index.tsx
+++ b/src/wizards/audience/views/content-gates/edit/index.tsx
@@ -35,7 +35,7 @@ const DEFAULT_GATE: Gate = {
 	id: 0,
 	title: '',
 	priority: 0,
-	status: 'draft',
+	status: 'publish',
 	content_rules: [ { slug: 'post_types', value: [ 'post' ] } ],
 	registration: { active: false, metering: { enabled: false, count: 1, period: 'month' }, require_verification: false, gate_layout_id: 0 },
 	custom_access: { active: false, metering: { enabled: false, count: 1, period: 'month' }, gate_layout_id: 0, access_rules: [] },
@@ -84,7 +84,6 @@ const Edit = ( { history, match, updateGatesData }: ContentGateEditProps ) => {
 		const _gate = {
 			...gate,
 			title,
-			status: 'publish',
 			content_rules: contentRules,
 			registration,
 			custom_access: customAccess,
@@ -357,7 +356,7 @@ const Edit = ( { history, match, updateGatesData }: ContentGateEditProps ) => {
 						isActive={ registration?.active }
 						onEnable={ () => setRegistration( { ...registration, active: ! registration.active } ) }
 					>
-						<Registration gateId={ gate.id } registration={ registration } onChange={ setRegistration } />
+						<Registration registration={ registration } onChange={ setRegistration } />
 					</CardSettingsGroup>
 					<CardSettingsGroup
 						actionType="toggle"
@@ -367,7 +366,7 @@ const Edit = ( { history, match, updateGatesData }: ContentGateEditProps ) => {
 						isActive={ customAccess?.active }
 						onEnable={ () => setCustomAccess( { ...customAccess, active: ! customAccess.active } ) }
 					>
-						<CustomAccess gateId={ gate.id } customAccess={ customAccess } onChange={ setCustomAccess } />
+						<CustomAccess customAccess={ customAccess } onChange={ setCustomAccess } />
 					</CardSettingsGroup>
 				</VStack>
 			</Grid>

--- a/src/wizards/audience/views/content-gates/edit/index.tsx
+++ b/src/wizards/audience/views/content-gates/edit/index.tsx
@@ -63,7 +63,7 @@ const Edit = ( { history, match, updateGatesData }: ContentGateEditProps ) => {
 	const id = _id ? parseInt( _id ) : 0;
 	const { gates = null as unknown as Gate[] } = useWizardData( AUDIENCE_CONTENT_GATES_WIZARD_SLUG ) as WizardData;
 	const { wizardApiFetch, isFetching, errorMessage, resetError, setError } = useWizardApiFetch( AUDIENCE_CONTENT_GATES_WIZARD_SLUG );
-	const { setHeaderData } = useDispatch( WIZARD_STORE_NAMESPACE );
+	const { setHeaderData, addNotice } = useDispatch( WIZARD_STORE_NAMESPACE );
 	const [ gate, setGate ] = useState< Gate >( ( gates && gates.find( g => g.id === id ) ) || DEFAULT_GATE ); // eslint-disable-line @typescript-eslint/no-unused-vars
 	const [ title, setTitle ] = useState< string >( gate.title );
 	const [ isRenaming, setIsRenaming ] = useState< boolean >( false );
@@ -127,6 +127,12 @@ const Edit = ( { history, match, updateGatesData }: ContentGateEditProps ) => {
 					updateGatesData( gates.map( g => ( g.id === data.id ? data : g ) ) );
 					setIsRenaming( false );
 					history.push( `/content-gates` );
+					addNotice( {
+						// translators: %s is the gate title.
+						message: sprintf( __( '“%s” gate updated.', 'newspack-plugin' ), data.title ),
+						type: 'success',
+						id: 'content-gate-updated',
+					} );
 				},
 			}
 		);

--- a/src/wizards/audience/views/content-gates/edit/index.tsx
+++ b/src/wizards/audience/views/content-gates/edit/index.tsx
@@ -8,7 +8,7 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { __experimentalVStack as VStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { useDispatch } from '@wordpress/data';
-import { useCallback, useEffect, useState } from '@wordpress/element';
+import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { commentAuthorAvatar, currencyDollar, postList, settings } from '@wordpress/icons';
 
 /**
@@ -104,9 +104,10 @@ const Edit = ( { match, updateGatesData }: ContentGateEditProps ) => {
 					history.push( `/content-gates` );
 					addNotice( {
 						// translators: %s is the gate title.
-						message: sprintf( __( '“%s” gate created.', 'newspack-plugin' ), title ),
+						message: sprintf( __( '"%s" gate created.', 'newspack-plugin' ), title ),
 						type: 'success',
 						id: 'content-gate-created',
+						actions: [ { label: __( 'Edit', 'newspack-plugin' ), url: `#/edit/${ data.id }` } ],
 					} );
 				},
 			}
@@ -119,6 +120,8 @@ const Edit = ( { match, updateGatesData }: ContentGateEditProps ) => {
 		}
 		resetError();
 		resetNotices();
+		const prevStatus = gate.status;
+		const gateTitle = title || gate.title;
 		const _gate = {
 			...gate,
 			title,
@@ -136,25 +139,60 @@ const Edit = ( { match, updateGatesData }: ContentGateEditProps ) => {
 			{
 				onSuccess( data: Gate ) {
 					updateGatesData( gates.map( g => ( g.id === data.id ? data : g ) ) );
-					setIsRenaming( false );
-					history.push( `/content-gates` );
 					addNotice( {
-						// translators: %s is the gate title.
-						message: sprintf( __( '“%s” gate updated.', 'newspack-plugin' ), data.title ),
+						message: sprintf(
+							// translators: 1: the gate title, or "Content" if we can't determine the gate title. 2: the gate status.
+							'%1$s gate %2$s.',
+							gateTitle ? `"${ gateTitle }"` : __( 'Content', 'newspack-plugin' ),
+							prevStatus === 'publish' ? __( 'disabled', 'newspack-plugin' ) : __( 'enabled', 'newspack-plugin' )
+						),
 						type: 'success',
-						id: 'content-gate-updated',
+						id: 'content-gate-status-changed',
+						actions: [ { label: __( 'Undo', 'newspack-plugin' ), onClick: () => updateStatus.current?.( prevStatus ) } ],
 					} );
 				},
 			}
 		);
 	}, [ gate, contentRules, registration, customAccess, status, title ] );
 
+	const updateStatus = useRef< ( _status: GateStatus ) => void >();
 	const handleStatusChange = ( _status: GateStatus ) => {
 		if ( isFetching ) {
 			return;
 		}
-		setStatus( _status );
+		resetError();
+		resetNotices();
+		const prevStatus = gate.status;
+		const gateTitle = gate.title;
+		const _gate = {
+			...gate,
+			status: _status,
+		};
+		wizardApiFetch< Gate >(
+			{
+				path: `/newspack/v1/wizard/${ AUDIENCE_CONTENT_GATES_WIZARD_SLUG }/${ gate.id }`,
+				method: 'POST',
+				data: { gate: _gate },
+			},
+			{
+				onSuccess( data: Gate ) {
+					updateGatesData( gates.map( g => ( g.id === data.id ? data : g ) ) );
+					addNotice( {
+						message: sprintf(
+							// translators: 1: the gate title, or "Content" if we can't determine the gate title. 2: the gate status.
+							'%1$s gate %2$s.',
+							gateTitle ? `"${ gateTitle }"` : __( 'Content', 'newspack-plugin' ),
+							prevStatus === 'publish' ? __( 'disabled', 'newspack-plugin' ) : __( 'enabled', 'newspack-plugin' )
+						),
+						type: 'success',
+						id: 'content-gate-status-changed',
+						actions: [ { label: __( 'Undo', 'newspack-plugin' ), onClick: () => updateStatus.current?.( prevStatus ) } ],
+					} );
+				},
+			}
+		);
 	};
+	updateStatus.current = handleStatusChange;
 
 	const handleDelete = useCallback(
 		( gateId: number ) => {
@@ -260,14 +298,14 @@ const Edit = ( { match, updateGatesData }: ContentGateEditProps ) => {
 				actions.push( {
 					type: 'more',
 					label: __( 'Activate', 'newspack-plugin' ),
-					action: () => handleStatusChange( 'publish' ),
+					action: () => updateStatus.current?.( 'publish' ),
 					disabled: isFetching,
 				} );
 			} else {
 				actions.push( {
 					type: 'more',
 					label: __( 'Deactivate', 'newspack-plugin' ),
-					action: () => handleStatusChange( 'draft' ),
+					action: () => updateStatus.current?.( 'draft' ),
 					disabled: isFetching,
 				} );
 			}
@@ -306,9 +344,9 @@ const Edit = ( { match, updateGatesData }: ContentGateEditProps ) => {
 	// Update gate status.
 	useEffect( () => {
 		if ( ! isNew && status !== gate.status ) {
-			handleSave();
+			updateStatus.current?.( status );
 		}
-	}, [ isNew, gate.status, status, handleSave ] );
+	}, [ isNew, gate.status, status, updateStatus ] );
 
 	return (
 		<div className="newspack-content-gate__edit">

--- a/src/wizards/audience/views/content-gates/edit/index.tsx
+++ b/src/wizards/audience/views/content-gates/edit/index.tsx
@@ -15,7 +15,16 @@ import { commentAuthorAvatar, currencyDollar, postList, settings } from '@wordpr
  * Internal dependencies
  */
 import { AUDIENCE_CONTENT_GATES_WIZARD_SLUG } from '../consts';
-import { CardSettingsGroup, Divider, Grid, Notice, Router, SectionHeader, TextControl } from '../../../../../../packages/components/src';
+import {
+	CardSettingsGroup,
+	ConfirmDialog,
+	Divider,
+	Grid,
+	Notice,
+	Router,
+	SectionHeader,
+	TextControl,
+} from '../../../../../../packages/components/src';
 import { WIZARD_STORE_NAMESPACE } from '../../../../../../packages/components/src/wizard/store';
 import { useWizardData } from '../../../../../../packages/components/src/wizard/store/utils';
 import { useWizardApiFetch } from '../../../../hooks/use-wizard-api-fetch';
@@ -25,7 +34,7 @@ import CustomAccess from './custom-access';
 import { getGateStatus, getGateStatusBadgeLevel } from '../utils';
 import './style.scss';
 
-const { useHistory, Prompt } = Router;
+const { useHistory } = Router;
 
 type ContentGateEditProps = {
 	history: { push: ( path: string ) => void };
@@ -76,9 +85,11 @@ const Edit = ( { match, updateGatesData }: ContentGateEditProps ) => {
 	const [ customAccess, setCustomAccess ] = useState< CustomAccess >( gate.custom_access );
 	const [ contentType, setContentType ] = useState< 'all' | 'custom' | undefined >( type as 'all' | 'custom' | undefined );
 	const [ status, setStatus ] = useState< GateStatus >( gate.status );
-
+	const [ showUnsavedChangesDialog, setShowUnsavedChangesDialog ] = useState( false );
+	const [ showDeleteDialog, setShowDeleteDialog ] = useState( false );
 	const isNew = _id === 'new' || ! id;
 	const isSaving = useRef( false );
+	const pendingNavigation = useRef< ( () => void ) | null >( null );
 
 	const isDirty =
 		isNew ||
@@ -204,10 +215,6 @@ const Edit = ( { match, updateGatesData }: ContentGateEditProps ) => {
 
 	const handleDelete = useCallback(
 		( gateId: number ) => {
-			// eslint-disable-next-line no-alert
-			if ( ! confirm( __( 'Are you sure you want to permanently delete this content gate?', 'newspack-plugin' ) ) ) {
-				return;
-			}
 			resetError();
 			setIsDeleting( true );
 			wizardApiFetch(
@@ -320,7 +327,7 @@ const Edit = ( { match, updateGatesData }: ContentGateEditProps ) => {
 			actions.push( {
 				type: 'more',
 				label: __( 'Delete', 'newspack-plugin' ),
-				action: () => handleDelete( gate.id ),
+				action: () => setShowDeleteDialog( true ),
 				disabled: isFetching,
 				destructive: true,
 			} );
@@ -356,12 +363,68 @@ const Edit = ( { match, updateGatesData }: ContentGateEditProps ) => {
 		}
 	}, [ isNew, gate.status, status, updateStatus ] );
 
+	// Block navigation when there are unsaved changes.
+	useEffect( () => {
+		if ( ! isDirty ) {
+			return;
+		}
+		const unblock = history.block( ( location: string, action: string ) => {
+			if ( isSaving.current ) {
+				return;
+			}
+			pendingNavigation.current = () => {
+				unblock();
+				if ( action === 'REPLACE' ) {
+					history.replace( location );
+				} else {
+					history.push( location );
+				}
+			};
+			setShowUnsavedChangesDialog( true );
+			return false;
+		} );
+		return unblock;
+	}, [ isDirty, history ] );
+
 	return (
 		<div className="newspack-content-gate__edit">
-			<Prompt
-				when={ isDirty }
-				message={ () => isSaving.current || __( 'This gate has unsaved changes. Discard changes?', 'newspack-plugin' ) }
-			/>
+			{ showUnsavedChangesDialog && (
+				<ConfirmDialog
+					title={ __( 'Unsaved changes', 'newspack-plugin' ) }
+					onConfirm={ () => {
+						setShowUnsavedChangesDialog( false );
+						pendingNavigation.current?.();
+						pendingNavigation.current = null;
+					} }
+					onCancel={ () => {
+						setShowUnsavedChangesDialog( false );
+						pendingNavigation.current = null;
+					} }
+					confirmButtonText={ __( 'Discard changes', 'newspack-plugin' ) }
+					isDestructive={ true }
+				>
+					<p>{ __( 'You have unsaved changes. Discard changes?', 'newspack-plugin' ) }</p>
+				</ConfirmDialog>
+			) }
+			{ showDeleteDialog && (
+				<ConfirmDialog
+					title={ __( 'Are you sure?', 'newspack-plugin' ) }
+					onConfirm={ () => handleDelete( gate.id ) }
+					onCancel={ () => setShowDeleteDialog( false ) }
+					confirmButtonText={ __( 'Delete', 'newspack-plugin' ) }
+					isDestructive={ true }
+				>
+					<p
+						dangerouslySetInnerHTML={ {
+							__html: sprintf(
+								// translators: %s is the gate title.
+								__( 'This will <strong>permanently delete</strong> “%s” and cannot be undone.', 'newspack-plugin' ),
+								gate.title
+							),
+						} }
+					/>
+				</ConfirmDialog>
+			) }
 			{ errorMessage && <Notice isError noticeText={ errorMessage } /> }
 			{ ( isNew || isRenaming ) && (
 				<>

--- a/src/wizards/audience/views/content-gates/edit/index.tsx
+++ b/src/wizards/audience/views/content-gates/edit/index.tsx
@@ -8,7 +8,7 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { __experimentalVStack as VStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { useDispatch } from '@wordpress/data';
-import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
+import { createInterpolateElement, useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { commentAuthorAvatar, currencyDollar, postList, settings } from '@wordpress/icons';
 
 /**
@@ -390,7 +390,6 @@ const Edit = ( { match, updateGatesData }: ContentGateEditProps ) => {
 		<div className="newspack-content-gate__edit">
 			{ showUnsavedChangesDialog && (
 				<ConfirmDialog
-					title={ __( 'Unsaved changes', 'newspack-plugin' ) }
 					onConfirm={ () => {
 						setShowUnsavedChangesDialog( false );
 						pendingNavigation.current?.();
@@ -401,9 +400,9 @@ const Edit = ( { match, updateGatesData }: ContentGateEditProps ) => {
 						pendingNavigation.current = null;
 					} }
 					confirmButtonText={ __( 'Discard changes', 'newspack-plugin' ) }
-					isDestructive={ true }
+					hideTitle
 				>
-					<p>{ __( 'You have unsaved changes. Discard changes?', 'newspack-plugin' ) }</p>
+					{ __( 'You have unsaved changes that will be lost. Discard changes?', 'newspack-plugin' ) }
 				</ConfirmDialog>
 			) }
 			{ showDeleteDialog && (
@@ -414,15 +413,14 @@ const Edit = ( { match, updateGatesData }: ContentGateEditProps ) => {
 					confirmButtonText={ __( 'Delete', 'newspack-plugin' ) }
 					isDestructive={ true }
 				>
-					<p
-						dangerouslySetInnerHTML={ {
-							__html: sprintf(
-								// translators: %s is the gate title.
-								__( 'This will <strong>permanently delete</strong> “%s” and cannot be undone.', 'newspack-plugin' ),
-								gate.title
-							),
-						} }
-					/>
+					{ createInterpolateElement(
+						sprintf(
+							// translators: %s is the gate title.
+							__( 'This will <strong>permanently delete</strong> “%s” and cannot be undone.', 'newspack-plugin' ),
+							gate.title
+						),
+						{ strong: <strong /> }
+					) }
 				</ConfirmDialog>
 			) }
 			{ errorMessage && <Notice isError noticeText={ errorMessage } /> }

--- a/src/wizards/audience/views/content-gates/edit/registration.tsx
+++ b/src/wizards/audience/views/content-gates/edit/registration.tsx
@@ -8,18 +8,16 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { ActionCard, Button } from '../../../../../../packages/components/src';
-import { getEditGateLayoutUrl } from '../utils';
+import { ActionCard } from '../../../../../../packages/components/src';
 import Metering from './metering';
 
 interface RegistrationProps {
-	gateId?: number;
 	registration: Registration;
 	onChange: ( registration: Partial< Registration > ) => void;
 	cardProps?: Partial< React.ComponentPropsWithoutRef< typeof ActionCard > >;
 }
 
-export default function Registration( { gateId, registration, onChange }: RegistrationProps ) {
+export default function Registration( { registration, onChange }: RegistrationProps ) {
 	const handleChange = useCallback(
 		( value: Partial< Registration > ) => {
 			onChange( {
@@ -33,16 +31,6 @@ export default function Registration( { gateId, registration, onChange }: Regist
 	);
 	return (
 		<>
-			{ gateId ? (
-				<>
-					<CardBody size="small">
-						<Button variant="secondary" href={ getEditGateLayoutUrl( gateId, 'registration' ) }>
-							{ __( 'Edit Layout', 'newspack-plugin' ) }
-						</Button>
-					</CardBody>
-					<CardDivider />
-				</>
-			) : null }
 			<CardBody size="small">
 				<ToggleControl
 					label={ __( 'Require verification', 'newspack-plugin' ) }

--- a/src/wizards/audience/views/content-gates/edit/style.scss
+++ b/src/wizards/audience/views/content-gates/edit/style.scss
@@ -10,4 +10,7 @@
 			line-height: 1.5;
 		}
 	}
+	.components-form-token-field {
+		margin-top: 16px;
+	}
 }

--- a/src/wizards/audience/views/content-gates/index.js
+++ b/src/wizards/audience/views/content-gates/index.js
@@ -42,11 +42,6 @@ const AudienceContentGates = ( props, ref ) => {
 				{
 					path: '/content-gates',
 					render: ContentGates,
-					title: __( 'Access control' ),
-					description: __(
-						'Set up gates to manage what content readers can access across your site. Start by selecting which content to restrict, then configure access through registered and/or paid options (including metered rules).',
-						'newspack-plugin'
-					),
 				},
 				{
 					path: '/edit/:id/:type?',

--- a/src/wizards/audience/views/content-gates/index.js
+++ b/src/wizards/audience/views/content-gates/index.js
@@ -42,6 +42,11 @@ const AudienceContentGates = ( props, ref ) => {
 				{
 					path: '/content-gates',
 					render: ContentGates,
+					title: __( 'Access control' ),
+					description: __(
+						'Set up gates to manage what content readers can access across your site. Start by selecting which content to restrict, then configure access through registered and/or paid options (including metered rules).',
+						'newspack-plugin'
+					),
 				},
 				{
 					path: '/edit/:id/:type?',

--- a/src/wizards/audience/views/content-gates/style.scss
+++ b/src/wizards/audience/views/content-gates/style.scss
@@ -3,6 +3,7 @@
  */
 
 @use "~@wordpress/base-styles/colors" as wp-colors;
+@use "~@wordpress/base-styles/variables" as wp;
 
 .audience_page_newspack-audience-access-control {
 	.newspack-content-gates {
@@ -21,6 +22,23 @@
 				> * + * {
 					margin-top: 32px !important;
 				}
+			}
+			&__settings {
+				h4 {
+					font-size: wp.$font-size-small;
+					font-weight: wp.$font-weight-medium;
+					line-height: wp.$font-line-height-small;
+					margin-bottom: 8px;
+					text-transform: uppercase;
+				}
+				p {
+					color: wp-colors.$gray-700;
+					margin: 0;
+				}
+				.components-button {
+					justify-content: center;
+					margin-top: 16px;
+					width: 100%;
 			}
 		}
 		&__content-rule-control {
@@ -46,4 +64,5 @@
 			z-index: 1;
 		}
 	}
+}
 }

--- a/src/wizards/audience/views/content-gates/types/index.d.ts
+++ b/src/wizards/audience/views/content-gates/types/index.d.ts
@@ -36,14 +36,23 @@ type Metering = {
 	period: 'week' | 'month';
 };
 
-type GateRuleProps = {
-	config: AccessRule | ContentRule;
-	rule?: GateAccessRule | GateContentRule;
+type GateAccessRuleProps = {
+	config: AccessRule;
+	rule?: GateAccessRule;
 	enabled?: boolean;
 	onToggle?: (slug: string) => void;
 	slug: string;
 	exclusion?: boolean;
 	onChange: (value: GateRuleValue) => void;
+};
+
+type GateContentRuleProps = {
+	config: ContentRule;
+	rule?: GateContentRule;
+	enabled?: boolean;
+	onToggle?: (slug: string) => void;
+	slug: string;
+	onChange: (value: GateContentRuleValue) => void;
 	onChangeExclusion?: (value: boolean) => void;
 };
 
@@ -53,6 +62,7 @@ type GateRuleControlProps = {
 	exclusion?: boolean;
 	onChange: (value: GateRuleValue) => void;
 	onChangeExclusion?: (value: boolean) => void;
+	isStatic?: boolean;
 };
 
 type AccessRules = {

--- a/src/wizards/componentsDemo/index.js
+++ b/src/wizards/componentsDemo/index.js
@@ -9,7 +9,7 @@ import '../../shared/js/public-path';
 /**
  * WordPress dependencies.
  */
-import { CardBody, CardDivider, CardMedia, ExternalLink, ToggleControl } from '@wordpress/components';
+import { CardBody, CardDivider, CardMedia, ExternalLink, ToggleControl, __experimentalVStack as VStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { Component, Fragment, render, createInterpolateElement, createRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Icon, audio, category, plus, postList, reusableBlock, settings, typography } from '@wordpress/icons';
@@ -712,98 +712,105 @@ class ComponentsDemo extends Component {
 								{ __( 'Component details', 'newspack-plugin' ) }
 							</ExternalLink>
 						</p>
-						<Card
-							__experimentalCoreCard
-							__experimentalCoreProps={ {
-								actionType: 'chevron',
-								as: 'a',
-								header: (
-									<>
-										<h3>{ __( 'Button card w/ icon', 'newspack-plugin' ) }</h3>
-										<p>{ __( 'Can be used in lieu of the Newspack ButtonCard component.', 'newspack-plugin' ) }</p>
-									</>
-								),
-								href: '#',
-								icon: plus,
-							} }
-						/>
-						<Card
-							isSmall
-							__experimentalCoreCard
-							__experimentalCoreProps={ {
-								actionType: 'chevron',
-								as: 'a',
-								header: (
-									<>
-										<h3>{ __( 'Small button card w/ icon + background color + chevron', 'newspack-plugin' ) }</h3>
-										<p>{ __( 'Can be used in lieu of the Newspack ButtonCard component.', 'newspack-plugin' ) }</p>
-									</>
-								),
-								href: '#',
-								icon: postList,
-								iconBackgroundColor: true,
-							} }
-						/>
-						<Card
-							__experimentalCoreCard
-							__experimentalCoreProps={ {
-								header: <h3>{ __( 'Card w/ child components', 'newspack-plugin' ) }</h3>,
-								footer: (
-									<>
-										<p>{ __( 'Card Footer', 'newspack-plugin' ) }</p>
-										<Button __next40pxDefaultSize variant="secondary">
-											{ __( 'Action Button', 'newspack-plugin' ) }
-										</Button>
-									</>
-								),
-							} }
-						>
-							<>
-								<CardBody key="1">
-									<p>{ __( 'Recommended top-level child components: CardBody, CardMedia, or CardDivider.', 'newspack-plugin' ) }</p>
-								</CardBody>
-								<CardMedia key="2">
-									<img
-										alt="Card Media"
-										src="https://images.unsplash.com/photo-1566125882500-87e10f726cdc?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1867&q=80"
-									/>
-								</CardMedia>
-								<CardBody key="4">
-									<p>{ __( 'CardBody (before CardDivider)', 'newspack-plugin' ) }</p>
-								</CardBody>
-								<CardDivider key="4" />
-								<CardBody key="5">
-									<p>{ __( 'CardBody (after CardDivider)', 'newspack-plugin' ) }</p>
-								</CardBody>
-							</>
-						</Card>
-						<CardSettingsGroup
-							actionType="toggle"
-							title={ __( 'Settings Group Card', 'newspack-plugin' ) }
-							description={ __( 'Can be used in lieu of the ActionCard component.', 'newspack-plugin' ) }
-							icon={ settings }
-							isActive={ this.state.settingsGroupCardActive }
-							onEnable={ () => this.setState( { settingsGroupCardActive: ! this.state.settingsGroupCardActive } ) }
-						>
-							<>
-								<CardBody>
-									<ToggleControl
-										label={ __( 'A settings option', 'newspack-plugin' ) }
-										help={ __( 'A description of the setting', 'newspack-plugin' ) }
-										checked={ false }
-									/>
-								</CardBody>
-								<CardDivider />
-								<CardBody>
-									<TextControl
-										label={ __( 'A text input', 'newspack-plugin' ) }
-										help={ __( 'A description of the input', 'newspack-plugin' ) }
-										placeholder={ __( 'A placeholder for the input', 'newspack-plugin' ) }
-										value={ '' }
-									/>
-								</CardBody>
-							</>
-						</CardSettingsGroup>
+						<VStack spacing="16px">
+							<Card
+								__experimentalCoreCard
+								__experimentalCoreProps={ {
+									actionType: 'chevron',
+									as: 'a',
+									header: (
+										<>
+											<h3>{ __( 'Button card w/ icon', 'newspack-plugin' ) }</h3>
+											<p>{ __( 'Can be used in lieu of the Newspack ButtonCard component.', 'newspack-plugin' ) }</p>
+										</>
+									),
+									href: '#',
+									icon: plus,
+								} }
+							/>
+							<Card
+								isSmall
+								__experimentalCoreCard
+								__experimentalCoreProps={ {
+									actionType: 'chevron',
+									as: 'a',
+									header: (
+										<>
+											<h3>{ __( 'Small button card w/ icon + background color + chevron', 'newspack-plugin' ) }</h3>
+											<p>{ __( 'Can be used in lieu of the Newspack ButtonCard component.', 'newspack-plugin' ) }</p>
+										</>
+									),
+									href: '#',
+									icon: postList,
+									iconBackgroundColor: true,
+								} }
+							/>
+							<Card
+								__experimentalCoreCard
+								__experimentalCoreProps={ {
+									header: <h3>{ __( 'Card w/ child components', 'newspack-plugin' ) }</h3>,
+									footer: (
+										<>
+											<p>{ __( 'Card Footer', 'newspack-plugin' ) }</p>
+											<Button __next40pxDefaultSize variant="secondary">
+												{ __( 'Action Button', 'newspack-plugin' ) }
+											</Button>
+										</>
+									),
+								} }
+							>
+								<>
+									<CardBody key="1">
+										<p>
+											{ __(
+												'Recommended top-level child components: CardBody, CardMedia, or CardDivider.',
+												'newspack-plugin'
+											) }
+										</p>
+									</CardBody>
+									<CardMedia key="2">
+										<img
+											alt="Card Media"
+											src="https://images.unsplash.com/photo-1566125882500-87e10f726cdc?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1867&q=80"
+										/>
+									</CardMedia>
+									<CardBody key="4">
+										<p>{ __( 'CardBody (before CardDivider)', 'newspack-plugin' ) }</p>
+									</CardBody>
+									<CardDivider key="4" />
+									<CardBody key="5">
+										<p>{ __( 'CardBody (after CardDivider)', 'newspack-plugin' ) }</p>
+									</CardBody>
+								</>
+							</Card>
+							<CardSettingsGroup
+								actionType="toggle"
+								title={ __( 'Settings Group Card', 'newspack-plugin' ) }
+								description={ __( 'Can be used in lieu of the ActionCard component.', 'newspack-plugin' ) }
+								icon={ settings }
+								isActive={ this.state.settingsGroupCardActive }
+								onEnable={ () => this.setState( { settingsGroupCardActive: ! this.state.settingsGroupCardActive } ) }
+							>
+								<>
+									<CardBody>
+										<ToggleControl
+											label={ __( 'A settings option', 'newspack-plugin' ) }
+											help={ __( 'A description of the setting', 'newspack-plugin' ) }
+											checked={ false }
+										/>
+									</CardBody>
+									<CardDivider />
+									<CardBody>
+										<TextControl
+											label={ __( 'A text input', 'newspack-plugin' ) }
+											help={ __( 'A description of the input', 'newspack-plugin' ) }
+											placeholder={ __( 'A placeholder for the input', 'newspack-plugin' ) }
+											value={ '' }
+										/>
+									</CardBody>
+								</>
+							</CardSettingsGroup>
+						</VStack>
 					</Card>
 					<Card>
 						<h2>{ __( 'Plugin Settings Section', 'newspack-plugin' ) }</h2>

--- a/src/wizards/hooks/use-wizard-api-fetch.ts
+++ b/src/wizards/hooks/use-wizard-api-fetch.ts
@@ -93,6 +93,12 @@ export function useWizardApiFetch( slug: string ) {
 	const requests = useRef< string[] >( [] );
 
 	useEffect( () => {
+		if ( wizardData?.error !== error ) {
+			setError( wizardData?.error ?? null );
+		}
+	}, [ wizardData?.error, error ] );
+
+	useEffect( () => {
 		updateWizardSettings( {
 			slug,
 			path: [ 'error' ],

--- a/src/wizards/index.tsx
+++ b/src/wizards/index.tsx
@@ -7,8 +7,9 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { createRoot, lazy, Suspense } from '@wordpress/element';
+import { __experimentalVStack as VStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 
 /**
  * Internal dependencies
@@ -60,18 +61,15 @@ const components: Record< string, any > = {
 const AdminPageLoader = ( { label }: { label: string } ) => {
 	return (
 		<div className="newspack-wizard__loader">
-			<div>
-				<Components.Waiting
-					style={ {
-						height: '50px',
-						width: '50px',
-					} }
-					isCenter
-				/>
-				<span>
-					{ label } { __( 'loading', 'newspack-plugin' ) }…
-				</span>
-			</div>
+			<VStack alignment="center" spacing={ 2 }>
+				<Components.Waiting noMargin />
+				<strong>
+					{
+						/* translators: %s is the label of the page */
+						sprintf( __( '%s loading…', 'newspack-plugin' ), label )
+					}
+				</strong>
+			</VStack>
 		</div>
 	);
 };


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Implements i3 designs for the "list" view for showing existing content gates in the Access Control wizard.

Also adds a new feature that allows the `Wizard` component to show [snackbar-style notices](https://wordpress.github.io/gutenberg/?path=/docs/components-snackbar--docs) via its Redux store. This is done via a new `WizardSnackbar` component that wraps the core `Snackbar` component, but is aware of and interfaces the the Wizard Redux store.

This PR only covers the list view for content gates. It doesn't cover i3 designs for priority management or other global settings such as Content Gifting and Countdown Banner features—these will come in future PRs.

Related NPPD-1244.

### How to test the changes in this Pull Request:

1. Check out this branch. Optionally delete any existing content gates to start fresh: `wp post delete $(wp post list --post_type=np_content_gate --format=ids) --force` and confirm that the Onboarding screen still works as described in #4474.
2. Create a new content gate. Try to tweak all available settings so you can see how they're represented in the list view. After editing some info, try to click the back button in the header and confirm that you're prompted about unsaved changes. 

<img width="1347" height="803" alt="Screenshot 2026-02-24 at 12 57 47 PM" src="https://github.com/user-attachments/assets/3b254dba-aa73-4dcd-8db9-3accd1275f13" />

3. Cancel out of the prompt, then save. Confirm that you're automatically redirected to the content gates list view with a small snackbar notice stating that the new gate was created. Confirm that the snackbar notice appears with an "Edit" link that links to the edit page for the newly created gate. Confirm that the newly created gate is "Active" and has a `publish` status in the back-end.

<img width="1350" height="797" alt="Screenshot 2026-02-24 at 1 04 17 PM" src="https://github.com/user-attachments/assets/88ea61e5-2734-44fc-af06-f838d4c5055b" />

4. View the list view here and confirm that the card element here accurately reflects the gate's settings. Also view at a mobile viewport size to ensure that the layout collapses gracefully.
5. Confirm that the "Customize registered/paid access layout" buttons work.
6. Click the three-dot dropdown menu and test each menu item:
  - Confirm that "Edit" navigates to the edit page for that content gate. Make some edits, save, and confirm that the list view updates to reflect any changed settings. 
  - Confirm that the "Deactivate" button unpublishes the content gate post and that the snackbar notice accurately reflects the updated status. Confirm that the "Undo" button in the snackbar notice reverts the status change.
  - Confirm that the "Delete" button prompts you about permanently deleting the content gate and that confirming the prompt deletes it.
7. Add more more than one content gate and confirm that a "Gate priority" link appears next to the "Access control" header in the list view. (Note: this just opens the existing "Add New" modal for now, no need to test anything in here. Priority management will come in a future PR)

<img width="1349" height="750" alt="Screenshot 2026-02-24 at 1 20 57 PM" src="https://github.com/user-attachments/assets/db1c4511-06bf-48dc-9dff-a140387e10e6" />

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->