### PR TITLE
fix: enable payment method deletion for Braintree

### DIFF
--- a/includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php
+++ b/includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php
@@ -1031,7 +1031,9 @@ class WooCommerce_My_Account {
 	 */
 	public static function remove_braintree_edit_actions( $item, $payment_token ) {
 		if ( str_starts_with( $payment_token->get_gateway_id(), 'braintree_' ) ) {
-			unset( $item['actions']['edit'], $item['actions']['save'] );
+			if ( ! empty( $item['actions']['edit'] ) || ! empty( $item['actions']['save'] ) ) {
+				unset( $item['actions']['edit'], $item['actions']['save'] );
+			}
 		}
 		return $item;
 	}

--- a/includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php
+++ b/includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php
@@ -54,6 +54,7 @@ class WooCommerce_My_Account {
 		\add_filter( 'woocommerce_get_checkout_url', [ __CLASS__, 'get_checkout_url' ] );
 		\add_filter( 'woocommerce_get_checkout_payment_url', [ __CLASS__, 'get_checkout_url' ] );
 		\add_filter( 'wc_stripe_update_subs_payment_method_card_statuses', [ __CLASS__, 'update_payment_methods_for_all_subs' ] );
+		\add_filter( 'wc_subscriptions_allow_subscription_token_deletion', [ __CLASS__, 'allow_braintree_token_deletion' ], 10, 2 );
 
 		// Reader Activation mods.
 		if ( Reader_Activation::is_enabled() ) {
@@ -999,6 +1000,24 @@ class WooCommerce_My_Account {
 			'on-hold',
 			'pending-cancel',
 		];
+	}
+
+	/**
+	 * Permit 'Delete payment method' option for Braintree.
+	 * This is usually disabled when no alternative payment method is
+	 * available, but some gateways may not permit a new payment with
+	 * similar details (e.g., credit card with same number but updated
+	 * expiration) to one already in the system.
+	 *
+	 * @param bool              $allow_deletion Whether deletion is allowed.
+	 * @param \WC_Payment_Token $payment_token  The payment token.
+	 * @return bool
+	 */
+	public static function allow_braintree_token_deletion( $allow_deletion, $payment_token ) {
+		if ( $payment_token instanceof \WC_Payment_Token && str_starts_with( $payment_token->get_gateway_id(), 'braintree_' ) ) {
+			return true;
+		}
+		return $allow_deletion;
 	}
 
 	/**

--- a/includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php
+++ b/includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php
@@ -55,6 +55,7 @@ class WooCommerce_My_Account {
 		\add_filter( 'woocommerce_get_checkout_payment_url', [ __CLASS__, 'get_checkout_url' ] );
 		\add_filter( 'wc_stripe_update_subs_payment_method_card_statuses', [ __CLASS__, 'update_payment_methods_for_all_subs' ] );
 		\add_filter( 'wc_subscriptions_allow_subscription_token_deletion', [ __CLASS__, 'allow_braintree_token_deletion' ], 10, 2 );
+		\add_filter( 'woocommerce_payment_methods_list_item', [ __CLASS__, 'remove_braintree_edit_actions' ], 20, 2 );
 
 		// Reader Activation mods.
 		if ( Reader_Activation::is_enabled() ) {
@@ -1018,6 +1019,21 @@ class WooCommerce_My_Account {
 			return true;
 		}
 		return $allow_deletion;
+	}
+
+	/**
+	 * Remove 'edit' and 'save' actions for Braintree.  This keeps parity
+	 * with existing Stripe integration.
+	 *
+	 * @param array             $item          Payment method list item data.
+	 * @param \WC_Payment_Token $payment_token The payment token.
+	 * @return array
+	 */
+	public static function remove_braintree_edit_actions( $item, $payment_token ) {
+		if ( $payment_token instanceof \WC_Payment_Token && str_starts_with( $payment_token->get_gateway_id(), 'braintree_' ) ) {
+			unset( $item['actions']['edit'], $item['actions']['save'] );
+		}
+		return $item;
 	}
 
 	/**

--- a/includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php
+++ b/includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php
@@ -1015,7 +1015,7 @@ class WooCommerce_My_Account {
 	 * @return bool
 	 */
 	public static function allow_braintree_token_deletion( $allow_deletion, $payment_token ) {
-		if ( $payment_token instanceof \WC_Payment_Token && str_starts_with( $payment_token->get_gateway_id(), 'braintree_' ) ) {
+		if ( str_starts_with( $payment_token->get_gateway_id(), 'braintree_' ) ) {
 			return true;
 		}
 		return $allow_deletion;
@@ -1030,7 +1030,7 @@ class WooCommerce_My_Account {
 	 * @return array
 	 */
 	public static function remove_braintree_edit_actions( $item, $payment_token ) {
-		if ( $payment_token instanceof \WC_Payment_Token && str_starts_with( $payment_token->get_gateway_id(), 'braintree_' ) ) {
+		if ( str_starts_with( $payment_token->get_gateway_id(), 'braintree_' ) ) {
 			unset( $item['actions']['edit'], $item['actions']['save'] );
 		}
 		return $item;

--- a/tests/mocks/wc-mocks.php
+++ b/tests/mocks/wc-mocks.php
@@ -1,5 +1,18 @@
 <?php // phpcs:disable WordPress.Files.FileName.InvalidClassFileName, Squiz.Commenting.FunctionComment.Missing, Squiz.Commenting.ClassComment.Missing, Squiz.Commenting.VariableComment.Missing, Squiz.Commenting.FileComment.Missing, Generic.Files.OneObjectStructurePerFile.MultipleFound, Universal.Files.SeparateFunctionsFromOO.Mixed
 
+/**
+ * Minimal mock for WC_Payment_Token, used when WooCommerce is not loaded in the test environment.
+ */
+class WC_Payment_Token {
+	private $gateway_id;
+	public function __construct( $gateway_id ) {
+		$this->gateway_id = $gateway_id;
+	}
+	public function get_gateway_id() {
+		return $this->gateway_id;
+	}
+}
+
 class WC_Install {
 	public static function create_pages() {
 		return true;

--- a/tests/unit-tests/plugins/woocommerce-my-account-braintree.php
+++ b/tests/unit-tests/plugins/woocommerce-my-account-braintree.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Tests for Braintree-specific methods in WooCommerce_My_Account.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\WooCommerce_My_Account;
+
+require_once __DIR__ . '/../../mocks/wc-mocks.php';
+
+/**
+ * Test Braintree payment token handling in WooCommerce_My_Account.
+ */
+class Newspack_Test_WooCommerce_My_Account_Braintree extends WP_UnitTestCase {
+
+	/**
+	 * Test that allow_braintree_token_deletion returns true for Braintree tokens
+	 * even when the caller passes false (i.e., when it is the only payment method).
+	 */
+	public function test_braintree_token_deletion_is_allowed() {
+		$braintree_token = new WC_Payment_Token( 'braintree_cc' );
+		$result          = WooCommerce_My_Account::allow_braintree_token_deletion( false, $braintree_token );
+		$this->assertTrue( $result, 'Deletion should be allowed for a Braintree payment token even when it is the only method.' );
+	}
+
+	/**
+	 * Test that remove_braintree_edit_actions removes edit and save actions
+	 * from the item array for Braintree payment methods.
+	 */
+	public function test_braintree_edit_and_save_actions_are_removed() {
+		$braintree_token = new WC_Payment_Token( 'braintree_paypal' );
+		$item            = [
+			'actions' => [
+				'edit'   => [
+					'url'  => '/edit',
+					'name' => 'Edit',
+				],
+				'save'   => [
+					'url'  => '/save',
+					'name' => 'Save',
+				],
+				'delete' => [
+					'url'  => '/delete',
+					'name' => 'Delete',
+				],
+			],
+		];
+
+		$result = WooCommerce_My_Account::remove_braintree_edit_actions( $item, $braintree_token );
+
+		$this->assertArrayNotHasKey( 'edit', $result['actions'], 'The edit action should be removed for Braintree payment methods.' );
+		$this->assertArrayNotHasKey( 'save', $result['actions'], 'The save action should be removed for Braintree payment methods.' );
+		$this->assertArrayHasKey( 'delete', $result['actions'], 'The delete action should remain for Braintree payment methods.' );
+	}
+
+	/**
+	 * Test that non-Braintree payment methods are not affected by either filter.
+	 */
+	public function test_non_braintree_payment_methods_are_unaffected() {
+		$stripe_token = new WC_Payment_Token( 'stripe' );
+		$item         = [
+			'actions' => [
+				'edit'   => [
+					'url'  => '/edit',
+					'name' => 'Edit',
+				],
+				'save'   => [
+					'url'  => '/save',
+					'name' => 'Save',
+				],
+				'delete' => [
+					'url'  => '/delete',
+					'name' => 'Delete',
+				],
+			],
+		];
+
+		// allow_braintree_token_deletion should pass through the original value.
+		$allow_deletion = WooCommerce_My_Account::allow_braintree_token_deletion( false, $stripe_token );
+		$this->assertFalse( $allow_deletion, 'Deletion flag should be unchanged for non-Braintree payment tokens.' );
+
+		// remove_braintree_edit_actions should leave the item unchanged.
+		$result = WooCommerce_My_Account::remove_braintree_edit_actions( $item, $stripe_token );
+		$this->assertArrayHasKey( 'edit', $result['actions'], 'The edit action should remain for non-Braintree payment methods.' );
+		$this->assertArrayHasKey( 'save', $result['actions'], 'The save action should remain for non-Braintree payment methods.' );
+		$this->assertArrayHasKey( 'delete', $result['actions'], 'The delete action should remain for non-Braintree payment methods.' );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
This PR allows payment methods using Braintree to be deleted even when they are the only payment method available for a subscription plan.  

Subscribers may update their payment info by adding a new payment method with the same credit card number but new expiration date.  However, Braintree considers cards with the same number to be duplicates, regardless of other info.  Here, we enable a workaround where subscribers remove their existing payment method first, then add it back with the new expiration date.

Braintree gateway also adds 'edit' and 'save' actions to saved payment types that aren't exposed in other integrations (i.e., Stripe) and aren't implemented in current My Account.  This PR hides those to head off user confusion.

Addresses [NPPM-2612: My Account updates & Braintree](https://linear.app/a8c/issue/NPPM-2612/my-account-updates-and-braintree).

### How to test the changes in this Pull Request:

1. Set up a test site with a Simple Subscription product with any renewal option.
2. Use @laurelfulford's [instructions on setting up Braintree for WooCommerce Payment Gateway](https://handbook.newspack.com/newspack-team-resources/technical/newspack-support/woocommerce-for-newspack/setting-up-braintree-for-woocommerce-payment-gateway/).
4. Enable the `Braintree (Credit Card)` payment provider.  (The plugin provides others, but this one's the only one you need.)
5. Use a non-admin user to sign up for the subscription and pay with a sample credit card number (ex. `4111 1111 1111 1111` with any expiration date and CVV).
6. Visit the Payment Methods page (`/my-account/payment-methods/`) and click the three dots next to your payment method.  You should see a menu with an 'Edit' option, a 'Save' option (both not working) and a greyed out 'Delete payment method' option (ditto).
7.  Apply this PR.
8. Revisit the Payment Methods page and check the menu.  You should see just a red 'Delete payment method' option and no others.
9. Click that option and confirm the payment method is removed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->