### PR TITLE
feat(content-gating): i3 designs for Metered Countdown + Content Gifting

### DIFF
--- a/packages/components/src/card/core-card.js
+++ b/packages/components/src/card/core-card.js
@@ -28,6 +28,9 @@ const CoreCard = ( {
 	className,
 	footer,
 	header,
+	headerStyle,
+	childrenStyle,
+	footerStyle,
 	icon,
 	iconBackgroundColor,
 	isActive,
@@ -75,6 +78,7 @@ const CoreCard = ( {
 				<CardHeader
 					as={ onHeaderClick ? 'button' : undefined }
 					className={ classNames( 'newspack-card--core__header', isDraggable && 'newspack-card--core__header--is-draggable' ) }
+					style={ headerStyle }
 					size={ sizeProps }
 					onClick={ onHeaderClick }
 				>
@@ -138,8 +142,16 @@ const CoreCard = ( {
 					) }
 				</CardHeader>
 			) }
-			{ children && <div className="newspack-card--core__body">{ children }</div> }
-			{ footer && <CardFooter size={ sizeProps }>{ footer }</CardFooter> }
+			{ children && (
+				<div className="newspack-card--core__body" style={ childrenStyle }>
+					{ children }
+				</div>
+			) }
+			{ footer && (
+				<CardFooter size={ sizeProps } style={ footerStyle }>
+					{ footer }
+				</CardFooter>
+			) }
 		</CardWrapper>
 	);
 };

--- a/packages/components/src/card/style-core.scss
+++ b/packages/components/src/card/style-core.scss
@@ -68,7 +68,7 @@
 				word-wrap: normal !important;
 			}
 		}
-		.components-dropdown-menu {
+		> .components-dropdown-menu {
 			aspect-ratio: 1;
 			border-left: 1px solid wp-colors.$gray-200;
 			display: grid;

--- a/packages/components/src/confirm-dialog/README.md
+++ b/packages/components/src/confirm-dialog/README.md
@@ -2,6 +2,8 @@
 
 A modal confirmation dialog that intercepts client-side navigation when there are unsaved changes. Built on top of WordPress's `__experimentalConfirmDialog`. The dialog is invisible until a navigation attempt is blocked; when `when` becomes `true` and the user navigates away, the dialog appears automatically and resumes or cancels the navigation based on the user's choice.
 
+For most imperative use cases (confirming a destructive action, guarding an action behind an unsaved-changes check) prefer the [`useConfirmDialog` hook](#useconfirmdialog-hook) over using `ConfirmDialog` directly.
+
 ## Props
 
 | Prop | Type | Default | Description |
@@ -63,4 +65,64 @@ const [ pendingAction, setPendingAction ] = useState( null );
 >
 	You have unsaved changes that will be lost. Discard changes?
 </ConfirmDialog>
+```
+
+---
+
+## `useConfirmDialog` hook
+
+A higher-level hook that wraps `ConfirmDialog` and manages the pending-action state for you. Prefer this over using `ConfirmDialog` directly when you need imperative confirmation.
+
+```jsx
+import { useConfirmDialog } from 'newspack-components';
+```
+
+### Options
+
+Accepts all `ConfirmDialog` props except `isOpen`, `onConfirm`, `onCancel`, and `children`, plus:
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `message` | `React.ReactNode` | — | Content rendered in the modal body. |
+| `when` | `boolean` | — | When explicitly `false`, `requestConfirm` skips the dialog and invokes the callback immediately. Omit (or pass `true`) to always show the dialog. Also controls router navigation blocking, same as the `when` prop on `ConfirmDialog`. |
+
+### Returns
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `confirmDialog` | `React.ReactElement` | The dialog element — render this somewhere in your JSX. |
+| `requestConfirm` | `( callback: () => void ) => void` | Call with a callback to request confirmation. Shows the dialog (unless `when` is `false`); invokes the callback only if the user confirms. |
+
+### Usage
+
+```jsx
+// Always-confirm dialog (e.g. destructive delete action).
+const { confirmDialog, requestConfirm } = useConfirmDialog( {
+	title: 'Are you sure?',
+	confirmButtonText: 'Delete',
+	isDestructive: true,
+	message: 'This will permanently delete the item and cannot be undone.',
+} );
+
+// Render the dialog element in JSX:
+{ confirmDialog }
+
+// Call requestConfirm when the user initiates the action:
+<Button onClick={ () => requestConfirm( handleDelete ) }>Delete</Button>
+
+// Conditional dialog — skips confirmation when there are no unsaved changes.
+// Combines navigation blocking with imperative use in a single instance.
+const { confirmDialog, requestConfirm } = useConfirmDialog( {
+	when: isDirty,
+	message: 'You have unsaved changes that will be lost. Discard changes?',
+	confirmButtonText: 'Discard changes',
+	isDestructive: true,
+	hideTitle: true,
+} );
+
+{ confirmDialog }
+
+// In an action handler — shows the dialog only if isDirty, otherwise
+// calls the callback immediately:
+requestConfirm( () => handleToggleEnabled( newConfig ) );
 ```

--- a/packages/components/src/confirm-dialog/README.md
+++ b/packages/components/src/confirm-dialog/README.md
@@ -12,6 +12,7 @@ A modal confirmation dialog that intercepts client-side navigation when there ar
 | `confirmButtonText` | `string` | — | Label for the confirm button. |
 | `hideTitle` | `boolean` | — | When `true`, hides the modal title and the × close button. |
 | `isDestructive` | `boolean` | — | When `true`, applies destructive (e.g. red) styling to the confirm button. |
+| `isOpen` | `boolean` | `false` | When `true`, shows the dialog immediately without blocking navigation. Use this for imperative confirmation (e.g. confirming a destructive action on a button click). |
 | `size` | `'small'` \| `'medium'` \| `'large'` \| `'x-large'` \| `'full'` | `'small'` | Controls the width of the modal. |
 | `title` | `string` | — | Title displayed in the modal header. |
 | `when` | `boolean` | `false` | When `true`, blocks router navigation and shows the dialog on any attempted navigation. Set this to reflect whether the current form has unsaved changes. |
@@ -42,5 +43,24 @@ import { ConfirmDialog } from 'newspack-components';
 	cancelButtonText="Keep editing"
 >
 	Your changes will be lost if you leave this page.
+</ConfirmDialog>
+
+// Guard both navigation and an imperative action with a single dialog instance.
+// isOpen triggers the dialog immediately (e.g. on a button click) without
+// blocking navigation. Both when and isOpen can be used together.
+const [ pendingAction, setPendingAction ] = useState( null );
+<ConfirmDialog
+	when={ hasUnsavedChanges }
+	isOpen={ !! pendingAction }
+	confirmButtonText="Discard changes"
+	isDestructive
+	hideTitle
+	onConfirm={ () => {
+		pendingAction?.();
+		setPendingAction( null );
+	} }
+	onCancel={ () => setPendingAction( null ) }
+>
+	You have unsaved changes that will be lost. Discard changes?
 </ConfirmDialog>
 ```

--- a/packages/components/src/confirm-dialog/README.md
+++ b/packages/components/src/confirm-dialog/README.md
@@ -1,0 +1,46 @@
+# ConfirmDialog
+
+A modal confirmation dialog that intercepts client-side navigation when there are unsaved changes. Built on top of WordPress's `__experimentalConfirmDialog`. The dialog is invisible until a navigation attempt is blocked; when `when` becomes `true` and the user navigates away, the dialog appears automatically and resumes or cancels the navigation based on the user's choice.
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `cancelButtonText` | `string` | — | Label for the cancel button. |
+| `children` | `React.ReactNode` | — | Content rendered in the modal body. |
+| `className` | `string` | — | Additional CSS class. |
+| `confirmButtonText` | `string` | — | Label for the confirm button. |
+| `hideTitle` | `boolean` | — | When `true`, hides the modal title and the × close button. |
+| `isDestructive` | `boolean` | — | When `true`, applies destructive (e.g. red) styling to the confirm button. |
+| `size` | `'small'` \| `'medium'` \| `'large'` \| `'x-large'` \| `'full'` | `'small'` | Controls the width of the modal. |
+| `title` | `string` | — | Title displayed in the modal header. |
+| `when` | `boolean` | `false` | When `true`, blocks router navigation and shows the dialog on any attempted navigation. Set this to reflect whether the current form has unsaved changes. |
+
+## Usage
+
+```jsx
+import { ConfirmDialog } from 'newspack-components';
+
+// Guard navigation when a form has unsaved changes.
+// The dialog appears automatically when the user tries to navigate away.
+<ConfirmDialog
+	when={ hasUnsavedChanges }
+	title="Unsaved changes"
+	confirmButtonText="Leave anyway"
+	cancelButtonText="Stay"
+	isDestructive
+>
+	You have unsaved changes. Are you sure you want to leave?
+</ConfirmDialog>
+
+// Larger modal with a custom size
+<ConfirmDialog
+	when={ hasUnsavedChanges }
+	size="medium"
+	title="Discard changes?"
+	confirmButtonText="Discard"
+	cancelButtonText="Keep editing"
+>
+	Your changes will be lost if you leave this page.
+</ConfirmDialog>
+```

--- a/packages/components/src/confirm-dialog/index.tsx
+++ b/packages/components/src/confirm-dialog/index.tsx
@@ -71,13 +71,13 @@ function ConfirmDialog(
 		pendingNavigation.current?.();
 		pendingNavigation.current = null;
 		onConfirm();
-	}, [ pendingNavigation ] );
+	}, [ onConfirm, pendingNavigation ] );
 
 	const handleOnCancel = useCallback( () => {
 		setShowDialog( false );
 		pendingNavigation.current = null;
 		onCancel();
-	}, [ pendingNavigation ] );
+	}, [ onCancel, pendingNavigation ] );
 
 	// Block navigation when there are unsaved changes.
 	useEffect( () => {

--- a/packages/components/src/confirm-dialog/index.tsx
+++ b/packages/components/src/confirm-dialog/index.tsx
@@ -29,6 +29,9 @@ type ConfirmDialogProps = {
 	hideTitle?: boolean;
 	title?: string;
 	isDestructive?: boolean;
+	isShowingDialog?: boolean;
+	onConfirm?: () => void;
+	onCancel?: () => void;
 	cancelButtonText?: string;
 	confirmButtonText?: string;
 	children?: React.ReactNode;
@@ -43,23 +46,37 @@ const sizeClassMap = {
 	full: 'newspack-modal--size-full',
 };
 
+const noOp = () => {};
+
 function ConfirmDialog(
-	{ className, size = 'small', hideTitle, isDestructive, when = false, ...otherProps }: ConfirmDialogProps,
+	{
+		className,
+		size = 'small',
+		hideTitle,
+		isDestructive,
+		onConfirm = noOp,
+		onCancel = noOp,
+		when = false,
+		isShowingDialog = false,
+		...otherProps
+	}: ConfirmDialogProps,
 	ref: React.Ref< HTMLDivElement >
 ) {
-	const [ showUnsavedChangesDialog, setShowUnsavedChangesDialog ] = useState( false );
+	const [ showDialog, setShowDialog ] = useState( isShowingDialog );
 	const history = useHistory();
 	const pendingNavigation = useRef< ( () => void ) | null >( null );
 
-	const onConfirm = useCallback( () => {
-		setShowUnsavedChangesDialog( false );
+	const handleOnConfirm = useCallback( () => {
+		setShowDialog( false );
 		pendingNavigation.current?.();
 		pendingNavigation.current = null;
+		onConfirm();
 	}, [ pendingNavigation ] );
 
-	const onCancel = useCallback( () => {
-		setShowUnsavedChangesDialog( false );
+	const handleOnCancel = useCallback( () => {
+		setShowDialog( false );
 		pendingNavigation.current = null;
+		onCancel();
 	}, [ pendingNavigation ] );
 
 	// Block navigation when there are unsaved changes.
@@ -76,13 +93,19 @@ function ConfirmDialog(
 					history.push( location );
 				}
 			};
-			setShowUnsavedChangesDialog( true );
+			setShowDialog( true );
 			return false;
 		} );
 		return unblock;
 	}, [ when, history ] );
 
-	if ( ! showUnsavedChangesDialog ) {
+	useEffect( () => {
+		if ( isShowingDialog && when ) {
+			setShowDialog( true );
+		}
+	}, [ isShowingDialog, when ] );
+
+	if ( ! showDialog ) {
 		return null;
 	}
 
@@ -99,8 +122,8 @@ function ConfirmDialog(
 			className={ classes }
 			{ ...otherProps }
 			ref={ ref }
-			onConfirm={ onConfirm }
-			onCancel={ onCancel }
+			onConfirm={ handleOnConfirm }
+			onCancel={ handleOnCancel }
 			__experimentalHideHeader={ false }
 		/>
 	);

--- a/packages/components/src/confirm-dialog/index.tsx
+++ b/packages/components/src/confirm-dialog/index.tsx
@@ -5,8 +5,14 @@
 /**
  * WordPress dependencies.
  */
-import { forwardRef } from '@wordpress/element';
 import { __experimentalConfirmDialog as BaseComponent } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import { forwardRef, useCallback, useEffect, useRef, useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies.
+ */
+import Router from '../proxied-imports/router';
+const { useHistory } = Router;
 
 /**
  * External dependencies.
@@ -25,9 +31,8 @@ type ConfirmDialogProps = {
 	isDestructive?: boolean;
 	cancelButtonText?: string;
 	confirmButtonText?: string;
-	onConfirm: () => void;
-	onCancel: () => void;
 	children?: React.ReactNode;
+	when?: boolean;
 };
 
 const sizeClassMap = {
@@ -39,9 +44,48 @@ const sizeClassMap = {
 };
 
 function ConfirmDialog(
-	{ className, size = 'small', hideTitle, isDestructive, onConfirm, onCancel, ...otherProps }: ConfirmDialogProps,
+	{ className, size = 'small', hideTitle, isDestructive, when = false, ...otherProps }: ConfirmDialogProps,
 	ref: React.Ref< HTMLDivElement >
 ) {
+	const [ showUnsavedChangesDialog, setShowUnsavedChangesDialog ] = useState( false );
+	const history = useHistory();
+	const pendingNavigation = useRef< ( () => void ) | null >( null );
+
+	const onConfirm = useCallback( () => {
+		setShowUnsavedChangesDialog( false );
+		pendingNavigation.current?.();
+		pendingNavigation.current = null;
+	}, [ pendingNavigation ] );
+
+	const onCancel = useCallback( () => {
+		setShowUnsavedChangesDialog( false );
+		pendingNavigation.current = null;
+	}, [ pendingNavigation ] );
+
+	// Block navigation when there are unsaved changes.
+	useEffect( () => {
+		if ( ! when ) {
+			return;
+		}
+		const unblock = history.block( ( location: string, action: string ) => {
+			pendingNavigation.current = () => {
+				unblock();
+				if ( action === 'REPLACE' ) {
+					history.replace( location );
+				} else {
+					history.push( location );
+				}
+			};
+			setShowUnsavedChangesDialog( true );
+			return false;
+		} );
+		return unblock;
+	}, [ when, history ] );
+
+	if ( ! showUnsavedChangesDialog ) {
+		return null;
+	}
+
 	const classes = classnames(
 		'newspack-modal',
 		sizeClassMap[ size ],

--- a/packages/components/src/confirm-dialog/index.tsx
+++ b/packages/components/src/confirm-dialog/index.tsx
@@ -29,7 +29,7 @@ type ConfirmDialogProps = {
 	hideTitle?: boolean;
 	title?: string;
 	isDestructive?: boolean;
-	isShowingDialog?: boolean;
+	isOpen?: boolean;
 	onConfirm?: () => void;
 	onCancel?: () => void;
 	cancelButtonText?: string;
@@ -57,12 +57,12 @@ function ConfirmDialog(
 		onConfirm = noOp,
 		onCancel = noOp,
 		when = false,
-		isShowingDialog = false,
+		isOpen = false,
 		...otherProps
 	}: ConfirmDialogProps,
 	ref: React.Ref< HTMLDivElement >
 ) {
-	const [ showDialog, setShowDialog ] = useState( isShowingDialog );
+	const [ showDialog, setShowDialog ] = useState( isOpen );
 	const history = useHistory();
 	const pendingNavigation = useRef< ( () => void ) | null >( null );
 
@@ -99,11 +99,12 @@ function ConfirmDialog(
 		return unblock;
 	}, [ when, history ] );
 
+	// Show the dialog imperatively without blocking navigation.
 	useEffect( () => {
-		if ( isShowingDialog && when ) {
+		if ( isOpen ) {
 			setShowDialog( true );
 		}
-	}, [ isShowingDialog, when ] );
+	}, [ isOpen ] );
 
 	if ( ! showDialog ) {
 		return null;

--- a/packages/components/src/hooks/index.ts
+++ b/packages/components/src/hooks/index.ts
@@ -6,10 +6,11 @@ import { useRef } from '@wordpress/element';
 import usePrompt from './usePrompt';
 import useObjectState from './useObjectState';
 import useOnClickOutside from './useOnClickOutside';
+import useConfirmDialog from './use-confirm-dialog';
 
 const useUniqueId = ( prefix: string ) => {
 	const id = useRef( `${ prefix }-${ Math.round( Math.random() * 99999 ) }` );
 	return id.current;
 };
 
-export default { usePrompt, useObjectState, useOnClickOutside, useUniqueId };
+export default { usePrompt, useObjectState, useOnClickOutside, useUniqueId, useConfirmDialog };

--- a/packages/components/src/hooks/use-confirm-dialog.tsx
+++ b/packages/components/src/hooks/use-confirm-dialog.tsx
@@ -1,0 +1,80 @@
+/**
+ * WordPress dependencies.
+ */
+import { useCallback, useRef, useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies.
+ */
+import ConfirmDialog from '../confirm-dialog';
+
+type UseConfirmDialogOptions = {
+	when?: boolean;
+	message: React.ReactNode;
+	title?: string;
+	confirmButtonText?: string;
+	cancelButtonText?: string;
+	isDestructive?: boolean;
+	hideTitle?: boolean;
+	size?: 'small' | 'medium' | 'large' | 'x-large' | 'full';
+	className?: string;
+};
+
+type UseConfirmDialogResult = {
+	confirmDialog: React.ReactElement;
+	requestConfirm: ( callback: () => void ) => void;
+};
+
+/**
+ * A hook that encapsulates the ConfirmDialog component and provides a
+ * `requestConfirm` function for imperative use.
+ *
+ * Calling `requestConfirm( callback )` will show a confirmation dialog.
+ * If the user confirms, `callback` is invoked. If the user cancels, it is not.
+ *
+ * When `when` is explicitly `false`, `requestConfirm( callback )` calls
+ * `callback` immediately without showing the dialog. This is useful for
+ * guarding actions that are only destructive when there are unsaved changes
+ * (e.g. `when={ isDirty }`). When `when` is omitted or `true`, the dialog
+ * is always shown.
+ *
+ * The `confirmDialog` element must be rendered somewhere in the component's
+ * JSX for the dialog to appear.
+ */
+function useConfirmDialog( options: UseConfirmDialogOptions ): UseConfirmDialogResult {
+	const { message, when, ...dialogProps } = options;
+	const [ pendingAction, setPendingAction ] = useState< ( () => void ) | null >( null );
+
+	// Keep a ref so `requestConfirm` can always read the latest `when` value
+	// without needing to be recreated on every render.
+	const whenRef = useRef( when );
+	whenRef.current = when;
+
+	const requestConfirm = useCallback( ( callback: () => void ) => {
+		if ( whenRef.current !== false ) {
+			// Store as a thunk to opt out of React's functional-update interpretation.
+			setPendingAction( () => callback );
+		} else {
+			callback();
+		}
+	}, [] );
+
+	const confirmDialog = (
+		<ConfirmDialog
+			{ ...dialogProps }
+			when={ when }
+			isOpen={ !! pendingAction }
+			onConfirm={ () => {
+				pendingAction?.();
+				setPendingAction( null );
+			} }
+			onCancel={ () => setPendingAction( null ) }
+		>
+			{ message }
+		</ConfirmDialog>
+	);
+
+	return { confirmDialog, requestConfirm };
+}
+
+export default useConfirmDialog;

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -48,6 +48,7 @@ export { default as withWizardScreen } from './with-wizard-screen';
 
 export { default as Router } from './proxied-imports/router';
 export { default as hooks } from './hooks';
+export { default as useConfirmDialog } from './hooks/use-confirm-dialog';
 export { default as utils } from './utils';
 
 import './style.scss';

--- a/packages/components/src/section-header/index.js
+++ b/packages/components/src/section-header/index.js
@@ -7,7 +7,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useEffect, useRef } from '@wordpress/element';
-import { Tooltip } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import { Tooltip, __experimentalHStack as HStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { Icon, chevronLeft } from '@wordpress/icons';
 
 /**
@@ -98,33 +98,35 @@ const SectionHeader = ( {
 			ref={ ref }
 		>
 			<Grid columns={ 1 } gutter={ 8 } className={ classes }>
-				{ icon && (
-					<div className="newspack-section-header__icon">
-						<Icon icon={ icon } size={ 48 } />
-					</div>
-				) }
-				{ backNav && (
-					<div className="newspack-section-header__back-nav">
-						<Tooltip text={ __( 'Go back', 'newspack-plugin' ) }>
-							<Button href={ backNav } icon={ chevronLeft } variant="tertiary" />
-						</Tooltip>
-					</div>
-				) }
-				{ typeof title === 'string' && (
-					<div className="newspack-section-header__title-container">
-						<HeadingTag>{ title }</HeadingTag>
-						{ badges?.length
-							? badges.map( ( badge, i ) => <Badge key={ i } text={ badge.label } level={ badge.level || 'default' } /> )
-							: null }
-						{ secondaryAction && (
-							<div className="newspack-section-header__secondary-action">
-								<Button variant="link" href={ secondaryAction.href } onClick={ secondaryAction.action }>
-									{ secondaryAction.label }
-								</Button>
-							</div>
-						) }
-					</div>
-				) }
+				<HStack alignment="left" style={ { position: 'relative' } }>
+					{ icon && (
+						<div className="newspack-section-header__icon">
+							<Icon icon={ icon } size={ 48 } />
+						</div>
+					) }
+					{ backNav && (
+						<div className="newspack-section-header__back-nav">
+							<Tooltip text={ __( 'Go back', 'newspack-plugin' ) }>
+								<Button href={ backNav } icon={ chevronLeft } variant="tertiary" />
+							</Tooltip>
+						</div>
+					) }
+					{ typeof title === 'string' && (
+						<div className="newspack-section-header__title-container">
+							<HeadingTag>{ title }</HeadingTag>
+							{ badges?.length
+								? badges.map( ( badge, i ) => <Badge key={ i } text={ badge.label } level={ badge.level || 'default' } /> )
+								: null }
+							{ secondaryAction && (
+								<div className="newspack-section-header__secondary-action">
+									<Button variant="link" href={ secondaryAction.href } onClick={ secondaryAction.action }>
+										{ secondaryAction.label }
+									</Button>
+								</div>
+							) }
+						</div>
+					) }
+				</HStack>
 				{ typeof title === 'function' && <HeadingTag>{ title() }</HeadingTag> }
 				{ description && typeof description === 'string' && <p>{ description }</p> }
 				{ typeof description === 'function' && <p>{ description() }</p> }

--- a/packages/components/src/section-header/index.js
+++ b/packages/components/src/section-header/index.js
@@ -86,6 +86,26 @@ const SectionHeader = ( {
 
 	const HeadingTag = pageHeader ? 'h1' : `h${ heading }`;
 
+	let titleContent = null;
+
+	if ( typeof title === 'string' ) {
+		titleContent = (
+			<div className="newspack-section-header__title-container">
+				<HeadingTag>{ title }</HeadingTag>
+				{ badges?.length ? badges.map( ( badge, i ) => <Badge key={ i } text={ badge.label } level={ badge.level || 'default' } /> ) : null }
+				{ secondaryAction && (
+					<div className="newspack-section-header__secondary-action">
+						<Button variant="link" href={ secondaryAction.href } onClick={ secondaryAction.action }>
+							{ secondaryAction.label }
+						</Button>
+					</div>
+				) }
+			</div>
+		);
+	} else if ( typeof title === 'function' ) {
+		titleContent = <HeadingTag>{ title() }</HeadingTag>;
+	}
+
 	return (
 		<div
 			id={ id }
@@ -98,36 +118,23 @@ const SectionHeader = ( {
 			ref={ ref }
 		>
 			<Grid columns={ 1 } gutter={ 8 } className={ classes }>
-				<HStack alignment="left" style={ { position: 'relative' } }>
-					{ icon && (
-						<div className="newspack-section-header__icon">
-							<Icon icon={ icon } size={ 48 } />
-						</div>
-					) }
-					{ backNav && (
+				{ icon && (
+					<div className="newspack-section-header__icon">
+						<Icon icon={ icon } size={ 48 } />
+					</div>
+				) }
+				{ backNav ? (
+					<HStack alignment="left" style={ { position: 'relative' } }>
 						<div className="newspack-section-header__back-nav">
 							<Tooltip text={ __( 'Go back', 'newspack-plugin' ) }>
 								<Button href={ backNav } icon={ chevronLeft } variant="tertiary" />
 							</Tooltip>
 						</div>
-					) }
-					{ typeof title === 'string' && (
-						<div className="newspack-section-header__title-container">
-							<HeadingTag>{ title }</HeadingTag>
-							{ badges?.length
-								? badges.map( ( badge, i ) => <Badge key={ i } text={ badge.label } level={ badge.level || 'default' } /> )
-								: null }
-							{ secondaryAction && (
-								<div className="newspack-section-header__secondary-action">
-									<Button variant="link" href={ secondaryAction.href } onClick={ secondaryAction.action }>
-										{ secondaryAction.label }
-									</Button>
-								</div>
-							) }
-						</div>
-					) }
-				</HStack>
-				{ typeof title === 'function' && <HeadingTag>{ title() }</HeadingTag> }
+						{ titleContent }
+					</HStack>
+				) : (
+					titleContent
+				) }
 				{ description && typeof description === 'string' && <p>{ description }</p> }
 				{ typeof description === 'function' && <p>{ description() }</p> }
 				{ description && typeof description !== 'string' && typeof description !== 'function' && <p>{ description }</p> }

--- a/packages/components/src/section-header/style.scss
+++ b/packages/components/src/section-header/style.scss
@@ -28,6 +28,10 @@
 			margin-left: calc(var(--back-nav-button-size) + 8px);
 			@media (min-width: 782px) {
 				margin-left: 0;
+				.newspack-section-header__title-container,
+				p {
+					max-width: 50%;
+				}
 			}
 		}
 	}

--- a/packages/components/src/section-header/style.scss
+++ b/packages/components/src/section-header/style.scss
@@ -24,10 +24,7 @@
 			}
 		}
 		&.newspack-section-header--has-back-nav {
-			--back-nav-button-size: 36px;
-			margin-left: calc(var(--back-nav-button-size) + 8px);
 			@media (min-width: 782px) {
-				margin-left: 0;
 				.newspack-section-header__title-container,
 				p {
 					max-width: 50%;
@@ -37,9 +34,12 @@
 	}
 
 	&__back-nav {
-		left: calc((var(--back-nav-button-size) + 8px) * -1);
-		position: absolute;
-		top: calc(50% - (var(--back-nav-button-size) / 2));
+		@media (min-width: 1280px) {
+			left: 0;
+			position: absolute;
+			top: 50%;
+			transform: translate(calc(-100% - 8px), -50%);
+		}
 		a,
 		button {
 			color: inherit !important;

--- a/packages/components/src/section-header/style.scss
+++ b/packages/components/src/section-header/style.scss
@@ -27,7 +27,7 @@
 			@media (min-width: 782px) {
 				.newspack-section-header__title-container,
 				p {
-					max-width: 50%;
+					max-width: calc(50% - 16px);
 				}
 			}
 		}

--- a/packages/components/src/with-wizard-screen/style.scss
+++ b/packages/components/src/with-wizard-screen/style.scss
@@ -17,6 +17,7 @@
 	--wp-admin-theme-color-lighter-10--rgb: #{colors.$primary-000--rgb};
 
 	color: wp-colors.$gray-900;
+	overflow-x: hidden;
 
 	// Headings
 	h1,
@@ -55,14 +56,6 @@
 			top: 0;
 			width: 100%;
 			z-index: 1000;
-			.admin-bar & {
-				@media only screen and ( min-width: 601px ) {
-					top: 46px;
-				}
-				@media only screen and ( min-width: 782px ) {
-					top: 32px;
-				}
-			}
 		}
 		&__inner {
 			flex: 1;

--- a/packages/components/src/with-wizard-screen/style.scss
+++ b/packages/components/src/with-wizard-screen/style.scss
@@ -82,6 +82,7 @@
 					display: flex;
 				}
 				&__more {
+					&--primary-only,
 					.newspack-wizard__header__actions__more__main {
 						display: none;
 					}

--- a/packages/components/src/with-wizard-screen/style.scss
+++ b/packages/components/src/with-wizard-screen/style.scss
@@ -17,7 +17,6 @@
 	--wp-admin-theme-color-lighter-10--rgb: #{colors.$primary-000--rgb};
 
 	color: wp-colors.$gray-900;
-	overflow-x: hidden;
 
 	// Headings
 	h1,
@@ -56,6 +55,14 @@
 			top: 0;
 			width: 100%;
 			z-index: 1000;
+			.admin-bar & {
+				@media only screen and ( min-width: 601px ) {
+					top: 46px;
+				}
+				@media only screen and ( min-width: 782px ) {
+					top: 32px;
+				}
+			}
 		}
 		&__inner {
 			flex: 1;
@@ -63,12 +70,30 @@
 		&__actions {
 			align-items: center;
 			display: flex;
-			flex: 1 1 auto;
 			gap: 8px;
 			justify-content: flex-end;
 			padding: 0 24px 0 0;
+			> .newspack-wizard__header__actions__main {
+				display: none;
+			}
+			@media only screen and ( min-width: 782px ) {
+				flex: 1 1 auto;
+				> .newspack-wizard__header__actions__main {
+					display: flex;
+				}
+				&__more {
+					.newspack-wizard__header__actions__more__main {
+						display: none;
+					}
+				}
+			}
 		}
 	}
+
+	&__main {
+		overflow-x: hidden;
+	}
+
 
 	&__title {
 		align-items: center;

--- a/packages/components/src/with-wizard-screen/style.scss
+++ b/packages/components/src/with-wizard-screen/style.scss
@@ -92,6 +92,7 @@
 
 	&__main {
 		overflow-x: hidden;
+		padding-bottom: 1px; /* Prevents borders from being cut off */
 	}
 
 

--- a/packages/components/src/with-wizard/style.scss
+++ b/packages/components/src/with-wizard/style.scss
@@ -51,6 +51,10 @@ body.newspack-wizard-page:not(.newspack-admin-header) {
 			padding-bottom: 136px;
 		}
 	}
+
+	.components-popover__content {
+		min-width: 192px;
+	}
 }
 
 // Styling for wizards that are admin-header-only.

--- a/packages/components/src/wizard/index.js
+++ b/packages/components/src/wizard/index.js
@@ -83,7 +83,6 @@ const Wizard = (
 	const { actions, backNav, badges, sectionDescription, sectionName, sectionTitle, sectionPrimaryAction, sectionSecondaryAction } = headerData;
 
 	const mainActions = actions?.filter( action => action.type === 'primary' || action.type === 'secondary' );
-	const moreActions = actions?.filter( action => action.type === 'more' );
 
 	// Trigger initial data fetch. Some sections might not use the wizard data,
 	// but for consistency, fetching is triggered regardless of the section.
@@ -153,6 +152,7 @@ const Wizard = (
 								{ mainActions.map( ( action, index ) => (
 									<Button
 										key={ index }
+										className="newspack-wizard__header__actions__main"
 										icon={ action.icon }
 										variant={ action.type }
 										onClick={ action.action }
@@ -162,12 +162,21 @@ const Wizard = (
 										{ action.label }
 									</Button>
 								) ) }
-								{ moreActions.length > 0 && (
-									<DropdownMenu icon={ moreVertical } label={ __( 'More', 'newspack-plugin' ) }>
+								{ actions?.length > 0 && (
+									<DropdownMenu
+										icon={ moreVertical }
+										label={ __( 'More', 'newspack-plugin' ) }
+										popoverProps={ { className: 'newspack-wizard__header__actions__more' } }
+									>
 										{ () =>
-											moreActions.map( ( action, index ) => (
+											actions.map( ( action, index ) => (
 												<MenuItem
 													key={ index }
+													className={
+														action.type === 'primary'
+															? 'newspack-wizard__header__actions__more__main'
+															: 'newspack-wizard__header__actions__more__more'
+													}
 													icon={ action.icon }
 													onClick={ action.action }
 													disabled={ action.disabled || false }
@@ -192,39 +201,41 @@ const Wizard = (
 
 					{ sections.length > 1 && <ResetHeaderData /> }
 
-					<Switch>
-						{ sections.map( ( section, index ) => {
-							const SectionComponent = section.render;
-							const sectionProps = section.props || {};
-							return (
-								<Route
-									key={ index }
-									exact={ section.exact ?? false }
-									path={ section.path }
-									render={ routerProps => (
-										<div className={ classnames( 'newspack-wizard__content', className ) }>
-											{ 'function' === typeof renderAboveSections ? renderAboveSections() : null }
-											{ ( sectionTitle || section.title ) && (
-												<SectionHeader
-													className="newspack-wizard__section-header"
-													backNav={ backNav || section.backNav }
-													title={ sectionTitle || section.title }
-													description={ sectionDescription || section.description }
-													badges={ badges || section.badges }
-													primaryAction={ sectionPrimaryAction || section.primaryAction }
-													secondaryAction={ sectionSecondaryAction || section.secondaryAction }
-													heading={ 1 }
-													noMargin
-												/>
-											) }
-											<SectionComponent { ...routerProps } { ...sectionProps } { ...sharedProps } />
-										</div>
-									) }
-								/>
-							);
-						} ) }
-						<Redirect to={ displayedSections[ 0 ].path } />
-					</Switch>
+					<div className="newspack-wizard__main">
+						<Switch>
+							{ sections.map( ( section, index ) => {
+								const SectionComponent = section.render;
+								const sectionProps = section.props || {};
+								return (
+									<Route
+										key={ index }
+										exact={ section.exact ?? false }
+										path={ section.path }
+										render={ routerProps => (
+											<div className={ classnames( 'newspack-wizard__content', className ) }>
+												{ 'function' === typeof renderAboveSections ? renderAboveSections() : null }
+												{ ( sectionTitle || section.title ) && (
+													<SectionHeader
+														className="newspack-wizard__section-header"
+														backNav={ backNav || section.backNav }
+														title={ sectionTitle || section.title }
+														description={ sectionDescription || section.description }
+														badges={ badges || section.badges }
+														primaryAction={ sectionPrimaryAction || section.primaryAction }
+														secondaryAction={ sectionSecondaryAction || section.secondaryAction }
+														heading={ 1 }
+														noMargin
+													/>
+												) }
+												<SectionComponent { ...routerProps } { ...sectionProps } { ...sharedProps } />
+											</div>
+										) }
+									/>
+								);
+							} ) }
+							<Redirect to={ displayedSections[ 0 ].path } />
+						</Switch>
+					</div>
 				</HashRouter>
 				{ notices?.length > 0 &&
 					notices.map( ( notice, index ) => (

--- a/packages/components/src/wizard/index.js
+++ b/packages/components/src/wizard/index.js
@@ -34,6 +34,7 @@ const ResetHeaderData = () => {
 
 	useEffect( () => {
 		resetHeaderData();
+		window.scrollTo( 0, 0 );
 	}, [ location.pathname, resetHeaderData ] );
 
 	return null;

--- a/packages/components/src/wizard/index.js
+++ b/packages/components/src/wizard/index.js
@@ -163,32 +163,31 @@ const Wizard = (
 										{ action.label }
 									</Button>
 								) ) }
-								{ moreActions?.length > 0 && (
-									<DropdownMenu
-										icon={ moreVertical }
-										label={ __( 'More', 'newspack-plugin' ) }
-										popoverProps={ { className: 'newspack-wizard__header__actions__more' } }
-									>
-										{ () =>
-											actions.map( ( action, index ) => (
-												<MenuItem
-													key={ index }
-													className={
-														action.type === 'primary' || action.type === 'secondary'
-															? 'newspack-wizard__header__actions__more__main'
-															: 'newspack-wizard__header__actions__more__more'
-													}
-													icon={ action.icon }
-													onClick={ action.action }
-													disabled={ action.disabled || false }
-													isDestructive={ action.destructive || false }
-												>
-													{ action.label }
-												</MenuItem>
-											) )
-										}
-									</DropdownMenu>
-								) }
+								<DropdownMenu
+									className={ moreActions?.length === 0 ? 'newspack-wizard__header__actions__more--primary-only' : '' }
+									icon={ moreVertical }
+									label={ __( 'More', 'newspack-plugin' ) }
+									popoverProps={ { className: 'newspack-wizard__header__actions__more' } }
+								>
+									{ () =>
+										actions.map( ( action, index ) => (
+											<MenuItem
+												key={ index }
+												className={
+													action.type === 'primary' || action.type === 'secondary'
+														? 'newspack-wizard__header__actions__more__main'
+														: 'newspack-wizard__header__actions__more__more'
+												}
+												icon={ action.icon }
+												onClick={ action.action }
+												disabled={ action.disabled || false }
+												isDestructive={ action.destructive || false }
+											>
+												{ action.label }
+											</MenuItem>
+										) )
+									}
+								</DropdownMenu>
 							</div>
 						) }
 					</div>

--- a/packages/components/src/wizard/index.js
+++ b/packages/components/src/wizard/index.js
@@ -83,6 +83,7 @@ const Wizard = (
 	const { actions, backNav, badges, sectionDescription, sectionName, sectionTitle, sectionPrimaryAction, sectionSecondaryAction } = headerData;
 
 	const mainActions = actions?.filter( action => action.type === 'primary' || action.type === 'secondary' );
+	const moreActions = actions?.filter( action => action.type === 'more' );
 
 	// Trigger initial data fetch. Some sections might not use the wizard data,
 	// but for consistency, fetching is triggered regardless of the section.
@@ -162,7 +163,7 @@ const Wizard = (
 										{ action.label }
 									</Button>
 								) ) }
-								{ actions?.length > 0 && (
+								{ moreActions?.length > 0 && (
 									<DropdownMenu
 										icon={ moreVertical }
 										label={ __( 'More', 'newspack-plugin' ) }
@@ -173,7 +174,7 @@ const Wizard = (
 												<MenuItem
 													key={ index }
 													className={
-														action.type === 'primary'
+														action.type === 'primary' || action.type === 'secondary'
 															? 'newspack-wizard__header__actions__more__main'
 															: 'newspack-wizard__header__actions__more__more'
 													}

--- a/src/wizards/audience/views/content-gates/consts.js
+++ b/src/wizards/audience/views/content-gates/consts.js
@@ -1,4 +1,4 @@
 import { __ } from '@wordpress/i18n';
 
 export const AUDIENCE_CONTENT_GATES_WIZARD_SLUG = 'newspack-audience-access-control';
-export const BASE_HEADER_TEXT = __( 'Audience Management / Access Control', 'newspack-plugin' );
+export const BASE_HEADER_TEXT = __( 'Audience Management / Access control', 'newspack-plugin' );

--- a/src/wizards/audience/views/content-gates/content-gate-settings.tsx
+++ b/src/wizards/audience/views/content-gates/content-gate-settings.tsx
@@ -98,24 +98,24 @@ export default function ContentGateSettings( { gate, updateGatesData }: { gate: 
 
 	return (
 		<>
-			{ showDeleteDialog && (
-				<ConfirmDialog
-					title={ __( 'Are you sure?', 'newspack-plugin' ) }
-					onConfirm={ handleDelete }
-					onCancel={ () => setShowDeleteDialog( false ) }
-					confirmButtonText={ __( 'Delete', 'newspack-plugin' ) }
-					isDestructive={ true }
-				>
-					{ createInterpolateElement(
-						sprintf(
-							// translators: %s is the gate title.
-							__( 'This will <strong>permanently delete</strong> “%s” and cannot be undone.', 'newspack-plugin' ),
-							gate.title
-						),
-						{ strong: <strong /> }
-					) }
-				</ConfirmDialog>
-			) }
+			<ConfirmDialog
+				title={ __( 'Are you sure?', 'newspack-plugin' ) }
+				onConfirm={ handleDelete }
+				onCancel={ () => setShowDeleteDialog( false ) }
+				confirmButtonText={ __( 'Delete', 'newspack-plugin' ) }
+				isDestructive={ true }
+				when={ showDeleteDialog && ! isFetching }
+				isShowingDialog={ showDeleteDialog }
+			>
+				{ createInterpolateElement(
+					sprintf(
+						// translators: %s is the gate title.
+						__( 'This will <strong>permanently delete</strong> “%s” and cannot be undone.', 'newspack-plugin' ),
+						gate.title
+					),
+					{ strong: <strong /> }
+				) }
+			</ConfirmDialog>
 			<Card
 				className="newspack-content-gates__gate"
 				id={ gate.id }

--- a/src/wizards/audience/views/content-gates/content-gate-settings.tsx
+++ b/src/wizards/audience/views/content-gates/content-gate-settings.tsx
@@ -4,12 +4,12 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { CardBody } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
-import { createInterpolateElement, useRef, useState } from '@wordpress/element';
+import { createInterpolateElement, useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-import { Badge, Button, Card, ConfirmDialog, Grid, Router } from '../../../../../packages/components/src';
+import { Badge, Button, Card, Grid, Router, useConfirmDialog } from '../../../../../packages/components/src';
 import { useWizardData } from '../../../../../packages/components/src/wizard/store/utils';
 import { useWizardApiFetch } from '../../../hooks/use-wizard-api-fetch';
 import { WIZARD_STORE_NAMESPACE } from '../../../../../packages/components/src/wizard/store';
@@ -28,7 +28,19 @@ export default function ContentGateSettings( { gate, updateGatesData }: { gate: 
 	const { gates = null as unknown as Gate[] } = useWizardData( AUDIENCE_CONTENT_GATES_WIZARD_SLUG ) as WizardData;
 	const { wizardApiFetch, isFetching, resetError } = useWizardApiFetch( AUDIENCE_CONTENT_GATES_WIZARD_SLUG );
 	const { addNotice, resetNotices } = useDispatch( WIZARD_STORE_NAMESPACE );
-	const [ showDeleteDialog, setShowDeleteDialog ] = useState( false );
+	const { confirmDialog: deleteDialog, requestConfirm: requestDelete } = useConfirmDialog( {
+		title: __( 'Are you sure?', 'newspack-plugin' ),
+		confirmButtonText: __( 'Delete', 'newspack-plugin' ),
+		isDestructive: true,
+		message: createInterpolateElement(
+			sprintf(
+				// translators: %s is the gate title.
+				__( 'This will <strong>permanently delete</strong> “%s” and cannot be undone.', 'newspack-plugin' ),
+				gate.title
+			),
+			{ strong: <strong /> }
+		),
+	} );
 
 	const updateStatus = useRef< ( status: GateStatus ) => void >();
 	const handleStatusChange = ( status: GateStatus ) => {
@@ -98,24 +110,7 @@ export default function ContentGateSettings( { gate, updateGatesData }: { gate: 
 
 	return (
 		<>
-			<ConfirmDialog
-				title={ __( 'Are you sure?', 'newspack-plugin' ) }
-				onConfirm={ handleDelete }
-				onCancel={ () => setShowDeleteDialog( false ) }
-				confirmButtonText={ __( 'Delete', 'newspack-plugin' ) }
-				isDestructive={ true }
-				when={ showDeleteDialog && ! isFetching }
-				isShowingDialog={ showDeleteDialog }
-			>
-				{ createInterpolateElement(
-					sprintf(
-						// translators: %s is the gate title.
-						__( 'This will <strong>permanently delete</strong> “%s” and cannot be undone.', 'newspack-plugin' ),
-						gate.title
-					),
-					{ strong: <strong /> }
-				) }
-			</ConfirmDialog>
+			{ deleteDialog }
 			<Card
 				className="newspack-content-gates__gate"
 				id={ gate.id }
@@ -145,7 +140,7 @@ export default function ContentGateSettings( { gate, updateGatesData }: { gate: 
 						},
 						{
 							label: __( 'Delete', 'newspack-plugin' ),
-							action: () => setShowDeleteDialog( true ),
+							action: () => requestDelete( handleDelete ),
 							disabled: isFetching,
 							destructive: true,
 						},

--- a/src/wizards/audience/views/content-gates/content-gates.tsx
+++ b/src/wizards/audience/views/content-gates/content-gates.tsx
@@ -83,7 +83,7 @@ const ContentGates = ( { updateGatesData }: { updateGatesData: ( gates: Gate[] )
 					addNotice( {
 						message: sprintf(
 							// translators: %s is the status of the countdown banner.
-							__( 'Countdown banner %s.', 'newspack-plugin' ),
+							__( 'Metered countdown %s.', 'newspack-plugin' ),
 							config.countdown_banner?.enabled ? __( 'disabled', 'newspack-plugin' ) : __( 'enabled', 'newspack-plugin' )
 						),
 						type: 'success',
@@ -117,7 +117,7 @@ const ContentGates = ( { updateGatesData }: { updateGatesData: ( gates: Gate[] )
 						message: sprintf(
 							// translators: %s is the status of the content gifting.
 							__( 'Content gifting %s.', 'newspack-plugin' ),
-							config.content_gifting?.enabled ? __( 'enabled', 'newspack-plugin' ) : __( 'disabled', 'newspack-plugin' )
+							config.content_gifting?.enabled ? __( 'disabled', 'newspack-plugin' ) : __( 'enabled', 'newspack-plugin' )
 						),
 						type: 'success',
 						id: 'content-gifting-config-updated',

--- a/src/wizards/audience/views/content-gates/content-gates.tsx
+++ b/src/wizards/audience/views/content-gates/content-gates.tsx
@@ -13,23 +13,26 @@ import { useEffect, useRef, useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { Notice } from '../../../../../packages/components/src';
+import { Divider, Grid, Notice } from '../../../../../packages/components/src';
 import { useWizardData } from '../../../../../packages/components/src/wizard/store/utils';
 import { useWizardApiFetch } from '../../../hooks/use-wizard-api-fetch';
 import { WIZARD_STORE_NAMESPACE } from '../../../../../packages/components/src/wizard/store';
 import ContentGatesOnboarding from './content-gates-onboarding';
 import ContentGatesPriority from './content-gates-priority';
 import ContentGateSettings from './content-gate-settings';
+import SettingsCard from './settings-card';
 import { AUDIENCE_CONTENT_GATES_WIZARD_SLUG } from './consts';
 import './style.scss';
 
 const ContentGates = ( { updateGatesData }: { updateGatesData: ( gates: Gate[] ) => void } ) => {
 	const wizardData = useWizardData( AUDIENCE_CONTENT_GATES_WIZARD_SLUG ) as WizardData;
-	const { isFetching, error, errorMessage } = useWizardApiFetch( AUDIENCE_CONTENT_GATES_WIZARD_SLUG );
-	const { resetHeaderData, setHeaderData } = useDispatch( WIZARD_STORE_NAMESPACE );
+	const { wizardApiFetch, isFetching, error, errorMessage, resetError } = useWizardApiFetch( AUDIENCE_CONTENT_GATES_WIZARD_SLUG );
+	const { addNotice, resetNotices, resetHeaderData, setHeaderData, updateWizardSettings } = useDispatch( WIZARD_STORE_NAMESPACE );
 	const [ showPriorityModal, setShowPriorityModal ] = useState( false );
 	const ref = useRef( null );
 	const gates = ( wizardData?.gates || [] ) as Gate[];
+	const config = ( wizardData?.config || {} ) as GateSettings;
+	const hasMetering = gates.some( gate => gate.registration?.metering?.enabled || gate.custom_access?.metering?.enabled );
 
 	useEffect( () => {
 		if ( isFetching ) {
@@ -59,6 +62,55 @@ const ContentGates = ( { updateGatesData }: { updateGatesData: ( gates: Gate[] )
 		} );
 	}, [ isFetching, gates ] );
 
+	const toggleCountdownBanner = useRef< () => void >();
+	const handleToggleCountdownBanner = () => {
+		resetError();
+		resetNotices();
+		wizardApiFetch(
+			{
+				path: '/newspack/v1/wizard/newspack-audience-access-control/countdown-banner',
+				method: 'POST',
+				quiet: true,
+				data: { enabled: config.countdown_banner?.enabled ? 0 : 1 },
+			},
+			{
+				onSuccess( data: MeteringCountdownConfig ) {
+					updateWizardSettings( {
+						slug: AUDIENCE_CONTENT_GATES_WIZARD_SLUG,
+						path: [ 'config' ],
+						value: { ...wizardData?.config, countdown_banner: data },
+					} );
+					addNotice( __( 'Countdown banner config updated successfully.', 'newspack-plugin' ) );
+				},
+			}
+		);
+	};
+	toggleCountdownBanner.current = handleToggleCountdownBanner;
+	const toggleContentGifting = useRef< () => void >();
+	const handleToggleContentGifting = () => {
+		resetError();
+		resetNotices();
+		wizardApiFetch(
+			{
+				path: '/newspack/v1/wizard/newspack-audience-access-control/content-gifting',
+				method: 'POST',
+				quiet: true,
+				data: { enabled: config.content_gifting?.enabled ? 0 : 1 },
+			},
+			{
+				onSuccess( data: ContentGiftingConfig ) {
+					updateWizardSettings( {
+						slug: AUDIENCE_CONTENT_GATES_WIZARD_SLUG,
+						path: [ 'config' ],
+						value: { ...wizardData?.config, content_gifting: data },
+					} );
+					addNotice( __( 'Countdown banner config updated successfully.', 'newspack-plugin' ) );
+				},
+			}
+		);
+	};
+	toggleContentGifting.current = handleToggleContentGifting;
+
 	if ( ! gates?.length ) {
 		return <ContentGatesOnboarding />;
 	}
@@ -76,6 +128,30 @@ const ContentGates = ( { updateGatesData }: { updateGatesData: ( gates: Gate[] )
 					return <ContentGateSettings key={ gate.id } gate={ gate } updateGatesData={ updateGatesData } />;
 				} ) }
 			</VStack>
+			<Divider alignment="full-width" />
+			<Grid className="newspack-content-gates__other-settings" columns={ 2 } gutter={ 32 }>
+				<SettingsCard
+					title={ __( 'Metered countdown', 'newspack-plugin' ) }
+					description={ __(
+						'Show a countdown banner letting readers know how many free views they have left before content is restricted.',
+						'newspack-plugin'
+					) }
+					enabled={ !! config.countdown_banner?.enabled }
+					requirements={ ! hasMetering ? __( 'Requires gate with metering', 'newspack-plugin' ) : undefined }
+					toggleEnabled={ toggleCountdownBanner.current }
+					href={ '/settings/countdown-banner' }
+				/>
+				<SettingsCard
+					title={ __( 'Content gifting', 'newspack-plugin' ) }
+					description={ __(
+						'Let members gift articles to non-subscribers. Recipients can read the full content without needing to subscribe.',
+						'newspack-plugin'
+					) }
+					enabled={ !! config.content_gifting?.enabled }
+					toggleEnabled={ toggleContentGifting.current }
+					href={ '/settings/content-gifting' }
+				/>
+			</Grid>
 		</>
 	);
 };

--- a/src/wizards/audience/views/content-gates/content-gates.tsx
+++ b/src/wizards/audience/views/content-gates/content-gates.tsx
@@ -5,7 +5,7 @@
 /**
  * WordPress dependencies.
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { __experimentalVStack as VStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { useDispatch } from '@wordpress/data';
 import { useEffect, useRef, useState } from '@wordpress/element';
@@ -80,7 +80,16 @@ const ContentGates = ( { updateGatesData }: { updateGatesData: ( gates: Gate[] )
 						path: [ 'config' ],
 						value: { ...wizardData?.config, countdown_banner: data },
 					} );
-					addNotice( __( 'Countdown banner config updated successfully.', 'newspack-plugin' ) );
+					addNotice( {
+						message: sprintf(
+							// translators: %s is the status of the countdown banner.
+							__( 'Countdown banner %s.', 'newspack-plugin' ),
+							config.countdown_banner?.enabled ? __( 'disabled', 'newspack-plugin' ) : __( 'enabled', 'newspack-plugin' )
+						),
+						type: 'success',
+						id: 'countdown-banner-config-updated',
+						actions: [ { label: __( 'Undo', 'newspack-plugin' ), onClick: () => toggleCountdownBanner.current?.() } ],
+					} );
 				},
 			}
 		);
@@ -104,7 +113,16 @@ const ContentGates = ( { updateGatesData }: { updateGatesData: ( gates: Gate[] )
 						path: [ 'config' ],
 						value: { ...wizardData?.config, content_gifting: data },
 					} );
-					addNotice( __( 'Countdown banner config updated successfully.', 'newspack-plugin' ) );
+					addNotice( {
+						message: sprintf(
+							// translators: %s is the status of the content gifting.
+							__( 'Content gifting %s.', 'newspack-plugin' ),
+							config.content_gifting?.enabled ? __( 'enabled', 'newspack-plugin' ) : __( 'disabled', 'newspack-plugin' )
+						),
+						type: 'success',
+						id: 'content-gifting-config-updated',
+						actions: [ { label: __( 'Undo', 'newspack-plugin' ), onClick: () => toggleContentGifting.current?.() } ],
+					} );
 				},
 			}
 		);

--- a/src/wizards/audience/views/content-gates/edit/content-gifting.tsx
+++ b/src/wizards/audience/views/content-gates/edit/content-gifting.tsx
@@ -10,12 +10,12 @@ import { useDispatch } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { Notice } from '../../../../../packages/components/src';
-import { useWizardData } from '../../../../../packages/components/src/wizard/store/utils';
-import { WIZARD_STORE_NAMESPACE } from '../../../../../packages/components/src/wizard/store';
-import { useWizardApiFetch } from '../../../hooks/use-wizard-api-fetch';
-import ContentGifting from '../setup/content-gifting';
-import { AUDIENCE_CONTENT_GATES_WIZARD_SLUG } from './consts';
+import { Notice } from '../../../../../../packages/components/src';
+import { useWizardData } from '../../../../../../packages/components/src/wizard/store/utils';
+import { WIZARD_STORE_NAMESPACE } from '../../../../../../packages/components/src/wizard/store';
+import { useWizardApiFetch } from '../../../../hooks/use-wizard-api-fetch';
+import ContentGifting from '../../setup/content-gifting';
+import { AUDIENCE_CONTENT_GATES_WIZARD_SLUG } from '../consts';
 import './style.scss';
 
 const ContentGiftingSettings = () => {

--- a/src/wizards/audience/views/content-gates/edit/content-gifting.tsx
+++ b/src/wizards/audience/views/content-gates/edit/content-gifting.tsx
@@ -24,7 +24,16 @@ import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { ConfirmDialog, Divider, Grid, Notice, Router, SectionHeader, SelectControl, TextControl } from '../../../../../../packages/components/src';
+import {
+	Divider,
+	Grid,
+	Notice,
+	Router,
+	SectionHeader,
+	SelectControl,
+	TextControl,
+	useConfirmDialog,
+} from '../../../../../../packages/components/src';
 import { useWizardData } from '../../../../../../packages/components/src/wizard/store/utils';
 import { WIZARD_STORE_NAMESPACE } from '../../../../../../packages/components/src/wizard/store';
 import { useWizardApiFetch } from '../../../../hooks/use-wizard-api-fetch';
@@ -39,7 +48,6 @@ const ContentGiftingSettings = () => {
 	const { addNotice, resetNotices, setHeaderData, updateWizardSettings } = useDispatch( WIZARD_STORE_NAMESPACE );
 	const { wizardApiFetch, errorMessage, resetError } = useWizardApiFetch( AUDIENCE_CONTENT_GATES_WIZARD_SLUG );
 	const [ config, setConfig ] = useState< GateSettings >( wizardData?.config || {} );
-	const [ pendingToggle, setPendingToggle ] = useState< ( () => void ) | null >( null );
 	const availableProducts = newspackAudience?.available_products || [];
 	const hasMetering = newspackAudience?.content_gifting?.has_metering;
 	const giftingErrors = Object.values( newspackAudience?.content_gifting?.can_use_gifting?.errors || {} ).flat() as string[];
@@ -51,6 +59,13 @@ const ContentGiftingSettings = () => {
 		);
 	}, [ config, wizardData?.config ] );
 	const isSaving = useRef( false );
+	const { confirmDialog, requestConfirm } = useConfirmDialog( {
+		when: !! ( isDirty && ! isSaving.current ),
+		message: __( 'You have unsaved changes that will be lost. Discard changes?', 'newspack-plugin' ),
+		confirmButtonText: __( 'Discard changes', 'newspack-plugin' ),
+		isDestructive: true,
+		hideTitle: true,
+	} );
 
 	const handleUpdateConfig = ( newConfig: GateSettings, message: string = __( 'Content gifting settings updated.', 'newspack-plugin' ) ) => {
 		isSaving.current = true;
@@ -108,11 +123,7 @@ const ContentGiftingSettings = () => {
 							__( 'Content gifting %s.', 'newspack-plugin' ),
 							config?.content_gifting?.enabled ? __( 'disabled', 'newspack-plugin' ) : __( 'enabled', 'newspack-plugin' )
 						);
-						if ( isDirty ) {
-							setPendingToggle( () => () => handleUpdateConfig( newConfig, message ) );
-						} else {
-							handleUpdateConfig( newConfig, message );
-						}
+						requestConfirm( () => handleUpdateConfig( newConfig, message ) );
 					},
 					type: 'more',
 				},
@@ -127,20 +138,7 @@ const ContentGiftingSettings = () => {
 
 	return (
 		<div className="newspack-content-gate__edit">
-			<ConfirmDialog
-				when={ isDirty && ! isSaving.current }
-				isOpen={ !! pendingToggle }
-				confirmButtonText={ __( 'Discard changes', 'newspack-plugin' ) }
-				isDestructive
-				hideTitle
-				onConfirm={ () => {
-					pendingToggle?.();
-					setPendingToggle( null );
-				} }
-				onCancel={ () => setPendingToggle( null ) }
-			>
-				{ __( 'You have unsaved changes that will be lost. Discard changes?', 'newspack-plugin' ) }
-			</ConfirmDialog>
+			{ confirmDialog }
 			{ errorMessage && <Notice isError noticeText={ errorMessage } /> }
 			{ giftingErrors.length > 0 && <Notice noticeText={ giftingErrors.join( ', ' ) } isError /> }
 			<Grid columns={ 2 } gutter={ 32 }>

--- a/src/wizards/audience/views/content-gates/edit/content-gifting.tsx
+++ b/src/wizards/audience/views/content-gates/edit/content-gifting.tsx
@@ -39,6 +39,7 @@ const ContentGiftingSettings = () => {
 	const { addNotice, resetNotices, setHeaderData, updateWizardSettings } = useDispatch( WIZARD_STORE_NAMESPACE );
 	const { wizardApiFetch, errorMessage, resetError } = useWizardApiFetch( AUDIENCE_CONTENT_GATES_WIZARD_SLUG );
 	const [ config, setConfig ] = useState< GateSettings >( wizardData?.config || {} );
+	const [ pendingToggle, setPendingToggle ] = useState< ( () => void ) | null >( null );
 	const availableProducts = newspackAudience?.available_products || [];
 	const hasMetering = newspackAudience?.content_gifting?.has_metering;
 	const giftingErrors = Object.values( newspackAudience?.content_gifting?.can_use_gifting?.errors || {} ).flat() as string[];
@@ -94,21 +95,25 @@ const ContentGiftingSettings = () => {
 				},
 				{
 					label: config?.content_gifting?.enabled ? __( 'Disable', 'newspack-plugin' ) : __( 'Enable', 'newspack-plugin' ),
-					action: () =>
-						handleUpdateConfig(
-							{
-								...wizardData?.config,
-								content_gifting: {
-									...wizardData?.config?.content_gifting,
-									enabled: wizardData?.config?.content_gifting?.enabled ? false : true,
-								},
+					action: () => {
+						const newConfig = {
+							...wizardData?.config,
+							content_gifting: {
+								...wizardData?.config?.content_gifting,
+								enabled: ! wizardData?.config?.content_gifting?.enabled,
 							},
-							sprintf(
-								// translators: %s is the status of content gifting.
-								__( 'Content gifting %s.', 'newspack-plugin' ),
-								config?.content_gifting?.enabled ? __( 'disabled', 'newspack-plugin' ) : __( 'enabled', 'newspack-plugin' )
-							)
-						),
+						};
+						const message = sprintf(
+							// translators: %s is the status of content gifting.
+							__( 'Content gifting %s.', 'newspack-plugin' ),
+							config?.content_gifting?.enabled ? __( 'disabled', 'newspack-plugin' ) : __( 'enabled', 'newspack-plugin' )
+						);
+						if ( isDirty ) {
+							setPendingToggle( () => () => handleUpdateConfig( newConfig, message ) );
+						} else {
+							handleUpdateConfig( newConfig, message );
+						}
+					},
 					type: 'more',
 				},
 			],
@@ -122,7 +127,18 @@ const ContentGiftingSettings = () => {
 
 	return (
 		<div className="newspack-content-gate__edit">
-			<ConfirmDialog when={ isDirty && ! isSaving.current } confirmButtonText={ __( 'Discard changes', 'newspack-plugin' ) } hideTitle>
+			<ConfirmDialog
+				when={ isDirty && ! isSaving.current }
+				isOpen={ !! pendingToggle }
+				confirmButtonText={ __( 'Discard changes', 'newspack-plugin' ) }
+				isDestructive
+				hideTitle
+				onConfirm={ () => {
+					pendingToggle?.();
+					setPendingToggle( null );
+				} }
+				onCancel={ () => setPendingToggle( null ) }
+			>
 				{ __( 'You have unsaved changes that will be lost. Discard changes?', 'newspack-plugin' ) }
 			</ConfirmDialog>
 			{ errorMessage && <Notice isError noticeText={ errorMessage } /> }

--- a/src/wizards/audience/views/content-gates/edit/content-gifting.tsx
+++ b/src/wizards/audience/views/content-gates/edit/content-gifting.tsx
@@ -246,6 +246,7 @@ const ContentGiftingSettings = () => {
 							onChange={ ( value: string ) =>
 								setConfig( { ...config, content_gifting: { ...config?.content_gifting, cta_url: value } } )
 							}
+							withMargin={ false }
 							__next40pxDefaultSize
 						/>
 					) }

--- a/src/wizards/audience/views/content-gates/edit/content-gifting.tsx
+++ b/src/wizards/audience/views/content-gates/edit/content-gifting.tsx
@@ -19,12 +19,12 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
-import { useEffect, useMemo, useState } from '@wordpress/element';
+import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-import { Divider, Grid, Notice, Router, SectionHeader, SelectControl, TextControl } from '../../../../../../packages/components/src';
+import { ConfirmDialog, Divider, Grid, Notice, Router, SectionHeader, SelectControl, TextControl } from '../../../../../../packages/components/src';
 import { useWizardData } from '../../../../../../packages/components/src/wizard/store/utils';
 import { WIZARD_STORE_NAMESPACE } from '../../../../../../packages/components/src/wizard/store';
 import { useWizardApiFetch } from '../../../../hooks/use-wizard-api-fetch';
@@ -42,12 +42,17 @@ const ContentGiftingSettings = () => {
 	const availableProducts = newspackAudience?.available_products || [];
 	const hasMetering = newspackAudience?.content_gifting?.has_metering;
 	const giftingErrors = Object.values( newspackAudience?.content_gifting?.can_use_gifting?.errors || {} ).flat() as string[];
-
 	const isDirty = useMemo( () => {
-		return JSON.stringify( config?.content_gifting ) !== JSON.stringify( wizardData?.config?.content_gifting );
+		return (
+			config?.content_gifting &&
+			wizardData?.config?.content_gifting &&
+			JSON.stringify( config?.content_gifting ) !== JSON.stringify( wizardData?.config?.content_gifting )
+		);
 	}, [ config, wizardData?.config ] );
+	const isSaving = useRef( false );
 
 	const handleUpdateConfig = ( newConfig: GateSettings, message: string = __( 'Content gifting settings updated.', 'newspack-plugin' ) ) => {
+		isSaving.current = true;
 		resetError();
 		resetNotices();
 		wizardApiFetch(
@@ -70,6 +75,9 @@ const ContentGiftingSettings = () => {
 						id: 'content-gifting-config-updated',
 					} );
 					history.push( '/content-gates' );
+				},
+				onFinally: () => {
+					isSaving.current = false;
 				},
 			}
 		);
@@ -114,24 +122,27 @@ const ContentGiftingSettings = () => {
 
 	return (
 		<div className="newspack-content-gate__edit">
+			<ConfirmDialog when={ isDirty && ! isSaving.current } confirmButtonText={ __( 'Discard changes', 'newspack-plugin' ) } hideTitle>
+				{ __( 'You have unsaved changes that will be lost. Discard changes?', 'newspack-plugin' ) }
+			</ConfirmDialog>
 			{ errorMessage && <Notice isError noticeText={ errorMessage } /> }
 			{ giftingErrors.length > 0 && <Notice noticeText={ giftingErrors.join( ', ' ) } isError /> }
 			<Grid columns={ 2 } gutter={ 32 }>
-				<SectionHeader heading={ 2 } title={ __( 'General Settings', 'newspack-plugin' ) } />
+				<SectionHeader heading={ 2 } title={ __( 'General settings', 'newspack-plugin' ) } />
 				<VStack spacing={ 4 }>
 					<RangeControl
 						label={ __( 'Gifting limit', 'newspack-plugin' ) }
 						help={ __( 'Maximum number of articles that can be gifted per user for the configured interval.', 'newspack-plugin' ) }
 						min={ 1 }
 						max={ 20 }
-						value={ config?.content_gifting?.limit }
+						value={ config?.content_gifting?.limit || 10 }
 						onChange={ ( value: number ) => setConfig( { ...config, content_gifting: { ...config?.content_gifting, limit: value } } ) }
 						__next40pxDefaultSize
 					/>
 					<SelectControl
 						label={ __( 'Gifting limit interval', 'newspack-plugin' ) }
 						help={ __( 'Interval at which the gifting limit is reset.', 'newspack-plugin' ) }
-						value={ config?.content_gifting?.interval }
+						value={ config?.content_gifting?.interval || 'month' }
 						onChange={ ( value: string ) => setConfig( { ...config, content_gifting: { ...config?.content_gifting, interval: value } } ) }
 						options={ [
 							{ value: 'day', label: __( 'Day', 'newspack-plugin' ) },
@@ -168,12 +179,12 @@ const ContentGiftingSettings = () => {
 			</Grid>
 			<Divider alignment="full-width" />
 			<Grid columns={ 2 } gutter={ 32 }>
-				<SectionHeader heading={ 2 } title={ __( 'Recipient Banner', 'newspack-plugin' ) } />
+				<SectionHeader heading={ 2 } title={ __( 'Recipient banner', 'newspack-plugin' ) } />
 				<VStack spacing={ 4 }>
 					<TextControl
 						label={ __( 'Message', 'newspack-plugin' ) }
 						help={ __( 'Text displayed in the banner shown to recipients of gifted articles.', 'newspack-plugin' ) }
-						value={ config?.content_gifting?.cta_label }
+						value={ config?.content_gifting?.cta_label || '' }
 						onChange={ ( value: string ) =>
 							setConfig( { ...config, content_gifting: { ...config?.content_gifting, cta_label: value } } )
 						}
@@ -183,7 +194,7 @@ const ContentGiftingSettings = () => {
 					<TextControl
 						label={ __( 'Subscribe button label', 'newspack-plugin' ) }
 						help={ __( 'Text displayed on the subscribe button in the banner.', 'newspack-plugin' ) }
-						value={ config?.content_gifting?.button_label }
+						value={ config?.content_gifting?.button_label || '' }
 						onChange={ ( value: string ) =>
 							setConfig( { ...config, content_gifting: { ...config?.content_gifting, button_label: value } } )
 						}
@@ -219,7 +230,7 @@ const ContentGiftingSettings = () => {
 							label={ __( 'Subscribe button product', 'newspack-plugin' ) }
 							help={ __( 'Product linked to the subscribe button.', 'newspack-plugin' ) }
 							options={ [ { label: __( 'Select a product', 'newspack-plugin' ), value: 0, disabled: true }, ...availableProducts ] }
-							value={ config?.content_gifting?.cta_product_id }
+							value={ config?.content_gifting?.cta_product_id || 0 }
 							suggestions={ availableProducts.map( o => o.label ) }
 							onChange={ ( value: number ) =>
 								setConfig( { ...config, content_gifting: { ...config?.content_gifting, cta_product_id: value } } )
@@ -231,7 +242,7 @@ const ContentGiftingSettings = () => {
 						<TextControl
 							label={ __( 'Subscribe button URL', 'newspack-plugin' ) }
 							help={ __( 'URL for the landing page to redirect to.', 'newspack-plugin' ) }
-							value={ config?.content_gifting?.cta_url }
+							value={ config?.content_gifting?.cta_url || '' }
 							onChange={ ( value: string ) =>
 								setConfig( { ...config, content_gifting: { ...config?.content_gifting, cta_url: value } } )
 							}

--- a/src/wizards/audience/views/content-gates/edit/content-gifting.tsx
+++ b/src/wizards/audience/views/content-gates/edit/content-gifting.tsx
@@ -1,3 +1,5 @@
+/* global newspackAudience */
+
 /**
  * Content Gifting settings page.
  */
@@ -5,54 +7,278 @@
 /**
  * WordPress dependencies.
  */
+import { __, sprintf } from '@wordpress/i18n';
+import {
+	BaseControl,
+	RangeControl,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
+import { useEffect, useMemo, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-import { Notice } from '../../../../../../packages/components/src';
+import { Divider, Grid, Notice, Router, SectionHeader, SelectControl, TextControl } from '../../../../../../packages/components/src';
 import { useWizardData } from '../../../../../../packages/components/src/wizard/store/utils';
 import { WIZARD_STORE_NAMESPACE } from '../../../../../../packages/components/src/wizard/store';
 import { useWizardApiFetch } from '../../../../hooks/use-wizard-api-fetch';
-import ContentGifting from '../../setup/content-gifting';
 import { AUDIENCE_CONTENT_GATES_WIZARD_SLUG } from '../consts';
 import './style.scss';
 
+const { useHistory } = Router;
+
 const ContentGiftingSettings = () => {
+	const history = useHistory();
 	const wizardData = useWizardData( AUDIENCE_CONTENT_GATES_WIZARD_SLUG ) as WizardData;
-	const { updateWizardSettings } = useDispatch( WIZARD_STORE_NAMESPACE );
+	const { addNotice, resetNotices, setHeaderData, updateWizardSettings } = useDispatch( WIZARD_STORE_NAMESPACE );
 	const { wizardApiFetch, errorMessage, resetError } = useWizardApiFetch( AUDIENCE_CONTENT_GATES_WIZARD_SLUG );
+	const [ config, setConfig ] = useState< GateSettings >( wizardData?.config || {} );
+	const availableProducts = newspackAudience?.available_products || [];
+	const hasMetering = newspackAudience?.content_gifting?.has_metering;
+	const giftingErrors = Object.values( newspackAudience?.content_gifting?.can_use_gifting?.errors || {} ).flat() as string[];
 
-	const onChange = ( newConfig: GateSettings ) => {
-		updateWizardSettings( {
-			slug: AUDIENCE_CONTENT_GATES_WIZARD_SLUG,
-			path: [ 'config' ],
-			value: newConfig,
-		} );
-	};
+	const isDirty = useMemo( () => {
+		return JSON.stringify( config?.content_gifting ) !== JSON.stringify( wizardData?.config?.content_gifting );
+	}, [ config, wizardData?.config ] );
 
-	const updateConfig = ( newConfig: GateSettings ) => {
+	const handleUpdateConfig = ( newConfig: GateSettings, message: string = __( 'Content gifting settings updated.', 'newspack-plugin' ) ) => {
 		resetError();
+		resetNotices();
 		wizardApiFetch(
 			{
 				path: '/newspack/v1/wizard/newspack-audience-access-control/content-gifting',
 				method: 'POST',
 				quiet: true,
-				data: newConfig.content_gifting,
+				data: newConfig?.content_gifting,
 			},
 			{
 				onSuccess( data ) {
-					onChange( { ...wizardData?.config, content_gifting: data } );
+					updateWizardSettings( {
+						slug: AUDIENCE_CONTENT_GATES_WIZARD_SLUG,
+						path: [ 'config' ],
+						value: { ...wizardData?.config, content_gifting: data },
+					} );
+					addNotice( {
+						message,
+						type: 'success',
+						id: 'content-gifting-config-updated',
+					} );
+					history.push( '/content-gates' );
 				},
 			}
 		);
 	};
 
+	useEffect( () => {
+		setHeaderData( {
+			actions: [
+				{
+					label: __( 'Save', 'newspack-plugin' ),
+					action: () => handleUpdateConfig( config ),
+					disabled: ! isDirty,
+					type: 'primary',
+				},
+				{
+					label: config?.content_gifting?.enabled ? __( 'Disable', 'newspack-plugin' ) : __( 'Enable', 'newspack-plugin' ),
+					action: () =>
+						handleUpdateConfig(
+							{
+								...wizardData?.config,
+								content_gifting: {
+									...wizardData?.config?.content_gifting,
+									enabled: wizardData?.config?.content_gifting?.enabled ? false : true,
+								},
+							},
+							sprintf(
+								// translators: %s is the status of content gifting.
+								__( 'Content gifting %s.', 'newspack-plugin' ),
+								config?.content_gifting?.enabled ? __( 'disabled', 'newspack-plugin' ) : __( 'enabled', 'newspack-plugin' )
+							)
+						),
+					type: 'more',
+				},
+			],
+			sectionName: __( 'Content gifting', 'newspack-plugin' ),
+		} );
+	}, [ config, isDirty, setHeaderData ] );
+
+	useEffect( () => {
+		setConfig( wizardData?.config || {} );
+	}, [ wizardData?.config ] );
+
 	return (
-		<>
+		<div className="newspack-content-gate__edit">
 			{ errorMessage && <Notice isError noticeText={ errorMessage } /> }
-			<ContentGifting config={ wizardData?.config || {} } setConfig={ onChange } updateConfig={ updateConfig } noBorder />
-		</>
+			{ giftingErrors.length > 0 && <Notice noticeText={ giftingErrors.join( ', ' ) } isError /> }
+			<Grid columns={ 2 } gutter={ 32 }>
+				<SectionHeader heading={ 2 } title={ __( 'General Settings', 'newspack-plugin' ) } />
+				<VStack spacing={ 4 }>
+					<RangeControl
+						label={ __( 'Gifting limit', 'newspack-plugin' ) }
+						help={ __( 'Maximum number of articles that can be gifted per user for the configured interval.', 'newspack-plugin' ) }
+						min={ 1 }
+						max={ 20 }
+						value={ config?.content_gifting?.limit }
+						onChange={ ( value: number ) => setConfig( { ...config, content_gifting: { ...config?.content_gifting, limit: value } } ) }
+						__next40pxDefaultSize
+					/>
+					<SelectControl
+						label={ __( 'Gifting limit interval', 'newspack-plugin' ) }
+						help={ __( 'Interval at which the gifting limit is reset.', 'newspack-plugin' ) }
+						value={ config?.content_gifting?.interval }
+						onChange={ ( value: string ) => setConfig( { ...config, content_gifting: { ...config?.content_gifting, interval: value } } ) }
+						options={ [
+							{ value: 'day', label: __( 'Day', 'newspack-plugin' ) },
+							{ value: 'week', label: __( 'Week', 'newspack-plugin' ) },
+							{ value: 'month', label: __( 'Month', 'newspack-plugin' ) },
+						] }
+						__next40pxDefaultSize
+					/>
+					<RangeControl
+						label={ __( 'Article link expiration time', 'newspack-plugin' ) }
+						help={ __( 'Time after which the article link expires.', 'newspack-plugin' ) }
+						min={ 1 }
+						max={ 60 }
+						value={ config?.content_gifting?.expiration_time || 5 }
+						onChange={ ( value: number ) =>
+							setConfig( { ...config, content_gifting: { ...config?.content_gifting, expiration_time: value } } )
+						}
+						__next40pxDefaultSize
+					/>
+					<SelectControl
+						label={ __( 'Article link expiration time unit', 'newspack-plugin' ) }
+						help={ __( 'Unit of time for the article link expiration time.', 'newspack-plugin' ) }
+						value={ config?.content_gifting?.expiration_time_unit || 'days' }
+						onChange={ ( value: string ) =>
+							setConfig( { ...config, content_gifting: { ...config?.content_gifting, expiration_time_unit: value } } )
+						}
+						options={ [
+							{ value: 'hours', label: __( 'Hours', 'newspack-plugin' ) },
+							{ value: 'days', label: __( 'Days', 'newspack-plugin' ) },
+						] }
+						__next40pxDefaultSize
+					/>
+				</VStack>
+			</Grid>
+			<Divider alignment="full-width" />
+			<Grid columns={ 2 } gutter={ 32 }>
+				<SectionHeader heading={ 2 } title={ __( 'Recipient Banner', 'newspack-plugin' ) } />
+				<VStack spacing={ 4 }>
+					<TextControl
+						label={ __( 'Message', 'newspack-plugin' ) }
+						help={ __( 'Text displayed in the banner shown to recipients of gifted articles.', 'newspack-plugin' ) }
+						value={ config?.content_gifting?.cta_label }
+						onChange={ ( value: string ) =>
+							setConfig( { ...config, content_gifting: { ...config?.content_gifting, cta_label: value } } )
+						}
+						withMargin={ false }
+						__next40pxDefaultSize
+					/>
+					<TextControl
+						label={ __( 'Subscribe button label', 'newspack-plugin' ) }
+						help={ __( 'Text displayed on the subscribe button in the banner.', 'newspack-plugin' ) }
+						value={ config?.content_gifting?.button_label }
+						onChange={ ( value: string ) =>
+							setConfig( { ...config, content_gifting: { ...config?.content_gifting, button_label: value } } )
+						}
+						withMargin={ false }
+						__next40pxDefaultSize
+					/>
+					<ToggleGroupControl
+						label={ __( 'Style', 'newspack-plugin' ) }
+						value={ config?.content_gifting?.style || 'light' }
+						onChange={ ( value: string ) => setConfig( { ...config, content_gifting: { ...config?.content_gifting, style: value } } ) }
+						isBlock
+						__next40pxDefaultSize
+					>
+						<ToggleGroupControlOption label={ __( 'Light', 'newspack-plugin' ) } value="light" />
+						<ToggleGroupControlOption label={ __( 'Dark', 'newspack-plugin' ) } value="dark" />
+					</ToggleGroupControl>
+					<ToggleGroupControl
+						label={ __( 'Subscribe button action', 'newspack-plugin' ) }
+						help={ __(
+							'Whether the subscribe button should start a product checkout or redirect to a landing page.',
+							'newspack-plugin'
+						) }
+						value={ config?.content_gifting?.cta_type || 'product' }
+						onChange={ ( value: string ) => setConfig( { ...config, content_gifting: { ...config?.content_gifting, cta_type: value } } ) }
+						isBlock
+						__next40pxDefaultSize
+					>
+						<ToggleGroupControlOption label={ __( 'Product', 'newspack-plugin' ) } value="product" />
+						<ToggleGroupControlOption label={ __( 'Landing page', 'newspack-plugin' ) } value="url" />
+					</ToggleGroupControl>
+					{ config?.content_gifting?.cta_type === 'product' && (
+						<SelectControl
+							label={ __( 'Subscribe button product', 'newspack-plugin' ) }
+							help={ __( 'Product linked to the subscribe button.', 'newspack-plugin' ) }
+							options={ [ { label: __( 'Select a product', 'newspack-plugin' ), value: 0, disabled: true }, ...availableProducts ] }
+							value={ config?.content_gifting?.cta_product_id }
+							suggestions={ availableProducts.map( o => o.label ) }
+							onChange={ ( value: number ) =>
+								setConfig( { ...config, content_gifting: { ...config?.content_gifting, cta_product_id: value } } )
+							}
+							__next40pxDefaultSize
+						/>
+					) }
+					{ config?.content_gifting?.cta_type === 'url' && (
+						<TextControl
+							label={ __( 'Subscribe button URL', 'newspack-plugin' ) }
+							help={ __( 'URL for the landing page to redirect to.', 'newspack-plugin' ) }
+							value={ config?.content_gifting?.cta_url }
+							onChange={ ( value: string ) =>
+								setConfig( { ...config, content_gifting: { ...config?.content_gifting, cta_url: value } } )
+							}
+							__next40pxDefaultSize
+						/>
+					) }
+				</VStack>
+			</Grid>
+			<div style={ { gridColumn: '1 / -1' } }>
+				<BaseControl id="newspack-content-gifting-cta-preview" label={ __( 'Preview', 'newspack-plugin' ) }>
+					<div className="newspack-content-gifting__cta-preview" inert="true">
+						<div className="newspack-ui">
+							<div className={ `banner newspack-content-gifting__cta is-style-${ config?.content_gifting?.style || 'light' }` }>
+								<div className="wrapper newspack-content-gifting__cta__content">
+									<div className="newspack-ui__font--s">
+										{ config?.content_gifting?.cta_label ||
+											__(
+												'This article has been gifted to you by someone who values great journalism.',
+												'newspack-plugin'
+											) }{ ' ' }
+										<div className="newspack-ui__font--xs newspack-content-gifting__cta__content__links">
+											{ hasMetering ? (
+												<a href="#register_modal">{ __( 'Create an account', 'newspack-plugin' ) }</a>
+											) : (
+												<a href="#signin_modal">{ __( 'Sign in to an existing account', 'newspack-plugin' ) }</a>
+											) }
+										</div>
+									</div>
+									{ ( ( config?.content_gifting?.cta_type === 'product' && config?.content_gifting?.cta_product_id ) ||
+										( config?.content_gifting?.cta_type === 'url' && config?.content_gifting?.cta_url ) ) && (
+										<button
+											className={ `newspack-ui__button newspack-ui__button--x-small ${
+												( config?.content_gifting?.style || 'light' ) === 'dark'
+													? 'newspack-ui__button--primary-light'
+													: 'newspack-ui__button--accent'
+											}` }
+										>
+											{ config?.content_gifting?.button_label || __( 'Subscribe now', 'newspack-plugin' ) }
+										</button>
+									) }
+								</div>
+							</div>
+						</div>
+					</div>
+				</BaseControl>
+			</div>
+		</div>
 	);
 };
 

--- a/src/wizards/audience/views/content-gates/edit/countdown-banner.tsx
+++ b/src/wizards/audience/views/content-gates/edit/countdown-banner.tsx
@@ -10,12 +10,12 @@ import { useDispatch } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { Notice } from '../../../../../packages/components/src';
-import { useWizardData } from '../../../../../packages/components/src/wizard/store/utils';
-import { WIZARD_STORE_NAMESPACE } from '../../../../../packages/components/src/wizard/store';
-import { useWizardApiFetch } from '../../../hooks/use-wizard-api-fetch';
-import CountdownBanner from '../setup/countdown-banner';
-import { AUDIENCE_CONTENT_GATES_WIZARD_SLUG } from './consts';
+import { Notice } from '../../../../../../packages/components/src';
+import { useWizardData } from '../../../../../../packages/components/src/wizard/store/utils';
+import { WIZARD_STORE_NAMESPACE } from '../../../../../../packages/components/src/wizard/store';
+import { useWizardApiFetch } from '../../../../hooks/use-wizard-api-fetch';
+import CountdownBanner from '../../setup/countdown-banner';
+import { AUDIENCE_CONTENT_GATES_WIZARD_SLUG } from '../consts';
 import './style.scss';
 
 const CountdownBannerSettings = () => {

--- a/src/wizards/audience/views/content-gates/edit/countdown-banner.tsx
+++ b/src/wizards/audience/views/content-gates/edit/countdown-banner.tsx
@@ -38,6 +38,7 @@ const CountdownBannerSettings = () => {
 	const { addNotice, resetNotices, setHeaderData, updateWizardSettings } = useDispatch( WIZARD_STORE_NAMESPACE );
 	const { wizardApiFetch, errorMessage, resetError } = useWizardApiFetch( AUDIENCE_CONTENT_GATES_WIZARD_SLUG );
 	const [ config, setConfig ] = useState< GateSettings >( wizardData?.config || {} );
+	const [ pendingToggle, setPendingToggle ] = useState< ( () => void ) | null >( null );
 	const availableProducts = newspackAudience?.available_products || [];
 	const isDirty = useMemo( () => {
 		return (
@@ -91,21 +92,25 @@ const CountdownBannerSettings = () => {
 				},
 				{
 					label: config?.countdown_banner?.enabled ? __( 'Disable', 'newspack-plugin' ) : __( 'Enable', 'newspack-plugin' ),
-					action: () =>
-						handleUpdateConfig(
-							{
-								...wizardData?.config,
-								countdown_banner: {
-									...wizardData?.config?.countdown_banner,
-									enabled: wizardData?.config?.countdown_banner?.enabled ? false : true,
-								},
+					action: () => {
+						const newConfig = {
+							...wizardData?.config,
+							countdown_banner: {
+								...wizardData?.config?.countdown_banner,
+								enabled: ! wizardData?.config?.countdown_banner?.enabled,
 							},
-							sprintf(
-								// translators: %s is the status of the countdown banner.
-								__( 'Countdown banner %s.', 'newspack-plugin' ),
-								config?.countdown_banner?.enabled ? __( 'disabled', 'newspack-plugin' ) : __( 'enabled', 'newspack-plugin' )
-							)
-						),
+						};
+						const message = sprintf(
+							// translators: %s is the status of the countdown banner.
+							__( 'Countdown banner %s.', 'newspack-plugin' ),
+							config?.countdown_banner?.enabled ? __( 'disabled', 'newspack-plugin' ) : __( 'enabled', 'newspack-plugin' )
+						);
+						if ( isDirty ) {
+							setPendingToggle( () => () => handleUpdateConfig( newConfig, message ) );
+						} else {
+							handleUpdateConfig( newConfig, message );
+						}
+					},
 					type: 'more',
 				},
 			],
@@ -119,7 +124,18 @@ const CountdownBannerSettings = () => {
 
 	return (
 		<div className="newspack-content-gate__edit">
-			<ConfirmDialog when={ isDirty && ! isSaving.current } confirmButtonText={ __( 'Discard changes', 'newspack-plugin' ) } hideTitle>
+			<ConfirmDialog
+				when={ isDirty && ! isSaving.current }
+				isOpen={ !! pendingToggle }
+				confirmButtonText={ __( 'Discard changes', 'newspack-plugin' ) }
+				isDestructive
+				hideTitle
+				onConfirm={ () => {
+					pendingToggle?.();
+					setPendingToggle( null );
+				} }
+				onCancel={ () => setPendingToggle( null ) }
+			>
 				{ __( 'You have unsaved changes that will be lost. Discard changes?', 'newspack-plugin' ) }
 			</ConfirmDialog>
 			{ errorMessage && <Notice isError noticeText={ errorMessage } /> }

--- a/src/wizards/audience/views/content-gates/edit/countdown-banner.tsx
+++ b/src/wizards/audience/views/content-gates/edit/countdown-banner.tsx
@@ -23,7 +23,7 @@ import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { ConfirmDialog, Grid, Notice, Router, SectionHeader, SelectControl, TextControl } from '../../../../../../packages/components/src';
+import { Grid, Notice, Router, SectionHeader, SelectControl, TextControl, useConfirmDialog } from '../../../../../../packages/components/src';
 import { useWizardData } from '../../../../../../packages/components/src/wizard/store/utils';
 import { WIZARD_STORE_NAMESPACE } from '../../../../../../packages/components/src/wizard/store';
 import { useWizardApiFetch } from '../../../../hooks/use-wizard-api-fetch';
@@ -38,7 +38,6 @@ const CountdownBannerSettings = () => {
 	const { addNotice, resetNotices, setHeaderData, updateWizardSettings } = useDispatch( WIZARD_STORE_NAMESPACE );
 	const { wizardApiFetch, errorMessage, resetError } = useWizardApiFetch( AUDIENCE_CONTENT_GATES_WIZARD_SLUG );
 	const [ config, setConfig ] = useState< GateSettings >( wizardData?.config || {} );
-	const [ pendingToggle, setPendingToggle ] = useState< ( () => void ) | null >( null );
 	const availableProducts = newspackAudience?.available_products || [];
 	const isDirty = useMemo( () => {
 		return (
@@ -48,6 +47,13 @@ const CountdownBannerSettings = () => {
 		);
 	}, [ config, wizardData?.config ] );
 	const isSaving = useRef( false );
+	const { confirmDialog, requestConfirm } = useConfirmDialog( {
+		when: !! ( isDirty && ! isSaving.current ),
+		message: __( 'You have unsaved changes that will be lost. Discard changes?', 'newspack-plugin' ),
+		confirmButtonText: __( 'Discard changes', 'newspack-plugin' ),
+		isDestructive: true,
+		hideTitle: true,
+	} );
 
 	const handleUpdateConfig = ( newConfig: GateSettings, message: string = __( 'Metered countdown settings updated.', 'newspack-plugin' ) ) => {
 		isSaving.current = true;
@@ -105,11 +111,7 @@ const CountdownBannerSettings = () => {
 							__( 'Countdown banner %s.', 'newspack-plugin' ),
 							config?.countdown_banner?.enabled ? __( 'disabled', 'newspack-plugin' ) : __( 'enabled', 'newspack-plugin' )
 						);
-						if ( isDirty ) {
-							setPendingToggle( () => () => handleUpdateConfig( newConfig, message ) );
-						} else {
-							handleUpdateConfig( newConfig, message );
-						}
+						requestConfirm( () => handleUpdateConfig( newConfig, message ) );
 					},
 					type: 'more',
 				},
@@ -124,20 +126,7 @@ const CountdownBannerSettings = () => {
 
 	return (
 		<div className="newspack-content-gate__edit">
-			<ConfirmDialog
-				when={ isDirty && ! isSaving.current }
-				isOpen={ !! pendingToggle }
-				confirmButtonText={ __( 'Discard changes', 'newspack-plugin' ) }
-				isDestructive
-				hideTitle
-				onConfirm={ () => {
-					pendingToggle?.();
-					setPendingToggle( null );
-				} }
-				onCancel={ () => setPendingToggle( null ) }
-			>
-				{ __( 'You have unsaved changes that will be lost. Discard changes?', 'newspack-plugin' ) }
-			</ConfirmDialog>
+			{ confirmDialog }
 			{ errorMessage && <Notice isError noticeText={ errorMessage } /> }
 			<Grid columns={ 2 } gutter={ 32 }>
 				<SectionHeader heading={ 2 } title={ __( 'Countdown banner', 'newspack-plugin' ) } />

--- a/src/wizards/audience/views/content-gates/edit/countdown-banner.tsx
+++ b/src/wizards/audience/views/content-gates/edit/countdown-banner.tsx
@@ -193,6 +193,7 @@ const CountdownBannerSettings = () => {
 							onChange={ ( value: string ) =>
 								setConfig( { ...config, countdown_banner: { ...config?.countdown_banner, cta_url: value } } )
 							}
+							withMargin={ false }
 							__next40pxDefaultSize
 						/>
 					) }

--- a/src/wizards/audience/views/content-gates/edit/countdown-banner.tsx
+++ b/src/wizards/audience/views/content-gates/edit/countdown-banner.tsx
@@ -18,12 +18,12 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
-import { useEffect, useMemo, useState } from '@wordpress/element';
+import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-import { Grid, Notice, Router, SectionHeader, SelectControl, TextControl } from '../../../../../../packages/components/src';
+import { ConfirmDialog, Grid, Notice, Router, SectionHeader, SelectControl, TextControl } from '../../../../../../packages/components/src';
 import { useWizardData } from '../../../../../../packages/components/src/wizard/store/utils';
 import { WIZARD_STORE_NAMESPACE } from '../../../../../../packages/components/src/wizard/store';
 import { useWizardApiFetch } from '../../../../hooks/use-wizard-api-fetch';
@@ -39,12 +39,17 @@ const CountdownBannerSettings = () => {
 	const { wizardApiFetch, errorMessage, resetError } = useWizardApiFetch( AUDIENCE_CONTENT_GATES_WIZARD_SLUG );
 	const [ config, setConfig ] = useState< GateSettings >( wizardData?.config || {} );
 	const availableProducts = newspackAudience?.available_products || [];
-
 	const isDirty = useMemo( () => {
-		return JSON.stringify( config?.countdown_banner ) !== JSON.stringify( wizardData?.config?.countdown_banner );
+		return (
+			config?.countdown_banner &&
+			wizardData?.config?.countdown_banner &&
+			JSON.stringify( config?.countdown_banner ) !== JSON.stringify( wizardData?.config?.countdown_banner )
+		);
 	}, [ config, wizardData?.config ] );
+	const isSaving = useRef( false );
 
 	const handleUpdateConfig = ( newConfig: GateSettings, message: string = __( 'Metered countdown settings updated.', 'newspack-plugin' ) ) => {
+		isSaving.current = true;
 		resetError();
 		resetNotices();
 		wizardApiFetch(
@@ -67,6 +72,9 @@ const CountdownBannerSettings = () => {
 						id: 'countdown-banner-config-updated',
 					} );
 					history.push( '/content-gates' );
+				},
+				onFinally: () => {
+					isSaving.current = false;
 				},
 			}
 		);
@@ -111,6 +119,9 @@ const CountdownBannerSettings = () => {
 
 	return (
 		<div className="newspack-content-gate__edit">
+			<ConfirmDialog when={ isDirty && ! isSaving.current } confirmButtonText={ __( 'Discard changes', 'newspack-plugin' ) } hideTitle>
+				{ __( 'You have unsaved changes that will be lost. Discard changes?', 'newspack-plugin' ) }
+			</ConfirmDialog>
 			{ errorMessage && <Notice isError noticeText={ errorMessage } /> }
 			<Grid columns={ 2 } gutter={ 32 }>
 				<SectionHeader heading={ 2 } title={ __( 'Countdown banner', 'newspack-plugin' ) } />
@@ -118,7 +129,7 @@ const CountdownBannerSettings = () => {
 					<TextControl
 						label={ __( 'Message', 'newspack-plugin' ) }
 						help={ __( 'Text displayed in the countdown banner.', 'newspack-plugin' ) }
-						value={ config?.countdown_banner?.cta_label }
+						value={ config?.countdown_banner?.cta_label || '' }
 						onChange={ ( value: string ) =>
 							setConfig( { ...config, countdown_banner: { ...config?.countdown_banner, cta_label: value } } )
 						}
@@ -128,7 +139,7 @@ const CountdownBannerSettings = () => {
 					<TextControl
 						label={ __( 'Subscribe button label', 'newspack-plugin' ) }
 						help={ __( 'Text displayed on the subscribe button in the banner.', 'newspack-plugin' ) }
-						value={ config?.countdown_banner?.button_label }
+						value={ config?.countdown_banner?.button_label || '' }
 						onChange={ ( value: string ) =>
 							setConfig( { ...config, countdown_banner: { ...config?.countdown_banner, button_label: value } } )
 						}
@@ -166,7 +177,7 @@ const CountdownBannerSettings = () => {
 							label={ __( 'Subscribe button product', 'newspack-plugin' ) }
 							help={ __( 'Product linked to the subscribe button.', 'newspack-plugin' ) }
 							options={ [ { label: __( 'Select a product', 'newspack-plugin' ), value: 0, disabled: true }, ...availableProducts ] }
-							value={ config?.countdown_banner?.cta_product_id }
+							value={ config?.countdown_banner?.cta_product_id || 0 }
 							suggestions={ availableProducts.map( o => o.label ) }
 							onChange={ ( value: number ) =>
 								setConfig( { ...config, countdown_banner: { ...config?.countdown_banner, cta_product_id: value } } )
@@ -178,7 +189,7 @@ const CountdownBannerSettings = () => {
 						<TextControl
 							label={ __( 'Subscribe button URL', 'newspack-plugin' ) }
 							help={ __( 'URL for the landing page to redirect to.', 'newspack-plugin' ) }
-							value={ config?.countdown_banner?.cta_url }
+							value={ config?.countdown_banner?.cta_url || '' }
 							onChange={ ( value: string ) =>
 								setConfig( { ...config, countdown_banner: { ...config?.countdown_banner, cta_url: value } } )
 							}

--- a/src/wizards/audience/views/content-gates/edit/countdown-banner.tsx
+++ b/src/wizards/audience/views/content-gates/edit/countdown-banner.tsx
@@ -1,3 +1,5 @@
+/* global newspackAudience */
+
 /**
  * Metered Countdown settings page.
  */
@@ -5,54 +7,221 @@
 /**
  * WordPress dependencies.
  */
+import { __, sprintf } from '@wordpress/i18n';
+import {
+	BaseControl,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
+import { useEffect, useMemo, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-import { Notice } from '../../../../../../packages/components/src';
+import { Grid, Notice, Router, SectionHeader, SelectControl, TextControl } from '../../../../../../packages/components/src';
 import { useWizardData } from '../../../../../../packages/components/src/wizard/store/utils';
 import { WIZARD_STORE_NAMESPACE } from '../../../../../../packages/components/src/wizard/store';
 import { useWizardApiFetch } from '../../../../hooks/use-wizard-api-fetch';
-import CountdownBanner from '../../setup/countdown-banner';
 import { AUDIENCE_CONTENT_GATES_WIZARD_SLUG } from '../consts';
 import './style.scss';
 
+const { useHistory } = Router;
+
 const CountdownBannerSettings = () => {
+	const history = useHistory();
 	const wizardData = useWizardData( AUDIENCE_CONTENT_GATES_WIZARD_SLUG ) as WizardData;
-	const { updateWizardSettings } = useDispatch( WIZARD_STORE_NAMESPACE );
+	const { addNotice, resetNotices, setHeaderData, updateWizardSettings } = useDispatch( WIZARD_STORE_NAMESPACE );
 	const { wizardApiFetch, errorMessage, resetError } = useWizardApiFetch( AUDIENCE_CONTENT_GATES_WIZARD_SLUG );
+	const [ config, setConfig ] = useState< GateSettings >( wizardData?.config || {} );
+	const availableProducts = newspackAudience?.available_products || [];
 
-	const onChange = ( newConfig: GateSettings ) => {
-		updateWizardSettings( {
-			slug: AUDIENCE_CONTENT_GATES_WIZARD_SLUG,
-			path: [ 'config' ],
-			value: newConfig,
-		} );
-	};
+	const isDirty = useMemo( () => {
+		return JSON.stringify( config?.countdown_banner ) !== JSON.stringify( wizardData?.config?.countdown_banner );
+	}, [ config, wizardData?.config ] );
 
-	const updateConfig = ( newConfig: GateSettings ) => {
+	const handleUpdateConfig = ( newConfig: GateSettings, message: string = __( 'Countdown banner updated.', 'newspack-plugin' ) ) => {
 		resetError();
+		resetNotices();
 		wizardApiFetch(
 			{
 				path: '/newspack/v1/wizard/newspack-audience-access-control/countdown-banner',
 				method: 'POST',
 				quiet: true,
-				data: newConfig.countdown_banner,
+				data: newConfig?.countdown_banner,
 			},
 			{
 				onSuccess( data ) {
-					onChange( { ...wizardData?.config, countdown_banner: data } );
+					updateWizardSettings( {
+						slug: AUDIENCE_CONTENT_GATES_WIZARD_SLUG,
+						path: [ 'config' ],
+						value: { ...wizardData?.config, countdown_banner: data },
+					} );
+					addNotice( {
+						message,
+						type: 'success',
+						id: 'countdown-banner-config-updated',
+					} );
+					history.push( '/content-gates' );
 				},
 			}
 		);
 	};
 
+	useEffect( () => {
+		setHeaderData( {
+			actions: [
+				{
+					label: __( 'Save', 'newspack-plugin' ),
+					action: () => handleUpdateConfig( config ),
+					disabled: ! isDirty,
+					type: 'primary',
+				},
+				{
+					label: config?.countdown_banner?.enabled ? __( 'Disable', 'newspack-plugin' ) : __( 'Enable', 'newspack-plugin' ),
+					action: () =>
+						handleUpdateConfig(
+							{
+								...wizardData?.config,
+								countdown_banner: {
+									...wizardData?.config?.countdown_banner,
+									enabled: wizardData?.config?.countdown_banner?.enabled ? false : true,
+								},
+							},
+							sprintf(
+								// translators: %s is the status of the countdown banner.
+								__( 'Countdown banner %s.', 'newspack-plugin' ),
+								config?.countdown_banner?.enabled ? __( 'disabled', 'newspack-plugin' ) : __( 'enabled', 'newspack-plugin' )
+							)
+						),
+					type: 'more',
+				},
+			],
+			sectionName: __( 'Metered countdown', 'newspack-plugin' ),
+		} );
+	}, [ config, isDirty, setHeaderData ] );
+
+	useEffect( () => {
+		setConfig( wizardData?.config || {} );
+	}, [ wizardData?.config ] );
+
 	return (
-		<>
+		<div className="newspack-content-gate__edit">
 			{ errorMessage && <Notice isError noticeText={ errorMessage } /> }
-			<CountdownBanner config={ wizardData?.config || {} } setConfig={ onChange } updateConfig={ updateConfig } noBorder />
-		</>
+			<Grid columns={ 2 } gutter={ 32 }>
+				<SectionHeader heading={ 2 } title={ __( 'Countdown banner', 'newspack-plugin' ) } />
+				<VStack spacing={ 4 }>
+					<TextControl
+						label={ __( 'Message', 'newspack-plugin' ) }
+						help={ __( 'Text displayed in the countdown banner.', 'newspack-plugin' ) }
+						value={ config?.countdown_banner?.cta_label }
+						onChange={ ( value: string ) =>
+							setConfig( { ...config, countdown_banner: { ...config?.countdown_banner, cta_label: value } } )
+						}
+						withMargin={ false }
+						__next40pxDefaultSize
+					/>
+					<TextControl
+						label={ __( 'Subscribe button label', 'newspack-plugin' ) }
+						help={ __( 'Text displayed on the subscribe button in the banner.', 'newspack-plugin' ) }
+						value={ config?.countdown_banner?.button_label }
+						onChange={ ( value: string ) =>
+							setConfig( { ...config, countdown_banner: { ...config?.countdown_banner, button_label: value } } )
+						}
+						withMargin={ false }
+						__next40pxDefaultSize
+					/>
+					<ToggleGroupControl
+						label={ __( 'Style', 'newspack-plugin' ) }
+						value={ config?.countdown_banner?.style || 'light' }
+						onChange={ ( value: string ) => setConfig( { ...config, countdown_banner: { ...config?.countdown_banner, style: value } } ) }
+						isBlock
+						__next40pxDefaultSize
+					>
+						<ToggleGroupControlOption label={ __( 'Light', 'newspack-plugin' ) } value="light" />
+						<ToggleGroupControlOption label={ __( 'Dark', 'newspack-plugin' ) } value="dark" />
+					</ToggleGroupControl>
+					<ToggleGroupControl
+						label={ __( 'Subscribe button action', 'newspack-plugin' ) }
+						help={ __(
+							'Whether the subscribe button should start a product checkout or redirect to a landing page.',
+							'newspack-plugin'
+						) }
+						value={ config?.countdown_banner?.cta_type || 'product' }
+						onChange={ ( value: string ) =>
+							setConfig( { ...config, countdown_banner: { ...config?.countdown_banner, cta_type: value } } )
+						}
+						isBlock
+						__next40pxDefaultSize
+					>
+						<ToggleGroupControlOption label={ __( 'Product', 'newspack-plugin' ) } value="product" />
+						<ToggleGroupControlOption label={ __( 'Landing page', 'newspack-plugin' ) } value="url" />
+					</ToggleGroupControl>
+					{ config?.countdown_banner?.cta_type === 'product' && (
+						<SelectControl
+							label={ __( 'Subscribe button product', 'newspack-plugin' ) }
+							help={ __( 'Product linked to the subscribe button.', 'newspack-plugin' ) }
+							options={ [ { label: __( 'Select a product', 'newspack-plugin' ), value: 0, disabled: true }, ...availableProducts ] }
+							value={ config?.countdown_banner?.cta_product_id }
+							suggestions={ availableProducts.map( o => o.label ) }
+							onChange={ ( value: number ) =>
+								setConfig( { ...config, countdown_banner: { ...config?.countdown_banner, cta_product_id: value } } )
+							}
+							__next40pxDefaultSize
+						/>
+					) }
+					{ config?.countdown_banner?.cta_type === 'url' && (
+						<TextControl
+							label={ __( 'Subscribe button URL', 'newspack-plugin' ) }
+							help={ __( 'URL for the landing page to redirect to.', 'newspack-plugin' ) }
+							value={ config?.countdown_banner?.cta_url }
+							onChange={ ( value: string ) =>
+								setConfig( { ...config, countdown_banner: { ...config?.countdown_banner, cta_url: value } } )
+							}
+							__next40pxDefaultSize
+						/>
+					) }
+				</VStack>
+			</Grid>
+			<div style={ { gridColumn: '1 / -1' } }>
+				<BaseControl id="newspack-countdown-banner-cta-preview" label={ __( 'Preview', 'newspack-plugin' ) }>
+					<div className="newspack-countdown-banner__cta-preview" inert="true">
+						<div className="newspack-ui">
+							<div className={ `banner newspack-countdown-banner__cta is-style-${ config?.countdown_banner?.style || 'light' }` }>
+								<div className="wrapper newspack-countdown-banner__cta__content">
+									<div className="newspack-countdown-banner__cta__content__wrapper">
+										<span className="newspack-countdown-banner__cta__content__countdown newspack-ui__font--s">
+											<strong>{ __( '1/10 free articles this month', 'newspack-plugin' ) }</strong>
+										</span>
+										<span className="newspack-countdown-banner__cta__content__message newspack-ui__font--xs">
+											{ config?.countdown_banner?.cta_label ||
+												__( 'Subscribe now and get unlimited access.', 'newspack-plugin' ) }{ ' ' }
+											<a href="#signin_modal">{ __( 'Sign in to an existing account', 'newspack-plugin' ) }</a>.
+										</span>
+									</div>
+									{ ( ( config?.countdown_banner?.cta_type === 'product' && config?.countdown_banner?.cta_product_id ) ||
+										( config?.countdown_banner?.cta_type === 'url' && config?.countdown_banner?.cta_url ) ) && (
+										<button
+											className={ `newspack-ui__button newspack-ui__button--x-small ${
+												( config?.countdown_banner?.style || 'light' ) === 'dark'
+													? 'newspack-ui__button--primary-light'
+													: 'newspack-ui__button--accent'
+											}` }
+										>
+											{ config?.countdown_banner?.button_label || __( 'Subscribe now', 'newspack-plugin' ) }
+										</button>
+									) }
+								</div>
+							</div>
+						</div>
+					</div>
+				</BaseControl>
+			</div>
+		</div>
 	);
 };
 

--- a/src/wizards/audience/views/content-gates/edit/countdown-banner.tsx
+++ b/src/wizards/audience/views/content-gates/edit/countdown-banner.tsx
@@ -44,7 +44,7 @@ const CountdownBannerSettings = () => {
 		return JSON.stringify( config?.countdown_banner ) !== JSON.stringify( wizardData?.config?.countdown_banner );
 	}, [ config, wizardData?.config ] );
 
-	const handleUpdateConfig = ( newConfig: GateSettings, message: string = __( 'Countdown banner updated.', 'newspack-plugin' ) ) => {
+	const handleUpdateConfig = ( newConfig: GateSettings, message: string = __( 'Metered countdown settings updated.', 'newspack-plugin' ) ) => {
 		resetError();
 		resetNotices();
 		wizardApiFetch(

--- a/src/wizards/audience/views/content-gates/edit/index.tsx
+++ b/src/wizards/audience/views/content-gates/edit/index.tsx
@@ -17,13 +17,13 @@ import { commentAuthorAvatar, currencyDollar, postList, settings } from '@wordpr
 import { AUDIENCE_CONTENT_GATES_WIZARD_SLUG } from '../consts';
 import {
 	CardSettingsGroup,
-	ConfirmDialog,
 	Divider,
 	Grid,
 	Notice,
 	Router,
 	SectionHeader,
 	TextControl,
+	useConfirmDialog,
 } from '../../../../../../packages/components/src';
 import { WIZARD_STORE_NAMESPACE } from '../../../../../../packages/components/src/wizard/store';
 import { useWizardData } from '../../../../../../packages/components/src/wizard/store/utils';
@@ -85,12 +85,10 @@ const Edit = ( { match, updateGatesData }: ContentGateEditProps ) => {
 	const [ customAccess, setCustomAccess ] = useState< CustomAccess >( gate.custom_access );
 	const [ contentType, setContentType ] = useState< 'all' | 'custom' | undefined >( type as 'all' | 'custom' | undefined );
 	const [ status, setStatus ] = useState< GateStatus >( gate.status );
-	const [ showDeleteDialog, setShowDeleteDialog ] = useState( false );
 	const [ error, setError ] = useState< string | null >( errorMessage );
 	const isNew = _id === 'new' || ! id;
 	const isSaving = useRef( false );
 	const gatesRef = useRef< Gate[] >( gates );
-
 	useEffect( () => {
 		if ( Array.isArray( gates ) ) {
 			gatesRef.current = gates;
@@ -103,6 +101,26 @@ const Edit = ( { match, updateGatesData }: ContentGateEditProps ) => {
 		JSON.stringify( contentRules ) !== JSON.stringify( gate.content_rules ) ||
 		JSON.stringify( registration ) !== JSON.stringify( gate.registration ) ||
 		JSON.stringify( customAccess ) !== JSON.stringify( gate.custom_access );
+
+	const { confirmDialog: navBlockDialog } = useConfirmDialog( {
+		when: isDirty && ! isSaving.current,
+		message: __( 'You have unsaved changes that will be lost. Discard changes?', 'newspack-plugin' ),
+		confirmButtonText: __( 'Discard changes', 'newspack-plugin' ),
+		hideTitle: true,
+	} );
+	const { confirmDialog: deleteDialog, requestConfirm: requestDelete } = useConfirmDialog( {
+		title: __( 'Are you sure?', 'newspack-plugin' ),
+		confirmButtonText: __( 'Delete', 'newspack-plugin' ),
+		isDestructive: true,
+		message: createInterpolateElement(
+			sprintf(
+				// translators: %s is the gate title.
+				__( 'This will <strong>permanently delete</strong> "%s" and cannot be undone.', 'newspack-plugin' ),
+				gate.title
+			),
+			{ strong: <strong /> }
+		),
+	} );
 
 	const handleCreate = useCallback( () => {
 		if ( isFetching ) {
@@ -257,7 +275,6 @@ const Edit = ( { match, updateGatesData }: ContentGateEditProps ) => {
 				},
 				onFinally() {
 					setIsDeleting( false );
-					setShowDeleteDialog( false );
 				},
 			}
 		);
@@ -346,7 +363,7 @@ const Edit = ( { match, updateGatesData }: ContentGateEditProps ) => {
 			actions.push( {
 				type: 'more',
 				label: __( 'Delete', 'newspack-plugin' ),
-				action: () => setShowDeleteDialog( true ),
+				action: () => requestDelete( handleDelete ),
 				disabled: isFetching,
 				destructive: true,
 			} );
@@ -389,27 +406,8 @@ const Edit = ( { match, updateGatesData }: ContentGateEditProps ) => {
 
 	return (
 		<div className="newspack-content-gate__edit">
-			<ConfirmDialog when={ isDirty && ! isSaving.current } confirmButtonText={ __( 'Discard changes', 'newspack-plugin' ) } hideTitle>
-				{ __( 'You have unsaved changes that will be lost. Discard changes?', 'newspack-plugin' ) }
-			</ConfirmDialog>
-			<ConfirmDialog
-				title={ __( 'Are you sure?', 'newspack-plugin' ) }
-				onConfirm={ handleDelete }
-				onCancel={ () => setShowDeleteDialog( false ) }
-				confirmButtonText={ __( 'Delete', 'newspack-plugin' ) }
-				isDestructive={ true }
-				when={ showDeleteDialog && ! isSaving.current && ! isDeleting && ! isFetching }
-				isShowingDialog={ showDeleteDialog }
-			>
-				{ createInterpolateElement(
-					sprintf(
-						// translators: %s is the gate title.
-						__( 'This will <strong>permanently delete</strong> “%s” and cannot be undone.', 'newspack-plugin' ),
-						gate.title
-					),
-					{ strong: <strong /> }
-				) }
-			</ConfirmDialog>
+			{ navBlockDialog }
+			{ deleteDialog }
 			{ error && <Notice isError noticeText={ error } /> }
 			{ ( isNew || isRenaming ) && (
 				<>

--- a/src/wizards/audience/views/content-gates/edit/index.tsx
+++ b/src/wizards/audience/views/content-gates/edit/index.tsx
@@ -85,11 +85,9 @@ const Edit = ( { match, updateGatesData }: ContentGateEditProps ) => {
 	const [ customAccess, setCustomAccess ] = useState< CustomAccess >( gate.custom_access );
 	const [ contentType, setContentType ] = useState< 'all' | 'custom' | undefined >( type as 'all' | 'custom' | undefined );
 	const [ status, setStatus ] = useState< GateStatus >( gate.status );
-	const [ showUnsavedChangesDialog, setShowUnsavedChangesDialog ] = useState( false );
 	const [ showDeleteDialog, setShowDeleteDialog ] = useState( false );
 	const isNew = _id === 'new' || ! id;
 	const isSaving = useRef( false );
-	const pendingNavigation = useRef< ( () => void ) | null >( null );
 
 	const isDirty =
 		isNew ||
@@ -102,6 +100,7 @@ const Edit = ( { match, updateGatesData }: ContentGateEditProps ) => {
 		if ( isFetching ) {
 			return;
 		}
+		isSaving.current = true;
 		resetNotices();
 		resetError();
 		const _gate = {
@@ -120,7 +119,6 @@ const Edit = ( { match, updateGatesData }: ContentGateEditProps ) => {
 			{
 				onSuccess( data ) {
 					updateGatesData( [ ...gates, { ...data } ] );
-					isSaving.current = true;
 					history.push( `/content-gates` );
 					addNotice( {
 						// translators: %s is the gate title.
@@ -130,6 +128,9 @@ const Edit = ( { match, updateGatesData }: ContentGateEditProps ) => {
 						actions: [ { label: __( 'Edit', 'newspack-plugin' ), url: `#/edit/${ data.id }` } ],
 					} );
 				},
+				onFinally: () => {
+					isSaving.current = false;
+				},
 			}
 		);
 	}, [ gate, contentRules, registration, customAccess, status, title ] );
@@ -138,6 +139,7 @@ const Edit = ( { match, updateGatesData }: ContentGateEditProps ) => {
 		if ( isFetching ) {
 			return;
 		}
+		isSaving.current = true;
 		resetError();
 		resetNotices();
 		const gateTitle = title || gate.title;
@@ -158,7 +160,6 @@ const Edit = ( { match, updateGatesData }: ContentGateEditProps ) => {
 			{
 				onSuccess( data: Gate ) {
 					updateGatesData( gates.map( g => ( g.id === data.id ? data : g ) ) );
-					isSaving.current = true;
 					history.push( '/content-gates' );
 					addNotice( {
 						message: sprintf(
@@ -170,6 +171,9 @@ const Edit = ( { match, updateGatesData }: ContentGateEditProps ) => {
 						id: 'content-gate-updated',
 					} );
 				},
+				onFinally: () => {
+					isSaving.current = false;
+				},
 			}
 		);
 	}, [ gate, contentRules, registration, customAccess, status, title ] );
@@ -179,6 +183,7 @@ const Edit = ( { match, updateGatesData }: ContentGateEditProps ) => {
 		if ( isFetching ) {
 			return;
 		}
+		isSaving.current = true;
 		resetError();
 		resetNotices();
 		const prevStatus = gate.status;
@@ -207,6 +212,9 @@ const Edit = ( { match, updateGatesData }: ContentGateEditProps ) => {
 						id: 'content-gate-status-changed',
 						actions: [ { label: __( 'Undo', 'newspack-plugin' ), onClick: () => updateStatus.current?.( prevStatus ) } ],
 					} );
+				},
+				onFinally: () => {
+					isSaving.current = false;
 				},
 			}
 		);
@@ -363,48 +371,11 @@ const Edit = ( { match, updateGatesData }: ContentGateEditProps ) => {
 		}
 	}, [ isNew, gate.status, status, updateStatus ] );
 
-	// Block navigation when there are unsaved changes.
-	useEffect( () => {
-		if ( ! isDirty ) {
-			return;
-		}
-		const unblock = history.block( ( location: string, action: string ) => {
-			if ( isSaving.current ) {
-				return;
-			}
-			pendingNavigation.current = () => {
-				unblock();
-				if ( action === 'REPLACE' ) {
-					history.replace( location );
-				} else {
-					history.push( location );
-				}
-			};
-			setShowUnsavedChangesDialog( true );
-			return false;
-		} );
-		return unblock;
-	}, [ isDirty, history ] );
-
 	return (
 		<div className="newspack-content-gate__edit">
-			{ showUnsavedChangesDialog && (
-				<ConfirmDialog
-					onConfirm={ () => {
-						setShowUnsavedChangesDialog( false );
-						pendingNavigation.current?.();
-						pendingNavigation.current = null;
-					} }
-					onCancel={ () => {
-						setShowUnsavedChangesDialog( false );
-						pendingNavigation.current = null;
-					} }
-					confirmButtonText={ __( 'Discard changes', 'newspack-plugin' ) }
-					hideTitle
-				>
-					{ __( 'You have unsaved changes that will be lost. Discard changes?', 'newspack-plugin' ) }
-				</ConfirmDialog>
-			) }
+			<ConfirmDialog when={ isDirty && ! isSaving.current } confirmButtonText={ __( 'Discard changes', 'newspack-plugin' ) } hideTitle>
+				{ __( 'You have unsaved changes that will be lost. Discard changes?', 'newspack-plugin' ) }
+			</ConfirmDialog>
 			{ showDeleteDialog && (
 				<ConfirmDialog
 					title={ __( 'Are you sure?', 'newspack-plugin' ) }

--- a/src/wizards/audience/views/content-gates/edit/index.tsx
+++ b/src/wizards/audience/views/content-gates/edit/index.tsx
@@ -159,7 +159,7 @@ const Edit = ( { match, updateGatesData }: ContentGateEditProps ) => {
 				onSuccess( data: Gate ) {
 					updateGatesData( gates.map( g => ( g.id === data.id ? data : g ) ) );
 					isSaving.current = true;
-					history.push( `/content-gates` );
+					history.push( '/content-gates' );
 					addNotice( {
 						message: sprintf(
 							// translators: %s is the gate title.

--- a/src/wizards/audience/views/content-gates/edit/index.tsx
+++ b/src/wizards/audience/views/content-gates/edit/index.tsx
@@ -74,7 +74,7 @@ const Edit = ( { match, updateGatesData }: ContentGateEditProps ) => {
 	const { id: _id, type } = match.params;
 	const id = _id ? parseInt( _id ) : 0;
 	const { gates = null as unknown as Gate[] } = useWizardData( AUDIENCE_CONTENT_GATES_WIZARD_SLUG ) as WizardData;
-	const { wizardApiFetch, isFetching, errorMessage, resetError, setError } = useWizardApiFetch( AUDIENCE_CONTENT_GATES_WIZARD_SLUG );
+	const { wizardApiFetch, isFetching, errorMessage, resetError } = useWizardApiFetch( AUDIENCE_CONTENT_GATES_WIZARD_SLUG );
 	const { addNotice, resetNotices, setHeaderData } = useDispatch( WIZARD_STORE_NAMESPACE );
 	const [ gate, setGate ] = useState< Gate >( ( gates && gates.find( g => g.id === id ) ) || DEFAULT_GATE ); // eslint-disable-line @typescript-eslint/no-unused-vars
 	const [ title, setTitle ] = useState< string >( gate.title );
@@ -86,8 +86,16 @@ const Edit = ( { match, updateGatesData }: ContentGateEditProps ) => {
 	const [ contentType, setContentType ] = useState< 'all' | 'custom' | undefined >( type as 'all' | 'custom' | undefined );
 	const [ status, setStatus ] = useState< GateStatus >( gate.status );
 	const [ showDeleteDialog, setShowDeleteDialog ] = useState( false );
+	const [ error, setError ] = useState< string | null >( errorMessage );
 	const isNew = _id === 'new' || ! id;
 	const isSaving = useRef( false );
+	const gatesRef = useRef< Gate[] >( gates );
+
+	useEffect( () => {
+		if ( Array.isArray( gates ) ) {
+			gatesRef.current = gates;
+		}
+	}, [ gates ] );
 
 	const isDirty =
 		isNew ||
@@ -118,7 +126,7 @@ const Edit = ( { match, updateGatesData }: ContentGateEditProps ) => {
 			},
 			{
 				onSuccess( data ) {
-					updateGatesData( [ ...gates, { ...data } ] );
+					updateGatesData( [ ...gatesRef.current, { ...data } ] );
 					history.push( `/content-gates` );
 					addNotice( {
 						// translators: %s is the gate title.
@@ -159,7 +167,7 @@ const Edit = ( { match, updateGatesData }: ContentGateEditProps ) => {
 			},
 			{
 				onSuccess( data: Gate ) {
-					updateGatesData( gates.map( g => ( g.id === data.id ? data : g ) ) );
+					updateGatesData( gatesRef.current.map( g => ( g.id === data.id ? data : g ) ) );
 					history.push( '/content-gates' );
 					addNotice( {
 						message: sprintf(
@@ -221,36 +229,39 @@ const Edit = ( { match, updateGatesData }: ContentGateEditProps ) => {
 	};
 	updateStatus.current = handleStatusChange;
 
-	const handleDelete = useCallback(
-		( gateId: number ) => {
-			resetError();
-			setIsDeleting( true );
-			wizardApiFetch(
-				{
-					path: `/newspack/v1/wizard/${ AUDIENCE_CONTENT_GATES_WIZARD_SLUG }/${ gateId }`,
-					method: 'DELETE',
+	const handleDelete = useCallback( () => {
+		if ( isFetching ) {
+			return;
+		}
+		resetError();
+		resetNotices();
+		setIsDeleting( true );
+		wizardApiFetch(
+			{
+				path: `/newspack/v1/wizard/${ AUDIENCE_CONTENT_GATES_WIZARD_SLUG }/${ id }`,
+				method: 'DELETE',
+			},
+			{
+				onSuccess() {
+					const deletedGate = gatesRef.current.find( g => g.id === id );
+					const gateTitle = deletedGate?.title || title;
+					const newGates = gatesRef.current.filter( g => g.id !== id );
+					updateGatesData( newGates );
+					history.push( `/content-gates` );
+					addNotice( {
+						// translators: %s is the gate title.
+						message: sprintf( __( '“%s” gate deleted.', 'newspack-plugin' ), gateTitle ),
+						type: 'success',
+						id: 'content-gate-deleted',
+					} );
 				},
-				{
-					onSuccess() {
-						const newGates = gates.filter( g => g.id !== gateId );
-						updateGatesData( newGates );
-						history.push( `/content-gates` );
-						setIsDeleting( false );
-						addNotice( {
-							// translators: %s is the gate title.
-							message: sprintf( __( '“%s” gate deleted.', 'newspack-plugin' ), title ),
-							type: 'success',
-							id: 'content-gate-deleted',
-						} );
-					},
-					onFinally() {
-						setIsDeleting( false );
-					},
-				}
-			);
-		},
-		[ gate, contentRules, registration, customAccess, status, title ]
-	);
+				onFinally() {
+					setIsDeleting( false );
+					setShowDeleteDialog( false );
+				},
+			}
+		);
+	}, [ id, title, isFetching ] );
 
 	// Load gate data.
 	useEffect( () => {
@@ -364,6 +375,11 @@ const Edit = ( { match, updateGatesData }: ContentGateEditProps ) => {
 		setContentRules( contentType === 'all' ? DEFAULT_GATE.content_rules : contentRules );
 	}, [ contentType ] );
 
+	// Update error.
+	useEffect( () => {
+		setError( errorMessage );
+	}, [ errorMessage ] );
+
 	// Update gate status.
 	useEffect( () => {
 		if ( ! isNew && status !== gate.status ) {
@@ -376,25 +392,25 @@ const Edit = ( { match, updateGatesData }: ContentGateEditProps ) => {
 			<ConfirmDialog when={ isDirty && ! isSaving.current } confirmButtonText={ __( 'Discard changes', 'newspack-plugin' ) } hideTitle>
 				{ __( 'You have unsaved changes that will be lost. Discard changes?', 'newspack-plugin' ) }
 			</ConfirmDialog>
-			{ showDeleteDialog && (
-				<ConfirmDialog
-					title={ __( 'Are you sure?', 'newspack-plugin' ) }
-					onConfirm={ () => handleDelete( gate.id ) }
-					onCancel={ () => setShowDeleteDialog( false ) }
-					confirmButtonText={ __( 'Delete', 'newspack-plugin' ) }
-					isDestructive={ true }
-				>
-					{ createInterpolateElement(
-						sprintf(
-							// translators: %s is the gate title.
-							__( 'This will <strong>permanently delete</strong> “%s” and cannot be undone.', 'newspack-plugin' ),
-							gate.title
-						),
-						{ strong: <strong /> }
-					) }
-				</ConfirmDialog>
-			) }
-			{ errorMessage && <Notice isError noticeText={ errorMessage } /> }
+			<ConfirmDialog
+				title={ __( 'Are you sure?', 'newspack-plugin' ) }
+				onConfirm={ handleDelete }
+				onCancel={ () => setShowDeleteDialog( false ) }
+				confirmButtonText={ __( 'Delete', 'newspack-plugin' ) }
+				isDestructive={ true }
+				when={ showDeleteDialog && ! isSaving.current && ! isDeleting && ! isFetching }
+				isShowingDialog={ showDeleteDialog }
+			>
+				{ createInterpolateElement(
+					sprintf(
+						// translators: %s is the gate title.
+						__( 'This will <strong>permanently delete</strong> “%s” and cannot be undone.', 'newspack-plugin' ),
+						gate.title
+					),
+					{ strong: <strong /> }
+				) }
+			</ConfirmDialog>
+			{ error && <Notice isError noticeText={ error } /> }
 			{ ( isNew || isRenaming ) && (
 				<>
 					<Grid columns={ 2 } gutter={ 32 }>

--- a/src/wizards/audience/views/content-gates/index.js
+++ b/src/wizards/audience/views/content-gates/index.js
@@ -18,6 +18,8 @@ import { Wizard, withWizard } from '../../../../../packages/components/src';
 import { WIZARD_STORE_NAMESPACE } from '../../../../../packages/components/src/wizard/store';
 import ContentGates from './content-gates';
 import Edit from './edit';
+import CountdownBanner from './edit/countdown-banner';
+import ContentGifting from './edit/content-gifting';
 import { AUDIENCE_CONTENT_GATES_WIZARD_SLUG, BASE_HEADER_TEXT } from './consts';
 
 const AudienceContentGates = ( props, ref ) => {
@@ -46,6 +48,18 @@ const AudienceContentGates = ( props, ref ) => {
 				{
 					path: '/edit/:id/:type?',
 					render: Edit,
+					isHidden: true,
+					exact: true,
+				},
+				{
+					path: '/settings/countdown-banner',
+					render: CountdownBanner,
+					isHidden: true,
+					exact: true,
+				},
+				{
+					path: '/settings/content-gifting',
+					render: ContentGifting,
 					isHidden: true,
 					exact: true,
 				},

--- a/src/wizards/audience/views/content-gates/index.js
+++ b/src/wizards/audience/views/content-gates/index.js
@@ -56,12 +56,24 @@ const AudienceContentGates = ( props, ref ) => {
 					render: CountdownBanner,
 					isHidden: true,
 					exact: true,
+					backNav: '#/content-gates',
+					title: __( 'Metered countdown', 'newspack-plugin' ),
+					description: __(
+						'Show a countdown banner letting readers know how many free views they have left before content is restricted.',
+						'newspack-plugin'
+					),
 				},
 				{
 					path: '/settings/content-gifting',
 					render: ContentGifting,
 					isHidden: true,
 					exact: true,
+					backNav: '#/content-gates',
+					title: __( 'Content gifting', 'newspack-plugin' ),
+					description: __(
+						'Let members gift articles to non-subscribers. Recipients can read the full content without needing to subscribe.',
+						'newspack-plugin'
+					),
 				},
 			] }
 		/>

--- a/src/wizards/audience/views/content-gates/index.js
+++ b/src/wizards/audience/views/content-gates/index.js
@@ -35,7 +35,7 @@ const AudienceContentGates = ( props, ref ) => {
 	return (
 		<Wizard
 			apiSlug={ AUDIENCE_CONTENT_GATES_WIZARD_SLUG }
-			title={ __( 'Access Control', 'newspack-plugin' ) }
+			title={ __( 'Access control', 'newspack-plugin' ) }
 			headerText={ BASE_HEADER_TEXT }
 			ref={ ref }
 			sharedProps={ { updateGatesData } }

--- a/src/wizards/audience/views/content-gates/settings-card.tsx
+++ b/src/wizards/audience/views/content-gates/settings-card.tsx
@@ -35,7 +35,7 @@ const SettingsCard = ( { title, description, enabled, requirements, toggleEnable
 	const history = useHistory();
 	const classes = classNames( 'newspack-content-gates__settings-card', {
 		'newspack-content-gates__settings-card--enabled': enabled && ! requirements,
-		'newspack-content-gates__settings-card--disabled': ! enabled && ! requirements,
+		'newspack-content-gates__settings-card--disabled': ! enabled || !! requirements,
 	} );
 	const status = enabled ? __( 'Enabled', 'newspack-plugin' ) : __( 'Disabled', 'newspack-plugin' );
 	const handleClick = () => {

--- a/src/wizards/audience/views/content-gates/settings-card.tsx
+++ b/src/wizards/audience/views/content-gates/settings-card.tsx
@@ -1,0 +1,84 @@
+/**
+ * Content Gate settings card component.
+ * Used for additional global settings.
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { __ } from '@wordpress/i18n';
+import { DropdownMenu, __experimentalHStack as HStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import { moreVertical } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import { Button, Card, Router } from '../../../../../packages/components/src';
+
+const { useHistory } = Router;
+
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+
+type SettingsCardProps = {
+	title: string;
+	description?: string;
+	enabled?: boolean;
+	href?: string;
+	requirements?: string;
+	toggleEnabled?: () => void;
+};
+
+const SettingsCard = ( { title, description, enabled, requirements, toggleEnabled = () => {}, href = '' }: SettingsCardProps ) => {
+	const history = useHistory();
+	const classes = classNames( 'newspack-content-gates__settings-card', {
+		'newspack-content-gates__settings-card--enabled': enabled && ! requirements,
+		'newspack-content-gates__settings-card--disabled': ! enabled && ! requirements,
+	} );
+	const status = enabled ? __( 'Enabled', 'newspack-plugin' ) : __( 'Disabled', 'newspack-plugin' );
+	const handleClick = () => {
+		if ( ! enabled ) {
+			toggleEnabled();
+		} else {
+			history.push( href );
+		}
+	};
+	return (
+		<Card
+			className={ classes }
+			__experimentalCoreCard
+			__experimentalCoreProps={ {
+				header: (
+					<>
+						<h2>{ title }</h2>
+						{ description && <p className="newspack-content-gates__settings-card__description">{ description }</p> }
+						<HStack alignment="edge">
+							<HStack expanded={ false } justify="flex-start" spacing="8px" className="newspack-content-gates__settings-card__buttons">
+								<Button variant="secondary" disabled={ !! requirements } onClick={ handleClick }>
+									{ ! enabled || requirements ? __( 'Enable', 'newspack-plugin' ) : __( 'Configure', 'newspack-plugin' ) }
+								</Button>
+								{ enabled && ! requirements && (
+									<DropdownMenu
+										icon={ moreVertical }
+										label={ __( 'More', 'newspack-plugin' ) }
+										controls={ [
+											{
+												title: __( 'Disable', 'newspack-plugin' ),
+												onClick: toggleEnabled,
+											},
+										] }
+									/>
+								) }
+							</HStack>
+							<p className="newspack-content-gates__settings-card__status">{ requirements || status }</p>
+						</HStack>
+					</>
+				),
+			} }
+		/>
+	);
+};
+
+export default SettingsCard;

--- a/src/wizards/audience/views/content-gates/settings-card.tsx
+++ b/src/wizards/audience/views/content-gates/settings-card.tsx
@@ -50,6 +50,7 @@ const SettingsCard = ( { title, description, enabled, requirements, toggleEnable
 			className={ classes }
 			__experimentalCoreCard
 			__experimentalCoreProps={ {
+				headerStyle: { padding: 32 },
 				header: (
 					<>
 						<h2>{ title }</h2>

--- a/src/wizards/audience/views/content-gates/style.scss
+++ b/src/wizards/audience/views/content-gates/style.scss
@@ -39,64 +39,70 @@
 					justify-content: center;
 					margin-top: 16px;
 					width: 100%;
+				}
 			}
-		}
-		&__content-rule-control {
-			margin-top: 16px;
-
-			> * + * {
+			&__content-rule-control {
 				margin-top: 16px;
-			}
-		}
-	}
-	&__other-settings {
-		margin-bottom: 32px;
-	}
-	&__settings-card {
-		p.newspack-content-gates__settings-card__description {
-			margin-bottom: 16px;
-		}
-		&__status {
-			color: var(--newspack-ui-color-error-60);
-			font-size: wp.$font-size-small;
-			text-transform: uppercase;
-			&::before {
-				content: '';
-				display: inline-block;
-				height: 8px;
-				border-radius: 50%;
-				background-color: var(--newspack-ui-color-error-60);
-				margin-right: 8px;
-				width: 8px;
-			}
-		}
-		&--enabled .newspack-content-gates__settings-card__status {
-			color: var(--newspack-ui-color-success-60);
-			&::before {
-				background-color: var(--newspack-ui-color-success-60);
-			}
-		}
-		&--disabled .newspack-content-gates__settings-card__status {
-			color: var(--newspack-ui-color-neutral-60);
-			&::before {
-				background-color: var(--newspack-ui-color-neutral-60);
-			}
-		}
-	}
 
-	.components-form-token-field {
-		position: relative;
-		&__suggestions-list {
-			background-color: #fff;
-			border-radius: 0 0 2px 2px;
-			border: 1px solid var(--wp-admin-theme-color);
-			border-top: none;
-			left: 0;
-			outline: 0.5px solid var(--wp-admin-theme-color);
-			position: absolute;
-			width: 100%;
-			z-index: 1;
+				> * + * {
+					margin-top: 16px;
+				}
+			}
+		}
+		&__other-settings {
+			margin-bottom: 32px;
+		}
+		&__settings-card {
+			p.newspack-content-gates__settings-card__description {
+				margin-bottom: 16px;
+			}
+			&__status {
+				color: var(--newspack-ui-color-error-60);
+				font-size: wp.$font-size-small;
+				text-transform: uppercase;
+				&::before {
+					background-color: var(--newspack-ui-color-error-60);
+					border-radius: 50%;
+					content: '';
+					display: inline-block;
+					height: 8px;
+					margin-right: 8px;
+					width: 8px;
+				}
+			}
+			&--enabled {
+				.newspack-content-gates__settings-card__status {
+					color: var(--newspack-ui-color-success-60);
+					&::before {
+						background-color: var(--newspack-ui-color-success-60);
+					}
+				}
+			}
+			&--disabled {
+				box-shadow: rgba(wp-colors.$black, 0.059) 0 0 0 1px;
+
+				.newspack-content-gates__settings-card__status {
+					color: var(--newspack-ui-color-neutral-60);
+					&::before {
+						background-color: var(--newspack-ui-color-neutral-60);
+					}
+				}
+			}
+		}
+
+		.components-form-token-field {
+			position: relative;
+			&__suggestions-list {
+				background-color: wp-colors.$white;
+				border: 1px solid var(--wp-admin-theme-color);
+				border-radius: 0 0 2px 2px;
+				border-top: none;
+				left: 0;
+				outline: 0.5px solid var(--wp-admin-theme-color);
+				position: absolute;
+				width: 100%;
+				z-index: 1;
+			}
 		}
 	}
-}
 }

--- a/src/wizards/audience/views/content-gates/style.scss
+++ b/src/wizards/audience/views/content-gates/style.scss
@@ -81,7 +81,7 @@
 			&--disabled {
 				box-shadow: rgba(wp-colors.$black, 0.06) 0 0 0 1px;
 
-				.newspack-content-gates__settings-card__status {
+				:not(:has(.components-button.is-secondary[disabled])) .newspack-content-gates__settings-card__status {
 					color: var(--newspack-ui-color-neutral-60);
 					&::before {
 						background-color: var(--newspack-ui-color-neutral-60);

--- a/src/wizards/audience/views/content-gates/style.scss
+++ b/src/wizards/audience/views/content-gates/style.scss
@@ -49,6 +49,40 @@
 			}
 		}
 	}
+	&__other-settings {
+		margin-bottom: 32px;
+	}
+	&__settings-card {
+		p.newspack-content-gates__settings-card__description {
+			margin-bottom: 16px;
+		}
+		&__status {
+			color: var(--newspack-ui-color-error-60);
+			font-size: wp.$font-size-small;
+			text-transform: uppercase;
+			&::before {
+				content: '';
+				display: inline-block;
+				height: 8px;
+				border-radius: 50%;
+				background-color: var(--newspack-ui-color-error-60);
+				margin-right: 8px;
+				width: 8px;
+			}
+		}
+		&--enabled .newspack-content-gates__settings-card__status {
+			color: var(--newspack-ui-color-success-60);
+			&::before {
+				background-color: var(--newspack-ui-color-success-60);
+			}
+		}
+		&--disabled .newspack-content-gates__settings-card__status {
+			color: var(--newspack-ui-color-neutral-60);
+			&::before {
+				background-color: var(--newspack-ui-color-neutral-60);
+			}
+		}
+	}
 
 	.components-form-token-field {
 		position: relative;

--- a/src/wizards/audience/views/content-gates/style.scss
+++ b/src/wizards/audience/views/content-gates/style.scss
@@ -79,7 +79,7 @@
 				}
 			}
 			&--disabled {
-				box-shadow: rgba(wp-colors.$black, 0.059) 0 0 0 1px;
+				box-shadow: rgba(wp-colors.$black, 0.06) 0 0 0 1px;
 
 				.newspack-content-gates__settings-card__status {
 					color: var(--newspack-ui-color-neutral-60);

--- a/src/wizards/audience/views/content-gates/types/index.d.ts
+++ b/src/wizards/audience/views/content-gates/types/index.d.ts
@@ -134,6 +134,9 @@ type MeteringCountdownConfig = {
 	cta_label: string;
 	button_label: string;
 	cta_url: string;
+	cta_type: string;
+	cta_product_id: number;
+	cta_url: string;
 };
 
 type GateSettings = {

--- a/src/wizards/audience/views/content-gates/types/index.d.ts
+++ b/src/wizards/audience/views/content-gates/types/index.d.ts
@@ -120,8 +120,12 @@ type ContentGiftingConfig = {
 	interval: string;
 	expiration_time: number;
 	expiration_time_unit: string;
+	style: string;
 	cta_label: string;
 	button_label: string;
+	cta_type: string;
+	cta_product_id: number;
+	cta_url: string;
 };
 
 type MeteringCountdownConfig = {

--- a/src/wizards/audience/views/content-gates/types/index.d.ts
+++ b/src/wizards/audience/views/content-gates/types/index.d.ts
@@ -136,7 +136,6 @@ type MeteringCountdownConfig = {
 	cta_url: string;
 	cta_type: string;
 	cta_product_id: number;
-	cta_url: string;
 };
 
 type GateSettings = {

--- a/src/wizards/audience/views/setup/content-gifting.js
+++ b/src/wizards/audience/views/setup/content-gifting.js
@@ -149,6 +149,7 @@ export default function ContentGifting( { config, setConfig, updateConfig, noBor
 								help={ __( 'URL for the landing page to redirect to.', 'newspack-plugin' ) }
 								value={ config.content_gifting.cta_url }
 								onChange={ value => setConfig( { ...config, content_gifting: { ...config.content_gifting, cta_url: value } } ) }
+								withMargin={ false }
 								__next40pxDefaultSize
 							/>
 						) }

--- a/src/wizards/audience/views/setup/countdown-banner.js
+++ b/src/wizards/audience/views/setup/countdown-banner.js
@@ -89,6 +89,7 @@ export default function CountdownBanner( { config, setConfig, updateConfig, noBo
 								help={ __( 'URL for the landing page to redirect to.', 'newspack-plugin' ) }
 								value={ config.countdown_banner.cta_url }
 								onChange={ value => setConfig( { ...config, countdown_banner: { ...config.countdown_banner, cta_url: value } } ) }
+								withMargin={ false }
 								__next40pxDefaultSize
 							/>
 						) }

--- a/src/wizards/index.tsx
+++ b/src/wizards/index.tsx
@@ -45,7 +45,7 @@ const components: Record< string, any > = {
 		component: lazy( () => import( /* webpackChunkName: "audience-wizards" */ './audience/views/campaigns' ) ),
 	},
 	'newspack-audience-access-control': {
-		label: __( 'Access Control', 'newspack-plugin' ),
+		label: __( 'Access control', 'newspack-plugin' ),
 		component: lazy( () => import( /* webpackChunkName: "audience-wizards" */ './audience/views/content-gates' ) ),
 	},
 	'newspack-audience-donations': {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Implements i3 designs for Metered Countdown and Content Gifting settings.

<img width="1071" height="219" alt="Screenshot 2026-02-26 at 5 46 10 PM" src="https://github.com/user-attachments/assets/b4df50b8-f77c-40ec-bcd5-7ae2f892690d" />

Also simplifies the usage of the new `ConfirmDialog` component and adds component documentation.

Also improves how Wizard header actions are presented at smaller viewports ("main" action buttons are hidden and shown in the dropdown menu instead).

Closes NPPD-1272.

### How to test the changes in this Pull Request:

1. Check out this branch.
2. Visit **Audience > Access control** and confirm there are two new settings cards below the list of content gates (only if you have at least one content gate).
3. Confirm that the cards accurately reflect the status of each feature (note that the Metered Countdown feature is considered disabled if you don't have any gates with metering enabled).
4. Confirm that you can enable/disable the features from each card.
5. Click "Configure" from each enabled card and confirm that the UI accurately shows all settings, that you can update all settings with the live preview, and that clicking "Save" and "Enable"/"Disable" in the wizard header bar work as expected.
6. Enable Woo Memberships, go to **Audience > Configuration > Content Gating** and confirm that the UI for these features still function as before without any changes.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->