### PR TITLE
fix(newspack-icon): background color

### DIFF
--- a/packages/components/src/newspack-icon/style.scss
+++ b/packages/components/src/newspack-icon/style.scss
@@ -1,20 +1,22 @@
+@use '../../../colors/colors.module.scss' as colors;
+
 /**
  * Newspack Icon
  */
 
 .newspack-icon {
-	background: var(--wp-admin-theme-color);
+	background: colors.$primary-600;
 	fill: white;
 	padding: 12px;
 
 	&--white {
 		background: white;
-		fill: var(--wp-admin-theme-color);
+		fill: colors.$primary-600;
 	}
 
 	&--simple {
 		background: none;
-		fill: var(--wp-admin-theme-color);
+		fill: colors.$primary-600;
 		padding: 0;
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The Newspack Icon isn't always using the right color. That's because it's relying on `var(--wp-admin-theme-color)`. The problem is, if we're outside our Newspack wizards (e.g. the Newsletter), then the admin theme color is the one from wp-admin, not our custom one (which makes sense) but then it means the Newspack icon gets the wrong background

<img width="864" height="580" alt="Screenshot 2026-02-25 at 17 21 34@2x" src="https://github.com/user-attachments/assets/0038630f-7637-4212-8a3a-0b6bac65950c" />

In the screenshot above our icon is against WordPress's "blueberry" colour.

So this PR uses our plain colors instead of the css variable

### How to test the changes in this Pull Request:

I'm not quite sure how you can test this outside the newspack plugin? But one thing for certain, we will need to create a new release of our components with this update so other plugins (e.g. Newsletters) display the right colour.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->