### PR TITLE
feat: (Newspack Integrations) new `getAll()` method to retrieve all items from the reader data store

### DIFF
--- a/src/reader-activation/store.js
+++ b/src/reader-activation/store.js
@@ -273,6 +273,27 @@ export default function Store() {
 			return _get( key );
 		},
 		/**
+		 * Get all values from the store.
+		 *
+		 * Iterates over keys in storage, filtering by our
+		 * store prefix to ensure only relevant items are included.
+		 *
+		 * @return {Object} Plain object with all key-value pairs.
+		 */
+		getAll: () => {
+			const data = {};
+			const { storePrefix, storage } = config;
+			const internalPrefix = storePrefix + '_';
+			for ( let i = 0; i < storage.length; i++ ) {
+				const storageKey = storage.key( i );
+				if ( storageKey.startsWith( storePrefix ) && ! storageKey.startsWith( internalPrefix ) ) {
+					const key = storageKey.slice( storePrefix.length );
+					data[ key ] = decode( storage.getItem( storageKey ) );
+				}
+			}
+			return data;
+		},
+		/**
 		 * Set a value in the store.
 		 *
 		 * @param {string}  key   Key to set.

--- a/src/reader-activation/store.js
+++ b/src/reader-activation/store.js
@@ -286,6 +286,9 @@ export default function Store() {
 			const internalPrefix = storePrefix + '_';
 			for ( let i = 0; i < storage.length; i++ ) {
 				const storageKey = storage.key( i );
+				if ( ! storageKey ) {
+					continue;
+				}
 				if ( storageKey.startsWith( storePrefix ) && ! storageKey.startsWith( internalPrefix ) ) {
 					const key = storageKey.slice( storePrefix.length );
 					data[ key ] = decode( storage.getItem( storageKey ) );

--- a/src/reader-activation/store.js
+++ b/src/reader-activation/store.js
@@ -45,6 +45,21 @@ function initializeSyncInterval( queue ) {
 /**
  * Get store item key
  *
+ * @param {boolean} internal Whether it's an internal (bookkeeping) prefix.
+ *
+ * @return {string} Store prefix string.
+ */
+function getStorePrefix( internal = false ) {
+	const parts = [ config.storePrefix ];
+	if ( internal ) {
+		parts.push( '_' );
+	}
+	return parts.join( '' );
+}
+
+/**
+ * Get store item key
+ *
  * @param {string}  key      Key to get.
  * @param {boolean} internal Whether it's an internal value.
  *
@@ -54,12 +69,7 @@ export function getStoreItemKey( key, internal = false ) {
 	if ( ! key ) {
 		throw new Error( 'Key is required.' );
 	}
-	const parts = [ config.storePrefix ];
-	if ( internal ) {
-		parts.push( '_' );
-	}
-	parts.push( key );
-	return parts.join( '' );
+	return getStorePrefix( internal ) + key;
 }
 
 /**
@@ -282,16 +292,16 @@ export default function Store() {
 		 */
 		getAll: () => {
 			const data = {};
-			const { storePrefix, storage } = config;
-			const internalPrefix = storePrefix + '_';
-			for ( let i = 0; i < storage.length; i++ ) {
-				const storageKey = storage.key( i );
+			const prefix = getStorePrefix( false );
+			const internalPrefix = getStorePrefix( true );
+			for ( let i = 0; i < config.storage.length; i++ ) {
+				const storageKey = config.storage.key( i );
 				if ( ! storageKey ) {
 					continue;
 				}
-				if ( storageKey.startsWith( storePrefix ) && ! storageKey.startsWith( internalPrefix ) ) {
-					const key = storageKey.slice( storePrefix.length );
-					data[ key ] = decode( storage.getItem( storageKey ) );
+				if ( storageKey.startsWith( prefix ) && ! storageKey.startsWith( internalPrefix ) ) {
+					const key = storageKey.slice( prefix.length );
+					data[ key ] = decode( config.storage.getItem( storageKey ) );
 				}
 			}
 			return data;

--- a/src/reader-activation/store.test.js
+++ b/src/reader-activation/store.test.js
@@ -97,6 +97,9 @@ describe( 'Store', () => {
 		expect( store.get( 'foo' ) ).toEqual( 'bar' );
 	} );
 	describe( 'getAll', () => {
+		beforeEach( () => {
+			window.newspack_reader_data = {};
+		} );
 		it( 'should return all store data as a plain object', () => {
 			const store = Store();
 			store.set( 'name', 'Leo' );

--- a/src/reader-activation/store.test.js
+++ b/src/reader-activation/store.test.js
@@ -9,6 +9,7 @@ describe( 'Store', () => {
 		const store = Store();
 		expect( typeof store ).toBe( 'object' );
 		expect( typeof store.get ).toBe( 'function' );
+		expect( typeof store.getAll ).toBe( 'function' );
 		expect( typeof store.set ).toBe( 'function' );
 		expect( typeof store.add ).toBe( 'function' );
 		expect( typeof store.delete ).toBe( 'function' );
@@ -94,6 +95,45 @@ describe( 'Store', () => {
 		};
 		const store = Store();
 		expect( store.get( 'foo' ) ).toEqual( 'bar' );
+	} );
+	describe( 'getAll', () => {
+		it( 'should return all store data as a plain object', () => {
+			const store = Store();
+			store.set( 'name', 'Leo' );
+			store.set( 'prefs', { theme: 'dark' } );
+			store.set( 'scores', [ 1, 2, 3 ] );
+			const all = store.getAll();
+			expect( all ).toEqual( {
+				name: 'Leo',
+				prefs: { theme: 'dark' },
+				scores: [ 1, 2, 3 ],
+			} );
+		} );
+		it( 'should not include internal keys in getAll', () => {
+			const store = Store();
+			store.set( 'visible', 'yes' );
+			const all = store.getAll();
+			expect( all.visible ).toEqual( 'yes' );
+			expect( all ).not.toHaveProperty( 'unsynced' );
+			// Verify internal key exists in storage but isn't surfaced.
+			expect( localStorage.getItem( 'np_reader__unsynced' ) ).not.toBeNull();
+		} );
+		it( 'should return an empty object when store is empty', () => {
+			const store = Store();
+			expect( store.getAll() ).toEqual( {} );
+		} );
+		it( 'should include rehydrated server items in getAll', () => {
+			window.newspack_reader_data = {
+				items: {
+					is_donor: 'true',
+					active_memberships: '[1,2]',
+				},
+			};
+			const store = Store();
+			const all = store.getAll();
+			expect( all.is_donor ).toEqual( true );
+			expect( all.active_memberships ).toEqual( [ 1, 2 ] );
+		} );
 	} );
 	describe( 'Read-only keys', () => {
 		beforeEach( () => {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

We currently have only a `get()` method that fetches individual items from our reader data store.  More extensive integrations may need more than just one key at a time.

This PR adds a `getAll()` method that fetches all reader data items in the store as a plain object.

Implements [DSGNEWS-104: Javascript API: get all data from Reader Data Library](https://linear.app/a8c/issue/DSGNEWS-104/javascript-api-get-all-data-from-reader-data-library).

### How to test the changes in this Pull Request:

#### Prerequisites:
* A test Newspack site with Reader Activation enabled (Newspack → Settings → Reader Activation).
* A plain old non-admin user (i.e., reader) account on the test site.

#### 1. Verify `getAll()` returns rehydrated server data (logged-in reader)

1. Log in as a reader (non-admin).
2. Open the browser's JavaScript console.
3. Run:
```
window.newspackReaderActivation.store.getAll();
```
4. Confirm it returns a plain object. If the reader has server-side data (e.g., donations, memberships, newsletter subscriptions), you should see keys like `is_donor`, `active_memberships`, `newsletter_subscribed_lists`, etc., alongside any client-set keys like `reader` and `activity`.

#### 2. Verify `getAll()` reflects client-side writes

1. In the console, set a custom key:
```
window.newspackReaderActivation.store.set( 'test_key', { hello: 'world' } );
window.newspackReaderActivation.store.getAll();
```
2. Confirm the returned object includes `test_key: { hello: "world" }` alongside any previously existing keys.

#### 3. Verify `getAll()` reflects deletions

1. Picking up from test 2 above:
```
window.newspackReaderActivation.store.delete( 'test_key' );
window.newspackReaderActivation.store.getAll();
```

2. Confirm `test_key` does not appear in the returned object.


#### 4. Verify `getAll()` on an anonymous/logged-out session

1. Open an incognito/private window and navigate to the site (do not log in).
2. Open the console and run:
```
window.newspackReaderActivation.store.getAll();
```
3. Confirm it returns an object. It may not be an empty object--it can contain client-side keys like `reader` or `activity` from page navigation.  It should not contain keys that would've been rehydrated for a logged-in user, like `is_donor`.


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->