### PR TITLE
feat(sync): prevent stale data on retry, improve logging and error handling

### DIFF
--- a/includes/reader-activation/sync/class-contact-sync.php
+++ b/includes/reader-activation/sync/class-contact-sync.php
@@ -147,6 +147,13 @@ class Contact_Sync extends Sync {
 		$user    = ! empty( $contact['email'] ) ? \get_user_by( 'email', $contact['email'] ) : false;
 		$user_id = $user ? $user->ID : 0;
 
+		// Preserve the previous email for retry when the contact's email has changed
+		// (e.g. Email_Change context) so integrations can upsert against the old address.
+		$previous_email = '';
+		if ( ! empty( $existing_contact['email'] ) && $existing_contact['email'] !== $contact['email'] ) {
+			$previous_email = $existing_contact['email'];
+		}
+
 		foreach ( $integrations as $integration_id => $integration ) {
 			$result = $integration->push_contact_data( $contact, $context, $existing_contact );
 			if ( \is_wp_error( $result ) ) {
@@ -173,7 +180,7 @@ class Contact_Sync extends Sync {
 						'reason'         => $result->get_error_message(),
 					]
 				);
-				self::schedule_integration_retry( $integration_id, $user_id, $context, 0, $result );
+				self::schedule_integration_retry( $integration_id, $user_id, $context, 0, $result, $previous_email );
 				$errors[] = sprintf( '[%s] %s', $integration_id, $result->get_error_message() );
 				if ( self::$current_as_action_id ) {
 					\ActionScheduler_Logger::instance()->log(
@@ -204,8 +211,9 @@ class Contact_Sync extends Sync {
 	 * @param string           $context        The sync context.
 	 * @param int              $retry_count    Current retry count (0 = first failure).
 	 * @param string|\WP_Error $error          The error from the failure.
+	 * @param string           $previous_email Optional. Previous email for email-change retries.
 	 */
-	private static function schedule_integration_retry( $integration_id, $user_id, $context, $retry_count, $error ) {
+	private static function schedule_integration_retry( $integration_id, $user_id, $context, $retry_count, $error, $previous_email = '' ) {
 		if ( ! function_exists( 'as_schedule_single_action' ) ) {
 			return;
 		}
@@ -273,6 +281,7 @@ class Contact_Sync extends Sync {
 			'retry_count'    => $next_retry,
 			'max_retries'    => self::MAX_RETRIES,
 			'reason'         => $error_message,
+			'previous_email' => $previous_email,
 		];
 
 		\as_schedule_single_action(
@@ -313,6 +322,7 @@ class Contact_Sync extends Sync {
 		$user_id        = $retry_data['user_id'];
 		$context        = $retry_data['context'] ?? static::$context;
 		$retry_count    = $retry_data['retry_count'] ?? 1;
+		$previous_email = $retry_data['previous_email'] ?? '';
 
 		$user = \get_userdata( $user_id );
 		if ( ! $user ) {
@@ -342,7 +352,14 @@ class Contact_Sync extends Sync {
 		$contact = \apply_filters( 'newspack_esp_sync_contact', $contact, $context );
 		$contact = Sync\Metadata::normalize_contact_data( $contact );
 
-		$result = $integration->push_contact_data( $contact, $context );
+		// Reconstruct existing_contact for email-change retries so integrations
+		// can upsert against the previous email address.
+		$existing_contact = null;
+		if ( ! empty( $previous_email ) ) {
+			$existing_contact = array_merge( $contact, [ 'email' => $previous_email ] );
+		}
+
+		$result = $integration->push_contact_data( $contact, $context, $existing_contact );
 		if ( \is_wp_error( $result ) ) {
 			$error_messages = implode( '; ', $result->get_error_messages() );
 			static::log(
@@ -360,7 +377,8 @@ class Contact_Sync extends Sync {
 				$user_id,
 				$context,
 				$retry_count,
-				$result
+				$result,
+				$previous_email
 			);
 			$error_message = sprintf(
 				'Retry %d/%d failed for integration "%s" sync of user %d (%s): %s',

--- a/includes/reader-activation/sync/class-contact-sync.php
+++ b/includes/reader-activation/sync/class-contact-sync.php
@@ -218,13 +218,13 @@ class Contact_Sync extends Sync {
 			return;
 		}
 
-		if ( empty( $user_id ) || ! \get_userdata( $user_id ) ) {
+		$user = \get_userdata( $user_id );
+		if ( ! $user ) {
 			static::log( sprintf( 'Cannot schedule retry for integration "%s": user %d not found.', $integration_id, $user_id ) );
 			return;
 		}
 
 		$error_message = $error instanceof \WP_Error ? $error->get_error_message() : (string) $error;
-		$user          = \get_userdata( $user_id );
 		$user_email    = $user ? $user->user_email : 'unknown';
 
 		$next_retry = $retry_count + 1;

--- a/includes/reader-activation/sync/class-contact-sync.php
+++ b/includes/reader-activation/sync/class-contact-sync.php
@@ -105,8 +105,9 @@ class Contact_Sync extends Sync {
 		if ( Data_Events::current_event() ) {
 			if ( ! isset( self::$queued_syncs[ $contact['email'] ] ) ) {
 				self::$queued_syncs[ $contact['email'] ] = [
-					'contexts' => [],
-					'contact'  => [],
+					'contexts'     => [],
+					'contact'      => [],
+					'as_action_id' => self::$current_as_action_id,
 				];
 			}
 			if ( ! empty( self::$queued_syncs[ $contact['email'] ]['contact']['metadata'] ) ) {
@@ -535,7 +536,12 @@ class Contact_Sync extends Sync {
 			return;
 		}
 
+		// Restore the AS action ID so push_to_integrations() can log against it.
+		$saved_action_id = self::$current_as_action_id;
+
 		foreach ( self::$queued_syncs as $email => $queued_sync ) {
+			self::$current_as_action_id = $queued_sync['as_action_id'] ?? null;
+
 			$user = get_user_by( 'email', $email );
 			$contact = null;
 			if ( $user ) {
@@ -552,6 +558,7 @@ class Contact_Sync extends Sync {
 			self::sync( $contact, implode( '; ', $contexts ) );
 		}
 
+		self::$current_as_action_id = $saved_action_id;
 		self::$queued_syncs = [];
 	}
 }

--- a/includes/reader-activation/sync/class-contact-sync.php
+++ b/includes/reader-activation/sync/class-contact-sync.php
@@ -337,6 +337,10 @@ class Contact_Sync extends Sync {
 
 		static::log( sprintf( 'Executing retry %d/%d for integration "%s" sync of user %d (%s).', $retry_count, self::MAX_RETRIES, $integration_id, $user_id, $contact['email'] ?? 'unknown' ) );
 
+		/** This filter is documented in includes/reader-activation/sync/class-contact-sync.php */
+		$contact = \apply_filters( 'newspack_esp_sync_contact', $contact, $context );
+		$contact = Sync\Metadata::normalize_contact_data( $contact );
+
 		$result = $integration->push_contact_data( $contact, $context );
 		if ( \is_wp_error( $result ) ) {
 			$error_messages = implode( '; ', $result->get_error_messages() );

--- a/includes/reader-activation/sync/class-contact-sync.php
+++ b/includes/reader-activation/sync/class-contact-sync.php
@@ -299,7 +299,7 @@ class Contact_Sync extends Sync {
 	/**
 	 * Execute an integration sync retry from ActionScheduler.
 	 *
-	 * @param array $retry_data The retry data containing integration_id, contact, context, and retry_count.
+	 * @param array $retry_data The retry data containing integration_id, user_id, context, and retry_count.
 	 *
 	 * @throws \Exception When the final retry fails, so ActionScheduler marks the action as "failed".
 	 */
@@ -364,12 +364,12 @@ class Contact_Sync extends Sync {
 			);
 			$error_message = sprintf(
 				'Retry %d/%d failed for integration "%s" sync of user %d (%s): %s',
-				absint( $retry_count ),
-				absint( self::MAX_RETRIES ),
-				esc_html( $integration_id ),
-				absint( $user_id ),
-				esc_html( $contact['email'] ?? 'unknown' ),
-				esc_html( $error_messages )
+				$retry_count,
+				self::MAX_RETRIES,
+				$integration_id,
+				$user_id,
+				$contact['email'] ?? 'unknown',
+				$error_messages
 			);
 			if ( self::$current_as_action_id ) {
 				\ActionScheduler_Logger::instance()->log(
@@ -385,11 +385,11 @@ class Contact_Sync extends Sync {
 		} else {
 			$success_message = sprintf(
 				'Retry %d/%d succeeded for integration "%s" sync of user %d (%s).',
-				absint( $retry_count ),
-				absint( self::MAX_RETRIES ),
-				esc_html( $integration_id ),
-				absint( $user_id ),
-				esc_html( $contact['email'] ?? 'unknown' )
+				$retry_count,
+				self::MAX_RETRIES,
+				$integration_id,
+				$user_id,
+				$contact['email'] ?? 'unknown'
 			);
 			static::log( $success_message );
 			if ( self::$current_as_action_id ) {

--- a/includes/reader-activation/sync/class-contact-sync.php
+++ b/includes/reader-activation/sync/class-contact-sync.php
@@ -331,13 +331,9 @@ class Contact_Sync extends Sync {
 		}
 
 		$contact = self::get_contact_data( $user_id );
-		if ( \is_wp_error( $contact ) ) {
-			// Basic fallback when WooCommerce is unavailable.
-			$contact = [
-				'email'    => $user->user_email,
-				'name'     => $user->display_name,
-				'metadata' => [],
-			];
+		if ( is_wp_error( $contact ) ) {
+			Logger::log( sprintf( 'Error getting contact data for user %d on retry %d: %s', $user_id, $retry_count, $contact->get_error_message() ), 'NEWSPACK-SYNC', 'error' );
+			return;
 		}
 
 		$integration = Integrations::get_integration( $integration_id );
@@ -471,13 +467,19 @@ class Contact_Sync extends Sync {
 	 * @return array|\WP_Error The contact data or WP_Error.
 	 */
 	public static function get_contact_data( $user_id ) {
-		if ( ! class_exists( '\WC_Customer' ) ) {
-			return new \WP_Error( 'newspack_esp_sync_contact', __( 'WC_Customer class unavailable.', 'newspack-plugin' ) );
-		}
 		$user = \get_userdata( $user_id );
+		if ( ! $user ) {
+			return new \WP_Error( 'newspack_esp_sync_contact', __( 'User not found.', 'newspack-plugin' ) );
+		}
+
+		$contact = [
+			'email'    => $user->user_email,
+			'name'     => $user->display_name,
+			'metadata' => [],
+		];
 
 		if ( ! class_exists( '\WC_Customer' ) ) {
-			return new \WP_Error( 'newspack_esp_sync_contact', __( 'WC_Customer class unavailable.', 'newspack-plugin' ) );
+			return $contact;
 		}
 		$customer = new \WC_Customer( $user_id );
 		if ( ! $customer || ! $customer->get_id() ) {
@@ -498,11 +500,6 @@ class Contact_Sync extends Sync {
 		}
 
 		$contact = Sync\WooCommerce::get_contact_from_customer( $customer );
-
-		// Include data from queued syncs too.
-		if ( ! empty( self::$queued_syncs[ $contact['email'] ]['contact']['metadata'] ) ) {
-			$contact['metadata'] = array_merge( self::$queued_syncs[ $contact['email'] ]['contact']['metadata'], $contact['metadata'] );
-		}
 
 		return $contact;
 	}

--- a/includes/reader-activation/sync/class-contact-sync.php
+++ b/includes/reader-activation/sync/class-contact-sync.php
@@ -142,6 +142,10 @@ class Contact_Sync extends Sync {
 		$integrations = Integrations::get_active_integrations();
 		$errors       = [];
 
+		// Resolve user ID for retry scheduling.
+		$user    = ! empty( $contact['email'] ) ? \get_user_by( 'email', $contact['email'] ) : false;
+		$user_id = $user ? $user->ID : 0;
+
 		foreach ( $integrations as $integration_id => $integration ) {
 			$result = $integration->push_contact_data( $contact, $context, $existing_contact );
 			if ( \is_wp_error( $result ) ) {
@@ -168,7 +172,7 @@ class Contact_Sync extends Sync {
 						'reason'         => $result->get_error_message(),
 					]
 				);
-				self::schedule_integration_retry( $integration_id, $contact, $context, $existing_contact, 0, $result );
+				self::schedule_integration_retry( $integration_id, $user_id, $context, 0, $result );
 				$errors[] = sprintf( '[%s] %s', $integration_id, $result->get_error_message() );
 				if ( self::$current_as_action_id ) {
 					\ActionScheduler_Logger::instance()->log(
@@ -194,28 +198,35 @@ class Contact_Sync extends Sync {
 	/**
 	 * Schedule a retry for a failed integration sync via ActionScheduler.
 	 *
-	 * @param string           $integration_id   The integration ID.
-	 * @param array            $contact          The contact data.
-	 * @param string           $context          The sync context.
-	 * @param array            $existing_contact Optional. Existing contact data.
-	 * @param int              $retry_count      Current retry count (0 = first failure).
-	 * @param string|\WP_Error $error            The error from the failure.
+	 * @param string           $integration_id The integration ID.
+	 * @param int              $user_id        The WordPress user ID.
+	 * @param string           $context        The sync context.
+	 * @param int              $retry_count    Current retry count (0 = first failure).
+	 * @param string|\WP_Error $error          The error from the failure.
 	 */
-	private static function schedule_integration_retry( $integration_id, $contact, $context, $existing_contact, $retry_count, $error ) {
+	private static function schedule_integration_retry( $integration_id, $user_id, $context, $retry_count, $error ) {
 		if ( ! function_exists( 'as_schedule_single_action' ) ) {
 			return;
 		}
 
+		if ( empty( $user_id ) || ! \get_userdata( $user_id ) ) {
+			static::log( sprintf( 'Cannot schedule retry for integration "%s": user %d not found.', $integration_id, $user_id ) );
+			return;
+		}
+
 		$error_message = $error instanceof \WP_Error ? $error->get_error_message() : (string) $error;
+		$user          = \get_userdata( $user_id );
+		$user_email    = $user ? $user->user_email : 'unknown';
 
 		$next_retry = $retry_count + 1;
 		if ( $next_retry > self::MAX_RETRIES ) {
 			static::log(
 				sprintf(
-					'Max retries (%d) reached for integration "%s" sync of %s. Giving up. Last error: %s',
+					'Max retries (%d) reached for integration "%s" sync of user %d (%s). Giving up. Last error: %s',
 					self::MAX_RETRIES,
 					$integration_id,
-					$contact['email'] ?? 'unknown',
+					$user_id,
+					$user_email,
 					$error_message
 				)
 			);
@@ -232,7 +243,7 @@ class Contact_Sync extends Sync {
 			 *     Alert data.
 			 *
 			 *     @type string $integration_id The integration that failed.
-			 *     @type array  $contact        The contact data that failed to sync.
+			 *     @type int    $user_id        The WordPress user ID.
 			 *     @type string $context        The sync context.
 			 *     @type int    $retry_count    Total retries attempted.
 			 *     @type string $reason         The final error message.
@@ -242,7 +253,7 @@ class Contact_Sync extends Sync {
 				'newspack_sync_retry_exhausted',
 				[
 					'integration_id' => $integration_id,
-					'contact'        => $contact,
+					'user_id'        => $user_id,
 					'context'        => $context,
 					'retry_count'    => self::MAX_RETRIES,
 					'reason'         => $error_message,
@@ -255,12 +266,12 @@ class Contact_Sync extends Sync {
 		$backoff_seconds = self::RETRY_BACKOFF[ $backoff_index ];
 
 		$retry_data = [
-			'integration_id'   => $integration_id,
-			'contact'          => $contact,
-			'context'          => $context,
-			'existing_contact' => $existing_contact,
-			'retry_count'      => $next_retry,
-			'reason'           => $error_message,
+			'integration_id' => $integration_id,
+			'user_id'        => $user_id,
+			'context'        => $context,
+			'retry_count'    => $next_retry,
+			'max_retries'    => self::MAX_RETRIES,
+			'reason'         => $error_message,
 		];
 
 		\as_schedule_single_action(
@@ -272,11 +283,12 @@ class Contact_Sync extends Sync {
 
 		static::log(
 			sprintf(
-				'Scheduled retry %d/%d for integration "%s" sync of %s in %ds. Error: %s',
+				'Scheduled retry %d/%d for integration "%s" sync of user %d (%s) in %ds. Error: %s',
 				$next_retry,
 				self::MAX_RETRIES,
 				$integration_id,
-				$contact['email'] ?? 'unknown',
+				$user_id,
+				$user_email,
 				$backoff_seconds,
 				$error_message
 			)
@@ -291,25 +303,30 @@ class Contact_Sync extends Sync {
 	 * @throws \Exception When the final retry fails, so ActionScheduler marks the action as "failed".
 	 */
 	public static function execute_integration_retry( $retry_data ) {
-		if ( ! is_array( $retry_data ) || empty( $retry_data['integration_id'] ) || empty( $retry_data['contact'] ) ) {
+		if ( ! is_array( $retry_data ) || empty( $retry_data['integration_id'] ) || empty( $retry_data['user_id'] ) ) {
 			Logger::log( 'Invalid integration retry data received from Action Scheduler.', 'NEWSPACK-SYNC', 'error' );
 			return;
 		}
 
-		$integration_id   = $retry_data['integration_id'];
-		$stored_contact   = $retry_data['contact'];
-		$context          = $retry_data['context'] ?? static::$context;
-		$existing_contact = $retry_data['existing_contact'] ?? null;
-		$retry_count      = $retry_data['retry_count'] ?? 1;
+		$integration_id = $retry_data['integration_id'];
+		$user_id        = $retry_data['user_id'];
+		$context        = $retry_data['context'] ?? static::$context;
+		$retry_count    = $retry_data['retry_count'] ?? 1;
 
-		// Fetch fresh contact data to avoid pushing stale state (e.g. outdated subscription status).
-		$email = $stored_contact['email'] ?? '';
-		$user  = $email ? \get_user_by( 'email', $email ) : false;
-		if ( $user ) {
-			$contact = self::get_contact_data( $user->ID );
-		} else {
-			// User deleted — fall back to the stored contact data.
-			$contact = $stored_contact;
+		$user = \get_userdata( $user_id );
+		if ( ! $user ) {
+			Logger::log( sprintf( 'User %d not found on retry %d.', $user_id, $retry_count ), 'NEWSPACK-SYNC', 'error' );
+			return;
+		}
+
+		$contact = self::get_contact_data( $user_id );
+		if ( \is_wp_error( $contact ) ) {
+			// Basic fallback when WooCommerce is unavailable.
+			$contact = [
+				'email'    => $user->user_email,
+				'name'     => $user->display_name,
+				'metadata' => [],
+			];
 		}
 
 		$integration = Integrations::get_integration( $integration_id );
@@ -318,33 +335,34 @@ class Contact_Sync extends Sync {
 			return;
 		}
 
-		static::log( sprintf( 'Executing retry %d/%d for integration "%s" sync of %s.', $retry_count, self::MAX_RETRIES, $integration_id, $contact['email'] ?? 'unknown' ) );
+		static::log( sprintf( 'Executing retry %d/%d for integration "%s" sync of user %d (%s).', $retry_count, self::MAX_RETRIES, $integration_id, $user_id, $contact['email'] ?? 'unknown' ) );
 
-		$result = $integration->push_contact_data( $contact, $context, $existing_contact );
+		$result = $integration->push_contact_data( $contact, $context );
 		if ( \is_wp_error( $result ) ) {
 			$error_messages = implode( '; ', $result->get_error_messages() );
 			static::log(
 				sprintf(
-					'Retry %d failed for integration "%s" sync of %s: %s',
+					'Retry %d failed for integration "%s" sync of user %d (%s): %s',
 					$retry_count,
 					$integration_id,
+					$user_id,
 					$contact['email'] ?? 'unknown',
 					$error_messages
 				)
 			);
 			self::schedule_integration_retry(
 				$integration_id,
-				$contact,
+				$user_id,
 				$context,
-				$existing_contact,
 				$retry_count,
 				$result
 			);
 			$error_message = sprintf(
-				'Retry %d/%d failed for integration "%s" sync of %s: %s',
+				'Retry %d/%d failed for integration "%s" sync of user %d (%s): %s',
 				absint( $retry_count ),
 				absint( self::MAX_RETRIES ),
 				esc_html( $integration_id ),
+				absint( $user_id ),
 				esc_html( $contact['email'] ?? 'unknown' ),
 				esc_html( $error_messages )
 			);
@@ -361,10 +379,11 @@ class Contact_Sync extends Sync {
 			}
 		} else {
 			$success_message = sprintf(
-				'Retry %d/%d succeeded for integration "%s" sync of %s.',
+				'Retry %d/%d succeeded for integration "%s" sync of user %d (%s).',
 				absint( $retry_count ),
 				absint( self::MAX_RETRIES ),
 				esc_html( $integration_id ),
+				absint( $user_id ),
 				esc_html( $contact['email'] ?? 'unknown' )
 			);
 			static::log( $success_message );

--- a/includes/reader-activation/sync/class-contact-sync.php
+++ b/includes/reader-activation/sync/class-contact-sync.php
@@ -218,7 +218,7 @@ class Contact_Sync extends Sync {
 			return;
 		}
 
-		$user = \get_userdata( $user_id );
+		$user = ! empty( $user_id ) ? get_userdata( $user_id ) : false;
 		if ( ! $user ) {
 			static::log( sprintf( 'Cannot schedule retry for integration "%s": user %d not found.', $integration_id, $user_id ) );
 			return;

--- a/includes/reader-activation/sync/class-contact-sync.php
+++ b/includes/reader-activation/sync/class-contact-sync.php
@@ -340,25 +340,37 @@ class Contact_Sync extends Sync {
 				$retry_count,
 				$result
 			);
+			$error_message = sprintf(
+				'Retry %d/%d failed for integration "%s" sync of %s: %s',
+				absint( $retry_count ),
+				absint( self::MAX_RETRIES ),
+				esc_html( $integration_id ),
+				esc_html( $contact['email'] ?? 'unknown' ),
+				esc_html( $error_messages )
+			);
+			if ( self::$current_as_action_id ) {
+				\ActionScheduler_Logger::instance()->log(
+					self::$current_as_action_id,
+					$error_message
+				);
+			}
 			// Only throw on the last retry so ActionScheduler marks it as "failed".
 			// Intermediate retries schedule the next attempt and complete normally.
 			if ( $retry_count >= self::MAX_RETRIES ) {
-				throw new \Exception(
-					sprintf(
-						'Retry %d/%d failed for integration "%s": %s',
-						(int) $retry_count,
-						(int) self::MAX_RETRIES,
-						esc_html( $integration_id ),
-						esc_html( $error_messages )
-					)
-				);
+				throw new \Exception( esc_html( $error_message ) );
 			}
-		}
-
-		$success_message = sprintf( 'Retry %d succeeded for integration "%s" sync of %s.', $retry_count, $integration_id, $contact['email'] ?? 'unknown' );
-		static::log( $success_message );
-		if ( self::$current_as_action_id ) {
-			\ActionScheduler_Logger::instance()->log( self::$current_as_action_id, $success_message );
+		} else {
+			$success_message = sprintf(
+				'Retry %d/%d succeeded for integration "%s" sync of %s.',
+				absint( $retry_count ),
+				absint( self::MAX_RETRIES ),
+				esc_html( $integration_id ),
+				esc_html( $contact['email'] ?? 'unknown' )
+			);
+			static::log( $success_message );
+			if ( self::$current_as_action_id ) {
+				\ActionScheduler_Logger::instance()->log( self::$current_as_action_id, $success_message );
+			}
 		}
 	}
 

--- a/includes/reader-activation/sync/class-contact-sync.php
+++ b/includes/reader-activation/sync/class-contact-sync.php
@@ -170,6 +170,17 @@ class Contact_Sync extends Sync {
 				);
 				self::schedule_integration_retry( $integration_id, $contact, $context, $existing_contact, 0, $result );
 				$errors[] = sprintf( '[%s] %s', $integration_id, $result->get_error_message() );
+				if ( self::$current_as_action_id ) {
+					\ActionScheduler_Logger::instance()->log(
+						self::$current_as_action_id,
+						sprintf( 'Sync failed for integration "%s" of %s: %s', $integration_id, $contact['email'] ?? 'unknown', $result->get_error_message() )
+					);
+				}
+			} elseif ( self::$current_as_action_id ) {
+				\ActionScheduler_Logger::instance()->log(
+					self::$current_as_action_id,
+					sprintf( 'Sync succeeded for integration "%s" of %s.', $integration_id, $contact['email'] ?? 'unknown' )
+				);
 			}
 		}
 
@@ -276,6 +287,8 @@ class Contact_Sync extends Sync {
 	 * Execute an integration sync retry from ActionScheduler.
 	 *
 	 * @param array $retry_data The retry data containing integration_id, contact, context, and retry_count.
+	 *
+	 * @throws \Exception When the final retry fails, so ActionScheduler marks the action as "failed".
 	 */
 	public static function execute_integration_retry( $retry_data ) {
 		if ( ! is_array( $retry_data ) || empty( $retry_data['integration_id'] ) || empty( $retry_data['contact'] ) ) {
@@ -309,21 +322,16 @@ class Contact_Sync extends Sync {
 
 		$result = $integration->push_contact_data( $contact, $context, $existing_contact );
 		if ( \is_wp_error( $result ) ) {
+			$error_messages = implode( '; ', $result->get_error_messages() );
 			static::log(
 				sprintf(
 					'Retry %d failed for integration "%s" sync of %s: %s',
 					$retry_count,
 					$integration_id,
 					$contact['email'] ?? 'unknown',
-					implode( '; ', $result->get_error_messages() )
+					$error_messages
 				)
 			);
-			if ( self::$current_as_action_id ) {
-				\ActionScheduler_Logger::instance()->log(
-					self::$current_as_action_id,
-					implode( '; ', $result->get_error_messages() )
-				);
-			}
 			self::schedule_integration_retry(
 				$integration_id,
 				$contact,
@@ -332,10 +340,26 @@ class Contact_Sync extends Sync {
 				$retry_count,
 				$result
 			);
-			return;
+			// Only throw on the last retry so ActionScheduler marks it as "failed".
+			// Intermediate retries schedule the next attempt and complete normally.
+			if ( $retry_count >= self::MAX_RETRIES ) {
+				throw new \Exception(
+					sprintf(
+						'Retry %d/%d failed for integration "%s": %s',
+						(int) $retry_count,
+						(int) self::MAX_RETRIES,
+						esc_html( $integration_id ),
+						esc_html( $error_messages )
+					)
+				);
+			}
 		}
 
-		static::log( sprintf( 'Retry %d succeeded for integration "%s" sync of %s.', $retry_count, $integration_id, $contact['email'] ?? 'unknown' ) );
+		$success_message = sprintf( 'Retry %d succeeded for integration "%s" sync of %s.', $retry_count, $integration_id, $contact['email'] ?? 'unknown' );
+		static::log( $success_message );
+		if ( self::$current_as_action_id ) {
+			\ActionScheduler_Logger::instance()->log( self::$current_as_action_id, $success_message );
+		}
 	}
 
 	/**

--- a/tests/mocks/wc-mocks.php
+++ b/tests/mocks/wc-mocks.php
@@ -108,6 +108,13 @@ class WC_Customer {
 	public function get_email() {
 		return get_userdata( $this->get_id() )->user_email;
 	}
+	public function get_billing_email() {
+		return $this->data['billing_email'] ?? '';
+	}
+	public function set_billing_email( $email ) {
+		$this->data['billing_email'] = $email;
+	}
+	public function save() {}
 }
 
 $orders_database = [];

--- a/tests/unit-tests/reader-activation-sync.php
+++ b/tests/unit-tests/reader-activation-sync.php
@@ -308,19 +308,14 @@ class Newspack_Test_Reader_Activation_Sync extends WP_UnitTestCase {
 		// Clear any pending retries.
 		as_unschedule_all_actions( Contact_Sync::RETRY_HOOK );
 
-		$contact = [
-			'email'    => 'retry@test.com',
-			'name'     => 'Retry Test',
-			'metadata' => [],
-		];
+		$user_id = $this->factory()->user->create( [ 'user_email' => 'retry@test.com' ] );
 
 		Contact_Sync::execute_integration_retry(
 			[
-				'integration_id'   => 'failing_mock',
-				'contact'          => $contact,
-				'context'          => 'Test',
-				'existing_contact' => null,
-				'retry_count'      => 1,
+				'integration_id' => 'failing_mock',
+				'user_id'        => $user_id,
+				'context'        => 'Test',
+				'retry_count'    => 1,
 			]
 		);
 
@@ -356,19 +351,14 @@ class Newspack_Test_Reader_Activation_Sync extends WP_UnitTestCase {
 		// Clear any pending retries.
 		as_unschedule_all_actions( Contact_Sync::RETRY_HOOK );
 
-		$contact = [
-			'email'    => 'success@test.com',
-			'name'     => 'Success Test',
-			'metadata' => [],
-		];
+		$user_id = $this->factory()->user->create( [ 'user_email' => 'success@test.com' ] );
 
 		Contact_Sync::execute_integration_retry(
 			[
-				'integration_id'   => 'success_mock',
-				'contact'          => $contact,
-				'context'          => 'Test',
-				'existing_contact' => null,
-				'retry_count'      => 1,
+				'integration_id' => 'success_mock',
+				'user_id'        => $user_id,
+				'context'        => 'Test',
+				'retry_count'    => 1,
 			]
 		);
 
@@ -400,22 +390,17 @@ class Newspack_Test_Reader_Activation_Sync extends WP_UnitTestCase {
 		// Clear any pending retries.
 		as_unschedule_all_actions( Contact_Sync::RETRY_HOOK );
 
-		$contact = [
-			'email'    => 'max@test.com',
-			'name'     => 'Max Retry Test',
-			'metadata' => [],
-		];
+		$user_id = $this->factory()->user->create( [ 'user_email' => 'max@test.com' ] );
 
 		// Simulate a retry at the max count — should NOT schedule another and should throw.
 		$threw = false;
 		try {
 			Contact_Sync::execute_integration_retry(
 				[
-					'integration_id'   => 'max_mock',
-					'contact'          => $contact,
-					'context'          => 'Test',
-					'existing_contact' => null,
-					'retry_count'      => Contact_Sync::MAX_RETRIES,
+					'integration_id' => 'max_mock',
+					'user_id'        => $user_id,
+					'context'        => 'Test',
+					'retry_count'    => Contact_Sync::MAX_RETRIES,
 				]
 			);
 		} catch ( \Exception $e ) {
@@ -449,11 +434,7 @@ class Newspack_Test_Reader_Activation_Sync extends WP_UnitTestCase {
 
 		as_unschedule_all_actions( Contact_Sync::RETRY_HOOK );
 
-		$contact = [
-			'email'    => 'log@test.com',
-			'name'     => 'Log Test',
-			'metadata' => [],
-		];
+		$user_id = $this->factory()->user->create( [ 'user_email' => 'log@test.com' ] );
 
 		// Schedule a dummy AS action to simulate the currently-executing action.
 		$dummy_action_id = as_schedule_single_action( time() + 3600, 'newspack_dummy_log_action' );
@@ -461,11 +442,10 @@ class Newspack_Test_Reader_Activation_Sync extends WP_UnitTestCase {
 
 		Contact_Sync::execute_integration_retry(
 			[
-				'integration_id'   => 'log_mock',
-				'contact'          => $contact,
-				'context'          => 'Test',
-				'existing_contact' => null,
-				'retry_count'      => 1,
+				'integration_id' => 'log_mock',
+				'user_id'        => $user_id,
+				'context'        => 'Test',
+				'retry_count'    => 1,
 			]
 		);
 
@@ -503,11 +483,7 @@ class Newspack_Test_Reader_Activation_Sync extends WP_UnitTestCase {
 
 		as_unschedule_all_actions( Contact_Sync::RETRY_HOOK );
 
-		$contact = [
-			'email'    => 'deadletter@test.com',
-			'name'     => 'Dead Letter Test',
-			'metadata' => [],
-		];
+		$user_id = $this->factory()->user->create( [ 'user_email' => 'deadletter@test.com' ] );
 
 		// Schedule a dummy AS action to simulate the currently-executing action.
 		$dummy_action_id = as_schedule_single_action( time() + 3600, 'newspack_dummy_sync_action' );
@@ -519,11 +495,10 @@ class Newspack_Test_Reader_Activation_Sync extends WP_UnitTestCase {
 		try {
 			Contact_Sync::execute_integration_retry(
 				[
-					'integration_id'   => 'deadletter_mock',
-					'contact'          => $contact,
-					'context'          => 'Test',
-					'existing_contact' => null,
-					'retry_count'      => Contact_Sync::MAX_RETRIES,
+					'integration_id' => 'deadletter_mock',
+					'user_id'        => $user_id,
+					'context'        => 'Test',
+					'retry_count'    => Contact_Sync::MAX_RETRIES,
 				]
 			);
 		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
@@ -573,21 +548,16 @@ class Newspack_Test_Reader_Activation_Sync extends WP_UnitTestCase {
 
 		as_unschedule_all_actions( Contact_Sync::RETRY_HOOK );
 
-		$contact = [
-			'email'    => 'exhaustion@test.com',
-			'name'     => 'Exhaustion Test',
-			'metadata' => [],
-		];
+		$user_id = $this->factory()->user->create( [ 'user_email' => 'exhaustion@test.com' ] );
 
 		// Execute at max retry count — triggers exhaustion and throws.
 		try {
 			Contact_Sync::execute_integration_retry(
 				[
-					'integration_id'   => 'exhaustion_mock',
-					'contact'          => $contact,
-					'context'          => 'Test',
-					'existing_contact' => null,
-					'retry_count'      => Contact_Sync::MAX_RETRIES,
+					'integration_id' => 'exhaustion_mock',
+					'user_id'        => $user_id,
+					'context'        => 'Test',
+					'retry_count'    => Contact_Sync::MAX_RETRIES,
 				]
 			);
 		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
@@ -596,6 +566,7 @@ class Newspack_Test_Reader_Activation_Sync extends WP_UnitTestCase {
 
 		$this->assertTrue( $hook_fired, 'newspack_sync_retry_exhausted should fire on max retries.' );
 		$this->assertEquals( 'exhaustion_mock', $hook_data['integration_id'] );
+		$this->assertEquals( $user_id, $hook_data['user_id'] );
 		$this->assertEquals( Contact_Sync::MAX_RETRIES, $hook_data['retry_count'] );
 		$this->assertArrayHasKey( 'reason', $hook_data );
 	}
@@ -614,12 +585,12 @@ class Newspack_Test_Reader_Activation_Sync extends WP_UnitTestCase {
 		// Missing integration_id.
 		Contact_Sync::execute_integration_retry(
 			[
-				'contact'     => [ 'email' => 'test@test.com' ],
+				'user_id'     => 1,
 				'retry_count' => 1,
 			]
 		);
 
-		// Missing contact.
+		// Missing user_id.
 		Contact_Sync::execute_integration_retry(
 			[
 				'integration_id' => 'failing_mock',

--- a/tests/unit-tests/reader-activation-sync.php
+++ b/tests/unit-tests/reader-activation-sync.php
@@ -451,8 +451,7 @@ class Newspack_Test_Reader_Activation_Sync extends WP_UnitTestCase {
 
 		Contact_Sync::clear_current_as_action_id();
 
-		// Intermediate retries complete normally without AS log entries
-		// (only the final retry logs via exception).
+		// Intermediate retries log a formatted failure message to the current AS action.
 		$logs     = \ActionScheduler_Logger::instance()->get_logs( $dummy_action_id );
 		$messages = array_map(
 			function ( $log ) {
@@ -460,9 +459,16 @@ class Newspack_Test_Reader_Activation_Sync extends WP_UnitTestCase {
 			},
 			$logs
 		);
-		$this->assertFalse(
-			in_array( 'Mock push failed', $messages, true ),
-			'Intermediate retries should not log errors to AS.'
+		$has_retry_log = false;
+		foreach ( $messages as $message ) {
+			if ( false !== strpos( $message, 'Retry 1/' . Contact_Sync::MAX_RETRIES . ' failed for integration "log_mock"' ) ) {
+				$has_retry_log = true;
+				break;
+			}
+		}
+		$this->assertTrue(
+			$has_retry_log,
+			'Intermediate retries should log a formatted failure message to AS.'
 		);
 
 		// Clean up.

--- a/tests/unit-tests/reader-activation-sync.php
+++ b/tests/unit-tests/reader-activation-sync.php
@@ -406,16 +406,23 @@ class Newspack_Test_Reader_Activation_Sync extends WP_UnitTestCase {
 			'metadata' => [],
 		];
 
-		// Simulate a retry at the max count — should NOT schedule another.
-		Contact_Sync::execute_integration_retry(
-			[
-				'integration_id'   => 'max_mock',
-				'contact'          => $contact,
-				'context'          => 'Test',
-				'existing_contact' => null,
-				'retry_count'      => Contact_Sync::MAX_RETRIES,
-			]
-		);
+		// Simulate a retry at the max count — should NOT schedule another and should throw.
+		$threw = false;
+		try {
+			Contact_Sync::execute_integration_retry(
+				[
+					'integration_id'   => 'max_mock',
+					'contact'          => $contact,
+					'context'          => 'Test',
+					'existing_contact' => null,
+					'retry_count'      => Contact_Sync::MAX_RETRIES,
+				]
+			);
+		} catch ( \Exception $e ) {
+			$threw = true;
+		}
+
+		$this->assertTrue( $threw, 'Should throw an exception on the last retry.' );
 
 		$pending = as_get_scheduled_actions(
 			[
@@ -464,7 +471,8 @@ class Newspack_Test_Reader_Activation_Sync extends WP_UnitTestCase {
 
 		Contact_Sync::clear_current_as_action_id();
 
-		// Verify AS log entry on the current action.
+		// Intermediate retries complete normally without AS log entries
+		// (only the final retry logs via exception).
 		$logs     = \ActionScheduler_Logger::instance()->get_logs( $dummy_action_id );
 		$messages = array_map(
 			function ( $log ) {
@@ -472,9 +480,9 @@ class Newspack_Test_Reader_Activation_Sync extends WP_UnitTestCase {
 			},
 			$logs
 		);
-		$this->assertTrue(
+		$this->assertFalse(
 			in_array( 'Mock push failed', $messages, true ),
-			'AS logs should contain the error message on the current action.'
+			'Intermediate retries should not log errors to AS.'
 		);
 
 		// Clean up.
@@ -507,16 +515,20 @@ class Newspack_Test_Reader_Activation_Sync extends WP_UnitTestCase {
 		// Set the current AS action ID.
 		Contact_Sync::set_current_as_action_id( $dummy_action_id );
 
-		// Execute at max retry count — push fails, triggers max-retries guard.
-		Contact_Sync::execute_integration_retry(
-			[
-				'integration_id'   => 'deadletter_mock',
-				'contact'          => $contact,
-				'context'          => 'Test',
-				'existing_contact' => null,
-				'retry_count'      => Contact_Sync::MAX_RETRIES,
-			]
-		);
+		// Execute at max retry count — push fails, triggers max-retries guard and throws.
+		try {
+			Contact_Sync::execute_integration_retry(
+				[
+					'integration_id'   => 'deadletter_mock',
+					'contact'          => $contact,
+					'context'          => 'Test',
+					'existing_contact' => null,
+					'retry_count'      => Contact_Sync::MAX_RETRIES,
+				]
+			);
+		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+			// Expected — final retry throws so AS marks the action as failed.
+		}
 
 		Contact_Sync::clear_current_as_action_id();
 
@@ -567,16 +579,20 @@ class Newspack_Test_Reader_Activation_Sync extends WP_UnitTestCase {
 			'metadata' => [],
 		];
 
-		// Execute at max retry count — triggers exhaustion.
-		Contact_Sync::execute_integration_retry(
-			[
-				'integration_id'   => 'exhaustion_mock',
-				'contact'          => $contact,
-				'context'          => 'Test',
-				'existing_contact' => null,
-				'retry_count'      => Contact_Sync::MAX_RETRIES,
-			]
-		);
+		// Execute at max retry count — triggers exhaustion and throws.
+		try {
+			Contact_Sync::execute_integration_retry(
+				[
+					'integration_id'   => 'exhaustion_mock',
+					'contact'          => $contact,
+					'context'          => 'Test',
+					'existing_contact' => null,
+					'retry_count'      => Contact_Sync::MAX_RETRIES,
+				]
+			);
+		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+			// Expected — final retry throws so AS marks the action as failed.
+		}
 
 		$this->assertTrue( $hook_fired, 'newspack_sync_retry_exhausted should fire on max retries.' );
 		$this->assertEquals( 'exhaustion_mock', $hook_data['integration_id'] );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Prevent stale data on sync retries by storing the user ID instead of a contact data snapshot. When a retry executes, fresh contact data is fetched from the database, ensuring retries always push the latest reader state rather than potentially outdated information captured at the time of the original failure.

Improve ActionScheduler logging by writing per-integration success/failure messages to the AS log on both the initial sync and retries, making it easier to diagnose sync issues from the ActionScheduler admin UI.

Preserve AS action ID for queued syncs so that deferred syncs executed via `run_queued_syncs()` can still log against the correct ActionScheduler action.

Mark final retries as failed in ActionScheduler by throwing an exception when the last retry fails. In our custom UI, being explored in #4561, we'll be able to manually trigger a run for the failed action.

### How to test the changes in this Pull Request:

1. Register a new reader and verify sync completes successfully
2. Check AS and confirm you get the successful sync logs in the data event handler action
3. Change your ESP config to use invalid credentials
4. Simulate a sync failure and confirm that AS logs show per-integration error messages.
5. Manually run every pending retry until it exhausts and confirm:
    - The newspack_sync_retry_exhausted action fires with user_id (not a contact array).
    - The final retry throws an exception, causing ActionScheduler to mark the action as "failed".
    - No further retries are scheduled.
6. Logged in as the reader, go through the email change flow
7. Before the next retry, restore the ESP configuration
8. Confirm the "Email_Change" sync works without regression on the next retry

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->