### PR TITLE
fix(block-theme): apply max-width to add payment method iframe

### DIFF
--- a/src/newspack-ui/scss/elements/woocommerce/_overrides.scss
+++ b/src/newspack-ui/scss/elements/woocommerce/_overrides.scss
@@ -217,6 +217,13 @@
 	.select2-container--default .select2-selection--single .select2-selection__arrow {
 		height: 46px;
 	}
+
+	/* stylelint-disable-next-line selector-id-pattern */
+	#add_payment_method {
+		iframe {
+			max-width: 100%;
+		}
+	}
 }
 
 /** See #3292. */


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://linear.app/a8c/issue/NPPD-1200/investigate-stripe-styling-issues-on-my-account-pages-with-block-theme

This applies a max width to the add payment method iframes so block theme matches classic theme styling

![Screenshot 2026-03-17 at 16 26 59](https://github.com/user-attachments/assets/4ae3c9b6-c03a-49b1-a3c7-4f89e62f8d31)


### How to test the changes in this Pull Request:
1. Ensure Stripe is the active payment method
2. Logged in a reader, go to my account > payment information
3. Click the add payment method button
4. Ensure the width of the Stripe payment method inputs match between classic and block theme

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->