### PR TITLE
fix(content-gating): allow for metering with paid access only

### DIFF
--- a/includes/content-gate/class-metering.php
+++ b/includes/content-gate/class-metering.php
@@ -489,8 +489,10 @@ class Metering {
 		if ( ! $post_id ) {
 			$post_id = get_the_ID();
 		}
-		$gate_post_id = Content_Gate::get_gate_post_id( $post_id );
-		$settings     = self::get_metering_settings( $gate_post_id );
+		$gate_post_id         = Content_Gate::get_gate_post_id( $post_id );
+		$anonymous_settings   = self::get_anonymous_settings( $gate_post_id );
+		$registered_settings  = self::get_registered_settings( $gate_post_id );
+		$settings = $anonymous_settings['enabled'] ? $anonymous_settings : $registered_settings;
 		return $settings['period'];
 	}
 

--- a/includes/content-gate/class-metering.php
+++ b/includes/content-gate/class-metering.php
@@ -171,9 +171,9 @@ class Metering {
 
 		$registration = Content_Gate::get_registration_settings( $gate_id );
 		return [
-			'enabled' => $registration['metering']['enabled'],
-			'count'   => absint( $registration['metering']['count'] ),
-			'period'  => $registration['metering']['period'],
+			'enabled' => $registration['active'] && $registration['metering']['enabled'],
+			'count'   => $registration['active'] ? absint( $registration['metering']['count'] ) : 0,
+			'period'  => $registration['active'] ? $registration['metering']['period'] : 'month',
 		];
 	}
 
@@ -197,9 +197,9 @@ class Metering {
 
 		$custom_access = Content_Gate::get_custom_access_settings( $gate_id );
 		return [
-			'enabled' => $custom_access['metering']['enabled'],
-			'count'   => absint( $custom_access['metering']['count'] ),
-			'period'  => $custom_access['metering']['period'],
+			'enabled' => $custom_access['active'] && $custom_access['metering']['enabled'],
+			'count'   => $custom_access['active'] ? absint( $custom_access['metering']['count'] ) : 0,
+			'period'  => $custom_access['active'] ? $custom_access['metering']['period'] : 'month',
 		];
 	}
 
@@ -238,15 +238,18 @@ class Metering {
 			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/dist/content-gate-metering.js' ),
 			true
 		);
-		$settings = self::get_metering_settings( $gate_post_id );
+
+		$anonymous_settings   = self::get_anonymous_settings( $gate_post_id );
+		$registered_settings  = self::get_registered_settings( $gate_post_id );
+		$settings = $anonymous_settings['enabled'] ? $anonymous_settings : $registered_settings;
 		\wp_localize_script(
 			$handle,
 			'newspack_metering_settings',
 			[
 				'visible_paragraphs' => \get_post_meta( $gate_layout_id, 'visible_paragraphs', true ),
 				'use_more_tag'       => \get_post_meta( $gate_layout_id, 'use_more_tag', true ),
-				'count'              => $settings['anonymous_count'],
-				'period'             => $settings['anonymous_period'],
+				'count'              => $settings['count'],
+				'period'             => $settings['period'],
 				'gate_id'            => $gate_post_id,
 				'post_id'            => get_the_ID(),
 				'article_view'       => self::$article_view,
@@ -325,7 +328,9 @@ class Metering {
 		}
 
 		$gate_post_id         = Content_Gate::get_gate_post_id();
-		$settings             = self::get_anonymous_settings( $gate_post_id );
+		$anonymous_settings   = self::get_anonymous_settings( $gate_post_id );
+		$registered_settings  = self::get_registered_settings( $gate_post_id );
+		$settings             = Memberships::is_active() || $anonymous_settings['enabled'] ? $anonymous_settings : $registered_settings;
 		$is_frontend_metering = $settings['enabled'] && $settings['count'] > 0;
 
 		/**
@@ -520,11 +525,12 @@ class Metering {
 		if ( ! $gate_post_id ) {
 			return false;
 		}
-		$metering_settings = self::get_metering_settings( $gate_post_id );
-		if ( ! $is_logged_in ) {
-			return $metering_settings['anonymous_count'];
+		$anonymous_settings   = self::get_anonymous_settings( $gate_post_id );
+		$registered_settings  = self::get_registered_settings( $gate_post_id );
+		if ( ! $is_logged_in && $anonymous_settings['enabled'] ) {
+			return $anonymous_settings['count'];
 		}
-		return $metering_settings['registered_count'];
+		return $registered_settings['count'];
 	}
 }
 Metering::init();

--- a/tests/unit-tests/content-gate/metering.php
+++ b/tests/unit-tests/content-gate/metering.php
@@ -98,7 +98,7 @@ class Test_Metering extends \WP_UnitTestCase {
 						'value' => [ 'post' ],
 					],
 				],
-				'registration'  => [
+				'registration'  => $args['registration'] ?? [
 					'active'               => true,
 					'metering'             => [
 						'enabled' => $args['metering_enabled'],
@@ -108,7 +108,7 @@ class Test_Metering extends \WP_UnitTestCase {
 					'require_verification' => $args['require_verification'],
 					'gate_id'              => 0,
 				],
-				'custom_access' => [
+				'custom_access' => $args['custom_access'] ?? [
 					'active'       => true,
 					'metering'     => [
 						'enabled' => $args['metering_enabled'],
@@ -553,5 +553,63 @@ class Test_Metering extends \WP_UnitTestCase {
 		// Logged-in metering should be blocked for anonymous users.
 		$result = Metering::is_logged_in_metering_allowed( $post_id );
 		$this->assertFalse( $result, 'Logged-in metering should be blocked for anonymous users' );
+	}
+
+	/**
+	 * Test that front-end metering settings fall back to registered settings if anonymous settings are not enabled.
+	 */
+	public function test_metering_settings_fall_back_to_registered_settings() {
+		// Create a gate with metering enabled.
+		$gate_id = $this->create_gate_with_settings(
+			[
+				'registration'  => [
+					'active'   => false,
+					'metering' => [
+						'enabled' => false,
+						'count'   => 0,
+						'period'  => 'month',
+					],
+				],
+				'custom_access' => [
+					'metering' => [
+						'enabled' => true,
+						'count'   => 5,
+						'period'  => 'month',
+					],
+				],
+			]
+		);
+
+		// Create a post.
+		$post_id = $this->factory->post->create();
+		$this->post_ids[] = $post_id;
+
+		// Set query to current post.
+		global $wp_query;
+		$wp_query = new \WP_Query( [ 'p' => $post_id ] );
+		add_filter( 'newspack_is_post_restricted', '__return_true' );
+
+		// Ensure no user is logged in.
+		wp_set_current_user( 0 );
+
+		// Apply the filter to control the gate context for testing.
+		add_filter(
+			'newspack_content_gate_post_id',
+			function() use ( $gate_id ) {
+				return $gate_id;
+			}
+		);
+
+		// Anonymous metering is not enabled.
+		$anonymous_settings = Metering::get_anonymous_settings( $gate_id );
+		$this->assertFalse( $anonymous_settings['enabled'], 'Anonymous settings should not be enabled' );
+
+		// Registered metering is enabled.
+		$registered_settings = Metering::get_registered_settings( $gate_id );
+		$this->assertTrue( $registered_settings['enabled'], 'Registered settings should be enabled' );
+
+		// Front-end metering should fall back to registered settings if anonymous settings are not enabled.
+		$this->assertTrue( Metering::is_frontend_metering(), 'Front-end metering should fall back to registered settings if anonymous settings are not enabled' );
+		$this->assertEquals( $registered_settings['count'], Metering::get_total_metered_views(), 'Total metered views should be the same as registered settings' );
 	}
 }

--- a/tests/unit-tests/content-gate/metering.php
+++ b/tests/unit-tests/content-gate/metering.php
@@ -571,6 +571,7 @@ class Test_Metering extends \WP_UnitTestCase {
 					],
 				],
 				'custom_access' => [
+					'active'   => true,
 					'metering' => [
 						'enabled' => true,
 						'count'   => 5,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a logical hole opened up by the ability to manage metering configuration for Registered vs. Paid Access separately. Front-end metering can now occur for a gate that has Registered Access disabled but Paid Access enabled with metering.

Also fixes a bug where if a gate that has Registered Access with metering enabled is edited to then disable Registered Access without touching metering settings, its metering settings may still be read for anonymous readers.

Closes NPPD-1361.

### How to test the changes in this Pull Request:

1. Publish a content gate restricting some posts with Registered Access DISABLED and Paid Access ENABLED with metering and some number of free posts allowed. You can also use an existing content gate; just disable Registered Access first.
2. Also turn on the Metered Countdown so you can see the viewed vs. total free views allowed.
3. On `trunk`, visit a restricted post as an anonymous reader and observe that you immediately see the Paid Access gate layout (no metering).
4. Check out this branch, refresh, and confirm that you can now access the restricted post due to metering. Confirm that the Metered Countdown banner appears and correctly shows the number of viewed vs. allowed posts as configured for Paid Access.
5. View enough posts to exhaust the free posts and confirm that you start seeing the Paid Access gate layout restricting subsequent posts.
6. Activate Woo Memberships and smoke test the metering settings here, too. There should be no changes to the behavior for Memberships-based gates.
7. Confirm the new unit tests are passing. 👇 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->