### PR TITLE
fix(integrations): integrations settings registration

### DIFF
--- a/includes/reader-activation/integrations/class-esp.php
+++ b/includes/reader-activation/integrations/class-esp.php
@@ -38,8 +38,8 @@ class ESP extends Integration {
 	 * Register the settings fields declared by this integration.
 	 *
 	 * Returns ALL possible ESP fields unconditionally as static
-	 * declarations. No provider check, no API calls. Labels, descriptions,
-	 * and options are added in get_settings_config() for the UI only.
+	 * declarations. No provider check, no API calls. Provider options
+	 * are added in get_settings_config().
 	 *
 	 * @return array Array of settings field declarations.
 	 */
@@ -142,9 +142,10 @@ class ESP extends Integration {
 				);
 				break;
 		}
-		$enriched[] = $config['sync_esp_delete'];
+		$enriched[]    = $config['sync_esp_delete'];
+		$metadata_keys = array_column( $this->get_metadata_fields(), 'key' );
 		foreach ( $config as $field ) {
-			if ( in_array( $field['key'], array_column( $this->get_metadata_fields(), 'key' ) ) ) {
+			if ( in_array( $field['key'], $metadata_keys ) ) {
 				$enriched[] = $config[ $field['key'] ];
 			}
 		}

--- a/includes/reader-activation/integrations/class-esp.php
+++ b/includes/reader-activation/integrations/class-esp.php
@@ -37,77 +37,118 @@ class ESP extends Integration {
 	/**
 	 * Register the settings fields declared by this integration.
 	 *
-	 * Dynamically builds the field list based on the active ESP provider.
-	 * Only returns fields when ESP is configured.
+	 * Returns ALL possible ESP fields unconditionally as static
+	 * declarations. No provider check, no API calls. Labels, descriptions,
+	 * and options are added in get_settings_config() for the UI only.
 	 *
 	 * @return array Array of settings field declarations.
 	 */
 	public function register_settings_fields() {
-		$fields = [];
+		return [
+			[
+				'key'         => 'mailchimp_audience_id',
+				'type'        => 'select',
+				'default'     => '',
+				'label'       => __( 'Mailchimp Audience', 'newspack-plugin' ),
+				'description' => __( 'Choose an audience to receive reader activity data.', 'newspack-plugin' ),
+			],
+			[
+				'key'         => 'mailchimp_reader_default_status',
+				'type'        => 'select',
+				'default'     => 'transactional',
+				'label'       => __( 'Default reader status', 'newspack-plugin' ),
+				'description' => __( 'Choose which Mailchimp status readers should have by default if they are not subscribed to any newsletters.', 'newspack-plugin' ),
+				'options'     => [
+					[
+						'label' => __( 'Transactional/Non-Subscribed', 'newspack-plugin' ),
+						'value' => 'transactional',
+					],
+					[
+						'label' => __( 'Subscribed', 'newspack-plugin' ),
+						'value' => 'subscribed',
+					],
+				],
+			],
+			[
+				'key'         => 'active_campaign_master_list',
+				'type'        => 'select',
+				'default'     => '',
+				'label'       => __( 'ActiveCampaign Master List', 'newspack-plugin' ),
+				'description' => __( 'Choose a master list to which all registered readers will be added.', 'newspack-plugin' ),
+			],
+			[
+				'key'         => 'constant_contact_list_id',
+				'type'        => 'select',
+				'default'     => '',
+				'label'       => __( 'Constant Contact Master List', 'newspack-plugin' ),
+				'description' => __( 'Choose a master list to which all registered readers will be added.', 'newspack-plugin' ),
+			],
+			[
+				'key'         => 'sync_esp_delete',
+				'type'        => 'checkbox',
+				'default'     => true,
+				'label'       => __( 'Sync user account deletion', 'newspack-plugin' ),
+				'description' => __( 'When a reader account is deleted, also remove the contact from the ESP.', 'newspack-plugin' ),
+			],
+		];
+	}
+
+	/**
+	 * Get settings config with current values, labels, descriptions, and options.
+	 *
+	 * Filters fields to the active provider and enriches them with
+	 * expensive data (API-fetched list options).
+	 * Only called when serving the settings UI.
+	 *
+	 * @return array Array of field declarations with current values.
+	 */
+	public function get_settings_config() {
 		if ( ! Reader_Activation::is_esp_configured() ) {
-			return $fields;
+			return [];
 		}
-		$list_options = $this->get_list_options();
-		$provider     = $this->get_provider();
-		if ( $provider ) {
-			switch ( $provider->service ) {
-				case 'mailchimp':
-					$fields[] = [
-						'key'         => 'mailchimp_audience_id',
-						'type'        => 'select',
-						'label'       => __( 'Mailchimp Audience', 'newspack-plugin' ),
-						'description' => __( 'Choose an audience to receive reader activity data.', 'newspack-plugin' ),
-						'options'     => $list_options,
-						'default'     => '',
-					];
-					$fields[] = [
-						'key'         => 'mailchimp_reader_default_status',
-						'type'        => 'select',
-						'label'       => __( 'Default reader status', 'newspack-plugin' ),
-						'description' => __( 'Choose which Mailchimp status readers should have by default if they are not subscribed to any newsletters.', 'newspack-plugin' ),
-						'options'     => [
-							[
-								'label' => __( 'Transactional/Non-Subscribed', 'newspack-plugin' ),
-								'value' => 'transactional',
-							],
-							[
-								'label' => __( 'Subscribed', 'newspack-plugin' ),
-								'value' => 'subscribed',
-							],
-						],
-						'default'     => 'transactional',
-					];
-					break;
-				case 'active_campaign':
-					$fields[] = [
-						'key'         => 'active_campaign_master_list',
-						'type'        => 'select',
-						'label'       => __( 'ActiveCampaign Master List', 'newspack-plugin' ),
-						'description' => __( 'Choose a master list to which all registered readers will be added.', 'newspack-plugin' ),
-						'options'     => $list_options,
-						'default'     => '',
-					];
-					break;
-				case 'constant_contact':
-					$fields[] = [
-						'key'         => 'constant_contact_list_id',
-						'type'        => 'select',
-						'label'       => __( 'Constant Contact Master List', 'newspack-plugin' ),
-						'description' => __( 'Choose a master list to which all registered readers will be added.', 'newspack-plugin' ),
-						'options'     => $list_options,
-						'default'     => '',
-					];
-					break;
+		$provider = $this->get_provider();
+		if ( ! $provider ) {
+			return [];
+		}
+
+		$enriched     = [];
+		$config       = parent::get_settings_config();
+		$config       = array_combine(
+			array_column( $config, 'key' ),
+			$config
+		);
+		$list_options = [
+			'options' => $this->get_list_options(),
+		];
+
+		$enriched[] = $config['sync_esp_delete'];
+		switch ( $provider->service ) {
+			case 'mailchimp':
+				$enriched[] = $config['mailchimp_reader_default_status'];
+				$enriched[] = array_merge(
+					$config['mailchimp_audience_id'],
+					$list_options
+				);
+				break;
+			case 'active_campaign':
+				$enriched[] = array_merge(
+					$config['active_campaign_master_list'],
+					$list_options
+				);
+				break;
+			case 'constant_contact':
+				$enriched[] = array_merge(
+					$config['constant_contact_list_id'],
+					$list_options
+				);
+				break;
+		}
+		foreach ( $config as $field ) {
+			if ( in_array( $field['key'], array_column( $this->get_metadata_fields(), 'key' ) ) ) {
+				$enriched[] = $config[ $field['key'] ];
 			}
 		}
-		$fields[] = [
-			'key'         => 'sync_esp_delete',
-			'type'        => 'checkbox',
-			'label'       => __( 'Sync user account deletion', 'newspack-plugin' ),
-			'description' => __( 'When a reader account is deleted, also remove the contact from the ESP.', 'newspack-plugin' ),
-			'default'     => true,
-		];
-		return $fields;
+		return $enriched;
 	}
 
 	/**

--- a/includes/reader-activation/integrations/class-esp.php
+++ b/includes/reader-activation/integrations/class-esp.php
@@ -121,14 +121,13 @@ class ESP extends Integration {
 			'options' => $this->get_list_options(),
 		];
 
-		$enriched[] = $config['sync_esp_delete'];
 		switch ( $provider->service ) {
 			case 'mailchimp':
-				$enriched[] = $config['mailchimp_reader_default_status'];
 				$enriched[] = array_merge(
 					$config['mailchimp_audience_id'],
 					$list_options
 				);
+				$enriched[] = $config['mailchimp_reader_default_status'];
 				break;
 			case 'active_campaign':
 				$enriched[] = array_merge(
@@ -143,6 +142,7 @@ class ESP extends Integration {
 				);
 				break;
 		}
+		$enriched[] = $config['sync_esp_delete'];
 		foreach ( $config as $field ) {
 			if ( in_array( $field['key'], array_column( $this->get_metadata_fields(), 'key' ) ) ) {
 				$enriched[] = $config[ $field['key'] ];

--- a/includes/reader-activation/integrations/class-integration.php
+++ b/includes/reader-activation/integrations/class-integration.php
@@ -96,7 +96,7 @@ abstract class Integration {
 		$this->name        = $name;
 		$this->description = $description;
 
-		add_action( 'init', [ $this, 'init' ] );
+		$this->settings_fields = $this->register_settings_fields();
 	}
 
 	/**
@@ -127,19 +127,11 @@ abstract class Integration {
 	}
 
 	/**
-	 * Initialize the integration, performing any necessary setup or validation.
-	 *
-	 * Currently only initializes settings fields, but can be extended by child classes for additional setup.
-	 */
-	public function init() {
-		$this->settings_fields = $this->register_settings_fields();
-	}
-
-	/**
 	 * Register settings fields for this integration.
 	 *
-	 * Child classes should override this method to define their settings fields.
-	 * Each field should be an associative array with keys: key, label, type, default, options (for select), etc.
+	 * Child classes should override this method to return static field
+	 * declarations (key, type, default at minimum). No API calls, no conditional
+	 * logic based on external state. Called directly in the constructor.
 	 *
 	 * @return array Array of settings field declarations.
 	 */
@@ -522,6 +514,8 @@ abstract class Integration {
 	/**
 	 * Get settings config with current values populated, for API responses.
 	 *
+	 * Child classes can override this method to return filtered or enriched settings.
+	 *
 	 * @return array Array of field declarations with current values.
 	 */
 	public function get_settings_config() {
@@ -578,6 +572,9 @@ abstract class Integration {
 				return is_numeric( $value ) ? $value + 0 : ( $field['default'] ?? 0 );
 			case 'select':
 				$valid_values = array_column( $field['options'] ?? [], 'value' );
+				if ( empty( $valid_values ) ) {
+					return \sanitize_text_field( $value );
+				}
 				return in_array( $value, $valid_values, true ) ? $value : ( $field['default'] ?? '' );
 			case 'metadata':
 				if ( ! is_array( $value ) ) {

--- a/includes/reader-activation/integrations/class-integration.php
+++ b/includes/reader-activation/integrations/class-integration.php
@@ -525,7 +525,7 @@ abstract class Integration {
 			$field['value'] = $this->get_settings_field_value( $field['key'] );
 			// Inject metadata options for metadata fields.
 			if ( 'incoming_metadata_fields' === $field['key'] ) {
-				$incoming_fields  = $this->get_filtered_incoming_contact_fields( true );
+				$incoming_fields  = $this->get_filtered_incoming_contact_fields();
 				$field['options'] = array_map(
 					function ( $incoming_field ) {
 						return $incoming_field->get_key();

--- a/tests/unit-tests/integrations/class-test-integrations.php
+++ b/tests/unit-tests/integrations/class-test-integrations.php
@@ -869,7 +869,6 @@ class Test_Integrations extends \WP_UnitTestCase {
 	 */
 	public function test_settings_field_value_routes_metadata_prefix() {
 		$integration = new Sample_Integration( 'route-test', 'Route Test' );
-		$integration->init();
 
 		$this->assertTrue( $integration->update_settings_field_value( 'metadata_prefix', 'API_' ) );
 		$this->assertSame( 'API_', $integration->get_settings_field_value( 'metadata_prefix' ) );
@@ -900,7 +899,6 @@ class Test_Integrations extends \WP_UnitTestCase {
 	 */
 	public function test_get_settings_config_includes_metadata_prefix() {
 		$integration = new Sample_Integration( 'config-test', 'Config Test' );
-		$integration->init();
 		$integration->update_metadata_prefix( 'CFG_' );
 
 		$config = $integration->get_settings_config();

--- a/tests/unit-tests/reader-activation-sync.php
+++ b/tests/unit-tests/reader-activation-sync.php
@@ -65,7 +65,6 @@ class Newspack_Test_Reader_Activation_Sync extends WP_UnitTestCase {
 	 */
 	public function test_esp_integration_checks() {
 		$esp_integration = new Integrations\ESP();
-		$esp_integration->init();
 		$errors = $esp_integration->can_sync( true );
 		$this->assertInstanceOf( 'WP_Error', $errors );
 		$this->assertTrue( $errors->has_errors() );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Closes https://linear.app/a8c/issue/DSGNEWS-125/issues-with-how-integrations-settings-are-being-registered

`Integration::__construct()` previously hooked `init` → `register_settings_fields()` on every request. For the ESP integration, this triggered `get_list_options()` → `Newspack_Newsletters_Subscription::get_lists()`, making an external ESP API call on every page load.

This PR splits field registration into two phases:

1. **`register_settings_fields()`** — now a cheap, static declaration of all possible fields (key, type, default only). Called directly in the constructor with no `init` hook. No API calls, no conditional logic.

2. **`get_settings_config()`** — the ESP subclass now overrides this to filter fields to the active provider and enrich them with labels, descriptions, and API-fetched list options. This method is only called when serving the settings UI.

#### Specific changes:

- **`class-integration.php`**: Constructor calls `register_settings_fields()` directly instead of via `add_action('init')`. Removed the `init()` method. Updated `sanitize_settings_field_value()` select case to handle fields without pre-populated options (falls back to `sanitize_text_field`).
- **`class-esp.php`**: `register_settings_fields()` returns all 5 ESP fields unconditionally as static declarations. New `get_settings_config()` override handles provider filtering and API-fetched enrichment.
- **Tests**: Removed `$integration->init()` calls that are no longer needed.

### How to test the changes in this Pull Request:

1. Enable Reader Activation with an ESP configured (e.g. Mailchimp).
2. Load a frontend page and confirm no ESP API calls are made (check server logs or add a temporary log to `get_list_options()`).
3. Open the Newspack → Reader Activation → Integrations settings page and confirm ESP settings render correctly with the proper audience/list options.
4. Change a setting value and save — confirm it persists correctly.
5. Switch to a different ESP provider and confirm the correct fields appear.
6. Regester a new reader and verify sync works as expected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?