### PR TITLE
fix: membership cancellation bug

### DIFF
--- a/includes/plugins/wc-memberships/class-membership-expiry.php
+++ b/includes/plugins/wc-memberships/class-membership-expiry.php
@@ -36,8 +36,14 @@ class Membership_Expiry {
 			return $cancel_membership;
 		}
 		$membership_product_id = $user_membership->get_product_id();
+		$cancelling_subscription_id = $user_membership->get_subscription_id();
 		$active_subscription_ids = WooCommerce_Connection::get_active_subscriptions_for_user( $user_membership->get_user_id() );
 		foreach ( $active_subscription_ids as $subscription_id ) {
+			// Skip the subscription that is being cancelled — it may still appear as "active"
+			// (e.g. in `pending-cancel` status) when this filter runs.
+			if ( $subscription_id == $cancelling_subscription_id ) {
+				continue;
+			}
 			$subscription = \wcs_get_subscription( $subscription_id );
 			foreach ( $subscription->get_items() as $item ) {
 				if ( $item->get_product()->get_id() == $membership_product_id ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a bug where a membership was not cancelled when a linked subscription was cancelled. 

Closes NPPM-2668

### How to test the changes in this Pull Request:

1. On `release`
2. Create a customer with one subscription linked to a membership
3. In WP Admin, go to WooCommerce > Subscriptions, edit the subscription
4. Change status to Cancelled, click Update
5. Check membership status: `wp eval 'echo get_post_status(MEMBERSHIP_ID);'` - observe it's `wcm-active`
6. Switch to this branch, redo the steps
7. Check membership status: `wp eval 'echo get_post_status(MEMBERSHIP_ID);'` - observe it's `wcm-cancelled`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->