### PR TITLE
feat(integrations): refactor metadata for integration specific selection

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -100,6 +100,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/reader-activation/class-reader-data.php';
 		include_once NEWSPACK_ABSPATH . 'includes/reader-activation/sync/class-sync.php';
 		include_once NEWSPACK_ABSPATH . 'includes/reader-activation/sync/class-metadata.php';
+		include_once NEWSPACK_ABSPATH . 'includes/reader-activation/sync/class-legacy-metadata.php';
 		include_once NEWSPACK_ABSPATH . 'includes/reader-activation/sync/class-woocommerce.php';
 		include_once NEWSPACK_ABSPATH . 'includes/reader-activation/sync/class-contact-sync.php';
 		include_once NEWSPACK_ABSPATH . 'includes/reader-activation/sync/class-contact-sync-admin.php';

--- a/includes/cli/class-mailchimp.php
+++ b/includes/cli/class-mailchimp.php
@@ -10,6 +10,7 @@ namespace Newspack\CLI;
 use WP_CLI;
 use Newspack\Reader_Activation;
 use Newspack\Reader_Activation\Sync\Metadata;
+use Newspack\Reader_Activation\Sync\Legacy_Metadata;
 use Newspack\Mailchimp_API;
 
 defined( 'ABSPATH' ) || exit;
@@ -44,8 +45,8 @@ class Mailchimp {
 				function( $acc, $field_slug ) use ( $prefix, $all_fields ) {
 					if ( ! empty( $all_fields[ $field_slug ] ) ) {
 						$acc[] = trim( $prefix . $all_fields[ $field_slug ] );
-					} elseif ( ! empty( Metadata::get_utm_key( $field_slug ) ) && ( ! $prefix || 0 === strpos( Metadata::get_utm_key( $field_slug ), $prefix ) ) ) {
-						$acc[] = trim( $prefix . str_replace( Metadata::PREFIX, '', Metadata::get_utm_key( $field_slug ) ) );
+					} elseif ( ! empty( Legacy_Metadata::get_utm_key( $field_slug ) ) && ( ! $prefix || 0 === strpos( Legacy_Metadata::get_utm_key( $field_slug ), $prefix ) ) ) {
+						$acc[] = trim( $prefix . str_replace( Metadata::PREFIX, '', Legacy_Metadata::get_utm_key( $field_slug ) ) );
 					} else {
 						\WP_CLI::warning( sprintf( 'Field %s not recognized.', $field_slug ) );
 					}
@@ -132,8 +133,8 @@ class Mailchimp {
 			function( $acc, $field_slug ) use ( $prefix, $all_fields ) {
 				if ( ! empty( $all_fields[ $field_slug ] ) ) {
 					$acc[] = trim( $prefix . $all_fields[ $field_slug ] );
-				} elseif ( ! empty( Metadata::get_utm_key( $field_slug ) ) && ( ! $prefix || 0 === strpos( Metadata::get_utm_key( $field_slug ), $prefix ) ) ) {
-					$acc[] = trim( $prefix . str_replace( Metadata::PREFIX, '', Metadata::get_utm_key( $field_slug ) ) );
+				} elseif ( ! empty( Legacy_Metadata::get_utm_key( $field_slug ) ) && ( ! $prefix || 0 === strpos( Legacy_Metadata::get_utm_key( $field_slug ), $prefix ) ) ) {
+					$acc[] = trim( $prefix . str_replace( Metadata::PREFIX, '', Legacy_Metadata::get_utm_key( $field_slug ) ) );
 				} else {
 					\WP_CLI::warning( sprintf( 'Field %s not recognized.', $field_slug ) );
 				}

--- a/includes/reader-activation/integrations/class-esp.php
+++ b/includes/reader-activation/integrations/class-esp.php
@@ -38,7 +38,7 @@ class ESP extends Integration {
 	 */
 	public function get_enabled_outgoing_fields() {
 		$fields = \get_option( self::OUTGOING_FIELDS_OPTION_PREFIX . $this->id, null );
-		if ( null !== $fields ) {
+		if ( null !== $fields && is_array( $fields ) ) {
 			return $fields;
 		}
 

--- a/includes/reader-activation/integrations/class-esp.php
+++ b/includes/reader-activation/integrations/class-esp.php
@@ -8,6 +8,7 @@
 namespace Newspack\Reader_Activation\Integrations;
 
 use Newspack\Reader_Activation\Integration;
+use Newspack\Reader_Activation\Sync;
 use Newspack\Reader_Activation;
 use Newspack_Newsletters_Contacts;
 use Newspack_Newsletters_Subscription;
@@ -25,6 +26,30 @@ class ESP extends Integration {
 	 */
 	public function __construct() {
 		parent::__construct( 'esp', __( 'ESPs Integration', 'newspack-plugin' ) );
+	}
+
+	/**
+	 * Get the enabled outgoing metadata fields for the ESP integration.
+	 *
+	 * Overrides the parent to provide lazy migration from the legacy global
+	 * option (Metadata::FIELDS_OPTION) to the per-integration option.
+	 *
+	 * @return string[] List of enabled field names.
+	 */
+	public function get_enabled_outgoing_fields() {
+		$fields = \get_option( self::OUTGOING_FIELDS_OPTION_PREFIX . $this->id, null );
+		if ( null !== $fields ) {
+			return $fields;
+		}
+
+		// Migrate from legacy global option.
+		$legacy = \get_option( Sync\Metadata::FIELDS_OPTION, null );
+		if ( null !== $legacy && is_array( $legacy ) ) {
+			$this->update_enabled_outgoing_fields( $legacy );
+			return $legacy;
+		}
+
+		return Sync\Metadata::get_default_fields();
 	}
 
 	/**

--- a/includes/reader-activation/integrations/class-integration.php
+++ b/includes/reader-activation/integrations/class-integration.php
@@ -23,6 +23,13 @@ abstract class Integration {
 	const OPTION_PREFIX = 'newspack_integration_selected_fields_';
 
 	/**
+	 * Option name prefix for storing enabled outgoing metadata fields per integration.
+	 *
+	 * @var string
+	 */
+	const OUTGOING_FIELDS_OPTION_PREFIX = 'newspack_integration_outgoing_fields_';
+
+	/**
 	 * The unique identifier for this integration.
 	 *
 	 * @var string
@@ -207,5 +214,81 @@ abstract class Integration {
 	 */
 	public function set_selected_fields( $fields ) {
 		return \update_option( self::OPTION_PREFIX . $this->id, array_values( $fields ) );
+	}
+
+	/**
+	 * Get the enabled outgoing metadata fields for this integration.
+	 *
+	 * @return string[] List of enabled field names.
+	 */
+	public function get_enabled_outgoing_fields() {
+		$fields = \get_option( self::OUTGOING_FIELDS_OPTION_PREFIX . $this->id, null );
+		if ( null === $fields ) {
+			return Sync\Metadata::get_default_fields();
+		}
+		return $fields;
+	}
+
+	/**
+	 * Update the enabled outgoing metadata fields for this integration.
+	 *
+	 * @param array $fields List of field names to enable.
+	 * @return bool True if updated, false otherwise.
+	 */
+	public function update_enabled_outgoing_fields( $fields ) {
+		return \update_option( self::OUTGOING_FIELDS_OPTION_PREFIX . $this->id, array_values( (array) $fields ) );
+	}
+
+	/**
+	 * Filter metadata keys to only those whose field name is enabled for outgoing sync.
+	 *
+	 * @param string[] $keys Array of raw metadata keys to filter.
+	 * @return array Filtered key-value pairs from Metadata::get_keys().
+	 */
+	public function filter_enabled_outgoing_fields( $keys ) {
+		$enabled_fields = $this->get_enabled_outgoing_fields();
+		return array_filter(
+			Sync\Metadata::get_keys(),
+			function( $val, $key ) use ( $keys, $enabled_fields ) {
+				return in_array( $key, $keys ) && in_array( $val, $enabled_fields );
+			},
+			ARRAY_FILTER_USE_BOTH
+		);
+	}
+
+	/**
+	 * Get the raw (unprefixed) metadata keys enabled for outgoing sync.
+	 *
+	 * @return string[] List of raw metadata keys.
+	 */
+	public function get_enabled_outgoing_fields_raw_keys() {
+		$enabled_fields = $this->get_enabled_outgoing_fields();
+		$raw_keys       = [];
+
+		foreach ( Sync\Metadata::get_keys() as $raw_key => $field_name ) {
+			if ( in_array( $field_name, $enabled_fields, true ) ) {
+				$raw_keys[] = $raw_key;
+			}
+		}
+
+		return array_unique( $raw_keys );
+	}
+
+	/**
+	 * Get the prefixed metadata keys enabled for outgoing sync.
+	 *
+	 * @return string[] List of prefixed metadata keys.
+	 */
+	public function get_enabled_outgoing_fields_prefixed_keys() {
+		$enabled_fields = $this->get_enabled_outgoing_fields();
+		$prefixed_keys  = [];
+
+		foreach ( Sync\Metadata::get_keys() as $raw_key => $field_name ) {
+			if ( in_array( $field_name, $enabled_fields, true ) ) {
+				$prefixed_keys[] = Sync\Metadata::get_key( $raw_key );
+			}
+		}
+
+		return array_unique( $prefixed_keys );
 	}
 }

--- a/includes/reader-activation/integrations/class-integration.php
+++ b/includes/reader-activation/integrations/class-integration.php
@@ -222,11 +222,7 @@ abstract class Integration {
 	 * @return string[] List of enabled field names.
 	 */
 	public function get_enabled_outgoing_fields() {
-		$fields = \get_option( self::OUTGOING_FIELDS_OPTION_PREFIX . $this->id, null );
-		if ( null === $fields ) {
-			return Sync\Metadata::get_default_fields();
-		}
-		return $fields;
+		return array_values( \get_option( self::OUTGOING_FIELDS_OPTION_PREFIX . $this->id, Sync\Metadata::get_default_fields() ) );
 	}
 
 	/**
@@ -236,7 +232,9 @@ abstract class Integration {
 	 * @return bool True if updated, false otherwise.
 	 */
 	public function update_enabled_outgoing_fields( $fields ) {
-		return \update_option( self::OUTGOING_FIELDS_OPTION_PREFIX . $this->id, array_values( (array) $fields ) );
+		// Only allow fields that are in the metadata keys map.
+		$fields = array_intersect( Sync\Metadata::get_default_fields(), $fields );
+		return \update_option( self::OUTGOING_FIELDS_OPTION_PREFIX . $this->id, array_values( $fields ) );
 	}
 
 	/**

--- a/includes/reader-activation/sync/class-legacy-metadata.php
+++ b/includes/reader-activation/sync/class-legacy-metadata.php
@@ -1,0 +1,269 @@
+<?php
+/**
+ * Reader Activation Sync Legacy Metadata.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Reader_Activation\Sync;
+
+use Newspack\Donations;
+use Newspack\Reader_Activation;
+use Newspack\Logger;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Legacy Metadata Class.
+ *
+ * Holds the logic for handling contact sync metadata prior the Newspack Integrations implementation.
+ *
+ * This serves as a fallback so we can do a smooth transition from these global options into the new per-integration selected fields, and to avoid breaking existing functionality until we can fully remove this legacy metadata handling.
+ */
+class Legacy_Metadata {
+
+	/**
+	 * Metadata keys map for Reader Activation.
+	 *
+	 * @var array
+	 */
+	public static $keys = [];
+
+	/**
+	 * Get the metadata keys map for Reader Activation.
+	 *
+	 * @return array List of fields.
+	 */
+	public static function get_keys() {
+		if ( empty( self::$keys ) ) {
+			// Only get Woo fields if using Woo.
+			$fields = Donations::is_platform_wc() ? self::get_all_fields() : self::get_basic_fields();
+
+			/**
+			 * Filters the list of key/value pairs for metadata fields to be synced to the connected ESP.
+			 *
+			 * @param array $keys The list of key/value pairs for metadata fields to be synced to the connected ESP.
+			 */
+			self::$keys = \apply_filters( 'newspack_ras_metadata_keys', $fields );
+		}
+		return self::$keys;
+	}
+
+	/**
+	 * Get all metadata fields.
+	 *
+	 * @return array List of fields.
+	 */
+	public static function get_all_fields() {
+		return array_merge( self::get_basic_fields(), self::get_payment_fields() );
+	}
+
+	/**
+	 * Get basic metadata fields.
+	 *
+	 * @return array List of fields.
+	 */
+	public static function get_basic_fields() {
+		return [
+			'account'              => 'Account',
+			'registration_date'    => 'Registration Date',
+			'connected_account'    => 'Connected Account',
+			'signup_page_utm'      => 'Signup UTM: ',
+			'newsletter_selection' => 'Newsletter Selection',
+			'referer'              => 'Referrer Path',
+			'registration_page'    => 'Registration Page',
+			'current_page_url'     => 'Registration Page',
+			'registration_method'  => 'Registration Method',
+		];
+	}
+
+	/**
+	 * Get payment-related metadata fields.
+	 *
+	 * @return array List of fields.
+	 */
+	public static function get_payment_fields() {
+		return [
+			'membership_status'   => 'Membership Status',
+			// URL of the page on which the payment has happened.
+			'payment_page'        => 'Payment Page',
+			'payment_page_utm'    => 'Payment UTM: ',
+			'sub_start_date'      => 'Current Subscription Start Date',
+			'sub_end_date'        => 'Current Subscription End Date',
+			'cancellation_reason' => 'Subscription Cancellation Reason',
+			// At what interval does the recurring payment occur – e.g. day, week, month or year.
+			'billing_cycle'       => 'Billing Cycle',
+			// The total value of the recurring payment.
+			'recurring_payment'   => 'Recurring Payment',
+			'last_payment_date'   => 'Last Payment Date',
+			'last_payment_amount' => 'Last Payment Amount',
+			// Product name, as it appears in WooCommerce.
+			'product_name'        => 'Product Name',
+			'next_payment_date'   => 'Next Payment Date',
+			// Total value spent by this customer on the site.
+			'total_paid'          => 'Total Paid',
+		];
+	}
+
+	/**
+	 * Get the UTM key from a raw or prefixed key.
+	 * The returned key must have a suffix (source, medium, campaign, content).
+	 *
+	 * @param string $key Key to check.
+	 *
+	 * @return string|false Formatted key if it is a UTM key, false otherwise.
+	 */
+	public static function get_utm_key( $key ) {
+		$keys     = [ 'signup_page_utm', 'payment_page_utm' ];
+		$raw_keys = Metadata::get_raw_keys();
+		foreach ( $keys as $utm_key ) {
+			if ( ! in_array( $utm_key, $raw_keys, true ) ) { // Skip if the UTM key is not in the list of fields to sync.
+				continue;
+			}
+			$prefixed_key = Metadata::get_key( $utm_key );
+			if ( 0 === strpos( $key, $utm_key ) ) {
+				$suffix = str_replace( $utm_key . '_', '', $key );
+				return ! empty( trim( $suffix ) ) && $suffix !== $key ? $prefixed_key . $suffix : false;
+			}
+			if ( 0 === strpos( $key, $prefixed_key ) && $key !== $prefixed_key ) {
+				return $key;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Add user's registration-related data to the given metadata.
+	 * These won't be included in every sync request, but they might be stored as user meta.
+	 *
+	 * @param array $metadata Metadata to add to.
+	 *
+	 * @return array Metadata with registration data added.
+	 */
+	private static function add_registration_data( $metadata ) {
+		$user = Metadata::has_key( 'account', $metadata ) ? \get_user_by( 'id', Metadata::get_key_value( 'account', $metadata ) ) : false;
+		if ( ! $user ) {
+			return $metadata;
+		}
+
+		$registration_method = Metadata::has_key( 'registration_method', $metadata ) ? Metadata::get_key_value( 'registration_method', $metadata ) : \get_user_meta( $user->ID, Reader_Activation::REGISTRATION_METHOD, true );
+		if ( ! empty( $registration_method ) ) {
+			$metadata['registration_method'] = $registration_method;
+		}
+
+		$registration_page = Metadata::has_key( 'registration_page', $metadata ) ? Metadata::get_key_value( 'registration_page', $metadata ) : \get_user_meta( $user->ID, Reader_Activation::REGISTRATION_PAGE, true );
+		if ( ! empty( $registration_page ) ) {
+			$metadata['registration_page'] = $registration_page;
+		}
+
+		$connected_account = Metadata::has_key( 'connected_account', $metadata ) ? Metadata::get_key_value( 'connected_account', $metadata ) : \get_user_meta( $user->ID, Reader_Activation::CONNECTED_ACCOUNT, true );
+		if ( ! empty( $connected_account ) && in_array( $connected_account, Reader_Activation::SSO_REGISTRATION_METHODS ) ) {
+			$metadata['connected_account'] = $connected_account;
+		} elseif ( ! empty( $registration_method ) && in_array( $registration_method, Reader_Activation::SSO_REGISTRATION_METHODS ) ) {
+			$metadata['connected_account'] = $registration_method;
+		}
+
+		return $metadata;
+	}
+
+	/**
+	 * Add UTM fields to the given metadata.
+	 *
+	 * @param array $metadata Metadata to add to.
+	 *
+	 * @return array Metadata with UTM fields added.
+	 */
+	public static function add_utm_data( $metadata ) {
+		// Capture UTM params and signup/payment page URLs as meta for registration or payment.
+		if ( Metadata::has_key( 'current_page_url', $metadata ) || Metadata::has_key( 'registration_page', $metadata ) || Metadata::has_key( 'payment_page', $metadata ) ) {
+			$payment_page = Metadata::has_key( 'payment_page', $metadata ) ? Metadata::get_key_value( 'payment_page', $metadata ) : false;
+			$raw_url    = false;
+			if ( ! empty( $payment_page ) ) {
+				$raw_url = Metadata::get_key_value( 'payment_page', $metadata );
+			} elseif ( Metadata::has_key( 'current_page_url', $metadata ) ) {
+				$raw_url = Metadata::get_key_value( 'current_page_url', $metadata );
+			} else {
+				$raw_url = Metadata::get_key_value( 'registration_page', $metadata );
+			}
+
+			$parsed_url = \wp_parse_url( $raw_url );
+
+			// Maybe set UTM meta.
+			if ( ! empty( $parsed_url['query'] ) ) {
+				$utm_key_prefix = ! empty( $payment_page ) ? 'payment_page_utm' : 'signup_page_utm';
+				$params         = [];
+				\wp_parse_str( $parsed_url['query'], $params );
+				foreach ( $params as $param => $value ) {
+					$param = \sanitize_text_field( $param );
+					if ( 'utm' === substr( $param, 0, 3 ) ) {
+						$param = str_replace( 'utm_', '', $param );
+						$key   = Metadata::get_key( $utm_key_prefix ) . $param;
+						if ( ! isset( $metadata[ $key ] ) || empty( $metadata[ $key ] ) ) {
+							$metadata[ $key ] = $value;
+						}
+					}
+				}
+			}
+		}
+
+		return $metadata;
+	}
+
+	/**
+	 * Normalizes contact metadata keys before syncing to ESP.
+	 *
+	 * @param array $contact Contact data.
+	 * @return array Normalized contact data.
+	 */
+	public static function normalize_contact_data( $contact ) {
+		if ( ! isset( $contact['metadata'] ) ) {
+			$contact['metadata'] = [];
+		}
+
+		$metadata            = $contact['metadata'];
+		$metadata            = self::add_registration_data( $metadata );
+		$metadata            = self::add_utm_data( $metadata );
+		$raw_keys            = Metadata::get_raw_keys();
+		$prefixed_keys       = Metadata::get_prefixed_keys();
+		$normalized_metadata = [];
+
+		// Keys allowed to pass through without prefixing.
+		$allowed_keys = [ 'status', 'status_if_new' ];
+
+		// UTM keys must be suffixed.
+		$disallowed_keys = [
+			'payment_page_utm',
+			'payment_page_utm_',
+			'signup_page_utm',
+			'signup_page_utm_',
+			Metadata::get_key( 'payment_page_utm' ),
+			Metadata::get_key( 'signup_page_utm' ),
+		];
+
+		foreach ( $metadata as $meta_key => $meta_value ) {
+			if ( in_array( $meta_key, $raw_keys, true ) && ! in_array( $meta_key, $disallowed_keys, true ) ) { // Handle raw keys.
+				$normalized_metadata[ Metadata::get_key( $meta_key ) ] = $meta_value;
+			} elseif ( in_array( $meta_key, $prefixed_keys, true ) && ! in_array( $meta_key, $disallowed_keys, true ) ) { // Handle prefixed keys.
+				$normalized_metadata[ $meta_key ] = $meta_value;
+			} elseif ( self::get_utm_key( $meta_key ) ) { // Handle UTM keys.
+				$normalized_metadata[ self::get_utm_key( $meta_key ) ] = $meta_value;
+			} elseif ( in_array( $meta_key, $allowed_keys, true ) ) { // Handle allowed keys.
+				$normalized_metadata[ $meta_key ] = $meta_value;
+			} else { // If the key is not in the list of fields to sync, ignore it.
+				Logger::log( 'Ignoring metadata key: ' . $meta_key );
+			}
+		}
+
+		$contact['metadata'] = $normalized_metadata;
+
+		Logger::log( 'Normalizing contact data for reader ESP sync:' );
+		Logger::log( $contact );
+
+		/**
+		 * Filters the normalized contact data before syncing to the ESP.
+		 *
+		 * @param array $contact Contact data.
+		 */
+		return apply_filters( 'newspack_esp_sync_normalize_contact', $contact );
+	}
+}

--- a/includes/reader-activation/sync/class-metadata.php
+++ b/includes/reader-activation/sync/class-metadata.php
@@ -8,9 +8,7 @@
 namespace Newspack\Reader_Activation\Sync;
 
 use Newspack\Donations;
-use Newspack\Reader_Activation;
 use Newspack\Reader_Activation\Integrations;
-use Newspack\Logger;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -167,7 +165,7 @@ class Metadata {
 	 */
 	public static function update_fields( $fields ) {
 		$esp_integration = Integrations::get_integration( 'esp' );
-		return $esp_integration ? $esp_integration->update_enabled_outgoing_fields( $fields ) : [];
+		return $esp_integration ? $esp_integration->update_enabled_outgoing_fields( $fields ) : false;
 	}
 
 	/**

--- a/includes/reader-activation/sync/class-metadata.php
+++ b/includes/reader-activation/sync/class-metadata.php
@@ -9,6 +9,7 @@ namespace Newspack\Reader_Activation\Sync;
 
 use Newspack\Donations;
 use Newspack\Reader_Activation;
+use Newspack\Reader_Activation\Integrations;
 use Newspack\Logger;
 
 defined( 'ABSPATH' ) || exit;
@@ -23,6 +24,13 @@ class Metadata {
 	const PREFIX_OPTION = '_newspack_metadata_prefix';
 
 	/**
+	 * The schema version for the metadata. Legacy is the default and fallsback to how things were before Newspack Integrations.
+	 *
+	 * @var string
+	 */
+	public static $version = 'legacy';
+
+	/**
 	 * The option name for choosing which metadata fields to sync.
 	 *
 	 * @var string
@@ -30,11 +38,22 @@ class Metadata {
 	const FIELDS_OPTION = '_newspack_metadata_fields';
 
 	/**
-	 * Metadata keys map for Reader Activation.
+	 * Get the current metadata schema version.
 	 *
-	 * @var array
+	 * @return string
 	 */
-	public static $keys = [];
+	protected static function get_version() {
+		if ( defined( 'NEWSPACK_SYNC_METADATA_VERSION' ) ) {
+			return NEWSPACK_SYNC_METADATA_VERSION;
+		}
+
+		// boolean version of the feature flag.
+		if ( defined( 'NEWSPACK_SYNC_METADATA_VERSION_1' ) && NEWSPACK_SYNC_METADATA_VERSION_1 ) {
+			return '1.0';
+		}
+
+		return self::$version;
+	}
 
 	/**
 	 * Get the metadata keys map for Reader Activation.
@@ -42,18 +61,11 @@ class Metadata {
 	 * @return array List of fields.
 	 */
 	public static function get_keys() {
-		if ( empty( self::$keys ) ) {
-			// Only get Woo fields if using Woo.
-			$fields = Donations::is_platform_wc() ? self::get_all_fields() : self::get_basic_fields();
-
-			/**
-			 * Filters the list of key/value pairs for metadata fields to be synced to the connected ESP.
-			 *
-			 * @param array $keys The list of key/value pairs for metadata fields to be synced to the connected ESP.
-			 */
-			self::$keys = \apply_filters( 'newspack_ras_metadata_keys', $fields );
+		if ( 'legacy' === self::get_version() ) {
+			return Legacy_Metadata::get_keys();
 		}
-		return self::$keys;
+
+		return self::get_all_fields();
 	}
 
 	/**
@@ -103,78 +115,87 @@ class Metadata {
 	}
 
 	/**
+	 * Get payment-related metadata fields.
+	 *
+	 * @return array List of fields.
+	 */
+	public static function get_payment_fields() {
+		// Not sure yet if this method will be useful in the new schema, so keeping it here for now.
+		// It's used in the Woocommerce class when we want to clear payment fields, so we might still need to have a list of "Woocommerce related fields".
+		return Legacy_Metadata::get_payment_fields();
+	}
+
+	/**
 	 * Get the list of fields to be synced.
 	 *
+	 * This method is deprecated. Now, each integration has its own set of enabled fields, which can be retrieved with Integration::get_enabled_outgoing_fields().
+	 * As a fallback, this method returns the fields enabled for the ESP Integration.
+	 *
+	 * @deprecated Use Integration::get_enabled_outgoing_fields() instead.
 	 * @return string[] List of fields to be synced.
 	 */
 	public static function get_fields() {
-		return array_values( \get_option( self::FIELDS_OPTION, self::get_default_fields() ) );
+		$esp_integration = Integrations::get_integration( 'esp' );
+		return $esp_integration ? $esp_integration->get_enabled_outgoing_fields() : [];
 	}
 
 	/**
 	 * Get enabled fields which match provided keys.
 	 * Will return key-value pairs of enabled fields which match the keys provided.
 	 *
+	 * This method is deprecated. Now, each integration has its own set of enabled fields.
+	 * As a fallback, this method delegates to the ESP Integration.
+	 *
+	 * @deprecated Use Integration::filter_enabled_outgoing_fields() instead.
 	 * @param string[] $keys Array of keys to match.
 	 */
 	public static function filter_enabled_fields( $keys ) {
-		$enabled_fields = self::get_fields();
-		return array_filter(
-			self::get_keys(),
-			function( $val, $key ) use ( $keys, $enabled_fields ) {
-				return in_array( $key, $keys ) && in_array( $val, $enabled_fields );
-			},
-			ARRAY_FILTER_USE_BOTH
-		);
+		$esp_integration = Integrations::get_integration( 'esp' );
+		return $esp_integration ? $esp_integration->filter_enabled_outgoing_fields( $keys ) : [];
 	}
 
 	/**
 	 * Update the list of fields to be synced.
 	 *
+	 * This method is deprecated. Now, each integration has its own set of enabled fields.
+	 * As a fallback, this method will update the fields enabled for the ESP Integration.
+	 *
 	 * @param array $fields List of fields to sync.
 	 *
+	 * @deprecated Use Integration::update_enabled_outgoing_fields() instead.
 	 * @return boolean True if updated, false otherwise.
 	 */
 	public static function update_fields( $fields ) {
-		// Only allow fields that are in the metadata keys map.
-		$fields = array_intersect( self::get_default_fields(), $fields );
-		return \update_option( self::FIELDS_OPTION, array_values( $fields ) );
+		$esp_integration = Integrations::get_integration( 'esp' );
+		return $esp_integration ? $esp_integration->update_enabled_outgoing_fields( $fields ) : [];
 	}
 
 	/**
 	 * Get the "raw" unprefixed metadata keys. Only return fields selected to sync.
 	 *
+	 * This method is deprecated. Now, each integration has its own set of enabled fields.
+	 * As a fallback, this method delegates to the ESP Integration.
+	 *
+	 * @deprecated Use Integration::get_enabled_outgoing_fields_raw_keys() instead.
 	 * @return string[] List of raw metadata keys.
 	 */
 	public static function get_raw_keys() {
-		$fields_to_sync = self::get_fields();
-		$raw_keys       = [];
-
-		foreach ( self::get_keys() as $raw_key => $field_name ) {
-			if ( in_array( $field_name, $fields_to_sync, true ) ) {
-				$raw_keys[] = $raw_key;
-			}
-		}
-
-		return array_unique( $raw_keys );
+		$esp_integration = Integrations::get_integration( 'esp' );
+		return $esp_integration ? $esp_integration->get_enabled_outgoing_fields_raw_keys() : [];
 	}
 
 	/**
 	 * Get the "prefixed" metadata keys. Only return fields selected to sync.
 	 *
+	 * This method is deprecated. Now, each integration has its own set of enabled fields.
+	 * As a fallback, this method delegates to the ESP Integration.
+	 *
+	 * @deprecated Use Integration::get_enabled_outgoing_fields_prefixed_keys() instead.
 	 * @return string[] List of prefixed metadata keys.
 	 */
 	public static function get_prefixed_keys() {
-		$fields_to_sync = self::get_fields();
-		$prefixed_keys  = [];
-
-		foreach ( self::get_keys() as $raw_key => $field_name ) {
-			if ( in_array( $field_name, $fields_to_sync, true ) ) {
-				$prefixed_keys[] = self::get_key( $raw_key );
-			}
-		}
-
-		return array_unique( $prefixed_keys );
+		$esp_integration = Integrations::get_integration( 'esp' );
+		return $esp_integration ? $esp_integration->get_enabled_outgoing_fields_prefixed_keys() : [];
 	}
 
 	/**
@@ -219,60 +240,23 @@ class Metadata {
 	}
 
 	/**
-	 * Get basic metadata fields.
-	 *
-	 * @return array List of fields.
-	 */
-	public static function get_basic_fields() {
-		return [
-			'account'              => 'Account',
-			'registration_date'    => 'Registration Date',
-			'connected_account'    => 'Connected Account',
-			'signup_page_utm'      => 'Signup UTM: ',
-			'newsletter_selection' => 'Newsletter Selection',
-			'referer'              => 'Referrer Path',
-			'registration_page'    => 'Registration Page',
-			'current_page_url'     => 'Registration Page',
-			'registration_method'  => 'Registration Method',
-		];
-	}
-
-	/**
-	 * Get payment-related metadata fields.
-	 *
-	 * @return array List of fields.
-	 */
-	public static function get_payment_fields() {
-		return [
-			'membership_status'   => 'Membership Status',
-			// URL of the page on which the payment has happened.
-			'payment_page'        => 'Payment Page',
-			'payment_page_utm'    => 'Payment UTM: ',
-			'sub_start_date'      => 'Current Subscription Start Date',
-			'sub_end_date'        => 'Current Subscription End Date',
-			'cancellation_reason' => 'Subscription Cancellation Reason',
-			// At what interval does the recurring payment occur – e.g. day, week, month or year.
-			'billing_cycle'       => 'Billing Cycle',
-			// The total value of the recurring payment.
-			'recurring_payment'   => 'Recurring Payment',
-			'last_payment_date'   => 'Last Payment Date',
-			'last_payment_amount' => 'Last Payment Amount',
-			// Product name, as it appears in WooCommerce.
-			'product_name'        => 'Product Name',
-			'next_payment_date'   => 'Next Payment Date',
-			// Total value spent by this customer on the site.
-			'total_paid'          => 'Total Paid',
-		];
-	}
-
-	/**
 	 * Get all metadata fields.
 	 *
 	 * @return array List of fields.
 	 */
 	public static function get_all_fields() {
-		return array_merge( self::get_basic_fields(), self::get_payment_fields() );
+		if ( 'legacy' === self::get_version() ) {
+			return Legacy_Metadata::get_all_fields();
+		}
+
+		return [
+			'first_name' => 'First Name',
+			'last_name'  => 'Last Name',
+			'full_name'  => 'Full Name',
+		];
 	}
+
+
 
 	/**
 	 * Check if a metadata key exists in the given metadata.
@@ -284,7 +268,7 @@ class Metadata {
 	 *
 	 * @return boolean
 	 */
-	private static function has_key( $key, $metadata ) {
+	public static function has_key( $key, $metadata ) {
 		return isset( $metadata[ $key ] ) || isset( $metadata[ self::get_key( $key ) ] );
 	}
 
@@ -309,164 +293,21 @@ class Metadata {
 	}
 
 	/**
-	 * Get the UTM key from a raw or prefixed key.
-	 * The returned key must have a suffix (source, medium, campaign, content).
-	 *
-	 * @param string $key Key to check.
-	 *
-	 * @return string|false Formatted key if it is a UTM key, false otherwise.
-	 */
-	public static function get_utm_key( $key ) {
-		$keys     = [ 'signup_page_utm', 'payment_page_utm' ];
-		$raw_keys = self::get_raw_keys();
-		foreach ( $keys as $utm_key ) {
-			if ( ! in_array( $utm_key, $raw_keys, true ) ) { // Skip if the UTM key is not in the list of fields to sync.
-				continue;
-			}
-			$prefixed_key = self::get_key( $utm_key );
-			if ( 0 === strpos( $key, $utm_key ) ) {
-				$suffix = str_replace( $utm_key . '_', '', $key );
-				return ! empty( trim( $suffix ) ) && $suffix !== $key ? $prefixed_key . $suffix : false;
-			}
-			if ( 0 === strpos( $key, $prefixed_key ) && $key !== $prefixed_key ) {
-				return $key;
-			}
-		}
-		return false;
-	}
-
-	/**
-	 * Add user's registration-related data to the given metadata.
-	 * These won't be included in every sync request, but they might be stored as user meta.
-	 *
-	 * @param array $metadata Metadata to add to.
-	 *
-	 * @return array Metadata with registration data added.
-	 */
-	private static function add_registration_data( $metadata ) {
-		$user = self::has_key( 'account', $metadata ) ? \get_user_by( 'id', self::get_key_value( 'account', $metadata ) ) : false;
-		if ( ! $user ) {
-			return $metadata;
-		}
-
-		$registration_method = self::has_key( 'registration_method', $metadata ) ? self::get_key_value( 'registration_method', $metadata ) : \get_user_meta( $user->ID, Reader_Activation::REGISTRATION_METHOD, true );
-		if ( ! empty( $registration_method ) ) {
-			$metadata['registration_method'] = $registration_method;
-		}
-
-		$registration_page = self::has_key( 'registration_page', $metadata ) ? self::get_key_value( 'registration_page', $metadata ) : \get_user_meta( $user->ID, Reader_Activation::REGISTRATION_PAGE, true );
-		if ( ! empty( $registration_page ) ) {
-			$metadata['registration_page'] = $registration_page;
-		}
-
-		$connected_account = self::has_key( 'connected_account', $metadata ) ? self::get_key_value( 'connected_account', $metadata ) : \get_user_meta( $user->ID, Reader_Activation::CONNECTED_ACCOUNT, true );
-		if ( ! empty( $connected_account ) && in_array( $connected_account, Reader_Activation::SSO_REGISTRATION_METHODS ) ) {
-			$metadata['connected_account'] = $connected_account;
-		} elseif ( ! empty( $registration_method ) && in_array( $registration_method, Reader_Activation::SSO_REGISTRATION_METHODS ) ) {
-			$metadata['connected_account'] = $registration_method;
-		}
-
-		return $metadata;
-	}
-
-	/**
-	 * Add UTM fields to the given metadata.
-	 *
-	 * @param array $metadata Metadata to add to.
-	 *
-	 * @return array Metadata with UTM fields added.
-	 */
-	public static function add_utm_data( $metadata ) {
-		// Capture UTM params and signup/payment page URLs as meta for registration or payment.
-		if ( self::has_key( 'current_page_url', $metadata ) || self::has_key( 'registration_page', $metadata ) || self::has_key( 'payment_page', $metadata ) ) {
-			$payment_page = self::has_key( 'payment_page', $metadata ) ? self::get_key_value( 'payment_page', $metadata ) : false;
-			$raw_url    = false;
-			if ( ! empty( $payment_page ) ) {
-				$raw_url = self::get_key_value( 'payment_page', $metadata );
-			} elseif ( self::has_key( 'current_page_url', $metadata ) ) {
-				$raw_url = self::get_key_value( 'current_page_url', $metadata );
-			} else {
-				$raw_url = self::get_key_value( 'registration_page', $metadata );
-			}
-
-			$parsed_url = \wp_parse_url( $raw_url );
-
-			// Maybe set UTM meta.
-			if ( ! empty( $parsed_url['query'] ) ) {
-				$utm_key_prefix = ! empty( $payment_page ) ? 'payment_page_utm' : 'signup_page_utm';
-				$params         = [];
-				\wp_parse_str( $parsed_url['query'], $params );
-				foreach ( $params as $param => $value ) {
-					$param = \sanitize_text_field( $param );
-					if ( 'utm' === substr( $param, 0, 3 ) ) {
-						$param = str_replace( 'utm_', '', $param );
-						$key   = self::get_key( $utm_key_prefix ) . $param;
-						if ( ! isset( $metadata[ $key ] ) || empty( $metadata[ $key ] ) ) {
-							$metadata[ $key ] = $value;
-						}
-					}
-				}
-			}
-		}
-
-		return $metadata;
-	}
-
-	/**
 	 * Normalizes contact metadata keys before syncing to ESP.
 	 *
 	 * @param array $contact Contact data.
 	 * @return array Normalized contact data.
 	 */
 	public static function normalize_contact_data( $contact ) {
+		if ( 'legacy' === self::get_version() ) {
+			return Legacy_Metadata::normalize_contact_data( $contact );
+		}
+
 		if ( ! isset( $contact['metadata'] ) ) {
 			$contact['metadata'] = [];
 		}
 
-		$metadata            = $contact['metadata'];
-		$metadata            = self::add_registration_data( $metadata );
-		$metadata            = self::add_utm_data( $metadata );
-		$raw_keys            = self::get_raw_keys();
-		$prefixed_keys       = self::get_prefixed_keys();
-		$normalized_metadata = [];
-
-		// Keys allowed to pass through without prefixing.
-		$allowed_keys = [ 'status', 'status_if_new' ];
-
-		// UTM keys must be suffixed.
-		$disallowed_keys = [
-			'payment_page_utm',
-			'payment_page_utm_',
-			'signup_page_utm',
-			'signup_page_utm_',
-			self::get_key( 'payment_page_utm' ),
-			self::get_key( 'signup_page_utm' ),
-		];
-
-		foreach ( $metadata as $meta_key => $meta_value ) {
-			if ( in_array( $meta_key, $raw_keys, true ) && ! in_array( $meta_key, $disallowed_keys, true ) ) { // Handle raw keys.
-				$normalized_metadata[ self::get_key( $meta_key ) ] = $meta_value;
-			} elseif ( in_array( $meta_key, $prefixed_keys, true ) && ! in_array( $meta_key, $disallowed_keys, true ) ) { // Handle prefixed keys.
-				$normalized_metadata[ $meta_key ] = $meta_value;
-			} elseif ( self::get_utm_key( $meta_key ) ) { // Handle UTM keys.
-				$normalized_metadata[ self::get_utm_key( $meta_key ) ] = $meta_value;
-			} elseif ( in_array( $meta_key, $allowed_keys, true ) ) { // Handle allowed keys.
-				$normalized_metadata[ $meta_key ] = $meta_value;
-			} else { // If the key is not in the list of fields to sync, ignore it.
-				Logger::log( 'Ignoring metadata key: ' . $meta_key );
-			}
-		}
-
-		$contact['metadata'] = $normalized_metadata;
-
-		Logger::log( 'Normalizing contact data for reader ESP sync:' );
-		Logger::log( $contact );
-
-		/**
-		 * Filters the normalized contact data before syncing to the ESP.
-		 *
-		 * @param array $contact Contact data.
-		 */
-		return apply_filters( 'newspack_esp_sync_normalize_contact', $contact );
+		// TODO: Do something new.
+		return $contact;
 	}
 }

--- a/tests/unit-tests/integrations/class-test-integrations.php
+++ b/tests/unit-tests/integrations/class-test-integrations.php
@@ -44,6 +44,7 @@ class Test_Integrations extends \WP_UnitTestCase {
 			remove_filter( 'pre_http_request', $this->loopback_filter );
 			$this->loopback_filter = null;
 		}
+		Integrations::register_integrations(); // recover core integrations for future tests.
 		parent::tear_down();
 	}
 

--- a/tests/unit-tests/reader-activation-sync.php
+++ b/tests/unit-tests/reader-activation-sync.php
@@ -28,7 +28,7 @@ class Newspack_Test_Reader_Activation_Sync extends WP_UnitTestCase {
 			'name'     => 'Test Contact',
 			'metadata' => [],
 		];
-		foreach ( array_keys( Sync\Metadata::$keys ) as $key ) {
+		foreach ( array_keys( Sync\Metadata::get_keys() ) as $key ) {
 			$contact['metadata'][ Sync\Metadata::get_key( $key ) ] = 'value';
 		}
 		return $contact;
@@ -225,8 +225,8 @@ class Newspack_Test_Reader_Activation_Sync extends WP_UnitTestCase {
 	 */
 	public function test_with_all_valid_selected() {
 		$contact = $this->get_sample_contact();
-		$defaults = array_keys( Sync\Metadata::$keys );
-		$this->set_option( [ Sync\Metadata::$keys[ $defaults[0] ], Sync\Metadata::$keys[ $defaults[1] ] ] );
+		$defaults = array_keys( Sync\Metadata::get_keys() );
+		$this->set_option( [ Sync\Metadata::get_keys()[ $defaults[0] ], Sync\Metadata::get_keys()[ $defaults[1] ] ] );
 		$normalized = Sync\Metadata::normalize_contact_data( $contact );
 		$this->assertArrayHasKey( Sync\Metadata::get_key( $defaults[0] ), $normalized['metadata'] );
 		$this->assertArrayHasKey( Sync\Metadata::get_key( $defaults[1] ), $normalized['metadata'] );
@@ -239,8 +239,8 @@ class Newspack_Test_Reader_Activation_Sync extends WP_UnitTestCase {
 	 */
 	public function test_with_valid_and_invalid_selected() {
 		$contact  = $this->get_sample_contact();
-		$defaults = array_keys( Sync\Metadata::$keys );
-		$this->set_option( [ Sync\Metadata::$keys[ $defaults[0] ], Sync\Metadata::$keys[ $defaults[1] ], 'invalid' ] );
+		$defaults = array_keys( Sync\Metadata::get_keys() );
+		$this->set_option( [ Sync\Metadata::get_keys()[ $defaults[0] ], Sync\Metadata::get_keys()[ $defaults[1] ], 'invalid' ] );
 		$normalized = Sync\Metadata::normalize_contact_data( $contact );
 		$this->assertArrayHasKey( Sync\Metadata::get_key( $defaults[0] ), $normalized['metadata'] );
 		$this->assertArrayHasKey( Sync\Metadata::get_key( $defaults[1] ), $normalized['metadata'] );
@@ -255,8 +255,8 @@ class Newspack_Test_Reader_Activation_Sync extends WP_UnitTestCase {
 	 */
 	public function test_with_utm_fields() {
 		$contact  = $this->get_sample_contact();
-		$defaults = array_keys( Sync\Metadata::$keys );
-		$this->set_option( [ Sync\Metadata::$keys['signup_page_utm'], Sync\Metadata::$keys['payment_page_utm'] ] );
+		$defaults = array_keys( Sync\Metadata::get_keys() );
+		$this->set_option( [ Sync\Metadata::get_keys()['signup_page_utm'], Sync\Metadata::get_keys()['payment_page_utm'] ] );
 		$contact['metadata'][ Sync\Metadata::get_key( 'signup_page_utm' ) . 'foo' ] = 'bar';
 		$contact['metadata'][ Sync\Metadata::get_key( 'payment_page_utm' ) . 'yyy' ] = 'zzz';
 		$normalized = Sync\Metadata::normalize_contact_data( $contact );
@@ -271,8 +271,8 @@ class Newspack_Test_Reader_Activation_Sync extends WP_UnitTestCase {
 	 */
 	public function test_with_raw_utm_fields() {
 		$contact  = $this->get_sample_contact();
-		$defaults = array_keys( Sync\Metadata::$keys );
-		$this->set_option( [ Sync\Metadata::$keys['signup_page_utm'], Sync\Metadata::$keys['payment_page_utm'] ] );
+		$defaults = array_keys( Sync\Metadata::get_keys() );
+		$this->set_option( [ Sync\Metadata::get_keys()['signup_page_utm'], Sync\Metadata::get_keys()['payment_page_utm'] ] );
 		$contact['metadata']['signup_page_utm_foo'] = 'bar';
 		$contact['metadata']['payment_page_utm_yyy'] = 'zzz';
 		$normalized = Sync\Metadata::normalize_contact_data( $contact );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR paves the way for creating a new metadata schema for sync. 

There were many possible approaches, and I spent quite some time considering how I would go about it, so what drove my decision was:

* Ease of review. This PR was written to be easy to read, understand, and test. The new methods in `Legacy_Metadata` and `Integration` classes are basically copied and pasted from the `Metadata` class. So that logic is safe and there are tests covering a big part of it.
* Stability. The goal was to make this PR as low-risk as possible — moving things around while ensuring that the current sync behavior remains unchanged unless a feature flag is explicitly set or a manual change is made in the site.
* Minimal refactoring. In that same spirit, this PR does not engage in a deeper refactor of the metadata class. There are some methods with confusing names, but even small changes there can break things, as they are the result of years of iterations. Hopefully the new metadata schema will allow us to simplify them. For now, methods are moved from one place to another, but behavior remains largely the same.

With all of that in mind, this PR introduces integration-specific settings. The current UI audience management should continue to work and seamlessly migrate from a global setting to a setting attached to the ESP integration.

### How to test the changes in this Pull Request:

* Smoke test. Make sure sync is still working as before. Verify that changing the enabled fields in the audience management settings page (ESP sync fields) still works as expected. Make sure all tests pass.
* Code review. Look through the code and check if you spot any issues or anything that may have been missed.
* Manual tweak. Manually adjust the integration enabled fields option (`newspack_integration_outgoing_fields_esp`) directly in the WP shell, and confirm that these changes are correctly reflected in the UI.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->