### PR TITLE
feat(content-gate): display matching gates in post editor

### DIFF
--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -70,6 +70,7 @@ class Content_Gate {
 	public static function init() {
 		add_action( 'init', [ __CLASS__, 'register_post_type' ] );
 		add_action( 'admin_init', [ __CLASS__, 'redirect_cpt' ] );
+		add_filter( 'get_edit_post_link', [ __CLASS__, 'filter_edit_post_link' ], 10, 2 );
 		add_action( 'admin_init', [ __CLASS__, 'handle_edit_gate_layout' ] );
 		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'enqueue_scripts' ] );
 		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'enqueue_block_editor_assets' ] );
@@ -369,6 +370,21 @@ class Content_Gate {
 	}
 
 	/**
+	 * Filter the edit post link for gate CPTs to point to the access control wizard.
+	 *
+	 * @param string $link    The edit link.
+	 * @param int    $post_id Post ID.
+	 *
+	 * @return string Filtered edit link.
+	 */
+	public static function filter_edit_post_link( $link, $post_id ) {
+		if ( get_post_type( $post_id ) === self::GATE_CPT ) {
+			return admin_url( 'admin.php?page=newspack-audience-access-control#/edit/' . $post_id );
+		}
+		return $link;
+	}
+
+	/**
 	 * Redirect the custom gate CPT to the Content Gating wizard
 	 */
 	public static function redirect_cpt() {
@@ -447,8 +463,9 @@ class Content_Gate {
 			'newspack-content-gate-post-settings',
 			'newspackContentGates',
 			[
-				'gates'       => $gates_data,
-				'taxonomyMap' => $taxonomy_map,
+				'gates'        => $gates_data,
+				'taxonomyMap'  => $taxonomy_map,
+				'canEditGates' => current_user_can( 'manage_options' ),
 			]
 		);
 	}

--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -414,6 +414,43 @@ class Content_Gate {
 		}
 		$asset = require dirname( NEWSPACK_PLUGIN_FILE ) . '/dist/content-gate-post-settings.asset.php';
 		wp_enqueue_script( 'newspack-content-gate-post-settings', Newspack::plugin_url() . '/dist/content-gate-post-settings.js', $asset['dependencies'], $asset['version'], true );
+
+		// Localize active gates data for reactive matching in the editor.
+		$gates      = self::get_gates( self::GATE_CPT, 'publish' );
+		$gates_data = [];
+		foreach ( $gates as $gate ) {
+			if ( empty( $gate['registration']['active'] ) && empty( $gate['custom_access']['active'] ) ) {
+				continue;
+			}
+			if ( empty( $gate['content_rules'] ) ) {
+				continue;
+			}
+			$gates_data[] = [
+				'id'            => $gate['id'],
+				'title'         => $gate['title'],
+				'edit_url'      => get_edit_post_link( $gate['id'], 'raw' ),
+				'content_rules' => $gate['content_rules'],
+			];
+		}
+
+		// Build taxonomy slug to REST attribute name map.
+		$taxonomy_map = [];
+		foreach ( Content_Restriction_Control::get_available_taxonomies() as $tax ) {
+			$taxonomy_obj = get_taxonomy( $tax['slug'] );
+			if ( $taxonomy_obj && $taxonomy_obj->show_in_rest ) {
+				$rest_base                    = ! empty( $taxonomy_obj->rest_base ) ? $taxonomy_obj->rest_base : $taxonomy_obj->name;
+				$taxonomy_map[ $tax['slug'] ] = $rest_base;
+			}
+		}
+
+		wp_localize_script(
+			'newspack-content-gate-post-settings',
+			'newspackContentGates',
+			[
+				'gates'       => $gates_data,
+				'taxonomyMap' => $taxonomy_map,
+			]
+		);
 	}
 
 	/**

--- a/src/content-gate/editor/post-settings.js
+++ b/src/content-gate/editor/post-settings.js
@@ -1,14 +1,14 @@
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { useMemo } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
 import { registerPlugin } from '@wordpress/plugins';
 import { ExternalLink, ToggleControl } from '@wordpress/components';
 
-const { gates = [], taxonomyMap = {} } = window.newspackContentGates || {};
+const { gates = [], taxonomyMap = {}, canEditGates = false } = window.newspackContentGates || {};
 
 /**
  * Check if a gate's content rules match the current post state.
@@ -62,11 +62,13 @@ function PostSettings() {
 		<PluginDocumentSettingPanel name="content-gate-post-exemptions-panel" title={ __( 'Access control settings', 'newspack-plugin' ) }>
 			{ matchingGates.length > 0 ? (
 				<p>
-					{ sprintf(
-						// translators: %s is the list of gates.
-						__( 'Gates that apply to this post: %s', 'newspack-plugin' ),
-						matchingGates.map( gate => gate.title ).join( ', ' )
-					) }
+					{ __( 'Gates that apply to this post: ', 'newspack-plugin' ) }
+					{ matchingGates.map( ( gate, index ) => (
+						<span key={ gate.id }>
+							{ index > 0 && ', ' }
+							{ canEditGates && gate.edit_url ? <a href={ gate.edit_url }>{ gate.title }</a> : gate.title }
+						</span>
+					) ) }
 				</p>
 			) : (
 				<p>{ __( 'No gates apply to this post.', 'newspack-plugin' ) }</p>

--- a/src/content-gate/editor/post-settings.js
+++ b/src/content-gate/editor/post-settings.js
@@ -55,7 +55,7 @@ function PostSettings() {
 
 	const matchingGates = useMemo(
 		() => gates.filter( gate => gateMatchesPost( gate.content_rules, postType, termsByTax ) ),
-		[ gates, postType, termsByTax ]
+		[ postType, termsByTax ]
 	);
 
 	return (

--- a/src/content-gate/editor/post-settings.js
+++ b/src/content-gate/editor/post-settings.js
@@ -1,22 +1,77 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
+import { useMemo } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
 import { registerPlugin } from '@wordpress/plugins';
 import { ExternalLink, ToggleControl } from '@wordpress/components';
 
+const { gates = [], taxonomyMap = {} } = window.newspackContentGates || {};
+
+/**
+ * Check if a gate's content rules match the current post state.
+ *
+ * @param {Array}  contentRules Gate content rules.
+ * @param {string} postType     Current post type.
+ * @param {Object} termsByTax   Map of taxonomy REST base to array of term IDs.
+ *
+ * @return {boolean} Whether all rules match.
+ */
+function gateMatchesPost( contentRules, postType, termsByTax ) {
+	return contentRules.every( rule => {
+		const isExclusion = rule.exclusion;
+		if ( rule.slug === 'post_types' ) {
+			return isExclusion ? ! rule.value.includes( postType ) : rule.value.includes( postType );
+		}
+		const restBase = taxonomyMap[ rule.slug ];
+		if ( ! restBase ) {
+			return false;
+		}
+		const postTerms = termsByTax[ restBase ] || [];
+		if ( ! isExclusion && ! postTerms.length ) {
+			return false;
+		}
+		const hasOverlap = rule.value.some( id => postTerms.includes( parseInt( id ) ) );
+		return isExclusion ? ! hasOverlap : hasOverlap;
+	} );
+}
+
 function PostSettings() {
-	const { meta } = useSelect( select => {
+	const { meta, postType, termsByTax } = useSelect( select => {
 		const { getEditedPostAttribute } = select( 'core/editor' );
+		const terms = {};
+		Object.values( taxonomyMap ).forEach( restBase => {
+			terms[ restBase ] = getEditedPostAttribute( restBase ) || [];
+		} );
 		return {
 			meta: getEditedPostAttribute( 'meta' ),
+			postType: getEditedPostAttribute( 'type' ),
+			termsByTax: terms,
 		};
 	} );
 	const { editPost } = useDispatch( 'core/editor' );
+
+	const matchingGates = useMemo(
+		() => gates.filter( gate => gateMatchesPost( gate.content_rules, postType, termsByTax ) ),
+		[ gates, postType, termsByTax ]
+	);
+
 	return (
 		<PluginDocumentSettingPanel name="content-gate-post-exemptions-panel" title={ __( 'Access control settings', 'newspack-plugin' ) }>
+			{ matchingGates.length > 0 ? (
+				<p>
+					{ sprintf(
+						// translators: %s is the list of gates.
+						__( 'Gates that apply to this post: %s', 'newspack-plugin' ),
+						matchingGates.map( gate => gate.title ).join( ', ' )
+					) }
+				</p>
+			) : (
+				<p>{ __( 'No gates apply to this post.', 'newspack-plugin' ) }</p>
+			) }
+			<hr />
 			<ToggleControl
 				label={ __( 'Disable access control restrictions for this post', 'newspack-plugin' ) }
 				help={


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Displays the matching gates in the editor's "Access control settings" panel:

<img width="279" height="251" alt="image" src="https://github.com/user-attachments/assets/33bda991-2a32-4a2c-8787-fe4e000e12c2" />

<img width="279" height="250" alt="image" src="https://github.com/user-attachments/assets/dbf4fbc4-0e60-4601-b29f-a0e7576f5a80" />

Closes NPPD-1356.

### How to test the changes in this Pull Request:

1. Create 3 gates with the following content rules:
    1. Post type: collections
    2. Post type: posts; category: Arts
    3. Post type: posts; category: News
4. Draft a new collection and confirm that the "Access control settings" show the gate that matches the collections post type
5. Draft a new post and confirm that initially it doesn't match any gate
6. Select the Arts category and confirm the panel updates to show the Arts gate
7. Select the News category and confirm that it now matches both gates

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->