### PR TITLE
docs: remove deprecated events from docs

### DIFF
--- a/includes/data-events/README.md
+++ b/includes/data-events/README.md
@@ -243,64 +243,6 @@ When a subscription of any type (donation or non-donation) renews, a renewal ord
 | `user_first_name` | `string` |
 | `user_last_name`  | `string` |
 
-## Membership Actions
-
-### `gate_interaction`
-
-When a reader interacts with the content gate.
-
-| Name           | Type     | Obs                                                                                               |
-| -------------- | -------- | ------------------------------------------------------------------------------------------------- |
-| `gate_post_id` | `int`    |                                                                                                   |
-| `action`       | `string` | Either `seen`, `form_submission_received`, `form_submission_success` or `form_submission_failure` |
-| `action_type`  | `string` | Either `paid_membership` or `registration`. Not applicable when `action` is `seen`                |
-| `referer`      | `string` |                                                                                                   |
-| `order_id`     | `int`    | Only applicable when `action_type` is `paid_membership`                                           |
-| `product_id`   | `int`    | Only applicable when `action_type` is `paid_membership`                                           |
-| `amount`       | `float`  | Only applicable when `action_type` is `paid_membership`                                           |
-| `currency`     | `string` | Only applicable when `action_type` is `paid_membership`                                           |
-
-## Newspack Popups Actions
-
-### `prompt_interaction`
-
-When a user interacts with a Newspack Popup's campaign prompt.
-
-| Name               | Type     | Obs                                                                                                                                          |
-| ------------------ | -------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| `newspack_popup_id`| `int`    |                                                                                                                                              |
-| `prompt_title`     | `string` |                                                                                                                                              |
-| `prompt_frequency` | `string` |                                                                                                                                              |
-| `prompt_placement` | `string` |                                                                                                                                              |
-| `prompt_blocks`    | `array`  | Array containing the blocks that are inside the prompt. Only 3 blocks are tracked: `donation`, `registration` and `newsletters_subscription` |
-| `action`           | `string` | `form_submission_received`, `form_submission_success` or `form_submission_failure`                                                           |
-| `action_type`      | `string` | `donation`, `registration` or `newsletters_subscription`                                                                                     |
-| `interaction_data` | `array`  | Depending on the action type, it will contain different information about the interaction.                                                   |
-
-#### Possible values for `interaction_data`
-
-If `action_type` is `registration`:
-
-| Name                  | Type     |
-| --------------------- | -------- |
-| `registration_method` | `string` |
-
-If `action_type` is `newsletters_subscription`:
-
-| Name                              | Type     |
-| --------------------------------- | -------- |
-| `newsletters_subscription_method` | `string` |
-
-If `action_type` is `donation`:
-
-| Name                  | Type     | Obs                                                                                              |
-| --------------------- | -------- | ------------------------------------------------------------------------------------------------ |
-| `donation_order_id`   | `string` | Only for successful donations in any platform' or any processed/failed donations via Woocommerce |
-| `donation_amount`     | `string` |                                                                                                  |
-| `donation_currency`   | `string` |                                                                                                  |
-| `donation_recurrence` | `string` |                                                                                                  |
-| `donation_platform`   | `string` |                                                                                                  |
-
 ## Registering a new action
 
 To dispatch an event, an action must first be registered with the following:


### PR DESCRIPTION
Remove events from docs. These events are now handled only in the front-end and sent to GA.