### PR TITLE
fix: change ip check cookie lifetime

### DIFF
--- a/includes/content-gate/class-ip-access-rule.php
+++ b/includes/content-gate/class-ip-access-rule.php
@@ -66,7 +66,7 @@ class IP_Access_Rule {
 		$valid_ip = apply_filters( 'newspack_content_gate_check_ip', false );
 
 		if ( $valid_ip ) {
-			setcookie( self::COOKIE_NAME, '1', time() + DAY_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN ); // phpcs:ignore
+			setcookie( self::COOKIE_NAME, '1', time() + MONTH_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN ); // phpcs:ignore
 		}
 
 		wp_safe_redirect( home_url( '/' ) );


### PR DESCRIPTION
We discussed and we are going to use a month as the default lifetime for this cookie.

This will likely be an option in the UI when we implement the proper access control rule