### PR TITLE
fix(block-theme): ensure content gate contents inserted in time for styles to be rendered

### DIFF
--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -73,11 +73,7 @@ class Content_Gate {
 		add_action( 'admin_init', [ __CLASS__, 'handle_edit_gate_layout' ] );
 		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'enqueue_scripts' ] );
 		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'enqueue_block_editor_assets' ] );
-		if ( function_exists( 'wp_is_block_theme' ) && wp_is_block_theme() ) {
-			add_filter( 'render_block', [ __CLASS__, 'inject_overlay_gate_after_post_content_block' ], 10, 2 );
-		} else {
-			add_action( 'get_footer', [ __CLASS__, 'render_overlay_gate' ], 1 );
-		}
+		add_action( 'after_setup_theme', [ __CLASS__, 'register_overlay_gate_hooks' ] );
 		add_action( 'before_delete_post', [ __CLASS__, 'delete_gate_layouts' ], 10, 2 );
 		add_filter( 'newspack_popups_assess_has_disabled_popups', [ __CLASS__, 'disable_popups' ] );
 		add_filter( 'newspack_reader_activity_article_view', [ __CLASS__, 'suppress_article_view_activity' ], 100 );
@@ -870,6 +866,20 @@ class Content_Gate {
 	}
 
 	/**
+	 * Register overlay gate hooks after the theme has been set up.
+	 *
+	 * Deferred to after_setup_theme so that wp_is_block_theme() can be called safely,
+	 * after theme directories have been registered.
+	 */
+	public static function register_overlay_gate_hooks() {
+		if ( self::is_block_theme() ) {
+			add_filter( 'render_block', [ __CLASS__, 'inject_overlay_gate_after_post_content_block' ], 10, 2 );
+		} else {
+			add_action( 'get_footer', [ __CLASS__, 'render_overlay_gate' ], 1 );
+		}
+	}
+
+	/**
 	 * Inject overlay gate markup right after the post content block.
 	 *
 	 * Used for block themes where there aren't hooks to use in time to get do_blocks() to run.
@@ -882,6 +892,8 @@ class Content_Gate {
 	public static function inject_overlay_gate_after_post_content_block( $block_content, $block ) {
 		static $injected = false;
 
+		// $injected prevents re-entry even if render_overlay_gate() bails early (e.g. gate style is not "overlay").
+		// $overlay_gate_output is only set when HTML is actually rendered. Both guards are needed.
 		if ( $injected || self::$overlay_gate_output || ! is_singular() ) {
 			return $block_content;
 		}

--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -58,6 +58,13 @@ class Content_Gate {
 	private static $restricted_content = [];
 
 	/**
+	 * Whether the overlay gate markup has been output in this execution.
+	 *
+	 * @var boolean
+	 */
+	private static $overlay_gate_output = false;
+
+	/**
 	 * Initialize hooks and filters.
 	 */
 	public static function init() {
@@ -66,7 +73,11 @@ class Content_Gate {
 		add_action( 'admin_init', [ __CLASS__, 'handle_edit_gate_layout' ] );
 		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'enqueue_scripts' ] );
 		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'enqueue_block_editor_assets' ] );
-		add_action( 'wp_footer', [ __CLASS__, 'render_overlay_gate' ], 1 );
+		if ( function_exists( 'wp_is_block_theme' ) && wp_is_block_theme() ) {
+			add_filter( 'render_block', [ __CLASS__, 'inject_overlay_gate_after_post_content_block' ], 10, 2 );
+		} else {
+			add_action( 'get_footer', [ __CLASS__, 'render_overlay_gate' ], 1 );
+		}
 		add_action( 'before_delete_post', [ __CLASS__, 'delete_gate_layouts' ], 10, 2 );
 		add_filter( 'newspack_popups_assess_has_disabled_popups', [ __CLASS__, 'disable_popups' ] );
 		add_filter( 'newspack_reader_activity_article_view', [ __CLASS__, 'suppress_article_view_activity' ], 100 );
@@ -850,12 +861,39 @@ class Content_Gate {
 		$_post = $post;
 		$post  = \get_post( $gate_layout_id ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		setup_postdata( $post );
-
 		self::render_overlay_gate_html( $gate_layout_id );
+		self::$overlay_gate_output = true;
 
 		self::mark_gate_as_rendered();
 		wp_reset_postdata();
 		$post = $_post; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+	}
+
+	/**
+	 * Inject overlay gate markup right after the post content block.
+	 *
+	 * Used for block themes where there aren't hooks to use in time to get do_blocks() to run.
+	 *
+	 * @param string $block_content Block content.
+	 * @param array  $block         Parsed block.
+	 *
+	 * @return string
+	 */
+	public static function inject_overlay_gate_after_post_content_block( $block_content, $block ) {
+		static $injected = false;
+
+		if ( $injected || self::$overlay_gate_output || ! is_singular() ) {
+			return $block_content;
+		}
+
+		if ( 'core/post-content' !== ( $block['blockName'] ?? '' ) ) {
+			return $block_content;
+		}
+
+		$injected = true;
+		ob_start();
+		self::render_overlay_gate();
+		return $block_content . ob_get_clean();
 	}
 
 	/**

--- a/src/content-gate/gate.scss
+++ b/src/content-gate/gate.scss
@@ -10,9 +10,10 @@
 		z-index: 99999;
 		pointer-events: none;
 		overflow: hidden;
+		max-width: 100%;
 		&::before {
 			content: "";
-			position: absolute;
+			position: fixed;
 			inset: 0;
 			background: #000;
 			opacity: 0;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR is an alternative to https://github.com/Automattic/newspack-plugin/pull/4449 -- rather than looping through the blocks in the content gate to build the styles, this PR moves where the content gate is inserted so the styles "just work". 

Certain block styles are generated as needed by WordPress, and they're not automatically available. By the time the overlay gate is injected at `wp_footer`, it's "too late" for its blocks to be included in those inline styles. This means certain styles -- like block alignments and spacing -- don't work in the gates.

This PR moves where the gate is injected, to `get_footer()` for the classic theme, and inserted at the post-content block for the Block Theme. The latter necessitated a bit of CSS tweaks to make sure the gate still looked right. 

Closes NPPD-1181

### How to test the changes in this Pull Request:

1. Start with the Classic Theme.
2. Set up a content gate (using Memberships or the new Newspack approach).
3. In the Content gate, insert the Registration Card (compact) pattern (the second one in the list of Content Gate block patterns.
4. Publish.
5. In an incognito window, trigger the gate on a post - note the layout is a little messed up (the button and text should be on opposite sides, and the spacing is wrong between the two lines of text):

<img width="1407" height="306" alt="CleanShot 2026-03-03 at 15 44 59" src="https://github.com/user-attachments/assets/2f54e222-110c-4705-ac11-9fdd9812fb3f" />

6. Apply this PR and run npm run build.
7. Repeat step 5 and confirm the blocks look closer to this:

<img width="1387" height="292" alt="CleanShot 2026-03-03 at 15 46 11" src="https://github.com/user-attachments/assets/4c62063e-9d58-4e45-95ba-b631c6db37b1" />

8. Switch to the Block Theme.
9. Repeat step 7 and confirm things still look okay:

<img width="1325" height="250" alt="CleanShot 2026-03-03 at 15 46 53" src="https://github.com/user-attachments/assets/233f892a-c504-4071-bbf9-663e5ca09e14" />

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->