### PR TITLE
feat(reader-activation): add integration health check system

### DIFF
--- a/includes/class-alert-manager.php
+++ b/includes/class-alert-manager.php
@@ -23,6 +23,7 @@ class Alert_Manager {
 	public static function init() {
 		add_action( 'newspack_sync_retry_exhausted', [ __CLASS__, 'handle_sync_retry_exhausted' ] );
 		add_action( 'newspack_data_event_retry_exhausted', [ __CLASS__, 'handle_data_event_retry_exhausted' ] );
+		add_action( 'newspack_integration_health_check_failed', [ __CLASS__, 'handle_health_check_failed' ] );
 	}
 
 	/**
@@ -87,6 +88,32 @@ class Alert_Manager {
 			'newspack_alert',
 			[
 				'type'      => 'data_event_retry_exhausted',
+				'severity'  => 'error',
+				'message'   => $message,
+				'context'   => $payload,
+				'timestamp' => time(),
+			]
+		);
+	}
+
+	/**
+	 * Handle integration health check failure.
+	 *
+	 * @param array $payload Health check failure data.
+	 */
+	public static function handle_health_check_failed( $payload ) {
+		$error   = $payload['error'] ?? null;
+		$message = sprintf(
+			'Integration "%s" health check failed: %s',
+			$payload['integration_name'] ?? 'unknown',
+			is_wp_error( $error ) ? implode( '; ', $error->get_error_messages() ) : 'unknown error'
+		);
+
+		/** This action is documented in includes/class-alert-manager.php */
+		do_action(
+			'newspack_alert',
+			[
+				'type'      => 'integration_health_check_failed',
 				'severity'  => 'error',
 				'message'   => $message,
 				'context'   => $payload,

--- a/includes/reader-activation/class-integrations.php
+++ b/includes/reader-activation/class-integrations.php
@@ -25,6 +25,11 @@ class Integrations {
 	const LOGGER_HEADER = 'NEWSPACK-INTEGRATION';
 
 	/**
+	 * Cron hook name for integration health checks.
+	 */
+	const HEALTH_CHECK_CRON_HOOK = 'newspack_integration_health_check';
+
+	/**
 	 * Registered integrations.
 	 *
 	 * @var Integration[]
@@ -66,6 +71,8 @@ class Integrations {
 		require_once __DIR__ . '/integrations/class-contact-pull.php';
 
 		add_action( 'init', [ __CLASS__, 'register_integrations' ], 5 );
+		add_action( 'init', [ __CLASS__, 'schedule_health_check' ] );
+		add_action( self::HEALTH_CHECK_CRON_HOOK, [ __CLASS__, 'run_health_checks' ] );
 
 		Integrations\Contact_Pull::init();
 	}
@@ -323,5 +330,69 @@ class Integrations {
 		}
 
 		$integration->{ $entry['method'] }( $timestamp, $data, $client_id );
+	}
+
+	/**
+	 * Schedule the hourly health check cron event.
+	 *
+	 * Respects NEWSPACK_CRON_DISABLE to allow selective disabling.
+	 */
+	public static function schedule_health_check() {
+		register_deactivation_hook( NEWSPACK_PLUGIN_FILE, [ __CLASS__, 'deactivate_health_check' ] );
+
+		if ( defined( 'NEWSPACK_CRON_DISABLE' ) && is_array( NEWSPACK_CRON_DISABLE ) && in_array( self::HEALTH_CHECK_CRON_HOOK, NEWSPACK_CRON_DISABLE, true ) ) {
+			self::deactivate_health_check();
+		} elseif ( ! \wp_next_scheduled( self::HEALTH_CHECK_CRON_HOOK ) ) {
+			\wp_schedule_event( time(), 'hourly', self::HEALTH_CHECK_CRON_HOOK );
+		}
+	}
+
+	/**
+	 * Deactivate the health check cron event.
+	 */
+	public static function deactivate_health_check() {
+		\wp_clear_scheduled_hook( self::HEALTH_CHECK_CRON_HOOK );
+	}
+
+	/**
+	 * Run health checks on all active integrations.
+	 *
+	 * Logs failures and fires an action for the Alert Manager.
+	 */
+	public static function run_health_checks() {
+		$active = self::get_active_integrations();
+		foreach ( $active as $integration ) {
+			$result = $integration->health_check();
+			if ( is_wp_error( $result ) ) {
+				Logger::error(
+					sprintf(
+						'Health check failed for integration "%s": %s',
+						$integration->get_name(),
+						implode( '; ', $result->get_error_messages() )
+					),
+					self::LOGGER_HEADER
+				);
+
+				/**
+				 * Fires when an integration health check fails.
+				 *
+				 * @param array $payload {
+				 *     Health check failure data.
+				 *
+				 *     @type string    $integration_id   The integration ID.
+				 *     @type string    $integration_name The integration display name.
+				 *     @type \WP_Error $error            The error object.
+				 * }
+				 */
+				do_action(
+					'newspack_integration_health_check_failed',
+					[
+						'integration_id'   => $integration->get_id(),
+						'integration_name' => $integration->get_name(),
+						'error'            => $result,
+					]
+				);
+			}
+		}
 	}
 }

--- a/includes/reader-activation/integrations/class-esp.php
+++ b/includes/reader-activation/integrations/class-esp.php
@@ -164,17 +164,16 @@ class ESP extends Integration {
 	/**
 	 * Test the live connection to the ESP.
 	 *
-	 * Calls get_incoming_available_contact_fields() which hits the ESP API.
+	 * Delegates to Newspack_Newsletters::test_connection() if available.
 	 * By the time this runs, can_sync() has already passed.
 	 *
 	 * @return true|\WP_Error True on success, WP_Error on failure.
 	 */
 	public function test_connection() {
-		$fields = $this->get_incoming_available_contact_fields();
-		if ( is_wp_error( $fields ) ) {
-			return $fields;
+		if ( ! method_exists( 'Newspack_Newsletters', 'test_connection' ) ) {
+			return true;
 		}
-		return true;
+		return \Newspack_Newsletters::test_connection();
 	}
 
 	/**

--- a/includes/reader-activation/integrations/class-esp.php
+++ b/includes/reader-activation/integrations/class-esp.php
@@ -137,6 +137,22 @@ class ESP extends Integration {
 	}
 
 	/**
+	 * Test the live connection to the ESP.
+	 *
+	 * Calls get_incoming_available_contact_fields() which hits the ESP API.
+	 * By the time this runs, can_sync() has already passed.
+	 *
+	 * @return true|\WP_Error True on success, WP_Error on failure.
+	 */
+	public function test_connection() {
+		$fields = $this->get_incoming_available_contact_fields();
+		if ( is_wp_error( $fields ) ) {
+			return $fields;
+		}
+		return true;
+	}
+
+	/**
 	 * Get incoming available contact fields from the integration.
 	 *
 	 * @return Incoming_Contact_Field[]|\WP_Error Array of incoming contact field objects or WP_Error on failure.

--- a/includes/reader-activation/integrations/class-integration.php
+++ b/includes/reader-activation/integrations/class-integration.php
@@ -238,7 +238,11 @@ abstract class Integration {
 		if ( is_wp_error( $errors ) && $errors->has_errors() ) {
 			return $errors;
 		}
-		$connection = $this->test_connection();
+		try {
+			$connection = $this->test_connection();
+		} catch ( \Throwable $e ) {
+			return new \WP_Error( 'newspack_integration_connection_error', $e->getMessage() );
+		}
 		if ( is_wp_error( $connection ) ) {
 			return $connection;
 		}

--- a/includes/reader-activation/integrations/class-integration.php
+++ b/includes/reader-activation/integrations/class-integration.php
@@ -208,4 +208,33 @@ abstract class Integration {
 	public function set_selected_fields( $fields ) {
 		return \update_option( self::OPTION_PREFIX . $this->id, array_values( $fields ) );
 	}
+
+	/**
+	 * Test the live connection to the integration service.
+	 *
+	 * Subclasses should override this to perform a lightweight API call
+	 * verifying credentials and reachability.
+	 *
+	 * @return true|\WP_Error True on success, WP_Error on failure.
+	 */
+	public function test_connection() {
+		return true;
+	}
+
+	/**
+	 * Run a full health check: settings validation + live connection test.
+	 *
+	 * @return true|\WP_Error True if healthy, WP_Error on failure.
+	 */
+	final public function health_check() {
+		$errors = $this->can_sync( true );
+		if ( is_wp_error( $errors ) && $errors->has_errors() ) {
+			return $errors;
+		}
+		$connection = $this->test_connection();
+		if ( is_wp_error( $connection ) ) {
+			return $connection;
+		}
+		return true;
+	}
 }

--- a/tests/unit-tests/integrations/class-test-integrations.php
+++ b/tests/unit-tests/integrations/class-test-integrations.php
@@ -685,6 +685,115 @@ class Test_Integrations extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test health_check returns true when can_sync passes and test_connection succeeds.
+	 */
+	public function test_health_check_returns_true_when_healthy() {
+		$integration = new Sample_Integration( 'healthy', 'Healthy' );
+		Integrations::register( $integration );
+
+		$result = $integration->health_check();
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test health_check returns WP_Error from can_sync when validation fails.
+	 */
+	public function test_health_check_returns_can_sync_error() {
+		$integration = new class( 'sync-fail', 'Sync Fail' ) extends Sample_Integration {
+			/**
+			 * Simulate can_sync validation failure.
+			 *
+			 * @param bool $return_errors Whether to return WP_Error.
+			 * @return bool|\WP_Error
+			 */
+			public function can_sync( $return_errors = false ) {
+				if ( $return_errors ) {
+					$errors = new \WP_Error();
+					$errors->add( 'missing_key', 'API key is missing.' );
+					$errors->add( 'missing_list', 'List ID is not set.' );
+					return $errors;
+				}
+				return false;
+			}
+		};
+		Integrations::register( $integration );
+
+		$result = $integration->health_check();
+
+		$this->assertWPError( $result );
+		$this->assertEquals( 'missing_key', $result->get_error_code() );
+		$this->assertCount( 2, $result->get_error_messages() );
+	}
+
+	/**
+	 * Test health_check returns WP_Error from test_connection when live check fails.
+	 */
+	public function test_health_check_returns_test_connection_error() {
+		$integration = new class( 'conn-fail', 'Conn Fail' ) extends Sample_Integration {
+			/**
+			 * Simulate a connection failure.
+			 *
+			 * @return \WP_Error
+			 */
+			public function test_connection() {
+				return new \WP_Error( 'connection_failed', 'Could not reach the API.' );
+			}
+		};
+		Integrations::register( $integration );
+
+		$result = $integration->health_check();
+
+		$this->assertWPError( $result );
+		$this->assertEquals( 'connection_failed', $result->get_error_code() );
+		$this->assertEquals( 'Could not reach the API.', $result->get_error_message() );
+	}
+
+	/**
+	 * Test health_check short-circuits on can_sync failure without calling test_connection.
+	 */
+	public function test_health_check_skips_test_connection_on_can_sync_failure() {
+		$integration = new class( 'short-circuit', 'Short Circuit' ) extends Sample_Integration {
+			/**
+			 * Whether test_connection was called.
+			 *
+			 * @var bool
+			 */
+			public static $connection_called = false;
+
+			/**
+			 * Simulate can_sync validation failure.
+			 *
+			 * @param bool $return_errors Whether to return WP_Error.
+			 * @return bool|\WP_Error
+			 */
+			public function can_sync( $return_errors = false ) {
+				if ( $return_errors ) {
+					$errors = new \WP_Error();
+					$errors->add( 'not_configured', 'Not configured.' );
+					return $errors;
+				}
+				return false;
+			}
+
+			/**
+			 * Track whether this method is called.
+			 *
+			 * @return true
+			 */
+			public function test_connection() {
+				self::$connection_called = true;
+				return true;
+			}
+		};
+		Integrations::register( $integration );
+
+		$integration->health_check();
+
+		$this->assertFalse( $integration::$connection_called, 'test_connection should not be called when can_sync fails.' );
+	}
+
+	/**
 	 * Test handle_ajax_pull processes data when called directly.
 	 */
 	public function test_handle_ajax_pull() {

--- a/tests/unit-tests/integrations/class-test-integrations.php
+++ b/tests/unit-tests/integrations/class-test-integrations.php
@@ -795,6 +795,29 @@ class Test_Integrations extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test health_check catches Throwable from test_connection and returns WP_Error.
+	 */
+	public function test_health_check_catches_throwable_from_test_connection() {
+		$integration = new class( 'throw-conn', 'Throw Conn' ) extends Sample_Integration {
+			/**
+			 * Simulate a fatal error during connection test.
+			 *
+			 * @throws \RuntimeException Always.
+			 */
+			public function test_connection() {
+				throw new \RuntimeException( 'Fatal: something exploded' );
+			}
+		};
+		Integrations::register( $integration );
+
+		$result = $integration->health_check();
+
+		$this->assertWPError( $result );
+		$this->assertEquals( 'newspack_integration_connection_error', $result->get_error_code() );
+		$this->assertEquals( 'Fatal: something exploded', $result->get_error_message() );
+	}
+
+	/**
 	 * Test handle_ajax_pull processes data when called directly.
 	 */
 	public function test_handle_ajax_pull() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds an integration health check system that combines settings validation (`can_sync`) with a live connection test (`test_connection`), run hourly via cron. Failures are logged and routed through the existing `newspack_alert` pipeline.

- **`Integration` base class**: adds `test_connection()` (defaults to `true`, subclasses override) and `final health_check()` template method that runs `can_sync(true)` then `test_connection()`.
- **`ESP` integration**: overrides `test_connection()` to call `get_incoming_available_contact_fields()`, which hits the ESP API to verify credentials and reachability.
- **`Integrations` manager**: schedules an hourly cron (`newspack_integration_health_check`) that iterates active integrations, runs `health_check()`, logs failures, and fires `newspack_integration_health_check_failed`. Respects `NEWSPACK_CRON_DISABLE` and unschedules on plugin deactivation.
- **`Alert_Manager`**: listens for `newspack_integration_health_check_failed` and fires `newspack_alert` with type `integration_health_check_failed` and severity `error`.

### How to test the changes in this Pull Request:

1. Build: `cd repos/newspack-plugin && n build`
2. Verify cron is scheduled: `n wp cron event list` — look for `newspack_integration_health_check`
3. Trigger manually: `n wp cron event run newspack_integration_health_check`
4. Verify that with a valid ESP configuration, no errors are logged
5. Test failure: temporarily set an invalid ESP API key, run the cron again, confirm "Health check failed" appears in Newspack logs and the `newspack_alert` action fires with type `integration_health_check_failed`
6. Verify `NEWSPACK_CRON_DISABLE` support: define `NEWSPACK_CRON_DISABLE` with `newspack_integration_health_check` in the array and confirm the cron event is not scheduled

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?