### PR TITLE
fix: check for string before decoding

### DIFF
--- a/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php
+++ b/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php
@@ -265,9 +265,15 @@ class My_Account_UI_V1 {
 			return self::delete_account_confirmation_modal();
 		}
 
-		$active_subscriptions     = json_decode( Reader_Data::get_data( $user->ID, 'active_subscriptions' ) );
+		$active_subscriptions = Reader_Data::get_data( $user->ID, 'active_subscriptions' );
+		if ( is_string( $active_subscriptions ) ) {
+			$active_subscriptions = json_decode( $active_subscriptions );
+		}
 		$active_donations         = boolval( Reader_Data::get_data( $user->ID, 'is_donor' ) );
-		$newsletter_subscriptions = json_decode( Reader_Data::get_data( $user->ID, 'newsletter_subscribed_lists' ) );
+		$newsletter_subscriptions = Reader_Data::get_data( $user->ID, 'newsletter_subscribed_lists' );
+		if ( is_string( $newsletter_subscriptions ) ) {
+			$newsletter_subscriptions = json_decode( $newsletter_subscriptions );
+		}
 
 		ob_start();
 		?>

--- a/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php
+++ b/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php
@@ -466,13 +466,15 @@ class My_Account_UI_V1 {
 	public static function add_after_delete_account_notice() {
 		$account_deleted = filter_input( INPUT_GET, WooCommerce_My_Account::AFTER_ACCOUNT_DELETION_PARAM, FILTER_VALIDATE_BOOLEAN );
 		if ( $account_deleted ) {
-			?>
-			<div class="newspack-ui">
-				<div class="newspack-ui__snackbar newspack-ui__snackbar--top-right newspack-ui__snackbar--success active-on-load">
-					<?php esc_html_e( 'Your account has been successfully deleted.', 'newspack-plugin' ); ?>
-				</div>
-			</div>
-			<?php
+			Newspack_UI::add_notice(
+				__( 'Your account has been deleted.', 'newspack-plugin' ),
+				[
+					'id'       => 'after-delete-account',
+					'type'     => 'success',
+					'corner'   => 'top-right',
+					'autohide' => true,
+				]
+			);
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

While fixing e2e tests, I ran into the following error:

```
[27-Feb-2026 22:49:48 UTC] PHP Fatal error:  Uncaught TypeError: json_decode(): Argument #1 ($json) must be of type string, array given in /newspack-repos/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php:268
Stack trace:
#0 /newspack-repos/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php(268): json_decode()
#1 /var/www/additional-sites-html/e2e/wp-includes/class-wp-hook.php(341): Newspack\My_Account_UI_V1::delete_account_modal()
#2 /var/www/additional-sites-html/e2e/wp-includes/class-wp-hook.php(365): WP_Hook->apply_filters()
#3 /var/www/additional-sites-html/e2e/wp-includes/plugin.php(522): WP_Hook->do_action()
#4 /newspack-repos/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/account-settings.php(275): do_action()
#5 /var/www/additional-sites-html/e2e/wp-content/plugins/woocommerce/includes/wc-core-functions.php(346): include('...')
#6 /var/www/additional-sites-html/e2e/wp-content/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-my-account.php(167): wc_get_template()
#7 /var/www/additional-sites-html/e2e/wp-content/plugins/woocommerce/includes/wc-template-functions.php(3564): WC_Shortcode_My_Account::edit_account()
#8 /var/www/additional-sites-html/e2e/wp-includes/class-wp-hook.php(341): woocommerce_account_edit_account()
#9 /var/www/additional-sites-html/e2e/wp-includes/class-wp-hook.php(365): WP_Hook->apply_filters()
#10 /var/www/additional-sites-html/e2e/wp-includes/plugin.php(522): WP_Hook->do_action()
#11 /var/www/additional-sites-html/e2e/wp-content/plugins/woocommerce/includes/wc-template-functions.php(3444): do_action()
#12 /var/www/additional-sites-html/e2e/wp-includes/class-wp-hook.php(341): woocommerce_account_content()
#13 /var/www/additional-sites-html/e2e/wp-includes/class-wp-hook.php(365): WP_Hook->apply_filters()
#14 /var/www/additional-sites-html/e2e/wp-includes/plugin.php(522): WP_Hook->do_action()
#15 /var/www/additional-sites-html/e2e/wp-content/plugins/woocommerce/templates/myaccount/my-account.php(34): do_action()
#16 /var/www/additional-sites-html/e2e/wp-content/plugins/woocommerce/includes/wc-core-functions.php(346): include('...')
#17 /var/www/additional-sites-html/e2e/wp-content/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-my-account.php(124): wc_get_template()
#18 /var/www/additional-sites-html/e2e/wp-content/plugins/woocommerce/includes/shortcodes/class-wc-shortcode-my-account.php(60): WC_Shortcode_My_Account::my_account()
#19 /var/www/additional-sites-html/e2e/wp-content/plugins/woocommerce/includes/class-wc-shortcodes.php(75): WC_Shortcode_My_Account::output()
#20 /var/www/additional-sites-html/e2e/wp-content/plugins/woocommerce/includes/class-wc-shortcodes.php(118): WC_Shortcodes::shortcode_wrapper()
#21 /var/www/additional-sites-html/e2e/wp-includes/shortcodes.php(434): WC_Shortcodes::my_account()
#22 [internal function]: do_shortcode_tag()
#23 /var/www/additional-sites-html/e2e/wp-includes/shortcodes.php(273): preg_replace_callback()
#24 /newspack-repos/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/my-account.php(46): do_shortcode()
#25 /var/www/additional-sites-html/e2e/wp-includes/template-loader.php(125): include('...')
#26 /var/www/additional-sites-html/e2e/wp-blog-header.php(19): require_once('...')
#27 /var/www/additional-sites-html/e2e/index.php(17): require('...')
#28 {main}
  thrown in /newspack-repos/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php on line 268
```
Looks like `Reader_Data::get_data` won't always return a non-serialized string here, so I'm adding an `is_string` check to make sure we don't run `json_decode` when an array is returned.

### How to test the changes in this Pull Request:

1. As a logged in reader go to my account 
2. Click the delete account button and confirm the modal renders as expected
3. Confirm you can delete your account

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->