### PR TITLE
feat(content-gate): comment restriction with metering support

### DIFF
--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -72,9 +72,9 @@ class Content_Gate {
 
 		add_action( 'the_post', [ __CLASS__, 'restrict_post' ], 10, 2 );
 		add_filter( 'the_content', [ __CLASS__, 'handle_restricted_content' ], PHP_INT_MAX );
-		add_filter( 'comments_open', [ __CLASS__, 'filter_comments_open' ] );
-		add_filter( 'comments_array', [ __CLASS__, 'filter_comments_array' ] );
-		add_filter( 'get_comments_number', [ __CLASS__, 'filter_comments_number' ] );
+		add_filter( 'comments_open', [ __CLASS__, 'filter_comments_open' ], 10, 2 );
+		add_filter( 'comments_array', [ __CLASS__, 'filter_comments_array' ], 10, 2 );
+		add_filter( 'get_comments_number', [ __CLASS__, 'filter_comments_number' ], 10, 2 );
 
 		/** Add gate content filters to mimic 'the_content'. See 'wp-includes/default-filters.php' for reference. */
 		add_filter( 'newspack_gate_content', 'capital_P_dangit', 11 );
@@ -230,11 +230,12 @@ class Content_Gate {
 	 * Close comments on gated and metered posts.
 	 *
 	 * @param bool $open    Whether comments are open.
+	 * @param int  $post_id Post ID.
 	 *
 	 * @return bool
 	 */
-	public static function filter_comments_open( $open ) {
-		if ( self::$is_gated || self::$is_metered ) {
+	public static function filter_comments_open( $open, $post_id ) {
+		if ( ( self::$is_gated || self::$is_metered ) && (int) $post_id === (int) get_queried_object_id() ) {
 			return false;
 		}
 		return $open;
@@ -246,11 +247,12 @@ class Content_Gate {
 	 * Hide all comments on fully gated posts.
 	 *
 	 * @param array $comments Array of comments.
+	 * @param int   $post_id  Post ID.
 	 *
 	 * @return array
 	 */
-	public static function filter_comments_array( $comments ) {
-		if ( self::$is_gated ) {
+	public static function filter_comments_array( $comments, $post_id ) {
+		if ( self::$is_gated && (int) $post_id === (int) get_queried_object_id() ) {
 			return [];
 		}
 		return $comments;
@@ -261,12 +263,13 @@ class Content_Gate {
 	 *
 	 * Return 0 on fully gated posts.
 	 *
-	 * @param int $count Comment count.
+	 * @param int $count   Comment count.
+	 * @param int $post_id Post ID.
 	 *
 	 * @return int
 	 */
-	public static function filter_comments_number( $count ) {
-		if ( self::$is_gated ) {
+	public static function filter_comments_number( $count, $post_id ) {
+		if ( self::$is_gated && (int) $post_id === (int) get_queried_object_id() ) {
 			return 0;
 		}
 		return $count;

--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -37,6 +37,13 @@ class Content_Gate {
 	private static $is_gated = false;
 
 	/**
+	 * Whether the post is being shown via metering.
+	 *
+	 * @var boolean
+	 */
+	private static $is_metered = false;
+
+	/**
 	 * Valid gate post statuses.
 	 *
 	 * @var array
@@ -65,6 +72,9 @@ class Content_Gate {
 
 		add_action( 'the_post', [ __CLASS__, 'restrict_post' ], 10, 2 );
 		add_filter( 'the_content', [ __CLASS__, 'handle_restricted_content' ], PHP_INT_MAX );
+		add_filter( 'comments_open', [ __CLASS__, 'filter_comments_open' ] );
+		add_filter( 'comments_array', [ __CLASS__, 'filter_comments_array' ] );
+		add_filter( 'get_comments_number', [ __CLASS__, 'filter_comments_number' ] );
 
 		/** Add gate content filters to mimic 'the_content'. See 'wp-includes/default-filters.php' for reference. */
 		add_filter( 'newspack_gate_content', 'capital_P_dangit', 11 );
@@ -171,6 +181,9 @@ class Content_Gate {
 			 */
 			! apply_filters( 'newspack_content_gate_restrict_post', true, $post->ID )
 		) {
+			// Content is accessible via metering — show comments but prevent commenting.
+			self::$is_metered        = true;
+			$post->comment_status    = 'closed';
 			return;
 		}
 
@@ -209,6 +222,54 @@ class Content_Gate {
 	 */
 	public static function is_gated() {
 		return self::$is_gated;
+	}
+
+	/**
+	 * Filter whether comments are open.
+	 *
+	 * Close comments on gated and metered posts.
+	 *
+	 * @param bool $open    Whether comments are open.
+	 *
+	 * @return bool
+	 */
+	public static function filter_comments_open( $open ) {
+		if ( self::$is_gated || self::$is_metered ) {
+			return false;
+		}
+		return $open;
+	}
+
+	/**
+	 * Filter comments array.
+	 *
+	 * Hide all comments on fully gated posts.
+	 *
+	 * @param array $comments Array of comments.
+	 *
+	 * @return array
+	 */
+	public static function filter_comments_array( $comments ) {
+		if ( self::$is_gated ) {
+			return [];
+		}
+		return $comments;
+	}
+
+	/**
+	 * Filter the comment count.
+	 *
+	 * Return 0 on fully gated posts.
+	 *
+	 * @param int $count Comment count.
+	 *
+	 * @return int
+	 */
+	public static function filter_comments_number( $count ) {
+		if ( self::$is_gated ) {
+			return 0;
+		}
+		return $count;
 	}
 
 	/**

--- a/includes/content-gate/class-content-restriction-control.php
+++ b/includes/content-gate/class-content-restriction-control.php
@@ -178,6 +178,11 @@ class Content_Restriction_Control {
 			return $is_post_restricted;
 		}
 
+		// Don't restrict posts for users with edit_posts capability.
+		if ( current_user_can( 'edit_posts' ) ) {
+			return false;
+		}
+
 		$post_gates = self::get_post_gates( $post_id );
 		if ( empty( $post_gates ) ) {
 			return false;

--- a/includes/content-gate/class-content-restriction-control.php
+++ b/includes/content-gate/class-content-restriction-control.php
@@ -178,8 +178,8 @@ class Content_Restriction_Control {
 			return $is_post_restricted;
 		}
 
-		// Don't restrict posts for users with edit_posts capability.
-		if ( current_user_can( 'edit_posts' ) ) {
+		// Don't restrict this post for users who can edit it.
+		if ( ! empty( $post_id ) && current_user_can( 'edit_post', $post_id ) ) {
 			return false;
 		}
 

--- a/tests/unit-tests/content-gate/content-gates.php
+++ b/tests/unit-tests/content-gate/content-gates.php
@@ -782,6 +782,101 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Helper to set a private static property on Content_Gate via reflection.
+	 *
+	 * @param string $property Property name.
+	 * @param mixed  $value    Value to set.
+	 */
+	private function set_content_gate_property( $property, $value ) {
+		$reflection = new \ReflectionProperty( Content_Gate::class, $property );
+		$reflection->setAccessible( true );
+		$reflection->setValue( null, $value );
+	}
+
+	/**
+	 * Test comment filters on fully gated posts.
+	 */
+	public function test_comments_closed_on_gated_post() {
+		$post_id = $this->post_ids[0];
+
+		$this->set_content_gate_property( 'is_gated', true );
+		$this->set_content_gate_property( 'is_metered', false );
+
+		// Simulate queried object.
+		$this->go_to( get_permalink( $post_id ) );
+
+		$this->assertFalse( Content_Gate::filter_comments_open( true, $post_id ), 'Comments should be closed on gated post' );
+		$this->assertEmpty( Content_Gate::filter_comments_array( [ 'comment1', 'comment2' ], $post_id ), 'Comments array should be empty on gated post' );
+		$this->assertSame( 0, Content_Gate::filter_comments_number( 5, $post_id ), 'Comment count should be 0 on gated post' );
+
+		// Reset.
+		$this->set_content_gate_property( 'is_gated', false );
+	}
+
+	/**
+	 * Test comment filters on metered posts.
+	 */
+	public function test_comments_closed_but_visible_on_metered_post() {
+		$post_id = $this->post_ids[0];
+
+		$this->set_content_gate_property( 'is_gated', false );
+		$this->set_content_gate_property( 'is_metered', true );
+
+		// Simulate queried object.
+		$this->go_to( get_permalink( $post_id ) );
+
+		$this->assertFalse( Content_Gate::filter_comments_open( true, $post_id ), 'Comments should be closed on metered post' );
+
+		$comments = [ 'comment1', 'comment2' ];
+		$this->assertSame( $comments, Content_Gate::filter_comments_array( $comments, $post_id ), 'Existing comments should remain visible on metered post' );
+		$this->assertSame( 5, Content_Gate::filter_comments_number( 5, $post_id ), 'Comment count should be unchanged on metered post' );
+
+		// Reset.
+		$this->set_content_gate_property( 'is_metered', false );
+	}
+
+	/**
+	 * Test comment filters do not affect unrelated posts.
+	 */
+	public function test_comments_unaffected_on_other_posts() {
+		$post_id = $this->post_ids[0];
+		$other_post_id = $this->factory->post->create();
+		$this->post_ids[] = $other_post_id;
+
+		$this->set_content_gate_property( 'is_gated', true );
+		$this->set_content_gate_property( 'is_metered', false );
+
+		// Simulate queried object as the gated post.
+		$this->go_to( get_permalink( $post_id ) );
+
+		// Filters should not affect the other post.
+		$this->assertTrue( Content_Gate::filter_comments_open( true, $other_post_id ), 'Comments should remain open on non-gated post' );
+		$comments = [ 'comment1' ];
+		$this->assertSame( $comments, Content_Gate::filter_comments_array( $comments, $other_post_id ), 'Comments array should be unchanged on non-gated post' );
+		$this->assertSame( 3, Content_Gate::filter_comments_number( 3, $other_post_id ), 'Comment count should be unchanged on non-gated post' );
+
+		// Reset.
+		$this->set_content_gate_property( 'is_gated', false );
+	}
+
+	/**
+	 * Test comment filters pass through on unrestricted posts.
+	 */
+	public function test_comments_unaffected_on_unrestricted_post() {
+		$post_id = $this->post_ids[0];
+
+		$this->set_content_gate_property( 'is_gated', false );
+		$this->set_content_gate_property( 'is_metered', false );
+
+		$this->go_to( get_permalink( $post_id ) );
+
+		$this->assertTrue( Content_Gate::filter_comments_open( true, $post_id ), 'Comments should remain open on unrestricted post' );
+		$comments = [ 'comment1', 'comment2' ];
+		$this->assertSame( $comments, Content_Gate::filter_comments_array( $comments, $post_id ), 'Comments array should be unchanged on unrestricted post' );
+		$this->assertSame( 5, Content_Gate::filter_comments_number( 5, $post_id ), 'Comment count should be unchanged on unrestricted post' );
+	}
+
+	/**
 	 * Test that already grouped access_rules remain unchanged.
 	 */
 	public function test_custom_access_preserves_grouped_rules() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Control comment visibility and interactivity based on restriction state. With this change:

- Fully gated posts: comment form is closed, existing comments are not rendered, and comment count returns 0.
- Metered posts: existing comments are visible, but the comment form is closed, so readers can see the discussion without being able to participate unless they have full access.
- Unrestricted posts: comments behave as WordPress normally allows.

I also noticed that, as an admin, I was getting restricted. Now users with `edit_posts` capability are no longer subject to content restriction.

Closes NPPD-1030 and NPPD-1031.

### How to test the changes in this Pull Request:

1. Create a content gate with registration mode active without metering
2. Visit a restricted post as a logged-out user and confirm the comments section is completely hidden.
3. Edit the gate and enable metering
4. Flush cache, refresh the article page, and confirm the comments are visible but without the comment form
5. Sign in and confirm that the content and full comments section are available
6. Edit the gate and enable paid access tied to a subscription your admin account doesn't own
7. Visit a restricted article as the admin and confirm the paid access restriction doesn't apply (no gate)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->