### PR TITLE
fix: exclude Jetpack Swiper CSS from perfmatters unused CSS feature

### DIFF
--- a/includes/plugins/class-perfmatters.php
+++ b/includes/plugins/class-perfmatters.php
@@ -96,6 +96,7 @@ class Perfmatters {
 			'modules/sharedaddy', // Jetpack's share buttons.
 			'_inc/social-logos', // Jetpack's social logos CSS.
 			'plugins/jetpack/css/jetpack.css', // Jetpack's main CSS.
+			'plugins/jetpack/_inc/blocks/swiper.css', // Jetpack's Swiper CSS.
 			'plugins/the-events-calendar', // The Events Calendar.
 			'plugins/events-calendar-pro', // The Events Calendar Pro.
 			'/themes/newspack-', // Any Newspack theme stylesheet.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds Jetpack's plugins/jetpack/_inc/blocks/swiper.css to the CSS excluded in Perfmatter's unused CSS feature.

It seems like Perfmatters is struggling with the nested CSS Swiper is using. When that happens, it takes this CSS:

```
.swiper-button-next, .swiper-button-prev {
    svg {
        fill: currentColor;
        height: 100%;
        object-fit: contain;
        pointer-events: none;
        transform-origin: center;
        width: 100%;
    }
}
```

And saves it inline as just:

```
svg {
    fill: currentColor;
    height: 100%;
    object-fit: contain;
    pointer-events: none;
    transform-origin: center;
    width: 100%;
}
```

... then, depending on where that ends up in the list of saved CSS, it can bleed into styles for other elements - so far, we've had it change the arrow colour in the Content Carousel, and change the size of the Google G SVG in the Audience Management sign up, and Yoast's time to read.

I've been able to recreate getting the svg saved in the used CSS like this, but not it affecting other blocks like it has on live sites.

Swiper was recently updated in Jetpack, which I think is where this change was introduced.

Closes NPPM-2654

### How to test the changes in this Pull Request:

Given that I don't have steps to recreate a visible issue, it's probably easiest to test by making sure the CSS file is showing up in the excluded stylesheet list. There are also a couple sites already running this in the Linear task.

1. If you don't have it already, install Perfmatters on your test site (we have a license)
2. Apply the PR.
3. Confirm that `plugins/jetpack/_inc/blocks/swiper.css` appears under WP Admin > Perfmatters > CSS in the Excluded Stylesheets list.


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->