### PR TITLE
fix(block-theme): load block styles when needed

### DIFF
--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -129,11 +129,24 @@ final class Blocks {
 	 * @return bool Whether to load block assets.
 	 */
 	private static function should_load_block_assets() {
-		return Collections::is_module_active() && (
-			( is_singular() && has_block( \Newspack\Blocks\Collections\Collections_Block::BLOCK_NAME, get_the_ID() ) ) ||
-			is_post_type_archive( \Newspack\Collections\Post_Type::get_post_type() ) ||
-			is_singular( \Newspack\Collections\Post_Type::get_post_type() )
-		);
+		// Load the block styles if we're on a single or archive Collections page.
+		if (
+			Collections::is_module_active() &&
+			(
+				is_post_type_archive( \Newspack\Collections\Post_Type::get_post_type() ) ||
+				is_singular( \Newspack\Collections\Post_Type::get_post_type() )
+			)
+		) {
+			return true;
+		}
+
+		if ( ! is_singular() ) {
+			return false;
+		}
+
+		// Load the block styles if we're on a post or page with a block from this plugin.
+		$post = get_post( get_the_ID() );
+		return $post && false !== strpos( $post->post_content, '"newspack/' );
 	}
 }
 Blocks::init();

--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -146,7 +146,7 @@ final class Blocks {
 
 		// Load the block styles if we're on a post or page with a block from this plugin.
 		$post = get_post( get_the_ID() );
-		return $post && false !== strpos( $post->post_content, '"newspack/' );
+		return $post && false !== strpos( $post->post_content, 'wp:newspack/' );
 	}
 }
 Blocks::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes a weird issue that seems to have started happening after I wiped my test site: blocks like the social links block from the Author Profile block aren't loading CSS on the front-end. 

Looking at the code I think this makes sense -- it's checking to see if we're [on a Collections page before loading](https://github.com/Automattic/newspack-plugin/blob/95f7c36acb6fa446afecdddd4beef5387b19e87e/includes/class-blocks.php#L126-L138). What I don't get is how it worked for me in the first place. I'm not sure if my test site was in a weird state before (like had a Collections block in the template), or is somehow in a weird state now. I did have a pretty mangled template, so it could be the former, but I wish I could get it back to check.

This PR adds a check for blocks in the content as well. I'm open to other approaches, too, if there's a better way - maybe removing the check entirely?

Also I'd be interested if this is working for anyone else? I'm so confused 😂 

Closes NPPD-1348

### How to test the changes in this Pull Request:

1. On a page/post without a Collections block, add an Author Profile block.
2. View on the front-end; note that the social links have bullets.
3. Apply this PR.
4. Confirm the styles now look right on the front-end.
5. Smoke test things like Collections or other blocks in the Newspack Plugin block 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->