### PR TITLE
(Newspack Integrations) feat:  reader data read only

### DIFF
--- a/includes/reader-activation/class-reader-data.php
+++ b/includes/reader-activation/class-reader-data.php
@@ -39,6 +39,34 @@ final class Reader_Data {
 	}
 
 	/**
+	 * Enumerate read-only keys.
+	 *
+	 * Server is the source of truth for these keys, and they
+	 * shouldn't be written to or deleted by the client.
+	 *
+	 * Implemented in a filter hook to permit plugins to alter the list.
+	 *
+	 * @return string[] Names of read-only keys.
+	 */
+	public static function get_read_only_keys() {
+		/**
+		 * Filters the list of read-only reader data keys.
+		 *
+		 * @param string[] $keys Names of read-only keys.
+		 */
+		return apply_filters(
+			'newspack_reader_data_read_only_keys',
+			[
+				'active_memberships',
+				'active_subscriptions',
+				'is_former_donor',
+				'is_donor',
+				'newsletter_subscribed_lists',
+			]
+		);
+	}
+
+	/**
 	 * Register all data event handlers.
 	 */
 	public static function register_data_event_handlers() {
@@ -79,6 +107,7 @@ final class Reader_Data {
 			'store_prefix'    => $store_prefix,
 			'is_temporary'    => $is_temporary,
 			'reader_activity' => self::$reader_activity,
+			'read_only_keys'  => self::get_read_only_keys(),
 		];
 
 		if ( \is_user_logged_in() ) {
@@ -250,6 +279,9 @@ final class Reader_Data {
 		if ( ! $key || ! $value ) {
 			return new \WP_Error( 'invalid_params', __( 'Invalid parameters.', 'newspack' ), [ 'status' => 400 ] );
 		}
+		if ( in_array( $key, self::get_read_only_keys(), true ) ) {
+			return new \WP_Error( 'read_only_key', __( 'This key is read-only.', 'newspack' ), [ 'status' => 403 ] );
+		}
 		// Value must be a valid stringified JSON.
 		if ( null === json_decode( $value ) ) {
 			return new \WP_Error( 'invalid_value', __( 'Invalid value.', 'newspack' ), [ 'status' => 400 ] );
@@ -272,6 +304,9 @@ final class Reader_Data {
 		$key = $request->get_param( 'key' );
 		if ( ! $key ) {
 			return new \WP_Error( 'invalid_params', __( 'Invalid parameters.', 'newspack' ), [ 'status' => 400 ] );
+		}
+		if ( in_array( $key, self::get_read_only_keys(), true ) ) {
+			return new \WP_Error( 'read_only_key', __( 'This key is read-only.', 'newspack' ), [ 'status' => 403 ] );
 		}
 		self::delete_item( \get_current_user_id(), $key );
 		return new \WP_REST_Response( [ 'success' => true ] );

--- a/includes/reader-activation/class-reader-data.php
+++ b/includes/reader-activation/class-reader-data.php
@@ -44,6 +44,10 @@ final class Reader_Data {
 	 * Server is the source of truth for these keys, and they
 	 * shouldn't be written to or deleted by the client.
 	 *
+	 * This list is surfaced to the client as
+	 * `newspack_reader_data.read_only_keys` to allow browser-side
+	 * validation and more graceful error handling.
+	 *
 	 * Implemented in a filter hook to permit plugins to alter the list.
 	 *
 	 * @return string[] Names of read-only keys.

--- a/src/reader-activation/store.js
+++ b/src/reader-activation/store.js
@@ -165,6 +165,18 @@ function decode( str ) {
 }
 
 /**
+ * Assert that a key is not read-only.
+ *
+ * @param {string} key Key to check.
+ * @throws {Error} If the key is read-only.
+ */
+function assertNotReadOnly( key ) {
+	if ( ( newspack_reader_data?.read_only_keys || [] ).includes( key ) ) {
+		throw new Error( `Key '${ key }' is read-only.` );
+	}
+}
+
+/**
  * Internal get function to fetch data from storage.
  *
  * @param {string}  key      Key to get.
@@ -265,6 +277,7 @@ export default function Store() {
 		 * @param {boolean} sync  Whether to sync the value with the server. Default true.
 		 */
 		set: ( key, value, sync = true ) => {
+			assertNotReadOnly( key );
 			_set( key, value, false );
 			if ( sync ) {
 				setPendingSync( key );
@@ -280,6 +293,7 @@ export default function Store() {
 			if ( ! key ) {
 				throw new Error( 'Key is required.' );
 			}
+			assertNotReadOnly( key );
 			config.storage.removeItem( getStoreItemKey( key ) );
 			emit( EVENTS.data, { key, value: undefined } );
 			setPendingSync( key );
@@ -296,6 +310,7 @@ export default function Store() {
 			if ( ! key ) {
 				throw new Error( 'Key cannot be empty.' );
 			}
+			assertNotReadOnly( key );
 			if ( ! value ) {
 				throw new Error( 'Value cannot be empty.' );
 			}

--- a/src/reader-activation/store.js
+++ b/src/reader-activation/store.js
@@ -238,7 +238,7 @@ export default function Store() {
 	// Push unsynced items to the sync queue, pruning existing read-only
 	// keys in order to address the upgrade case.
 	const readOnlyKeys = newspack_reader_data?.read_only_keys || [];
-	const unsynced = _get( 'unsynced', true ).filter( key => ! readOnlyKeys.includes( key ) );
+	const unsynced = ( _get( 'unsynced', true ) || [] ).filter( key => ! readOnlyKeys.includes( key ) );
 	_set( 'unsynced', unsynced, true );
 	for ( const key of unsynced ) {
 		if ( ! syncQueue.includes( key ) ) {

--- a/src/reader-activation/store.js
+++ b/src/reader-activation/store.js
@@ -235,8 +235,11 @@ export default function Store() {
 	const syncQueue = [];
 	initializeSyncInterval( syncQueue );
 
-	// Push unsynced items to the sync queue.
-	const unsynced = _get( 'unsynced', true ) || [];
+	// Push unsynced items to the sync queue, pruning existing read-only
+	// keys in order to address the upgrade case.
+	const readOnlyKeys = newspack_reader_data?.read_only_keys || [];
+	const unsynced = _get( 'unsynced', true ).filter( key => ! readOnlyKeys.includes( key ) );
+	_set( 'unsynced', unsynced, true );
 	for ( const key of unsynced ) {
 		if ( ! syncQueue.includes( key ) ) {
 			syncQueue.push( key );

--- a/src/reader-activation/store.test.js
+++ b/src/reader-activation/store.test.js
@@ -130,5 +130,14 @@ describe( 'Store', () => {
 			store.delete( 'custom_key' );
 			expect( store.get( 'custom_key' ) ).toBeNull();
 		} );
+		it( 'should prune read-only keys from the unsynced queue on init', () => {
+			// Simulate a pre-upgrade state where a read-only key was queued for sync.
+			localStorage.setItem( 'np_reader__unsynced', JSON.stringify( [ 'is_donor', 'custom_key' ] ) );
+			localStorage.setItem( 'np_reader_is_donor', true );
+			localStorage.setItem( 'np_reader_custom_key', '"value"' );
+			Store();
+			const unsynced = JSON.parse( localStorage.getItem( 'np_reader__unsynced' ) );
+			expect( unsynced ).toEqual( [ 'custom_key' ] );
+		} );
 	} );
 } );

--- a/src/reader-activation/store.test.js
+++ b/src/reader-activation/store.test.js
@@ -95,4 +95,40 @@ describe( 'Store', () => {
 		const store = Store();
 		expect( store.get( 'foo' ) ).toEqual( 'bar' );
 	} );
+	describe( 'Read-only keys', () => {
+		beforeEach( () => {
+			window.newspack_reader_data = {
+				read_only_keys: [ 'is_donor', 'active_memberships' ],
+			};
+		} );
+		it( 'should throw when setting a read-only key', () => {
+			const store = Store();
+			expect( () => store.set( 'is_donor', true ) ).toThrow( "Key 'is_donor' is read-only." );
+		} );
+		it( 'should throw when deleting a read-only key', () => {
+			const store = Store();
+			expect( () => store.delete( 'active_memberships' ) ).toThrow( "Key 'active_memberships' is read-only." );
+		} );
+		it( 'should throw when adding to a read-only key', () => {
+			const store = Store();
+			expect( () => store.add( 'is_donor', { foo: 'bar' } ) ).toThrow( "Key 'is_donor' is read-only." );
+		} );
+		it( 'should allow getting read-only keys populated via rehydration', () => {
+			window.newspack_reader_data = {
+				read_only_keys: [ 'is_donor' ],
+				items: {
+					is_donor: '"true"',
+				},
+			};
+			const store = Store();
+			expect( store.get( 'is_donor' ) ).toEqual( 'true' );
+		} );
+		it( 'should not affect non-read-only keys', () => {
+			const store = Store();
+			store.set( 'custom_key', 'value' );
+			expect( store.get( 'custom_key' ) ).toEqual( 'value' );
+			store.delete( 'custom_key' );
+			expect( store.get( 'custom_key' ) ).toBeNull();
+		} );
+	} );
 } );

--- a/src/reader-activation/store.test.js
+++ b/src/reader-activation/store.test.js
@@ -117,11 +117,11 @@ describe( 'Store', () => {
 			window.newspack_reader_data = {
 				read_only_keys: [ 'is_donor' ],
 				items: {
-					is_donor: '"true"',
+					is_donor: true,
 				},
 			};
 			const store = Store();
-			expect( store.get( 'is_donor' ) ).toEqual( 'true' );
+			expect( store.get( 'is_donor' ) ).toEqual( true );
 		} );
 		it( 'should not affect non-read-only keys', () => {
 			const store = Store();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Up to now, the Reader Data library has persisted keys to store backed by local storage (and, for signed-in users, via API to the database) unconditionally.  With the new data flows introduced in Newspack Integrations, we'll need to protect stored data from unexpected changes.  

This PR enumerates specific keys that should be protected from client-side writes and denies writes to those keys both at the JS store and the API.  

Addresses [NPPD-1067: Reader Data library read only data](https://linear.app/a8c/issue/NPPD-1067/reader-data-library-read-only-data).

### How to test the changes in this Pull Request:

#### Prerequisites

You'll need:

1. A test site set up for Reader Activation.
2. A reader account (i.e., not admin!) on the test site.
3. This PR applied.
4. A browser with a Javascript console you can enter commands into.

This PR changes things under the hood, so these tests will look a bit like human-powered unit tests.  

#### JS store blocks writes to read-only keys

Load up your site and try the following in your JS console:

```
  const store = window.newspackReaderActivation.store;

  // Should throw for each read-only key:
  try { store.set('is_donor', true); } catch (e) { console.log('set blocked:', e.message);
   }
  try { store.delete('is_donor'); } catch (e) { console.log('delete blocked:', e.message);
   }
  try { store.add('active_memberships', 123); } catch (e) { console.log('add blocked:',
  e.message); }
```

Result:  You should see `Key 'is_donor' is read-only` for each operation (`set`, `delete`, `add`). 


#### JS store still allows other keys to be set

Test snippet:

```
  const store = window.newspackReaderActivation.store;

  store.set('my_test_key', 'hello');
  console.log(store.get('my_test_key')); // "hello"
  store.delete('my_test_key');
  console.log(store.get('my_test_key')); // null
```

Result:  No errors. Non-protected keys work as before.


#### Reading read-only keys still works

Snippet:

```
  const store = window.newspackReaderActivation.store;
  console.log(store.get('is_donor'));
  console.log(store.get('active_memberships'));
```

Result: Returns the current value (or null if not set). No error thrown.


#### REST API rejects POST to a read-only key

Log in for this one!  Here's the snippet:

```
  fetch(newspack_reader_data.api_url, {
    method: 'POST',
    headers: {
      'Content-Type': 'application/json',
      'X-WP-Nonce': newspack_reader_data.nonce,
    },
    body: JSON.stringify({ key: 'is_donor', value: '"true"' }),
  }).then(r => r.json()).then(console.log);
```

Result: Response with code: "read_only_key", message: "This key is read-only.", HTTP status 403.


#### REST API rejects DELETE of a read-only key

Again, using the API, so this requires you to be logged in: 

```
  fetch(newspack_reader_data.api_url + '?key=active_memberships', {
    method: 'DELETE',
    headers: { 'X-WP-Nonce': newspack_reader_data.nonce },
  }).then(r => r.json()).then(console.log);
```

Result: Same 403 / read_only_key response.


#### REST API still allows non-protected keys

Log in before trying, etc.

```
  // Create
  fetch(newspack_reader_data.api_url, {
    method: 'POST',
    headers: {
      'Content-Type': 'application/json',
      'X-WP-Nonce': newspack_reader_data.nonce,
    },
    body: JSON.stringify({ key: 'test_manual', value: '"works"' }),
  }).then(r => r.json()).then(console.log);

  // Delete
  fetch(newspack_reader_data.api_url + '?key=test_manual', {
    method: 'DELETE',
    headers: { 'X-WP-Nonce': newspack_reader_data.nonce },
  }).then(r => r.json()).then(console.log);
```

Result: Both return { success: true }.


#### Bonus round: server-side writes

If you've got access to WP CLI (you should!), you can verify that nothing's happened to writes on the server side (replace `1` here with the ID of your test user):

```
  wp eval "Newspack\Reader_Data::update_item(1, 'is_donor', true);"
```

And verify by reading back the new value:

```
  wp user meta get 1 'newspack_reader_data_item_is_donor'
```


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->