### PR TITLE
Fix Avatar block duotone filter for custom colors

### DIFF
--- a/src/blocks/avatar/avatar-wrapper.jsx
+++ b/src/blocks/avatar/avatar-wrapper.jsx
@@ -6,11 +6,8 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import {
-	useBlockProps,
-	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
-	__experimentalUseBorderProps as useBorderProps,
-} from '@wordpress/block-editor';
+// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+import { __experimentalUseBorderProps as useBorderProps } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { useEffect, useState } from '@wordpress/element';
 import { addQueryArgs, removeQueryArgs } from '@wordpress/url';
@@ -27,7 +24,6 @@ import { addQueryArgs, removeQueryArgs } from '@wordpress/url';
  * @return {JSX.Element|null} The avatar wrapper element.
  */
 const AvatarWrapper = ( { avatar, size, attributes, placeholder = false, overlapMaskStyle = {} } ) => {
-	const { className } = useBlockProps();
 	const borderProps = useBorderProps( attributes );
 
 	// Debounce the size used for image fetching so dragging the slider
@@ -43,17 +39,13 @@ const AvatarWrapper = ( { avatar, size, attributes, placeholder = false, overlap
 		return null;
 	}
 
-	const duotoneClassName = className ? className.split( ' ' ).filter( classes => classes.includes( 'wp-duotone' ) ) : '';
-	const classNames = clsx( 'newspack-avatar-wrapper', duotoneClassName );
-
 	// Render placeholder for text-only bylines.
 	if ( placeholder ) {
 		return (
 			<div
-				className={ clsx( 'newspack-avatar-wrapper--placeholder', classNames ) }
+				className="newspack-avatar-wrapper newspack-avatar-wrapper--placeholder"
 				style={ {
 					'--avatar-size': size + 'px',
-					filter: duotoneClassName?.length ? `url(#${ duotoneClassName[ 0 ] })` : undefined,
 					...borderProps.style,
 				} }
 				role="img"
@@ -90,7 +82,7 @@ const AvatarWrapper = ( { avatar, size, attributes, placeholder = false, overlap
 	);
 	return (
 		<div
-			className={ classNames }
+			className="newspack-avatar-wrapper"
 			style={ {
 				'--avatar-size': size + 'px',
 				...overlapMaskStyle,

--- a/src/blocks/avatar/block.json
+++ b/src/blocks/avatar/block.json
@@ -49,7 +49,7 @@
 	"selectors": {
 		"border": "img.wp-block-newspack-avatar__image",
 		"filter": {
-			"duotone": ".newspack-avatar-wrapper img"
+			"duotone": ".wp-block-newspack-avatar .newspack-avatar-wrapper img"
 		}
 	},
 	"usesContext": ["postId", "postType", "newspack-blocks/author"],

--- a/src/blocks/avatar/class-avatar-block.php
+++ b/src/blocks/avatar/class-avatar-block.php
@@ -97,8 +97,6 @@ final class Avatar_Block {
 		}
 
 		$wrapper_attributes = get_block_wrapper_attributes( [ 'style' => $wrapper_style ] );
-		$duotone_preset     = $attributes['style']['color']['duotone'] ?? null;
-		$duotone_class      = self::newspack_get_duotone_class_name( $duotone_preset );
 
 		ob_start();
 		?>
@@ -111,8 +109,7 @@ final class Avatar_Block {
 					get_author_posts_url( $author->ID ),
 					$image_size,
 					$link_to_author,
-					$attributes,
-					$duotone_class
+					$attributes
 				);
 			endforeach;
 			?>
@@ -153,8 +150,6 @@ final class Avatar_Block {
 		$author_url  = $author['url'] ?? '';
 
 		$wrapper_attributes = get_block_wrapper_attributes( [ 'style' => '--avatar-size: ' . esc_attr( $image_size ) . 'px;' ] );
-		$duotone_preset     = $attributes['style']['color']['duotone'] ?? null;
-		$duotone_class      = self::newspack_get_duotone_class_name( $duotone_preset );
 
 		ob_start();
 		?>
@@ -166,8 +161,7 @@ final class Avatar_Block {
 				$author_url,
 				$image_size,
 				$link_to_author,
-				$attributes,
-				$duotone_class
+				$attributes
 			);
 			?>
 		</div>
@@ -184,11 +178,10 @@ final class Avatar_Block {
 	 * @param int    $image_size      Avatar size in pixels.
 	 * @param bool   $link_to_author  Whether to wrap the image in a link.
 	 * @param array  $attributes      Block attributes (for border props).
-	 * @param string $duotone_class   Duotone filter class name.
 	 *
 	 * @return void Outputs directly (callers are inside ob_start).
 	 */
-	private static function render_avatar_image( string $avatar_url, string $author_name, string $author_url, int $image_size, bool $link_to_author, array $attributes, string $duotone_class ): void {
+	private static function render_avatar_image( string $avatar_url, string $author_name, string $author_url, int $image_size, bool $link_to_author, array $attributes ): void {
 		$border_attributes = function_exists( 'get_block_core_avatar_border_attributes' )
 			? get_block_core_avatar_border_attributes( $attributes )
 			: [
@@ -199,7 +192,7 @@ final class Avatar_Block {
 		$class     = 'avatar avatar-' . esc_attr( $image_size ) . ' photo wp-block-newspack-avatar__image ' . ( $border_attributes['class'] ?? '' );
 		$show_link = $link_to_author && ! empty( $author_url );
 		?>
-		<div class="newspack-avatar-wrapper <?php echo esc_attr( $duotone_class ); ?>">
+		<div class="newspack-avatar-wrapper">
 			<?php if ( $show_link ) : ?>
 				<a href="<?php echo esc_url( $author_url ); ?>" class="wp-block-newspack-avatar__link">
 			<?php endif; ?>
@@ -323,20 +316,6 @@ final class Avatar_Block {
 		// Default WordPress author.
 		$default_author = get_userdata( get_post_field( 'post_author', $post_id ) );
 		return $default_author ? [ $default_author ] : [];
-	}
-
-	/**
-	 * This function is used to get the duotone class name from the preset value.
-	 *
-	 * @param  mixed $preset_value Duotone preset value.
-	 * @return string Constructed class name.
-	 */
-	public static function newspack_get_duotone_class_name( mixed $preset_value ): string {
-		if ( is_string( $preset_value ) && str_starts_with( $preset_value, 'var:preset|duotone|' ) ) {
-			$slug = str_replace( 'var:preset|duotone|', '', $preset_value );
-			return 'wp-duotone-' . sanitize_title( $slug );
-		}
-		return '';
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The Avatar block's duotone filter was not applied on the frontend when using custom (non-preset) colors. Preset duotone values (e.g. "Magenta and yellow") worked, but picking custom colors from the color picker had no effect.

The root cause was the `selectors.filter.duotone` value in `block.json`. It was set to `.newspack-avatar-wrapper img`, but WordPress core's duotone system scopes CSS by prepending the filter class as a compound selector (no space): `.wp-duotone-xxx.newspack-avatar-wrapper img`. Since the filter class is added to the outer block wrapper and `.newspack-avatar-wrapper` is an inner element, the compound selector never matched.

Preset duotone happened to work because a manual `newspack_get_duotone_class_name()` method copied the class to the inner wrapper. But that method only handled preset values (`var:preset|duotone|slug`), not custom color arrays.

The fix updates the selector to `.wp-block-newspack-avatar .newspack-avatar-wrapper img`, which correctly scopes to the block wrapper where core adds the filter class. This makes the manual duotone class propagation redundant, so it has been removed from both PHP and JS.

Closes NPPD-1269.

### How to test the changes in this Pull Request:

1. Add an Avatar block to a post. Apply a custom duotone filter (pick two custom colors, not a preset). Verify the filter shows in the editor preview and on the frontend.
2. Add an Avatar block to a template in the Site Editor (e.g. Single Posts). Apply a custom duotone filter. Save, then view a post using that template. Verify the filter renders on the frontend.
3. Add an Author Profile block (nested/v2 mode) to a post with a specific author. Set a custom duotone on the inner Avatar block. Verify it renders in the editor and on the frontend.
4. Edit a template in the Site Editor and add a contextual Author Profile block. Set a custom duotone on the inner Avatar block. Save and verify the filter renders on the frontend for all authors.
5. In any of the above scenarios, also test with a preset duotone (e.g. "Magenta and yellow") to confirm no regression.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?