### PR TITLE
feat(content-gate): institutions

### DIFF
--- a/includes/content-gate/class-access-rules.php
+++ b/includes/content-gate/class-access-rules.php
@@ -103,10 +103,11 @@ class Access_Rules {
 				'callback'    => [ __CLASS__, 'has_reader_data' ],
 			],
 			'institution'  => [
-				'name'        => __( 'Institutional access', 'newspack-plugin' ),
-				'description' => __( 'Grant access to readers from selected institutions.', 'newspack-plugin' ),
-				'options'     => [ Institution::class, 'get_options' ],
-				'callback'    => [ Institution::class, 'evaluate' ],
+				'name'               => __( 'Institutional access', 'newspack-plugin' ),
+				'description'        => __( 'Grant access to readers from selected institutions.', 'newspack-plugin' ),
+				'options'            => [ Institution::class, 'get_options' ],
+				'callback'           => [ Institution::class, 'evaluate' ],
+				'supports_anonymous' => true,
 			],
 		];
 
@@ -160,9 +161,9 @@ class Access_Rules {
 			return true;
 		}
 
-		// If evaluating for the current user, they must be logged in.
+		// If evaluating for the current user, they must be logged in (unless the rule supports anonymous evaluation).
 		$user_id = $user_id ?? \get_current_user_id();
-		if ( ! $user_id ) {
+		if ( ! $user_id && empty( $rule['supports_anonymous'] ) ) {
 			return false;
 		}
 

--- a/includes/content-gate/class-access-rules.php
+++ b/includes/content-gate/class-access-rules.php
@@ -102,6 +102,12 @@ class Access_Rules {
 				'description' => __( 'Set custom conditions based on reader data key/value pairs.', 'newspack-plugin' ),
 				'callback'    => [ __CLASS__, 'has_reader_data' ],
 			],
+			'institution'  => [
+				'name'        => __( 'Institutional access', 'newspack-plugin' ),
+				'description' => __( 'Grant access to readers from selected institutions.', 'newspack-plugin' ),
+				'options'     => [ Institution::class, 'get_options' ],
+				'callback'    => [ Institution::class, 'evaluate' ],
+			],
 		];
 
 		foreach ( $rules as $id => $rule ) {

--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -103,6 +103,7 @@ class Content_Gate {
 		include __DIR__ . '/class-metering-countdown.php';
 		include __DIR__ . '/content-gifting/class-content-gifting.php';
 		include __DIR__ . '/class-ip-access-rule.php';
+		include __DIR__ . '/class-institution.php';
 		include __DIR__ . '/class-user-gate-access.php';
 	}
 

--- a/includes/content-gate/class-institution.php
+++ b/includes/content-gate/class-institution.php
@@ -47,6 +47,41 @@ class Institution {
 	}
 
 	/**
+	 * Create an institution.
+	 *
+	 * @param string $name  Institution name.
+	 * @param array  $rules {
+	 *     Optional. Institution rules.
+	 *
+	 *     @type string $email_domain Comma-separated domains (e.g., 'university.edu,uni.ac.uk').
+	 *     @type string $ip_range     Comma-separated IPs/CIDR (e.g., '192.168.1.0/24,10.0.0.5').
+	 *     @type string $reader_data  Semicolon-delimited key=value pairs (e.g., 'org=uni;role=staff').
+	 * }
+	 *
+	 * @return int|\WP_Error Post ID on success, WP_Error on failure.
+	 */
+	public static function create( $name, $rules = [] ) {
+		$post_id = \wp_insert_post(
+			[
+				'post_type'   => self::POST_TYPE,
+				'post_title'  => $name,
+				'post_status' => 'publish',
+			],
+			true
+		);
+		if ( \is_wp_error( $post_id ) ) {
+			return $post_id;
+		}
+		$allowed_keys = [ 'email_domain', 'ip_range', 'reader_data' ];
+		foreach ( $rules as $key => $value ) {
+			if ( in_array( $key, $allowed_keys, true ) && ! empty( $value ) ) {
+				\update_post_meta( $post_id, self::META_PREFIX . $key, sanitize_text_field( $value ) );
+			}
+		}
+		return $post_id;
+	}
+
+	/**
 	 * Get institution options for the access rule multi-select.
 	 *
 	 * @return array Array of [ 'label' => string, 'value' => int ].

--- a/includes/content-gate/class-institution.php
+++ b/includes/content-gate/class-institution.php
@@ -58,7 +58,7 @@ class Institution {
 				'show_ui'      => false,
 				'show_in_menu' => false,
 				'show_in_rest' => true,
-				'supports'     => [ 'title' ],
+				'supports'     => [ 'title', 'excerpt' ],
 				/**
 				 * Institutions effectively grant access, so restrict all CRUD operations
 				 * (including via REST) to the `manage_options` user capability.
@@ -76,6 +76,7 @@ class Institution {
 	 * @param array  $rules {
 	 *     Optional. Institution rules.
 	 *
+	 *     @type string $description  Institution description.
 	 *     @type string $email_domain Comma-separated domains (e.g., 'university.edu,uni.ac.uk').
 	 *     @type string $ip_range     Comma-separated IPs/CIDR (e.g., '192.168.1.0/24,10.0.0.5').
 	 *     @type string $reader_data  Semicolon-delimited key=value pairs (e.g., 'org=uni;role=staff').
@@ -84,11 +85,13 @@ class Institution {
 	 * @return int|\WP_Error Post ID on success, WP_Error on failure.
 	 */
 	public static function create( $name, $rules = [] ) {
+		$description = $rules['description'] ?? '';
 		$post_id = \wp_insert_post(
 			[
-				'post_type'   => self::POST_TYPE,
-				'post_title'  => $name,
-				'post_status' => 'publish',
+				'post_type'    => self::POST_TYPE,
+				'post_title'   => sanitize_text_field( $name ),
+				'post_excerpt' => sanitize_text_field( $description ),
+				'post_status'  => 'publish',
 			],
 			true
 		);

--- a/includes/content-gate/class-institution.php
+++ b/includes/content-gate/class-institution.php
@@ -213,7 +213,7 @@ class Institution {
 
 		if ( ! empty( $rules['ip_range'] ) ) {
 			$has_any_rule = true;
-			if ( isset( $_COOKIE[ IP_Access_Rule::COOKIE_NAME ] ) ) {
+			if ( IP_Access_Rule::ip_matches_ranges( IP_Access_Rule::get_visitor_ip(), $rules['ip_range'] ) ) {
 				return true;
 			}
 		}
@@ -234,7 +234,7 @@ class Institution {
 	 *
 	 * @param bool $valid_ip Current validation result.
 	 *
-	 * @return bool Whether the IP is valid.
+	 * @return bool Whether the IP matches any institutional IP range.
 	 */
 	public static function check_ip( $valid_ip ) {
 		if ( $valid_ip ) {

--- a/includes/content-gate/class-institution.php
+++ b/includes/content-gate/class-institution.php
@@ -64,7 +64,6 @@ class Institution {
 				 * (including via REST) to the `manage_options` user capability.
 				 */
 				'capabilities' => $capabilities,
-				'map_meta_cap' => true,
 			]
 		);
 	}

--- a/includes/content-gate/class-institution.php
+++ b/includes/content-gate/class-institution.php
@@ -71,11 +71,11 @@ class Institution {
 	/**
 	 * Create an institution.
 	 *
-	 * @param string $name  Institution name.
+	 * @param string $name        Institution name.
+	 * @param string $description Optional. Institution description.
 	 * @param array  $rules {
 	 *     Optional. Institution rules.
 	 *
-	 *     @type string $description  Institution description.
 	 *     @type string $email_domain Comma-separated domains (e.g., 'university.edu,uni.ac.uk').
 	 *     @type string $ip_range     Comma-separated IPs/CIDR (e.g., '192.168.1.0/24,10.0.0.5').
 	 *     @type string $reader_data  Semicolon-delimited key=value pairs (e.g., 'org=uni;role=staff').
@@ -83,8 +83,7 @@ class Institution {
 	 *
 	 * @return int|\WP_Error Post ID on success, WP_Error on failure.
 	 */
-	public static function create( $name, $rules = [] ) {
-		$description = $rules['description'] ?? '';
+	public static function create( $name, $description = '', $rules = [] ) {
 		$post_id = \wp_insert_post(
 			[
 				'post_type'    => self::POST_TYPE,

--- a/includes/content-gate/class-institution.php
+++ b/includes/content-gate/class-institution.php
@@ -17,7 +17,7 @@ defined( 'ABSPATH' ) || exit;
 class Institution {
 
 	const POST_TYPE     = 'np_institution';
-	const META_PREFIX   = '_np_institution_';
+	const META_PREFIX   = 'np_institution_';
 	const TRANSIENT_KEY = 'newspack_institutions';
 	const TRANSIENT_TTL = 300;
 

--- a/includes/content-gate/class-institution.php
+++ b/includes/content-gate/class-institution.php
@@ -213,7 +213,11 @@ class Institution {
 
 		if ( ! empty( $rules['ip_range'] ) ) {
 			$has_any_rule = true;
-			if ( IP_Access_Rule::ip_matches_ranges( IP_Access_Rule::get_visitor_ip(), $rules['ip_range'] ) ) {
+			// Only evaluate IP on uncached requests (cookie signals cache bypass via /institutional-access).
+			if (
+				isset( $_COOKIE[ IP_Access_Rule::COOKIE_NAME ] ) && // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+				IP_Access_Rule::ip_matches_ranges( IP_Access_Rule::get_visitor_ip(), $rules['ip_range'] )
+			) {
 				return true;
 			}
 		}

--- a/includes/content-gate/class-institution.php
+++ b/includes/content-gate/class-institution.php
@@ -203,7 +203,10 @@ class Institution {
 
 		if ( ! empty( $rules['email_domain'] ) ) {
 			$has_any_rule = true;
-			if ( Access_Rules::is_email_domain_whitelisted( $user_id, $rules['email_domain'] ) ) {
+			if (
+				\get_user_meta( $user_id, Reader_Activation::EMAIL_VERIFIED, true ) &&
+				Access_Rules::is_email_domain_whitelisted( $user_id, $rules['email_domain'] )
+			) {
 				return true;
 			}
 		}

--- a/includes/content-gate/class-institution.php
+++ b/includes/content-gate/class-institution.php
@@ -35,13 +35,36 @@ class Institution {
 	 * Register the institution post type.
 	 */
 	public static function register_post_type() {
+		$capabilities = array_fill_keys(
+			[
+				'edit_post',
+				'read_post',
+				'delete_post',
+				'edit_posts',
+				'edit_others_posts',
+				'delete_posts',
+				'publish_posts',
+				'read_private_posts',
+				'create_posts',
+			],
+			'manage_options'
+		);
+
 		\register_post_type(
 			self::POST_TYPE,
 			[
 				'label'        => __( 'Institutions', 'newspack-plugin' ),
 				'public'       => false,
+				'show_ui'      => false,
+				'show_in_menu' => false,
 				'show_in_rest' => true,
 				'supports'     => [ 'title' ],
+				/**
+				 * Institutions effectively grant access, so restrict all CRUD operations
+				 * (including via REST) to the `manage_options` user capability.
+				 */
+				'capabilities' => $capabilities,
+				'map_meta_cap' => true,
 			]
 		);
 	}

--- a/includes/content-gate/class-institution.php
+++ b/includes/content-gate/class-institution.php
@@ -224,10 +224,7 @@ class Institution {
 	 */
 	private static function user_matches_institution( $user_id, $rules ) {
 		if ( ! empty( $rules['email_domain'] ) ) {
-			if (
-				\get_user_meta( $user_id, Reader_Activation::EMAIL_VERIFIED, true ) &&
-				Access_Rules::is_email_domain_whitelisted( $user_id, $rules['email_domain'] )
-			) {
+			if ( Access_Rules::is_email_domain_whitelisted( $user_id, $rules['email_domain'] ) ) {
 				return true;
 			}
 		}

--- a/includes/content-gate/class-institution.php
+++ b/includes/content-gate/class-institution.php
@@ -1,0 +1,221 @@
+<?php
+/**
+ * Newspack Institutional Access.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+use Newspack\Content_Gate\IP_Access_Rule;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Institution CPT and access rule evaluation.
+ */
+class Institution {
+
+	const POST_TYPE     = 'np_institution';
+	const META_PREFIX   = '_np_institution_';
+	const TRANSIENT_KEY = 'newspack_institutions';
+	const TRANSIENT_TTL = 300;
+
+	/**
+	 * Initialize hooks.
+	 */
+	public static function init() {
+		add_action( 'init', [ __CLASS__, 'register_post_type' ] );
+		add_action( 'save_post_' . self::POST_TYPE, [ __CLASS__, 'invalidate_cache' ] );
+		add_action( 'before_delete_post', [ __CLASS__, 'maybe_invalidate_cache_on_delete' ] );
+		add_filter( 'newspack_content_gate_check_ip', [ __CLASS__, 'check_ip' ] );
+	}
+
+	/**
+	 * Register the institution post type.
+	 */
+	public static function register_post_type() {
+		\register_post_type(
+			self::POST_TYPE,
+			[
+				'label'        => __( 'Institutions', 'newspack-plugin' ),
+				'public'       => false,
+				'show_in_rest' => true,
+				'supports'     => [ 'title' ],
+			]
+		);
+	}
+
+	/**
+	 * Get institution options for the access rule multi-select.
+	 *
+	 * @return array Array of [ 'label' => string, 'value' => int ].
+	 */
+	public static function get_options() {
+		$posts   = \get_posts(
+			[
+				'post_type'      => self::POST_TYPE,
+				'post_status'    => 'publish',
+				'posts_per_page' => -1,
+				'orderby'        => 'title',
+				'order'          => 'ASC',
+			]
+		);
+		$options = [];
+		foreach ( $posts as $post ) {
+			$options[] = [
+				'label' => $post->post_title,
+				'value' => $post->ID,
+			];
+		}
+		return $options;
+	}
+
+	/**
+	 * Get all cached institutions with their rules.
+	 *
+	 * @return array Keyed by post ID.
+	 */
+	public static function get_cached_institutions() {
+		$cached = get_transient( self::TRANSIENT_KEY );
+		if ( false !== $cached ) {
+			return $cached;
+		}
+		return self::rebuild_cache();
+	}
+
+	/**
+	 * Rebuild the institutions transient cache.
+	 *
+	 * @return array The rebuilt cache.
+	 */
+	public static function rebuild_cache() {
+		$posts        = \get_posts(
+			[
+				'post_type'      => self::POST_TYPE,
+				'post_status'    => 'publish',
+				'posts_per_page' => -1,
+			]
+		);
+		$institutions = [];
+		foreach ( $posts as $post ) {
+			$institutions[ $post->ID ] = [
+				'email_domain' => get_post_meta( $post->ID, self::META_PREFIX . 'email_domain', true ),
+				'ip_range'     => get_post_meta( $post->ID, self::META_PREFIX . 'ip_range', true ),
+				'reader_data'  => get_post_meta( $post->ID, self::META_PREFIX . 'reader_data', true ),
+			];
+		}
+		set_transient( self::TRANSIENT_KEY, $institutions, self::TRANSIENT_TTL );
+		return $institutions;
+	}
+
+	/**
+	 * Invalidate the institutions cache.
+	 */
+	public static function invalidate_cache() {
+		delete_transient( self::TRANSIENT_KEY );
+	}
+
+	/**
+	 * Invalidate cache on post deletion if it's an institution.
+	 *
+	 * @param int $post_id Post ID.
+	 */
+	public static function maybe_invalidate_cache_on_delete( $post_id ) {
+		if ( get_post_type( $post_id ) === self::POST_TYPE ) {
+			self::invalidate_cache();
+		}
+	}
+
+	/**
+	 * Evaluate whether a user matches any of the selected institutions.
+	 *
+	 * @param int   $user_id         User ID.
+	 * @param array $institution_ids Selected institution IDs.
+	 *
+	 * @return bool Whether the user matches any institution.
+	 */
+	public static function evaluate( $user_id, $institution_ids ) {
+		if ( empty( $institution_ids ) || ! is_array( $institution_ids ) ) {
+			return true;
+		}
+
+		$institutions = self::get_cached_institutions();
+
+		foreach ( $institution_ids as $inst_id ) {
+			$inst_id = absint( $inst_id );
+			if ( ! isset( $institutions[ $inst_id ] ) ) {
+				continue;
+			}
+			if ( self::user_matches_institution( $user_id, $institutions[ $inst_id ] ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Check if a user matches an institution's rules (OR logic).
+	 *
+	 * @param int   $user_id User ID.
+	 * @param array $rules   Institution rules with keys: email_domain, ip_range, reader_data.
+	 *
+	 * @return bool Whether the user matches any rule.
+	 */
+	private static function user_matches_institution( $user_id, $rules ) {
+		$has_any_rule = false;
+
+		if ( ! empty( $rules['email_domain'] ) ) {
+			$has_any_rule = true;
+			if ( Access_Rules::is_email_domain_whitelisted( $user_id, $rules['email_domain'] ) ) {
+				return true;
+			}
+		}
+
+		if ( ! empty( $rules['ip_range'] ) ) {
+			$has_any_rule = true;
+			if ( isset( $_COOKIE[ IP_Access_Rule::COOKIE_NAME ] ) ) {
+				return true;
+			}
+		}
+
+		if ( ! empty( $rules['reader_data'] ) ) {
+			$has_any_rule = true;
+			if ( Access_Rules::has_reader_data( $user_id, $rules['reader_data'] ) ) {
+				return true;
+			}
+		}
+
+		return $has_any_rule ? false : false;
+	}
+
+	/**
+	 * Check visitor's IP against all institutional IP ranges.
+	 * Hooked to newspack_content_gate_check_ip filter.
+	 *
+	 * @param bool $valid_ip Current validation result.
+	 *
+	 * @return bool Whether the IP is valid.
+	 */
+	public static function check_ip( $valid_ip ) {
+		if ( $valid_ip ) {
+			return $valid_ip;
+		}
+
+		$visitor_ip = IP_Access_Rule::get_visitor_ip();
+		if ( empty( $visitor_ip ) ) {
+			return $valid_ip;
+		}
+
+		$institutions = self::get_cached_institutions();
+		foreach ( $institutions as $rules ) {
+			if ( ! empty( $rules['ip_range'] ) && IP_Access_Rule::ip_matches_ranges( $visitor_ip, $rules['ip_range'] ) ) {
+				return true;
+			}
+		}
+
+		return $valid_ip;
+	}
+}
+Institution::init();

--- a/includes/content-gate/class-institution.php
+++ b/includes/content-gate/class-institution.php
@@ -199,10 +199,7 @@ class Institution {
 	 * @return bool Whether the user matches any rule.
 	 */
 	private static function user_matches_institution( $user_id, $rules ) {
-		$has_any_rule = false;
-
 		if ( ! empty( $rules['email_domain'] ) ) {
-			$has_any_rule = true;
 			if (
 				\get_user_meta( $user_id, Reader_Activation::EMAIL_VERIFIED, true ) &&
 				Access_Rules::is_email_domain_whitelisted( $user_id, $rules['email_domain'] )
@@ -212,24 +209,19 @@ class Institution {
 		}
 
 		if ( ! empty( $rules['ip_range'] ) ) {
-			$has_any_rule = true;
-			// Only evaluate IP on uncached requests (cookie signals cache bypass via /institutional-access).
-			if (
-				isset( $_COOKIE[ IP_Access_Rule::COOKIE_NAME ] ) && // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
-				IP_Access_Rule::ip_matches_ranges( IP_Access_Rule::get_visitor_ip(), $rules['ip_range'] )
-			) {
+			$is_uncached = ! empty( $user_id ) || isset( $_COOKIE[ IP_Access_Rule::COOKIE_NAME ] ); // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+			if ( $is_uncached && IP_Access_Rule::ip_matches_ranges( IP_Access_Rule::get_visitor_ip(), $rules['ip_range'] ) ) {
 				return true;
 			}
 		}
 
 		if ( ! empty( $rules['reader_data'] ) ) {
-			$has_any_rule = true;
 			if ( Access_Rules::has_reader_data( $user_id, $rules['reader_data'] ) ) {
 				return true;
 			}
 		}
 
-		return $has_any_rule ? false : false;
+		return false;
 	}
 
 	/**

--- a/includes/content-gate/class-ip-access-rule.php
+++ b/includes/content-gate/class-ip-access-rule.php
@@ -72,5 +72,60 @@ class IP_Access_Rule {
 		wp_safe_redirect( home_url( '/' ) );
 		exit;
 	}
+	/**
+	 * Check if an IP address matches any of the given ranges.
+	 *
+	 * @param string $ip     The IP address to check.
+	 * @param string $ranges Comma-separated list of IPs and/or CIDR blocks.
+	 *
+	 * @return bool Whether the IP matches any range.
+	 */
+	public static function ip_matches_ranges( $ip, $ranges ) {
+		if ( empty( $ranges ) || ! filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 ) ) {
+			return false;
+		}
+		$ranges  = array_map( 'trim', explode( ',', $ranges ) );
+		$ranges  = array_filter( $ranges );
+		$ip_long = ip2long( $ip );
+
+		foreach ( $ranges as $range ) {
+			if ( strpos( $range, '/' ) !== false ) {
+				list( $subnet, $bits ) = explode( '/', $range, 2 );
+				$bits = (int) $bits;
+				if ( $bits < 0 || $bits > 32 || ! filter_var( $subnet, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 ) ) {
+					continue;
+				}
+				$subnet_long = ip2long( $subnet );
+				$mask        = -1 << ( 32 - $bits );
+				if ( ( $ip_long & $mask ) === ( $subnet_long & $mask ) ) {
+					return true;
+				}
+			} elseif ( filter_var( $range, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 ) ) {
+				if ( $ip_long === ip2long( $range ) ) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Get the visitor's IP address, accounting for proxy headers.
+	 *
+	 * @return string The visitor's IP address.
+	 */
+	public static function get_visitor_ip() {
+		$headers = [ 'HTTP_X_FORWARDED_FOR', 'HTTP_X_REAL_IP', 'REMOTE_ADDR' ];
+		foreach ( $headers as $header ) {
+			if ( ! empty( $_SERVER[ $header ] ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated
+				$ip = explode( ',', sanitize_text_field( wp_unslash( $_SERVER[ $header ] ) ) )[0];
+				$ip = trim( $ip );
+				if ( filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 ) ) {
+					return $ip;
+				}
+			}
+		}
+		return '';
+	}
 }
 IP_Access_Rule::init();

--- a/includes/content-gate/class-ip-access-rule.php
+++ b/includes/content-gate/class-ip-access-rule.php
@@ -110,18 +110,51 @@ class IP_Access_Rule {
 	}
 
 	/**
-	 * Get the visitor's IP address, accounting for proxy headers.
+	 * Get the visitor's IP address.
+	 *
+	 * By default only REMOTE_ADDR is trusted, because proxy headers like
+	 * X-Forwarded-For and X-Real-IP can be set by the client and used to
+	 * spoof an allowed IP for institutional access.
+	 *
+	 * To trust proxy headers (when the site sits behind a known reverse
+	 * proxy), use the `newspack_trusted_proxy_headers` filter:
+	 *
+	 *     add_filter( 'newspack_trusted_proxy_headers', function () {
+	 *         return [ 'HTTP_X_FORWARDED_FOR', 'HTTP_X_REAL_IP' ];
+	 *     } );
+	 *
+	 * For full control over IP resolution use `newspack_visitor_ip`.
 	 *
 	 * @return string The visitor's IP address.
 	 */
 	public static function get_visitor_ip() {
-		$headers = [ 'HTTP_X_FORWARDED_FOR', 'HTTP_X_REAL_IP', 'REMOTE_ADDR' ];
+		/**
+		 * Filter the list of trusted proxy headers checked before REMOTE_ADDR.
+		 *
+		 * Return an array of `$_SERVER` keys (e.g. `HTTP_X_FORWARDED_FOR`,
+		 * `HTTP_X_REAL_IP`) that your reverse-proxy infrastructure is known
+		 * to set reliably. An empty array (the default) means only
+		 * REMOTE_ADDR is used.
+		 *
+		 * @param string[] $headers Trusted header keys. Default empty array.
+		 */
+		$trusted_headers = apply_filters( 'newspack_trusted_proxy_headers', [] );
+
+		// Always end with REMOTE_ADDR as the final fallback.
+		$headers = array_merge( (array) $trusted_headers, [ 'REMOTE_ADDR' ] );
+
 		foreach ( $headers as $header ) {
 			if ( ! empty( $_SERVER[ $header ] ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated
 				$ip = explode( ',', sanitize_text_field( wp_unslash( $_SERVER[ $header ] ) ) )[0];
 				$ip = trim( $ip );
 				if ( filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 ) ) {
-					return $ip;
+					/**
+					 * Filter the resolved visitor IP address.
+					 *
+					 * @param string $ip     Resolved IP address.
+					 * @param string $header The $_SERVER key it was read from.
+					 */
+					return apply_filters( 'newspack_visitor_ip', $ip, $header );
 				}
 			}
 		}

--- a/tests/unit-tests/content-gate/class-institution.php
+++ b/tests/unit-tests/content-gate/class-institution.php
@@ -109,9 +109,9 @@ class Newspack_Test_Institution extends WP_UnitTestCase {
 		$this->assertEquals( 'API University', $post->post_title );
 		$this->assertEquals( 'API University description', $post->post_excerpt );
 		$this->assertEquals( 'publish', $post->post_status );
-		$this->assertEquals( 'api.edu', get_post_meta( $post_id, '_np_institution_email_domain', true ) );
-		$this->assertEquals( '10.0.0.0/8', get_post_meta( $post_id, '_np_institution_ip_range', true ) );
-		$this->assertEmpty( get_post_meta( $post_id, '_np_institution_reader_data', true ) );
+		$this->assertEquals( 'api.edu', get_post_meta( $post_id, 'np_institution_email_domain', true ) );
+		$this->assertEquals( '10.0.0.0/8', get_post_meta( $post_id, 'np_institution_ip_range', true ) );
+		$this->assertEmpty( get_post_meta( $post_id, 'np_institution_reader_data', true ) );
 	}
 
 	/**

--- a/tests/unit-tests/content-gate/class-institution.php
+++ b/tests/unit-tests/content-gate/class-institution.php
@@ -214,27 +214,30 @@ class Test_Institution extends WP_UnitTestCase {
 
 		delete_transient( Institution::TRANSIENT_KEY );
 
-		// phpcs:disable WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__REMOTE_ADDR__
+		// phpcs:disable WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__REMOTE_ADDR__, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
 
-		// No IP set — no match.
-		unset( $_SERVER['REMOTE_ADDR'] );
+		// Without cache-bypass cookie — no IP evaluation happens.
+		$_SERVER['REMOTE_ADDR'] = '10.1.2.3';
 		$this->assertFalse( Institution::evaluate( $reader_id, [ $inst_id ] ) );
 
-		// Matching IP.
+		// Set cache-bypass cookie (simulates having visited /institutional-access).
+		$_COOKIE[ \Newspack\Content_Gate\IP_Access_Rule::COOKIE_NAME ] = '1';
+
+		// Matching IP with cookie.
 		$_SERVER['REMOTE_ADDR'] = '10.1.2.3';
 		$this->assertTrue( Institution::evaluate( $reader_id, [ $inst_id ] ) );
 
-		// Non-matching IP.
+		// Non-matching IP with cookie.
 		$_SERVER['REMOTE_ADDR'] = '192.168.1.1';
 		$this->assertFalse( Institution::evaluate( $reader_id, [ $inst_id ] ) );
 
-		unset( $_SERVER['REMOTE_ADDR'] );
+		unset( $_SERVER['REMOTE_ADDR'], $_COOKIE[ \Newspack\Content_Gate\IP_Access_Rule::COOKIE_NAME ] );
 
 		// phpcs:enable
 	}
 
 	/**
-	 * Test anonymous user can match via IP range.
+	 * Test anonymous user can match via IP range on uncached request.
 	 */
 	public function test_anonymous_ip_range_match() {
 		$inst_id = $this->create_institution(
@@ -244,18 +247,29 @@ class Test_Institution extends WP_UnitTestCase {
 
 		delete_transient( Institution::TRANSIENT_KEY );
 
-		// phpcs:disable WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__REMOTE_ADDR__
+		// phpcs:disable WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__REMOTE_ADDR__, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+
+		// Set cache-bypass cookie.
+		$_COOKIE[ \Newspack\Content_Gate\IP_Access_Rule::COOKIE_NAME ] = '1';
 
 		$_SERVER['REMOTE_ADDR'] = '10.1.2.3';
 		$this->assertTrue(
 			\Newspack\Access_Rules::evaluate_rule( 'institution', [ $inst_id ], 0 ),
-			'Anonymous user with matching IP should get institutional access'
+			'Anonymous user with matching IP on uncached request should get institutional access'
 		);
 
 		$_SERVER['REMOTE_ADDR'] = '192.168.1.1';
 		$this->assertFalse(
 			\Newspack\Access_Rules::evaluate_rule( 'institution', [ $inst_id ], 0 ),
 			'Anonymous user with non-matching IP should not get access'
+		);
+
+		// Without cookie — no evaluation even with matching IP.
+		unset( $_COOKIE[ \Newspack\Content_Gate\IP_Access_Rule::COOKIE_NAME ] );
+		$_SERVER['REMOTE_ADDR'] = '10.1.2.3';
+		$this->assertFalse(
+			\Newspack\Access_Rules::evaluate_rule( 'institution', [ $inst_id ], 0 ),
+			'Anonymous user without cache-bypass cookie should not trigger IP evaluation'
 		);
 
 		unset( $_SERVER['REMOTE_ADDR'] );

--- a/tests/unit-tests/content-gate/class-institution.php
+++ b/tests/unit-tests/content-gate/class-institution.php
@@ -45,28 +45,6 @@ class Newspack_Test_Institution extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Create an institution post.
-	 *
-	 * @param string $name Institution name.
-	 * @param array  $meta Post meta to set.
-	 * @return int Post ID.
-	 */
-	private function create_institution( $name, $meta = [] ) {
-		$post_id = wp_insert_post(
-			[
-				'post_type'   => Institution::POST_TYPE,
-				'post_title'  => $name,
-				'post_status' => 'publish',
-			]
-		);
-		foreach ( $meta as $key => $value ) {
-			update_post_meta( $post_id, $key, $value );
-		}
-		$this->post_ids[] = $post_id;
-		return $post_id;
-	}
-
-	/**
 	 * Create a reader user with verified email.
 	 *
 	 * @param string $email    Email address.
@@ -98,6 +76,7 @@ class Newspack_Test_Institution extends WP_UnitTestCase {
 		$post_id = Institution::create(
 			'API University',
 			[
+				'description'  => 'API University description',
 				'email_domain' => 'api.edu',
 				'ip_range'     => '10.0.0.0/8',
 			]
@@ -107,6 +86,7 @@ class Newspack_Test_Institution extends WP_UnitTestCase {
 
 		$post = get_post( $post_id );
 		$this->assertEquals( 'API University', $post->post_title );
+		$this->assertEquals( 'API University description', $post->post_excerpt );
 		$this->assertEquals( 'publish', $post->post_status );
 		$this->assertEquals( 'api.edu', get_post_meta( $post_id, '_np_institution_email_domain', true ) );
 		$this->assertEquals( '10.0.0.0/8', get_post_meta( $post_id, '_np_institution_ip_range', true ) );
@@ -124,7 +104,10 @@ class Newspack_Test_Institution extends WP_UnitTestCase {
 	 * Test get_options returns published institutions.
 	 */
 	public function test_get_options_returns_published_institutions() {
-		$id      = $this->create_institution( 'Test University' );
+		$id = Institution::create( 'Test University' );
+		$this->assertIsInt( $id );
+		$this->post_ids[] = $id;
+
 		$options = Institution::get_options();
 		$this->assertCount( 1, $options );
 		$this->assertEquals( 'Test University', $options[0]['label'] );
@@ -135,10 +118,12 @@ class Newspack_Test_Institution extends WP_UnitTestCase {
 	 * Test cache is built and can be invalidated.
 	 */
 	public function test_cache_built_and_invalidated() {
-		$id = $this->create_institution(
+		$id = Institution::create(
 			'Cached University',
-			[ '_np_institution_email_domain' => 'cached.edu' ]
+			[ 'email_domain' => 'cached.edu' ]
 		);
+		$this->assertIsInt( $id );
+		$this->post_ids[] = $id;
 		delete_transient( Institution::TRANSIENT_KEY );
 
 		$cached = Institution::get_cached_institutions();
@@ -155,7 +140,9 @@ class Newspack_Test_Institution extends WP_UnitTestCase {
 	 * Test institution with no rules matches nobody.
 	 */
 	public function test_institution_with_no_rules_matches_nobody() {
-		$inst_id   = $this->create_institution( 'Empty Institution' );
+		$inst_id = Institution::create( 'Empty Institution' );
+		$this->assertIsInt( $inst_id );
+		$this->post_ids[] = $inst_id;
 		$reader_id = $this->create_reader( 'reader@test.com' );
 
 		delete_transient( Institution::TRANSIENT_KEY );
@@ -166,10 +153,12 @@ class Newspack_Test_Institution extends WP_UnitTestCase {
 	 * Test email domain matching.
 	 */
 	public function test_email_domain_match() {
-		$inst_id = $this->create_institution(
+		$inst_id = Institution::create(
 			'University of Test',
-			[ '_np_institution_email_domain' => 'university.edu' ]
+			[ 'email_domain' => 'university.edu' ]
 		);
+		$this->assertIsInt( $inst_id );
+		$this->post_ids[] = $inst_id;
 		$match_reader    = $this->create_reader( 'student@university.edu' );
 		$no_match_reader = $this->create_reader( 'student@other.com' );
 
@@ -182,10 +171,12 @@ class Newspack_Test_Institution extends WP_UnitTestCase {
 	 * Test email domain requires verified email.
 	 */
 	public function test_email_domain_requires_verification() {
-		$inst_id = $this->create_institution(
+		$inst_id = Institution::create(
 			'Verified University',
-			[ '_np_institution_email_domain' => 'verified.edu' ]
+			[ 'email_domain' => 'verified.edu' ]
 		);
+		$this->assertIsInt( $inst_id );
+		$this->post_ids[] = $inst_id;
 		$unverified_reader = $this->create_reader( 'student@verified.edu', false );
 
 		delete_transient( Institution::TRANSIENT_KEY );
@@ -199,10 +190,12 @@ class Newspack_Test_Institution extends WP_UnitTestCase {
 	 * Test IP range match via real IP.
 	 */
 	public function test_ip_range_match() {
-		$inst_id   = $this->create_institution(
+		$inst_id = Institution::create(
 			'IP Institution',
-			[ '_np_institution_ip_range' => '10.0.0.0/8' ]
+			[ 'ip_range' => '10.0.0.0/8' ]
 		);
+		$this->assertIsInt( $inst_id );
+		$this->post_ids[] = $inst_id;
 		$reader_id = $this->create_reader( 'reader@test.com' );
 
 		delete_transient( Institution::TRANSIENT_KEY );
@@ -230,10 +223,12 @@ class Newspack_Test_Institution extends WP_UnitTestCase {
 	 * Test anonymous user can match via IP range on uncached request.
 	 */
 	public function test_anonymous_ip_range_match() {
-		$inst_id = $this->create_institution(
+		$inst_id = Institution::create(
 			'Anon IP Institution',
-			[ '_np_institution_ip_range' => '10.0.0.0/8' ]
+			[ 'ip_range' => '10.0.0.0/8' ]
 		);
+		$this->assertIsInt( $inst_id );
+		$this->post_ids[] = $inst_id;
 
 		delete_transient( Institution::TRANSIENT_KEY );
 
@@ -271,13 +266,15 @@ class Newspack_Test_Institution extends WP_UnitTestCase {
 	 * Test OR logic within an institution (any rule match is enough).
 	 */
 	public function test_or_logic_within_institution() {
-		$inst_id = $this->create_institution(
+		$inst_id = Institution::create(
 			'OR Logic Institution',
 			[
-				'_np_institution_email_domain' => 'university.edu',
-				'_np_institution_ip_range'     => '10.0.0.0/8',
+				'email_domain' => 'university.edu',
+				'ip_range'     => '10.0.0.0/8',
 			]
 		);
+		$this->assertIsInt( $inst_id );
+		$this->post_ids[] = $inst_id;
 		$reader_id = $this->create_reader( 'student@university.edu' );
 
 		delete_transient( Institution::TRANSIENT_KEY );
@@ -288,14 +285,19 @@ class Newspack_Test_Institution extends WP_UnitTestCase {
 	 * Test multi-institution selection (any institution match is enough).
 	 */
 	public function test_multi_institution_selection() {
-		$inst_a = $this->create_institution(
+		$inst_a = Institution::create(
 			'Institution A',
-			[ '_np_institution_email_domain' => 'a.edu' ]
+			[ 'email_domain' => 'a.edu' ]
 		);
-		$inst_b = $this->create_institution(
+		$this->assertIsInt( $inst_a );
+		$this->post_ids[] = $inst_a;
+
+		$inst_b = Institution::create(
 			'Institution B',
-			[ '_np_institution_email_domain' => 'b.edu' ]
+			[ 'email_domain' => 'b.edu' ]
 		);
+		$this->assertIsInt( $inst_b );
+		$this->post_ids[] = $inst_b;
 		$reader_id = $this->create_reader( 'reader@b.edu' );
 
 		delete_transient( Institution::TRANSIENT_KEY );
@@ -314,10 +316,12 @@ class Newspack_Test_Institution extends WP_UnitTestCase {
 	 * Test evaluate_rule integration with the institution rule.
 	 */
 	public function test_evaluate_rule_integration() {
-		$inst_id = $this->create_institution(
+		$inst_id = Institution::create(
 			'Integration Test University',
-			[ '_np_institution_email_domain' => 'integration.edu' ]
+			[ 'email_domain' => 'integration.edu' ]
 		);
+		$this->assertIsInt( $inst_id );
+		$this->post_ids[] = $inst_id;
 		$reader_id = $this->create_reader( 'reader@integration.edu' );
 
 		delete_transient( Institution::TRANSIENT_KEY );
@@ -330,10 +334,12 @@ class Newspack_Test_Institution extends WP_UnitTestCase {
 	 * Test that evaluate_rule returns false for anonymous users without matching IP.
 	 */
 	public function test_evaluate_rule_anonymous_no_ip_returns_false() {
-		$inst_id = $this->create_institution(
+		$inst_id = Institution::create(
 			'Anon Test',
-			[ '_np_institution_email_domain' => 'test.edu' ]
+			[ 'email_domain' => 'test.edu' ]
 		);
+		$this->assertIsInt( $inst_id );
+		$this->post_ids[] = $inst_id;
 		delete_transient( Institution::TRANSIENT_KEY );
 		// Anonymous user can't match email domain rules.
 		$this->assertFalse(
@@ -345,10 +351,12 @@ class Newspack_Test_Institution extends WP_UnitTestCase {
 	 * Test check_ip filter handler.
 	 */
 	public function test_check_ip_filter() {
-		$this->create_institution(
+		$inst_id = Institution::create(
 			'IP Filter Institution',
-			[ '_np_institution_ip_range' => '192.168.1.0/24' ]
+			[ 'ip_range' => '192.168.1.0/24' ]
 		);
+		$this->assertIsInt( $inst_id );
+		$this->post_ids[] = $inst_id;
 		delete_transient( Institution::TRANSIENT_KEY );
 
 		$_SERVER['REMOTE_ADDR'] = '192.168.1.50'; // phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__REMOTE_ADDR__

--- a/tests/unit-tests/content-gate/class-institution.php
+++ b/tests/unit-tests/content-gate/class-institution.php
@@ -29,6 +29,21 @@ class Newspack_Test_Institution extends WP_UnitTestCase {
 	private $user_ids = [];
 
 	/**
+	 * Original REMOTE_ADDR value to restore after tests that modify it.
+	 *
+	 * @var string|null
+	 */
+	private $original_remote_addr;
+
+	/**
+	 * Setup.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->original_remote_addr = isset( $_SERVER['REMOTE_ADDR'] ) ? $_SERVER['REMOTE_ADDR'] : null; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__REMOTE_ADDR__
+	}
+
+	/**
 	 * Teardown.
 	 */
 	public function tear_down() {
@@ -41,6 +56,12 @@ class Newspack_Test_Institution extends WP_UnitTestCase {
 		}
 		$this->user_ids = [];
 		delete_transient( Institution::TRANSIENT_KEY );
+		// Restore REMOTE_ADDR to avoid polluting other test classes.
+		if ( null === $this->original_remote_addr ) {
+			unset( $_SERVER['REMOTE_ADDR'] ); // phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__REMOTE_ADDR__
+		} else {
+			$_SERVER['REMOTE_ADDR'] = $this->original_remote_addr; // phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__REMOTE_ADDR__
+		}
 		parent::tear_down();
 	}
 

--- a/tests/unit-tests/content-gate/class-institution.php
+++ b/tests/unit-tests/content-gate/class-institution.php
@@ -208,6 +208,44 @@ class Test_Institution extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that the institution access rule is registered.
+	 */
+	public function test_access_rule_registered() {
+		$rules = \Newspack\Access_Rules::get_registered_rules();
+		$this->assertArrayHasKey( 'institution', $rules );
+	}
+
+	/**
+	 * Test evaluate_rule integration with the institution rule.
+	 */
+	public function test_evaluate_rule_integration() {
+		$inst_id = $this->create_institution(
+			'Integration Test University',
+			[ '_np_institution_email_domain' => 'integration.edu' ]
+		);
+		$reader_id = $this->create_reader( 'reader@integration.edu' );
+
+		delete_transient( Institution::TRANSIENT_KEY );
+		$this->assertTrue(
+			\Newspack\Access_Rules::evaluate_rule( 'institution', [ $inst_id ], $reader_id )
+		);
+	}
+
+	/**
+	 * Test evaluate_rule returns false for anonymous users.
+	 */
+	public function test_evaluate_rule_anonymous_returns_false() {
+		$inst_id = $this->create_institution(
+			'Anon Test',
+			[ '_np_institution_ip_range' => '10.0.0.0/8' ]
+		);
+		delete_transient( Institution::TRANSIENT_KEY );
+		$this->assertFalse(
+			\Newspack\Access_Rules::evaluate_rule( 'institution', [ $inst_id ], 0 )
+		);
+	}
+
+	/**
 	 * Test check_ip filter handler.
 	 */
 	public function test_check_ip_filter() {

--- a/tests/unit-tests/content-gate/class-institution.php
+++ b/tests/unit-tests/content-gate/class-institution.php
@@ -67,12 +67,6 @@ class Test_Institution extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Create a reader user.
-	 *
-	 * @param string $email Email address.
-	 * @return int User ID.
-	 */
-	/**
 	 * Create a reader user with verified email.
 	 *
 	 * @param string $email    Email address.

--- a/tests/unit-tests/content-gate/class-institution.php
+++ b/tests/unit-tests/content-gate/class-institution.php
@@ -72,7 +72,14 @@ class Test_Institution extends WP_UnitTestCase {
 	 * @param string $email Email address.
 	 * @return int User ID.
 	 */
-	private function create_reader( $email ) {
+	/**
+	 * Create a reader user with verified email.
+	 *
+	 * @param string $email    Email address.
+	 * @param bool   $verified Whether the email is verified. Default true.
+	 * @return int User ID.
+	 */
+	private function create_reader( $email, $verified = true ) {
 		$user_id = wp_insert_user(
 			[
 				'user_login' => 'reader-' . wp_generate_password( 6, false ),
@@ -83,6 +90,9 @@ class Test_Institution extends WP_UnitTestCase {
 		);
 		if ( ! is_wp_error( $user_id ) ) {
 			update_user_meta( $user_id, '_newspack_reader', true );
+			if ( $verified ) {
+				update_user_meta( $user_id, \Newspack\Reader_Activation::EMAIL_VERIFIED, true );
+			}
 			$this->user_ids[] = $user_id;
 		}
 		return $user_id;
@@ -173,6 +183,23 @@ class Test_Institution extends WP_UnitTestCase {
 		delete_transient( Institution::TRANSIENT_KEY );
 		$this->assertTrue( Institution::evaluate( $match_reader, [ $inst_id ] ) );
 		$this->assertFalse( Institution::evaluate( $no_match_reader, [ $inst_id ] ) );
+	}
+
+	/**
+	 * Test email domain requires verified email.
+	 */
+	public function test_email_domain_requires_verification() {
+		$inst_id = $this->create_institution(
+			'Verified University',
+			[ '_np_institution_email_domain' => 'verified.edu' ]
+		);
+		$unverified_reader = $this->create_reader( 'student@verified.edu', false );
+
+		delete_transient( Institution::TRANSIENT_KEY );
+		$this->assertFalse(
+			Institution::evaluate( $unverified_reader, [ $inst_id ] ),
+			'Unverified email should not grant institutional access'
+		);
 	}
 
 	/**

--- a/tests/unit-tests/content-gate/class-institution.php
+++ b/tests/unit-tests/content-gate/class-institution.php
@@ -1,0 +1,229 @@
+<?php
+/**
+ * Tests for the Institution class.
+ *
+ * @package Newspack\Tests\Content_Gate
+ */
+
+use Newspack\Institution;
+
+/**
+ * Test Institution functionality.
+ *
+ * @group Access_Rules
+ */
+class Test_Institution extends WP_UnitTestCase {
+
+	/**
+	 * Post IDs for cleanup.
+	 *
+	 * @var int[]
+	 */
+	private $post_ids = [];
+
+	/**
+	 * User IDs for cleanup.
+	 *
+	 * @var int[]
+	 */
+	private $user_ids = [];
+
+	/**
+	 * Teardown.
+	 */
+	public function tear_down() {
+		foreach ( $this->post_ids as $post_id ) {
+			wp_delete_post( $post_id, true );
+		}
+		$this->post_ids = [];
+		foreach ( $this->user_ids as $user_id ) {
+			wp_delete_user( $user_id );
+		}
+		$this->user_ids = [];
+		delete_transient( Institution::TRANSIENT_KEY );
+		parent::tear_down();
+	}
+
+	/**
+	 * Create an institution post.
+	 *
+	 * @param string $name Institution name.
+	 * @param array  $meta Post meta to set.
+	 * @return int Post ID.
+	 */
+	private function create_institution( $name, $meta = [] ) {
+		$post_id = wp_insert_post(
+			[
+				'post_type'   => Institution::POST_TYPE,
+				'post_title'  => $name,
+				'post_status' => 'publish',
+			]
+		);
+		foreach ( $meta as $key => $value ) {
+			update_post_meta( $post_id, $key, $value );
+		}
+		$this->post_ids[] = $post_id;
+		return $post_id;
+	}
+
+	/**
+	 * Create a reader user.
+	 *
+	 * @param string $email Email address.
+	 * @return int User ID.
+	 */
+	private function create_reader( $email ) {
+		$user_id = wp_insert_user(
+			[
+				'user_login' => 'reader-' . wp_generate_password( 6, false ),
+				'user_pass'  => wp_generate_password(),
+				'user_email' => $email,
+				'role'       => 'subscriber',
+			]
+		);
+		if ( ! is_wp_error( $user_id ) ) {
+			update_user_meta( $user_id, '_newspack_reader', true );
+			$this->user_ids[] = $user_id;
+		}
+		return $user_id;
+	}
+
+	/**
+	 * Test CPT is registered.
+	 */
+	public function test_cpt_registered() {
+		$this->assertTrue( post_type_exists( Institution::POST_TYPE ) );
+	}
+
+	/**
+	 * Test get_options returns published institutions.
+	 */
+	public function test_get_options_returns_published_institutions() {
+		$id      = $this->create_institution( 'Test University' );
+		$options = Institution::get_options();
+		$this->assertCount( 1, $options );
+		$this->assertEquals( 'Test University', $options[0]['label'] );
+		$this->assertEquals( $id, $options[0]['value'] );
+	}
+
+	/**
+	 * Test cache is built and can be invalidated.
+	 */
+	public function test_cache_built_and_invalidated() {
+		$id = $this->create_institution(
+			'Cached University',
+			[ '_np_institution_email_domain' => 'cached.edu' ]
+		);
+		delete_transient( Institution::TRANSIENT_KEY );
+
+		$cached = Institution::get_cached_institutions();
+		$this->assertArrayHasKey( $id, $cached );
+		$this->assertEquals( 'cached.edu', $cached[ $id ]['email_domain'] );
+
+		$this->assertNotFalse( get_transient( Institution::TRANSIENT_KEY ) );
+
+		Institution::invalidate_cache();
+		$this->assertFalse( get_transient( Institution::TRANSIENT_KEY ) );
+	}
+
+	/**
+	 * Test institution with no rules matches nobody.
+	 */
+	public function test_institution_with_no_rules_matches_nobody() {
+		$inst_id   = $this->create_institution( 'Empty Institution' );
+		$reader_id = $this->create_reader( 'reader@test.com' );
+
+		delete_transient( Institution::TRANSIENT_KEY );
+		$this->assertFalse( Institution::evaluate( $reader_id, [ $inst_id ] ) );
+	}
+
+	/**
+	 * Test email domain matching.
+	 */
+	public function test_email_domain_match() {
+		$inst_id = $this->create_institution(
+			'University of Test',
+			[ '_np_institution_email_domain' => 'university.edu' ]
+		);
+		$match_reader    = $this->create_reader( 'student@university.edu' );
+		$no_match_reader = $this->create_reader( 'student@other.com' );
+
+		delete_transient( Institution::TRANSIENT_KEY );
+		$this->assertTrue( Institution::evaluate( $match_reader, [ $inst_id ] ) );
+		$this->assertFalse( Institution::evaluate( $no_match_reader, [ $inst_id ] ) );
+	}
+
+	/**
+	 * Test IP range match via cookie.
+	 */
+	public function test_ip_range_match_via_cookie() {
+		$inst_id   = $this->create_institution(
+			'IP Institution',
+			[ '_np_institution_ip_range' => '10.0.0.0/8' ]
+		);
+		$reader_id = $this->create_reader( 'reader@test.com' );
+
+		delete_transient( Institution::TRANSIENT_KEY );
+
+		$this->assertFalse( Institution::evaluate( $reader_id, [ $inst_id ] ) );
+
+		$_COOKIE[ \Newspack\Content_Gate\IP_Access_Rule::COOKIE_NAME ] = '1'; // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+		$this->assertTrue( Institution::evaluate( $reader_id, [ $inst_id ] ) );
+		unset( $_COOKIE[ \Newspack\Content_Gate\IP_Access_Rule::COOKIE_NAME ] ); // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+	}
+
+	/**
+	 * Test OR logic within an institution (any rule match is enough).
+	 */
+	public function test_or_logic_within_institution() {
+		$inst_id = $this->create_institution(
+			'OR Logic Institution',
+			[
+				'_np_institution_email_domain' => 'university.edu',
+				'_np_institution_ip_range'     => '10.0.0.0/8',
+			]
+		);
+		$reader_id = $this->create_reader( 'student@university.edu' );
+
+		delete_transient( Institution::TRANSIENT_KEY );
+		$this->assertTrue( Institution::evaluate( $reader_id, [ $inst_id ] ) );
+	}
+
+	/**
+	 * Test multi-institution selection (any institution match is enough).
+	 */
+	public function test_multi_institution_selection() {
+		$inst_a = $this->create_institution(
+			'Institution A',
+			[ '_np_institution_email_domain' => 'a.edu' ]
+		);
+		$inst_b = $this->create_institution(
+			'Institution B',
+			[ '_np_institution_email_domain' => 'b.edu' ]
+		);
+		$reader_id = $this->create_reader( 'reader@b.edu' );
+
+		delete_transient( Institution::TRANSIENT_KEY );
+		$this->assertTrue( Institution::evaluate( $reader_id, [ $inst_a, $inst_b ] ) );
+	}
+
+	/**
+	 * Test check_ip filter handler.
+	 */
+	public function test_check_ip_filter() {
+		$this->create_institution(
+			'IP Filter Institution',
+			[ '_np_institution_ip_range' => '192.168.1.0/24' ]
+		);
+		delete_transient( Institution::TRANSIENT_KEY );
+
+		$_SERVER['REMOTE_ADDR'] = '192.168.1.50'; // phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__REMOTE_ADDR__
+		$this->assertTrue( Institution::check_ip( false ) );
+
+		$_SERVER['REMOTE_ADDR'] = '10.0.0.1'; // phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__REMOTE_ADDR__
+		delete_transient( Institution::TRANSIENT_KEY );
+		$this->assertFalse( Institution::check_ip( false ) );
+
+		unset( $_SERVER['REMOTE_ADDR'] ); // phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__REMOTE_ADDR__
+	}
+}

--- a/tests/unit-tests/content-gate/class-institution.php
+++ b/tests/unit-tests/content-gate/class-institution.php
@@ -89,6 +89,28 @@ class Test_Institution extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test creating an institution via the public API.
+	 */
+	public function test_create_institution() {
+		$post_id = Institution::create(
+			'API University',
+			[
+				'email_domain' => 'api.edu',
+				'ip_range'     => '10.0.0.0/8',
+			]
+		);
+		$this->assertIsInt( $post_id );
+		$this->post_ids[] = $post_id;
+
+		$post = get_post( $post_id );
+		$this->assertEquals( 'API University', $post->post_title );
+		$this->assertEquals( 'publish', $post->post_status );
+		$this->assertEquals( 'api.edu', get_post_meta( $post_id, '_np_institution_email_domain', true ) );
+		$this->assertEquals( '10.0.0.0/8', get_post_meta( $post_id, '_np_institution_ip_range', true ) );
+		$this->assertEmpty( get_post_meta( $post_id, '_np_institution_reader_data', true ) );
+	}
+
+	/**
 	 * Test CPT is registered.
 	 */
 	public function test_cpt_registered() {

--- a/tests/unit-tests/content-gate/class-institution.php
+++ b/tests/unit-tests/content-gate/class-institution.php
@@ -214,24 +214,21 @@ class Test_Institution extends WP_UnitTestCase {
 
 		delete_transient( Institution::TRANSIENT_KEY );
 
-		// phpcs:disable WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__REMOTE_ADDR__, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+		// phpcs:disable WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__REMOTE_ADDR__
 
-		// Without cache-bypass cookie — no IP evaluation happens.
-		$_SERVER['REMOTE_ADDR'] = '10.1.2.3';
-		$this->assertFalse( Institution::evaluate( $reader_id, [ $inst_id ] ) );
+		// Logged-in users are always uncached — IP is checked directly, no cookie needed.
 
-		// Set cache-bypass cookie (simulates having visited /institutional-access).
-		$_COOKIE[ \Newspack\Content_Gate\IP_Access_Rule::COOKIE_NAME ] = '1';
-
-		// Matching IP with cookie.
+		// Matching IP.
 		$_SERVER['REMOTE_ADDR'] = '10.1.2.3';
 		$this->assertTrue( Institution::evaluate( $reader_id, [ $inst_id ] ) );
 
-		// Non-matching IP with cookie.
+		// Non-matching IP.
 		$_SERVER['REMOTE_ADDR'] = '192.168.1.1';
 		$this->assertFalse( Institution::evaluate( $reader_id, [ $inst_id ] ) );
 
-		unset( $_SERVER['REMOTE_ADDR'], $_COOKIE[ \Newspack\Content_Gate\IP_Access_Rule::COOKIE_NAME ] );
+		// No IP set.
+		unset( $_SERVER['REMOTE_ADDR'] );
+		$this->assertFalse( Institution::evaluate( $reader_id, [ $inst_id ] ) );
 
 		// phpcs:enable
 	}

--- a/tests/unit-tests/content-gate/class-institution.php
+++ b/tests/unit-tests/content-gate/class-institution.php
@@ -83,7 +83,6 @@ class Test_Institution extends WP_UnitTestCase {
 			]
 		);
 		if ( ! is_wp_error( $user_id ) ) {
-			update_user_meta( $user_id, '_newspack_reader', true );
 			if ( $verified ) {
 				update_user_meta( $user_id, \Newspack\Reader_Activation::EMAIL_VERIFIED, true );
 			}

--- a/tests/unit-tests/content-gate/class-institution.php
+++ b/tests/unit-tests/content-gate/class-institution.php
@@ -96,8 +96,8 @@ class Newspack_Test_Institution extends WP_UnitTestCase {
 	public function test_create_institution() {
 		$post_id = Institution::create(
 			'API University',
+			'API University description',
 			[
-				'description'  => 'API University description',
 				'email_domain' => 'api.edu',
 				'ip_range'     => '10.0.0.0/8',
 			]
@@ -141,6 +141,7 @@ class Newspack_Test_Institution extends WP_UnitTestCase {
 	public function test_cache_built_and_invalidated() {
 		$id = Institution::create(
 			'Cached University',
+			'',
 			[ 'email_domain' => 'cached.edu' ]
 		);
 		$this->assertIsInt( $id );
@@ -176,6 +177,7 @@ class Newspack_Test_Institution extends WP_UnitTestCase {
 	public function test_email_domain_match() {
 		$inst_id = Institution::create(
 			'University of Test',
+			'',
 			[ 'email_domain' => 'university.edu' ]
 		);
 		$this->assertIsInt( $inst_id );
@@ -194,6 +196,7 @@ class Newspack_Test_Institution extends WP_UnitTestCase {
 	public function test_email_domain_requires_verification() {
 		$inst_id = Institution::create(
 			'Verified University',
+			'',
 			[ 'email_domain' => 'verified.edu' ]
 		);
 		$this->assertIsInt( $inst_id );
@@ -213,6 +216,7 @@ class Newspack_Test_Institution extends WP_UnitTestCase {
 	public function test_ip_range_match() {
 		$inst_id = Institution::create(
 			'IP Institution',
+			'',
 			[ 'ip_range' => '10.0.0.0/8' ]
 		);
 		$this->assertIsInt( $inst_id );
@@ -246,6 +250,7 @@ class Newspack_Test_Institution extends WP_UnitTestCase {
 	public function test_anonymous_ip_range_match() {
 		$inst_id = Institution::create(
 			'Anon IP Institution',
+			'',
 			[ 'ip_range' => '10.0.0.0/8' ]
 		);
 		$this->assertIsInt( $inst_id );
@@ -289,6 +294,7 @@ class Newspack_Test_Institution extends WP_UnitTestCase {
 	public function test_or_logic_within_institution() {
 		$inst_id = Institution::create(
 			'OR Logic Institution',
+			'',
 			[
 				'email_domain' => 'university.edu',
 				'ip_range'     => '10.0.0.0/8',
@@ -308,6 +314,7 @@ class Newspack_Test_Institution extends WP_UnitTestCase {
 	public function test_multi_institution_selection() {
 		$inst_a = Institution::create(
 			'Institution A',
+			'',
 			[ 'email_domain' => 'a.edu' ]
 		);
 		$this->assertIsInt( $inst_a );
@@ -315,6 +322,7 @@ class Newspack_Test_Institution extends WP_UnitTestCase {
 
 		$inst_b = Institution::create(
 			'Institution B',
+			'',
 			[ 'email_domain' => 'b.edu' ]
 		);
 		$this->assertIsInt( $inst_b );
@@ -339,6 +347,7 @@ class Newspack_Test_Institution extends WP_UnitTestCase {
 	public function test_evaluate_rule_integration() {
 		$inst_id = Institution::create(
 			'Integration Test University',
+			'',
 			[ 'email_domain' => 'integration.edu' ]
 		);
 		$this->assertIsInt( $inst_id );
@@ -357,6 +366,7 @@ class Newspack_Test_Institution extends WP_UnitTestCase {
 	public function test_evaluate_rule_anonymous_no_ip_returns_false() {
 		$inst_id = Institution::create(
 			'Anon Test',
+			'',
 			[ 'email_domain' => 'test.edu' ]
 		);
 		$this->assertIsInt( $inst_id );
@@ -374,6 +384,7 @@ class Newspack_Test_Institution extends WP_UnitTestCase {
 	public function test_check_ip_filter() {
 		$inst_id = Institution::create(
 			'IP Filter Institution',
+			'',
 			[ 'ip_range' => '192.168.1.0/24' ]
 		);
 		$this->assertIsInt( $inst_id );

--- a/tests/unit-tests/content-gate/class-institution.php
+++ b/tests/unit-tests/content-gate/class-institution.php
@@ -12,7 +12,7 @@ use Newspack\Institution;
  *
  * @group Access_Rules
  */
-class Test_Institution extends WP_UnitTestCase {
+class Newspack_Test_Institution extends WP_UnitTestCase {
 
 	/**
 	 * Post IDs for cleanup.

--- a/tests/unit-tests/content-gate/class-institution.php
+++ b/tests/unit-tests/content-gate/class-institution.php
@@ -203,9 +203,9 @@ class Test_Institution extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test IP range match via cookie.
+	 * Test IP range match via real IP.
 	 */
-	public function test_ip_range_match_via_cookie() {
+	public function test_ip_range_match() {
 		$inst_id   = $this->create_institution(
 			'IP Institution',
 			[ '_np_institution_ip_range' => '10.0.0.0/8' ]
@@ -214,11 +214,53 @@ class Test_Institution extends WP_UnitTestCase {
 
 		delete_transient( Institution::TRANSIENT_KEY );
 
+		// phpcs:disable WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__REMOTE_ADDR__
+
+		// No IP set — no match.
+		unset( $_SERVER['REMOTE_ADDR'] );
 		$this->assertFalse( Institution::evaluate( $reader_id, [ $inst_id ] ) );
 
-		$_COOKIE[ \Newspack\Content_Gate\IP_Access_Rule::COOKIE_NAME ] = '1'; // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+		// Matching IP.
+		$_SERVER['REMOTE_ADDR'] = '10.1.2.3';
 		$this->assertTrue( Institution::evaluate( $reader_id, [ $inst_id ] ) );
-		unset( $_COOKIE[ \Newspack\Content_Gate\IP_Access_Rule::COOKIE_NAME ] ); // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+
+		// Non-matching IP.
+		$_SERVER['REMOTE_ADDR'] = '192.168.1.1';
+		$this->assertFalse( Institution::evaluate( $reader_id, [ $inst_id ] ) );
+
+		unset( $_SERVER['REMOTE_ADDR'] );
+
+		// phpcs:enable
+	}
+
+	/**
+	 * Test anonymous user can match via IP range.
+	 */
+	public function test_anonymous_ip_range_match() {
+		$inst_id = $this->create_institution(
+			'Anon IP Institution',
+			[ '_np_institution_ip_range' => '10.0.0.0/8' ]
+		);
+
+		delete_transient( Institution::TRANSIENT_KEY );
+
+		// phpcs:disable WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__REMOTE_ADDR__
+
+		$_SERVER['REMOTE_ADDR'] = '10.1.2.3';
+		$this->assertTrue(
+			\Newspack\Access_Rules::evaluate_rule( 'institution', [ $inst_id ], 0 ),
+			'Anonymous user with matching IP should get institutional access'
+		);
+
+		$_SERVER['REMOTE_ADDR'] = '192.168.1.1';
+		$this->assertFalse(
+			\Newspack\Access_Rules::evaluate_rule( 'institution', [ $inst_id ], 0 ),
+			'Anonymous user with non-matching IP should not get access'
+		);
+
+		unset( $_SERVER['REMOTE_ADDR'] );
+
+		// phpcs:enable
 	}
 
 	/**
@@ -283,12 +325,16 @@ class Test_Institution extends WP_UnitTestCase {
 	/**
 	 * Test evaluate_rule returns false for anonymous users.
 	 */
-	public function test_evaluate_rule_anonymous_returns_false() {
+	/**
+	 * Test anonymous user without matching IP is denied.
+	 */
+	public function test_evaluate_rule_anonymous_no_ip_returns_false() {
 		$inst_id = $this->create_institution(
 			'Anon Test',
-			[ '_np_institution_ip_range' => '10.0.0.0/8' ]
+			[ '_np_institution_email_domain' => 'test.edu' ]
 		);
 		delete_transient( Institution::TRANSIENT_KEY );
+		// Anonymous user can't match email domain rules.
 		$this->assertFalse(
 			\Newspack\Access_Rules::evaluate_rule( 'institution', [ $inst_id ], 0 )
 		);

--- a/tests/unit-tests/content-gate/class-institution.php
+++ b/tests/unit-tests/content-gate/class-institution.php
@@ -327,10 +327,7 @@ class Test_Institution extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test evaluate_rule returns false for anonymous users.
-	 */
-	/**
-	 * Test anonymous user without matching IP is denied.
+	 * Test that evaluate_rule returns false for anonymous users without matching IP.
 	 */
 	public function test_evaluate_rule_anonymous_no_ip_returns_false() {
 		$inst_id = $this->create_institution(

--- a/tests/unit-tests/content-gate/class-ip-access-rule.php
+++ b/tests/unit-tests/content-gate/class-ip-access-rule.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Tests for IP_Access_Rule utility methods.
+ *
+ * @package Newspack\Tests\Content_Gate
+ */
+
+use Newspack\Content_Gate\IP_Access_Rule;
+
+/**
+ * Test IP_Access_Rule functionality.
+ *
+ * @group Access_Rules
+ */
+class Test_IP_Access_Rule extends WP_UnitTestCase {
+
+	/**
+	 * Test exact IP matching.
+	 */
+	public function test_exact_ip_match() {
+		$this->assertTrue( IP_Access_Rule::ip_matches_ranges( '10.0.0.5', '10.0.0.5' ) );
+		$this->assertFalse( IP_Access_Rule::ip_matches_ranges( '10.0.0.6', '10.0.0.5' ) );
+	}
+
+	/**
+	 * Test CIDR block matching.
+	 */
+	public function test_cidr_match() {
+		$this->assertTrue( IP_Access_Rule::ip_matches_ranges( '192.168.1.50', '192.168.1.0/24' ) );
+		$this->assertFalse( IP_Access_Rule::ip_matches_ranges( '192.168.2.1', '192.168.1.0/24' ) );
+	}
+
+	/**
+	 * Test comma-separated ranges.
+	 */
+	public function test_comma_separated_ranges() {
+		$ranges = '10.0.0.5,192.168.1.0/24';
+		$this->assertTrue( IP_Access_Rule::ip_matches_ranges( '10.0.0.5', $ranges ) );
+		$this->assertTrue( IP_Access_Rule::ip_matches_ranges( '192.168.1.100', $ranges ) );
+		$this->assertFalse( IP_Access_Rule::ip_matches_ranges( '172.16.0.1', $ranges ) );
+	}
+
+	/**
+	 * Test that empty ranges string returns false.
+	 */
+	public function test_empty_ranges_returns_false() {
+		$this->assertFalse( IP_Access_Rule::ip_matches_ranges( '10.0.0.1', '' ) );
+	}
+
+	/**
+	 * Test that an invalid CIDR entry is skipped and returns false.
+	 */
+	public function test_invalid_cidr_is_skipped() {
+		$this->assertFalse( IP_Access_Rule::ip_matches_ranges( '10.0.0.1', '999.999.999.999/24' ) );
+	}
+
+	/**
+	 * Test that an invalid IP address returns false.
+	 */
+	public function test_invalid_ip_returns_false() {
+		$this->assertFalse( IP_Access_Rule::ip_matches_ranges( 'not-an-ip', '10.0.0.0/8' ) );
+	}
+}

--- a/tests/unit-tests/content-gate/class-ip-access-rule.php
+++ b/tests/unit-tests/content-gate/class-ip-access-rule.php
@@ -12,7 +12,7 @@ use Newspack\Content_Gate\IP_Access_Rule;
  *
  * @group Access_Rules
  */
-class Test_IP_Access_Rule extends WP_UnitTestCase {
+class Newspack_Test_IP_Access_Rule extends WP_UnitTestCase {
 
 	/**
 	 * Test exact IP matching.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

NPPD-1048

Adds institutional access to the content gate system. Institutions can grant access to gated content based on email domain, IP address range, or reader data attributes.

<img width="519" height="569" alt="image" src="https://github.com/user-attachments/assets/fd2fe009-d4c2-4bc1-ac20-c7391da70d7b" />

A new `np_institution` CPT stores institution definitions with their access rules. A new `institution` access rule type is available in the content gate editor, allowing publishers to select which institutions can bypass a specific gate.

For anonymous visitors, the IP-based access works with the existing `/institutional-access` endpoint, which stores a cache-busting cookie.

All institution rules are mapped to a transient, so gate evaluation can be performed more efficiently.

### How to test the changes in this Pull Request:

1. Create an institution via CLI: `wp eval 'Newspack\Institution::create("Test University", "Test University Description", ["email_domain" => "test.edu"]);'`
2. Create a content gate with an institution access rule and select the created institution.
3. Register a new reader with a `@test.edu` email and verify they can access a gated article **only after account verification**
4. Log in as a reader with a different email domain and verify the content is gated
5. Create an institution with an IP range rule: `wp eval 'Newspack\Institution::create("Campus Access", "Test campus access description", ["ip_range" => "192.168.1.0/24"]);'` (use your public IP address if tunneled)
6. Assign the new institution to the created gate
7. As an anonymous reader, visit `/institutional-access` from a matching IP and verify the `wp_nocache_ip` cookie is set, and gated content becomes accessible.
8. In a fresh session, authenticate as a reader without an institutional email
9. Confirm you have access to the gated article via IP without having to go through the `/institutional-access` endpoint
10. Delete the IP range institution and confirm the access is now revoked (transient cleared)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->