### PR TITLE
feat(integrations): add integrations settings

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -182,6 +182,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/audience/class-audience-content-gates.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/audience/class-audience-donations.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/audience/class-audience-subscriptions.php';
+		include_once NEWSPACK_ABSPATH . 'includes/wizards/audience/class-audience-integrations.php';
 
 		// Network Wizard.
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-network-wizard.php';

--- a/includes/class-wizards.php
+++ b/includes/class-wizards.php
@@ -66,6 +66,7 @@ class Wizards {
 			'audience-campaigns'      => new Audience_Campaigns(),
 			'audience-content-gates'  => new Audience_Content_Gates(),
 			'audience-donations'      => new Audience_Donations(),
+			'audience-integrations'   => new Audience_Integrations(),
 			'listings'                => new Listings_Wizard(),
 			'network'                 => new Network_Wizard(),
 			'newsletters'             => new Newsletters_Wizard(),

--- a/includes/reader-activation/class-integrations.php
+++ b/includes/reader-activation/class-integrations.php
@@ -87,7 +87,7 @@ class Integrations {
 		// Hook for other plugins/code to register their integrations.
 		do_action( 'newspack_reader_activation_register_integrations' );
 
-		// hardcode ESP integration as enabled for now..
+		// hardcode ESP integration as enabled for now.
 		self::enable( 'esp' );
 
 		// Let each integration register its data event handlers.

--- a/includes/reader-activation/class-integrations.php
+++ b/includes/reader-activation/class-integrations.php
@@ -87,8 +87,8 @@ class Integrations {
 		// Hook for other plugins/code to register their integrations.
 		do_action( 'newspack_reader_activation_register_integrations' );
 
-		// Migrate ESP enabled state from legacy option.
-		self::maybe_migrate_esp_enabled();
+		// hardcode ESP integration as enabled for now..
+		self::enable( 'esp' );
 
 		// Let each integration register its data event handlers.
 		foreach ( self::$integrations as $integration ) {
@@ -229,27 +229,6 @@ class Integrations {
 		}
 
 		return $enabled;
-	}
-
-	/**
-	 * Migrate ESP enabled state from the legacy sync_esp option.
-	 *
-	 * On first run, reads the legacy option and sets the ESP integration
-	 * enabled/disabled accordingly. Defaults to enabled if no legacy option exists.
-	 */
-	private static function maybe_migrate_esp_enabled() {
-		$migrated_key = 'newspack_esp_enabled_migrated';
-		if ( \get_option( $migrated_key ) ) {
-			return;
-		}
-
-		$legacy_sync_esp = \get_option( 'newspack_reader_activation_sync_esp', null );
-		if ( null !== $legacy_sync_esp && ! $legacy_sync_esp ) {
-			self::disable( 'esp' );
-		} else {
-			self::enable( 'esp' );
-		}
-		\update_option( $migrated_key, true );
 	}
 
 	/**

--- a/includes/reader-activation/class-integrations.php
+++ b/includes/reader-activation/class-integrations.php
@@ -87,8 +87,11 @@ class Integrations {
 		// Hook for other plugins/code to register their integrations.
 		do_action( 'newspack_reader_activation_register_integrations' );
 
-		// hardcode ESP integration as enabled for now.
-		self::enable( 'esp' );
+		// Auto-enable all integrations if the option has never been saved.
+		if ( false === get_option( self::OPTION_NAME ) ) {
+			$all_ids = array_keys( self::$integrations );
+			update_option( self::OPTION_NAME, $all_ids );
+		}
 
 		// Let each integration register its data event handlers.
 		foreach ( self::$integrations as $integration ) {
@@ -253,9 +256,11 @@ class Integrations {
 				continue;
 			}
 			$result[ $id ] = [
-				'id'       => $id,
-				'name'     => $integration->get_name(),
-				'settings' => $integration->get_settings_config(),
+				'id'          => $id,
+				'name'        => $integration->get_name(),
+				'description' => $integration->get_description(),
+				'enabled'     => self::is_enabled( $id ),
+				'settings'    => $integration->get_settings_config(),
 			];
 		}
 		return $result;

--- a/includes/reader-activation/class-integrations.php
+++ b/includes/reader-activation/class-integrations.php
@@ -87,11 +87,8 @@ class Integrations {
 		// Hook for other plugins/code to register their integrations.
 		do_action( 'newspack_reader_activation_register_integrations' );
 
-		// Auto-enable all integrations if the option has never been saved.
-		if ( false === get_option( self::OPTION_NAME ) ) {
-			$all_ids = array_keys( self::$integrations );
-			update_option( self::OPTION_NAME, $all_ids );
-		}
+		// hardcode ESP integration as enabled for now.
+		self::enable( 'esp' );
 
 		// Let each integration register its data event handlers.
 		foreach ( self::$integrations as $integration ) {

--- a/includes/reader-activation/class-integrations.php
+++ b/includes/reader-activation/class-integrations.php
@@ -87,8 +87,8 @@ class Integrations {
 		// Hook for other plugins/code to register their integrations.
 		do_action( 'newspack_reader_activation_register_integrations' );
 
-		// hardcode ESP integration as enabled for now.
-		self::enable( 'esp' );
+		// Migrate ESP enabled state from legacy option.
+		self::maybe_migrate_esp_enabled();
 
 		// Let each integration register its data event handlers.
 		foreach ( self::$integrations as $integration ) {
@@ -229,6 +229,27 @@ class Integrations {
 		}
 
 		return $enabled;
+	}
+
+	/**
+	 * Migrate ESP enabled state from the legacy sync_esp option.
+	 *
+	 * On first run, reads the legacy option and sets the ESP integration
+	 * enabled/disabled accordingly. Defaults to enabled if no legacy option exists.
+	 */
+	private static function maybe_migrate_esp_enabled() {
+		$migrated_key = 'newspack_esp_enabled_migrated';
+		if ( \get_option( $migrated_key ) ) {
+			return;
+		}
+
+		$legacy_sync_esp = \get_option( 'newspack_reader_activation_sync_esp', null );
+		if ( null !== $legacy_sync_esp && ! $legacy_sync_esp ) {
+			self::disable( 'esp' );
+		} else {
+			self::enable( 'esp' );
+		}
+		\update_option( $migrated_key, true );
 	}
 
 	/**

--- a/includes/reader-activation/class-integrations.php
+++ b/includes/reader-activation/class-integrations.php
@@ -241,6 +241,45 @@ class Integrations {
 	}
 
 	/**
+	 * Get settings config for all integrations that have settings fields.
+	 *
+	 * @return array Keyed array of integration settings.
+	 */
+	public static function get_all_integration_settings() {
+		$result = [];
+		foreach ( self::$integrations as $id => $integration ) {
+			$fields = $integration->get_settings_fields();
+			if ( empty( $fields ) ) {
+				continue;
+			}
+			$result[ $id ] = [
+				'id'       => $id,
+				'name'     => $integration->get_name(),
+				'settings' => $integration->get_settings_config(),
+			];
+		}
+		return $result;
+	}
+
+	/**
+	 * Update settings for a specific integration.
+	 *
+	 * @param string $integration_id The integration ID.
+	 * @param array  $settings       Key-value pairs of settings to update.
+	 * @return bool|null True if updated, null if integration not found.
+	 */
+	public static function update_integration_settings( $integration_id, $settings ) {
+		$integration = self::get_integration( $integration_id );
+		if ( ! $integration ) {
+			return null;
+		}
+		foreach ( $settings as $key => $value ) {
+			$integration->update_settings_field_value( $key, $value );
+		}
+		return true;
+	}
+
+	/**
 	 * Register a data event handler for an integration.
 	 *
 	 * Validates the method, stores the handler in the map, and registers

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -431,6 +431,15 @@ final class Reader_Activation {
 		if ( ! isset( $config[ $name ] ) ) {
 			return null;
 		}
+
+		// When integration settings are enabled, route ESP settings to the integration.
+		if ( Audience_Integrations::is_enabled() ) {
+			$esp_setting = self::get_esp_integration_setting( $name );
+			if ( null !== $esp_setting ) {
+				return apply_filters( 'newspack_reader_activation_setting', $esp_setting, $name );
+			}
+		}
+
 		$value = \get_option( self::OPTIONS_PREFIX . $name, $config[ $name ] );
 
 		// Use default value type for casting bool option value.
@@ -438,6 +447,33 @@ final class Reader_Activation {
 			$value = (bool) $value;
 		}
 		return apply_filters( 'newspack_reader_activation_setting', $value, $name );
+	}
+
+	/**
+	 * Get an ESP setting value from the integration instance.
+	 *
+	 * @param string $name Setting name.
+	 * @return mixed|null The setting value, or null if this setting is not an ESP integration setting.
+	 */
+	private static function get_esp_integration_setting( $name ) {
+		static $esp_keys = [
+			'mailchimp_audience_id',
+			'mailchimp_reader_default_status',
+			'active_campaign_master_list',
+			'constant_contact_list_id',
+			'sync_esp_delete',
+		];
+
+		if ( ! in_array( $name, $esp_keys, true ) ) {
+			return null;
+		}
+
+		$esp = Reader_Activation\Integrations::get_integration( 'esp' );
+		if ( ! $esp ) {
+			return null;
+		}
+
+		return $esp->get_settings_field_value( $name );
 	}
 
 	/**
@@ -470,6 +506,23 @@ final class Reader_Activation {
 		}
 		if ( 'metadata_fields' === $key ) {
 			return Sync\Metadata::update_fields( $value );
+		}
+
+		// When integration settings are enabled, route ESP settings to the integration.
+		if ( Audience_Integrations::is_enabled() ) {
+			$esp = Reader_Activation\Integrations::get_integration( 'esp' );
+			if ( $esp ) {
+				static $esp_keys = [
+					'mailchimp_audience_id',
+					'mailchimp_reader_default_status',
+					'active_campaign_master_list',
+					'constant_contact_list_id',
+					'sync_esp_delete',
+				];
+				if ( in_array( $key, $esp_keys, true ) ) {
+					return $esp->update_settings_field_value( $key, $value );
+				}
+			}
 		}
 
 		return \update_option( self::OPTIONS_PREFIX . $key, $value );

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -512,14 +512,7 @@ final class Reader_Activation {
 		if ( Audience_Integrations::is_enabled() ) {
 			$esp = Reader_Activation\Integrations::get_integration( 'esp' );
 			if ( $esp ) {
-				static $esp_keys = [
-					'mailchimp_audience_id',
-					'mailchimp_reader_default_status',
-					'active_campaign_master_list',
-					'constant_contact_list_id',
-					'sync_esp_delete',
-				];
-				if ( in_array( $key, $esp_keys, true ) ) {
+				if ( null !== self::get_esp_integration_setting( $key ) ) {
 					return $esp->update_settings_field_value( $key, $value );
 				}
 			}

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -432,12 +432,10 @@ final class Reader_Activation {
 			return null;
 		}
 
-		// When integration settings are enabled, route ESP settings to the integration.
-		if ( Audience_Integrations::is_enabled() ) {
-			$esp_setting = self::get_esp_integration_setting( $name );
-			if ( null !== $esp_setting ) {
-				return apply_filters( 'newspack_reader_activation_setting', $esp_setting, $name );
-			}
+		// Route ESP settings to the integration.
+		$esp_setting = self::get_esp_integration_setting( $name );
+		if ( null !== $esp_setting ) {
+			return apply_filters( 'newspack_reader_activation_setting', $esp_setting, $name );
 		}
 
 		$value = \get_option( self::OPTIONS_PREFIX . $name, $config[ $name ] );
@@ -462,6 +460,7 @@ final class Reader_Activation {
 			'active_campaign_master_list',
 			'constant_contact_list_id',
 			'sync_esp_delete',
+			'sync_esp',
 		];
 
 		if ( ! in_array( $name, $esp_keys, true ) ) {
@@ -471,6 +470,10 @@ final class Reader_Activation {
 		$esp = Reader_Activation\Integrations::get_integration( 'esp' );
 		if ( ! $esp ) {
 			return null;
+		}
+
+		if ( 'sync_esp' === $name ) {
+			return $esp->is_enabled();
 		}
 
 		return $esp->get_settings_field_value( $name );
@@ -508,14 +511,22 @@ final class Reader_Activation {
 			return Sync\Metadata::update_fields( $value );
 		}
 
-		// When integration settings are enabled, route ESP settings to the integration.
-		if ( Audience_Integrations::is_enabled() ) {
-			$esp = Reader_Activation\Integrations::get_integration( 'esp' );
-			if ( $esp ) {
-				if ( null !== self::get_esp_integration_setting( $key ) ) {
-					return $esp->update_settings_field_value( $key, $value );
-				}
+		// Route sync_esp to the integration enabled state.
+		if ( 'sync_esp' === $key ) {
+			if ( $value ) {
+				Reader_Activation\Integrations::enable( 'esp' );
+			} else {
+				Reader_Activation\Integrations::disable( 'esp' );
 			}
+			// Also write to legacy option for backward compat with external hooks.
+			\update_option( self::OPTIONS_PREFIX . $key, $value );
+			return true;
+		}
+
+		// Route ESP settings to the integration.
+		$esp = Reader_Activation\Integrations::get_integration( 'esp' );
+		if ( $esp && null !== self::get_esp_integration_setting( $key ) ) {
+			return $esp->update_settings_field_value( $key, $value );
 		}
 
 		return \update_option( self::OPTIONS_PREFIX . $key, $value );

--- a/includes/reader-activation/integrations/class-contact-pull.php
+++ b/includes/reader-activation/integrations/class-contact-pull.php
@@ -144,7 +144,7 @@ class Contact_Pull {
 		$failed = [];
 
 		foreach ( $integrations as $id => $integration ) {
-			$selected_fields = $integration->get_selected_fields();
+			$selected_fields = $integration->get_incoming_fields();
 			if ( empty( $selected_fields ) ) {
 				continue;
 			}
@@ -235,9 +235,9 @@ class Contact_Pull {
 	 * @return true|\WP_Error True on success, WP_Error on failure.
 	 */
 	public static function pull_single_integration( $user_id, $integration ) {
-		$selected_fields = $integration->get_selected_fields();
+		$selected_fields = $integration->get_incoming_fields();
 		if ( empty( $selected_fields ) ) {
-			return new \WP_Error( 'no_selected_fields', 'No selected fields for ' . $integration->get_id() );
+			return new \WP_Error( 'no_selected_incoming_fields', 'No selected incoming fields for ' . $integration->get_id() );
 		}
 
 		try {
@@ -275,7 +275,7 @@ class Contact_Pull {
 		}
 
 		foreach ( $integrations as $integration ) {
-			$selected_fields = $integration->get_selected_fields();
+			$selected_fields = $integration->get_incoming_fields();
 			if ( empty( $selected_fields ) ) {
 				continue;
 			}

--- a/includes/reader-activation/integrations/class-contact-pull.php
+++ b/includes/reader-activation/integrations/class-contact-pull.php
@@ -144,7 +144,7 @@ class Contact_Pull {
 		$failed = [];
 
 		foreach ( $integrations as $id => $integration ) {
-			$selected_fields = $integration->get_incoming_fields();
+			$selected_fields = $integration->get_enabled_incoming_fields();
 			if ( empty( $selected_fields ) ) {
 				continue;
 			}
@@ -235,7 +235,7 @@ class Contact_Pull {
 	 * @return true|\WP_Error True on success, WP_Error on failure.
 	 */
 	public static function pull_single_integration( $user_id, $integration ) {
-		$selected_fields = $integration->get_incoming_fields();
+		$selected_fields = $integration->get_enabled_incoming_fields();
 		if ( empty( $selected_fields ) ) {
 			return new \WP_Error( 'no_selected_incoming_fields', 'No selected incoming fields for ' . $integration->get_id() );
 		}
@@ -275,7 +275,7 @@ class Contact_Pull {
 		}
 
 		foreach ( $integrations as $integration ) {
-			$selected_fields = $integration->get_incoming_fields();
+			$selected_fields = $integration->get_enabled_incoming_fields();
 			if ( empty( $selected_fields ) ) {
 				continue;
 			}

--- a/includes/reader-activation/integrations/class-contact-pull.php
+++ b/includes/reader-activation/integrations/class-contact-pull.php
@@ -27,7 +27,7 @@ class Contact_Pull {
 	 *
 	 * @var int
 	 */
-	const PULL_INTERVAL = 30;
+	const PULL_INTERVAL = 300;
 
 	/**
 	 * Threshold in seconds (24 hours) for synchronous vs async pull.

--- a/includes/reader-activation/integrations/class-contact-pull.php
+++ b/includes/reader-activation/integrations/class-contact-pull.php
@@ -27,7 +27,7 @@ class Contact_Pull {
 	 *
 	 * @var int
 	 */
-	const PULL_INTERVAL = 300;
+	const PULL_INTERVAL = 30;
 
 	/**
 	 * Threshold in seconds (24 hours) for synchronous vs async pull.

--- a/includes/reader-activation/integrations/class-esp.php
+++ b/includes/reader-activation/integrations/class-esp.php
@@ -165,12 +165,12 @@ class ESP extends Integration {
 	 */
 	public function get_master_list_id() {
 		$provider = $this->get_provider();
+		if ( ! $provider ) {
+			return false;
+		}
 		switch ( $provider->service ) {
 			case 'mailchimp':
 				$audience_id = $this->get_settings_field_value( 'mailchimp_audience_id' );
-				if ( ! $audience_id && function_exists( 'mailchimp_get_list_id' ) ) {
-					$audience_id = \mailchimp_get_list_id();
-				}
 				return ! empty( $audience_id ) ? $audience_id : false;
 			case 'active_campaign':
 				$list_id = $this->get_settings_field_value( 'active_campaign_master_list' );

--- a/includes/reader-activation/integrations/class-esp.php
+++ b/includes/reader-activation/integrations/class-esp.php
@@ -359,23 +359,28 @@ class ESP extends Integration {
 			return $fields;
 		}
 
-		$incoming_fields = array_map(
+		if ( $filtered ) {
+			$keys_to_filter = Sync\Metadata::get_all_prefixed_keys();
+			$fields         = (array) array_values(
+				array_filter(
+					$fields,
+					function( $field ) use ( $keys_to_filter ) {
+						foreach ( $keys_to_filter as $key_to_filter ) {
+							if ( strpos( $field['key'], $key_to_filter ) === 0 ) {
+								return false;
+							}
+						}
+						return true;
+					}
+				)
+			);
+		}
+
+		return array_map(
 			function( $field ) {
 				return new Incoming_Contact_Field( $field['key'] );
 			},
 			$fields
 		);
-
-		if ( $filtered ) {
-			$keys_to_filter  = Sync\Metadata::get_all_prefixed_keys();
-			$incoming_fields = array_filter(
-				$incoming_fields,
-				function( $field ) use ( $keys_to_filter ) {
-					return ! in_array( $field->get_key(), $keys_to_filter, true );
-				}
-			);
-		}
-
-		return $incoming_fields;
 	}
 }

--- a/includes/reader-activation/integrations/class-esp.php
+++ b/includes/reader-activation/integrations/class-esp.php
@@ -28,7 +28,106 @@ class ESP extends Integration {
 	 * Constructor.
 	 */
 	public function __construct() {
-		parent::__construct( 'esp', __( 'ESP', 'newspack-plugin' ), __( 'Sync reader data and activity to the connected email service provider.', 'newspack-plugin' ) );
+		parent::__construct(
+			'esp',
+			__( 'ESP', 'newspack-plugin' ),
+			__( 'Sync reader data and activity to the connected email service provider.', 'newspack-plugin' )
+		);
+	}
+
+	/**
+	 * Register the settings fields declared by this integration.
+	 *
+	 * Dynamically builds the field list based on the active ESP provider.
+	 * Only returns fields when the integrations feature flag is ON and ESP is configured.
+	 *
+	 * @return array Array of settings field declarations.
+	 */
+	public function register_settings_fields() {
+		if ( ! Audience_Integrations::is_enabled() || ! Reader_Activation::is_esp_configured() ) {
+			return;
+		}
+
+		$fields       = [];
+		$list_options = $this->get_list_options();
+		$provider     = $this->get_provider();
+		switch ( $provider ) {
+			case 'mailchimp':
+				$fields[] = [
+					'key'         => 'mailchimp_audience_id',
+					'type'        => 'select',
+					'label'       => __( 'Mailchimp Audience', 'newspack-plugin' ),
+					'description' => __( 'Choose an audience to receive reader activity data.', 'newspack-plugin' ),
+					'options'     => $list_options,
+					'default'     => '',
+				];
+				$fields[] = [
+					'key'         => 'mailchimp_reader_default_status',
+					'type'        => 'select',
+					'label'       => __( 'Default reader status', 'newspack-plugin' ),
+					'description' => __( 'Choose which Mailchimp status readers should have by default if they are not subscribed to any newsletters.', 'newspack-plugin' ),
+					'options'     => [
+						[
+							'label' => __( 'Transactional/Non-Subscribed', 'newspack-plugin' ),
+							'value' => 'transactional',
+						],
+						[
+							'label' => __( 'Subscribed', 'newspack-plugin' ),
+							'value' => 'subscribed',
+						],
+					],
+					'default'     => 'transactional',
+				];
+				break;
+			case 'active_campaign':
+				$fields[] = [
+					'key'         => 'active_campaign_master_list',
+					'type'        => 'select',
+					'label'       => __( 'ActiveCampaign Master List', 'newspack-plugin' ),
+					'description' => __( 'Choose a master list to which all registered readers will be added.', 'newspack-plugin' ),
+					'options'     => $list_options,
+					'default'     => '',
+				];
+				break;
+			case 'constant_contact':
+				$fields[] = [
+					'key'         => 'constant_contact_list_id',
+					'type'        => 'select',
+					'label'       => __( 'Constant Contact Master List', 'newspack-plugin' ),
+					'description' => __( 'Choose a master list to which all registered readers will be added.', 'newspack-plugin' ),
+					'options'     => $list_options,
+					'default'     => '',
+				];
+				break;
+		}
+		$fields[] = [
+			'key'         => 'sync_esp_delete',
+			'type'        => 'checkbox',
+			'label'       => __( 'Sync user account deletion', 'newspack-plugin' ),
+			'description' => __( 'When a reader account is deleted, also remove the contact from the ESP.', 'newspack-plugin' ),
+			'default'     => true,
+		];
+		$fields[] = [
+			'key'         => 'metadata_prefix',
+			'type'        => 'text',
+			'label'       => __( 'Metadata field prefix', 'newspack-plugin' ),
+			'description' => __( 'A string to prefix metadata fields attached to each contact synced to the ESP. Required to ensure that metadata field names are unique. Default: NP_', 'newspack-plugin' ),
+			'default'     => 'NP_',
+		];
+		$fields[] = [
+			'key'     => 'metadata_fields',
+			'type'    => 'metadata',
+			'label'   => __( 'Metadata fields', 'newspack-plugin' ),
+			'default' => [],
+		];
+		$fields[] = [
+			'key'     => 'custom_metadata_fields',
+			'type'    => 'custom_metadata',
+			'label'   => __( 'Custom metadata fields', 'newspack-plugin' ),
+			'default' => [],
+		];
+
+		$this->settings_fields = $fields;
 	}
 
 	/**
@@ -90,103 +189,6 @@ class ESP extends Integration {
 		}
 
 		return $options;
-	}
-
-	/**
-	 * Get the settings fields declared by this integration.
-	 *
-	 * Dynamically builds the field list based on the active ESP provider.
-	 * Only returns fields when the integrations feature flag is ON and ESP is configured.
-	 *
-	 * @return array Array of settings field declarations.
-	 */
-	public function get_settings_fields() {
-		if ( ! Audience_Integrations::is_enabled() ) {
-			return [];
-		}
-
-		if ( ! Reader_Activation::is_esp_configured() ) {
-			return [];
-		}
-
-		$fields = [
-			[
-				'key'         => 'sync_esp_delete',
-				'type'        => 'checkbox',
-				'label'       => __( 'Sync user account deletion', 'newspack-plugin' ),
-				'description' => __( 'When a reader account is deleted, also remove the contact from the ESP.', 'newspack-plugin' ),
-				'default'     => true,
-			],
-		];
-
-		$provider     = $this->get_provider();
-		$list_options = $this->get_list_options();
-
-		switch ( $provider ) {
-			case 'mailchimp':
-				$fields[] = [
-					'key'         => 'mailchimp_audience_id',
-					'type'        => 'select',
-					'label'       => __( 'Mailchimp Audience', 'newspack-plugin' ),
-					'description' => __( 'Choose an audience to receive reader activity data.', 'newspack-plugin' ),
-					'options'     => $list_options,
-					'default'     => '',
-				];
-				$fields[] = [
-					'key'         => 'mailchimp_reader_default_status',
-					'type'        => 'select',
-					'label'       => __( 'Default reader status', 'newspack-plugin' ),
-					'description' => __( 'Choose which Mailchimp status readers should have by default if they are not subscribed to any newsletters.', 'newspack-plugin' ),
-					'options'     => [
-						[
-							'label' => __( 'Transactional/Non-Subscribed', 'newspack-plugin' ),
-							'value' => 'transactional',
-						],
-						[
-							'label' => __( 'Subscribed', 'newspack-plugin' ),
-							'value' => 'subscribed',
-						],
-					],
-					'default'     => 'transactional',
-				];
-				break;
-			case 'active_campaign':
-				$fields[] = [
-					'key'         => 'active_campaign_master_list',
-					'type'        => 'select',
-					'label'       => __( 'ActiveCampaign Master List', 'newspack-plugin' ),
-					'description' => __( 'Choose a master list to which all registered readers will be added.', 'newspack-plugin' ),
-					'options'     => $list_options,
-					'default'     => '',
-				];
-				break;
-			case 'constant_contact':
-				$fields[] = [
-					'key'         => 'constant_contact_list_id',
-					'type'        => 'select',
-					'label'       => __( 'Constant Contact Master List', 'newspack-plugin' ),
-					'description' => __( 'Choose a master list to which all registered readers will be added.', 'newspack-plugin' ),
-					'options'     => $list_options,
-					'default'     => '',
-				];
-				break;
-		}
-
-		$fields[] = [
-			'key'         => 'metadata_prefix',
-			'type'        => 'text',
-			'label'       => __( 'Metadata field prefix', 'newspack-plugin' ),
-			'description' => __( 'A string to prefix metadata fields attached to each contact synced to the ESP. Required to ensure that metadata field names are unique. Default: NP_', 'newspack-plugin' ),
-			'default'     => 'NP_',
-		];
-		$fields[] = [
-			'key'     => 'metadata_fields',
-			'type'    => 'metadata',
-			'label'   => __( 'Metadata fields to sync', 'newspack-plugin' ),
-			'default' => [],
-		];
-
-		return $fields;
 	}
 
 	/**

--- a/includes/reader-activation/integrations/class-esp.php
+++ b/includes/reader-activation/integrations/class-esp.php
@@ -49,54 +49,56 @@ class ESP extends Integration {
 		}
 		$list_options = $this->get_list_options();
 		$provider     = $this->get_provider();
-		switch ( $provider->service ) {
-			case 'mailchimp':
-				$fields[] = [
-					'key'         => 'mailchimp_audience_id',
-					'type'        => 'select',
-					'label'       => __( 'Mailchimp Audience', 'newspack-plugin' ),
-					'description' => __( 'Choose an audience to receive reader activity data.', 'newspack-plugin' ),
-					'options'     => $list_options,
-					'default'     => '',
-				];
-				$fields[] = [
-					'key'         => 'mailchimp_reader_default_status',
-					'type'        => 'select',
-					'label'       => __( 'Default reader status', 'newspack-plugin' ),
-					'description' => __( 'Choose which Mailchimp status readers should have by default if they are not subscribed to any newsletters.', 'newspack-plugin' ),
-					'options'     => [
-						[
-							'label' => __( 'Transactional/Non-Subscribed', 'newspack-plugin' ),
-							'value' => 'transactional',
+		if ( $provider ) {
+			switch ( $provider->service ) {
+				case 'mailchimp':
+					$fields[] = [
+						'key'         => 'mailchimp_audience_id',
+						'type'        => 'select',
+						'label'       => __( 'Mailchimp Audience', 'newspack-plugin' ),
+						'description' => __( 'Choose an audience to receive reader activity data.', 'newspack-plugin' ),
+						'options'     => $list_options,
+						'default'     => '',
+					];
+					$fields[] = [
+						'key'         => 'mailchimp_reader_default_status',
+						'type'        => 'select',
+						'label'       => __( 'Default reader status', 'newspack-plugin' ),
+						'description' => __( 'Choose which Mailchimp status readers should have by default if they are not subscribed to any newsletters.', 'newspack-plugin' ),
+						'options'     => [
+							[
+								'label' => __( 'Transactional/Non-Subscribed', 'newspack-plugin' ),
+								'value' => 'transactional',
+							],
+							[
+								'label' => __( 'Subscribed', 'newspack-plugin' ),
+								'value' => 'subscribed',
+							],
 						],
-						[
-							'label' => __( 'Subscribed', 'newspack-plugin' ),
-							'value' => 'subscribed',
-						],
-					],
-					'default'     => 'transactional',
-				];
-				break;
-			case 'active_campaign':
-				$fields[] = [
-					'key'         => 'active_campaign_master_list',
-					'type'        => 'select',
-					'label'       => __( 'ActiveCampaign Master List', 'newspack-plugin' ),
-					'description' => __( 'Choose a master list to which all registered readers will be added.', 'newspack-plugin' ),
-					'options'     => $list_options,
-					'default'     => '',
-				];
-				break;
-			case 'constant_contact':
-				$fields[] = [
-					'key'         => 'constant_contact_list_id',
-					'type'        => 'select',
-					'label'       => __( 'Constant Contact Master List', 'newspack-plugin' ),
-					'description' => __( 'Choose a master list to which all registered readers will be added.', 'newspack-plugin' ),
-					'options'     => $list_options,
-					'default'     => '',
-				];
-				break;
+						'default'     => 'transactional',
+					];
+					break;
+				case 'active_campaign':
+					$fields[] = [
+						'key'         => 'active_campaign_master_list',
+						'type'        => 'select',
+						'label'       => __( 'ActiveCampaign Master List', 'newspack-plugin' ),
+						'description' => __( 'Choose a master list to which all registered readers will be added.', 'newspack-plugin' ),
+						'options'     => $list_options,
+						'default'     => '',
+					];
+					break;
+				case 'constant_contact':
+					$fields[] = [
+						'key'         => 'constant_contact_list_id',
+						'type'        => 'select',
+						'label'       => __( 'Constant Contact Master List', 'newspack-plugin' ),
+						'description' => __( 'Choose a master list to which all registered readers will be added.', 'newspack-plugin' ),
+						'options'     => $list_options,
+						'default'     => '',
+					];
+					break;
+			}
 		}
 		$fields[] = [
 			'key'         => 'sync_esp_delete',
@@ -332,11 +334,9 @@ class ESP extends Integration {
 	/**
 	 * Get incoming available contact fields from the integration.
 	 *
-	 * @param bool $filtered Optional. Whether to filter out fields that are already in the metadata. Default false.
-	 *
 	 * @return Incoming_Contact_Field[]|\WP_Error Array of incoming contact field objects or WP_Error on failure.
 	 */
-	public function get_available_incoming_contact_fields( $filtered = false ) {
+	public function get_available_incoming_contact_fields() {
 		if ( ! class_exists( 'Newspack_Newsletters_Contacts' ) ) {
 			return new \WP_Error(
 				'newspack_newsletters_contacts_not_found',
@@ -357,23 +357,6 @@ class ESP extends Integration {
 
 		if ( is_wp_error( $fields ) ) {
 			return $fields;
-		}
-
-		if ( $filtered ) {
-			$keys_to_filter = Sync\Metadata::get_all_prefixed_keys();
-			$fields         = (array) array_values(
-				array_filter(
-					$fields,
-					function( $field ) use ( $keys_to_filter ) {
-						foreach ( $keys_to_filter as $key_to_filter ) {
-							if ( strpos( $field['key'], $key_to_filter ) === 0 ) {
-								return false;
-							}
-						}
-						return true;
-					}
-				)
-			);
 		}
 
 		return array_map(

--- a/includes/reader-activation/integrations/class-esp.php
+++ b/includes/reader-activation/integrations/class-esp.php
@@ -106,13 +106,6 @@ class ESP extends Integration {
 			'description' => __( 'When a reader account is deleted, also remove the contact from the ESP.', 'newspack-plugin' ),
 			'default'     => true,
 		];
-		$fields[] = [
-			'key'         => 'metadata_prefix',
-			'type'        => 'text',
-			'label'       => __( 'Metadata field prefix', 'newspack-plugin' ),
-			'description' => __( 'A string to prefix metadata fields attached to each contact synced to the ESP. Required to ensure that metadata field names are unique. Default: NP_', 'newspack-plugin' ),
-			'default'     => 'NP_',
-		];
 		return $fields;
 	}
 

--- a/includes/reader-activation/integrations/class-esp.php
+++ b/includes/reader-activation/integrations/class-esp.php
@@ -50,7 +50,7 @@ class ESP extends Integration {
 		}
 		$list_options = $this->get_list_options();
 		$provider     = $this->get_provider();
-		switch ( $provider ) {
+		switch ( $provider->service ) {
 			case 'mailchimp':
 				$fields[] = [
 					'key'         => 'mailchimp_audience_id',
@@ -112,13 +112,13 @@ class ESP extends Integration {
 	/**
 	 * Get the active ESP provider name.
 	 *
-	 * @return string The provider name or empty string.
+	 * @return Newspack_Newsletters_Service_Provider|null The service provider object or null if not available.
 	 */
 	private function get_provider() {
 		if ( class_exists( 'Newspack_Newsletters' ) ) {
-			return \Newspack_Newsletters::service_provider();
+			return \Newspack_Newsletters::get_service_provider();
 		}
-		return '';
+		return null;
 	}
 
 	/**
@@ -139,19 +139,8 @@ class ESP extends Integration {
 		$provider = $this->get_provider();
 
 		// For Mailchimp, filter out groups and tags, only include remote lists.
-		if ( 'mailchimp' === $provider ) {
-			$lists = array_filter(
-				$lists,
-				function( $list ) {
-					if ( ! isset( $list['type'] ) || 'remote' !== $list['type'] ) {
-						return false;
-					}
-					if ( isset( $list['id'] ) && preg_match( '/^(group-|tag-)/', $list['id'] ) ) {
-						return false;
-					}
-					return true;
-				}
-			);
+		if ( 'mailchimp' === $provider->service ) {
+			$lists = $provider->get_lists( true );
 		}
 
 		$options = [
@@ -177,7 +166,7 @@ class ESP extends Integration {
 	 */
 	public function get_master_list_id() {
 		$provider = $this->get_provider();
-		switch ( $provider ) {
+		switch ( $provider->service ) {
 			case 'mailchimp':
 				$audience_id = $this->get_settings_field_value( 'mailchimp_audience_id' );
 				if ( ! $audience_id && function_exists( 'mailchimp_get_list_id' ) ) {

--- a/includes/reader-activation/integrations/class-esp.php
+++ b/includes/reader-activation/integrations/class-esp.php
@@ -44,11 +44,10 @@ class ESP extends Integration {
 	 * @return array Array of settings field declarations.
 	 */
 	public function register_settings_fields() {
+		$fields = [];
 		if ( ! Audience_Integrations::is_enabled() || ! Reader_Activation::is_esp_configured() ) {
-			return;
+			return $fields;
 		}
-
-		$fields       = [];
 		$list_options = $this->get_list_options();
 		$provider     = $this->get_provider();
 		switch ( $provider ) {
@@ -114,8 +113,7 @@ class ESP extends Integration {
 			'description' => __( 'A string to prefix metadata fields attached to each contact synced to the ESP. Required to ensure that metadata field names are unique. Default: NP_', 'newspack-plugin' ),
 			'default'     => 'NP_',
 		];
-
-		$this->settings_fields = $fields;
+		return $fields;
 	}
 
 	/**

--- a/includes/reader-activation/integrations/class-esp.php
+++ b/includes/reader-activation/integrations/class-esp.php
@@ -24,19 +24,6 @@ defined( 'ABSPATH' ) || exit;
  */
 class ESP extends Integration {
 	/**
-	 * Map of ESP setting keys to their legacy option names.
-	 *
-	 * @var array<string, string>
-	 */
-	private static $legacy_option_map = [
-		'mailchimp_audience_id'           => 'newspack_reader_activation_mailchimp_audience_id',
-		'mailchimp_reader_default_status' => 'newspack_reader_activation_mailchimp_reader_default_status',
-		'active_campaign_master_list'     => 'newspack_reader_activation_active_campaign_master_list',
-		'constant_contact_list_id'        => 'newspack_reader_activation_constant_contact_list_id',
-		'sync_esp_delete'                 => 'newspack_reader_activation_sync_esp_delete',
-	];
-
-	/**
 	 * Constructor.
 	 */
 	public function __construct() {
@@ -169,62 +156,6 @@ class ESP extends Integration {
 		}
 
 		return $options;
-	}
-
-	/**
-	 * Get a settings field value with lazy migration from legacy options.
-	 *
-	 * On first access, if the new per-integration option doesn't exist yet,
-	 * reads the legacy global option, persists it to the new location, and returns it.
-	 *
-	 * @param string $key The field key.
-	 * @return mixed The field value.
-	 */
-	public function get_settings_field_value( $key ) {
-		// For non-legacy keys, delegate to parent.
-		if ( ! isset( self::$legacy_option_map[ $key ] ) ) {
-			return parent::get_settings_field_value( $key );
-		}
-
-		// Check if new option exists (use sentinel to distinguish "not set" from falsy).
-		$sentinel    = '__newspack_not_set__';
-		$option_name = self::SETTINGS_OPTION_PREFIX . $this->id . '_' . $key;
-		$value       = \get_option( $option_name, $sentinel );
-		if ( $sentinel !== $value ) {
-			return $value;
-		}
-
-		// Lazy migrate from legacy option.
-		$legacy_value = \get_option( self::$legacy_option_map[ $key ], $sentinel );
-		if ( $sentinel !== $legacy_value ) {
-			$this->update_settings_field_value( $key, $legacy_value );
-			return $legacy_value;
-		}
-
-		// Fall back to field default.
-		return parent::get_settings_field_value( $key );
-	}
-
-	/**
-	 * Get the metadata prefix with lazy migration from legacy option.
-	 *
-	 * @return string The metadata prefix.
-	 */
-	public function get_metadata_prefix() {
-		$sentinel = '__newspack_not_set__';
-		$value    = \get_option( self::METADATA_PREFIX_OPTION_PREFIX . $this->id, $sentinel );
-		if ( $sentinel !== $value ) {
-			return $value;
-		}
-
-		// Lazy migrate from legacy global option.
-		$legacy = \get_option( Sync\Metadata::PREFIX_OPTION, $sentinel );
-		if ( $sentinel !== $legacy && ! empty( $legacy ) ) {
-			$this->update_metadata_prefix( $legacy );
-			return $legacy;
-		}
-
-		return 'NP_';
 	}
 
 	/**
@@ -401,10 +332,11 @@ class ESP extends Integration {
 	/**
 	 * Get incoming available contact fields from the integration.
 	 *
+	 * @param bool $filtered Optional. Whether to filter out fields that are already in the metadata. Default false.
+	 *
 	 * @return Incoming_Contact_Field[]|\WP_Error Array of incoming contact field objects or WP_Error on failure.
 	 */
-	public function get_incoming_available_contact_fields() {
-
+	public function get_available_incoming_contact_fields( $filtered = false ) {
 		if ( ! class_exists( 'Newspack_Newsletters_Contacts' ) ) {
 			return new \WP_Error(
 				'newspack_newsletters_contacts_not_found',
@@ -427,11 +359,23 @@ class ESP extends Integration {
 			return $fields;
 		}
 
-		return array_map(
+		$incoming_fields = array_map(
 			function( $field ) {
 				return new Incoming_Contact_Field( $field['key'] );
 			},
 			$fields
 		);
+
+		if ( $filtered ) {
+			$keys_to_filter  = Sync\Metadata::get_all_prefixed_keys();
+			$incoming_fields = array_filter(
+				$incoming_fields,
+				function( $field ) use ( $keys_to_filter ) {
+					return ! in_array( $field->get_key(), $keys_to_filter, true );
+				}
+			);
+		}
+
+		return $incoming_fields;
 	}
 }

--- a/includes/reader-activation/integrations/class-esp.php
+++ b/includes/reader-activation/integrations/class-esp.php
@@ -7,7 +7,6 @@
 
 namespace Newspack\Reader_Activation\Integrations;
 
-use Newspack\Audience_Integrations;
 use Newspack\Reader_Activation\Integration;
 use Newspack\Reader_Activation\Sync;
 use Newspack\Reader_Activation\Sync\Metadata;
@@ -25,6 +24,19 @@ defined( 'ABSPATH' ) || exit;
  */
 class ESP extends Integration {
 	/**
+	 * Map of ESP setting keys to their legacy option names.
+	 *
+	 * @var array<string, string>
+	 */
+	private static $legacy_option_map = [
+		'mailchimp_audience_id'           => 'newspack_reader_activation_mailchimp_audience_id',
+		'mailchimp_reader_default_status' => 'newspack_reader_activation_mailchimp_reader_default_status',
+		'active_campaign_master_list'     => 'newspack_reader_activation_active_campaign_master_list',
+		'constant_contact_list_id'        => 'newspack_reader_activation_constant_contact_list_id',
+		'sync_esp_delete'                 => 'newspack_reader_activation_sync_esp_delete',
+	];
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
@@ -39,13 +51,13 @@ class ESP extends Integration {
 	 * Register the settings fields declared by this integration.
 	 *
 	 * Dynamically builds the field list based on the active ESP provider.
-	 * Only returns fields when the integrations feature flag is ON and ESP is configured.
+	 * Only returns fields when ESP is configured.
 	 *
 	 * @return array Array of settings field declarations.
 	 */
 	public function register_settings_fields() {
 		$fields = [];
-		if ( ! Audience_Integrations::is_enabled() || ! Reader_Activation::is_esp_configured() ) {
+		if ( ! Reader_Activation::is_esp_configured() ) {
 			return $fields;
 		}
 		$list_options = $this->get_list_options();
@@ -160,6 +172,62 @@ class ESP extends Integration {
 	}
 
 	/**
+	 * Get a settings field value with lazy migration from legacy options.
+	 *
+	 * On first access, if the new per-integration option doesn't exist yet,
+	 * reads the legacy global option, persists it to the new location, and returns it.
+	 *
+	 * @param string $key The field key.
+	 * @return mixed The field value.
+	 */
+	public function get_settings_field_value( $key ) {
+		// For non-legacy keys, delegate to parent.
+		if ( ! isset( self::$legacy_option_map[ $key ] ) ) {
+			return parent::get_settings_field_value( $key );
+		}
+
+		// Check if new option exists (use sentinel to distinguish "not set" from falsy).
+		$sentinel    = '__newspack_not_set__';
+		$option_name = self::SETTINGS_OPTION_PREFIX . $this->id . '_' . $key;
+		$value       = \get_option( $option_name, $sentinel );
+		if ( $sentinel !== $value ) {
+			return $value;
+		}
+
+		// Lazy migrate from legacy option.
+		$legacy_value = \get_option( self::$legacy_option_map[ $key ], $sentinel );
+		if ( $sentinel !== $legacy_value ) {
+			$this->update_settings_field_value( $key, $legacy_value );
+			return $legacy_value;
+		}
+
+		// Fall back to field default.
+		return parent::get_settings_field_value( $key );
+	}
+
+	/**
+	 * Get the metadata prefix with lazy migration from legacy option.
+	 *
+	 * @return string The metadata prefix.
+	 */
+	public function get_metadata_prefix() {
+		$sentinel = '__newspack_not_set__';
+		$value    = \get_option( self::METADATA_PREFIX_OPTION_PREFIX . $this->id, $sentinel );
+		if ( $sentinel !== $value ) {
+			return $value;
+		}
+
+		// Lazy migrate from legacy global option.
+		$legacy = \get_option( Sync\Metadata::PREFIX_OPTION, $sentinel );
+		if ( $sentinel !== $legacy && ! empty( $legacy ) ) {
+			$this->update_metadata_prefix( $legacy );
+			return $legacy;
+		}
+
+		return 'NP_';
+	}
+
+	/**
 	 * Get the master list ID from integration settings.
 	 *
 	 * @return string|false The master list ID or false.
@@ -240,32 +308,17 @@ class ESP extends Integration {
 			);
 		}
 
-		if ( Audience_Integrations::is_enabled() ) {
-			if ( ! Integrations::is_enabled( $this->get_id() ) ) {
-				$errors->add(
-					'ras_esp_sync_not_enabled',
-					__( 'ESP sync is not enabled.', 'newspack-plugin' )
-				);
-			}
-			if ( ! $this->get_master_list_id() ) {
-				$errors->add(
-					'ras_esp_master_list_id_not_found',
-					__( 'ESP master list ID is not set.', 'newspack-plugin' )
-				);
-			}
-		} else {
-			if ( ! Reader_Activation::get_setting( 'sync_esp' ) ) {
-				$errors->add(
-					'ras_esp_sync_not_enabled',
-					__( 'ESP sync is not enabled.', 'newspack-plugin' )
-				);
-			}
-			if ( ! Reader_Activation::get_esp_master_list_id() ) {
-				$errors->add(
-					'ras_esp_master_list_id_not_found',
-					__( 'ESP master list ID is not set.', 'newspack-plugin' )
-				);
-			}
+		if ( ! Integrations::is_enabled( $this->get_id() ) ) {
+			$errors->add(
+				'ras_esp_sync_not_enabled',
+				__( 'ESP sync is not enabled.', 'newspack-plugin' )
+			);
+		}
+		if ( ! $this->get_master_list_id() ) {
+			$errors->add(
+				'ras_esp_master_list_id_not_found',
+				__( 'ESP master list ID is not set.', 'newspack-plugin' )
+			);
 		}
 
 		if ( $return_errors ) {
@@ -289,17 +342,12 @@ class ESP extends Integration {
 	 * @return true|\WP_Error True on success or WP_Error on failure.
 	 */
 	public function push_contact_data( $contact, $context = '', $existing_contact = null ) {
-
 		$can_sync = $this->can_sync( true );
 		if ( $can_sync->has_errors() ) {
 			return $can_sync;
 		}
 
-		if ( Audience_Integrations::is_enabled() ) {
-			$master_list_id = $this->get_master_list_id();
-		} else {
-			$master_list_id = Reader_Activation::get_esp_master_list_id();
-		}
+		$master_list_id = $this->get_master_list_id();
 
 		return Newspack_Newsletters_Contacts::upsert( $contact, $master_list_id, $context, $existing_contact );
 	}
@@ -364,11 +412,7 @@ class ESP extends Integration {
 			);
 		}
 
-		if ( Audience_Integrations::is_enabled() ) {
-			$master_list_id = $this->get_master_list_id();
-		} else {
-			$master_list_id = Reader_Activation::get_esp_master_list_id();
-		}
+		$master_list_id = $this->get_master_list_id();
 
 		if ( empty( $master_list_id ) ) {
 			return new \WP_Error(

--- a/includes/reader-activation/integrations/class-esp.php
+++ b/includes/reader-activation/integrations/class-esp.php
@@ -7,8 +7,11 @@
 
 namespace Newspack\Reader_Activation\Integrations;
 
+use Newspack\Audience_Integrations;
 use Newspack\Reader_Activation\Integration;
 use Newspack\Reader_Activation\Sync;
+use Newspack\Reader_Activation\Sync\Metadata;
+use Newspack\Reader_Activation\Integrations;
 use Newspack\Reader_Activation;
 use Newspack_Newsletters_Contacts;
 use Newspack_Newsletters_Subscription;
@@ -25,7 +28,190 @@ class ESP extends Integration {
 	 * Constructor.
 	 */
 	public function __construct() {
-		parent::__construct( 'esp', __( 'ESPs Integration', 'newspack-plugin' ) );
+		parent::__construct( 'esp', __( 'ESP', 'newspack-plugin' ), __( 'Sync reader data and activity to the connected email service provider.', 'newspack-plugin' ) );
+	}
+
+	/**
+	 * Get the active ESP provider name.
+	 *
+	 * @return string The provider name or empty string.
+	 */
+	private function get_provider() {
+		if ( class_exists( 'Newspack_Newsletters' ) ) {
+			return \Newspack_Newsletters::service_provider();
+		}
+		return '';
+	}
+
+	/**
+	 * Get list options from the Newsletters API for select fields.
+	 *
+	 * @return array Array of options with label and value keys.
+	 */
+	private function get_list_options() {
+		if ( ! method_exists( 'Newspack_Newsletters_Subscription', 'get_lists' ) ) {
+			return [];
+		}
+
+		$lists = Newspack_Newsletters_Subscription::get_lists();
+		if ( is_wp_error( $lists ) || ! is_array( $lists ) ) {
+			return [];
+		}
+
+		$provider = $this->get_provider();
+
+		// For Mailchimp, filter out groups and tags, only include remote lists.
+		if ( 'mailchimp' === $provider ) {
+			$lists = array_filter(
+				$lists,
+				function( $list ) {
+					if ( ! isset( $list['type'] ) || 'remote' !== $list['type'] ) {
+						return false;
+					}
+					if ( isset( $list['id'] ) && preg_match( '/^(group-|tag-)/', $list['id'] ) ) {
+						return false;
+					}
+					return true;
+				}
+			);
+		}
+
+		$options = [
+			[
+				'label' => __( 'None', 'newspack-plugin' ),
+				'value' => '',
+			],
+		];
+		foreach ( $lists as $list ) {
+			$options[] = [
+				'label' => $list['name'] ?? $list['id'],
+				'value' => $list['id'],
+			];
+		}
+
+		return $options;
+	}
+
+	/**
+	 * Get the settings fields declared by this integration.
+	 *
+	 * Dynamically builds the field list based on the active ESP provider.
+	 * Only returns fields when the integrations feature flag is ON and ESP is configured.
+	 *
+	 * @return array Array of settings field declarations.
+	 */
+	public function get_settings_fields() {
+		if ( ! Audience_Integrations::is_enabled() ) {
+			return [];
+		}
+
+		if ( ! Reader_Activation::is_esp_configured() ) {
+			return [];
+		}
+
+		$fields = [
+			[
+				'key'         => 'sync_esp_delete',
+				'type'        => 'checkbox',
+				'label'       => __( 'Sync user account deletion', 'newspack-plugin' ),
+				'description' => __( 'When a reader account is deleted, also remove the contact from the ESP.', 'newspack-plugin' ),
+				'default'     => true,
+			],
+		];
+
+		$provider     = $this->get_provider();
+		$list_options = $this->get_list_options();
+
+		switch ( $provider ) {
+			case 'mailchimp':
+				$fields[] = [
+					'key'         => 'mailchimp_audience_id',
+					'type'        => 'select',
+					'label'       => __( 'Mailchimp Audience', 'newspack-plugin' ),
+					'description' => __( 'Choose an audience to receive reader activity data.', 'newspack-plugin' ),
+					'options'     => $list_options,
+					'default'     => '',
+				];
+				$fields[] = [
+					'key'         => 'mailchimp_reader_default_status',
+					'type'        => 'select',
+					'label'       => __( 'Default reader status', 'newspack-plugin' ),
+					'description' => __( 'Choose which Mailchimp status readers should have by default if they are not subscribed to any newsletters.', 'newspack-plugin' ),
+					'options'     => [
+						[
+							'label' => __( 'Transactional/Non-Subscribed', 'newspack-plugin' ),
+							'value' => 'transactional',
+						],
+						[
+							'label' => __( 'Subscribed', 'newspack-plugin' ),
+							'value' => 'subscribed',
+						],
+					],
+					'default'     => 'transactional',
+				];
+				break;
+			case 'active_campaign':
+				$fields[] = [
+					'key'         => 'active_campaign_master_list',
+					'type'        => 'select',
+					'label'       => __( 'ActiveCampaign Master List', 'newspack-plugin' ),
+					'description' => __( 'Choose a master list to which all registered readers will be added.', 'newspack-plugin' ),
+					'options'     => $list_options,
+					'default'     => '',
+				];
+				break;
+			case 'constant_contact':
+				$fields[] = [
+					'key'         => 'constant_contact_list_id',
+					'type'        => 'select',
+					'label'       => __( 'Constant Contact Master List', 'newspack-plugin' ),
+					'description' => __( 'Choose a master list to which all registered readers will be added.', 'newspack-plugin' ),
+					'options'     => $list_options,
+					'default'     => '',
+				];
+				break;
+		}
+
+		$fields[] = [
+			'key'         => 'metadata_prefix',
+			'type'        => 'text',
+			'label'       => __( 'Metadata field prefix', 'newspack-plugin' ),
+			'description' => __( 'A string to prefix metadata fields attached to each contact synced to the ESP. Required to ensure that metadata field names are unique. Default: NP_', 'newspack-plugin' ),
+			'default'     => 'NP_',
+		];
+		$fields[] = [
+			'key'     => 'metadata_fields',
+			'type'    => 'metadata',
+			'label'   => __( 'Metadata fields to sync', 'newspack-plugin' ),
+			'default' => [],
+		];
+
+		return $fields;
+	}
+
+	/**
+	 * Get the master list ID from integration settings.
+	 *
+	 * @return string|false The master list ID or false.
+	 */
+	public function get_master_list_id() {
+		$provider = $this->get_provider();
+		switch ( $provider ) {
+			case 'mailchimp':
+				$audience_id = $this->get_settings_field_value( 'mailchimp_audience_id' );
+				if ( ! $audience_id && function_exists( 'mailchimp_get_list_id' ) ) {
+					$audience_id = \mailchimp_get_list_id();
+				}
+				return ! empty( $audience_id ) ? $audience_id : false;
+			case 'active_campaign':
+				$list_id = $this->get_settings_field_value( 'active_campaign_master_list' );
+				return ! empty( $list_id ) ? $list_id : false;
+			case 'constant_contact':
+				$list_id = $this->get_settings_field_value( 'constant_contact_list_id' );
+				return ! empty( $list_id ) ? $list_id : false;
+			default:
+				return false;
+		}
 	}
 
 	/**
@@ -84,18 +270,32 @@ class ESP extends Integration {
 			);
 		}
 
-		if ( ! Reader_Activation::get_setting( 'sync_esp' ) ) {
-			$errors->add(
-				'ras_esp_sync_not_enabled',
-				__( 'ESP sync is not enabled.', 'newspack-plugin' )
-			);
-		}
-
-		if ( ! Reader_Activation::get_esp_master_list_id() ) {
-			$errors->add(
-				'ras_esp_master_list_id_not_found',
-				__( 'ESP master list ID is not set.', 'newspack-plugin' )
-			);
+		if ( Audience_Integrations::is_enabled() ) {
+			if ( ! Integrations::is_enabled( $this->get_id() ) ) {
+				$errors->add(
+					'ras_esp_sync_not_enabled',
+					__( 'ESP sync is not enabled.', 'newspack-plugin' )
+				);
+			}
+			if ( ! $this->get_master_list_id() ) {
+				$errors->add(
+					'ras_esp_master_list_id_not_found',
+					__( 'ESP master list ID is not set.', 'newspack-plugin' )
+				);
+			}
+		} else {
+			if ( ! Reader_Activation::get_setting( 'sync_esp' ) ) {
+				$errors->add(
+					'ras_esp_sync_not_enabled',
+					__( 'ESP sync is not enabled.', 'newspack-plugin' )
+				);
+			}
+			if ( ! Reader_Activation::get_esp_master_list_id() ) {
+				$errors->add(
+					'ras_esp_master_list_id_not_found',
+					__( 'ESP master list ID is not set.', 'newspack-plugin' )
+				);
+			}
 		}
 
 		if ( $return_errors ) {
@@ -125,7 +325,11 @@ class ESP extends Integration {
 			return $can_sync;
 		}
 
-		$master_list_id = Reader_Activation::get_esp_master_list_id();
+		if ( Audience_Integrations::is_enabled() ) {
+			$master_list_id = $this->get_master_list_id();
+		} else {
+			$master_list_id = Reader_Activation::get_esp_master_list_id();
+		}
 
 		return Newspack_Newsletters_Contacts::upsert( $contact, $master_list_id, $context, $existing_contact );
 	}
@@ -190,7 +394,11 @@ class ESP extends Integration {
 			);
 		}
 
-		$master_list_id = Reader_Activation::get_esp_master_list_id();
+		if ( Audience_Integrations::is_enabled() ) {
+			$master_list_id = $this->get_master_list_id();
+		} else {
+			$master_list_id = Reader_Activation::get_esp_master_list_id();
+		}
 
 		if ( empty( $master_list_id ) ) {
 			return new \WP_Error(

--- a/includes/reader-activation/integrations/class-esp.php
+++ b/includes/reader-activation/integrations/class-esp.php
@@ -114,18 +114,6 @@ class ESP extends Integration {
 			'description' => __( 'A string to prefix metadata fields attached to each contact synced to the ESP. Required to ensure that metadata field names are unique. Default: NP_', 'newspack-plugin' ),
 			'default'     => 'NP_',
 		];
-		$fields[] = [
-			'key'     => 'metadata_fields',
-			'type'    => 'metadata',
-			'label'   => __( 'Metadata fields', 'newspack-plugin' ),
-			'default' => [],
-		];
-		$fields[] = [
-			'key'     => 'custom_metadata_fields',
-			'type'    => 'custom_metadata',
-			'label'   => __( 'Custom metadata fields', 'newspack-plugin' ),
-			'default' => [],
-		];
 
 		$this->settings_fields = $fields;
 	}

--- a/includes/reader-activation/integrations/class-integration.php
+++ b/includes/reader-activation/integrations/class-integration.php
@@ -288,7 +288,7 @@ abstract class Integration {
 	 * @return string[] List of enabled field names.
 	 */
 	public function get_enabled_outgoing_fields() {
-		return array_values( \get_option( self::OUTGOING_FIELDS_OPTION_PREFIX . $this->id, Sync\Metadata::get_default_fields() ) );
+		return array_values( \get_option( self::OUTGOING_FIELDS_OPTION_PREFIX . $this->id, [] ) );
 	}
 
 	/**
@@ -324,8 +324,8 @@ abstract class Integration {
 		$enabled_fields = $this->get_enabled_outgoing_fields();
 		return array_filter(
 			Sync\Metadata::get_keys(),
-			function( $val, $key ) use ( $keys, $enabled_fields ) {
-				return in_array( $key, $keys ) && in_array( $val, $enabled_fields );
+			function ( $val, $key ) use ( $keys, $enabled_fields ) {
+				return in_array( $key, $keys, true ) && in_array( $val, $enabled_fields, true );
 			},
 			ARRAY_FILTER_USE_BOTH
 		);
@@ -507,9 +507,9 @@ abstract class Integration {
 			$field['value'] = $this->get_settings_field_value( $field['key'] );
 			// Inject metadata options for metadata fields.
 			if ( 'incoming_metadata_fields' === $field['key'] ) {
-				$incoming_fields = $this->get_available_incoming_contact_fields( true );
+				$incoming_fields  = $this->get_available_incoming_contact_fields( true );
 				$field['options'] = array_map(
-					function( $incoming_field ) {
+					function ( $incoming_field ) {
 						return $incoming_field->get_key();
 					},
 					is_wp_error( $incoming_fields ) ? [] : $incoming_fields

--- a/includes/reader-activation/integrations/class-integration.php
+++ b/includes/reader-activation/integrations/class-integration.php
@@ -232,12 +232,36 @@ abstract class Integration {
 	 *
 	 * Integrations that support pulling contact data should implement this method.
 	 *
-	 * @param bool $filtered Optional. Whether to filter out fields that are already in the metadata. Default false.
-	 *
 	 * @return Integrations\Incoming_Contact_Field[]|\WP_Error Array of incoming contact field objects or WP_Error on failure.
 	 */
-	public function get_available_incoming_contact_fields( $filtered = false ) {
+	public function get_available_incoming_contact_fields() {
 		return [];
+	}
+
+	/**
+	 * Get filtered incoming contact fields from the integration.
+	 *
+	 * @return Integrations\Incoming_Contact_Field[] Array of incoming contact field objects.
+	 */
+	public function get_filtered_incoming_contact_fields() {
+		$fields = $this->get_available_incoming_contact_fields();
+		if ( is_wp_error( $fields ) ) {
+			return [];
+		}
+		$keys_to_filter = Sync\Metadata::get_all_prefixed_keys();
+		return array_values(
+			array_filter(
+				$fields,
+				function( $field ) use ( $keys_to_filter ) {
+					foreach ( $keys_to_filter as $key_to_filter ) {
+						if ( strpos( $field->get_key(), $key_to_filter ) === 0 ) {
+							return false;
+						}
+					}
+					return true;
+				}
+			)
+		);
 	}
 
 	/**
@@ -507,7 +531,7 @@ abstract class Integration {
 			$field['value'] = $this->get_settings_field_value( $field['key'] );
 			// Inject metadata options for metadata fields.
 			if ( 'incoming_metadata_fields' === $field['key'] ) {
-				$incoming_fields  = $this->get_available_incoming_contact_fields( true );
+				$incoming_fields  = $this->get_filtered_incoming_contact_fields( true );
 				$field['options'] = array_map(
 					function ( $incoming_field ) {
 						return $incoming_field->get_key();

--- a/includes/reader-activation/integrations/class-integration.php
+++ b/includes/reader-activation/integrations/class-integration.php
@@ -65,9 +65,9 @@ abstract class Integration {
 	 * @param string $description Optional. A short description for this integration.
 	 */
 	public function __construct( $id, $name, $description = '' ) {
-		$this->id              = $id;
-		$this->name            = $name;
-		$this->description     = $description;
+		$this->id          = $id;
+		$this->name        = $name;
+		$this->description = $description;
 
 		add_action( 'init', [ $this, 'register_settings_fields' ] );
 	}

--- a/includes/reader-activation/integrations/class-integration.php
+++ b/includes/reader-activation/integrations/class-integration.php
@@ -236,7 +236,7 @@ abstract class Integration {
 	 *
 	 * @return Integrations\Incoming_Contact_Field[]|\WP_Error Array of incoming contact field objects or WP_Error on failure.
 	 */
-	public function get_available_incoming_contact_fields( $filtered ) {
+	public function get_available_incoming_contact_fields( $filtered = false ) {
 		return [];
 	}
 
@@ -507,7 +507,7 @@ abstract class Integration {
 			$field['value'] = $this->get_settings_field_value( $field['key'] );
 			// Inject metadata options for metadata fields.
 			if ( 'incoming_metadata_fields' === $field['key'] ) {
-				$incoming_fields = $this->get_available_incoming_contact_fields( false );
+				$incoming_fields = $this->get_available_incoming_contact_fields( true );
 				$field['options'] = array_map(
 					function( $incoming_field ) {
 						return $incoming_field->get_key();

--- a/includes/reader-activation/integrations/class-integration.php
+++ b/includes/reader-activation/integrations/class-integration.php
@@ -32,8 +32,7 @@ abstract class Integration {
 	/**
 	 * Option name prefix for storing all integration settings.
 	 *
-	 * @var strin
-	 * const SETTINGS_OPTION_PREFIX = 'newspack_integration_settings_';g
+	 * @var string
 	 */
 	const SETTINGS_OPTION_PREFIX = 'newspack_integration_settings_';
 
@@ -115,6 +114,15 @@ abstract class Integration {
 	}
 
 	/**
+	 * Initialize the integration, performing any necessary setup or validation.
+	 *
+	 * Currently only initializes settings fields, but can be extended by child classes for additional setup.
+	 */
+	public function init() {
+		$this->settings_fields = $this->register_settings_fields();
+	}
+
+	/**
 	 * Register settings fields for this integration.
 	 *
 	 * Child classes should override this method to define their settings fields.
@@ -155,15 +163,6 @@ abstract class Integration {
 	 * for each data event they need to handle.
 	 */
 	public function register_handlers() {}
-
-	/**
-	 * Initialize the integration, performing any necessary setup or validation.
-	 *
-	 * Currently only initializes settings fields, but can be extended by child classes for additional setup.
-	 */
-	public function init() {
-		$this->settings_fields = $this->register_settings_fields();
-	}
 
 	/**
 	 * Register a data event handler for this integration.
@@ -319,7 +318,7 @@ abstract class Integration {
 	 *
 	 * @return bool True if updated, false otherwise.
 	 */
-	public function update_enabled_incoming_fields( $fields ) {
+	public function update_incoming_fields( $fields ) {
 		return \update_option( self::INCOMING_FIELDS_OPTION_PREFIX . $this->id, $fields );
 	}
 
@@ -353,7 +352,7 @@ abstract class Integration {
 	}
 
 	/**
-	 * Get the raw (unprefixed) metadata keys enabled for outgoing sync.
+	 * Get the metadata keys enabled for outgoing sync.
 	 *
 	 * @param bool $prefixed Optional. Whether to return prefixed keys instead of raw keys. Default false.
 	 *
@@ -365,7 +364,7 @@ abstract class Integration {
 
 		foreach ( Sync\Metadata::get_keys() as $raw_key => $field_name ) {
 			if ( in_array( $field_name, $enabled_fields, true ) ) {
-				$keys[] = $prefixed ? $this->get_metadata_prefix() . $field_name : $raw_key;
+				$keys[] = $prefixed ? Sync\Metadata::get_key( $raw_kley ) : $raw_key;
 			}
 		}
 
@@ -484,7 +483,7 @@ abstract class Integration {
 			return $this->update_enabled_outgoing_fields( $sanitized );
 		}
 		if ( 'incoming_metadata_fields' === $key ) {
-			return $this->update_enabled_incoming_fields( $sanitized );
+			return $this->update_incoming_fields( $sanitized );
 		}
 
 		$option_name = self::SETTINGS_OPTION_PREFIX . $this->id . '_' . $key;

--- a/includes/reader-activation/integrations/class-integration.php
+++ b/includes/reader-activation/integrations/class-integration.php
@@ -16,6 +16,19 @@ defined( 'ABSPATH' ) || exit;
  */
 abstract class Integration {
 	/**
+	 * Map of ESP setting keys to their legacy option names.
+	 *
+	 * @var array<string, string>
+	 */
+	private static $legacy_option_map = [
+		'mailchimp_audience_id'           => 'newspack_reader_activation_mailchimp_audience_id',
+		'mailchimp_reader_default_status' => 'newspack_reader_activation_mailchimp_reader_default_status',
+		'active_campaign_master_list'     => 'newspack_reader_activation_active_campaign_master_list',
+		'constant_contact_list_id'        => 'newspack_reader_activation_constant_contact_list_id',
+		'sync_esp_delete'                 => 'newspack_reader_activation_sync_esp_delete',
+	];
+
+	/**
 	 * Option name prefix for storing enabled incoming metadata fields per integration.
 	 *
 	 * @var string
@@ -219,35 +232,12 @@ abstract class Integration {
 	 *
 	 * Integrations that support pulling contact data should implement this method.
 	 *
+	 * @param bool $filtered Optional. Whether to filter out fields that are already in the metadata. Default false.
+	 *
 	 * @return Integrations\Incoming_Contact_Field[]|\WP_Error Array of incoming contact field objects or WP_Error on failure.
 	 */
-	public function get_incoming_available_contact_fields() {
+	public function get_available_incoming_contact_fields( $filtered ) {
 		return [];
-	}
-
-	/**
-	 * Get incoming contact fields that are not already in the metadata.
-	 *
-	 * This method filters the available contact fields to exclude fields
-	 * whose keys already exist in the synced metadata.
-	 *
-	 * @return Integrations\Incoming_Contact_Field[]|\WP_Error Array of filtered incoming contact field objects or WP_Error on failure.
-	 */
-	public function get_incoming_contact_fields() {
-		$available_fields = $this->get_incoming_available_contact_fields();
-
-		if ( is_wp_error( $available_fields ) ) {
-			return $available_fields;
-		}
-
-		$prefixed_keys = Sync\Metadata::get_all_prefixed_keys();
-
-		return array_filter(
-			$available_fields,
-			function( $field ) use ( $prefixed_keys ) {
-				return ! in_array( $field->get_key(), $prefixed_keys, true );
-			}
-		);
 	}
 
 	/**
@@ -367,6 +357,9 @@ abstract class Integration {
 	 * @return array Array of settings field declarations.
 	 */
 	public function get_metadata_fields() {
+		$incoming_fields = $this->get_available_incoming_contact_fields( true );
+		$outgoing_fields = Sync\Metadata::get_default_fields();
+
 		return [
 			[
 				'key'         => 'metadata_prefix',
@@ -377,15 +370,23 @@ abstract class Integration {
 			],
 			[
 				'key'     => 'outgoing_metadata_fields',
-				'type'    => 'outgoing_metadata',
+				'type'    => 'metadata',
 				'label'   => __( 'Outgoing metadata fields', 'newspack-plugin' ),
-				'default' => [],
+				'options' => $outgoing_fields,
 			],
 			[
 				'key'     => 'incoming_metadata_fields',
-				'type'    => 'incoming_metadata',
+				'type'    => 'metadata',
 				'label'   => __( 'Incoming metadata fields', 'newspack-plugin' ),
 				'default' => [],
+				'options' => array_values(
+					array_map(
+						function( $field ) {
+							return $field->get_key();
+						},
+						is_wp_error( $incoming_fields ) ? [] : $incoming_fields
+					)
+				),
 			],
 		];
 	}
@@ -396,7 +397,18 @@ abstract class Integration {
 	 * @return string The metadata prefix.
 	 */
 	public function get_metadata_prefix() {
-		return \get_option( self::METADATA_PREFIX_OPTION_PREFIX . $this->id, 'NP_' );
+		$value = \get_option( self::METADATA_PREFIX_OPTION_PREFIX . $this->id, null );
+		if ( null !== $value ) {
+			return $value;
+		}
+		// Lazy migrate from legacy global option.
+		$legacy_value = \get_option( Sync\Metadata::PREFIX_OPTION, null );
+		if ( null !== $legacy_value ) {
+			// update option directly to avoid infinite loop.
+			\update_option( self::METADATA_PREFIX_OPTION_PREFIX . $this->id, $legacy_value );
+			return $legacy_value;
+		}
+		return 'NP_';
 	}
 
 	/**
@@ -447,8 +459,22 @@ abstract class Integration {
 			return null;
 		}
 		$option_name = self::SETTINGS_OPTION_PREFIX . $this->id . '_' . $key;
-		$default     = $field['default'] ?? '';
-		return \get_option( $option_name, $default );
+		$value       = \get_option( $option_name, null );
+
+		if ( null !== $value ) {
+			return $value;
+		}
+		// Attempt to migrate old setting if the field is found in the key map.
+		if ( isset( self::$legacy_option_map[ $key ] ) ) {
+			// Lazy migrate from legacy option.
+			$legacy_value = \get_option( self::$legacy_option_map[ $key ], null );
+			if ( null !== $legacy_value ) {
+				// update option directly to avoid infinite loop.
+				\update_option( $option_name, $legacy_value );
+				return $legacy_value;
+			}
+		}
+		return $field['default'] ?? '';
 	}
 
 	/**

--- a/includes/reader-activation/integrations/class-integration.php
+++ b/includes/reader-activation/integrations/class-integration.php
@@ -251,25 +251,6 @@ abstract class Integration {
 	}
 
 	/**
-	 * Get the enabled incoming metadata fields for this integration.
-	 *
-	 * @return string[] List of enabled field names.
-	 */
-	public function get_incoming_fields() {
-		return \get_option( self::INCOMING_FIELDS_OPTION_PREFIX . $this->id, [] );
-	}
-
-	/**
-	 * Set the selected fields for this integration.
-	 *
-	 * @param array $fields Array of field keys to store.
-	 * @return bool True if the option was updated, false otherwise.
-	 */
-	public function set_incoming_fields( $fields ) {
-		return \update_option( self::INCOMING_FIELDS_OPTION_PREFIX . $this->id, $fields );
-	}
-
-	/**
 	 * Test the live connection to the integration service.
 	 *
 	 * Subclasses should override this to perform a lightweight API call
@@ -303,6 +284,15 @@ abstract class Integration {
 	}
 
 	/**
+	 * Get the enabled incoming metadata fields for this integration.
+	 *
+	 * @return string[] List of enabled field names.
+	 */
+	public function get_enabled_incoming_fields() {
+		return \get_option( self::INCOMING_FIELDS_OPTION_PREFIX . $this->id, [] );
+	}
+
+	/**
 	 * Get the enabled outgoing metadata fields for this integration.
 	 *
 	 * @return string[] List of enabled field names.
@@ -318,7 +308,7 @@ abstract class Integration {
 	 *
 	 * @return bool True if updated, false otherwise.
 	 */
-	public function update_incoming_fields( $fields ) {
+	public function update_enabled_incoming_fields( $fields ) {
 		return \update_option( self::INCOMING_FIELDS_OPTION_PREFIX . $this->id, $fields );
 	}
 
@@ -449,7 +439,7 @@ abstract class Integration {
 			return $this->get_enabled_outgoing_fields();
 		}
 		if ( 'incoming_metadata_fields' === $key ) {
-			return $this->get_incoming_fields();
+			return $this->get_enabled_incoming_fields();
 		}
 
 		$field = $this->get_settings_field_by_key( $key );
@@ -483,7 +473,7 @@ abstract class Integration {
 			return $this->update_enabled_outgoing_fields( $sanitized );
 		}
 		if ( 'incoming_metadata_fields' === $key ) {
-			return $this->update_incoming_fields( $sanitized );
+			return $this->update_enabled_incoming_fields( $sanitized );
 		}
 
 		$option_name = self::SETTINGS_OPTION_PREFIX . $this->id . '_' . $key;

--- a/includes/reader-activation/integrations/class-integration.php
+++ b/includes/reader-activation/integrations/class-integration.php
@@ -322,4 +322,102 @@ abstract class Integration {
 
 		return array_unique( $prefixed_keys );
 	}
+
+	/**
+	 * Get the settings fields declared by this integration.
+	 *
+	 * @return array Array of settings field declarations.
+	 */
+	public function get_settings_fields() {
+		return $this->settings_fields;
+	}
+
+	/**
+	 * Get the value of a settings field.
+	 *
+	 * @param string $key The field key.
+	 * @return mixed The field value, or the default if not set.
+	 */
+	public function get_settings_field_value( $key ) {
+		$field = $this->get_settings_field_by_key( $key );
+		if ( ! $field ) {
+			return null;
+		}
+		$option_name = self::SETTINGS_OPTION_PREFIX . $this->id . '_' . $key;
+		$default     = $field['default'] ?? '';
+		return \get_option( $option_name, $default );
+	}
+
+	/**
+	 * Update the value of a settings field.
+	 *
+	 * @param string $key   The field key.
+	 * @param mixed  $value The new value.
+	 * @return bool True if updated, false otherwise.
+	 */
+	public function update_settings_field_value( $key, $value ) {
+		$field = $this->get_settings_field_by_key( $key );
+		if ( ! $field ) {
+			return false;
+		}
+		$sanitized   = $this->sanitize_settings_field_value( $field, $value );
+		$option_name = self::SETTINGS_OPTION_PREFIX . $this->id . '_' . $key;
+		return \update_option( $option_name, $sanitized );
+	}
+
+	/**
+	 * Get settings config with current values populated, for API responses.
+	 *
+	 * @return array Array of field declarations with current values.
+	 */
+	public function get_settings_config() {
+		$fields = $this->get_settings_fields();
+		$config = [];
+		foreach ( $fields as $field ) {
+			$field['value'] = $this->get_settings_field_value( $field['key'] );
+			$config[]       = $field;
+		}
+		return $config;
+	}
+
+	/**
+	 * Get a settings field declaration by key.
+	 *
+	 * @param string $key The field key.
+	 * @return array|null The field declaration or null if not found.
+	 */
+	private function get_settings_field_by_key( $key ) {
+		foreach ( $this->settings_fields as $field ) {
+			if ( $field['key'] === $key ) {
+				return $field;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Sanitize a settings field value based on its type.
+	 *
+	 * @param array $field The field declaration.
+	 * @param mixed $value The value to sanitize.
+	 * @return mixed The sanitized value.
+	 */
+	private function sanitize_settings_field_value( $field, $value ) {
+		$type = $field['type'] ?? 'text';
+		switch ( $type ) {
+			case 'checkbox':
+				return (bool) $value;
+			case 'number':
+				return is_numeric( $value ) ? $value + 0 : ( $field['default'] ?? 0 );
+			case 'select':
+				$valid_values = array_column( $field['options'] ?? [], 'value' );
+				return in_array( $value, $valid_values, true ) ? $value : ( $field['default'] ?? '' );
+			case 'textarea':
+				return \sanitize_textarea_field( $value );
+			case 'text':
+			case 'password':
+			default:
+				return \sanitize_text_field( $value );
+		}
+	}
 }

--- a/includes/reader-activation/integrations/class-integration.php
+++ b/includes/reader-activation/integrations/class-integration.php
@@ -38,6 +38,13 @@ abstract class Integration {
 	const SETTINGS_OPTION_PREFIX = 'newspack_integration_settings_';
 
 	/**
+	 * Option name prefix for storing metadata prefix per integration.
+	 *
+	 * @var string
+	 */
+	const METADATA_PREFIX_OPTION_PREFIX = 'newspack_integration_metadata_prefix_';
+
+	/**
 	 * The unique identifier for this integration.
 	 *
 	 * @var string
@@ -348,37 +355,21 @@ abstract class Integration {
 	/**
 	 * Get the raw (unprefixed) metadata keys enabled for outgoing sync.
 	 *
+	 * @param bool $prefixed Optional. Whether to return prefixed keys instead of raw keys. Default false.
+	 *
 	 * @return string[] List of raw metadata keys.
 	 */
-	public function get_enabled_outgoing_fields_raw_keys() {
+	public function get_enabled_outgoing_fields_keys( $prefixed = false ) {
 		$enabled_fields = $this->get_enabled_outgoing_fields();
-		$raw_keys       = [];
+		$keys           = [];
 
 		foreach ( Sync\Metadata::get_keys() as $raw_key => $field_name ) {
 			if ( in_array( $field_name, $enabled_fields, true ) ) {
-				$raw_keys[] = $raw_key;
+				$keys[] = $prefixed ? $this->get_metadata_prefix() . $field_name : $raw_key;
 			}
 		}
 
-		return array_unique( $raw_keys );
-	}
-
-	/**
-	 * Get the prefixed metadata keys enabled for outgoing sync.
-	 *
-	 * @return string[] List of prefixed metadata keys.
-	 */
-	public function get_enabled_outgoing_fields_prefixed_keys() {
-		$enabled_fields = $this->get_enabled_outgoing_fields();
-		$prefixed_keys  = [];
-
-		foreach ( Sync\Metadata::get_keys() as $raw_key => $field_name ) {
-			if ( in_array( $field_name, $enabled_fields, true ) ) {
-				$prefixed_keys[] = Sync\Metadata::get_key( $raw_key );
-			}
-		}
-
-		return array_unique( $prefixed_keys );
+		return array_unique( $keys );
 	}
 
 	/**
@@ -388,6 +379,13 @@ abstract class Integration {
 	 */
 	public function get_metadata_fields() {
 		return [
+			[
+				'key'         => 'metadata_prefix',
+				'type'        => 'text',
+				'label'       => __( 'Metadata field prefix', 'newspack-plugin' ),
+				'description' => __( 'A string to prefix metadata fields attached to each contact synced to the integration. Required to ensure that metadata field names are unique. Default: NP_', 'newspack-plugin' ),
+				'default'     => 'NP_',
+			],
 			[
 				'key'     => 'outgoing_metadata_fields',
 				'type'    => 'outgoing_metadata',
@@ -401,6 +399,28 @@ abstract class Integration {
 				'default' => [],
 			],
 		];
+	}
+
+	/**
+	 * Get the metadata prefix for this integration.
+	 *
+	 * @return string The metadata prefix.
+	 */
+	public function get_metadata_prefix() {
+		return \get_option( self::METADATA_PREFIX_OPTION_PREFIX . $this->id, 'NP_' );
+	}
+
+	/**
+	 * Update the metadata prefix for this integration.
+	 *
+	 * @param string $prefix The new prefix value.
+	 * @return bool True if updated, false otherwise.
+	 */
+	public function update_metadata_prefix( $prefix ) {
+		if ( empty( $prefix ) ) {
+			$prefix = 'NP_';
+		}
+		return \update_option( self::METADATA_PREFIX_OPTION_PREFIX . $this->id, \sanitize_text_field( $prefix ) );
 	}
 
 	/**
@@ -423,6 +443,9 @@ abstract class Integration {
 	 */
 	public function get_settings_field_value( $key ) {
 		// Route metadata fields to their dedicated getters.
+		if ( 'metadata_prefix' === $key ) {
+			return $this->get_metadata_prefix();
+		}
 		if ( 'outgoing_metadata_fields' === $key ) {
 			return $this->get_enabled_outgoing_fields();
 		}
@@ -454,6 +477,9 @@ abstract class Integration {
 		$sanitized = $this->sanitize_settings_field_value( $field, $value );
 
 		// Route metadata fields to their dedicated setters.
+		if ( 'metadata_prefix' === $key ) {
+			return $this->update_metadata_prefix( $sanitized );
+		}
 		if ( 'outgoing_metadata_fields' === $key ) {
 			return $this->update_enabled_outgoing_fields( $sanitized );
 		}

--- a/includes/reader-activation/integrations/class-integration.php
+++ b/includes/reader-activation/integrations/class-integration.php
@@ -16,13 +16,6 @@ defined( 'ABSPATH' ) || exit;
  */
 abstract class Integration {
 	/**
-	 * Option name prefix for storing selected fields per integration.
-	 *
-	 * @var string
-	 */
-	const OPTION_PREFIX = 'newspack_integration_selected_fields_';
-
-	/**
 	 * Option name prefix for storing enabled incoming metadata fields per integration.
 	 *
 	 * @var string
@@ -252,12 +245,12 @@ abstract class Integration {
 	}
 
 	/**
-	 * Get the selected fields for this integration.
+	 * Get the enabled incoming metadata fields for this integration.
 	 *
-	 * @return array Array of selected field keys.
+	 * @return string[] List of enabled field names.
 	 */
-	public function get_selected_fields() {
-		return \get_option( self::OPTION_PREFIX . $this->id, [] );
+	public function get_incoming_fields() {
+		return \get_option( self::INCOMING_FIELDS_OPTION_PREFIX . $this->id, [] );
 	}
 
 	/**
@@ -266,17 +259,8 @@ abstract class Integration {
 	 * @param array $fields Array of field keys to store.
 	 * @return bool True if the option was updated, false otherwise.
 	 */
-	public function set_selected_fields( $fields ) {
-		return \update_option( self::OPTION_PREFIX . $this->id, array_values( $fields ) );
-	}
-
-	/**
-	 * Get the enabled incoming metadata fields for this integration.
-	 *
-	 * @return string[] List of enabled field names.
-	 */
-	public function get_enabled_incoming_fields() {
-		return \get_option( self::INCOMING_FIELDS_OPTION_PREFIX . $this->id, [] );
+	public function set_incoming_fields( $fields ) {
+		return \update_option( self::INCOMING_FIELDS_OPTION_PREFIX . $this->id, $fields );
 	}
 
 	/**
@@ -443,7 +427,7 @@ abstract class Integration {
 			return $this->get_enabled_outgoing_fields();
 		}
 		if ( 'incoming_metadata_fields' === $key ) {
-			return $this->get_enabled_incoming_fields();
+			return $this->get_incoming_fields();
 		}
 
 		$field = $this->get_settings_field_by_key( $key );

--- a/includes/reader-activation/integrations/class-integration.php
+++ b/includes/reader-activation/integrations/class-integration.php
@@ -44,6 +44,13 @@ abstract class Integration {
 	protected $name;
 
 	/**
+	 * A short description for this integration.
+	 *
+	 * @var string
+	 */
+	protected $description = '';
+
+	/**
 	 * Settings fields for this integration.
 	 *
 	 * @var array
@@ -53,12 +60,14 @@ abstract class Integration {
 	/**
 	 * Constructor.
 	 *
-	 * @param string $id              The unique identifier for this integration.
-	 * @param string $name            The display name for this integration.
+	 * @param string $id          The unique identifier for this integration.
+	 * @param string $name        The display name for this integration.
+	 * @param string $description Optional. A short description for this integration.
 	 */
-	public function __construct( $id, $name ) {
-		$this->id   = $id;
-		$this->name = $name;
+	public function __construct( $id, $name, $description = '' ) {
+		$this->id          = $id;
+		$this->name        = $name;
+		$this->description = $description;
 	}
 
 	/**
@@ -77,6 +86,15 @@ abstract class Integration {
 	 */
 	public function get_name() {
 		return $this->name;
+	}
+
+	/**
+	 * Get the integration description.
+	 *
+	 * @return string The integration description.
+	 */
+	public function get_description() {
+		return $this->description;
 	}
 
 	/**
@@ -387,7 +405,7 @@ abstract class Integration {
 	 * @return array|null The field declaration or null if not found.
 	 */
 	private function get_settings_field_by_key( $key ) {
-		foreach ( $this->settings_fields as $field ) {
+		foreach ( $this->get_settings_fields() as $field ) {
 			if ( $field['key'] === $key ) {
 				return $field;
 			}
@@ -412,6 +430,11 @@ abstract class Integration {
 			case 'select':
 				$valid_values = array_column( $field['options'] ?? [], 'value' );
 				return in_array( $value, $valid_values, true ) ? $value : ( $field['default'] ?? '' );
+			case 'metadata':
+				if ( ! is_array( $value ) ) {
+					return $field['default'] ?? [];
+				}
+				return array_values( array_map( 'sanitize_text_field', $value ) );
 			case 'textarea':
 				return \sanitize_textarea_field( $value );
 			case 'text':

--- a/includes/reader-activation/integrations/class-integration.php
+++ b/includes/reader-activation/integrations/class-integration.php
@@ -65,9 +65,11 @@ abstract class Integration {
 	 * @param string $description Optional. A short description for this integration.
 	 */
 	public function __construct( $id, $name, $description = '' ) {
-		$this->id          = $id;
-		$this->name        = $name;
-		$this->description = $description;
+		$this->id              = $id;
+		$this->name            = $name;
+		$this->description     = $description;
+
+		add_action( 'init', [ $this, 'register_settings_fields' ] );
 	}
 
 	/**
@@ -96,6 +98,14 @@ abstract class Integration {
 	public function get_description() {
 		return $this->description;
 	}
+
+	/**
+	 * Register settings fields for this integration.
+	 *
+	 * Child classes should override this method to define their settings fields.
+	 * Each field should be an associative array with keys: key, label, type, default, options (for select), etc.
+	 */
+	abstract public function register_settings_fields();
 
 	/**
 	 * Whether contacts can be synced to the ESP.
@@ -431,6 +441,7 @@ abstract class Integration {
 				$valid_values = array_column( $field['options'] ?? [], 'value' );
 				return in_array( $value, $valid_values, true ) ? $value : ( $field['default'] ?? '' );
 			case 'metadata':
+			case 'custom_metadata':
 				if ( ! is_array( $value ) ) {
 					return $field['default'] ?? [];
 				}

--- a/includes/reader-activation/integrations/class-integration.php
+++ b/includes/reader-activation/integrations/class-integration.php
@@ -51,6 +51,13 @@ abstract class Integration {
 	protected $description = '';
 
 	/**
+	 * Metadata fields for this integration.
+	 *
+	 * @var array
+	 */
+	protected $metadata_fields = [];
+
+	/**
 	 * Settings fields for this integration.
 	 *
 	 * @var array
@@ -68,7 +75,8 @@ abstract class Integration {
 		$this->id          = $id;
 		$this->name        = $name;
 		$this->description = $description;
-
+		$this->register_metadata_settings_fields();
+		// Register settings fields on init to ensure they're available when needed.
 		add_action( 'init', [ $this, 'register_settings_fields' ] );
 	}
 
@@ -97,6 +105,24 @@ abstract class Integration {
 	 */
 	public function get_description() {
 		return $this->description;
+	}
+
+	/**
+	 * Register metadata settings fields for this integration.
+	 */
+	public function register_metadata_settings_fields() {
+		$this->metadata_fields[] = [
+			'key'     => 'metadata_fields',
+			'type'    => 'metadata',
+			'label'   => __( 'Metadata fields', 'newspack-plugin' ),
+			'default' => [],
+		];
+		$this->metadata_fields[] = [
+			'key'     => 'custom_metadata_fields',
+			'type'    => 'custom_metadata',
+			'label'   => __( 'Custom metadata fields', 'newspack-plugin' ),
+			'default' => [],
+		];
 	}
 
 	/**
@@ -231,7 +257,7 @@ abstract class Integration {
 	 * @return array Array of selected field keys.
 	 */
 	public function get_selected_fields() {
-		return \get_option( self::OPTION_PREFIX . $this->id, [] );
+		return $this->get_settings_field_value( 'custom_metadata_fields' );
 	}
 
 	/**
@@ -241,7 +267,7 @@ abstract class Integration {
 	 * @return bool True if the option was updated, false otherwise.
 	 */
 	public function set_selected_fields( $fields ) {
-		return \update_option( self::OPTION_PREFIX . $this->id, array_values( $fields ) );
+		return $this->update_settings_field_value( 'custom_metadata_fields', $fields );
 	}
 
 	/**
@@ -357,7 +383,10 @@ abstract class Integration {
 	 * @return array Array of settings field declarations.
 	 */
 	public function get_settings_fields() {
-		return $this->settings_fields;
+		return array_merge(
+			$this->settings_fields,
+			$this->metadata_fields
+		);
 	}
 
 	/**

--- a/includes/reader-activation/integrations/class-integration.php
+++ b/includes/reader-activation/integrations/class-integration.php
@@ -23,11 +23,26 @@ abstract class Integration {
 	const OPTION_PREFIX = 'newspack_integration_selected_fields_';
 
 	/**
+	 * Option name prefix for storing enabled incoming metadata fields per integration.
+	 *
+	 * @var string
+	 */
+	const INCOMING_FIELDS_OPTION_PREFIX = 'newspack_integration_incoming_fields_';
+
+	/**
 	 * Option name prefix for storing enabled outgoing metadata fields per integration.
 	 *
 	 * @var string
 	 */
 	const OUTGOING_FIELDS_OPTION_PREFIX = 'newspack_integration_outgoing_fields_';
+
+	/**
+	 * Option name prefix for storing all integration settings.
+	 *
+	 * @var strin
+	 * const SETTINGS_OPTION_PREFIX = 'newspack_integration_settings_';g
+	 */
+	const SETTINGS_OPTION_PREFIX = 'newspack_integration_settings_';
 
 	/**
 	 * The unique identifier for this integration.
@@ -51,13 +66,6 @@ abstract class Integration {
 	protected $description = '';
 
 	/**
-	 * Metadata fields for this integration.
-	 *
-	 * @var array
-	 */
-	protected $metadata_fields = [];
-
-	/**
 	 * Settings fields for this integration.
 	 *
 	 * @var array
@@ -75,9 +83,8 @@ abstract class Integration {
 		$this->id          = $id;
 		$this->name        = $name;
 		$this->description = $description;
-		$this->register_metadata_settings_fields();
-		// Register settings fields on init to ensure they're available when needed.
-		add_action( 'init', [ $this, 'register_settings_fields' ] );
+
+		add_action( 'init', [ $this, 'init' ] );
 	}
 
 	/**
@@ -108,28 +115,12 @@ abstract class Integration {
 	}
 
 	/**
-	 * Register metadata settings fields for this integration.
-	 */
-	public function register_metadata_settings_fields() {
-		$this->metadata_fields[] = [
-			'key'     => 'metadata_fields',
-			'type'    => 'metadata',
-			'label'   => __( 'Metadata fields', 'newspack-plugin' ),
-			'default' => [],
-		];
-		$this->metadata_fields[] = [
-			'key'     => 'custom_metadata_fields',
-			'type'    => 'custom_metadata',
-			'label'   => __( 'Custom metadata fields', 'newspack-plugin' ),
-			'default' => [],
-		];
-	}
-
-	/**
 	 * Register settings fields for this integration.
 	 *
 	 * Child classes should override this method to define their settings fields.
 	 * Each field should be an associative array with keys: key, label, type, default, options (for select), etc.
+	 *
+	 * @return array Array of settings field declarations.
 	 */
 	abstract public function register_settings_fields();
 
@@ -164,6 +155,15 @@ abstract class Integration {
 	 * for each data event they need to handle.
 	 */
 	public function register_handlers() {}
+
+	/**
+	 * Initialize the integration, performing any necessary setup or validation.
+	 *
+	 * Currently only initializes settings fields, but can be extended by child classes for additional setup.
+	 */
+	public function init() {
+		$this->settings_fields = $this->register_settings_fields();
+	}
 
 	/**
 	 * Register a data event handler for this integration.
@@ -257,7 +257,7 @@ abstract class Integration {
 	 * @return array Array of selected field keys.
 	 */
 	public function get_selected_fields() {
-		return $this->get_settings_field_value( 'custom_metadata_fields' );
+		return \get_option( self::OPTION_PREFIX . $this->id, [] );
 	}
 
 	/**
@@ -267,7 +267,16 @@ abstract class Integration {
 	 * @return bool True if the option was updated, false otherwise.
 	 */
 	public function set_selected_fields( $fields ) {
-		return $this->update_settings_field_value( 'custom_metadata_fields', $fields );
+		return \update_option( self::OPTION_PREFIX . $this->id, array_values( $fields ) );
+	}
+
+	/**
+	 * Get the enabled incoming metadata fields for this integration.
+	 *
+	 * @return string[] List of enabled field names.
+	 */
+	public function get_enabled_incoming_fields() {
+		return \get_option( self::INCOMING_FIELDS_OPTION_PREFIX . $this->id, [] );
 	}
 
 	/**
@@ -310,6 +319,17 @@ abstract class Integration {
 	 */
 	public function get_enabled_outgoing_fields() {
 		return array_values( \get_option( self::OUTGOING_FIELDS_OPTION_PREFIX . $this->id, Sync\Metadata::get_default_fields() ) );
+	}
+
+	/**
+	 * Update the enabled incoming metadata fields for this integration.
+	 *
+	 * @param array $fields List of field names to enable.
+	 *
+	 * @return bool True if updated, false otherwise.
+	 */
+	public function update_enabled_incoming_fields( $fields ) {
+		return \update_option( self::INCOMING_FIELDS_OPTION_PREFIX . $this->id, $fields );
 	}
 
 	/**
@@ -378,6 +398,28 @@ abstract class Integration {
 	}
 
 	/**
+	 * Get the metadata fields declared by this integration.
+	 *
+	 * @return array Array of settings field declarations.
+	 */
+	public function get_metadata_fields() {
+		return [
+			[
+				'key'     => 'outgoing_metadata_fields',
+				'type'    => 'outgoing_metadata',
+				'label'   => __( 'Outgoing metadata fields', 'newspack-plugin' ),
+				'default' => [],
+			],
+			[
+				'key'     => 'incoming_metadata_fields',
+				'type'    => 'incoming_metadata',
+				'label'   => __( 'Incoming metadata fields', 'newspack-plugin' ),
+				'default' => [],
+			],
+		];
+	}
+
+	/**
 	 * Get the settings fields declared by this integration.
 	 *
 	 * @return array Array of settings field declarations.
@@ -385,7 +427,7 @@ abstract class Integration {
 	public function get_settings_fields() {
 		return array_merge(
 			$this->settings_fields,
-			$this->metadata_fields
+			$this->get_metadata_fields()
 		);
 	}
 
@@ -396,6 +438,14 @@ abstract class Integration {
 	 * @return mixed The field value, or the default if not set.
 	 */
 	public function get_settings_field_value( $key ) {
+		// Route metadata fields to their dedicated getters.
+		if ( 'outgoing_metadata_fields' === $key ) {
+			return $this->get_enabled_outgoing_fields();
+		}
+		if ( 'incoming_metadata_fields' === $key ) {
+			return $this->get_enabled_incoming_fields();
+		}
+
 		$field = $this->get_settings_field_by_key( $key );
 		if ( ! $field ) {
 			return null;
@@ -417,7 +467,16 @@ abstract class Integration {
 		if ( ! $field ) {
 			return false;
 		}
-		$sanitized   = $this->sanitize_settings_field_value( $field, $value );
+		$sanitized = $this->sanitize_settings_field_value( $field, $value );
+
+		// Route metadata fields to their dedicated setters.
+		if ( 'outgoing_metadata_fields' === $key ) {
+			return $this->update_enabled_outgoing_fields( $sanitized );
+		}
+		if ( 'incoming_metadata_fields' === $key ) {
+			return $this->update_enabled_incoming_fields( $sanitized );
+		}
+
 		$option_name = self::SETTINGS_OPTION_PREFIX . $this->id . '_' . $key;
 		return \update_option( $option_name, $sanitized );
 	}
@@ -469,8 +528,8 @@ abstract class Integration {
 			case 'select':
 				$valid_values = array_column( $field['options'] ?? [], 'value' );
 				return in_array( $value, $valid_values, true ) ? $value : ( $field['default'] ?? '' );
-			case 'metadata':
-			case 'custom_metadata':
+			case 'outgoing_metadata':
+			case 'incoming_metadata':
 				if ( ! is_array( $value ) ) {
 					return $field['default'] ?? [];
 				}

--- a/includes/reader-activation/integrations/class-integration.php
+++ b/includes/reader-activation/integrations/class-integration.php
@@ -357,36 +357,25 @@ abstract class Integration {
 	 * @return array Array of settings field declarations.
 	 */
 	public function get_metadata_fields() {
-		$incoming_fields = $this->get_available_incoming_contact_fields( true );
-		$outgoing_fields = Sync\Metadata::get_default_fields();
-
 		return [
 			[
 				'key'         => 'metadata_prefix',
 				'type'        => 'text',
 				'label'       => __( 'Metadata field prefix', 'newspack-plugin' ),
-				'description' => __( 'A string to prefix metadata fields attached to each contact synced to the integration. Required to ensure that metadata field names are unique. Default: NP_', 'newspack-plugin' ),
+				'description' => __( 'A string to prefix metadata fields synced to the integration. Required to ensure that metadata field names are unique. Default: NP_', 'newspack-plugin' ),
 				'default'     => 'NP_',
 			],
 			[
 				'key'     => 'outgoing_metadata_fields',
 				'type'    => 'metadata',
 				'label'   => __( 'Outgoing metadata fields', 'newspack-plugin' ),
-				'options' => $outgoing_fields,
+				'default' => [],
 			],
 			[
 				'key'     => 'incoming_metadata_fields',
 				'type'    => 'metadata',
 				'label'   => __( 'Incoming metadata fields', 'newspack-plugin' ),
 				'default' => [],
-				'options' => array_values(
-					array_map(
-						function( $field ) {
-							return $field->get_key();
-						},
-						is_wp_error( $incoming_fields ) ? [] : $incoming_fields
-					)
-				),
 			],
 		];
 	}
@@ -516,7 +505,20 @@ abstract class Integration {
 		$config = [];
 		foreach ( $fields as $field ) {
 			$field['value'] = $this->get_settings_field_value( $field['key'] );
-			$config[]       = $field;
+			// Inject metadata options for metadata fields.
+			if ( 'incoming_metadata_fields' === $field['key'] ) {
+				$incoming_fields = $this->get_available_incoming_contact_fields( false );
+				$field['options'] = array_map(
+					function( $incoming_field ) {
+						return $incoming_field->get_key();
+					},
+					is_wp_error( $incoming_fields ) ? [] : $incoming_fields
+				);
+			}
+			if ( 'outgoing_metadata_fields' === $field['key'] ) {
+				$field['options'] = Sync\Metadata::get_default_fields();
+			}
+			$config[] = $field;
 		}
 		return $config;
 	}
@@ -553,8 +555,7 @@ abstract class Integration {
 			case 'select':
 				$valid_values = array_column( $field['options'] ?? [], 'value' );
 				return in_array( $value, $valid_values, true ) ? $value : ( $field['default'] ?? '' );
-			case 'outgoing_metadata':
-			case 'incoming_metadata':
+			case 'metadata':
 				if ( ! is_array( $value ) ) {
 					return $field['default'] ?? [];
 				}

--- a/includes/reader-activation/integrations/class-integration.php
+++ b/includes/reader-activation/integrations/class-integration.php
@@ -364,7 +364,7 @@ abstract class Integration {
 
 		foreach ( Sync\Metadata::get_keys() as $raw_key => $field_name ) {
 			if ( in_array( $field_name, $enabled_fields, true ) ) {
-				$keys[] = $prefixed ? Sync\Metadata::get_key( $raw_kley ) : $raw_key;
+				$keys[] = $prefixed ? $this->get_metadata_prefix() . $field_name : $raw_key;
 			}
 		}
 

--- a/includes/reader-activation/sync/class-metadata.php
+++ b/includes/reader-activation/sync/class-metadata.php
@@ -70,6 +70,11 @@ class Metadata {
 	 * Fetch the prefix for synced metadata fields.
 	 * Default is NP_ but it can be configured in the Reader Activation settings page.
 	 *
+	 * This method is deprecated. Now, each integration has its own metadata prefix, which can be retrieved with Integration::get_metadata_prefix().
+	 * As a fallback, this method returns the metadata prefix for the ESP Integration.
+	 *
+	 * @deprecated Use Integration::get_metadata_prefix() instead.
+	 *
 	 * @return string
 	 */
 	public static function get_prefix() {

--- a/includes/reader-activation/sync/class-metadata.php
+++ b/includes/reader-activation/sync/class-metadata.php
@@ -73,6 +73,19 @@ class Metadata {
 	 * @return string
 	 */
 	public static function get_prefix() {
+		// When the integrations feature is enabled, read prefix from the ESP integration.
+		if ( \Newspack\Audience_Integrations::is_enabled() ) {
+			$esp_integration = Integrations::get_integration( 'esp' );
+			if ( $esp_integration ) {
+				$prefix = $esp_integration->get_metadata_prefix();
+				if ( ! empty( $prefix ) ) {
+					/** This filter is documented below. */
+					return apply_filters( 'newspack_ras_metadata_prefix', $prefix );
+				}
+			}
+		}
+
+		// Legacy: read from global option.
 		$prefix = \get_option( self::PREFIX_OPTION, self::PREFIX );
 
 		// Guard against empty strings and falsy values.
@@ -174,12 +187,12 @@ class Metadata {
 	 * This method is deprecated. Now, each integration has its own set of enabled fields.
 	 * As a fallback, this method delegates to the ESP Integration.
 	 *
-	 * @deprecated Use Integration::get_enabled_outgoing_fields_raw_keys() instead.
+	 * @deprecated Use Integration::get_enabled_outgoing_fields_keys() instead.
 	 * @return string[] List of raw metadata keys.
 	 */
 	public static function get_raw_keys() {
 		$esp_integration = Integrations::get_integration( 'esp' );
-		return $esp_integration ? $esp_integration->get_enabled_outgoing_fields_raw_keys() : [];
+		return $esp_integration ? $esp_integration->get_enabled_outgoing_fields_keys() : [];
 	}
 
 	/**
@@ -188,12 +201,12 @@ class Metadata {
 	 * This method is deprecated. Now, each integration has its own set of enabled fields.
 	 * As a fallback, this method delegates to the ESP Integration.
 	 *
-	 * @deprecated Use Integration::get_enabled_outgoing_fields_prefixed_keys() instead.
+	 * @deprecated Use Integration::get_enabled_outgoing_fields_keys() instead.
 	 * @return string[] List of prefixed metadata keys.
 	 */
 	public static function get_prefixed_keys() {
 		$esp_integration = Integrations::get_integration( 'esp' );
-		return $esp_integration ? $esp_integration->get_enabled_outgoing_fields_prefixed_keys() : [];
+		return $esp_integration ? $esp_integration->get_enabled_outgoing_fields_keys( true ) : [];
 	}
 
 	/**

--- a/includes/reader-activation/sync/class-metadata.php
+++ b/includes/reader-activation/sync/class-metadata.php
@@ -73,19 +73,16 @@ class Metadata {
 	 * @return string
 	 */
 	public static function get_prefix() {
-		// When the integrations feature is enabled, read prefix from the ESP integration.
-		if ( \Newspack\Audience_Integrations::is_enabled() ) {
-			$esp_integration = Integrations::get_integration( 'esp' );
-			if ( $esp_integration ) {
-				$prefix = $esp_integration->get_metadata_prefix();
-				if ( ! empty( $prefix ) ) {
-					/** This filter is documented below. */
-					return apply_filters( 'newspack_ras_metadata_prefix', $prefix );
-				}
+		$esp_integration = Integrations::get_integration( 'esp' );
+		if ( $esp_integration ) {
+			$prefix = $esp_integration->get_metadata_prefix();
+			if ( ! empty( $prefix ) ) {
+				/** This filter is documented below. */
+				return apply_filters( 'newspack_ras_metadata_prefix', $prefix );
 			}
 		}
 
-		// Legacy: read from global option.
+		// Fallback for edge case where integration isn't registered yet (before init priority 5).
 		$prefix = \get_option( self::PREFIX_OPTION, self::PREFIX );
 
 		// Guard against empty strings and falsy values.
@@ -109,11 +106,8 @@ class Metadata {
 	 * @return boolean True if updated, false otherwise.
 	 */
 	public static function update_prefix( $prefix ) {
-		if ( empty( $prefix ) ) {
-			$prefix = self::PREFIX;
-		}
-
-		return \update_option( self::PREFIX_OPTION, $prefix );
+		$esp_integration = Integrations::get_integration( 'esp' );
+		return $esp_integration ? $esp_integration->update_metadata_prefix( $prefix ) : false;
 	}
 
 	/**

--- a/includes/wizards/audience/class-audience-integrations.php
+++ b/includes/wizards/audience/class-audience-integrations.php
@@ -88,7 +88,6 @@ class Audience_Integrations extends Wizard {
 
 		$localized_data = [
 			'integrations_settings_enabled' => self::is_enabled(),
-			'esp_metadata_fields'           => Reader_Activation\Sync\Metadata::get_default_fields(),
 		];
 
 		if ( class_exists( 'Newspack_Newsletters' ) ) {

--- a/includes/wizards/audience/class-audience-integrations.php
+++ b/includes/wizards/audience/class-audience-integrations.php
@@ -7,6 +7,7 @@
 
 namespace Newspack;
 
+use Newspack\Reader_Activation;
 use Newspack\Reader_Activation\Integrations;
 use WP_Error, WP_REST_Request, WP_REST_Response, WP_REST_Server;
 
@@ -85,12 +86,19 @@ class Audience_Integrations extends Wizard {
 
 		wp_enqueue_script( 'newspack-wizards' );
 
+		$localized_data = [
+			'integrations_settings_enabled' => self::is_enabled(),
+			'esp_metadata_fields'           => Reader_Activation\Sync\Metadata::get_default_fields(),
+		];
+
+		if ( class_exists( 'Newspack_Newsletters' ) ) {
+			$localized_data['esp_provider'] = \Newspack_Newsletters::service_provider();
+		}
+
 		\wp_localize_script(
 			'newspack-wizards',
 			'newspackAudienceIntegrations',
-			[
-				'integrations_settings_enabled' => self::is_enabled(),
-			]
+			$localized_data
 		);
 	}
 
@@ -114,6 +122,16 @@ class Audience_Integrations extends Wizard {
 			[
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => [ $this, 'api_update_integration_settings' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+			]
+		);
+
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->slug . '/settings/(?P<integration_id>[a-zA-Z0-9_-]+)/enabled',
+			[
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => [ $this, 'api_update_integration_enabled' ],
 				'permission_callback' => [ $this, 'api_permissions_check' ],
 			]
 		);
@@ -153,6 +171,34 @@ class Audience_Integrations extends Wizard {
 				esc_html__( 'Integration not found.', 'newspack-plugin' ),
 				[ 'status' => 404 ]
 			);
+		}
+
+		return rest_ensure_response( Integrations::get_all_integration_settings() );
+	}
+
+	/**
+	 * Update the enabled state of a specific integration.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function api_update_integration_enabled( WP_REST_Request $request ) {
+		$integration_id = $request->get_param( 'integration_id' );
+		$enabled        = $request->get_param( 'enabled' );
+
+		$integration = Integrations::get_integration( $integration_id );
+		if ( ! $integration ) {
+			return new WP_Error(
+				'newspack_integration_not_found',
+				esc_html__( 'Integration not found.', 'newspack-plugin' ),
+				[ 'status' => 404 ]
+			);
+		}
+
+		if ( $enabled ) {
+			Integrations::enable( $integration_id );
+		} else {
+			Integrations::disable( $integration_id );
 		}
 
 		return rest_ensure_response( Integrations::get_all_integration_settings() );

--- a/includes/wizards/audience/class-audience-integrations.php
+++ b/includes/wizards/audience/class-audience-integrations.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * Audience Integrations Wizard
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+use Newspack\Reader_Activation\Integrations;
+use WP_Error, WP_REST_Request, WP_REST_Response, WP_REST_Server;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Audience Integrations Wizard.
+ */
+class Audience_Integrations extends Wizard {
+	/**
+	 * Admin page slug.
+	 *
+	 * @var string
+	 */
+	protected $slug = 'newspack-audience-integrations';
+
+	/**
+	 * Parent slug.
+	 *
+	 * @var string
+	 */
+	protected $parent_slug = 'newspack-audience';
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		if ( ! self::is_enabled() ) {
+			return;
+		}
+		parent::__construct();
+		add_action( 'rest_api_init', [ $this, 'register_api_endpoints' ] );
+	}
+
+	/**
+	 * Check if the integrations settings feature is enabled.
+	 *
+	 * @return bool
+	 */
+	public static function is_enabled() {
+		return defined( 'NEWSPACK_INTEGRATIONS_SETTINGS_ENABLED' ) && NEWSPACK_INTEGRATIONS_SETTINGS_ENABLED;
+	}
+
+	/**
+	 * Get the name for this wizard.
+	 *
+	 * @return string The wizard name.
+	 */
+	public function get_name() {
+		return esc_html__( 'Audience Management / Integrations', 'newspack-plugin' );
+	}
+
+	/**
+	 * Add Integrations page.
+	 */
+	public function add_page() {
+		add_submenu_page(
+			$this->parent_slug,
+			$this->get_name(),
+			esc_html__( 'Integrations', 'newspack-plugin' ),
+			$this->capability,
+			$this->slug,
+			[ $this, 'render_wizard' ]
+		);
+	}
+
+	/**
+	 * Enqueue scripts and styles.
+	 */
+	public function enqueue_scripts_and_styles() {
+		if ( ! $this->is_wizard_page() ) {
+			return;
+		}
+
+		parent::enqueue_scripts_and_styles();
+
+		wp_enqueue_script( 'newspack-wizards' );
+
+		\wp_localize_script(
+			'newspack-wizards',
+			'newspackAudienceIntegrations',
+			[
+				'integrations_settings_enabled' => self::is_enabled(),
+			]
+		);
+	}
+
+	/**
+	 * Register the endpoints needed for the wizard screens.
+	 */
+	public function register_api_endpoints() {
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->slug . '/settings',
+			[
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'api_get_integration_settings' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+			]
+		);
+
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/' . $this->slug . '/settings/(?P<integration_id>[a-zA-Z0-9_-]+)',
+			[
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => [ $this, 'api_update_integration_settings' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+			]
+		);
+	}
+
+	/**
+	 * Get all integration settings.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function api_get_integration_settings() {
+		return rest_ensure_response( Integrations::get_all_integration_settings() );
+	}
+
+	/**
+	 * Update settings for a specific integration.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function api_update_integration_settings( WP_REST_Request $request ) {
+		$integration_id = $request->get_param( 'integration_id' );
+		$settings       = $request->get_param( 'settings' );
+
+		if ( ! is_array( $settings ) ) {
+			return new WP_Error(
+				'newspack_invalid_param',
+				esc_html__( 'Settings must be an object of key-value pairs.', 'newspack-plugin' ),
+				[ 'status' => 400 ]
+			);
+		}
+
+		$result = Integrations::update_integration_settings( $integration_id, $settings );
+		if ( null === $result ) {
+			return new WP_Error(
+				'newspack_integration_not_found',
+				esc_html__( 'Integration not found.', 'newspack-plugin' ),
+				[ 'status' => 404 ]
+			);
+		}
+
+		return rest_ensure_response( Integrations::get_all_integration_settings() );
+	}
+}

--- a/src/wizards/audience/views/integrations/index.js
+++ b/src/wizards/audience/views/integrations/index.js
@@ -1,0 +1,216 @@
+/**
+ * WordPress dependencies.
+ */
+import { __ } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
+import { forwardRef, useState, useEffect, useCallback } from '@wordpress/element';
+import { CheckboxControl, ExternalLink } from '@wordpress/components';
+
+/**
+ * Internal dependencies.
+ */
+import { Button, Card, SectionHeader, SelectControl, TextControl, Wizard, withWizard } from '../../../../../packages/components/src';
+import WizardsTab from '../../../wizards-tab';
+import WizardSection from '../../../wizards-section';
+
+const API_PATH = '/newspack/v1/wizard/newspack-audience-integrations/settings';
+
+/**
+ * Render a single settings field.
+ *
+ * @param {Object}   props          Component props.
+ * @param {Object}   props.field    Field declaration.
+ * @param {*}        props.value    Current value.
+ * @param {Function} props.onChange Change handler.
+ */
+function SettingsField( { field, value, onChange } ) {
+	const { key, type, label, description, placeholder, options, help_url: helpUrl } = field;
+	const help = (
+		<>
+			{ description }
+			{ helpUrl && (
+				<>
+					{ ' ' }
+					<ExternalLink href={ helpUrl }>{ __( 'Learn more', 'newspack-plugin' ) }</ExternalLink>
+				</>
+			) }
+		</>
+	);
+
+	switch ( type ) {
+		case 'checkbox':
+			return <CheckboxControl key={ key } label={ label } help={ help } checked={ !! value } onChange={ onChange } />;
+		case 'select':
+			return (
+				<SelectControl
+					key={ key }
+					label={ label }
+					help={ help }
+					value={ value }
+					options={ ( options || [] ).map( opt => ( {
+						label: opt.label,
+						value: opt.value,
+					} ) ) }
+					onChange={ onChange }
+				/>
+			);
+		case 'textarea':
+			return (
+				<TextControl
+					key={ key }
+					label={ label }
+					help={ help }
+					value={ value || '' }
+					placeholder={ placeholder }
+					onChange={ onChange }
+					isTextarea
+				/>
+			);
+		case 'number':
+			return (
+				<TextControl
+					key={ key }
+					label={ label }
+					help={ help }
+					value={ value ?? '' }
+					placeholder={ placeholder }
+					onChange={ onChange }
+					type="number"
+				/>
+			);
+		case 'password':
+			return (
+				<TextControl
+					key={ key }
+					label={ label }
+					help={ help }
+					value={ value || '' }
+					placeholder={ placeholder }
+					onChange={ onChange }
+					type="password"
+				/>
+			);
+		case 'text':
+		default:
+			return <TextControl key={ key } label={ label } help={ help } value={ value || '' } placeholder={ placeholder } onChange={ onChange } />;
+	}
+}
+
+function AudienceIntegrations( props, ref ) {
+	const [ integrations, setIntegrations ] = useState( {} );
+	const [ pendingChanges, setPendingChanges ] = useState( {} );
+	const [ saving, setSaving ] = useState( {} );
+	const [ loading, setLoading ] = useState( true );
+
+	const fetchSettings = useCallback( () => {
+		setLoading( true );
+		apiFetch( { path: API_PATH } )
+			.then( data => {
+				setIntegrations( data );
+				setPendingChanges( {} );
+			} )
+			.finally( () => setLoading( false ) );
+	}, [] );
+
+	useEffect( () => {
+		fetchSettings();
+	}, [ fetchSettings ] );
+
+	const handleFieldChange = ( integrationId, fieldKey, value ) => {
+		setPendingChanges( prev => ( {
+			...prev,
+			[ integrationId ]: {
+				...( prev[ integrationId ] || {} ),
+				[ fieldKey ]: value,
+			},
+		} ) );
+	};
+
+	const handleSave = integrationId => {
+		const changes = pendingChanges[ integrationId ];
+		if ( ! changes || Object.keys( changes ).length === 0 ) {
+			return;
+		}
+		setSaving( prev => ( { ...prev, [ integrationId ]: true } ) );
+		apiFetch( {
+			path: `${ API_PATH }/${ integrationId }`,
+			method: 'POST',
+			data: { settings: changes },
+		} )
+			.then( data => {
+				setIntegrations( data );
+				setPendingChanges( prev => {
+					const next = { ...prev };
+					delete next[ integrationId ];
+					return next;
+				} );
+			} )
+			.finally( () => {
+				setSaving( prev => ( { ...prev, [ integrationId ]: false } ) );
+			} );
+	};
+
+	const getFieldValue = ( integrationId, field ) => {
+		if ( pendingChanges[ integrationId ] && field.key in pendingChanges[ integrationId ] ) {
+			return pendingChanges[ integrationId ][ field.key ];
+		}
+		return field.value;
+	};
+
+	const integrationIds = Object.keys( integrations );
+
+	return (
+		<Wizard
+			headerText={ __( 'Audience Management / Integrations', 'newspack-plugin' ) }
+			sections={ [
+				{
+					label: __( 'Settings', 'newspack-plugin' ),
+					path: '/settings',
+					render: () => (
+						<WizardsTab title={ __( 'Integrations Settings', 'newspack-plugin' ) }>
+							<WizardSection>
+								{ loading && <p>{ __( 'Loading…', 'newspack-plugin' ) }</p> }
+								{ ! loading && integrationIds.length === 0 && (
+									<Card>
+										<p>{ __( 'No integrations with configurable settings are registered.', 'newspack-plugin' ) }</p>
+									</Card>
+								) }
+								{ ! loading &&
+									integrationIds.map( id => {
+										const integration = integrations[ id ];
+										const hasPending = pendingChanges[ id ] && Object.keys( pendingChanges[ id ] ).length > 0;
+										return (
+											<div key={ id }>
+												<SectionHeader title={ integration.name } />
+												<Card>
+													{ integration.settings.map( field => (
+														<SettingsField
+															key={ field.key }
+															field={ field }
+															value={ getFieldValue( id, field ) }
+															onChange={ val => handleFieldChange( id, field.key, val ) }
+														/>
+													) ) }
+													<Button
+														variant="primary"
+														onClick={ () => handleSave( id ) }
+														disabled={ ! hasPending || saving[ id ] }
+														isBusy={ saving[ id ] }
+													>
+														{ __( 'Save', 'newspack-plugin' ) }
+													</Button>
+												</Card>
+											</div>
+										);
+									} ) }
+							</WizardSection>
+						</WizardsTab>
+					),
+				},
+			] }
+			ref={ ref }
+		/>
+	);
+}
+
+export default withWizard( forwardRef( AudienceIntegrations ) );

--- a/src/wizards/audience/views/integrations/index.js
+++ b/src/wizards/audience/views/integrations/index.js
@@ -10,7 +10,17 @@ import { CheckboxControl, ExternalLink } from '@wordpress/components';
 /**
  * Internal dependencies.
  */
-import { ActionCard, Button, Card, Grid, SelectControl, TextControl, Wizard, withWizard } from '../../../../../packages/components/src';
+import {
+	ActionCard,
+	Button,
+	Card,
+	FormTokenField,
+	Grid,
+	SelectControl,
+	TextControl,
+	Wizard,
+	withWizard,
+} from '../../../../../packages/components/src';
 import WizardsTab from '../../../wizards-tab';
 import WizardSection from '../../../wizards-section';
 
@@ -60,8 +70,10 @@ function SettingsField( { field, value, onChange } ) {
 			const selectedFields = Array.isArray( value ) ? value : [];
 			return (
 				<div key={ key }>
-					<h3>{ __( 'Metadata fields to sync', 'newspack-plugin' ) }</h3>
-					<p className="components-base-control__help">{ __( 'Select which data to sync for each contact.', 'newspack-plugin' ) }</p>
+					<h3>{ __( 'Metadata fields', 'newspack-plugin' ) }</h3>
+					<p className="components-base-control__help">
+						{ __( 'Select which data to sync to the integration for each contact.', 'newspack-plugin' ) }
+					</p>
 					<Grid columns={ 3 } rowGap={ 16 }>
 						{ availableFields.map( ( fieldName, index ) => (
 							<CheckboxControl
@@ -79,6 +91,25 @@ function SettingsField( { field, value, onChange } ) {
 				</div>
 			);
 		}
+		case 'custom_metadata':
+			return (
+				<div key={ key }>
+					<p className="components-base-control__help">
+						{ __( 'Select which data to sync from the integration for each contact.', 'newspack-plugin' ) }
+					</p>
+					<Grid columns={ 1 } rowGap={ 16 }>
+						<FormTokenField
+							key={ key }
+							label={ __( 'Custom Metadata fields', 'newspack-plugin' ) }
+							description={ help }
+							value={ Array.isArray( value ) ? value : [] }
+							onChange={ onChange }
+							__next40pxDefaultSize
+							tokenizeOnBlur
+						/>
+					</Grid>
+				</div>
+			);
 		case 'textarea':
 			return (
 				<TextControl

--- a/src/wizards/audience/views/integrations/index.js
+++ b/src/wizards/audience/views/integrations/index.js
@@ -65,15 +65,12 @@ function SettingsField( { field, value, onChange } ) {
 					onChange={ onChange }
 				/>
 			);
-		case 'metadata': {
+		case 'outgoing_metadata': {
 			const availableFields = newspackAudienceIntegrations?.esp_metadata_fields || [];
 			const selectedFields = Array.isArray( value ) ? value : [];
 			return (
 				<div key={ key }>
-					<h3>{ __( 'Metadata fields', 'newspack-plugin' ) }</h3>
-					<p className="components-base-control__help">
-						{ __( 'Select which data to sync to the integration for each contact.', 'newspack-plugin' ) }
-					</p>
+					<h3>{ label }</h3>
 					<Grid columns={ 3 } rowGap={ 16 }>
 						{ availableFields.map( ( fieldName, index ) => (
 							<CheckboxControl
@@ -91,16 +88,14 @@ function SettingsField( { field, value, onChange } ) {
 				</div>
 			);
 		}
-		case 'custom_metadata':
+		case 'incoming_metadata':
 			return (
 				<div key={ key }>
-					<p className="components-base-control__help">
-						{ __( 'Select which data to sync from the integration for each contact.', 'newspack-plugin' ) }
-					</p>
+					<h3>{ label }</h3>
 					<Grid columns={ 1 } rowGap={ 16 }>
 						<FormTokenField
 							key={ key }
-							label={ __( 'Custom Metadata fields', 'newspack-plugin' ) }
+							label={ null }
 							description={ help }
 							value={ Array.isArray( value ) ? value : [] }
 							onChange={ onChange }

--- a/src/wizards/audience/views/integrations/index.js
+++ b/src/wizards/audience/views/integrations/index.js
@@ -1,3 +1,4 @@
+/* global newspackAudienceIntegrations */
 /**
  * WordPress dependencies.
  */
@@ -9,7 +10,7 @@ import { CheckboxControl, ExternalLink } from '@wordpress/components';
 /**
  * Internal dependencies.
  */
-import { Button, Card, SectionHeader, SelectControl, TextControl, Wizard, withWizard } from '../../../../../packages/components/src';
+import { ActionCard, Button, Card, Grid, SelectControl, TextControl, Wizard, withWizard } from '../../../../../packages/components/src';
 import WizardsTab from '../../../wizards-tab';
 import WizardSection from '../../../wizards-section';
 
@@ -54,6 +55,30 @@ function SettingsField( { field, value, onChange } ) {
 					onChange={ onChange }
 				/>
 			);
+		case 'metadata': {
+			const availableFields = newspackAudienceIntegrations?.esp_metadata_fields || [];
+			const selectedFields = Array.isArray( value ) ? value : [];
+			return (
+				<div key={ key }>
+					<h3>{ __( 'Metadata fields to sync', 'newspack-plugin' ) }</h3>
+					<p className="components-base-control__help">{ __( 'Select which data to sync for each contact.', 'newspack-plugin' ) }</p>
+					<Grid columns={ 3 } rowGap={ 16 }>
+						{ availableFields.map( ( fieldName, index ) => (
+							<CheckboxControl
+								className="newspack-checkbox-control"
+								key={ index }
+								label={ fieldName.replace( ': ', '' ) }
+								checked={ selectedFields.includes( fieldName ) }
+								onChange={ checked => {
+									const newFields = checked ? [ ...selectedFields, fieldName ] : selectedFields.filter( f => f !== fieldName );
+									onChange( newFields );
+								} }
+							/>
+						) ) }
+					</Grid>
+				</div>
+			);
+		}
 		case 'textarea':
 			return (
 				<TextControl
@@ -100,6 +125,7 @@ function AudienceIntegrations( props, ref ) {
 	const [ integrations, setIntegrations ] = useState( {} );
 	const [ pendingChanges, setPendingChanges ] = useState( {} );
 	const [ saving, setSaving ] = useState( {} );
+	const [ toggling, setToggling ] = useState( {} );
 	const [ loading, setLoading ] = useState( true );
 
 	const fetchSettings = useCallback( () => {
@@ -150,6 +176,21 @@ function AudienceIntegrations( props, ref ) {
 			} );
 	};
 
+	const handleToggleEnabled = ( integrationId, enabled ) => {
+		setToggling( prev => ( { ...prev, [ integrationId ]: true } ) );
+		apiFetch( {
+			path: `${ API_PATH }/${ integrationId }/enabled`,
+			method: 'POST',
+			data: { enabled },
+		} )
+			.then( data => {
+				setIntegrations( data );
+			} )
+			.finally( () => {
+				setToggling( prev => ( { ...prev, [ integrationId ]: false } ) );
+			} );
+	};
+
 	const getFieldValue = ( integrationId, field ) => {
 		if ( pendingChanges[ integrationId ] && field.key in pendingChanges[ integrationId ] ) {
 			return pendingChanges[ integrationId ][ field.key ];
@@ -179,28 +220,44 @@ function AudienceIntegrations( props, ref ) {
 									integrationIds.map( id => {
 										const integration = integrations[ id ];
 										const hasPending = pendingChanges[ id ] && Object.keys( pendingChanges[ id ] ).length > 0;
+										const isEnabled = integration.enabled;
 										return (
-											<div key={ id }>
-												<SectionHeader title={ integration.name } />
-												<Card>
-													{ integration.settings.map( field => (
-														<SettingsField
-															key={ field.key }
-															field={ field }
-															value={ getFieldValue( id, field ) }
-															onChange={ val => handleFieldChange( id, field.key, val ) }
-														/>
-													) ) }
-													<Button
-														variant="primary"
-														onClick={ () => handleSave( id ) }
-														disabled={ ! hasPending || saving[ id ] }
-														isBusy={ saving[ id ] }
-													>
-														{ __( 'Save', 'newspack-plugin' ) }
-													</Button>
-												</Card>
-											</div>
+											<ActionCard
+												key={ id }
+												title={ integration.name }
+												description={ integration.description }
+												toggleChecked={ isEnabled }
+												toggleOnChange={ () => handleToggleEnabled( id, ! isEnabled ) }
+												disabled={ toggling[ id ] }
+												hasGreyHeader={ isEnabled }
+												actionContent={
+													isEnabled ? (
+														<Button
+															variant="primary"
+															onClick={ () => handleSave( id ) }
+															disabled={ ! hasPending || saving[ id ] }
+															isBusy={ saving[ id ] }
+														>
+															{ __( 'Save Settings', 'newspack-plugin' ) }
+														</Button>
+													) : null
+												}
+											>
+												{ isEnabled && (
+													<>
+														<Grid columns={ 1 } rowGap={ 16 }>
+															{ integration.settings.map( field => (
+																<SettingsField
+																	key={ field.key }
+																	field={ field }
+																	value={ getFieldValue( id, field ) }
+																	onChange={ val => handleFieldChange( id, field.key, val ) }
+																/>
+															) ) }
+														</Grid>
+													</>
+												) }
+											</ActionCard>
 										);
 									} ) }
 							</WizardSection>

--- a/src/wizards/audience/views/integrations/index.js
+++ b/src/wizards/audience/views/integrations/index.js
@@ -4,121 +4,19 @@
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import { forwardRef, useState, useEffect, useCallback } from '@wordpress/element';
-import { CheckboxControl, ExternalLink } from '@wordpress/components';
 
 /**
  * Internal dependencies.
  */
-import { ActionCard, Button, Card, Grid, SelectControl, TextControl, Wizard, withWizard } from '../../../../../packages/components/src';
+import { ActionCard, Button, Card, Grid, Wizard, withWizard } from '../../../../../packages/components/src';
 import WizardsTab from '../../../wizards-tab';
 import WizardSection from '../../../wizards-section';
 
+import { SettingsField } from './settings-field';
+
 const API_PATH = '/newspack/v1/wizard/newspack-audience-integrations/settings';
 
-/**
- * Render a single settings field.
- *
- * @param {Object}   props          Component props.
- * @param {Object}   props.field    Field declaration.
- * @param {*}        props.value    Current value.
- * @param {Function} props.onChange Change handler.
- */
-function SettingsField( { field, value, onChange } ) {
-	const { key, type, label, description, placeholder, options, help_url: helpUrl } = field;
-	const help = (
-		<>
-			{ description }
-			{ helpUrl && (
-				<>
-					{ ' ' }
-					<ExternalLink href={ helpUrl }>{ __( 'Learn more', 'newspack-plugin' ) }</ExternalLink>
-				</>
-			) }
-		</>
-	);
-
-	switch ( type ) {
-		case 'metadata': {
-			const selectedFields = Array.isArray( value ) ? value : [];
-			return (
-				<div key={ key }>
-					<h3>{ label }</h3>
-					<Grid columns={ 3 } rowGap={ 16 }>
-						{ options.map( fieldName => (
-							<CheckboxControl
-								className="newspack-checkbox-control"
-								key={ fieldName }
-								label={ fieldName.replace( ': ', '' ) }
-								checked={ selectedFields.includes( fieldName ) }
-								onChange={ checked => {
-									const newFields = checked ? [ ...selectedFields, fieldName ] : selectedFields.filter( f => f !== fieldName );
-									onChange( newFields );
-								} }
-							/>
-						) ) }
-					</Grid>
-				</div>
-			);
-		}
-		case 'checkbox':
-			return <CheckboxControl key={ key } label={ label } help={ help } checked={ !! value } onChange={ onChange } />;
-		case 'select':
-			return (
-				<SelectControl
-					key={ key }
-					label={ label }
-					help={ help }
-					value={ value }
-					options={ ( options || [] ).map( opt => ( {
-						label: opt.label,
-						value: opt.value,
-					} ) ) }
-					onChange={ onChange }
-				/>
-			);
-		case 'textarea':
-			return (
-				<TextControl
-					key={ key }
-					label={ label }
-					help={ help }
-					value={ value || '' }
-					placeholder={ placeholder }
-					onChange={ onChange }
-					isTextarea
-				/>
-			);
-		case 'number':
-			return (
-				<TextControl
-					key={ key }
-					label={ label }
-					help={ help }
-					value={ value ?? '' }
-					placeholder={ placeholder }
-					onChange={ onChange }
-					type="number"
-				/>
-			);
-		case 'password':
-			return (
-				<TextControl
-					key={ key }
-					label={ label }
-					help={ help }
-					value={ value || '' }
-					placeholder={ placeholder }
-					onChange={ onChange }
-					type="password"
-				/>
-			);
-		case 'text':
-		default:
-			return <TextControl key={ key } label={ label } help={ help } value={ value || '' } placeholder={ placeholder } onChange={ onChange } />;
-	}
-}
-
-function AudienceIntegrations( props, ref ) {
+const AudienceIntegrations = ( props, ref ) => {
 	const [ integrations, setIntegrations ] = useState( {} );
 	const [ pendingChanges, setPendingChanges ] = useState( {} );
 	const [ saving, setSaving ] = useState( {} );
@@ -265,6 +163,6 @@ function AudienceIntegrations( props, ref ) {
 			ref={ ref }
 		/>
 	);
-}
+};
 
 export default withWizard( forwardRef( AudienceIntegrations ) );

--- a/src/wizards/audience/views/integrations/index.js
+++ b/src/wizards/audience/views/integrations/index.js
@@ -8,11 +8,8 @@ import { forwardRef, useState, useEffect, useCallback } from '@wordpress/element
 /**
  * Internal dependencies.
  */
-import { ActionCard, Button, Card, Grid, Wizard, withWizard } from '../../../../../packages/components/src';
-import WizardsTab from '../../../wizards-tab';
-import WizardSection from '../../../wizards-section';
-
-import { SettingsField } from './settings-field';
+import { Wizard, withWizard } from '../../../../../packages/components/src';
+import { SettingsSection } from './settings-section';
 
 const API_PATH = '/newspack/v1/wizard/newspack-audience-integrations/settings';
 
@@ -37,7 +34,7 @@ const AudienceIntegrations = ( props, ref ) => {
 		fetchSettings();
 	}, [ fetchSettings ] );
 
-	const handleFieldChange = ( integrationId, fieldKey, value ) => {
+	const handleFieldChange = useCallback( ( integrationId, fieldKey, value ) => {
 		setPendingChanges( prev => ( {
 			...prev,
 			[ integrationId ]: {
@@ -45,33 +42,36 @@ const AudienceIntegrations = ( props, ref ) => {
 				[ fieldKey ]: value,
 			},
 		} ) );
-	};
+	}, [] );
 
-	const handleSave = integrationId => {
-		const changes = pendingChanges[ integrationId ];
-		if ( ! changes || Object.keys( changes ).length === 0 ) {
-			return;
-		}
-		setSaving( prev => ( { ...prev, [ integrationId ]: true } ) );
-		apiFetch( {
-			path: `${ API_PATH }/${ integrationId }`,
-			method: 'POST',
-			data: { settings: changes },
-		} )
-			.then( data => {
-				setIntegrations( data );
-				setPendingChanges( prev => {
-					const next = { ...prev };
-					delete next[ integrationId ];
-					return next;
-				} );
+	const handleSave = useCallback( integrationId => {
+		setPendingChanges( currentPendingChanges => {
+			const changes = currentPendingChanges[ integrationId ];
+			if ( ! changes || Object.keys( changes ).length === 0 ) {
+				return currentPendingChanges;
+			}
+			setSaving( prev => ( { ...prev, [ integrationId ]: true } ) );
+			apiFetch( {
+				path: `${ API_PATH }/${ integrationId }`,
+				method: 'POST',
+				data: { settings: changes },
 			} )
-			.finally( () => {
-				setSaving( prev => ( { ...prev, [ integrationId ]: false } ) );
-			} );
-	};
+				.then( data => {
+					setIntegrations( data );
+					setPendingChanges( prev => {
+						const next = { ...prev };
+						delete next[ integrationId ];
+						return next;
+					} );
+				} )
+				.finally( () => {
+					setSaving( prev => ( { ...prev, [ integrationId ]: false } ) );
+				} );
+			return currentPendingChanges;
+		} );
+	}, [] );
 
-	const handleToggleEnabled = ( integrationId, enabled ) => {
+	const handleToggleEnabled = useCallback( ( integrationId, enabled ) => {
 		setToggling( prev => ( { ...prev, [ integrationId ]: true } ) );
 		apiFetch( {
 			path: `${ API_PATH }/${ integrationId }/enabled`,
@@ -84,16 +84,7 @@ const AudienceIntegrations = ( props, ref ) => {
 			.finally( () => {
 				setToggling( prev => ( { ...prev, [ integrationId ]: false } ) );
 			} );
-	};
-
-	const getFieldValue = ( integrationId, field ) => {
-		if ( pendingChanges[ integrationId ] && field.key in pendingChanges[ integrationId ] ) {
-			return pendingChanges[ integrationId ][ field.key ];
-		}
-		return field.value;
-	};
-
-	const integrationIds = Object.keys( integrations );
+	}, [] );
 
 	return (
 		<Wizard
@@ -102,62 +93,17 @@ const AudienceIntegrations = ( props, ref ) => {
 				{
 					label: __( 'Settings', 'newspack-plugin' ),
 					path: '/settings',
-					render: () => (
-						<WizardsTab title={ __( 'Integrations Settings', 'newspack-plugin' ) }>
-							<WizardSection>
-								{ loading && <p>{ __( 'Loading…', 'newspack-plugin' ) }</p> }
-								{ ! loading && integrationIds.length === 0 && (
-									<Card>
-										<p>{ __( 'No integrations with configurable settings are registered.', 'newspack-plugin' ) }</p>
-									</Card>
-								) }
-								{ ! loading &&
-									integrationIds.map( id => {
-										const integration = integrations[ id ];
-										const hasPending = pendingChanges[ id ] && Object.keys( pendingChanges[ id ] ).length > 0;
-										const isEnabled = integration.enabled;
-										return (
-											<ActionCard
-												key={ id }
-												title={ integration.name }
-												description={ integration.description }
-												toggleChecked={ isEnabled }
-												toggleOnChange={ () => handleToggleEnabled( id, ! isEnabled ) }
-												disabled={ toggling[ id ] }
-												hasGreyHeader={ isEnabled }
-												actionContent={
-													isEnabled ? (
-														<Button
-															variant="primary"
-															onClick={ () => handleSave( id ) }
-															disabled={ ! hasPending || saving[ id ] }
-															isBusy={ saving[ id ] }
-														>
-															{ __( 'Save Settings', 'newspack-plugin' ) }
-														</Button>
-													) : null
-												}
-											>
-												{ isEnabled && (
-													<>
-														<Grid columns={ 1 } rowGap={ 16 }>
-															{ integration.settings.map( field => (
-																<SettingsField
-																	key={ field.key }
-																	field={ field }
-																	value={ getFieldValue( id, field ) }
-																	onChange={ val => handleFieldChange( id, field.key, val ) }
-																/>
-															) ) }
-														</Grid>
-													</>
-												) }
-											</ActionCard>
-										);
-									} ) }
-							</WizardSection>
-						</WizardsTab>
-					),
+					render: SettingsSection,
+					props: {
+						integrations,
+						pendingChanges,
+						saving,
+						toggling,
+						loading,
+						onFieldChange: handleFieldChange,
+						onSave: handleSave,
+						onToggleEnabled: handleToggleEnabled,
+					},
 				},
 			] }
 			ref={ ref }

--- a/src/wizards/audience/views/integrations/index.js
+++ b/src/wizards/audience/views/integrations/index.js
@@ -72,10 +72,10 @@ function SettingsField( { field, value, onChange } ) {
 				<div key={ key }>
 					<h3>{ label }</h3>
 					<Grid columns={ 3 } rowGap={ 16 }>
-						{ availableFields.map( ( fieldName, index ) => (
+						{ availableFields.map( fieldName => (
 							<CheckboxControl
 								className="newspack-checkbox-control"
-								key={ index }
+								key={ fieldName }
 								label={ fieldName.replace( ': ', '' ) }
 								checked={ selectedFields.includes( fieldName ) }
 								onChange={ checked => {

--- a/src/wizards/audience/views/integrations/index.js
+++ b/src/wizards/audience/views/integrations/index.js
@@ -1,4 +1,3 @@
-/* global newspackAudienceIntegrations */
 /**
  * WordPress dependencies.
  */
@@ -10,17 +9,7 @@ import { CheckboxControl, ExternalLink } from '@wordpress/components';
 /**
  * Internal dependencies.
  */
-import {
-	ActionCard,
-	Button,
-	Card,
-	FormTokenField,
-	Grid,
-	SelectControl,
-	TextControl,
-	Wizard,
-	withWizard,
-} from '../../../../../packages/components/src';
+import { ActionCard, Button, Card, Grid, SelectControl, TextControl, Wizard, withWizard } from '../../../../../packages/components/src';
 import WizardsTab from '../../../wizards-tab';
 import WizardSection from '../../../wizards-section';
 
@@ -49,30 +38,13 @@ function SettingsField( { field, value, onChange } ) {
 	);
 
 	switch ( type ) {
-		case 'checkbox':
-			return <CheckboxControl key={ key } label={ label } help={ help } checked={ !! value } onChange={ onChange } />;
-		case 'select':
-			return (
-				<SelectControl
-					key={ key }
-					label={ label }
-					help={ help }
-					value={ value }
-					options={ ( options || [] ).map( opt => ( {
-						label: opt.label,
-						value: opt.value,
-					} ) ) }
-					onChange={ onChange }
-				/>
-			);
-		case 'outgoing_metadata': {
-			const availableFields = newspackAudienceIntegrations?.esp_metadata_fields || [];
+		case 'metadata': {
 			const selectedFields = Array.isArray( value ) ? value : [];
 			return (
 				<div key={ key }>
 					<h3>{ label }</h3>
 					<Grid columns={ 3 } rowGap={ 16 }>
-						{ availableFields.map( fieldName => (
+						{ options.map( fieldName => (
 							<CheckboxControl
 								className="newspack-checkbox-control"
 								key={ fieldName }
@@ -88,22 +60,21 @@ function SettingsField( { field, value, onChange } ) {
 				</div>
 			);
 		}
-		case 'incoming_metadata':
+		case 'checkbox':
+			return <CheckboxControl key={ key } label={ label } help={ help } checked={ !! value } onChange={ onChange } />;
+		case 'select':
 			return (
-				<div key={ key }>
-					<h3>{ label }</h3>
-					<Grid columns={ 1 } rowGap={ 16 }>
-						<FormTokenField
-							key={ key }
-							label={ null }
-							description={ help }
-							value={ Array.isArray( value ) ? value : [] }
-							onChange={ onChange }
-							__next40pxDefaultSize
-							tokenizeOnBlur
-						/>
-					</Grid>
-				</div>
+				<SelectControl
+					key={ key }
+					label={ label }
+					help={ help }
+					value={ value }
+					options={ ( options || [] ).map( opt => ( {
+						label: opt.label,
+						value: opt.value,
+					} ) ) }
+					onChange={ onChange }
+				/>
 			);
 		case 'textarea':
 			return (

--- a/src/wizards/audience/views/integrations/settings-field.js
+++ b/src/wizards/audience/views/integrations/settings-field.js
@@ -1,0 +1,113 @@
+/**
+ * WordPress dependencies.
+ */
+import { __ } from '@wordpress/i18n';
+import { CheckboxControl, ExternalLink } from '@wordpress/components';
+
+/**
+ * Internal dependencies.
+ */
+import { Grid, SelectControl, TextControl } from '../../../../../packages/components/src';
+
+/**
+ * Render a single settings field.
+ *
+ * @param {Object}   props          Component props.
+ * @param {Object}   props.field    Field declaration.
+ * @param {*}        props.value    Current value.
+ * @param {Function} props.onChange Change handler.
+ */
+export const SettingsField = ( { field, value, onChange } ) => {
+	const { key, type, label, description, placeholder, options, help_url: helpUrl } = field;
+	const help = (
+		<>
+			{ description }
+			{ helpUrl && (
+				<>
+					{ ' ' }
+					<ExternalLink href={ helpUrl }>{ __( 'Learn more', 'newspack-plugin' ) }</ExternalLink>
+				</>
+			) }
+		</>
+	);
+
+	switch ( type ) {
+		case 'metadata': {
+			const selectedFields = Array.isArray( value ) ? value : [];
+			return (
+				<div key={ key }>
+					<h3>{ label }</h3>
+					<Grid columns={ 3 } rowGap={ 16 }>
+						{ options.map( fieldName => (
+							<CheckboxControl
+								className="newspack-checkbox-control"
+								key={ fieldName }
+								label={ fieldName.replace( ': ', '' ) }
+								checked={ selectedFields.includes( fieldName ) }
+								onChange={ checked => {
+									const newFields = checked ? [ ...selectedFields, fieldName ] : selectedFields.filter( f => f !== fieldName );
+									onChange( newFields );
+								} }
+							/>
+						) ) }
+					</Grid>
+				</div>
+			);
+		}
+		case 'checkbox':
+			return <CheckboxControl key={ key } label={ label } help={ help } checked={ !! value } onChange={ onChange } />;
+		case 'select':
+			return (
+				<SelectControl
+					key={ key }
+					label={ label }
+					help={ help }
+					value={ value }
+					options={ ( options || [] ).map( opt => ( {
+						label: opt.label,
+						value: opt.value,
+					} ) ) }
+					onChange={ onChange }
+				/>
+			);
+		case 'textarea':
+			return (
+				<TextControl
+					key={ key }
+					label={ label }
+					help={ help }
+					value={ value || '' }
+					placeholder={ placeholder }
+					onChange={ onChange }
+					isTextarea
+				/>
+			);
+		case 'number':
+			return (
+				<TextControl
+					key={ key }
+					label={ label }
+					help={ help }
+					value={ value ?? '' }
+					placeholder={ placeholder }
+					onChange={ onChange }
+					type="number"
+				/>
+			);
+		case 'password':
+			return (
+				<TextControl
+					key={ key }
+					label={ label }
+					help={ help }
+					value={ value || '' }
+					placeholder={ placeholder }
+					onChange={ onChange }
+					type="password"
+				/>
+			);
+		case 'text':
+		default:
+			return <TextControl key={ key } label={ label } help={ help } value={ value || '' } placeholder={ placeholder } onChange={ onChange } />;
+	}
+};

--- a/src/wizards/audience/views/integrations/settings-section.js
+++ b/src/wizards/audience/views/integrations/settings-section.js
@@ -1,0 +1,77 @@
+/**
+ * Internal dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { ActionCard, Button, Card, Grid } from '../../../../../packages/components/src';
+import WizardsTab from '../../../wizards-tab';
+import WizardSection from '../../../wizards-section';
+
+import { SettingsField } from './settings-field';
+
+export const SettingsSection = ( { integrations, pendingChanges, saving, toggling, loading, onFieldChange, onSave, onToggleEnabled } ) => {
+	const getFieldValue = ( integrationId, field ) => {
+		if ( pendingChanges[ integrationId ] && field.key in pendingChanges[ integrationId ] ) {
+			return pendingChanges[ integrationId ][ field.key ];
+		}
+		return field.value;
+	};
+
+	const integrationIds = Object.keys( integrations );
+
+	return (
+		<WizardsTab title={ __( 'Integrations Settings', 'newspack-plugin' ) }>
+			<WizardSection>
+				{ loading && <p>{ __( 'Loading…', 'newspack-plugin' ) }</p> }
+				{ ! loading && integrationIds.length === 0 && (
+					<Card>
+						<p>{ __( 'No integrations with configurable settings are registered.', 'newspack-plugin' ) }</p>
+					</Card>
+				) }
+				{ ! loading &&
+					integrationIds.map( id => {
+						const integration = integrations[ id ];
+						const hasPending = pendingChanges[ id ] && Object.keys( pendingChanges[ id ] ).length > 0;
+						const isEnabled = integration.enabled;
+						return (
+							<ActionCard
+								key={ id }
+								title={ integration.name }
+								description={ integration.description }
+								toggleChecked={ isEnabled }
+								toggleOnChange={ () => onToggleEnabled( id, ! isEnabled ) }
+								disabled={ toggling[ id ] }
+								hasGreyHeader={ isEnabled }
+								actionContent={
+									isEnabled ? (
+										<Button
+											variant="primary"
+											onClick={ () => onSave( id ) }
+											disabled={ ! hasPending || saving[ id ] }
+											isBusy={ saving[ id ] }
+										>
+											{ __( 'Save Settings', 'newspack-plugin' ) }
+										</Button>
+									) : null
+								}
+							>
+								{ isEnabled && (
+									<>
+										<Grid columns={ 1 } rowGap={ 16 }>
+											{ integration.settings.map( field => (
+												<SettingsField
+													key={ field.key }
+													field={ field }
+													value={ getFieldValue( id, field ) }
+													onChange={ val => onFieldChange( id, field.key, val ) }
+												/>
+											) ) }
+										</Grid>
+									</>
+								) }
+							</ActionCard>
+						);
+					} ) }
+			</WizardSection>
+		</WizardsTab>
+	);
+};

--- a/src/wizards/index.tsx
+++ b/src/wizards/index.tsx
@@ -58,6 +58,14 @@ const components: Record< string, any > = {
 	},
 } as const;
 
+// Conditionally add the Audience Integrations page if the feature is enabled.
+if ( window.newspackAudienceIntegrations?.integrations_settings_enabled ) {
+	components[ 'newspack-audience-integrations' ] = {
+		label: __( 'Audience Integrations', 'newspack-plugin' ),
+		component: lazy( () => import( /* webpackChunkName: "audience-wizards" */ './audience/views/integrations' ) ),
+	};
+}
+
 const AdminPageLoader = ( { label }: { label: string } ) => {
 	return (
 		<div className="newspack-wizard__loader">

--- a/src/wizards/types/window.d.ts
+++ b/src/wizards/types/window.d.ts
@@ -57,6 +57,9 @@ declare global {
 			}>;
 			upgrade_subscription_url: string;
 		};
+		newspackAudienceIntegrations: {
+			integrations_settings_enabled: boolean;
+		};
 		newspackAudienceContentGates: {
 			api: string;
 			available_access_rules: AccessRules;

--- a/tests/mocks/newsletters-mocks.php
+++ b/tests/mocks/newsletters-mocks.php
@@ -11,5 +11,47 @@ if ( ! class_exists( 'Newspack_Newsletters' ) ) {
 		public static function service_provider() {
 			return get_option( 'newspack_newsletters_service_provider', false );
 		}
+
+		public static function get_service_provider() {
+			return new Newspack_Newsletters_Service_Provider();
+		}
+
+		public static function is_service_provider_configured() {
+			return true;
+		}
+	}
+}
+
+if ( ! class_exists( 'Newspack_Newsletters_Settings' ) ) {
+	class Newspack_Newsletters_Settings {}
+}
+
+if ( ! class_exists( 'Newspack_Newsletters_Subscription' ) ) {
+	class Newspack_Newsletters_Subscription {
+		public static function get_lists() {
+			return [
+				[
+					'active' => true,
+					'name'   => 'test',
+					'id'     => '123',
+				],
+			];
+		}
+	}
+}
+
+if ( ! class_exists( 'Newspack_Newsletters_Service_Provider' ) ) {
+	class Newspack_Newsletters_Service_Provider {
+		public $service = 'mailchimp';
+
+		public static function get_lists() {
+			return [
+				[
+					'active' => true,
+					'name'   => 'test',
+					'id'     => '123',
+				],
+			];
+		}
 	}
 }

--- a/tests/unit-tests/integrations/class-failing-sample-integration.php
+++ b/tests/unit-tests/integrations/class-failing-sample-integration.php
@@ -72,11 +72,9 @@ class Failing_Sample_Integration extends Integration {
 	/**
 	 * Get incoming available contact fields (test implementation).
 	 *
-	 * @param bool $filtered Whether to return only filtered fields.
-	 *
 	 * @return array
 	 */
-	public function get_available_incoming_contact_fields( $filtered = false ) {
+	public function get_available_incoming_contact_fields() {
 		return [];
 	}
 

--- a/tests/unit-tests/integrations/class-failing-sample-integration.php
+++ b/tests/unit-tests/integrations/class-failing-sample-integration.php
@@ -26,6 +26,14 @@ class Failing_Sample_Integration extends Integration {
 	public static $push_count = 0;
 
 	/**
+	 * Register settings fields (test implementation).
+	 */
+	public function register_settings_fields() {
+		// No settings fields for this test implementation.
+		$this->settings_fields = [];
+	}
+
+	/**
 	 * Push contact data (test implementation).
 	 *
 	 * @param array      $contact The contact data.

--- a/tests/unit-tests/integrations/class-failing-sample-integration.php
+++ b/tests/unit-tests/integrations/class-failing-sample-integration.php
@@ -72,9 +72,11 @@ class Failing_Sample_Integration extends Integration {
 	/**
 	 * Get incoming available contact fields (test implementation).
 	 *
+	 * @param bool $filtered Whether to return only filtered fields.
+	 *
 	 * @return array
 	 */
-	public function get_available_incoming_contact_fields() {
+	public function get_available_incoming_contact_fields( $filtered = false ) {
 		return [];
 	}
 

--- a/tests/unit-tests/integrations/class-failing-sample-integration.php
+++ b/tests/unit-tests/integrations/class-failing-sample-integration.php
@@ -74,7 +74,7 @@ class Failing_Sample_Integration extends Integration {
 	 *
 	 * @return array
 	 */
-	public function get_incoming_available_contact_fields() {
+	public function get_available_incoming_contact_fields() {
 		return [];
 	}
 

--- a/tests/unit-tests/integrations/class-failing-sample-integration.php
+++ b/tests/unit-tests/integrations/class-failing-sample-integration.php
@@ -30,7 +30,7 @@ class Failing_Sample_Integration extends Integration {
 	 */
 	public function register_settings_fields() {
 		// No settings fields for this test implementation.
-		$this->settings_fields = [];
+		return [];
 	}
 
 	/**

--- a/tests/unit-tests/integrations/class-sample-integration.php
+++ b/tests/unit-tests/integrations/class-sample-integration.php
@@ -23,7 +23,7 @@ class Sample_Integration extends Integration {
 	 */
 	public function register_settings_fields() {
 		// No settings fields for this test implementation.
-		$this->settings_fields = [];
+		return [];
 	}
 
 	/**

--- a/tests/unit-tests/integrations/class-sample-integration.php
+++ b/tests/unit-tests/integrations/class-sample-integration.php
@@ -97,9 +97,11 @@ class Sample_Integration extends Integration {
 	 * This method should be implemented by child classes to return
 	 * an array of available contact fields from their integration.
 	 *
+	 * @param bool $filtered Whether to return only filtered fields.
+	 *
 	 * @return Integrations\Incoming_Contact_Field[]|\WP_Error Array of incoming contact field objects or WP_Error on failure.
 	 */
-	public function get_available_incoming_contact_fields() {
+	public function get_available_incoming_contact_fields( $filtered = false ) {
 		return [];
 	}
 }

--- a/tests/unit-tests/integrations/class-sample-integration.php
+++ b/tests/unit-tests/integrations/class-sample-integration.php
@@ -99,7 +99,7 @@ class Sample_Integration extends Integration {
 	 *
 	 * @return Integrations\Incoming_Contact_Field[]|\WP_Error Array of incoming contact field objects or WP_Error on failure.
 	 */
-	public function get_incoming_available_contact_fields() {
+	public function get_available_incoming_contact_fields() {
 		return [];
 	}
 }

--- a/tests/unit-tests/integrations/class-sample-integration.php
+++ b/tests/unit-tests/integrations/class-sample-integration.php
@@ -97,11 +97,9 @@ class Sample_Integration extends Integration {
 	 * This method should be implemented by child classes to return
 	 * an array of available contact fields from their integration.
 	 *
-	 * @param bool $filtered Whether to return only filtered fields.
-	 *
 	 * @return Integrations\Incoming_Contact_Field[]|\WP_Error Array of incoming contact field objects or WP_Error on failure.
 	 */
-	public function get_available_incoming_contact_fields( $filtered = false ) {
+	public function get_available_incoming_contact_fields() {
 		return [];
 	}
 }

--- a/tests/unit-tests/integrations/class-sample-integration.php
+++ b/tests/unit-tests/integrations/class-sample-integration.php
@@ -19,6 +19,14 @@ class Sample_Integration extends Integration {
 	public static $handler_args = null;
 
 	/**
+	 * Register settings fields (test implementation).
+	 */
+	public function register_settings_fields() {
+		// No settings fields for this test implementation.
+		$this->settings_fields = [];
+	}
+
+	/**
 	 * Push contact data (test implementation).
 	 *
 	 * @param array      $contact The contact data.

--- a/tests/unit-tests/integrations/class-test-integrations.php
+++ b/tests/unit-tests/integrations/class-test-integrations.php
@@ -323,19 +323,19 @@ class Test_Integrations extends \WP_UnitTestCase {
 	public function test_get_incoming_fields_default_empty() {
 		$integration = new Sample_Integration( 'test-id', 'Test Integration' );
 
-		$this->assertSame( [], $integration->get_incoming_fields() );
+		$this->assertSame( [], $integration->get_enabled_incoming_fields() );
 	}
 
 	/**
 	 * Test update_incoming_fields and get_incoming_fields round-trip.
 	 */
-	public function test_set_and_get_incoming_fields() {
+	public function test_set_and_get_enabled_incoming_fields() {
 		$integration = new Sample_Integration( 'test-id', 'Test Integration' );
 		$fields      = [ 'first_name', 'last_name', 'phone' ];
 
-		$integration->update_incoming_fields( $fields );
+		$integration->update_enabled_incoming_fields( $fields );
 
-		$this->assertSame( $fields, $integration->get_incoming_fields() );
+		$this->assertSame( $fields, $integration->get_enabled_incoming_fields() );
 	}
 
 	/**
@@ -345,9 +345,9 @@ class Test_Integrations extends \WP_UnitTestCase {
 		$integration = new Sample_Integration( 'test-id', 'Test Integration' );
 		$fields      = [ 'nonexistent_field', 'another_unknown' ];
 
-		$integration->update_incoming_fields( $fields );
+		$integration->update_enabled_incoming_fields( $fields );
 
-		$this->assertSame( $fields, $integration->get_incoming_fields() );
+		$this->assertSame( $fields, $integration->get_enabled_incoming_fields() );
 	}
 
 	/**
@@ -403,7 +403,7 @@ class Test_Integrations extends \WP_UnitTestCase {
 			}
 		};
 
-		$integration->update_incoming_fields( [ 'favorite_color' ] );
+		$integration->update_enabled_incoming_fields( [ 'favorite_color' ] );
 		Integrations::register( $integration );
 		Integrations::enable( 'pull-test' );
 
@@ -445,7 +445,7 @@ class Test_Integrations extends \WP_UnitTestCase {
 		};
 
 		// Only select fields a and c.
-		$integration->update_incoming_fields( [ 'field_a', 'field_c' ] );
+		$integration->update_enabled_incoming_fields( [ 'field_a', 'field_c' ] );
 		Integrations::register( $integration );
 		Integrations::enable( 'filter-test' );
 
@@ -481,7 +481,7 @@ class Test_Integrations extends \WP_UnitTestCase {
 			}
 		};
 
-		$integration->update_incoming_fields( [ 'some_field' ] );
+		$integration->update_enabled_incoming_fields( [ 'some_field' ] );
 		Integrations::register( $integration );
 		Integrations::enable( 'throw-test' );
 
@@ -516,7 +516,7 @@ class Test_Integrations extends \WP_UnitTestCase {
 			}
 		};
 
-		$integration->update_incoming_fields( [ 'city' ] );
+		$integration->update_enabled_incoming_fields( [ 'city' ] );
 		Integrations::register( $integration );
 		Integrations::enable( 'async-test' );
 
@@ -554,7 +554,7 @@ class Test_Integrations extends \WP_UnitTestCase {
 			}
 		};
 
-		$integration->update_incoming_fields( [ 'language' ] );
+		$integration->update_enabled_incoming_fields( [ 'language' ] );
 		Integrations::register( $integration );
 		Integrations::enable( 'handle-test' );
 
@@ -587,7 +587,7 @@ class Test_Integrations extends \WP_UnitTestCase {
 			}
 		};
 
-		$integration->update_incoming_fields( [ 'pet' ] );
+		$integration->update_enabled_incoming_fields( [ 'pet' ] );
 		Integrations::register( $integration );
 		// Not enabled.
 
@@ -623,7 +623,7 @@ class Test_Integrations extends \WP_UnitTestCase {
 			}
 		};
 
-		$integration->update_incoming_fields( [ 'first_field' ] );
+		$integration->update_enabled_incoming_fields( [ 'first_field' ] );
 		Integrations::register( $integration );
 		Integrations::enable( 'first-test' );
 
@@ -656,7 +656,7 @@ class Test_Integrations extends \WP_UnitTestCase {
 			}
 		};
 
-		$integration->update_incoming_fields( [ 'timeout_field' ] );
+		$integration->update_enabled_incoming_fields( [ 'timeout_field' ] );
 		Integrations::register( $integration );
 		Integrations::enable( 'timeout-test' );
 
@@ -935,7 +935,7 @@ class Test_Integrations extends \WP_UnitTestCase {
 			}
 		};
 
-		$integration->update_incoming_fields( [ 'ajax_field' ] );
+		$integration->update_enabled_incoming_fields( [ 'ajax_field' ] );
 		Integrations::register( $integration );
 		Integrations::enable( 'ajax-test' );
 

--- a/tests/unit-tests/integrations/class-test-integrations.php
+++ b/tests/unit-tests/integrations/class-test-integrations.php
@@ -294,7 +294,7 @@ class Test_Integrations extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test get_incoming_contact_fields propagates WP_Error from get_incoming_available_contact_fields.
+	 * Test get_incoming_contact_fields propagates WP_Error from get_available_incoming_contact_fields.
 	 */
 	public function test_get_incoming_contact_fields_propagates_error() {
 		$integration = new class( 'error-test', 'Error Test' ) extends Sample_Integration {
@@ -303,7 +303,7 @@ class Test_Integrations extends \WP_UnitTestCase {
 			 *
 			 * @return \WP_Error
 			 */
-			public function get_incoming_available_contact_fields() {
+			public function get_available_incoming_contact_fields() {
 				return new \WP_Error( 'test_error', 'Test error message' );
 			}
 		};

--- a/tests/unit-tests/integrations/class-test-integrations.php
+++ b/tests/unit-tests/integrations/class-test-integrations.php
@@ -818,6 +818,105 @@ class Test_Integrations extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test get_metadata_prefix returns default 'NP_' when no custom prefix is set.
+	 */
+	public function test_get_metadata_prefix_default() {
+		$integration = new Sample_Integration( 'prefix-test', 'Prefix Test' );
+
+		$this->assertSame( 'NP_', $integration->get_metadata_prefix() );
+	}
+
+	/**
+	 * Test update_metadata_prefix stores and retrieves a custom prefix.
+	 */
+	public function test_update_and_get_metadata_prefix() {
+		$integration = new Sample_Integration( 'prefix-test', 'Prefix Test' );
+
+		$integration->update_metadata_prefix( 'CUSTOM_' );
+
+		$this->assertSame( 'CUSTOM_', $integration->get_metadata_prefix() );
+		$this->assertSame( 'CUSTOM_', get_option( 'newspack_integration_metadata_prefix_prefix-test' ) );
+	}
+
+	/**
+	 * Test update_metadata_prefix with empty string falls back to 'NP_'.
+	 */
+	public function test_update_metadata_prefix_empty_falls_back() {
+		$integration = new Sample_Integration( 'prefix-test', 'Prefix Test' );
+
+		$integration->update_metadata_prefix( 'CUSTOM_' );
+		$integration->update_metadata_prefix( '' );
+
+		$this->assertSame( 'NP_', $integration->get_metadata_prefix() );
+	}
+
+	/**
+	 * Test metadata prefix is isolated per integration.
+	 */
+	public function test_metadata_prefix_per_integration_isolation() {
+		$integration_a = new Sample_Integration( 'iso-a', 'Integration A' );
+		$integration_b = new Sample_Integration( 'iso-b', 'Integration B' );
+
+		$integration_a->update_metadata_prefix( 'AAA_' );
+		$integration_b->update_metadata_prefix( 'BBB_' );
+
+		$this->assertSame( 'AAA_', $integration_a->get_metadata_prefix() );
+		$this->assertSame( 'BBB_', $integration_b->get_metadata_prefix() );
+	}
+
+	/**
+	 * Test settings field value routing for metadata_prefix.
+	 */
+	public function test_settings_field_value_routes_metadata_prefix() {
+		$integration = new Sample_Integration( 'route-test', 'Route Test' );
+		$integration->init();
+
+		$this->assertTrue( $integration->update_settings_field_value( 'metadata_prefix', 'API_' ) );
+		$this->assertSame( 'API_', $integration->get_settings_field_value( 'metadata_prefix' ) );
+
+		// Verify it wrote to the dedicated option, not the generic settings option.
+		$this->assertSame( 'API_', get_option( 'newspack_integration_metadata_prefix_route-test' ) );
+		$this->assertFalse( get_option( 'newspack_integration_settings_route-test_metadata_prefix' ) );
+	}
+
+	/**
+	 * Test get_enabled_outgoing_fields_keys uses integration prefix when prefixed flag is true.
+	 */
+	public function test_get_enabled_outgoing_fields_keys_uses_integration_prefix() {
+		$integration = new Sample_Integration( 'keys-test', 'Keys Test' );
+		$integration->update_metadata_prefix( 'TEST_' );
+
+		$keys = $integration->get_enabled_outgoing_fields_keys( true );
+
+		$this->assertNotEmpty( $keys );
+		foreach ( $keys as $key ) {
+			$this->assertStringStartsWith( 'TEST_', $key, "Key '$key' should start with 'TEST_'" );
+		}
+	}
+
+	/**
+	 * Test get_settings_config includes metadata_prefix field with correct value.
+	 */
+	public function test_get_settings_config_includes_metadata_prefix() {
+		$integration = new Sample_Integration( 'config-test', 'Config Test' );
+		$integration->init();
+		$integration->update_metadata_prefix( 'CFG_' );
+
+		$config = $integration->get_settings_config();
+
+		$prefix_field = null;
+		foreach ( $config as $field ) {
+			if ( 'metadata_prefix' === $field['key'] ) {
+				$prefix_field = $field;
+				break;
+			}
+		}
+
+		$this->assertNotNull( $prefix_field, 'Settings config should contain a metadata_prefix field.' );
+		$this->assertSame( 'CFG_', $prefix_field['value'] );
+	}
+
+	/**
 	 * Test handle_ajax_pull processes data when called directly.
 	 */
 	public function test_handle_ajax_pull() {

--- a/tests/unit-tests/integrations/class-test-integrations.php
+++ b/tests/unit-tests/integrations/class-test-integrations.php
@@ -281,36 +281,38 @@ class Test_Integrations extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test get_incoming_contact_fields returns empty array when no fields available.
+	 * Test get_available_incoming_contact_fields returns empty array when no fields available.
 	 */
-	public function test_get_incoming_contact_fields_empty() {
+	public function test_get_available_incoming_contact_fields_empty() {
 		$integration = new Sample_Integration( 'test-id', 'Test Integration' );
 		Integrations::register( $integration );
 
-		$fields = $integration->get_incoming_contact_fields();
+		$fields = $integration->get_available_incoming_contact_fields();
 
 		$this->assertIsArray( $fields );
 		$this->assertEmpty( $fields );
 	}
 
 	/**
-	 * Test get_incoming_contact_fields propagates WP_Error from get_available_incoming_contact_fields.
+	 * Test get_available_incoming_contact_fields propagates WP_Error from get_available_incoming_contact_fields.
 	 */
-	public function test_get_incoming_contact_fields_propagates_error() {
+	public function test_get_available_incoming_contact_fields_propagates_error() {
 		$integration = new class( 'error-test', 'Error Test' ) extends Sample_Integration {
 			/**
 			 * Get incoming available contact fields (returns error for test).
 			 *
+			 * @param bool $filtered Whether to return only filtered fields.
+			 *
 			 * @return \WP_Error
 			 */
-			public function get_available_incoming_contact_fields() {
+			public function get_available_incoming_contact_fields( $filtered = false ) {
 				return new \WP_Error( 'test_error', 'Test error message' );
 			}
 		};
 
 		Integrations::register( $integration );
 
-		$result = $integration->get_incoming_contact_fields();
+		$result = $integration->get_available_incoming_contact_fields();
 
 		$this->assertWPError( $result );
 		$this->assertEquals( 'test_error', $result->get_error_code() );
@@ -885,6 +887,7 @@ class Test_Integrations extends \WP_UnitTestCase {
 	public function test_get_enabled_outgoing_fields_keys_uses_integration_prefix() {
 		$integration = new Sample_Integration( 'keys-test', 'Keys Test' );
 		$integration->update_metadata_prefix( 'TEST_' );
+		$integration->update_enabled_outgoing_fields( [ 'Account' ] );
 
 		$keys = $integration->get_enabled_outgoing_fields_keys( true );
 

--- a/tests/unit-tests/integrations/class-test-integrations.php
+++ b/tests/unit-tests/integrations/class-test-integrations.php
@@ -327,25 +327,25 @@ class Test_Integrations extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test set_incoming_fields and get_incoming_fields round-trip.
+	 * Test update_incoming_fields and get_incoming_fields round-trip.
 	 */
 	public function test_set_and_get_incoming_fields() {
 		$integration = new Sample_Integration( 'test-id', 'Test Integration' );
 		$fields      = [ 'first_name', 'last_name', 'phone' ];
 
-		$integration->set_incoming_fields( $fields );
+		$integration->update_incoming_fields( $fields );
 
 		$this->assertSame( $fields, $integration->get_incoming_fields() );
 	}
 
 	/**
-	 * Test set_incoming_fields stores any keys without validation.
+	 * Test update_incoming_fields stores any keys without validation.
 	 */
-	public function test_set_incoming_fields_stores_any_keys() {
+	public function test_update_incoming_fields_stores_any_keys() {
 		$integration = new Sample_Integration( 'test-id', 'Test Integration' );
 		$fields      = [ 'nonexistent_field', 'another_unknown' ];
 
-		$integration->set_incoming_fields( $fields );
+		$integration->update_incoming_fields( $fields );
 
 		$this->assertSame( $fields, $integration->get_incoming_fields() );
 	}
@@ -403,7 +403,7 @@ class Test_Integrations extends \WP_UnitTestCase {
 			}
 		};
 
-		$integration->set_incoming_fields( [ 'favorite_color' ] );
+		$integration->update_incoming_fields( [ 'favorite_color' ] );
 		Integrations::register( $integration );
 		Integrations::enable( 'pull-test' );
 
@@ -445,7 +445,7 @@ class Test_Integrations extends \WP_UnitTestCase {
 		};
 
 		// Only select fields a and c.
-		$integration->set_incoming_fields( [ 'field_a', 'field_c' ] );
+		$integration->update_incoming_fields( [ 'field_a', 'field_c' ] );
 		Integrations::register( $integration );
 		Integrations::enable( 'filter-test' );
 
@@ -481,7 +481,7 @@ class Test_Integrations extends \WP_UnitTestCase {
 			}
 		};
 
-		$integration->set_incoming_fields( [ 'some_field' ] );
+		$integration->update_incoming_fields( [ 'some_field' ] );
 		Integrations::register( $integration );
 		Integrations::enable( 'throw-test' );
 
@@ -516,7 +516,7 @@ class Test_Integrations extends \WP_UnitTestCase {
 			}
 		};
 
-		$integration->set_incoming_fields( [ 'city' ] );
+		$integration->update_incoming_fields( [ 'city' ] );
 		Integrations::register( $integration );
 		Integrations::enable( 'async-test' );
 
@@ -554,7 +554,7 @@ class Test_Integrations extends \WP_UnitTestCase {
 			}
 		};
 
-		$integration->set_incoming_fields( [ 'language' ] );
+		$integration->update_incoming_fields( [ 'language' ] );
 		Integrations::register( $integration );
 		Integrations::enable( 'handle-test' );
 
@@ -587,7 +587,7 @@ class Test_Integrations extends \WP_UnitTestCase {
 			}
 		};
 
-		$integration->set_incoming_fields( [ 'pet' ] );
+		$integration->update_incoming_fields( [ 'pet' ] );
 		Integrations::register( $integration );
 		// Not enabled.
 
@@ -623,7 +623,7 @@ class Test_Integrations extends \WP_UnitTestCase {
 			}
 		};
 
-		$integration->set_incoming_fields( [ 'first_field' ] );
+		$integration->update_incoming_fields( [ 'first_field' ] );
 		Integrations::register( $integration );
 		Integrations::enable( 'first-test' );
 
@@ -656,7 +656,7 @@ class Test_Integrations extends \WP_UnitTestCase {
 			}
 		};
 
-		$integration->set_incoming_fields( [ 'timeout_field' ] );
+		$integration->update_incoming_fields( [ 'timeout_field' ] );
 		Integrations::register( $integration );
 		Integrations::enable( 'timeout-test' );
 
@@ -935,7 +935,7 @@ class Test_Integrations extends \WP_UnitTestCase {
 			}
 		};
 
-		$integration->set_incoming_fields( [ 'ajax_field' ] );
+		$integration->update_incoming_fields( [ 'ajax_field' ] );
 		Integrations::register( $integration );
 		Integrations::enable( 'ajax-test' );
 

--- a/tests/unit-tests/integrations/class-test-integrations.php
+++ b/tests/unit-tests/integrations/class-test-integrations.php
@@ -301,11 +301,9 @@ class Test_Integrations extends \WP_UnitTestCase {
 			/**
 			 * Get incoming available contact fields (returns error for test).
 			 *
-			 * @param bool $filtered Whether to return only filtered fields.
-			 *
 			 * @return \WP_Error
 			 */
-			public function get_available_incoming_contact_fields( $filtered = false ) {
+			public function get_available_incoming_contact_fields() {
 				return new \WP_Error( 'test_error', 'Test error message' );
 			}
 		};

--- a/tests/unit-tests/integrations/class-test-integrations.php
+++ b/tests/unit-tests/integrations/class-test-integrations.php
@@ -318,36 +318,36 @@ class Test_Integrations extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test get_selected_fields returns empty array by default.
+	 * Test get_incoming_fields returns empty array by default.
 	 */
-	public function test_get_selected_fields_default_empty() {
+	public function test_get_incoming_fields_default_empty() {
 		$integration = new Sample_Integration( 'test-id', 'Test Integration' );
 
-		$this->assertSame( [], $integration->get_selected_fields() );
+		$this->assertSame( [], $integration->get_incoming_fields() );
 	}
 
 	/**
-	 * Test set_selected_fields and get_selected_fields round-trip.
+	 * Test set_incoming_fields and get_incoming_fields round-trip.
 	 */
-	public function test_set_and_get_selected_fields() {
+	public function test_set_and_get_incoming_fields() {
 		$integration = new Sample_Integration( 'test-id', 'Test Integration' );
 		$fields      = [ 'first_name', 'last_name', 'phone' ];
 
-		$integration->set_selected_fields( $fields );
+		$integration->set_incoming_fields( $fields );
 
-		$this->assertSame( $fields, $integration->get_selected_fields() );
+		$this->assertSame( $fields, $integration->get_incoming_fields() );
 	}
 
 	/**
-	 * Test set_selected_fields stores any keys without validation.
+	 * Test set_incoming_fields stores any keys without validation.
 	 */
-	public function test_set_selected_fields_stores_any_keys() {
+	public function test_set_incoming_fields_stores_any_keys() {
 		$integration = new Sample_Integration( 'test-id', 'Test Integration' );
 		$fields      = [ 'nonexistent_field', 'another_unknown' ];
 
-		$integration->set_selected_fields( $fields );
+		$integration->set_incoming_fields( $fields );
 
-		$this->assertSame( $fields, $integration->get_selected_fields() );
+		$this->assertSame( $fields, $integration->get_incoming_fields() );
 	}
 
 	/**
@@ -403,7 +403,7 @@ class Test_Integrations extends \WP_UnitTestCase {
 			}
 		};
 
-		$integration->set_selected_fields( [ 'favorite_color' ] );
+		$integration->set_incoming_fields( [ 'favorite_color' ] );
 		Integrations::register( $integration );
 		Integrations::enable( 'pull-test' );
 
@@ -422,7 +422,7 @@ class Test_Integrations extends \WP_UnitTestCase {
 	/**
 	 * Test sync pull filters returned data by selected fields only.
 	 */
-	public function test_sync_pull_filters_by_selected_fields() {
+	public function test_sync_pull_filters_by_incoming_fields() {
 		$user_id = $this->factory()->user->create();
 		wp_set_current_user( $user_id );
 
@@ -445,7 +445,7 @@ class Test_Integrations extends \WP_UnitTestCase {
 		};
 
 		// Only select fields a and c.
-		$integration->set_selected_fields( [ 'field_a', 'field_c' ] );
+		$integration->set_incoming_fields( [ 'field_a', 'field_c' ] );
 		Integrations::register( $integration );
 		Integrations::enable( 'filter-test' );
 
@@ -481,7 +481,7 @@ class Test_Integrations extends \WP_UnitTestCase {
 			}
 		};
 
-		$integration->set_selected_fields( [ 'some_field' ] );
+		$integration->set_incoming_fields( [ 'some_field' ] );
 		Integrations::register( $integration );
 		Integrations::enable( 'throw-test' );
 
@@ -516,7 +516,7 @@ class Test_Integrations extends \WP_UnitTestCase {
 			}
 		};
 
-		$integration->set_selected_fields( [ 'city' ] );
+		$integration->set_incoming_fields( [ 'city' ] );
 		Integrations::register( $integration );
 		Integrations::enable( 'async-test' );
 
@@ -554,7 +554,7 @@ class Test_Integrations extends \WP_UnitTestCase {
 			}
 		};
 
-		$integration->set_selected_fields( [ 'language' ] );
+		$integration->set_incoming_fields( [ 'language' ] );
 		Integrations::register( $integration );
 		Integrations::enable( 'handle-test' );
 
@@ -587,7 +587,7 @@ class Test_Integrations extends \WP_UnitTestCase {
 			}
 		};
 
-		$integration->set_selected_fields( [ 'pet' ] );
+		$integration->set_incoming_fields( [ 'pet' ] );
 		Integrations::register( $integration );
 		// Not enabled.
 
@@ -623,7 +623,7 @@ class Test_Integrations extends \WP_UnitTestCase {
 			}
 		};
 
-		$integration->set_selected_fields( [ 'first_field' ] );
+		$integration->set_incoming_fields( [ 'first_field' ] );
 		Integrations::register( $integration );
 		Integrations::enable( 'first-test' );
 
@@ -656,7 +656,7 @@ class Test_Integrations extends \WP_UnitTestCase {
 			}
 		};
 
-		$integration->set_selected_fields( [ 'timeout_field' ] );
+		$integration->set_incoming_fields( [ 'timeout_field' ] );
 		Integrations::register( $integration );
 		Integrations::enable( 'timeout-test' );
 
@@ -836,7 +836,7 @@ class Test_Integrations extends \WP_UnitTestCase {
 			}
 		};
 
-		$integration->set_selected_fields( [ 'ajax_field' ] );
+		$integration->set_incoming_fields( [ 'ajax_field' ] );
 		Integrations::register( $integration );
 		Integrations::enable( 'ajax-test' );
 

--- a/tests/unit-tests/reader-activation-sync.php
+++ b/tests/unit-tests/reader-activation-sync.php
@@ -64,8 +64,8 @@ class Newspack_Test_Reader_Activation_Sync extends WP_UnitTestCase {
 	 * Test specific ESP integration checks.
 	 */
 	public function test_esp_integration_checks() {
-
 		$esp_integration = new Integrations\ESP();
+		$esp_integration->init();
 		$errors = $esp_integration->can_sync( true );
 		$this->assertInstanceOf( 'WP_Error', $errors );
 		$this->assertTrue( $errors->has_errors() );
@@ -74,12 +74,13 @@ class Newspack_Test_Reader_Activation_Sync extends WP_UnitTestCase {
 		$this->assertContains( 'ras_esp_master_list_id_not_found', $error_codes, 'Missing master list ID' );
 
 		// Disable ESP sync.
-		Reader_Activation::update_setting( 'sync_esp', false );
+		Integrations::disable( 'esp' );
+		$esp_integration->update_settings_field_value( 'sync_esp', false );
 		$errors = $esp_integration->can_sync( true );
 		$this->assertContains( 'ras_esp_sync_not_enabled', $errors->get_error_codes(), 'RAS ESP Sync is disabled' );
 
 		// Reenable ESP sync.
-		Reader_Activation::update_setting( 'sync_esp', true );
+		Integrations::enable( 'esp' );
 
 		// Allow ESP sync via constant. We're not testing `Newspack_Manager::is_connected_to_production_manager()` here.
 		define( 'NEWSPACK_ALLOW_READER_SYNC', true );
@@ -87,8 +88,7 @@ class Newspack_Test_Reader_Activation_Sync extends WP_UnitTestCase {
 		$this->assertNotContains( 'esp_sync_not_allowed', $errors->get_error_codes(), 'RAS ESP Sync is allowed via constant' );
 
 		// Set master list ID.
-		update_option( 'newspack_newsletters_service_provider', 'mailchimp' );
-		Reader_Activation::update_setting( 'mailchimp_audience_id', '123' );
+		$esp_integration->update_settings_field_value( 'mailchimp_audience_id', '123' );
 		$errors = $esp_integration->can_sync( true );
 		$this->assertNotContains( 'ras_esp_master_list_id_not_found', $errors->get_error_codes(), 'Master list ID is set' );
 
@@ -148,7 +148,7 @@ class Newspack_Test_Reader_Activation_Sync extends WP_UnitTestCase {
 		);
 
 		// Clear from last test.
-		\delete_option( Sync\Metadata::PREFIX_OPTION );
+		Sync\Metadata::update_prefix( '' );
 
 		$contact_data_with_prefixed_keys['metadata']['NP_Invalid_Key'] = 'Invalid data';
 		$this->assertEquals(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Closes https://linear.app/a8c/issue/NPPD-1325/framework-allow-integrations-to-declare-settings-fields-plus-prototype

Adds a settings framework for reader activation integrations. Integrations can now declare settings fields (text, checkbox, select, number, textarea, password) that are stored as WordPress options and managed via a new Audience Integrations admin page.

This PR also adds a prototype UI that mostly copies the UI for sync in Audience > Configuration.

![Screenshot 2026-03-09 at 14 08 06](https://github.com/user-attachments/assets/50c37a96-2f60-45c7-ab35-b823111e91ad)

**Backend:**
- `Integration` base class: new `settings_fields` property, getter/setter methods with type-aware sanitization, `register_settings_fields` for declaring settings fields, and `get_settings_config()` for API responses.
- `Integrations`: new `get_all_integration_settings()` and `update_integration_settings()` static methods.
- `Audience_Integrations` wizard: REST API endpoints (`GET /settings`, `POST /settings`) gated behind a `NEWSPACK_INTEGRATIONS_SETTINGS_ENABLED` feature flag.

**Frontend:**
- React settings page under the Audience wizard that renders each integration's settings fields and supports save/reset.
- Page is conditionally registered only when the feature flag is enabled

### How to test the changes in this Pull Request:

Before testing, make sure either https://github.com/Automattic/newspack-newsletters/pull/2028 has been merged, or you checkout the branch.

1. Enable the feature by adding the `NEWSPACK_INTEGRATIONS_SETTINGS_ENABLED` flag to `wp-config.php`. Also enabled logging to more easily identify sync data in the logs (`define( 'Newspack_Log_Level', 3 );`)
2. Build the plugin: `n build newspack-plugin`.
3. Navigate to **Audience > Integrations** in wp-admin.
4. Verify that integrations with declared `settings_fields` appear with their fields rendered correctly.
5. Change values, save, and confirm persistence on page reload.
6. As a reader create a new reader account and verify the sync looks correct.
7. Disable the feature flag in `wp-config.php` and confirm the page no longer appears.
8. As a reader create a new reader account and verify the sync looks correct. (Should follow settings defined in **Audience > Configuration**).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?