### PR TITLE
fix: use correct is_enabled method

### DIFF
--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -473,7 +473,7 @@ final class Reader_Activation {
 		}
 
 		if ( 'sync_esp' === $name ) {
-			return $esp->is_enabled();
+			return Reader_Activation\Integrations::is_enabled( 'esp' );
 		}
 
 		return $esp->get_settings_field_value( $name );


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This fixes a fatal that resulted in calling the incorrect `is_enabled` method in https://github.com/Automattic/newspack-plugin/pull/4541

### How to test the changes in this Pull Request:

1. Visit Audience Management
2. Verify you don't get a fatal

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->