### PR TITLE
fix(co-authors-plus): sanitize user_login before building dummy email…

### DIFF
--- a/includes/plugins/co-authors-plus/class-guest-contributor-role.php
+++ b/includes/plugins/co-authors-plus/class-guest-contributor-role.php
@@ -292,12 +292,12 @@ class Guest_Contributor_Role {
 	 */
 	public static function get_dummy_email_address( $user_or_name ) {
 		$email_domain = self::get_dummy_email_domain();
+		// Strip @ from the login — it may contain @ from legacy migrations, which produces
+		// a double-@ dummy email that sanitize_email() mangles into a non-detectable format.
 		if ( is_string( $user_or_name ) ) {
-			return $user_or_name . '@' . $email_domain;
+			$login = str_replace( '@', '', $user_or_name );
+			return $login . '@' . $email_domain;
 		}
-		// user_login may contain @ from legacy migrations, which produces a double-@ dummy
-		// email that sanitize_email() mangles into a non-detectable format. 
-		// Strip @ from the login to avoid this.
 		$login = str_replace( '@', '', $user_or_name->user_login );
 		return $login . '@' . $email_domain;
 	}

--- a/includes/plugins/co-authors-plus/class-guest-contributor-role.php
+++ b/includes/plugins/co-authors-plus/class-guest-contributor-role.php
@@ -295,7 +295,11 @@ class Guest_Contributor_Role {
 		if ( is_string( $user_or_name ) ) {
 			return $user_or_name . '@' . $email_domain;
 		}
-		return $user_or_name->user_login . '@' . $email_domain;
+		// user_login may contain @ from legacy migrations, which produces a double-@ dummy
+		// email that sanitize_email() mangles into a non-detectable format. 
+		// Strip @ from the login to avoid this.
+		$login = str_replace( '@', '', $user_or_name->user_login );
+		return $login . '@' . $email_domain;
 	}
 
 	/**

--- a/tests/unit-tests/guest-contributor-role.php
+++ b/tests/unit-tests/guest-contributor-role.php
@@ -42,8 +42,13 @@ class Newspack_Test_Guest_Contributor_Role extends WP_UnitTestCase {
 		$user             = new stdClass();
 		$user->user_login = 'legacy-author@old-domain.com';
 
+		$expected = 'legacy-authorold-domain.com@' . $email_domain;
+
 		$dummy_email = Guest_Contributor_Role::get_dummy_email_address( $user );
-		$this->assertSame( 'legacy-authorold-domain.com@' . $email_domain, $dummy_email );
+		$this->assertSame( $expected, $dummy_email );
+
+		$dummy_email = Guest_Contributor_Role::get_dummy_email_address( $user->user_login );
+		$this->assertSame( $expected, $dummy_email );
 	}
 
 	/**

--- a/tests/unit-tests/guest-contributor-role.php
+++ b/tests/unit-tests/guest-contributor-role.php
@@ -23,13 +23,27 @@ class Newspack_Test_Guest_Contributor_Role extends WP_UnitTestCase {
 		$email_domain = Guest_Contributor_Role::get_dummy_email_domain();
 		$user = get_userdata( 1 );
 
-		$expected = $user->user_login . '@' . $email_domain;
+		// Mirror the sanitization in get_dummy_email_address() — user_login could contain @.
+		$expected = str_replace( '@', '', $user->user_login ) . '@' . $email_domain;
 
 		$dummy_email = Guest_Contributor_Role::get_dummy_email_address( $user );
 		$this->assertSame( $expected, $dummy_email );
 
 		$dummy_email = Guest_Contributor_Role::get_dummy_email_address( $user->user_login );
 		$this->assertSame( $expected, $dummy_email );
+	}
+
+	/**
+	 * Test that @ in user_login is stripped when generating dummy email.
+	 */
+	public function test_guest_contributor_role_get_dummy_email_with_at_in_login() {
+		$email_domain = Guest_Contributor_Role::get_dummy_email_domain();
+
+		$user             = new stdClass();
+		$user->user_login = 'legacy-author@old-domain.com';
+
+		$dummy_email = Guest_Contributor_Role::get_dummy_email_address( $user );
+		$this->assertSame( 'legacy-authorold-domain.com@' . $email_domain, $dummy_email );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

When a guest contributor's `user_login` contains an `@` symbol, `get_dummy_email_address()` would produce a double-`@` email address. For example:

user_login:  `kermit@muppets.org`
→ produces:  `kermit@muppets.org@example.com`   (double @)
→ sanitize_email() strips the inner @ turning it into: `kermit@muppets.orgexample.com`
→ is_dummy_email_address() looks for `@example.com` which isn't a match, so this email is displayed on the frontend

This fix strips `@` from `user_login` before building the dummy email:

→ produces:  kermitmuppets.org@example.com

Also, updated the existing `test_guest_contributor_role_get_dummy_email` test and added `test_guest_contributor_role_get_dummy_email_with_at_in_login` to cover the edge case directly.

Closes `NPPM-2636`

### How to test the changes in this Pull Request:

**Before applying this PR, do the following:**

1. Use WP-CLI to create a user whose `user_login` contains `@` like the following: `wp user create "kermit@muppets.org" "kermit@example.com" --role=contributor_no_edit`
2. Confirm the @ was preserved in the user_login: `wp user get "kermit@muppets.org" --field=user_login`
3. Find and edit the user in wp-admin.
4. Clear the email field and save. The dummy email regenerates a non `@example.com` address like  `kermit@muppets.orgexample.com`


**After applying this PR:**

5. Clear the email field and save again. The dummy email is now a clean `kermitmuppets.org@example.com`

**Regression check:**

6. Create a new guest contributor with only a display name (no email).
7. Confirm a dummy email in the format `username@example.com` was generated.
8. Clear the email field and save. Confirm it resets to a fresh `username@example.com` dummy.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
