### PR TITLE
feat(content-gate): default block patterns

### DIFF
--- a/includes/content-gate/block-patterns/pay-wall-one-tier-metering.php
+++ b/includes/content-gate/block-patterns/pay-wall-one-tier-metering.php
@@ -10,23 +10,23 @@
 <hr class="wp-block-separator has-alpha-channel-opacity is-style-dots"/>
 <!-- /wp:separator -->
 
-<!-- wp:group {"metadata":{"name":"<?php esc_html_e( 'Wall', 'newspack' ); ?>"},"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|80","bottom":"var:preset|spacing|80","left":"var:preset|spacing|80","right":"var:preset|spacing|80"}},"border":{"radius":"6px","width":"1px"}},"borderColor":"base-3","layout":{"type":"constrained"}} -->
+<!-- wp:group {"metadata":{"name":"<?php esc_html_e( 'Wall', 'newspack-plugin' ); ?>"},"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|80","bottom":"var:preset|spacing|80","left":"var:preset|spacing|80","right":"var:preset|spacing|80"}},"border":{"radius":"6px","width":"1px"}},"borderColor":"base-3","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignwide has-border-color has-base-3-border-color" style="border-width:1px;border-radius:6px;padding-top:var(--wp--preset--spacing--80);padding-right:var(--wp--preset--spacing--80);padding-bottom:var(--wp--preset--spacing--80);padding-left:var(--wp--preset--spacing--80)">
 
 	<!-- wp:heading {"textAlign":"center","level":3} -->
 	<h3 class="wp-block-heading has-text-align-center">
-		<?php esc_html_e( "You've read all free articles for the week", 'newspack' ); ?>
+		<?php esc_html_e( 'Continue reading for free', 'newspack-plugin' ); ?>
 	</h3>
 	<!-- /wp:heading -->
 
-	<!-- wp:columns {"metadata":{"name":"<?php esc_html_e( 'Content', 'newspack' ); ?>"},"className":"is-style-borders","fontSize":"small"} -->
+	<!-- wp:columns {"metadata":{"name":"<?php esc_html_e( 'Content', 'newspack-plugin' ); ?>"},"className":"is-style-borders","fontSize":"small"} -->
 	<div class="wp-block-columns is-style-borders has-small-font-size">
 
 		<!-- wp:column -->
 		<div class="wp-block-column">
 			<!-- wp:paragraph {"align":"center"} -->
 			<p class="has-text-align-center">
-				<?php echo wp_kses( __( 'Register now and get<br><strong>3 free articles every week.</strong>', 'newspack' ), 'post' ); ?>
+				<?php echo wp_kses( __( 'Register now and get<br><strong>3 free articles every week.</strong>', 'newspack-plugin' ), 'post' ); ?>
 			</p>
 			<!-- /wp:paragraph -->
 
@@ -35,7 +35,7 @@
 				<!-- wp:button {"width":100,"className":"is-style-outline"} -->
 				<div class="wp-block-button has-custom-width wp-block-button__width-100 is-style-outline">
 					<a class="wp-block-button__link wp-element-button" href="#register_modal">
-						<?php esc_html_e( 'Register for free', 'newspack' ); ?>
+						<?php esc_html_e( 'Register for free', 'newspack-plugin' ); ?>
 					</a>
 				</div>
 				<!-- /wp:button -->
@@ -48,11 +48,11 @@
 		<div class="wp-block-column">
 			<!-- wp:paragraph {"align":"center"} -->
 			<p class="has-text-align-center">
-				<?php echo wp_kses( __( 'Unlimited access to our<br><strong>daily content and archives</strong>.', 'newspack' ), 'post' ); ?>
+				<?php echo wp_kses( __( 'Unlimited access to our<br><strong>daily content and archives</strong>.', 'newspack-plugin' ), 'post' ); ?>
 			</p>
 			<!-- /wp:paragraph -->
 
-			<!-- wp:newspack-blocks/checkout-button {"text":"<?php esc_html_e( 'Subscribe for $5/month', 'newspack' ); ?>","width":100,"align":"wide"} /-->
+			<!-- wp:newspack-blocks/checkout-button {"text":"<?php esc_html_e( 'Subscribe for $5/month', 'newspack-plugin' ); ?>","width":100,"align":"wide"} /-->
 		</div>
 		<!-- /wp:column -->
 
@@ -64,7 +64,7 @@
 		<!-- wp:button {"backgroundColor":"base","textColor":"contrast","style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast"}}}}} -->
 		<div class="wp-block-button">
 			<a class="wp-block-button__link has-contrast-color has-base-background-color has-text-color has-background has-link-color wp-element-button" href="#signin_modal">
-				<?php esc_html_e( 'Sign in to an existing account', 'newspack' ); ?>
+				<?php esc_html_e( 'Sign in to an existing account', 'newspack-plugin' ); ?>
 			</a>
 		</div>
 		<!-- /wp:button -->

--- a/includes/content-gate/block-patterns/registration-wall.php
+++ b/includes/content-gate/block-patterns/registration-wall.php
@@ -15,21 +15,21 @@
 
 	<!-- wp:heading {"textAlign":"center","level":3} -->
 	<h3 class="wp-block-heading has-text-align-center">
-		<?php esc_html_e( 'Continue reading for free', 'newspack' ); ?>
+		<?php esc_html_e( 'Continue reading for free', 'newspack-plugin' ); ?>
 	</h3>
 	<!-- /wp:heading -->
 
 	<!-- wp:paragraph {"align":"center"} -->
 	<p class="has-text-align-center">
-		<?php esc_html_e( 'Get unlimited access to this article and our full collection.', 'newspack' ); ?><br>
-		<?php esc_html_e( 'A free account unlocks everything.', 'newspack' ); ?>
+		<?php esc_html_e( 'Get unlimited access to this article and our full collection.', 'newspack-plugin' ); ?><br>
+		<?php esc_html_e( 'A free account unlocks everything.', 'newspack-plugin' ); ?>
 	</p>
 	<!-- /wp:paragraph -->
 
 	<!-- wp:newspack/reader-registration -->
 	<div class="wp-block-newspack-reader-registration">
 		<!-- wp:paragraph {"align":"center"} -->
-		<p class="has-text-align-center"><?php esc_html_e( 'Thank you for registering.', 'newspack' ); ?></p>
+		<p class="has-text-align-center"><?php esc_html_e( 'Thank you for registering.', 'newspack-plugin' ); ?></p>
 		<!-- /wp:paragraph -->
 	</div>
 	<!-- /wp:newspack/reader-registration -->

--- a/includes/content-gate/block-patterns/registration-wall.php
+++ b/includes/content-gate/block-patterns/registration-wall.php
@@ -10,19 +10,26 @@
 <hr class="wp-block-separator has-alpha-channel-opacity is-style-dots"/>
 <!-- /wp:separator -->
 
-<!-- wp:group {"metadata":{"name":"<?php esc_html_e( 'Wall', 'newspack' ); ?>"},"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|80","bottom":"var:preset|spacing|80","left":"var:preset|spacing|80","right":"var:preset|spacing|80"}},"border":{"radius":"6px","width":"1px"}},"borderColor":"base-3","layout":{"type":"constrained"}} -->
+<!-- wp:group {"metadata":{"name":"Wall"},"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|80","bottom":"var:preset|spacing|80","left":"var:preset|spacing|80","right":"var:preset|spacing|80"}},"border":{"radius":"6px","width":"1px"}},"borderColor":"base-3","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignwide has-border-color has-base-3-border-color" style="border-width:1px;border-radius:6px;padding-top:var(--wp--preset--spacing--80);padding-right:var(--wp--preset--spacing--80);padding-bottom:var(--wp--preset--spacing--80);padding-left:var(--wp--preset--spacing--80)">
 
 	<!-- wp:heading {"textAlign":"center","level":3} -->
 	<h3 class="wp-block-heading has-text-align-center">
-		<?php esc_html_e( 'Register to continue reading', 'newspack' ); ?>
+		<?php esc_html_e( 'Continue reading for free', 'newspack' ); ?>
 	</h3>
 	<!-- /wp:heading -->
+
+	<!-- wp:paragraph {"align":"center"} -->
+	<p class="has-text-align-center">
+		<?php esc_html_e( 'Get unlimited access to this article and our full collection.', 'newspack' ); ?><br>
+		<?php esc_html_e( 'A free account unlocks everything.', 'newspack' ); ?>
+	</p>
+	<!-- /wp:paragraph -->
 
 	<!-- wp:newspack/reader-registration -->
 	<div class="wp-block-newspack-reader-registration">
 		<!-- wp:paragraph {"align":"center"} -->
-		<p class="has-text-align-center"><?php echo esc_html_e( 'Thank you for registering.', 'newspack' ); ?></p>
+		<p class="has-text-align-center"><?php esc_html_e( 'Thank you for registering.', 'newspack' ); ?></p>
 		<!-- /wp:paragraph -->
 	</div>
 	<!-- /wp:newspack/reader-registration -->

--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -340,14 +340,14 @@ class Content_Gate {
 		\register_post_type(
 			self::GATE_CPT,
 			[
-				'label'        => __( 'Content Gate', 'newspack' ),
+				'label'        => __( 'Content Gate', 'newspack-plugin' ),
 				'labels'       => [
-					'item_published'         => __( 'Content Gate published.', 'newspack' ),
-					'item_reverted_to_draft' => __( 'Content Gate reverted to draft.', 'newspack' ),
-					'item_updated'           => __( 'Content Gate updated.', 'newspack' ),
-					'new_item'               => __( 'New Content Gate', 'newspack' ),
-					'edit_item'              => __( 'Edit Content Gate', 'newspack' ),
-					'view_item'              => __( 'View Content Gate', 'newspack' ),
+					'item_published'         => __( 'Content Gate published.', 'newspack-plugin' ),
+					'item_reverted_to_draft' => __( 'Content Gate reverted to draft.', 'newspack-plugin' ),
+					'item_updated'           => __( 'Content Gate updated.', 'newspack-plugin' ),
+					'new_item'               => __( 'New Content Gate', 'newspack-plugin' ),
+					'edit_item'              => __( 'Edit Content Gate', 'newspack-plugin' ),
+					'view_item'              => __( 'View Content Gate', 'newspack-plugin' ),
 				],
 				'public'       => false,
 				'show_ui'      => true,
@@ -357,7 +357,7 @@ class Content_Gate {
 			]
 		);
 		// Register the layout post type.
-		self::register_layout_post_type( self::GATE_LAYOUT_CPT, __( 'Content Gate Layout', 'newspack' ) );
+		self::register_layout_post_type( self::GATE_LAYOUT_CPT, __( 'Content Gate Layout', 'newspack-plugin' ) );
 	}
 
 	/**
@@ -622,7 +622,7 @@ class Content_Gate {
 		if ( ! $registration_layout_id ) {
 			$registration_content   = self::get_layout_default_content( $gate_id, 'registration', $registration_settings, $custom_access_settings );
 			$registration_layout_id = self::create_gate_layout(
-				__( 'Registration Access Layout', 'newspack' ),
+				__( 'Registration Access Layout', 'newspack-plugin' ),
 				$registration_content
 			);
 		}
@@ -634,7 +634,7 @@ class Content_Gate {
 		if ( ! $custom_access_layout_id ) {
 			$custom_access_content   = self::get_layout_default_content( $gate_id, 'custom_access', $registration_settings, $custom_access_settings );
 			$custom_access_layout_id = self::create_gate_layout(
-				__( 'Paid Access Layout', 'newspack' ),
+				__( 'Paid Access Layout', 'newspack-plugin' ),
 				$custom_access_content
 			);
 			if ( ! is_wp_error( $custom_access_layout_id ) ) {
@@ -683,7 +683,7 @@ class Content_Gate {
 	 */
 	public static function create_gate_layout( $title = '', $content = '' ) {
 		if ( empty( $title ) ) {
-			$title = __( 'Content Gate Layout', 'newspack' );
+			$title = __( 'Content Gate Layout', 'newspack-plugin' );
 		}
 		if ( empty( $content ) ) {
 			$content = self::get_default_gate_content();
@@ -753,7 +753,7 @@ class Content_Gate {
 		}
 
 		if ( empty( $pattern_slug ) ) {
-			return '<p>' . esc_html( __( 'This article is only available to members.', 'newspack' ) ) . '</p>';
+			return '<p>' . esc_html( __( 'This article is only available to members.', 'newspack-plugin' ) ) . '</p>';
 		}
 		return self::get_block_pattern_content( $pattern_slug );
 	}
@@ -792,30 +792,30 @@ class Content_Gate {
 
 		$gate_id = isset( $_GET['gate_id'] ) ? \absint( $_GET['gate_id'] ) : false;
 		if ( ! $gate_id ) {
-			\wp_die( esc_html( __( 'Gate ID is required.', 'newspack' ) ) );
+			\wp_die( esc_html( __( 'Gate ID is required.', 'newspack-plugin' ) ) );
 		}
 
 		$gate_mode = isset( $_GET['gate_mode'] ) ? \sanitize_text_field( $_GET['gate_mode'] ) : false;
 		if ( ! $gate_mode ) {
-			\wp_die( esc_html( __( 'Gate mode is required.', 'newspack' ) ) );
+			\wp_die( esc_html( __( 'Gate mode is required.', 'newspack-plugin' ) ) );
 		}
 
 		$gate = self::get_gate( $gate_id );
 		if ( ! $gate ) {
-			\wp_die( esc_html( __( 'Gate not found.', 'newspack' ) ) );
+			\wp_die( esc_html( __( 'Gate not found.', 'newspack-plugin' ) ) );
 		}
 
 		$gate_layout_id            = 0;
-		$gate_layout_default_title = __( 'Content Gate Layout', 'newspack' );
+		$gate_layout_default_title = __( 'Content Gate Layout', 'newspack-plugin' );
 
 		if ( 'registration' === $gate_mode ) {
 			$gate_layout_id = $gate['registration']['gate_layout_id'];
-			$gate_layout_default_title = __( 'Registration Access Layout', 'newspack' );
+			$gate_layout_default_title = __( 'Registration Access Layout', 'newspack-plugin' );
 		} elseif ( 'custom_access' === $gate_mode ) {
 			$gate_layout_id = $gate['custom_access']['gate_layout_id'];
-			$gate_layout_default_title = __( 'Paid Access Layout', 'newspack' );
+			$gate_layout_default_title = __( 'Paid Access Layout', 'newspack-plugin' );
 		} else {
-			\wp_die( esc_html( __( 'Invalid gate mode.', 'newspack' ) ) );
+			\wp_die( esc_html( __( 'Invalid gate mode.', 'newspack-plugin' ) ) );
 		}
 
 		$gate_layout = get_post( $gate_layout_id );
@@ -1045,7 +1045,7 @@ class Content_Gate {
 	public static function get_gate( $id ) {
 		$post = get_post( $id );
 		if ( ! $post ) {
-			return new \WP_Error( 'newspack_content_gate_not_found', __( 'Gate not found.', 'newspack' ) );
+			return new \WP_Error( 'newspack_content_gate_not_found', __( 'Gate not found.', 'newspack-plugin' ) );
 		}
 
 		return [
@@ -1121,7 +1121,7 @@ class Content_Gate {
 	public static function update_gate_setting( $id, $key, $value ) {
 		$post = get_post( $id );
 		if ( ! $post ) {
-			return new \WP_Error( 'newspack_content_gate_not_found', __( 'Gate not found.', 'newspack' ) );
+			return new \WP_Error( 'newspack_content_gate_not_found', __( 'Gate not found.', 'newspack-plugin' ) );
 		}
 
 		$update = [];
@@ -1144,7 +1144,7 @@ class Content_Gate {
 			self::update_custom_access_settings( $id, $value );
 			return self::get_gate( $id );
 		} else {
-			return new \WP_Error( 'newspack_content_gate_invalid_key', __( 'Invalid gate setting key.', 'newspack' ) );
+			return new \WP_Error( 'newspack_content_gate_invalid_key', __( 'Invalid gate setting key.', 'newspack-plugin' ) );
 		}
 
 		// Update title and description.
@@ -1171,7 +1171,7 @@ class Content_Gate {
 	public static function update_gate_settings( $id, $gate ) {
 		$post = get_post( $id );
 		if ( ! $post ) {
-			return new \WP_Error( 'newspack_content_gate_not_found', __( 'Gate not found.', 'newspack' ) );
+			return new \WP_Error( 'newspack_content_gate_not_found', __( 'Gate not found.', 'newspack-plugin' ) );
 		}
 
 		// Update title, priority, and status.

--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -745,7 +745,7 @@ class Content_Gate {
 		$pattern_slug = '';
 		if ( 'registration' === $gate_mode ) {
 			$pattern_slug = 'registration-wall';
-			if ( $custom_access_settings['active'] ) {
+			if ( ! empty( $custom_access_settings['active'] ) ) {
 				$pattern_slug = 'pay-wall-one-tier-metering';
 			}
 		} elseif ( 'custom_access' === $gate_mode ) {

--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -617,7 +617,7 @@ class Content_Gate {
 		$registration_settings  = $gate['registration'] ?? [];
 		$registration_layout_id = $registration_settings['gate_layout_id'] ?? 0;
 		if ( ! $registration_layout_id ) {
-			$registration_content   = self::get_block_pattern_content( 'registration-card' );
+			$registration_content   = self::get_block_pattern_content( 'registration-wall' );
 			$registration_layout_id = self::create_gate_layout(
 				__( 'Registration Access Layout', 'newspack' ),
 				$registration_content
@@ -790,7 +790,7 @@ class Content_Gate {
 			exit;
 		} else {
 			// Use registration pattern for registration mode, default content for custom_access.
-			$gate_layout_content = 'registration' === $gate_mode ? self::get_block_pattern_content( 'registration-card' ) : '';
+			$gate_layout_content = 'registration' === $gate_mode ? self::get_block_pattern_content( 'registration-wall' ) : '';
 			$gate_layout_id      = self::create_gate_layout( $gate_layout_default_title, $gate_layout_content );
 			if ( is_wp_error( $gate_layout_id ) ) {
 				\wp_die( esc_html( $gate_layout_id->get_error_message() ) );

--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -616,8 +616,11 @@ class Content_Gate {
 		// Create default layouts for registration and custom_access modes.
 		$registration_settings  = $gate['registration'] ?? [];
 		$registration_layout_id = $registration_settings['gate_layout_id'] ?? 0;
+		$custom_access_settings  = $gate['custom_access'] ?? [];
+		$custom_access_layout_id = $custom_access_settings['gate_layout_id'] ?? 0;
+
 		if ( ! $registration_layout_id ) {
-			$registration_content   = self::get_block_pattern_content( 'registration-wall' );
+			$registration_content   = self::get_layout_default_content( $gate_id, 'registration', $registration_settings, $custom_access_settings );
 			$registration_layout_id = self::create_gate_layout(
 				__( 'Registration Access Layout', 'newspack' ),
 				$registration_content
@@ -628,11 +631,11 @@ class Content_Gate {
 		}
 		self::update_registration_settings( $gate_id, $registration_settings );
 
-		$custom_access_settings  = $gate['custom_access'] ?? [];
-		$custom_access_layout_id = $custom_access_settings['gate_layout_id'] ?? 0;
 		if ( ! $custom_access_layout_id ) {
+			$custom_access_content   = self::get_layout_default_content( $gate_id, 'custom_access', $registration_settings, $custom_access_settings );
 			$custom_access_layout_id = self::create_gate_layout(
-				__( 'Paid Access Layout', 'newspack' )
+				__( 'Paid Access Layout', 'newspack' ),
+				$custom_access_content
 			);
 			if ( ! is_wp_error( $custom_access_layout_id ) ) {
 				$custom_access_settings['gate_layout_id'] = $custom_access_layout_id;
@@ -703,7 +706,7 @@ class Content_Gate {
 	 *
 	 * @return string The pattern content, or empty string if not found.
 	 */
-	public static function get_block_pattern_content( $pattern_slug ) {
+	private static function get_block_pattern_content( $pattern_slug ) {
 		$patterns_dir = realpath( __DIR__ . '/block-patterns' );
 		if ( ! $patterns_dir ) {
 			return '';
@@ -719,6 +722,40 @@ class Content_Gate {
 		ob_start();
 		require $path;
 		return ob_get_clean();
+	}
+
+	/**
+	 * Get the block pattern content for a gate layout.
+	 *
+	 * @param int    $gate_id                Gate ID.
+	 * @param string $gate_mode              Gate mode.
+	 * @param array  $registration_settings  Registration settings.
+	 * @param array  $custom_access_settings Custom access settings.
+	 *
+	 * @return string
+	 */
+	private static function get_layout_default_content( $gate_id, $gate_mode, $registration_settings = [], $custom_access_settings = [] ) {
+		if ( empty( $registration_settings ) ) {
+			$registration_settings = self::get_registration_settings( $gate_id );
+		}
+		if ( empty( $custom_access_settings ) ) {
+			$custom_access_settings = self::get_custom_access_settings( $gate_id );
+		}
+
+		$pattern_slug = '';
+		if ( 'registration' === $gate_mode ) {
+			$pattern_slug = 'registration-wall';
+			if ( $custom_access_settings['active'] ) {
+				$pattern_slug = 'pay-wall-one-tier-metering';
+			}
+		} elseif ( 'custom_access' === $gate_mode ) {
+			$pattern_slug = 'pay-wall-one-tier';
+		}
+
+		if ( empty( $pattern_slug ) ) {
+			return '<p>' . esc_html( __( 'This article is only available to members.', 'newspack' ) ) . '</p>';
+		}
+		return self::get_block_pattern_content( $pattern_slug );
 	}
 
 	/**
@@ -790,7 +827,7 @@ class Content_Gate {
 			exit;
 		} else {
 			// Use registration pattern for registration mode, default content for custom_access.
-			$gate_layout_content = 'registration' === $gate_mode ? self::get_block_pattern_content( 'registration-wall' ) : '';
+			$gate_layout_content = self::get_layout_default_content( $gate_id, $gate_mode, $gate['registration'], $gate['custom_access'] );
 			$gate_layout_id      = self::create_gate_layout( $gate_layout_default_title, $gate_layout_content );
 			if ( is_wp_error( $gate_layout_id ) ) {
 				\wp_die( esc_html( $gate_layout_id->get_error_message() ) );

--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -79,7 +79,7 @@ class Memberships {
 	 * Register post type for custom gate.
 	 */
 	public static function register_post_type() {
-		self::register_layout_post_type( self::GATE_CPT, __( 'Memberships Gate', 'newspack' ) );
+		self::register_layout_post_type( self::GATE_CPT, __( 'Memberships Gate', 'newspack-plugin' ) );
 	}
 
 	/**
@@ -131,7 +131,7 @@ class Memberships {
 			$gate_post_id = absint( $_GET['gate_post_id'] );
 			$is_primary   = false;
 			if ( ! $gate_post_id || ! get_post( $gate_post_id ) ) {
-				\wp_die( esc_html( __( 'Invalid gate post ID.', 'newspack' ) ) );
+				\wp_die( esc_html( __( 'Invalid gate post ID.', 'newspack-plugin' ) ) );
 			}
 		}
 
@@ -145,7 +145,7 @@ class Memberships {
 			exit;
 		} else {
 			// Gate not found, create it.
-			$post_title   = __( 'Content Gate', 'newspack' );
+			$post_title   = __( 'Content Gate', 'newspack-plugin' );
 			$gate_post_id = Content_Gate::create_gate( [ 'title' => $post_title ], self::GATE_CPT );
 			if ( is_wp_error( $gate_post_id ) ) {
 				\wp_die( esc_html( $gate_post_id->get_error_message() ) );
@@ -258,7 +258,7 @@ class Memberships {
 
 		$plan_id = isset( $_GET['plan_id'] ) ? \absint( $_GET['plan_id'] ) : false;
 		if ( ! $plan_id ) {
-			\wp_die( esc_html( __( 'Plan ID is required.', 'newspack' ) ) );
+			\wp_die( esc_html( __( 'Plan ID is required.', 'newspack-plugin' ) ) );
 		}
 
 		$gate_post_id = self::get_plan_gate_id( $plan_id );
@@ -275,11 +275,11 @@ class Memberships {
 			// Gate not found, create it.
 			$plan = \wc_memberships_get_membership_plan( $plan_id );
 			if ( ! $plan ) {
-				\wp_die( esc_html( __( 'Plan not found.', 'newspack' ) ) );
+				\wp_die( esc_html( __( 'Plan not found.', 'newspack-plugin' ) ) );
 			}
 			$post_title = sprintf(
 				// Translators: %s is the plan name.
-				__( '%s Gate', 'newspack' ),
+				__( '%s Gate', 'newspack-plugin' ),
 				$plan->get_name()
 			);
 			$gate_post_id = Content_Gate::create_gate( [ 'title' => $post_title ], self::GATE_CPT );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

NPPD-1191

Introduces a more advanced handling of the content gate default layouts based on the gate configuration:

1. Registration Access Layout:
   1. Without paid access, uses the `registration-wall` pattern
   2. With paid Access (metering), uses `pay-wall-one-tier-metering` pattern
2. Paid Access Layout uses `pay-wall-one-tier` pattern

### How to test the changes in this Pull Request:

1. Create 2 new gates, one with registration access alone and another with both registration and paid access
2. Edit the gates and confirm they reflect the description above

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->