### PR TITLE
feat(content-gate): user access information

### DIFF
--- a/includes/content-gate/class-access-rules.php
+++ b/includes/content-gate/class-access-rules.php
@@ -176,10 +176,11 @@ class Access_Rules {
 	 * - Rules within a group use AND logic: reader must pass all rules in the group
 	 *
 	 * @param array $access_rules The access rules (array of groups, each group is an array of rules).
+	 * @param int   $user_id     Optional. User ID to evaluate rules for. Defaults to current user.
 	 *
 	 * @return bool True if access is granted, false if restricted.
 	 */
-	public static function evaluate_rules( $access_rules ) {
+	public static function evaluate_rules( $access_rules, $user_id = null ) {
 		if ( empty( $access_rules ) ) {
 			return true;
 		}
@@ -189,7 +190,7 @@ class Access_Rules {
 
 		// Evaluate each group with OR logic - if any group passes, grant access.
 		foreach ( $access_rules as $group ) {
-			if ( self::evaluate_rules_group( $group ) ) {
+			if ( self::evaluate_rules_group( $group, $user_id ) ) {
 				return true;
 			}
 		}
@@ -201,11 +202,12 @@ class Access_Rules {
 	/**
 	 * Evaluate a single group of access rules with AND logic.
 	 *
-	 * @param array $group Array of rules in the group.
+	 * @param array $group   Array of rules in the group.
+	 * @param int   $user_id Optional. User ID to evaluate rules for. Defaults to current user.
 	 *
 	 * @return bool True if all rules in the group pass, false otherwise.
 	 */
-	private static function evaluate_rules_group( $group ) {
+	private static function evaluate_rules_group( $group, $user_id = null ) {
 		if ( empty( $group ) || ! is_array( $group ) ) {
 			return true;
 		}
@@ -214,7 +216,7 @@ class Access_Rules {
 			if ( ! isset( $rule['slug'] ) ) {
 				continue;
 			}
-			if ( ! self::evaluate_rule( $rule['slug'], $rule['value'] ?? null ) ) {
+			if ( ! self::evaluate_rule( $rule['slug'], $rule['value'] ?? null, $user_id ) ) {
 				return false;
 			}
 		}

--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -96,6 +96,7 @@ class Content_Gate {
 		include __DIR__ . '/class-metering-countdown.php';
 		include __DIR__ . '/content-gifting/class-content-gifting.php';
 		include __DIR__ . '/class-ip-access-rule.php';
+		include __DIR__ . '/class-user-gate-access.php';
 	}
 
 	/**

--- a/includes/content-gate/class-user-gate-access.php
+++ b/includes/content-gate/class-user-gate-access.php
@@ -1,0 +1,202 @@
+<?php
+/**
+ * Newspack Content Gate User Access.
+ *
+ * Displays gate bypass information on user profile pages.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * User Gate Access class.
+ */
+class User_Gate_Access {
+
+	/**
+	 * Initialize hooks.
+	 */
+	public static function init() {
+		add_action( 'edit_user_profile', [ __CLASS__, 'render_user_gate_access' ] );
+		add_action( 'show_user_profile', [ __CLASS__, 'render_user_gate_access' ] );
+	}
+
+	/**
+	 * Get published gates that have custom access enabled.
+	 *
+	 * @return array Array of gates with active custom access.
+	 */
+	private static function get_custom_access_gates() {
+		$gates = Content_Gate::get_gates( Content_Gate::GATE_CPT, 'publish' );
+		return array_filter(
+			$gates,
+			function( $gate ) {
+				return ! empty( $gate['custom_access']['active'] );
+			}
+		);
+	}
+
+	/**
+	 * Evaluate gate access for a specific user and return detailed results.
+	 *
+	 * @param array $gate    Gate data from Content_Gate::get_gate().
+	 * @param int   $user_id User ID to evaluate.
+	 *
+	 * @return array {
+	 *     @type bool  $can_bypass Whether the user can bypass the gate.
+	 *     @type array $groups     Array of group results, each containing:
+	 *         @type bool  $passes Whether the group passes (AND logic).
+	 *         @type array $rules  Array of rule results with slug, name, value, and passes.
+	 * }
+	 */
+	private static function evaluate_gate_for_user( $gate, $user_id ) {
+		$access_rules = $gate['custom_access']['access_rules'] ?? [];
+		$access_rules = Access_Rules::normalize_rules( $access_rules );
+
+		$can_bypass = false;
+		$groups     = [];
+
+		foreach ( $access_rules as $group_rules ) {
+			$group_passes = true;
+			$rules        = [];
+
+			foreach ( $group_rules as $rule ) {
+				if ( ! isset( $rule['slug'] ) ) {
+					continue;
+				}
+				$rule_config = Access_Rules::get_rule( $rule['slug'] );
+				$passes      = Access_Rules::evaluate_rule( $rule['slug'], $rule['value'] ?? null, $user_id );
+
+				if ( ! $passes ) {
+					$group_passes = false;
+				}
+
+				$rules[] = [
+					'slug'   => $rule['slug'],
+					'name'   => $rule_config ? $rule_config['name'] : $rule['slug'],
+					'value'  => $rule['value'] ?? '',
+					'passes' => $passes,
+				];
+			}
+
+			if ( $group_passes ) {
+				$can_bypass = true;
+			}
+
+			$groups[] = [
+				'passes' => $group_passes,
+				'rules'  => $rules,
+			];
+		}
+
+		return [
+			'can_bypass' => $can_bypass,
+			'groups'     => $groups,
+		];
+	}
+
+	/**
+	 * Format rule value for human-readable display.
+	 *
+	 * @param string $slug  Rule slug.
+	 * @param mixed  $value Rule value.
+	 *
+	 * @return string Formatted value.
+	 */
+	private static function format_rule_value( $slug, $value ) {
+		if ( empty( $value ) ) {
+			return __( '(any)', 'newspack-plugin' );
+		}
+
+		if ( 'subscription' === $slug && is_array( $value ) ) {
+			$names = array_map(
+				function( $product_id ) {
+					if ( function_exists( 'wc_get_product' ) ) {
+						$product = wc_get_product( $product_id );
+						if ( $product ) {
+							return $product->get_name();
+						}
+					}
+					return '#' . $product_id;
+				},
+				$value
+			);
+			return implode( ', ', $names );
+		}
+
+		if ( is_array( $value ) ) {
+			return implode( ', ', $value );
+		}
+
+		return (string) $value;
+	}
+
+	/**
+	 * Render gate access info on user profile page.
+	 *
+	 * @param \WP_User $user The user being viewed.
+	 */
+	public static function render_user_gate_access( $user ) {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		$gates = self::get_custom_access_gates();
+		?>
+		<h2><?php esc_html_e( 'Content Gate Access', 'newspack-plugin' ); ?></h2>
+		<?php if ( empty( $gates ) ) : ?>
+			<p><?php esc_html_e( 'No custom-access content gates are configured.', 'newspack-plugin' ); ?></p>
+			<?php
+			return;
+		endif;
+		?>
+		<table class="form-table" role="presentation">
+			<?php foreach ( $gates as $gate ) : ?>
+				<?php $result = self::evaluate_gate_for_user( $gate, $user->ID ); ?>
+				<tr>
+					<th>
+						<span style="margin-right: 5px;">
+							<?php echo wp_kses( $result['can_bypass'] ? '<span style="color: #00a32a;">&#10003;</span>' : '<span style="color: #d63638;">&#10005;</span>', [ 'span' => [ 'style' => [] ] ] ); ?>
+						</span>
+						<?php echo esc_html( $gate['title'] ); ?>
+					</th>
+					<td>
+						<?php if ( empty( $result['groups'] ) ) : ?>
+							<p class="description"><?php esc_html_e( 'No access rules configured.', 'newspack-plugin' ); ?></p>
+						<?php else : ?>
+							<?php foreach ( $result['groups'] as $group_index => $group ) : ?>
+								<?php if ( count( $result['groups'] ) > 1 ) : ?>
+									<p><strong>
+										<?php
+										printf(
+											/* translators: %d: group number. */
+											esc_html__( 'Group %d:', 'newspack-plugin' ),
+											intval( $group_index + 1 )
+										);
+										?>
+									</strong></p>
+								<?php endif; ?>
+								<ul style="margin: 4px 0 12px;">
+									<?php foreach ( $group['rules'] as $rule ) : ?>
+										<li style="margin: 2px 0;">
+											<span style="margin-right: 5px;">
+												<?php echo wp_kses( $rule['passes'] ? '<span style="color: #00a32a;">&#10003;</span>' : '<span style="color: #d63638;">&#10005;</span>', [ 'span' => [ 'style' => [] ] ] ); ?>
+											</span>
+											<?php echo esc_html( $rule['name'] ); ?>:
+											<code><?php echo esc_html( self::format_rule_value( $rule['slug'], $rule['value'] ) ); ?></code>
+										</li>
+									<?php endforeach; ?>
+								</ul>
+							<?php endforeach; ?>
+						<?php endif; ?>
+					</td>
+				</tr>
+			<?php endforeach; ?>
+		</table>
+		<?php
+	}
+}
+User_Gate_Access::init();

--- a/includes/content-gate/class-user-gate-access.php
+++ b/includes/content-gate/class-user-gate-access.php
@@ -155,9 +155,10 @@ class User_Gate_Access {
 				<?php $result = self::evaluate_gate_for_user( $gate, $user->ID ); ?>
 				<tr>
 					<th>
-						<span style="margin-right: 5px;">
+						<span style="margin-right: 5px;" aria-hidden="true">
 							<?php echo wp_kses( $result['can_bypass'] ? '<span style="color: #00a32a;">&#10003;</span>' : '<span style="color: #d63638;">&#10005;</span>', [ 'span' => [ 'style' => [] ] ] ); ?>
 						</span>
+						<span class="screen-reader-text"><?php echo $result['can_bypass'] ? esc_html__( 'Pass', 'newspack-plugin' ) : esc_html__( 'Fail', 'newspack-plugin' ); ?></span>
 						<?php echo esc_html( $gate['title'] ); ?>
 					</th>
 					<td>
@@ -179,9 +180,10 @@ class User_Gate_Access {
 								<ul style="margin: 4px 0 12px;">
 									<?php foreach ( $group['rules'] as $rule ) : ?>
 										<li style="margin: 2px 0;">
-											<span style="margin-right: 5px;">
+											<span style="margin-right: 5px;" aria-hidden="true">
 												<?php echo wp_kses( $rule['passes'] ? '<span style="color: #00a32a;">&#10003;</span>' : '<span style="color: #d63638;">&#10005;</span>', [ 'span' => [ 'style' => [] ] ] ); ?>
 											</span>
+											<span class="screen-reader-text"><?php echo $rule['passes'] ? esc_html__( 'Pass', 'newspack-plugin' ) : esc_html__( 'Fail', 'newspack-plugin' ); ?></span>
 											<?php echo esc_html( $rule['name'] ); ?>:
 											<code><?php echo esc_html( self::format_rule_value( $rule['slug'], $rule['value'] ) ); ?></code>
 										</li>

--- a/includes/content-gate/class-user-gate-access.php
+++ b/includes/content-gate/class-user-gate-access.php
@@ -31,12 +31,13 @@ class User_Gate_Access {
 	 */
 	private static function get_custom_access_gates() {
 		$gates = Content_Gate::get_gates( Content_Gate::GATE_CPT, 'publish' );
-		return array_filter(
+		$custom_access_gates = array_filter(
 			$gates,
 			function( $gate ) {
-				return ! empty( $gate['custom_access']['active'] );
+				return ! is_wp_error( $gate ) && ! empty( $gate['custom_access']['active'] );
 			}
 		);
+		return array_values( $custom_access_gates );
 	}
 
 	/**

--- a/includes/content-gate/class-user-gate-access.php
+++ b/includes/content-gate/class-user-gate-access.php
@@ -145,14 +145,11 @@ class User_Gate_Access {
 		}
 
 		$gates = self::get_custom_access_gates();
+		if ( empty( $gates ) ) {
+			return;
+		}
 		?>
 		<h2><?php esc_html_e( 'Content Gate Access', 'newspack-plugin' ); ?></h2>
-		<?php if ( empty( $gates ) ) : ?>
-			<p><?php esc_html_e( 'No custom-access content gates are configured.', 'newspack-plugin' ); ?></p>
-			<?php
-			return;
-		endif;
-		?>
 		<table class="form-table" role="presentation">
 			<?php foreach ( $gates as $gate ) : ?>
 				<?php $result = self::evaluate_gate_for_user( $gate, $user->ID ); ?>

--- a/includes/content-gate/class-user-gate-access.php
+++ b/includes/content-gate/class-user-gate-access.php
@@ -55,7 +55,6 @@ class User_Gate_Access {
 	 */
 	private static function evaluate_gate_for_user( $gate, $user_id ) {
 		$access_rules = $gate['custom_access']['access_rules'] ?? [];
-		$access_rules = Access_Rules::normalize_rules( $access_rules );
 
 		// Empty rules means the gate does not restrict — matches Content_Restriction_Control behavior.
 		if ( empty( $access_rules ) ) {

--- a/includes/content-gate/class-user-gate-access.php
+++ b/includes/content-gate/class-user-gate-access.php
@@ -56,6 +56,14 @@ class User_Gate_Access {
 		$access_rules = $gate['custom_access']['access_rules'] ?? [];
 		$access_rules = Access_Rules::normalize_rules( $access_rules );
 
+		// Empty rules means the gate does not restrict — matches Content_Restriction_Control behavior.
+		if ( empty( $access_rules ) ) {
+			return [
+				'can_bypass' => true,
+				'groups'     => [],
+			];
+		}
+
 		$can_bypass = false;
 		$groups     = [];
 

--- a/tests/unit-tests/content-gate/class-access-rules.php
+++ b/tests/unit-tests/content-gate/class-access-rules.php
@@ -211,6 +211,78 @@ class Newspack_Test_Access_Rules extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test evaluate_rules passes user_id to rule callbacks.
+	 */
+	public function test_evaluate_rules_with_explicit_user_id() {
+		// Register a simple test rule that checks user meta.
+		Access_Rules::register_rule(
+			[
+				'id'       => 'test_meta_rule',
+				'name'     => 'Test meta rule',
+				'callback' => function( $user_id, $args ) {
+					return (bool) get_user_meta( $user_id, $args, true );
+				},
+			]
+		);
+
+		// Set meta on member but not on non-member.
+		update_user_meta( self::$member_user_id, 'test_gate_pass', '1' );
+
+		$rules = [
+			[
+				[
+					'slug'  => 'test_meta_rule',
+					'value' => 'test_gate_pass',
+				],
+			],
+		];
+
+		// Member should pass.
+		$this->assertTrue(
+			Access_Rules::evaluate_rules( $rules, self::$member_user_id ),
+			'User with matching meta should pass evaluate_rules.'
+		);
+
+		// Non-member should fail.
+		$this->assertFalse(
+			Access_Rules::evaluate_rules( $rules, self::$non_member_user_id ),
+			'User without matching meta should fail evaluate_rules.'
+		);
+	}
+
+	/**
+	 * Test evaluate_rules defaults to current user when no user_id is passed.
+	 */
+	public function test_evaluate_rules_defaults_to_current_user() {
+		Access_Rules::register_rule(
+			[
+				'id'       => 'test_current_user_rule',
+				'name'     => 'Test current user rule',
+				'callback' => function( $user_id, $args ) {
+					return $user_id === (int) $args;
+				},
+			]
+		);
+
+		wp_set_current_user( self::$member_user_id );
+
+		$rules = [
+			[
+				[
+					'slug'  => 'test_current_user_rule',
+					'value' => (string) self::$member_user_id,
+				],
+			],
+		];
+
+		// Should pass using current user (no user_id argument).
+		$this->assertTrue(
+			Access_Rules::evaluate_rules( $rules ),
+			'evaluate_rules should default to current user when no user_id is passed.'
+		);
+	}
+
+	/**
 	 * Test pending-cancel status still grants access.
 	 */
 	public function test_pending_cancel_status_grants_access() {

--- a/tests/unit-tests/content-gate/class-user-gate-access.php
+++ b/tests/unit-tests/content-gate/class-user-gate-access.php
@@ -1,0 +1,220 @@
+<?php
+/**
+ * Tests the User Gate Access class.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Access_Rules;
+use Newspack\Content_Gate;
+use Newspack\User_Gate_Access;
+
+/**
+ * Test User Gate Access functionality.
+ *
+ * @group User_Gate_Access
+ */
+class Newspack_Test_User_Gate_Access extends WP_UnitTestCase {
+
+	/**
+	 * Test user ID.
+	 *
+	 * @var int
+	 */
+	private static $user_id;
+
+	/**
+	 * Admin user ID.
+	 *
+	 * @var int
+	 */
+	private static $admin_id;
+
+	/**
+	 * Set up before each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+		self::$user_id  = $this->factory->user->create(
+			[
+				'role'       => 'subscriber',
+				'user_email' => 'reader@example.com',
+			]
+		);
+		self::$admin_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
+	}
+
+	/**
+	 * Helper to create a gate with custom access rules.
+	 *
+	 * @param string $title        Gate title.
+	 * @param array  $access_rules Access rules array.
+	 *
+	 * @return int Gate post ID.
+	 */
+	private function create_gate_with_rules( $title, $access_rules ) {
+		$gate_id = $this->factory->post->create(
+			[
+				'post_type'   => Content_Gate::GATE_CPT,
+				'post_status' => 'publish',
+				'post_title'  => $title,
+			]
+		);
+		update_post_meta(
+			$gate_id,
+			'custom_access',
+			[
+				'active'       => true,
+				'access_rules' => $access_rules,
+			]
+		);
+		return $gate_id;
+	}
+
+	/**
+	 * Test get_custom_access_gates returns only active custom access gates.
+	 */
+	public function test_get_custom_access_gates_filters_correctly() {
+		// Create a gate with custom access active.
+		$this->create_gate_with_rules( 'Active Gate', [] );
+
+		// Create a gate without custom access.
+		$inactive_id = $this->factory->post->create(
+			[
+				'post_type'   => Content_Gate::GATE_CPT,
+				'post_status' => 'publish',
+				'post_title'  => 'Inactive Gate',
+			]
+		);
+		update_post_meta( $inactive_id, 'custom_access', [ 'active' => false ] );
+
+		// Use reflection to test private method.
+		$method = new ReflectionMethod( User_Gate_Access::class, 'get_custom_access_gates' );
+		$method->setAccessible( true );
+		$gates = $method->invoke( null );
+
+		$this->assertCount( 1, $gates, 'Should only return gates with active custom access.' );
+		$this->assertEquals( 'Active Gate', reset( $gates )['title'] );
+	}
+
+	/**
+	 * Test evaluate_gate_for_user with email domain rule.
+	 */
+	public function test_evaluate_gate_email_domain_pass() {
+		$rules = [
+			[
+				[
+					'slug'  => 'email_domain',
+					'value' => 'example.com',
+				],
+			],
+		];
+		$gate_id = $this->create_gate_with_rules( 'Domain Gate', $rules );
+		$gate    = Content_Gate::get_gate( $gate_id );
+
+		$method = new ReflectionMethod( User_Gate_Access::class, 'evaluate_gate_for_user' );
+		$method->setAccessible( true );
+		$result = $method->invoke( null, $gate, self::$user_id );
+
+		$this->assertTrue( $result['can_bypass'], 'User with example.com email should pass email_domain rule.' );
+		$this->assertTrue( $result['groups'][0]['passes'] );
+		$this->assertTrue( $result['groups'][0]['rules'][0]['passes'] );
+	}
+
+	/**
+	 * Test evaluate_gate_for_user with email domain rule - fail case.
+	 */
+	public function test_evaluate_gate_email_domain_fail() {
+		$rules = [
+			[
+				[
+					'slug'  => 'email_domain',
+					'value' => 'other.com',
+				],
+			],
+		];
+		$gate_id = $this->create_gate_with_rules( 'Domain Gate', $rules );
+		$gate    = Content_Gate::get_gate( $gate_id );
+
+		$method = new ReflectionMethod( User_Gate_Access::class, 'evaluate_gate_for_user' );
+		$method->setAccessible( true );
+		$result = $method->invoke( null, $gate, self::$user_id );
+
+		$this->assertFalse( $result['can_bypass'], 'User with example.com email should fail other.com domain rule.' );
+		$this->assertFalse( $result['groups'][0]['passes'] );
+	}
+
+	/**
+	 * Test metabox only renders for users with manage_options capability.
+	 */
+	public function test_render_requires_manage_options() {
+		wp_set_current_user( self::$user_id ); // Subscriber, no manage_options.
+		$user = get_user_by( 'id', self::$user_id );
+
+		ob_start();
+		User_Gate_Access::render_user_gate_access( $user );
+		$output = ob_get_clean();
+
+		$this->assertEmpty( $output, 'Should not render for users without manage_options.' );
+	}
+
+	/**
+	 * Test metabox renders for admin users.
+	 */
+	public function test_render_for_admin() {
+		wp_set_current_user( self::$admin_id );
+		$user = get_user_by( 'id', self::$user_id );
+
+		ob_start();
+		User_Gate_Access::render_user_gate_access( $user );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'Content Gate Access', $output, 'Should render heading for admin users.' );
+	}
+
+	/**
+	 * Test metabox shows message when no gates configured.
+	 */
+	public function test_render_no_gates_message() {
+		wp_set_current_user( self::$admin_id );
+		$user = get_user_by( 'id', self::$user_id );
+
+		ob_start();
+		User_Gate_Access::render_user_gate_access( $user );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'No custom-access content gates are configured', $output );
+	}
+
+	/**
+	 * Test OR logic between groups - user passes one group but not another.
+	 */
+	public function test_evaluate_gate_or_logic_between_groups() {
+		$rules = [
+			// Group 1: email domain that won't match.
+			[
+				[
+					'slug'  => 'email_domain',
+					'value' => 'other.com',
+				],
+			],
+			// Group 2: email domain that will match.
+			[
+				[
+					'slug'  => 'email_domain',
+					'value' => 'example.com',
+				],
+			],
+		];
+		$gate_id = $this->create_gate_with_rules( 'OR Gate', $rules );
+		$gate    = Content_Gate::get_gate( $gate_id );
+
+		$method = new ReflectionMethod( User_Gate_Access::class, 'evaluate_gate_for_user' );
+		$method->setAccessible( true );
+		$result = $method->invoke( null, $gate, self::$user_id );
+
+		$this->assertTrue( $result['can_bypass'], 'User should pass when at least one group matches (OR logic).' );
+		$this->assertFalse( $result['groups'][0]['passes'], 'First group should fail.' );
+		$this->assertTrue( $result['groups'][1]['passes'], 'Second group should pass.' );
+	}
+}

--- a/tests/unit-tests/content-gate/class-user-gate-access.php
+++ b/tests/unit-tests/content-gate/class-user-gate-access.php
@@ -98,6 +98,21 @@ class Newspack_Test_User_Gate_Access extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test evaluate_gate_for_user with empty rules returns can_bypass true.
+	 */
+	public function test_evaluate_gate_empty_rules_means_bypass() {
+		$gate_id = $this->create_gate_with_rules( 'Empty Gate', [] );
+		$gate    = Content_Gate::get_gate( $gate_id );
+
+		$method = new ReflectionMethod( User_Gate_Access::class, 'evaluate_gate_for_user' );
+		$method->setAccessible( true );
+		$result = $method->invoke( null, $gate, self::$user_id );
+
+		$this->assertTrue( $result['can_bypass'], 'Empty access rules should mean the user can bypass (gate does not restrict).' );
+		$this->assertEmpty( $result['groups'] );
+	}
+
+	/**
 	 * Test evaluate_gate_for_user with email domain rule.
 	 */
 	public function test_evaluate_gate_email_domain_pass() {

--- a/tests/unit-tests/content-gate/class-user-gate-access.php
+++ b/tests/unit-tests/content-gate/class-user-gate-access.php
@@ -173,20 +173,6 @@ class Newspack_Test_User_Gate_Access extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test metabox shows message when no gates configured.
-	 */
-	public function test_render_no_gates_message() {
-		wp_set_current_user( self::$admin_id );
-		$user = get_user_by( 'id', self::$user_id );
-
-		ob_start();
-		User_Gate_Access::render_user_gate_access( $user );
-		$output = ob_get_clean();
-
-		$this->assertStringContainsString( 'No custom-access content gates are configured', $output );
-	}
-
-	/**
 	 * Test OR logic between groups - user passes one group but not another.
 	 */
 	public function test_evaluate_gate_or_logic_between_groups() {

--- a/tests/unit-tests/content-gate/class-user-gate-access.php
+++ b/tests/unit-tests/content-gate/class-user-gate-access.php
@@ -159,10 +159,11 @@ class Newspack_Test_User_Gate_Access extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test metabox renders for admin users.
+	 * Test metabox renders for admin users when gates exist.
 	 */
 	public function test_render_for_admin() {
 		wp_set_current_user( self::$admin_id );
+		$this->create_gate_with_rules( 'Test Gate', [] );
 		$user = get_user_by( 'id', self::$user_id );
 
 		ob_start();
@@ -170,6 +171,20 @@ class Newspack_Test_User_Gate_Access extends WP_UnitTestCase {
 		$output = ob_get_clean();
 
 		$this->assertStringContainsString( 'Content Gate Access', $output, 'Should render heading for admin users.' );
+	}
+
+	/**
+	 * Test metabox does not render when no custom-access gates exist.
+	 */
+	public function test_render_empty_when_no_gates() {
+		wp_set_current_user( self::$admin_id );
+		$user = get_user_by( 'id', self::$user_id );
+
+		ob_start();
+		User_Gate_Access::render_user_gate_access( $user );
+		$output = ob_get_clean();
+
+		$this->assertEmpty( $output, 'Should not render when no custom-access gates exist.' );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Add a "Content Gate Access" section to user profile pages in WP admin, showing which custom-access content gates the user can bypass and the per-rule pass/fail breakdown. This gives admins visibility into reader gate access without the concept of membership plans.

<img width="640" height="238" alt="image" src="https://github.com/user-attachments/assets/c5def138-273f-46e9-a061-3a5748bb9221" />

Closes NPPD-953

### How to test the changes in this Pull Request:

1. Create a content gate with paid access enabled.
2. Add multiple access rules (subscription, reader data, email whitelist)
3. Navigate to Users and click on any user to open their profile.
4. Scroll down and verify that a Content Gate Access section is displayed.
5. Verify the section shows each custom-access gate with a pass/fail indicator, and per-rule detail
6. Verify the section is not displayed when viewing your own profile as a non-admin (author, editor)
7. If no paid-access gates are configured, verify the section is also not shown

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->