### PR TITLE
fix(my-account): render payment and address modals for all logged-in users

### DIFF
--- a/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php
+++ b/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php
@@ -676,9 +676,12 @@ class My_Account_UI_V1 {
 	 * Render the "Add Payment Method" modal.
 	 */
 	public static function add_payment_method_modal() {
-		if ( ! \is_user_logged_in() || ! Reader_Activation::is_user_reader( \wp_get_current_user() ) ) {
+		if ( ! \is_user_logged_in() ) {
 			return;
 		}
+		// No is_user_reader() check here. The modal needs to be available to all logged-in users,
+		// including legacy subscribers who predate Reader Activation and lack the np_reader meta.
+		// Restricting to readers causes the button to silently break for those users.
 		// Set the query var so payment gateways can detect the add-payment-method context.
 		global $wp;
 		$wp->query_vars['add-payment-method'] = true;
@@ -710,9 +713,10 @@ class My_Account_UI_V1 {
 	 * Render the "Add Address" modal.
 	 */
 	public static function add_address_modals() {
-		if ( ! \is_user_logged_in() || ! Reader_Activation::is_user_reader( \wp_get_current_user() ) ) {
+		if ( ! \is_user_logged_in() ) {
 			return;
 		}
+		// No is_user_reader() check here. The same reasoning as add_payment_method_modal().
 		$address_types = [ 'billing' => __( 'Billing', 'newspack-plugin' ) ];
 		if ( ! \wc_ship_to_billing_address_only() && \wc_shipping_enabled() ) {
 			$address_types['shipping'] = __( 'Shipping', 'newspack-plugin' );

--- a/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php
+++ b/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php
@@ -769,9 +769,10 @@ class My_Account_UI_V1 {
 	 * Render the "Delete Address" confirmation modals.
 	 */
 	public static function delete_address_modals() {
-		if ( ! \is_user_logged_in() || ! Reader_Activation::is_user_reader( \wp_get_current_user() ) ) {
+		if ( ! \is_user_logged_in() ) {
 			return;
 		}
+		// No is_user_reader() check here. The same reasoning as add_payment_method_modal().
 
 		$address_types = [ 'billing' => __( 'Billing', 'newspack-plugin' ) ];
 		if ( ! \wc_ship_to_billing_address_only() && \wc_shipping_enabled() ) {

--- a/src/my-account/v1/payment-information.js
+++ b/src/my-account/v1/payment-information.js
@@ -48,9 +48,6 @@ function setupModalHandlers( selector, modalId, dataAttribute = null ) {
 					dropdown.classList.remove( 'active' );
 				}
 				jQuery( document.body ).trigger( 'refresh' );
-			} else if ( button.href ) {
-				// Modal not found in DOM (e.g. non-reader user) — fall back to native navigation rather than failing silently.
-				window.location.href = button.href;
 			}
 		} );
 	} );

--- a/src/my-account/v1/payment-information.js
+++ b/src/my-account/v1/payment-information.js
@@ -48,6 +48,9 @@ function setupModalHandlers( selector, modalId, dataAttribute = null ) {
 					dropdown.classList.remove( 'active' );
 				}
 				jQuery( document.body ).trigger( 'refresh' );
+			} else if ( button.href ) {
+				// Modal not found in DOM (e.g. non-reader user) — fall back to native navigation rather than failing silently.
+				window.location.href = button.href;
 			}
 		} );
 	} );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes proposed in this Pull Request:

The "Add payment method" button and address Edit/Delete actions on `/my-account/payment-methods/` were silently broken for users without the `np_reader` user meta flag.

This removes the `is_user_reader()` guard from `add_payment_method_modal()` and `add_address_modals()`. The modal needs to be available to any logged-in user, not just users who would have been through the Reader Activation flow.

Closes `NPPM-2662`

### How to test the changes in this Pull Request:

**Before applying this PR:**

1. Create a test user with the `customer` role and no `np_reader` user meta:
`n wp user create testcustomer testcustomer@example.com --role=customer --user_pass=test1234`

2. Then set the email as verified which we be needed to access account pages. Use the ID printed by the create command:
`n wp user meta update <ID> np_reader_email_verified 1`

3. Log in as that user and navigate to `/my-account/payment-methods/`

4. Confirm "Add payment method" button does **not** open the modal

5. Confirm that the address Edit/Delete actions in the three-dot menu also both do **not** work


**Optional: test the effect of the `np_reader` meta value:**

6. Set `np_reader` on the user:
`n wp user meta update <ID> np_reader 1`

7. Reload the Payment Methods page and confirm the "Add payment method" button now opens the modal, and the address Edit/Delete actions also work

8. Remove `np_reader` to restore the broken state:
`n wp user meta delete <ID> np_reader`

9. Reload to confirm the modals no longer open

**Apply the PR:**

10. Reload the Payment Methods to confirm "Add payment method" button opens the modal

11. Confirm that the address Edit/Delete actions in the three-dot menu work

12. Set `np_reader` on the user to confirm everything still works
`n wp user meta update <ID> np_reader 1`

13. Remove `np_reader` to confirm everything still works
`n wp user meta delete <ID> np_reader`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
