### PR TITLE
fix: enable payment method deletion for Braintree

### DIFF
--- a/includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php
+++ b/includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php
@@ -59,6 +59,8 @@ class WooCommerce_My_Account {
 		\add_filter( 'woocommerce_get_checkout_url', [ __CLASS__, 'get_checkout_url' ] );
 		\add_filter( 'woocommerce_get_checkout_payment_url', [ __CLASS__, 'get_checkout_url' ] );
 		\add_filter( 'wc_stripe_update_subs_payment_method_card_statuses', [ __CLASS__, 'update_payment_methods_for_all_subs' ] );
+		\add_filter( 'wc_subscriptions_allow_subscription_token_deletion', [ __CLASS__, 'allow_braintree_token_deletion' ], 10, 2 );
+		\add_filter( 'woocommerce_payment_methods_list_item', [ __CLASS__, 'remove_braintree_edit_actions' ], 20, 2 );
 
 		// Reader Activation mods.
 		if ( Reader_Activation::is_enabled() ) {
@@ -982,6 +984,41 @@ class WooCommerce_My_Account {
 			'on-hold',
 			'pending-cancel',
 		];
+	}
+
+	/**
+	 * Permit 'Delete payment method' option for Braintree.
+	 * This is usually disabled when no alternative payment method is
+	 * available, but some gateways may not permit a new payment with
+	 * similar details (e.g., credit card with same number but updated
+	 * expiration) to one already in the system.
+	 *
+	 * @param bool              $allow_deletion Whether deletion is allowed.
+	 * @param \WC_Payment_Token $payment_token  The payment token.
+	 * @return bool
+	 */
+	public static function allow_braintree_token_deletion( $allow_deletion, $payment_token ) {
+		if ( str_starts_with( $payment_token->get_gateway_id(), 'braintree_' ) ) {
+			return true;
+		}
+		return $allow_deletion;
+	}
+
+	/**
+	 * Remove 'edit' and 'save' actions for Braintree.  This keeps parity
+	 * with existing Stripe integration.
+	 *
+	 * @param array             $item          Payment method list item data.
+	 * @param \WC_Payment_Token $payment_token The payment token.
+	 * @return array
+	 */
+	public static function remove_braintree_edit_actions( $item, $payment_token ) {
+		if ( str_starts_with( $payment_token->get_gateway_id(), 'braintree_' ) ) {
+			if ( ! empty( $item['actions']['edit'] ) || ! empty( $item['actions']['save'] ) ) {
+				unset( $item['actions']['edit'], $item['actions']['save'] );
+			}
+		}
+		return $item;
 	}
 
 	/**

--- a/tests/mocks/wc-mocks.php
+++ b/tests/mocks/wc-mocks.php
@@ -1,5 +1,18 @@
 <?php // phpcs:disable WordPress.Files.FileName.InvalidClassFileName, Squiz.Commenting.FunctionComment.Missing, Squiz.Commenting.ClassComment.Missing, Squiz.Commenting.VariableComment.Missing, Squiz.Commenting.FileComment.Missing, Generic.Files.OneObjectStructurePerFile.MultipleFound, Universal.Files.SeparateFunctionsFromOO.Mixed
 
+/**
+ * Minimal mock for WC_Payment_Token, used when WooCommerce is not loaded in the test environment.
+ */
+class WC_Payment_Token {
+	private $gateway_id;
+	public function __construct( $gateway_id ) {
+		$this->gateway_id = $gateway_id;
+	}
+	public function get_gateway_id() {
+		return $this->gateway_id;
+	}
+}
+
 class WC_Install {
 	public static function create_pages() {
 		return true;

--- a/tests/unit-tests/plugins/woocommerce-my-account-braintree.php
+++ b/tests/unit-tests/plugins/woocommerce-my-account-braintree.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Tests for Braintree-specific methods in WooCommerce_My_Account.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\WooCommerce_My_Account;
+
+require_once __DIR__ . '/../../mocks/wc-mocks.php';
+
+/**
+ * Test Braintree payment token handling in WooCommerce_My_Account.
+ */
+class Newspack_Test_WooCommerce_My_Account_Braintree extends WP_UnitTestCase {
+
+	/**
+	 * Test that allow_braintree_token_deletion returns true for Braintree tokens
+	 * even when the caller passes false (i.e., when it is the only payment method).
+	 */
+	public function test_braintree_token_deletion_is_allowed() {
+		$braintree_token = new WC_Payment_Token( 'braintree_cc' );
+		$result          = WooCommerce_My_Account::allow_braintree_token_deletion( false, $braintree_token );
+		$this->assertTrue( $result, 'Deletion should be allowed for a Braintree payment token even when it is the only method.' );
+	}
+
+	/**
+	 * Test that remove_braintree_edit_actions removes edit and save actions
+	 * from the item array for Braintree payment methods.
+	 */
+	public function test_braintree_edit_and_save_actions_are_removed() {
+		$braintree_token = new WC_Payment_Token( 'braintree_paypal' );
+		$item            = [
+			'actions' => [
+				'edit'   => [
+					'url'  => '/edit',
+					'name' => 'Edit',
+				],
+				'save'   => [
+					'url'  => '/save',
+					'name' => 'Save',
+				],
+				'delete' => [
+					'url'  => '/delete',
+					'name' => 'Delete',
+				],
+			],
+		];
+
+		$result = WooCommerce_My_Account::remove_braintree_edit_actions( $item, $braintree_token );
+
+		$this->assertArrayNotHasKey( 'edit', $result['actions'], 'The edit action should be removed for Braintree payment methods.' );
+		$this->assertArrayNotHasKey( 'save', $result['actions'], 'The save action should be removed for Braintree payment methods.' );
+		$this->assertArrayHasKey( 'delete', $result['actions'], 'The delete action should remain for Braintree payment methods.' );
+	}
+
+	/**
+	 * Test that non-Braintree payment methods are not affected by either filter.
+	 */
+	public function test_non_braintree_payment_methods_are_unaffected() {
+		$stripe_token = new WC_Payment_Token( 'stripe' );
+		$item         = [
+			'actions' => [
+				'edit'   => [
+					'url'  => '/edit',
+					'name' => 'Edit',
+				],
+				'save'   => [
+					'url'  => '/save',
+					'name' => 'Save',
+				],
+				'delete' => [
+					'url'  => '/delete',
+					'name' => 'Delete',
+				],
+			],
+		];
+
+		// allow_braintree_token_deletion should pass through the original value.
+		$allow_deletion = WooCommerce_My_Account::allow_braintree_token_deletion( false, $stripe_token );
+		$this->assertFalse( $allow_deletion, 'Deletion flag should be unchanged for non-Braintree payment tokens.' );
+
+		// remove_braintree_edit_actions should leave the item unchanged.
+		$result = WooCommerce_My_Account::remove_braintree_edit_actions( $item, $stripe_token );
+		$this->assertArrayHasKey( 'edit', $result['actions'], 'The edit action should remain for non-Braintree payment methods.' );
+		$this->assertArrayHasKey( 'save', $result['actions'], 'The save action should remain for non-Braintree payment methods.' );
+		$this->assertArrayHasKey( 'delete', $result['actions'], 'The delete action should remain for non-Braintree payment methods.' );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

#4522 as a hotfix

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->