### PR TITLE
fix(wizard): restore PluginInstaller routing when required plugins unsatisfied

### DIFF
--- a/packages/components/src/wizard/index.js
+++ b/packages/components/src/wizard/index.js
@@ -103,6 +103,10 @@ const Wizard = (
 		];
 	}
 
+	// When plugins are required but not yet satisfied, `displayedSections` is replaced with
+	// the PluginInstaller. Use it for routing so the installer actually mounts and runs.
+	const routedSections = pluginRequirementsSatisfied ? sections : displayedSections;
+
 	const urlWithoutHash = window.location.href.split( '#' )[ 0 ];
 
 	return (
@@ -192,7 +196,7 @@ const Wizard = (
 					{ sections.length > 1 && <ResetHeaderData /> }
 
 					<Switch>
-						{ sections.map( ( section, index ) => {
+						{ routedSections.map( ( section, index ) => {
 							const SectionComponent = section.render;
 							const sectionProps = section.props || {};
 							return (


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The Audience > Donations page was stuck on a blank "Required plugin" screen and would never load. The page correctly detected that `newspack-blocks` needed to be verified, but the `PluginInstaller` component responsible for that check was never mounting.

The root cause was a regression introduced in #4474, which changed `displayedSections.map` to `sections.map` in the Wizard's `<Switch>`. When required plugins are unsatisfied, `displayedSections` is replaced with a single PluginInstaller route. Since the Switch was using `sections` instead, that route never existed in the router, the installer never ran, and the page stayed stuck permanently.

The fix introduces `routedSections`: when plugins are unsatisfied it uses `displayedSections` (so the PluginInstaller mounts and runs), and when satisfied it falls back to `sections` (preserving the #4474 behavior for hidden routes).

### How to test the changes in this Pull Request:

**Before applying this PR**
1. Go to **Audience -> Donations** and the page will show a blank "Required plugin" screen.

**Apply this PR**
1. Force reload (Shift + Reload) on the **Audience -> Donations** page and the page loads and routes to `#/configuration` as expected.
2. Verify the **Audience -> Access Control** (content gates) wizard still works as expected. Create/edit gates to confirm hidden section routing is unaffected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->