### PR TITLE
docs(author-social): add README for social links blocks

### DIFF
--- a/src/blocks/author-profile-social/README.md
+++ b/src/blocks/author-profile-social/README.md
@@ -1,12 +1,12 @@
 # Author Social Links Block
 
-A Gutenberg block that displays the author's social media links and contact information as a row of icon links.
+A Gutenberg block that displays the author's social media links and contact information as a row of linked icons.
 
 ## Overview
 
-The Author Social Links block (`newspack/author-profile-social`) renders social media icons for the current author. It is designed exclusively as an inner block of the [Author Profile block](https://github.com/Automattic/newspack-blocks/tree/trunk/src/blocks/author-profile) and appears only in block themes that support nested layout mode.
+The Author Social Links block (`newspack/author-profile-social`) renders social media icons for the current author. It is designed exclusively as an inner block of the [Author Profile block](https://github.com/Automattic/newspack-blocks/tree/trunk/src/blocks/author-profile) and appears only in the nested layout mode of the block, available when using a block theme.
 
-Each social link is a separate [Author Social Link](../author-social-link/README.md) child block, allowing publishers to reorder or remove individual links.
+Each social link is a separate [Author Social Link](../author-social-link/) child block, allowing publishers to reorder or remove individual links.
 
 ## Block attributes
 
@@ -58,6 +58,6 @@ This block is only registered for the inserter in block themes. It requires the 
 
 ## Related
 
-- [Author Social Link Block](../author-social-link/README.md) - Child block for individual social icons.
+- [Author Social Link Block](../author-social-link/) - Child block for individual social icons.
 - [Author Profile Block](https://github.com/Automattic/newspack-blocks/tree/trunk/src/blocks/author-profile) - Parent block that provides author context.
 - [Social_Icons class](../../../includes/class-social-icons.php) - Backend SVG icon provider.

--- a/src/blocks/author-profile-social/README.md
+++ b/src/blocks/author-profile-social/README.md
@@ -1,0 +1,63 @@
+# Author Social Links Block
+
+A Gutenberg block that displays the author's social media links and contact information as a row of icon links.
+
+## Overview
+
+The Author Social Links block (`newspack/author-profile-social`) renders social media icons for the current author. It is designed exclusively as an inner block of the [Author Profile block](../../../../repos/newspack-blocks/src/blocks/author-profile/README.md) and appears only in block themes that support nested layout mode.
+
+Each social link is a separate [Author Social Link](../author-social-link/README.md) child block, allowing publishers to reorder or remove individual links.
+
+## Block attributes
+
+| Attribute | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `showEmail` | boolean | `false` | Whether to display the author's email as a link |
+| `iconSize` | number | `24` | Icon size in pixels. Rounded to the nearest even number for rendering |
+
+## Context
+
+| Context key | Direction | Description |
+|-------------|-----------|-------------|
+| `newspack-blocks/author` | Consumes | Author data object from the parent Author Profile block |
+| `newspack-blocks/iconSize` | Provides | Icon size passed down to child Author Social Link blocks |
+
+## Supported services
+
+The block displays icons for any social service present in the author's profile data. Common services include: Facebook, X (Twitter), Instagram, LinkedIn, YouTube, Bluesky, Pinterest, Myspace, SoundCloud, Tumblr, Wikipedia, email, and phone.
+
+## Editor behavior
+
+- **Auto-population**: On first render (when no saved inner blocks exist), the block fetches the full list of supported services from the `/newspack/v1/social-icons` REST endpoint and creates an `Author Social Link` inner block for each service. This ensures all possible icons are available in the template; icons without author data are hidden on the frontend.
+- **Reset button**: A toolbar button resets inner blocks to the full set of available services.
+- **Add missing links**: If the author has services that don't have a corresponding inner block, an "Add missing links" button appears in the inspector panel.
+- **Empty state**: When the author has no social links and no inner blocks exist, a placeholder message is shown.
+
+## Icon size
+
+The icon size is configurable via a dropdown in the inspector panel. Available options are defined in `getIconSizeOptions()` in [utils.js](./utils.js). Values are stored as-is but rounded to the nearest even number for display (e.g., 23 renders as 24px). The size is exposed as a `--icon-size` CSS custom property on the wrapper.
+
+## Rendering
+
+### Frontend (PHP)
+
+Two rendering paths exist in [class-author-profile-social-block.php](./class-author-profile-social-block.php):
+
+1. **InnerBlocks mode**: When saved inner blocks exist, each `Author Social Link` child block is rendered with the author context propagated.
+2. **Flat mode**: Legacy fallback that builds social links directly from the author data array without inner blocks.
+
+Both modes output a `<ul class="author-profile-social__list">` wrapper.
+
+### Editor (React)
+
+The [edit.jsx](./edit.jsx) component uses `InnerBlocks` with `allowedBlocks` restricted to `newspack/author-social-link`. Author data is consumed from the shared `AuthorContext` (via `window.NewspackAuthorContext`).
+
+## Availability
+
+This block is only registered for the inserter in block themes. It requires the Author Profile block as an ancestor ([`newspack-blocks/author-profile`](https://github.com/Automattic/newspack-blocks/tree/trunk/src/blocks/author-profile)).
+
+## Related
+
+- [Author Social Link Block](../author-social-link/README.md) - Child block for individual social icons.
+- [Author Profile Block](https://github.com/Automattic/newspack-blocks/tree/trunk/src/blocks/author-profile) - Parent block that provides author context.
+- [Social_Icons class](../../../includes/class-social-icons.php) - Backend SVG icon provider.

--- a/src/blocks/author-profile-social/README.md
+++ b/src/blocks/author-profile-social/README.md
@@ -4,7 +4,7 @@ A Gutenberg block that displays the author's social media links and contact info
 
 ## Overview
 
-The Author Social Links block (`newspack/author-profile-social`) renders social media icons for the current author. It is designed exclusively as an inner block of the [Author Profile block](../../../../repos/newspack-blocks/src/blocks/author-profile/README.md) and appears only in block themes that support nested layout mode.
+The Author Social Links block (`newspack/author-profile-social`) renders social media icons for the current author. It is designed exclusively as an inner block of the [Author Profile block](https://github.com/Automattic/newspack-blocks/tree/trunk/src/blocks/author-profile) and appears only in block themes that support nested layout mode.
 
 Each social link is a separate [Author Social Link](../author-social-link/README.md) child block, allowing publishers to reorder or remove individual links.
 

--- a/src/blocks/author-social-link/README.md
+++ b/src/blocks/author-social-link/README.md
@@ -1,0 +1,72 @@
+# Author Social Link Block
+
+A Gutenberg block that displays a single social media icon link for the author.
+
+## Overview
+
+The Author Social Link block (`newspack/author-social-link`) renders a single social media or contact icon within the [Author Social Links](../author-profile-social/README.md) parent block. Each instance represents a specific service (e.g., Facebook, email, phone) and automatically resolves the URL and icon from the author's profile data.
+
+## Block attributes
+
+| Attribute | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `service` | string | `""` | Service key (e.g., `facebook`, `email`, `phone`, `linkedin`) |
+
+## Context
+
+| Context key | Direction | Description |
+|-------------|-----------|-------------|
+| `newspack-blocks/author` | Consumes | Author data object from the Author Profile block |
+| `newspack-blocks/iconSize` | Consumes | Icon size in pixels from the parent Social Links block |
+
+## Service resolution
+
+The block resolves the URL for each service from the author data:
+
+| Service | URL source |
+|---------|------------|
+| `email` | `author.email` (plain string becomes `mailto:`, object uses `.url`) |
+| `phone` | `author.newspack_phone_number` (plain string becomes `tel:`, object uses `.url`) |
+| Other services | `author.social[service].url` |
+
+If the author has no data for the service, the block renders nothing (returns empty string on frontend, `null` in editor).
+
+## Icon resolution
+
+Icons are resolved in order:
+
+1. **Author data SVG**: If the REST API provided an SVG with the author's social data (e.g., `author.social.facebook.svg`), it is used directly.
+2. **Built-in SVG map**: Falls back to `Social_Icons::get_svg( $service )`, which provides SVG icons for all supported services.
+3. **Text fallback**: If no SVG is available, the service name is displayed as plain text.
+
+## Supported services
+
+Labels are defined in [utils.js](./utils.js):
+
+| Key | Label |
+|-----|-------|
+| `facebook` | Facebook |
+| `twitter` | X |
+| `instagram` | Instagram |
+| `linkedin` | LinkedIn |
+| `youtube` | YouTube |
+| `bluesky` | Bluesky |
+| `pinterest` | Pinterest |
+| `myspace` | Myspace |
+| `soundcloud` | SoundCloud |
+| `tumblr` | Tumblr |
+| `wikipedia` | Wikipedia |
+| `email` | Email |
+| `phone` | Phone |
+
+Unknown service keys fall through to the raw key string as both label and fallback text.
+
+## Availability
+
+This block requires the Author Social Links block as its parent ([`newspack/author-profile-social`]()). It cannot be inserted independently.
+
+## Related
+
+- [Author Social Links Block](../author-profile-social/README.md) - Parent block that manages the collection of social icons.
+- [Author Profile Block](https://github.com/Automattic/newspack-blocks/tree/trunk/src/blocks/author-profile) - Root block that provides author context.
+- [Social_Icons class](../../../includes/class-social-icons.php) - Backend SVG icon provider.

--- a/src/blocks/author-social-link/README.md
+++ b/src/blocks/author-social-link/README.md
@@ -4,7 +4,7 @@ A Gutenberg block that displays a single social media icon link for the author.
 
 ## Overview
 
-The Author Social Link block (`newspack/author-social-link`) renders a single social media or contact icon within the [Author Social Links](../author-profile-social/README.md) parent block. Each instance represents a specific service (e.g., Facebook, email, phone) and automatically resolves the URL and icon from the author's profile data.
+The Author Social Link block (`newspack/author-social-link`) renders a single social media or contact icon within the [Author Social Links](../author-profile-social/) parent block. Each instance represents a specific service (e.g., Facebook, email, phone) and automatically resolves the URL and icon from the author's profile data.
 
 ## Block attributes
 
@@ -67,6 +67,6 @@ This block requires the Author Social Links block as its parent ([`newspack/auth
 
 ## Related
 
-- [Author Social Links Block](../author-profile-social/README.md) - Parent block that manages the collection of social icons.
+- [Author Social Links Block](../author-profile-social/) - Parent block that manages the collection of social icons.
 - [Author Profile Block](https://github.com/Automattic/newspack-blocks/tree/trunk/src/blocks/author-profile) - Root block that provides author context.
 - [Social_Icons class](../../../includes/class-social-icons.php) - Backend SVG icon provider.

--- a/src/blocks/author-social-link/README.md
+++ b/src/blocks/author-social-link/README.md
@@ -63,7 +63,7 @@ Unknown service keys fall through to the raw key string as both label and fallba
 
 ## Availability
 
-This block requires the Author Social Links block as its parent ([`newspack/author-profile-social`]()). It cannot be inserted independently.
+This block requires the Author Social Links block as its parent ([`newspack/author-profile-social`](../author-profile-social/)). It cannot be inserted independently.
 
 ## Related
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds developer-facing READMEs for the Author Social Links and Author Social Link blocks.

Closes NPPD-1220.

### How to test the changes in this Pull Request:

1. Open `src/blocks/author-profile-social/README.md` and verify the content renders correctly on GitHub.
2. Open `src/blocks/author-social-link/README.md` and verify the content renders correctly on GitHub.
3. Confirm that relative links (to sibling blocks, PHP classes within the repo) resolve correctly.
4. Confirm that absolute GitHub links (to newspack-blocks author-profile) resolve correctly.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?