### PR TITLE
fix(newspack-ui): remove overflow when modal is open

### DIFF
--- a/src/newspack-ui/scss/_modals.scss
+++ b/src/newspack-ui/scss/_modals.scss
@@ -39,6 +39,9 @@
 				opacity: 1;
 				transform: translateY(0);
 			}
+			@at-root body:has(&) {
+				overflow: hidden;
+			}
 		}
 	}
 

--- a/src/reader-activation-auth/auth-modal.js
+++ b/src/reader-activation-auth/auth-modal.js
@@ -101,7 +101,6 @@ export function openAuthModal( config = {} ) {
 		container.config = {};
 		modal.setAttribute( 'data-state', 'closed' );
 		document.body.classList.remove( 'newspack-signin' );
-		document.body.style.overflow = 'auto';
 		if ( modal.overlayId && window.newspackReaderActivation?.overlays ) {
 			window.newspackReaderActivation.overlays.remove( modal.overlayId );
 		}
@@ -209,7 +208,6 @@ export function openAuthModal( config = {} ) {
 	} );
 
 	document.body.classList.add( 'newspack-signin' );
-	document.body.style.overflow = 'hidden';
 	modal.setAttribute( 'data-state', 'open' );
 	if ( window.newspackReaderActivation?.overlays ) {
 		modal.overlayId = window.newspackReaderActivation.overlays.add( 'auth-modal' );


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When a modal is open (e.g. in my account), the user can scroll up/down. The overflow on the body should be hidden just like we're doing it of the "Sign in/My account" button with JS.

So this PR replaces the JS with CSS that targets the body if it has an opened modal.

Screencast of the problem:
https://github.com/user-attachments/assets/789d86bf-2669-418a-aca2-2ff3c14fb55e

### How to test the changes in this Pull Request:

1. Navigate to My account (Branch: trunk)
2. Execute an action that triggers a modal (e.g. delete payment method)
3. Notice that you can still scroll (you might need to reduce your window's height)
4. Signed out, open the homepage and "Sign in".
5. Notice you can't scroll (there's a `style="overflow: hidden"` added via JS)
6. Switch to this branch
7. Repeat 2 -> 5. You shouldn't be able to scroll when a modal is open

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->