### PR TITLE
IP access cache booster endpoint

### DIFF
--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -84,6 +84,7 @@ class Content_Gate {
 		include __DIR__ . '/class-metering.php';
 		include __DIR__ . '/class-metering-countdown.php';
 		include __DIR__ . '/content-gifting/class-content-gifting.php';
+		include __DIR__ . '/class-ip-access-rule.php';
 	}
 
 	/**

--- a/includes/content-gate/class-ip-access-rule.php
+++ b/includes/content-gate/class-ip-access-rule.php
@@ -65,7 +65,7 @@ class IP_Access_Rule {
 		$valid_ip = apply_filters( 'newspack_content_gate_check_ip', false );
 
 		if ( $valid_ip ) {
-			setcookie( self::COOKIE_NAME, '1', time() + DAY_IN_SECONDS, '/' ); // phpcs:ignore
+			setcookie( self::COOKIE_NAME, '1', time() + DAY_IN_SECONDS, '/', COOKIEPATH, COOKIE_DOMAIN ); // phpcs:ignore
 		}
 
 		wp_safe_redirect( home_url( '/' ) );

--- a/includes/content-gate/class-ip-access-rule.php
+++ b/includes/content-gate/class-ip-access-rule.php
@@ -56,7 +56,7 @@ class IP_Access_Rule {
 
 		// Never cache this page.
 		if ( function_exists( 'batcache_cancel' ) ) {
-				batcache_cancel();
+			batcache_cancel();
 		}
 
 		/**

--- a/includes/content-gate/class-ip-access-rule.php
+++ b/includes/content-gate/class-ip-access-rule.php
@@ -7,8 +7,6 @@
 
 namespace Newspack\Content_Gate;
 
-use Newspack\Newspack;
-
 /**
  * IP Access Rule class.
  */

--- a/includes/content-gate/class-ip-access-rule.php
+++ b/includes/content-gate/class-ip-access-rule.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Content Gate IP Access Rule.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Content_Gate;
+
+use Newspack\Newspack;
+
+/**
+ * IP Access Rule class.
+ */
+class IP_Access_Rule {
+
+	/**
+	 * The name of the cookie used to bypass cache and allow server side IP checking.
+	 */
+	const COOKIE_NAME = 'wp_nocache_ip';
+
+	/**
+	 * The endpoint for institutional access.
+	 */
+	const ENDPOINT = 'institutional-access';
+
+	/**
+	 * Initialize hooks.
+	 */
+	public static function init() {
+		add_action( 'init', [ __CLASS__, 'add_rewrite_rule' ] );
+		add_action( 'template_redirect', [ __CLASS__, 'handle_redirect' ] );
+	}
+
+	/**
+	 * Register the rewrite rule for the institutional access endpoint.
+	 */
+	public static function add_rewrite_rule() {
+		add_rewrite_rule( '^' . self::ENDPOINT . '/?$', 'index.php?' . self::ENDPOINT . '=1', 'top' );
+		add_rewrite_tag( '%' . self::ENDPOINT . '%', '1' );
+
+		$option_key = 'newspack_ip_access_rule_flushed';
+		if ( ! get_option( $option_key ) ) {
+			flush_rewrite_rules(); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.flush_rewrite_rules_flush_rewrite_rules
+			update_option( $option_key, true );
+		}
+	}
+
+	/**
+	 * Handle the institutional access redirect.
+	 */
+	public static function handle_redirect() {
+		if ( ! get_query_var( self::ENDPOINT ) ) {
+			return;
+		}
+
+		// Never cache this page.
+		if ( function_exists( 'batcache_cancel' ) ) {
+				batcache_cancel();
+		}
+
+		/**
+		 * Filter whether the current IP is valid for content gate access.
+		 *
+		 * @param bool $valid_ip Whether the IP is valid. Default false.
+		 */
+		$valid_ip = apply_filters( 'newspack_content_gate_check_ip', false );
+
+		if ( $valid_ip ) {
+			setcookie( self::COOKIE_NAME, '1', time() + DAY_IN_SECONDS, '/' ); // phpcs:ignore
+		}
+
+		wp_safe_redirect( home_url( '/' ) );
+		exit;
+	}
+}
+IP_Access_Rule::init();

--- a/includes/content-gate/class-ip-access-rule.php
+++ b/includes/content-gate/class-ip-access-rule.php
@@ -56,6 +56,7 @@ class IP_Access_Rule {
 		if ( function_exists( 'batcache_cancel' ) ) {
 			batcache_cancel();
 		}
+		nocache_headers();
 
 		/**
 		 * Filter whether the current IP is valid for content gate access.


### PR DESCRIPTION
## Summary

- Adds a `/institutional-access` endpoint that checks the reader's IP via the `newspack_content_gate_check_ip` filter
- If the IP is valid, sets a `wp_nocache_ip` cookie (24h TTL) so subsequent requests bypass cache and allow server-side IP checking
- Redirects the reader to the homepage after processing
- Flushes rewrite rules once on first deployment

## Test plan

- [ ] Visit `/institutional-access` on the site and confirm you are redirected to the homepage
- [ ] Confirm that by default no `wp_nocache_ip` cookie is set (the filter returns `false`)
- [ ] To test the valid IP flow, temporarily add the following snippet to a plugin or `functions.php`:
  ```php
  add_filter( 'newspack_content_gate_check_ip', '__return_true' );
  ```
- [ ] Visit `/institutional-access` again and confirm the `wp_nocache_ip` cookie is now set with a 24h expiration
- [ ] Remove the snippet (or change to `__return_false`) and visit the endpoint again to confirm the cookie is **not** set on new requests
