### PR TITLE
feat(post-date): centralize date features from theme into plugin

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -139,6 +139,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/corrections/class-corrections.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-syndication.php';
 		include_once NEWSPACK_ABSPATH . 'includes/bylines/class-bylines.php';
+		include_once NEWSPACK_ABSPATH . 'includes/class-post-date.php';
 		include_once NEWSPACK_ABSPATH . 'includes/lite-site/class-lite-site.php';
 		include_once NEWSPACK_ABSPATH . 'includes/content-gate/trait-content-gate-layout.php';
 		include_once NEWSPACK_ABSPATH . 'includes/content-gate/class-content-gate.php';

--- a/includes/class-post-date.php
+++ b/includes/class-post-date.php
@@ -260,14 +260,14 @@ class Post_Date {
 		}
 
 		$handle = 'newspack-relative-time';
-		$path   = NEWSPACK_ABSPATH . 'dist/other-scripts/relative-time/index.js';
-		$url    = plugins_url( 'dist/other-scripts/relative-time/index.js', NEWSPACK_PLUGIN_FILE );
+		$path   = NEWSPACK_ABSPATH . 'dist/other-scripts/relative-time.js';
+		$url    = plugins_url( 'dist/other-scripts/relative-time.js', NEWSPACK_PLUGIN_FILE );
 
 		if ( ! file_exists( $path ) ) {
 			return;
 		}
 
-		$asset = include NEWSPACK_ABSPATH . 'dist/other-scripts/relative-time/index.asset.php';
+		$asset = include NEWSPACK_ABSPATH . 'dist/other-scripts/relative-time.asset.php';
 
 		wp_enqueue_script( $handle, $url, $asset['dependencies'] ?? [], $asset['version'] ?? false, true );
 		wp_localize_script(
@@ -293,14 +293,14 @@ class Post_Date {
 		$post_types = apply_filters( 'newspack_updated_date_supported_post_types', [ 'post' ] );
 
 		$handle = 'newspack-post-date-editor';
-		$path   = NEWSPACK_ABSPATH . 'dist/other-scripts/post-date-editor/index.js';
-		$url    = plugins_url( 'dist/other-scripts/post-date-editor/index.js', NEWSPACK_PLUGIN_FILE );
+		$path   = NEWSPACK_ABSPATH . 'dist/other-scripts/post-date-editor.js';
+		$url    = plugins_url( 'dist/other-scripts/post-date-editor.js', NEWSPACK_PLUGIN_FILE );
 
 		if ( ! file_exists( $path ) ) {
 			return;
 		}
 
-		$asset = include NEWSPACK_ABSPATH . 'dist/other-scripts/post-date-editor/index.asset.php';
+		$asset = include NEWSPACK_ABSPATH . 'dist/other-scripts/post-date-editor.asset.php';
 
 		wp_enqueue_script( $handle, $url, $asset['dependencies'] ?? [], $asset['version'] ?? false, true );
 		wp_localize_script(

--- a/includes/class-post-date.php
+++ b/includes/class-post-date.php
@@ -41,7 +41,7 @@ class Post_Date {
 		add_filter( 'newspack_blocks_formatted_displayed_post_date', [ __CLASS__, 'filter_blocks_formatted_date' ], 10, 2 );
 		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'enqueue_scripts' ] );
 		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'enqueue_editor_assets' ] );
-		add_action( 'newspack_theme_entry_meta', [ __CLASS__, 'render_updated_date_classic' ], 5 );
+		add_action( 'newspack_theme_after_posted_on', [ __CLASS__, 'render_updated_date_classic' ] );
 	}
 
 	/**
@@ -269,7 +269,7 @@ class Post_Date {
 
 	/**
 	 * Render updated date for classic (non-block) themes.
-	 * Hooked to `newspack_theme_entry_meta` which fires after `newspack_posted_on()`.
+	 * Hooked to `newspack_theme_after_posted_on` which fires after `newspack_posted_on()`.
 	 */
 	public static function render_updated_date_classic() {
 		if ( wp_is_block_theme() || ! is_singular() ) {

--- a/includes/class-post-date.php
+++ b/includes/class-post-date.php
@@ -94,6 +94,7 @@ class Post_Date {
 			return false;
 		}
 
+		/** This filter is documented in includes/class-post-date.php */
 		$post_types = apply_filters( 'newspack_updated_date_supported_post_types', [ 'post' ] );
 		if ( ! in_array( $post->post_type, $post_types, true ) ) {
 			return false;
@@ -421,6 +422,7 @@ class Post_Date {
 	 * Enqueue editor sidebar script for per-post toggles.
 	 */
 	public static function enqueue_editor_assets() {
+		/** This filter is documented in includes/class-post-date.php */
 		$post_types = apply_filters( 'newspack_updated_date_supported_post_types', [ 'post' ] );
 
 		$screen = get_current_screen();

--- a/includes/class-post-date.php
+++ b/includes/class-post-date.php
@@ -131,6 +131,28 @@ class Post_Date {
 	}
 
 	/**
+	 * Replace the text content of a <time> tag, preserving any <a> wrapper.
+	 *
+	 * @param string $block_content Block HTML containing a <time> tag.
+	 * @param string $new_text      Replacement text (should already be escaped).
+	 * @return string Modified block content, or original if no <time> tag found.
+	 */
+	private static function replace_time_text( $block_content, $new_text ) {
+		return preg_replace_callback(
+			'/(<time[^>]*>)(.*?)(<\/time>)/s',
+			function ( $matches ) use ( $new_text ) {
+				// Preserve <a> wrapper when isLink is enabled.
+				if ( preg_match( '/^(\s*<a\s[^>]*>).*?(<\/a>\s*)$/s', $matches[2], $link ) ) {
+					return $matches[1] . $link[1] . $new_text . $link[2] . $matches[3];
+				}
+				return $matches[1] . $new_text . $matches[3];
+			},
+			$block_content,
+			1
+		) ?? $block_content;
+	}
+
+	/**
 	 * Apply time-ago conversion to block content if enabled and within cutoff.
 	 *
 	 * @param string $block_content Rendered block content containing a <time> tag.
@@ -153,14 +175,7 @@ class Post_Date {
 			return $block_content;
 		}
 
-		return preg_replace_callback(
-			'/(<time[^>]*>)(.*?)(<\/time>)/s',
-			function ( $matches ) use ( $time_ago ) {
-				return $matches[1] . esc_html( $time_ago ) . $matches[3];
-			},
-			$block_content,
-			1
-		);
+		return self::replace_time_text( $block_content, esc_html( $time_ago ) );
 	}
 
 	/**
@@ -191,16 +206,10 @@ class Post_Date {
 			$block_content = self::maybe_apply_time_ago_to_block( $block_content );
 
 			// Wrap the date text with a translatable "Updated %s" label.
-			return preg_replace_callback(
-				'/(<time[^>]*>)(.*?)(<\/time>)/s',
-				function ( $matches ) {
-					/* translators: %s: Modified date. */
-					$label = sprintf( __( 'Updated %s', 'newspack-plugin' ), esc_html( $matches[2] ) );
-					return $matches[1] . $label . $matches[3];
-				},
-				$block_content,
-				1
-			);
+			$date_text = wp_strip_all_tags( preg_match( '/(<time[^>]*>)(.*?)(<\/time>)/s', $block_content, $m ) ? $m[2] : '' );
+			/* translators: %s: Modified date. */
+			$label = sprintf( __( 'Updated %s', 'newspack-plugin' ), $date_text );
+			return self::replace_time_text( $block_content, $label );
 		}
 
 		// Handle time-ago for publish dates.

--- a/includes/class-post-date.php
+++ b/includes/class-post-date.php
@@ -55,11 +55,11 @@ class Post_Date {
 		if ( false === $timestamp ) {
 			return null;
 		}
-		$now  = time();
-		$diff = $now - $timestamp;
-		$cutoff    = $cutoff_days * DAY_IN_SECONDS;
+		$now    = time();
+		$diff   = $now - $timestamp;
+		$cutoff = $cutoff_days * DAY_IN_SECONDS;
 
-		if ( $diff >= $cutoff ) {
+		if ( $diff < 0 || $diff >= $cutoff ) {
 			return null;
 		}
 

--- a/includes/class-post-date.php
+++ b/includes/class-post-date.php
@@ -87,11 +87,16 @@ class Post_Date {
 		$show_meta = get_post_meta( $post_id, 'newspack_show_updated_date', true );
 		$hide_meta = get_post_meta( $post_id, 'newspack_hide_updated_date', true );
 
+		// Per-post show override bypasses threshold (matches classic theme behavior).
+		if ( ! $sitewide && $show_meta ) {
+			return true;
+		}
+
 		if ( $sitewide ) {
 			if ( $hide_meta ) {
 				return false;
 			}
-		} elseif ( ! $show_meta ) {
+		} else {
 			return false;
 		}
 
@@ -197,8 +202,9 @@ class Post_Date {
 			return $the_date;
 		}
 
-		// Skip machine-readable formats (ISO 8601, Unix timestamp).
-		if ( 'Y-m-d\TH:i:sP' === $format || 'c' === $format || 'U' === $format ) {
+		// Only convert the default date format (empty string). Explicit formats must be preserved
+		// because they may be machine-readable (ISO 8601, Unix) or requested by templates/blocks.
+		if ( ! empty( $format ) ) {
 			return $the_date;
 		}
 

--- a/includes/class-post-date.php
+++ b/includes/class-post-date.php
@@ -102,8 +102,8 @@ class Post_Date {
 
 		// Apply threshold.
 		$threshold = (int) get_theme_mod( 'post_updated_date_threshold', 24 );
-		$published = strtotime( $post->post_date );
-		$modified  = strtotime( $post->post_modified );
+		$published = strtotime( $post->post_date_gmt );
+		$modified  = strtotime( $post->post_modified_gmt );
 
 		if ( ( $modified - $published ) < $threshold * HOUR_IN_SECONDS ) {
 			return false;

--- a/includes/class-post-date.php
+++ b/includes/class-post-date.php
@@ -124,6 +124,17 @@ class Post_Date {
 			if ( ! self::should_display_updated_date( $post_id ) ) {
 				return '';
 			}
+			// Wrap the date text with a translatable "Updated %s" label.
+			$block_content = preg_replace_callback(
+				'/(<time[^>]*>)(.*?)(<\/time>)/s',
+				function ( $matches ) {
+					/* translators: %s: Modified date. */
+					$label = sprintf( __( 'Updated %s', 'newspack-plugin' ), $matches[2] );
+					return $matches[1] . $label . $matches[3];
+				},
+				$block_content,
+				1
+			);
 			return $block_content;
 		}
 

--- a/includes/class-post-date.php
+++ b/includes/class-post-date.php
@@ -325,13 +325,18 @@ class Post_Date {
 	 * Enqueue editor sidebar script for per-post toggles.
 	 */
 	public static function enqueue_editor_assets() {
+		$post_types = apply_filters( 'newspack_updated_date_supported_post_types', [ 'post' ] );
+
+		$screen = get_current_screen();
+		if ( $screen && ! in_array( $screen->post_type, $post_types, true ) ) {
+			return;
+		}
+
 		if ( ! get_theme_mod( 'post_updated_date', false ) ) {
 			$mode = 'show';
 		} else {
 			$mode = 'hide';
 		}
-
-		$post_types = apply_filters( 'newspack_updated_date_supported_post_types', [ 'post' ] );
 
 		$handle = 'newspack-post-date-editor';
 		$path   = NEWSPACK_ABSPATH . 'dist/other-scripts/post-date-editor.js';

--- a/includes/class-post-date.php
+++ b/includes/class-post-date.php
@@ -48,8 +48,11 @@ class Post_Date {
 	 */
 	public static function convert_to_time_ago( $date_string, $cutoff_days ) {
 		$timestamp = strtotime( $date_string );
-		$now       = time();
-		$diff      = $now - $timestamp;
+		if ( false === $timestamp ) {
+			return null;
+		}
+		$now  = time();
+		$diff = $now - $timestamp;
 		$cutoff    = $cutoff_days * DAY_IN_SECONDS;
 
 		if ( $diff >= $cutoff ) {
@@ -152,9 +155,9 @@ class Post_Date {
 	/**
 	 * Filter get_the_date() for classic theme support.
 	 *
-	 * @param string  $the_date Formatted date.
-	 * @param string  $format   Date format.
-	 * @param WP_Post $post     Post object.
+	 * @param string   $the_date Formatted date.
+	 * @param string   $format   Date format.
+	 * @param \WP_Post $post     Post object.
 	 * @return string
 	 */
 	public static function filter_get_the_date( $the_date, $format, $post ) {
@@ -201,21 +204,34 @@ class Post_Date {
 				$post_type,
 				'newspack_hide_updated_date',
 				[
-					'show_in_rest' => true,
-					'single'       => true,
-					'type'         => 'boolean',
+					'show_in_rest'  => true,
+					'single'        => true,
+					'type'          => 'boolean',
+					'default'       => false,
+					'auth_callback' => [ __CLASS__, 'auth_callback' ],
 				]
 			);
 			register_post_meta(
 				$post_type,
 				'newspack_show_updated_date',
 				[
-					'show_in_rest' => true,
-					'single'       => true,
-					'type'         => 'boolean',
+					'show_in_rest'  => true,
+					'single'        => true,
+					'type'          => 'boolean',
+					'default'       => false,
+					'auth_callback' => [ __CLASS__, 'auth_callback' ],
 				]
 			);
 		}
+	}
+
+	/**
+	 * Auth callback for post meta.
+	 *
+	 * @return bool
+	 */
+	public static function auth_callback() {
+		return current_user_can( 'edit_posts' );
 	}
 
 	/**

--- a/includes/class-post-date.php
+++ b/includes/class-post-date.php
@@ -208,7 +208,7 @@ class Post_Date {
 			// Wrap the date text with a translatable "Updated %s" label.
 			$date_text = wp_strip_all_tags( preg_match( '/(<time[^>]*>)(.*?)(<\/time>)/s', $block_content, $m ) ? $m[2] : '' );
 			/* translators: %s: Modified date. */
-			$label = sprintf( __( 'Updated %s', 'newspack-plugin' ), $date_text );
+			$label = sprintf( esc_html__( 'Updated %s', 'newspack-plugin' ), esc_html( $date_text ) );
 			return self::replace_time_text( $block_content, $label );
 		}
 

--- a/includes/class-post-date.php
+++ b/includes/class-post-date.php
@@ -1,0 +1,300 @@
+<?php
+/**
+ * Post Date features: time-ago and modified date.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Post Date class.
+ */
+class Post_Date {
+
+	/**
+	 * Theme mod keys to migrate on theme switch.
+	 *
+	 * @var string[]
+	 */
+	const THEME_MOD_KEYS = [
+		'post_time_ago',
+		'post_time_ago_cut_off',
+		'post_updated_date',
+		'post_updated_date_threshold',
+	];
+
+	/**
+	 * Initialize hooks.
+	 */
+	public static function init() {
+		add_action( 'init', [ __CLASS__, 'register_meta' ] );
+		add_action( 'after_switch_theme', [ __CLASS__, 'migrate_date_settings' ], 10, 2 );
+		add_filter( 'render_block_core/post-date', [ __CLASS__, 'filter_post_date_block' ], 10, 2 );
+		add_filter( 'get_the_date', [ __CLASS__, 'filter_get_the_date' ], 10, 3 );
+		add_filter( 'newspack_blocks_formatted_displayed_post_date', [ __CLASS__, 'filter_blocks_formatted_date' ], 10, 2 );
+		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'enqueue_scripts' ] );
+		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'enqueue_editor_assets' ] );
+	}
+
+	/**
+	 * Convert a date string to "X ago" format if within cutoff.
+	 *
+	 * @param string $date_string Date in 'Y-m-d H:i:s' format (GMT).
+	 * @param int    $cutoff_days Number of days for cutoff.
+	 * @return string|null Relative date string or null if beyond cutoff.
+	 */
+	public static function convert_to_time_ago( $date_string, $cutoff_days ) {
+		$timestamp = strtotime( $date_string );
+		$now       = time();
+		$diff      = $now - $timestamp;
+		$cutoff    = $cutoff_days * DAY_IN_SECONDS;
+
+		if ( $diff >= $cutoff ) {
+			return null;
+		}
+
+		/* translators: %s: Human-readable time difference. */
+		return sprintf( __( '%s ago', 'newspack-plugin' ), human_time_diff( $timestamp, $now ) );
+	}
+
+	/**
+	 * Determine whether the updated date should be displayed for a post.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return bool
+	 */
+	public static function should_display_updated_date( $post_id = 0 ) {
+		if ( ! $post_id ) {
+			$post_id = get_the_ID();
+		}
+		$post = get_post( $post_id );
+		if ( ! $post ) {
+			return false;
+		}
+
+		$post_types = apply_filters( 'newspack_updated_date_supported_post_types', [ 'post' ] );
+		if ( ! in_array( $post->post_type, $post_types, true ) ) {
+			return false;
+		}
+
+		$sitewide  = get_theme_mod( 'post_updated_date', false );
+		$show_meta = get_post_meta( $post_id, 'newspack_show_updated_date', true );
+		$hide_meta = get_post_meta( $post_id, 'newspack_hide_updated_date', true );
+
+		if ( $sitewide ) {
+			if ( $hide_meta ) {
+				return false;
+			}
+		} elseif ( ! $show_meta ) {
+			return false;
+		}
+
+		// Apply threshold.
+		$threshold = (int) get_theme_mod( 'post_updated_date_threshold', 24 );
+		$published = strtotime( $post->post_date );
+		$modified  = strtotime( $post->post_modified );
+
+		if ( ( $modified - $published ) < $threshold * HOUR_IN_SECONDS ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Filter the render output of core/post-date blocks.
+	 * Handles both time-ago conversion (publish dates) and modified date visibility.
+	 *
+	 * @param string $block_content Rendered block content.
+	 * @param array  $block         Block data.
+	 * @return string
+	 */
+	public static function filter_post_date_block( $block_content, $block ) {
+		$is_modified = str_contains( $block_content, 'wp-block-post-date__modified-date' );
+
+		// Handle modified date visibility.
+		if ( $is_modified ) {
+			$post_id = get_the_ID();
+			if ( ! self::should_display_updated_date( $post_id ) ) {
+				return '';
+			}
+			return $block_content;
+		}
+
+		// Handle time-ago for publish dates.
+		if ( ! get_theme_mod( 'post_time_ago', false ) ) {
+			return $block_content;
+		}
+
+		$cutoff_days = (int) get_theme_mod( 'post_time_ago_cut_off', 14 );
+
+		// Extract datetime attribute from <time datetime="...">.
+		if ( ! preg_match( '/datetime="([^"]+)"/', $block_content, $matches ) ) {
+			return $block_content;
+		}
+
+		$datetime  = $matches[1];
+		$timestamp = strtotime( $datetime );
+		$gmt_date  = gmdate( 'Y-m-d H:i:s', $timestamp );
+		$time_ago  = self::convert_to_time_ago( $gmt_date, $cutoff_days );
+
+		if ( null === $time_ago ) {
+			return $block_content;
+		}
+
+		// Replace visible text between <time> tags while preserving the datetime attribute.
+		return preg_replace( '/(<time[^>]*>)(.*?)(<\/time>)/s', '${1}' . esc_html( $time_ago ) . '${3}', $block_content );
+	}
+
+	/**
+	 * Filter get_the_date() for classic theme support.
+	 *
+	 * @param string  $the_date Formatted date.
+	 * @param string  $format   Date format.
+	 * @param WP_Post $post     Post object.
+	 * @return string
+	 */
+	public static function filter_get_the_date( $the_date, $format, $post ) {
+		if ( ! get_theme_mod( 'post_time_ago', false ) ) {
+			return $the_date;
+		}
+
+		// Skip machine-readable formats.
+		if ( 'Y-m-d\TH:i:sP' === $format || 'c' === $format ) {
+			return $the_date;
+		}
+
+		$cutoff_days = (int) get_theme_mod( 'post_time_ago_cut_off', 14 );
+		$time_ago    = self::convert_to_time_ago( $post->post_date_gmt, $cutoff_days );
+
+		return null !== $time_ago ? $time_ago : $the_date;
+	}
+
+	/**
+	 * Filter formatted date for Newspack Blocks Homepage Posts.
+	 *
+	 * @param string   $date Formatted date.
+	 * @param \WP_Post $post Post object.
+	 * @return string
+	 */
+	public static function filter_blocks_formatted_date( $date, $post ) {
+		if ( ! get_theme_mod( 'post_time_ago', false ) ) {
+			return $date;
+		}
+
+		$cutoff_days = (int) get_theme_mod( 'post_time_ago_cut_off', 14 );
+		$time_ago    = self::convert_to_time_ago( $post->post_date_gmt, $cutoff_days );
+
+		return null !== $time_ago ? $time_ago : $date;
+	}
+
+	/**
+	 * Register per-post meta for updated date toggles.
+	 */
+	public static function register_meta() {
+		$post_types = apply_filters( 'newspack_updated_date_supported_post_types', [ 'post' ] );
+		foreach ( $post_types as $post_type ) {
+			register_post_meta(
+				$post_type,
+				'newspack_hide_updated_date',
+				[
+					'show_in_rest' => true,
+					'single'       => true,
+					'type'         => 'boolean',
+				]
+			);
+			register_post_meta(
+				$post_type,
+				'newspack_show_updated_date',
+				[
+					'show_in_rest' => true,
+					'single'       => true,
+					'type'         => 'boolean',
+				]
+			);
+		}
+	}
+
+	/**
+	 * Migrate date settings from old theme to new theme on theme switch.
+	 *
+	 * @param string    $old_name  Old theme name.
+	 * @param \WP_Theme $old_theme Old theme object.
+	 */
+	public static function migrate_date_settings( $old_name, $old_theme ) {
+		$old_stylesheet = $old_theme->get_stylesheet();
+		$old_mods       = get_option( "theme_mods_$old_stylesheet", [] );
+
+		foreach ( self::THEME_MOD_KEYS as $key ) {
+			if ( isset( $old_mods[ $key ] ) ) {
+				set_theme_mod( $key, $old_mods[ $key ] );
+			}
+		}
+	}
+
+	/**
+	 * Enqueue relative-time script on frontend.
+	 */
+	public static function enqueue_scripts() {
+		if ( ! get_theme_mod( 'post_time_ago', false ) ) {
+			return;
+		}
+
+		$handle = 'newspack-relative-time';
+		$path   = NEWSPACK_ABSPATH . 'dist/other-scripts/relative-time/index.js';
+		$url    = plugins_url( 'dist/other-scripts/relative-time/index.js', NEWSPACK_PLUGIN_FILE );
+
+		if ( ! file_exists( $path ) ) {
+			return;
+		}
+
+		$asset = include NEWSPACK_ABSPATH . 'dist/other-scripts/relative-time/index.asset.php';
+
+		wp_enqueue_script( $handle, $url, $asset['dependencies'] ?? [], $asset['version'] ?? false, true );
+		wp_localize_script(
+			$handle,
+			'newspackRelativeTime',
+			[
+				'cutoff' => (int) get_theme_mod( 'post_time_ago_cut_off', 14 ) * DAY_IN_SECONDS,
+				'locale' => get_locale(),
+			]
+		);
+	}
+
+	/**
+	 * Enqueue editor sidebar script for per-post toggles.
+	 */
+	public static function enqueue_editor_assets() {
+		if ( ! get_theme_mod( 'post_updated_date', false ) ) {
+			$mode = 'show';
+		} else {
+			$mode = 'hide';
+		}
+
+		$post_types = apply_filters( 'newspack_updated_date_supported_post_types', [ 'post' ] );
+
+		$handle = 'newspack-post-date-editor';
+		$path   = NEWSPACK_ABSPATH . 'dist/other-scripts/post-date-editor/index.js';
+		$url    = plugins_url( 'dist/other-scripts/post-date-editor/index.js', NEWSPACK_PLUGIN_FILE );
+
+		if ( ! file_exists( $path ) ) {
+			return;
+		}
+
+		$asset = include NEWSPACK_ABSPATH . 'dist/other-scripts/post-date-editor/index.asset.php';
+
+		wp_enqueue_script( $handle, $url, $asset['dependencies'] ?? [], $asset['version'] ?? false, true );
+		wp_localize_script(
+			$handle,
+			'newspackPostDate',
+			[
+				'mode'      => $mode,
+				'postTypes' => $post_types,
+			]
+		);
+	}
+}
+Post_Date::init();

--- a/includes/class-post-date.php
+++ b/includes/class-post-date.php
@@ -41,6 +41,7 @@ class Post_Date {
 		add_filter( 'newspack_blocks_formatted_displayed_post_date', [ __CLASS__, 'filter_blocks_formatted_date' ], 10, 2 );
 		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'enqueue_scripts' ] );
 		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'enqueue_editor_assets' ] );
+		add_action( 'newspack_theme_entry_meta', [ __CLASS__, 'render_updated_date_classic' ], 5 );
 	}
 
 	/**
@@ -267,6 +268,43 @@ class Post_Date {
 	}
 
 	/**
+	 * Render updated date for classic (non-block) themes.
+	 * Hooked to `newspack_theme_entry_meta` which fires after `newspack_posted_on()`.
+	 */
+	public static function render_updated_date_classic() {
+		if ( wp_is_block_theme() || ! is_singular() ) {
+			return;
+		}
+
+		$post_id = get_the_ID();
+		if ( ! self::should_display_updated_date( $post_id ) ) {
+			return;
+		}
+
+		$post = get_post( $post_id );
+		if ( ! $post ) {
+			return;
+		}
+
+		$modified_date = get_the_modified_date( '', $post );
+		if ( get_theme_mod( 'post_time_ago', false ) ) {
+			$time_ago = self::convert_to_time_ago( $post->post_modified_gmt, self::get_time_ago_cutoff_days() );
+			if ( null !== $time_ago ) {
+				$modified_date = $time_ago;
+			}
+		}
+
+		/* translators: %s: Modified date. */
+		$label = sprintf( esc_html__( 'Updated %s', 'newspack-plugin' ), esc_html( $modified_date ) );
+
+		printf(
+			'<span class="posted-on updated-date" data-newspack-modified><time class="entry-date updated" datetime="%1$s">%2$s</time></span>',
+			esc_attr( get_the_modified_date( DATE_W3C, $post ) ),
+			wp_kses_post( $label )
+		);
+	}
+
+	/**
 	 * Register per-post meta for updated date toggles.
 	 */
 	public static function register_meta() {
@@ -327,9 +365,17 @@ class Post_Date {
 	}
 
 	/**
-	 * Enqueue relative-time script on frontend.
+	 * Enqueue relative-time script and updated date styles on frontend.
 	 */
 	public static function enqueue_scripts() {
+		// Inline styles for the classic theme updated date.
+		// Always enqueue on classic themes since per-post overrides can show the date even when sitewide is off.
+		if ( ! wp_is_block_theme() ) {
+			wp_register_style( 'newspack-post-date', false, [], NEWSPACK_PLUGIN_VERSION );
+			wp_enqueue_style( 'newspack-post-date' );
+			wp_add_inline_style( 'newspack-post-date', '.entry-meta .updated-date { margin-inline-start: 1em; }' );
+		}
+
 		if ( ! get_theme_mod( 'post_time_ago', false ) ) {
 			return;
 		}

--- a/includes/class-post-date.php
+++ b/includes/class-post-date.php
@@ -14,9 +14,20 @@ defined( 'ABSPATH' ) || exit;
  */
 class Post_Date {
 
+	/**
+	 * Default number of days for the time-ago cutoff.
+	 * Posts older than this show the full date instead.
+	 *
+	 * @var int
+	 */
 	const DEFAULT_TIME_AGO_CUTOFF_DAYS = 14;
 
-	const UPDATED_DATE_TIME_AGO_CUTOFF_DAYS = 1;
+	/**
+	 * Default time-ago cutoff in days when the updated date feature is enabled.
+	 *
+	 * @var int
+	 */
+	const DEFAULT_UPDATED_DATE_TIME_AGO_CUTOFF_DAYS = 1;
 
 	/**
 	 * Theme mod keys to migrate on theme switch.
@@ -125,7 +136,7 @@ class Post_Date {
 	 */
 	public static function get_time_ago_cutoff_days() {
 		$cutoff = get_theme_mod( 'post_updated_date', false )
-			? self::UPDATED_DATE_TIME_AGO_CUTOFF_DAYS
+			? self::DEFAULT_UPDATED_DATE_TIME_AGO_CUTOFF_DAYS
 			: (int) get_theme_mod( 'post_time_ago_cut_off', self::DEFAULT_TIME_AGO_CUTOFF_DAYS );
 
 		return (int) apply_filters( 'newspack_time_ago_cutoff_days', $cutoff );
@@ -209,7 +220,7 @@ class Post_Date {
 			// Wrap the date text with a translatable "Updated %s" label.
 			$date_text = wp_strip_all_tags( preg_match( '/(<time[^>]*>)(.*?)(<\/time>)/s', $block_content, $m ) ? $m[2] : '' );
 			/* translators: %s: Modified date. */
-			$label = sprintf( esc_html__( 'Updated %s', 'newspack-plugin' ), esc_html( $date_text ) );
+			$label = sprintf( esc_html__( 'Updated %s', 'newspack-plugin' ), $date_text );
 			$block_content = self::replace_time_text( $block_content, $label );
 
 			// Mark as modified so the relative-time JS can skip text replacement,
@@ -295,7 +306,7 @@ class Post_Date {
 		}
 
 		/* translators: %s: Modified date. */
-		$label = sprintf( esc_html__( 'Updated %s', 'newspack-plugin' ), esc_html( $modified_date ) );
+		$label = sprintf( esc_html__( 'Updated %s', 'newspack-plugin' ), $modified_date );
 
 		printf(
 			'<span class="posted-on updated-date" data-newspack-modified><time class="entry-date updated" datetime="%1$s">%2$s</time></span>',
@@ -308,6 +319,11 @@ class Post_Date {
 	 * Register per-post meta for updated date toggles.
 	 */
 	public static function register_meta() {
+		/**
+		 * Filters the post types that support the updated date feature.
+		 *
+		 * @param string[] $post_types Array of post type slugs. Default: [ 'post' ].
+		 */
 		$post_types = apply_filters( 'newspack_updated_date_supported_post_types', [ 'post' ] );
 		foreach ( $post_types as $post_type ) {
 			register_post_meta(
@@ -358,7 +374,7 @@ class Post_Date {
 		$old_mods       = get_option( "theme_mods_$old_stylesheet", [] );
 
 		foreach ( self::THEME_MOD_KEYS as $key ) {
-			if ( isset( $old_mods[ $key ] ) ) {
+			if ( isset( $old_mods[ $key ] ) && false === get_theme_mod( $key, false ) ) {
 				set_theme_mod( $key, $old_mods[ $key ] );
 			}
 		}

--- a/includes/class-post-date.php
+++ b/includes/class-post-date.php
@@ -209,7 +209,16 @@ class Post_Date {
 			$date_text = wp_strip_all_tags( preg_match( '/(<time[^>]*>)(.*?)(<\/time>)/s', $block_content, $m ) ? $m[2] : '' );
 			/* translators: %s: Modified date. */
 			$label = sprintf( esc_html__( 'Updated %s', 'newspack-plugin' ), esc_html( $date_text ) );
-			return self::replace_time_text( $block_content, $label );
+			$block_content = self::replace_time_text( $block_content, $label );
+
+			// Mark as modified so the relative-time JS can skip text replacement,
+			// even when core omits the wp-block-post-date__modified-date class (block bindings path).
+			$processor = new \WP_HTML_Tag_Processor( $block_content );
+			if ( $processor->next_tag() ) {
+				$processor->set_attribute( 'data-newspack-modified', '' );
+				$block_content = $processor->get_updated_html();
+			}
+			return $block_content;
 		}
 
 		// Handle time-ago for publish dates.

--- a/includes/class-post-date.php
+++ b/includes/class-post-date.php
@@ -130,7 +130,14 @@ class Post_Date {
 			return $block_content;
 		}
 
-		return preg_replace( '/(<time[^>]*>)(.*?)(<\/time>)/s', '${1}' . esc_html( $time_ago ) . '${3}', $block_content, 1 );
+		return preg_replace_callback(
+			'/(<time[^>]*>)(.*?)(<\/time>)/s',
+			function ( $matches ) use ( $time_ago ) {
+				return $matches[1] . esc_html( $time_ago ) . $matches[3];
+			},
+			$block_content,
+			1
+		);
 	}
 
 	/**
@@ -165,7 +172,7 @@ class Post_Date {
 				'/(<time[^>]*>)(.*?)(<\/time>)/s',
 				function ( $matches ) {
 					/* translators: %s: Modified date. */
-					$label = sprintf( __( 'Updated %s', 'newspack-plugin' ), $matches[2] );
+					$label = sprintf( __( 'Updated %s', 'newspack-plugin' ), esc_html( $matches[2] ) );
 					return $matches[1] . $label . $matches[3];
 				},
 				$block_content,
@@ -253,10 +260,13 @@ class Post_Date {
 	/**
 	 * Auth callback for post meta.
 	 *
+	 * @param bool   $allowed  Whether the user can add the post meta.
+	 * @param string $meta_key The meta key.
+	 * @param int    $post_id  Post ID.
 	 * @return bool
 	 */
-	public static function auth_callback() {
-		return current_user_can( 'edit_posts' );
+	public static function auth_callback( $allowed, $meta_key, $post_id ) {
+		return current_user_can( 'edit_post', $post_id );
 	}
 
 	/**

--- a/includes/class-post-date.php
+++ b/includes/class-post-date.php
@@ -116,13 +116,28 @@ class Post_Date {
 	 * @return string
 	 */
 	public static function filter_post_date_block( $block_content, $block ) {
-		$is_modified = str_contains( $block_content, 'wp-block-post-date__modified-date' );
+		// Detect modified date blocks via CSS class or block bindings attributes.
+		$is_modified = str_contains( $block_content, 'wp-block-post-date__modified-date' )
+			|| ( isset( $block['attrs']['metadata']['bindings']['datetime']['args']['field'] )
+				&& 'modified' === $block['attrs']['metadata']['bindings']['datetime']['args']['field'] )
+			|| ( isset( $block['attrs']['displayType'] ) && 'modified' === $block['attrs']['displayType'] );
 
 		// Handle modified date visibility.
 		if ( $is_modified ) {
 			$post_id = get_the_ID();
 			if ( ! self::should_display_updated_date( $post_id ) ) {
 				return '';
+			}
+			// If core returned empty (e.g. block bindings resolved to ''), render the date ourselves.
+			if ( empty( $block_content ) ) {
+				$post             = get_post( $post_id );
+				$format           = $block['attrs']['format'] ?? get_option( 'date_format' );
+				$modified_date    = get_the_modified_date( $format, $post );
+				$modified_iso     = get_the_modified_date( 'c', $post );
+				$wrapper_attrs    = get_block_wrapper_attributes( [ 'class' => 'wp-block-post-date__modified-date' ] );
+				/* translators: %s: Modified date. */
+				$label = sprintf( __( 'Updated %s', 'newspack-plugin' ), esc_html( $modified_date ) );
+				return sprintf( '<div %1$s><time datetime="%2$s">%3$s</time></div>', $wrapper_attrs, esc_attr( $modified_iso ), $label );
 			}
 			// Wrap the date text with a translatable "Updated %s" label.
 			$block_content = preg_replace_callback(
@@ -176,8 +191,8 @@ class Post_Date {
 			return $the_date;
 		}
 
-		// Skip machine-readable formats.
-		if ( 'Y-m-d\TH:i:sP' === $format || 'c' === $format ) {
+		// Skip machine-readable formats (ISO 8601, Unix timestamp).
+		if ( 'Y-m-d\TH:i:sP' === $format || 'c' === $format || 'U' === $format ) {
 			return $the_date;
 		}
 

--- a/includes/class-post-date.php
+++ b/includes/class-post-date.php
@@ -14,6 +14,10 @@ defined( 'ABSPATH' ) || exit;
  */
 class Post_Date {
 
+	const DEFAULT_TIME_AGO_CUTOFF_DAYS = 14;
+
+	const UPDATED_DATE_TIME_AGO_CUTOFF_DAYS = 1;
+
 	/**
 	 * Theme mod keys to migrate on theme switch.
 	 *
@@ -113,6 +117,20 @@ class Post_Date {
 	}
 
 	/**
+	 * Get the effective time-ago cutoff in days. Reduced to 1 day when the
+	 * updated date feature is also enabled.
+	 *
+	 * @return int Cutoff in days.
+	 */
+	public static function get_time_ago_cutoff_days() {
+		$cutoff = get_theme_mod( 'post_updated_date', false )
+			? self::UPDATED_DATE_TIME_AGO_CUTOFF_DAYS
+			: (int) get_theme_mod( 'post_time_ago_cut_off', self::DEFAULT_TIME_AGO_CUTOFF_DAYS );
+
+		return (int) apply_filters( 'newspack_time_ago_cutoff_days', $cutoff );
+	}
+
+	/**
 	 * Apply time-ago conversion to block content if enabled and within cutoff.
 	 *
 	 * @param string $block_content Rendered block content containing a <time> tag.
@@ -127,7 +145,7 @@ class Post_Date {
 			return $block_content;
 		}
 
-		$cutoff_days = (int) get_theme_mod( 'post_time_ago_cut_off', 14 );
+		$cutoff_days = self::get_time_ago_cutoff_days();
 		$gmt_date    = gmdate( 'Y-m-d H:i:s', strtotime( $matches[1] ) );
 		$time_ago    = self::convert_to_time_ago( $gmt_date, $cutoff_days );
 
@@ -208,8 +226,7 @@ class Post_Date {
 			return $the_date;
 		}
 
-		$cutoff_days = (int) get_theme_mod( 'post_time_ago_cut_off', 14 );
-		$time_ago    = self::convert_to_time_ago( $post->post_date_gmt, $cutoff_days );
+		$time_ago = self::convert_to_time_ago( $post->post_date_gmt, self::get_time_ago_cutoff_days() );
 
 		return null !== $time_ago ? $time_ago : $the_date;
 	}
@@ -226,8 +243,7 @@ class Post_Date {
 			return $date;
 		}
 
-		$cutoff_days = (int) get_theme_mod( 'post_time_ago_cut_off', 14 );
-		$time_ago    = self::convert_to_time_ago( $post->post_date_gmt, $cutoff_days );
+		$time_ago = self::convert_to_time_ago( $post->post_date_gmt, self::get_time_ago_cutoff_days() );
 
 		return null !== $time_ago ? $time_ago : $date;
 	}
@@ -315,7 +331,7 @@ class Post_Date {
 			$handle,
 			'newspackRelativeTime',
 			[
-				'cutoff' => (int) get_theme_mod( 'post_time_ago_cut_off', 14 ) * DAY_IN_SECONDS,
+				'cutoff' => self::get_time_ago_cutoff_days() * DAY_IN_SECONDS,
 				'locale' => get_locale(),
 			]
 		);

--- a/includes/class-post-date.php
+++ b/includes/class-post-date.php
@@ -108,14 +108,6 @@ class Post_Date {
 	}
 
 	/**
-	 * Filter the render output of core/post-date blocks.
-	 * Handles both time-ago conversion (publish dates) and modified date visibility.
-	 *
-	 * @param string $block_content Rendered block content.
-	 * @param array  $block         Block data.
-	 * @return string
-	 */
-	/**
 	 * Apply time-ago conversion to block content if enabled and within cutoff.
 	 *
 	 * @param string $block_content Rendered block content containing a <time> tag.

--- a/includes/class-post-date.php
+++ b/includes/class-post-date.php
@@ -128,16 +128,8 @@ class Post_Date {
 			if ( ! self::should_display_updated_date( $post_id ) ) {
 				return '';
 			}
-			// If core returned empty (e.g. block bindings resolved to ''), render the date ourselves.
 			if ( empty( $block_content ) ) {
-				$post             = get_post( $post_id );
-				$format           = $block['attrs']['format'] ?? get_option( 'date_format' );
-				$modified_date    = get_the_modified_date( $format, $post );
-				$modified_iso     = get_the_modified_date( 'c', $post );
-				$wrapper_attrs    = get_block_wrapper_attributes( [ 'class' => 'wp-block-post-date__modified-date' ] );
-				/* translators: %s: Modified date. */
-				$label = sprintf( __( 'Updated %s', 'newspack-plugin' ), esc_html( $modified_date ) );
-				return sprintf( '<div %1$s><time datetime="%2$s">%3$s</time></div>', $wrapper_attrs, esc_attr( $modified_iso ), $label );
+				return '';
 			}
 			// Wrap the date text with a translatable "Updated %s" label.
 			$block_content = preg_replace_callback(

--- a/includes/class-post-date.php
+++ b/includes/class-post-date.php
@@ -115,6 +115,40 @@ class Post_Date {
 	 * @param array  $block         Block data.
 	 * @return string
 	 */
+	/**
+	 * Apply time-ago conversion to block content if enabled and within cutoff.
+	 *
+	 * @param string $block_content Rendered block content containing a <time> tag.
+	 * @return string Block content with time-ago applied, or unchanged.
+	 */
+	private static function maybe_apply_time_ago_to_block( $block_content ) {
+		if ( ! get_theme_mod( 'post_time_ago', false ) ) {
+			return $block_content;
+		}
+
+		if ( ! preg_match( '/datetime="([^"]+)"/', $block_content, $matches ) ) {
+			return $block_content;
+		}
+
+		$cutoff_days = (int) get_theme_mod( 'post_time_ago_cut_off', 14 );
+		$gmt_date    = gmdate( 'Y-m-d H:i:s', strtotime( $matches[1] ) );
+		$time_ago    = self::convert_to_time_ago( $gmt_date, $cutoff_days );
+
+		if ( null === $time_ago ) {
+			return $block_content;
+		}
+
+		return preg_replace( '/(<time[^>]*>)(.*?)(<\/time>)/s', '${1}' . esc_html( $time_ago ) . '${3}', $block_content, 1 );
+	}
+
+	/**
+	 * Filter the render output of core/post-date blocks.
+	 * Handles time-ago conversion, modified date visibility, and "Updated" label.
+	 *
+	 * @param string $block_content Rendered block content.
+	 * @param array  $block         Block data.
+	 * @return string Filtered block content.
+	 */
 	public static function filter_post_date_block( $block_content, $block ) {
 		// Detect modified date blocks via CSS class or block bindings attributes.
 		$is_modified = str_contains( $block_content, 'wp-block-post-date__modified-date' )
@@ -131,8 +165,11 @@ class Post_Date {
 			if ( empty( $block_content ) ) {
 				return '';
 			}
+
+			$block_content = self::maybe_apply_time_ago_to_block( $block_content );
+
 			// Wrap the date text with a translatable "Updated %s" label.
-			$block_content = preg_replace_callback(
+			return preg_replace_callback(
 				'/(<time[^>]*>)(.*?)(<\/time>)/s',
 				function ( $matches ) {
 					/* translators: %s: Modified date. */
@@ -142,32 +179,10 @@ class Post_Date {
 				$block_content,
 				1
 			);
-			return $block_content;
 		}
 
 		// Handle time-ago for publish dates.
-		if ( ! get_theme_mod( 'post_time_ago', false ) ) {
-			return $block_content;
-		}
-
-		$cutoff_days = (int) get_theme_mod( 'post_time_ago_cut_off', 14 );
-
-		// Extract datetime attribute from <time datetime="...">.
-		if ( ! preg_match( '/datetime="([^"]+)"/', $block_content, $matches ) ) {
-			return $block_content;
-		}
-
-		$datetime  = $matches[1];
-		$timestamp = strtotime( $datetime );
-		$gmt_date  = gmdate( 'Y-m-d H:i:s', $timestamp );
-		$time_ago  = self::convert_to_time_ago( $gmt_date, $cutoff_days );
-
-		if ( null === $time_ago ) {
-			return $block_content;
-		}
-
-		// Replace visible text between <time> tags while preserving the datetime attribute.
-		return preg_replace( '/(<time[^>]*>)(.*?)(<\/time>)/s', '${1}' . esc_html( $time_ago ) . '${3}', $block_content );
+		return self::maybe_apply_time_ago_to_block( $block_content );
 	}
 
 	/**

--- a/src/other-scripts/post-date-editor/index.js
+++ b/src/other-scripts/post-date-editor/index.js
@@ -1,9 +1,9 @@
 /**
  * WordPress dependencies.
  */
-import { ToggleControl } from '@wordpress/components';
+import { FormToggle } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { PluginDocumentSettingPanel } from '@wordpress/editor';
+import { PluginPostStatusInfo } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 import { registerPlugin } from '@wordpress/plugins';
 
@@ -35,26 +35,26 @@ const PostDateSettingsPanel = () => {
 
 	if ( mode === 'hide' ) {
 		return (
-			<PluginDocumentSettingPanel name="newspack-post-date-settings" title={ __( 'Updated Date', 'newspack-plugin' ) }>
-				<ToggleControl
-					label={ __( 'Hide last updated date', 'newspack-plugin' ) }
-					help={ __( 'Override the sitewide setting and hide the updated date on this post.', 'newspack-plugin' ) }
+			<PluginPostStatusInfo>
+				<label htmlFor="newspack_hide_updated_date">{ __( 'Hide last updated date', 'newspack-plugin' ) }</label>
+				<FormToggle
 					checked={ !! meta.newspack_hide_updated_date }
-					onChange={ value => updateMeta( 'newspack_hide_updated_date', value ) }
+					onChange={ () => updateMeta( 'newspack_hide_updated_date', ! meta.newspack_hide_updated_date ) }
+					id="newspack_hide_updated_date"
 				/>
-			</PluginDocumentSettingPanel>
+			</PluginPostStatusInfo>
 		);
 	}
 
 	return (
-		<PluginDocumentSettingPanel name="newspack-post-date-settings" title={ __( 'Updated Date', 'newspack-plugin' ) }>
-			<ToggleControl
-				label={ __( 'Show last updated date', 'newspack-plugin' ) }
-				help={ __( 'Show the updated date on this post even though the sitewide setting is off.', 'newspack-plugin' ) }
+		<PluginPostStatusInfo>
+			<label htmlFor="newspack_show_updated_date">{ __( 'Show last updated date', 'newspack-plugin' ) }</label>
+			<FormToggle
 				checked={ !! meta.newspack_show_updated_date }
-				onChange={ value => updateMeta( 'newspack_show_updated_date', value ) }
+				onChange={ () => updateMeta( 'newspack_show_updated_date', ! meta.newspack_show_updated_date ) }
+				id="newspack_show_updated_date"
 			/>
-		</PluginDocumentSettingPanel>
+		</PluginPostStatusInfo>
 	);
 };
 

--- a/src/other-scripts/post-date-editor/index.js
+++ b/src/other-scripts/post-date-editor/index.js
@@ -1,0 +1,64 @@
+/**
+ * WordPress dependencies.
+ */
+import { ToggleControl } from '@wordpress/components';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { PluginDocumentSettingPanel } from '@wordpress/editor';
+import { __ } from '@wordpress/i18n';
+import { registerPlugin } from '@wordpress/plugins';
+
+const PostDateSettingsPanel = () => {
+	const { postType, meta } = useSelect( select => {
+		const editor = select( 'core/editor' );
+		return {
+			postType: editor.getCurrentPostType(),
+			meta: editor.getEditedPostAttribute( 'meta' ) || {},
+		};
+	}, [] );
+
+	const { editPost } = useDispatch( 'core/editor' );
+
+	const config = window.newspackPostDate;
+	if ( ! config ) {
+		return null;
+	}
+
+	const { mode, postTypes } = config;
+
+	if ( ! postTypes.includes( postType ) ) {
+		return null;
+	}
+
+	const updateMeta = ( key, value ) => {
+		editPost( { meta: { [ key ]: value } } );
+	};
+
+	if ( mode === 'hide' ) {
+		return (
+			<PluginDocumentSettingPanel name="newspack-post-date-settings" title={ __( 'Updated Date', 'newspack-plugin' ) }>
+				<ToggleControl
+					label={ __( 'Hide last updated date', 'newspack-plugin' ) }
+					help={ __( 'Override the sitewide setting and hide the updated date on this post.', 'newspack-plugin' ) }
+					checked={ !! meta.newspack_hide_updated_date }
+					onChange={ value => updateMeta( 'newspack_hide_updated_date', value ) }
+				/>
+			</PluginDocumentSettingPanel>
+		);
+	}
+
+	return (
+		<PluginDocumentSettingPanel name="newspack-post-date-settings" title={ __( 'Updated Date', 'newspack-plugin' ) }>
+			<ToggleControl
+				label={ __( 'Show last updated date', 'newspack-plugin' ) }
+				help={ __( 'Show the updated date on this post even though the sitewide setting is off.', 'newspack-plugin' ) }
+				checked={ !! meta.newspack_show_updated_date }
+				onChange={ value => updateMeta( 'newspack_show_updated_date', value ) }
+			/>
+		</PluginDocumentSettingPanel>
+	);
+};
+
+registerPlugin( 'newspack-post-date', {
+	render: PostDateSettingsPanel,
+	icon: null,
+} );

--- a/src/other-scripts/relative-time/index.js
+++ b/src/other-scripts/relative-time/index.js
@@ -49,57 +49,47 @@
 	 * Format and replace date text in time elements.
 	 */
 	function updateDates() {
+		const localeTag = locale.replace( '_', '-' );
+
 		let formatter;
 		try {
-			formatter = new Intl.RelativeTimeFormat( locale.replace( '_', '-' ), {
-				numeric: 'auto',
-			} );
+			formatter = new Intl.RelativeTimeFormat( localeTag, { numeric: 'auto' } );
 		} catch {
-			// Fallback: no Intl support.
-			return;
+			return; // No Intl support.
 		}
 
-		// Block theme: .wp-block-post-date time
-		// Classic theme / newspack-blocks: time.entry-date
-		const selectors = [
-			'.wp-block-post-date:not(.wp-block-post-date__modified-date) time[datetime]',
-			'time.entry-date.published[datetime]',
-			'.comment-meta time[datetime]',
-		];
-		const elements = document.querySelectorAll( selectors.join( ', ' ) );
+		const elements = document.querySelectorAll(
+			'.wp-block-post-date time[datetime], time.entry-date.published[datetime], .comment-meta time[datetime]'
+		);
 		const now = Date.now();
 
 		elements.forEach( function ( el ) {
-			// Skip if already inside a modified date wrapper.
-			if ( el.closest( '.wp-block-post-date__modified-date' ) ) {
-				return;
-			}
-
 			const datetime = el.getAttribute( 'datetime' );
 			if ( ! datetime ) {
 				return;
 			}
 
-			const timestamp = new Date( datetime ).getTime();
-			const diffSeconds = Math.round( ( now - timestamp ) / 1000 );
+			// Show full date on hover for all date elements.
+			if ( ! el.getAttribute( 'title' ) ) {
+				el.setAttribute( 'title', new Date( datetime ).toLocaleString( localeTag ) );
+			}
 
+			// Only replace text on publish dates, not modified date blocks.
+			if ( el.closest( '.wp-block-post-date__modified-date' ) ) {
+				return;
+			}
+
+			const diffSeconds = Math.round( ( now - new Date( datetime ).getTime() ) / 1000 );
 			if ( diffSeconds < 0 ) {
-				return; // Future date.
+				return;
 			}
 
 			const relative = getRelativeUnit( diffSeconds );
 			if ( ! relative ) {
-				return; // Beyond cutoff.
+				return;
 			}
 
 			const formatted = formatter.format( relative.value, relative.unit );
-
-			// Store original text as title for hover.
-			if ( ! el.getAttribute( 'title' ) ) {
-				el.setAttribute( 'title', el.textContent );
-			}
-
-			// Preserve <a> wrapper when isLink is enabled.
 			const anchor = el.querySelector( 'a' );
 			if ( anchor ) {
 				anchor.textContent = formatted;

--- a/src/other-scripts/relative-time/index.js
+++ b/src/other-scripts/relative-time/index.js
@@ -31,12 +31,14 @@
 			{ unit: 'second', threshold: 60 },
 			{ unit: 'minute', threshold: 3600 },
 			{ unit: 'hour', threshold: 86400 },
-			{ unit: 'day', threshold: Infinity },
+			{ unit: 'day', threshold: 2592000 },
+			{ unit: 'month', threshold: 31536000 },
+			{ unit: 'year', threshold: Infinity },
 		];
 
 		for ( const { unit, threshold } of units ) {
 			if ( diffSeconds < threshold ) {
-				const divisors = { second: 1, minute: 60, hour: 3600, day: 86400 };
+				const divisors = { second: 1, minute: 60, hour: 3600, day: 86400, month: 2592000, year: 31536000 };
 				return { value: -Math.round( diffSeconds / divisors[ unit ] ), unit };
 			}
 		}
@@ -59,7 +61,11 @@
 
 		// Block theme: .wp-block-post-date time
 		// Classic theme / newspack-blocks: time.entry-date
-		const selectors = [ '.wp-block-post-date:not(.wp-block-post-date__modified-date) time[datetime]', 'time.entry-date.published[datetime]' ];
+		const selectors = [
+			'.wp-block-post-date:not(.wp-block-post-date__modified-date) time[datetime]',
+			'time.entry-date.published[datetime]',
+			'.comment-meta time[datetime]',
+		];
 		const elements = document.querySelectorAll( selectors.join( ', ' ) );
 		const now = Date.now();
 

--- a/src/other-scripts/relative-time/index.js
+++ b/src/other-scripts/relative-time/index.js
@@ -75,7 +75,7 @@
 			}
 
 			// Only replace text on publish dates, not modified date blocks.
-			if ( el.closest( '.wp-block-post-date__modified-date' ) ) {
+			if ( el.closest( '[data-newspack-modified]' ) || el.closest( '.wp-block-post-date__modified-date' ) ) {
 				return;
 			}
 

--- a/src/other-scripts/relative-time/index.js
+++ b/src/other-scripts/relative-time/index.js
@@ -1,0 +1,107 @@
+/**
+ * Relative Time script.
+ *
+ * Replaces post dates with relative "time ago" format on the frontend.
+ * Runs client-side to bypass page caching (the PHP filter renders at cache time,
+ * this script corrects stale relative dates).
+ *
+ * Reads: window.newspackRelativeTime.cutoff (seconds), window.newspackRelativeTime.locale
+ */
+
+( function () {
+	const config = window.newspackRelativeTime;
+	if ( ! config ) {
+		return;
+	}
+
+	const { cutoff, locale } = config;
+
+	/**
+	 * Determine the best unit and value for Intl.RelativeTimeFormat.
+	 *
+	 * @param {number} diffSeconds Difference in seconds (positive = past).
+	 * @return {{ value: number, unit: string }|null} Value and unit, or null if beyond cutoff.
+	 */
+	function getRelativeUnit( diffSeconds ) {
+		if ( diffSeconds >= cutoff ) {
+			return null;
+		}
+
+		const units = [
+			{ unit: 'second', threshold: 60 },
+			{ unit: 'minute', threshold: 3600 },
+			{ unit: 'hour', threshold: 86400 },
+			{ unit: 'day', threshold: Infinity },
+		];
+
+		for ( const { unit, threshold } of units ) {
+			if ( diffSeconds < threshold ) {
+				const divisors = { second: 1, minute: 60, hour: 3600, day: 86400 };
+				return { value: -Math.round( diffSeconds / divisors[ unit ] ), unit };
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Format and replace date text in time elements.
+	 */
+	function updateDates() {
+		// Block theme: .wp-block-post-date time
+		// Classic theme / newspack-blocks: time.entry-date
+		let formatter;
+		try {
+			formatter = new Intl.RelativeTimeFormat( locale.replace( '_', '-' ), {
+				numeric: 'auto',
+			} );
+		} catch {
+			// Fallback: no Intl support.
+			return;
+		}
+
+		// Block theme: .wp-block-post-date time
+		// Classic theme / newspack-blocks: time.entry-date
+		const selectors = [ '.wp-block-post-date:not(.wp-block-post-date__modified-date) time[datetime]', 'time.entry-date.published[datetime]' ];
+		const elements = document.querySelectorAll( selectors.join( ', ' ) );
+		const now = Date.now();
+
+		elements.forEach( function ( el ) {
+			// Skip if already inside a modified date wrapper.
+			if ( el.closest( '.wp-block-post-date__modified-date' ) ) {
+				return;
+			}
+
+			const datetime = el.getAttribute( 'datetime' );
+			if ( ! datetime ) {
+				return;
+			}
+
+			const timestamp = new Date( datetime ).getTime();
+			const diffSeconds = Math.round( ( now - timestamp ) / 1000 );
+
+			if ( diffSeconds < 0 ) {
+				return; // Future date.
+			}
+
+			const relative = getRelativeUnit( diffSeconds );
+			if ( ! relative ) {
+				return; // Beyond cutoff.
+			}
+
+			const formatted = formatter.format( relative.value, relative.unit );
+
+			// Store original text as title for hover.
+			if ( ! el.getAttribute( 'title' ) ) {
+				el.setAttribute( 'title', el.textContent );
+			}
+
+			el.textContent = formatted;
+		} );
+	}
+
+	if ( document.readyState === 'loading' ) {
+		document.addEventListener( 'DOMContentLoaded', updateDates );
+	} else {
+		updateDates();
+	}
+} )();

--- a/src/other-scripts/relative-time/index.js
+++ b/src/other-scripts/relative-time/index.js
@@ -93,7 +93,13 @@
 				el.setAttribute( 'title', el.textContent );
 			}
 
-			el.textContent = formatted;
+			// Preserve <a> wrapper when isLink is enabled.
+			const anchor = el.querySelector( 'a' );
+			if ( anchor ) {
+				anchor.textContent = formatted;
+			} else {
+				el.textContent = formatted;
+			}
 		} );
 	}
 

--- a/src/other-scripts/relative-time/index.js
+++ b/src/other-scripts/relative-time/index.js
@@ -49,7 +49,7 @@
 	 * Format and replace date text in time elements.
 	 */
 	function updateDates() {
-		const localeTag = locale.replace( '_', '-' );
+		const localeTag = locale.replaceAll( '_', '-' );
 
 		let formatter;
 		try {

--- a/src/other-scripts/relative-time/index.js
+++ b/src/other-scripts/relative-time/index.js
@@ -47,8 +47,6 @@
 	 * Format and replace date text in time elements.
 	 */
 	function updateDates() {
-		// Block theme: .wp-block-post-date time
-		// Classic theme / newspack-blocks: time.entry-date
 		let formatter;
 		try {
 			formatter = new Intl.RelativeTimeFormat( locale.replace( '_', '-' ), {

--- a/src/other-scripts/relative-time/index.js
+++ b/src/other-scripts/relative-time/index.js
@@ -58,9 +58,7 @@
 			return; // No Intl support.
 		}
 
-		const elements = document.querySelectorAll(
-			'.wp-block-post-date time[datetime], time.entry-date.published[datetime], .comment-meta time[datetime]'
-		);
+		const elements = document.querySelectorAll( '.wp-block-post-date time[datetime], time.entry-date[datetime], .comment-meta time[datetime]' );
 		const now = Date.now();
 
 		elements.forEach( function ( el ) {

--- a/src/other-scripts/relative-time/index.test.js
+++ b/src/other-scripts/relative-time/index.test.js
@@ -1,0 +1,134 @@
+describe( 'relative-time', () => {
+	const HOUR = 3600;
+	const DAY = 86400;
+
+	let dateNowSpy;
+
+	const NOW = new Date( '2026-03-17T12:00:00Z' ).getTime();
+
+	beforeEach( () => {
+		document.body.innerHTML = '';
+		delete window.newspackRelativeTime;
+		dateNowSpy = jest.spyOn( Date, 'now' ).mockReturnValue( NOW );
+	} );
+
+	afterEach( () => {
+		dateNowSpy.mockRestore();
+		jest.resetModules();
+	} );
+
+	function createTimeElement( datetime, text, { parentClass = 'wp-block-post-date', isLink = false } = {} ) {
+		const div = document.createElement( 'div' );
+		div.className = parentClass;
+		const time = document.createElement( 'time' );
+		time.setAttribute( 'datetime', datetime );
+		if ( isLink ) {
+			const a = document.createElement( 'a' );
+			a.href = '/test/';
+			a.textContent = text;
+			time.appendChild( a );
+		} else {
+			time.textContent = text;
+		}
+		div.appendChild( time );
+		document.body.appendChild( div );
+		return time;
+	}
+
+	function loadScript( config ) {
+		window.newspackRelativeTime = config;
+		jest.isolateModules( () => {
+			require( './index' );
+		} );
+	}
+
+	it( 'should replace date text with relative time when within cutoff', () => {
+		const twoHoursAgo = new Date( NOW - 2 * HOUR * 1000 ).toISOString();
+		createTimeElement( twoHoursAgo, 'March 17, 2026' );
+		loadScript( { cutoff: 14 * DAY, locale: 'en_US' } );
+
+		const time = document.querySelector( 'time' );
+		expect( time.textContent ).toContain( 'ago' );
+	} );
+
+	it( 'should not replace date text beyond cutoff', () => {
+		const twentyDaysAgo = new Date( NOW - 20 * DAY * 1000 ).toISOString();
+		createTimeElement( twentyDaysAgo, 'February 25, 2026' );
+		loadScript( { cutoff: 14 * DAY, locale: 'en_US' } );
+
+		const time = document.querySelector( 'time' );
+		expect( time.textContent ).toBe( 'February 25, 2026' );
+	} );
+
+	it( 'should skip future dates', () => {
+		const tomorrow = new Date( NOW + DAY * 1000 ).toISOString();
+		createTimeElement( tomorrow, 'March 18, 2026' );
+		loadScript( { cutoff: 14 * DAY, locale: 'en_US' } );
+
+		const time = document.querySelector( 'time' );
+		expect( time.textContent ).toBe( 'March 18, 2026' );
+	} );
+
+	it( 'should set title attribute with localized date', () => {
+		const twoHoursAgo = new Date( NOW - 2 * HOUR * 1000 ).toISOString();
+		createTimeElement( twoHoursAgo, 'March 17, 2026' );
+		loadScript( { cutoff: 14 * DAY, locale: 'en_US' } );
+
+		const time = document.querySelector( 'time' );
+		expect( time.getAttribute( 'title' ) ).toBeTruthy();
+	} );
+
+	it( 'should preserve anchor tag when isLink is enabled', () => {
+		const twoHoursAgo = new Date( NOW - 2 * HOUR * 1000 ).toISOString();
+		createTimeElement( twoHoursAgo, 'March 17, 2026', { isLink: true } );
+		loadScript( { cutoff: 14 * DAY, locale: 'en_US' } );
+
+		const anchor = document.querySelector( 'time a' );
+		expect( anchor ).not.toBeNull();
+		expect( anchor.textContent ).toContain( 'ago' );
+		expect( anchor.getAttribute( 'href' ) ).toBe( '/test/' );
+	} );
+
+	it( 'should skip text replacement for modified date blocks with CSS class', () => {
+		const twoHoursAgo = new Date( NOW - 2 * HOUR * 1000 ).toISOString();
+		createTimeElement( twoHoursAgo, 'Updated 2 hours ago', {
+			parentClass: 'wp-block-post-date__modified-date wp-block-post-date',
+		} );
+		loadScript( { cutoff: 14 * DAY, locale: 'en_US' } );
+
+		const time = document.querySelector( 'time' );
+		expect( time.textContent ).toBe( 'Updated 2 hours ago' );
+	} );
+
+	it( 'should skip text replacement for modified date blocks with data attribute', () => {
+		const twoHoursAgo = new Date( NOW - 2 * HOUR * 1000 ).toISOString();
+		const time = createTimeElement( twoHoursAgo, 'Updated 2 hours ago' );
+		time.parentElement.setAttribute( 'data-newspack-modified', '' );
+		loadScript( { cutoff: 14 * DAY, locale: 'en_US' } );
+
+		expect( time.textContent ).toBe( 'Updated 2 hours ago' );
+	} );
+
+	it( 'should still set title on modified date blocks', () => {
+		const twoHoursAgo = new Date( NOW - 2 * HOUR * 1000 ).toISOString();
+		createTimeElement( twoHoursAgo, 'Updated 2 hours ago', {
+			parentClass: 'wp-block-post-date__modified-date wp-block-post-date',
+		} );
+		loadScript( { cutoff: 14 * DAY, locale: 'en_US' } );
+
+		const time = document.querySelector( 'time' );
+		expect( time.getAttribute( 'title' ) ).toBeTruthy();
+	} );
+
+	it( 'should not run when config is missing', () => {
+		const twoHoursAgo = new Date( NOW - 2 * HOUR * 1000 ).toISOString();
+		createTimeElement( twoHoursAgo, 'March 17, 2026' );
+
+		jest.isolateModules( () => {
+			require( './index' );
+		} );
+
+		const time = document.querySelector( 'time' );
+		expect( time.textContent ).toBe( 'March 17, 2026' );
+	} );
+} );

--- a/src/wizards/newspack/views/settings/advanced-settings/index.tsx
+++ b/src/wizards/newspack/views/settings/advanced-settings/index.tsx
@@ -21,6 +21,7 @@ import AuthorBio from './author-bio';
 import FeaturedImagePostsAll from './featured-image-posts-all';
 import FeaturedImagePostsNew from './featured-image-posts-new';
 import MediaCredits from './media-credits';
+import PostDate from './post-date';
 import AccessibilityStatement from './accessibility-statement';
 import PwaDisplayMode from './pwa-display-mode';
 
@@ -137,6 +138,9 @@ export default function AdvancedSettings() {
 				) }
 			>
 				<FeaturedImagePostsAll data={ data } postCount={ etc.post_count } update={ setData } />
+			</WizardSection>
+			<WizardSection title={ __( 'Post Date', 'newspack-plugin' ) }>
+				<PostDate update={ setData } data={ data } isFetching={ isFetching } />
 			</WizardSection>
 			<WizardSection title={ __( 'Media Credits', 'newspack-plugin' ) }>
 				<MediaCredits data={ data } update={ setData } />

--- a/src/wizards/newspack/views/settings/advanced-settings/post-date.tsx
+++ b/src/wizards/newspack/views/settings/advanced-settings/post-date.tsx
@@ -25,6 +25,7 @@ export default function PostDate( { data, isFetching, update }: ThemeModComponen
 						label={ __( 'Maximum post age (days)', 'newspack-plugin' ) }
 						help={ __( 'Posts older than this will show the full date instead.', 'newspack-plugin' ) }
 						type="number"
+						min={ 1 }
 						disabled={ isFetching }
 						value={ data.post_time_ago_cut_off }
 						onChange={ ( post_time_ago_cut_off: number ) => update( { post_time_ago_cut_off } ) }
@@ -44,6 +45,7 @@ export default function PostDate( { data, isFetching, update }: ThemeModComponen
 						label={ __( 'Minimum hours after publish', 'newspack-plugin' ) }
 						help={ __( 'Only show the updated date for posts modified at least this many hours after publication.', 'newspack-plugin' ) }
 						type="number"
+						min={ 0 }
 						disabled={ isFetching }
 						value={ data.post_updated_date_threshold }
 						onChange={ ( post_updated_date_threshold: number ) => update( { post_updated_date_threshold } ) }

--- a/src/wizards/newspack/views/settings/advanced-settings/post-date.tsx
+++ b/src/wizards/newspack/views/settings/advanced-settings/post-date.tsx
@@ -1,0 +1,55 @@
+/**
+ * WordPress dependencies.
+ */
+import { __ } from '@wordpress/i18n';
+import { ToggleControl } from '@wordpress/components';
+
+/**
+ * Internal dependencies.
+ */
+import { Grid, TextControl } from '../../../../../../packages/components/src';
+
+export default function PostDate( { data, isFetching, update }: ThemeModComponentProps< AdvancedSettings > ) {
+	return (
+		<Grid gutter={ 32 }>
+			<Grid columns={ 1 } gutter={ 16 }>
+				<ToggleControl
+					label={ __( 'Show relative dates', 'newspack-plugin' ) }
+					help={ __( 'Display post dates in "time ago" format (e.g. "2 hours ago").', 'newspack-plugin' ) }
+					disabled={ isFetching }
+					checked={ data.post_time_ago }
+					onChange={ ( post_time_ago: boolean ) => update( { post_time_ago } ) }
+				/>
+				{ data.post_time_ago && (
+					<TextControl
+						label={ __( 'Maximum post age (days)', 'newspack-plugin' ) }
+						help={ __( 'Posts older than this will show the full date instead.', 'newspack-plugin' ) }
+						type="number"
+						disabled={ isFetching }
+						value={ data.post_time_ago_cut_off }
+						onChange={ ( post_time_ago_cut_off: number ) => update( { post_time_ago_cut_off } ) }
+					/>
+				) }
+			</Grid>
+			<Grid columns={ 1 } gutter={ 16 }>
+				<ToggleControl
+					label={ __( 'Show last updated date', 'newspack-plugin' ) }
+					help={ __( 'Display when a post was last modified.', 'newspack-plugin' ) }
+					disabled={ isFetching }
+					checked={ data.post_updated_date }
+					onChange={ ( post_updated_date: boolean ) => update( { post_updated_date } ) }
+				/>
+				{ data.post_updated_date && (
+					<TextControl
+						label={ __( 'Minimum hours after publish', 'newspack-plugin' ) }
+						help={ __( 'Only show the updated date for posts modified at least this many hours after publication.', 'newspack-plugin' ) }
+						type="number"
+						disabled={ isFetching }
+						value={ data.post_updated_date_threshold }
+						onChange={ ( post_updated_date_threshold: number ) => update( { post_updated_date_threshold } ) }
+					/>
+				) }
+			</Grid>
+		</Grid>
+	);
+}

--- a/src/wizards/newspack/views/settings/constants.ts
+++ b/src/wizards/newspack/views/settings/constants.ts
@@ -58,6 +58,11 @@ export const ADVANCED_SETTINGS_DEFAULTS = {
 	newspack_image_credits_prefix_label: 'Credit:',
 	newspack_image_credits_placeholder: null,
 	newspack_image_credits_auto_populate: false,
+	// Post Date.
+	post_time_ago: false,
+	post_time_ago_cut_off: 14,
+	post_updated_date: false,
+	post_updated_date_threshold: 24,
 	// PWA Display Mode.
 	pwa_display_mode: 'minimal-ui',
 	// Post content fallback image.

--- a/src/wizards/newspack/views/settings/theme-mods.d.ts
+++ b/src/wizards/newspack/views/settings/theme-mods.d.ts
@@ -6,7 +6,7 @@ type ThemeNames = 'theme' | 'scott' | 'nelson' | 'katharine' | 'sacha' | 'joseph
 /**
  * Theme names with `newspack` prefix.
  */
-type NewspackThemes = `newspack-${ThemeNames}`;
+type NewspackThemes = `newspack-${ ThemeNames }`;
 
 /**
  * Property on theme mods endpoint.
@@ -19,10 +19,10 @@ interface Etc {
 /**
  * Theme and brand schema.
  */
-interface ThemeData<T = {}> {
+interface ThemeData< T = {} > {
 	etc: Etc;
 	theme: '' | NewspackThemes;
-	theme_mods: ThemeMods<T>;
+	theme_mods: ThemeMods< T >;
 	homepage_patterns: HomepagePattern[];
 }
 
@@ -77,8 +77,8 @@ interface ThemeAndBrand {
 /**
  * Theme mods component.
  */
-type ThemeModComponentProps<T = ThemeMods> = {
-	update: (a: Partial<T>) => void;
+type ThemeModComponentProps< T = ThemeMods > = {
+	update: ( a: Partial< T > ) => void;
 	isFetching?: boolean;
 	data: T;
 };
@@ -124,6 +124,12 @@ interface AdvancedSettings {
 		pageUrl: string;
 	};
 
+	// Post Date.
+	post_time_ago: boolean;
+	post_time_ago_cut_off: number;
+	post_updated_date: boolean;
+	post_updated_date_threshold: number;
+
 	// PWA Display Mode.
 	pwa_display_mode: string;
 
@@ -138,4 +144,4 @@ interface MiscSettings {
 	custom_css_post_id: number;
 }
 
-interface ThemeMods extends ThemeAndBrand, AdvancedSettings, MiscSettings { }
+interface ThemeMods extends ThemeAndBrand, AdvancedSettings, MiscSettings {}

--- a/tests/unit-tests/class-post-date-test.php
+++ b/tests/unit-tests/class-post-date-test.php
@@ -52,6 +52,36 @@ class Test_Post_Date extends \WP_UnitTestCase {
 		parent::tear_down();
 	}
 
+	/**
+	 * Helper: create a post and set its modified date via direct DB update.
+	 *
+	 * WordPress ignores `post_modified` in wp_insert_post, so we must update it
+	 * directly in the database after creation.
+	 *
+	 * @param string $post_date     Post date in 'Y-m-d H:i:s' format.
+	 * @param string $post_modified Post modified date in 'Y-m-d H:i:s' format.
+	 * @return int Post ID.
+	 */
+	private function create_post_with_modified_date( $post_date, $post_modified ) {
+		global $wpdb;
+		$post_id = static::factory()->post->create(
+			[
+				'post_date'     => $post_date,
+				'post_date_gmt' => $post_date,
+			]
+		);
+		$wpdb->update( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->posts,
+			[
+				'post_modified'     => $post_modified,
+				'post_modified_gmt' => $post_modified,
+			],
+			[ 'ID' => $post_id ]
+		);
+		clean_post_cache( $post_id );
+		return $post_id;
+	}
+
 	// ─── Time Ago: convert_to_time_ago() ───
 
 	/**
@@ -212,11 +242,9 @@ class Test_Post_Date extends \WP_UnitTestCase {
 		set_theme_mod( 'post_updated_date', true );
 		set_theme_mod( 'post_updated_date_threshold', 24 );
 
-		$post_id = static::factory()->post->create(
-			[
-				'post_date'     => gmdate( 'Y-m-d H:i:s', time() - 7 * DAY_IN_SECONDS ),
-				'post_modified' => gmdate( 'Y-m-d H:i:s', time() - 3 * DAY_IN_SECONDS ),
-			] 
+		$post_id = $this->create_post_with_modified_date(
+			gmdate( 'Y-m-d H:i:s', time() - 7 * DAY_IN_SECONDS ),
+			gmdate( 'Y-m-d H:i:s', time() - 3 * DAY_IN_SECONDS )
 		);
 
 		$this->assertTrue(
@@ -234,11 +262,9 @@ class Test_Post_Date extends \WP_UnitTestCase {
 		set_theme_mod( 'post_updated_date', true );
 		set_theme_mod( 'post_updated_date_threshold', 24 );
 
-		$post_id = static::factory()->post->create(
-			[
-				'post_date'     => gmdate( 'Y-m-d H:i:s', time() - 2 * HOUR_IN_SECONDS ),
-				'post_modified' => gmdate( 'Y-m-d H:i:s', time() - 1 * HOUR_IN_SECONDS ),
-			] 
+		$post_id = $this->create_post_with_modified_date(
+			gmdate( 'Y-m-d H:i:s', time() - 2 * HOUR_IN_SECONDS ),
+			gmdate( 'Y-m-d H:i:s', time() - 1 * HOUR_IN_SECONDS )
 		);
 
 		$this->assertFalse(
@@ -255,11 +281,9 @@ class Test_Post_Date extends \WP_UnitTestCase {
 	public function test_modified_date_sitewide_off_no_override() {
 		set_theme_mod( 'post_updated_date', false );
 
-		$post_id = static::factory()->post->create(
-			[
-				'post_date'     => gmdate( 'Y-m-d H:i:s', time() - 7 * DAY_IN_SECONDS ),
-				'post_modified' => gmdate( 'Y-m-d H:i:s', time() - 3 * DAY_IN_SECONDS ),
-			] 
+		$post_id = $this->create_post_with_modified_date(
+			gmdate( 'Y-m-d H:i:s', time() - 7 * DAY_IN_SECONDS ),
+			gmdate( 'Y-m-d H:i:s', time() - 3 * DAY_IN_SECONDS )
 		);
 
 		$this->assertFalse(
@@ -276,11 +300,9 @@ class Test_Post_Date extends \WP_UnitTestCase {
 	public function test_modified_date_per_post_show_override() {
 		set_theme_mod( 'post_updated_date', false );
 
-		$post_id = static::factory()->post->create(
-			[
-				'post_date'     => gmdate( 'Y-m-d H:i:s', time() - 7 * DAY_IN_SECONDS ),
-				'post_modified' => gmdate( 'Y-m-d H:i:s', time() - 3 * DAY_IN_SECONDS ),
-			] 
+		$post_id = $this->create_post_with_modified_date(
+			gmdate( 'Y-m-d H:i:s', time() - 7 * DAY_IN_SECONDS ),
+			gmdate( 'Y-m-d H:i:s', time() - 3 * DAY_IN_SECONDS )
 		);
 		update_post_meta( $post_id, 'newspack_show_updated_date', true );
 
@@ -299,11 +321,9 @@ class Test_Post_Date extends \WP_UnitTestCase {
 		set_theme_mod( 'post_updated_date', true );
 		set_theme_mod( 'post_updated_date_threshold', 24 );
 
-		$post_id = static::factory()->post->create(
-			[
-				'post_date'     => gmdate( 'Y-m-d H:i:s', time() - 7 * DAY_IN_SECONDS ),
-				'post_modified' => gmdate( 'Y-m-d H:i:s', time() - 3 * DAY_IN_SECONDS ),
-			] 
+		$post_id = $this->create_post_with_modified_date(
+			gmdate( 'Y-m-d H:i:s', time() - 7 * DAY_IN_SECONDS ),
+			gmdate( 'Y-m-d H:i:s', time() - 3 * DAY_IN_SECONDS )
 		);
 		update_post_meta( $post_id, 'newspack_hide_updated_date', true );
 
@@ -322,11 +342,9 @@ class Test_Post_Date extends \WP_UnitTestCase {
 		set_theme_mod( 'post_updated_date', true );
 		set_theme_mod( 'post_updated_date_threshold', 0 );
 
-		$post_id = static::factory()->post->create(
-			[
-				'post_date'     => gmdate( 'Y-m-d H:i:s', time() - 1 * HOUR_IN_SECONDS ),
-				'post_modified' => gmdate( 'Y-m-d H:i:s', time() - 30 * MINUTE_IN_SECONDS ),
-			] 
+		$post_id = $this->create_post_with_modified_date(
+			gmdate( 'Y-m-d H:i:s', time() - 1 * HOUR_IN_SECONDS ),
+			gmdate( 'Y-m-d H:i:s', time() - 30 * MINUTE_IN_SECONDS )
 		);
 
 		$this->assertTrue(
@@ -348,11 +366,9 @@ class Test_Post_Date extends \WP_UnitTestCase {
 		$block_content = '<div class="wp-block-post-date wp-block-post-date__modified-date"><time datetime="2026-03-10T10:00:00+00:00">March 10, 2026</time></div>';
 		$block = [ 'blockName' => 'core/post-date' ];
 
-		$post_id = static::factory()->post->create(
-			[
-				'post_date'     => gmdate( 'Y-m-d H:i:s', time() - 7 * DAY_IN_SECONDS ),
-				'post_modified' => gmdate( 'Y-m-d H:i:s', time() - 3 * DAY_IN_SECONDS ),
-			] 
+		$post_id = $this->create_post_with_modified_date(
+			gmdate( 'Y-m-d H:i:s', time() - 7 * DAY_IN_SECONDS ),
+			gmdate( 'Y-m-d H:i:s', time() - 3 * DAY_IN_SECONDS )
 		);
 
 		global $post;
@@ -379,9 +395,15 @@ class Test_Post_Date extends \WP_UnitTestCase {
 		$old_mods['post_updated_date_threshold'] = 12;
 		update_option( "theme_mods_$old_theme_slug", $old_mods );
 
-		// Create a mock old WP_Theme object.
-		$old_theme = $this->createMock( \WP_Theme::class );
-		$old_theme->method( 'get_stylesheet' )->willReturn( $old_theme_slug );
+		// Create a simple object that implements get_stylesheet().
+		$old_theme = new class() {
+			/**
+			 * Return the old theme stylesheet slug.
+			 */
+			public function get_stylesheet() {
+				return 'newspack-theme';
+			}
+		};
 
 		\Newspack\Post_Date::migrate_date_settings( 'Newspack', $old_theme );
 

--- a/tests/unit-tests/class-post-date-test.php
+++ b/tests/unit-tests/class-post-date-test.php
@@ -494,6 +494,42 @@ class Test_Post_Date extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test modified date output includes data-newspack-modified attribute.
+	 */
+	public function test_render_block_modified_has_data_attribute() {
+		set_theme_mod( 'post_updated_date', true );
+		set_theme_mod( 'post_updated_date_threshold', 24 );
+
+		$post_id = $this->create_post_with_modified_date(
+			gmdate( 'Y-m-d H:i:s', time() - 7 * DAY_IN_SECONDS ),
+			gmdate( 'Y-m-d H:i:s', time() - 3 * DAY_IN_SECONDS )
+		);
+
+		global $post;
+		$post = get_post( $post_id );
+
+		// Block without the CSS class (block bindings path).
+		$block_content = '<div class="wp-block-post-date"><time datetime="2026-03-15T10:00:00+00:00">March 15, 2026</time></div>';
+		$block         = [
+			'blockName' => 'core/post-date',
+			'attrs'     => [
+				'metadata' => [
+					'bindings' => [
+						'datetime' => [
+							'source' => 'core/post-data',
+							'args'   => [ 'field' => 'modified' ],
+						],
+					],
+				],
+			],
+		];
+
+		$result = Post_Date::filter_post_date_block( $block_content, $block );
+		$this->assertStringContainsString( 'data-newspack-modified', $result, 'Modified date block should have data-newspack-modified attribute.' );
+		$this->assertStringContainsString( 'Updated', $result, 'Modified date block should have Updated label.' );
+	}
+
+	/**
 	 * Test Updated label appears even when time-ago is disabled.
 	 */
 	public function test_render_block_updated_label_without_time_ago() {

--- a/tests/unit-tests/class-post-date-test.php
+++ b/tests/unit-tests/class-post-date-test.php
@@ -429,6 +429,91 @@ class Test_Post_Date extends \WP_UnitTestCase {
 		wp_delete_post( $post_id, true );
 	}
 
+	/**
+	 * Test render_block detects modified date via displayType attribute.
+	 */
+	public function test_render_block_detects_modified_via_display_type() {
+		set_theme_mod( 'post_updated_date', false );
+
+		$post_id = $this->create_post_with_modified_date(
+			gmdate( 'Y-m-d H:i:s', time() - 7 * DAY_IN_SECONDS ),
+			gmdate( 'Y-m-d H:i:s', time() - 3 * DAY_IN_SECONDS )
+		);
+
+		global $post;
+		$post = get_post( $post_id );
+
+		$block_content = '<div class="wp-block-post-date"><time datetime="2026-03-16T10:00:00+00:00">March 16, 2026</time></div>';
+		$block         = [
+			'blockName' => 'core/post-date',
+			'attrs'     => [ 'displayType' => 'modified' ],
+		];
+
+		$result = \Newspack\Post_Date::filter_post_date_block( $block_content, $block );
+		$this->assertEmpty( $result, 'Modified date block detected via displayType should be hidden when sitewide is off.' );
+	}
+
+	/**
+	 * Test Updated label appears even when time-ago is disabled.
+	 */
+	public function test_render_block_updated_label_without_time_ago() {
+		set_theme_mod( 'post_time_ago', false );
+		set_theme_mod( 'post_updated_date', true );
+		set_theme_mod( 'post_updated_date_threshold', 24 );
+
+		$post_id = $this->create_post_with_modified_date(
+			gmdate( 'Y-m-d H:i:s', time() - 7 * DAY_IN_SECONDS ),
+			gmdate( 'Y-m-d H:i:s', time() - 3 * DAY_IN_SECONDS )
+		);
+
+		global $post;
+		$post = get_post( $post_id );
+
+		$block_content = '<div class="wp-block-post-date wp-block-post-date__modified-date"><time datetime="2026-03-14T10:00:00+00:00">March 14, 2026</time></div>';
+		$block         = [ 'blockName' => 'core/post-date' ];
+
+		$result = \Newspack\Post_Date::filter_post_date_block( $block_content, $block );
+		$this->assertStringContainsString( 'Updated', $result, 'Modified date should have Updated label even without time-ago.' );
+		$this->assertStringNotContainsString( 'ago', $result, 'Date should not show time-ago when feature is off.' );
+	}
+
+	// ─── Time Ago: Newspack Blocks filter ───
+
+	/**
+	 * Test filter_blocks_formatted_date converts date when enabled.
+	 */
+	public function test_blocks_formatted_date_enabled() {
+		set_theme_mod( 'post_time_ago', true );
+		set_theme_mod( 'post_time_ago_cut_off', 14 );
+
+		$post_id = static::factory()->post->create(
+			[
+				'post_date'     => gmdate( 'Y-m-d H:i:s', time() - 2 * HOUR_IN_SECONDS ),
+				'post_date_gmt' => gmdate( 'Y-m-d H:i:s', time() - 2 * HOUR_IN_SECONDS ),
+			]
+		);
+
+		$result = \Newspack\Post_Date::filter_blocks_formatted_date( 'March 17, 2026', get_post( $post_id ) );
+		$this->assertStringContainsString( 'ago', $result, 'Blocks formatted date should show relative date when enabled.' );
+	}
+
+	/**
+	 * Test filter_blocks_formatted_date preserves date when disabled.
+	 */
+	public function test_blocks_formatted_date_disabled() {
+		set_theme_mod( 'post_time_ago', false );
+
+		$post_id = static::factory()->post->create(
+			[
+				'post_date'     => gmdate( 'Y-m-d H:i:s', time() - 2 * HOUR_IN_SECONDS ),
+				'post_date_gmt' => gmdate( 'Y-m-d H:i:s', time() - 2 * HOUR_IN_SECONDS ),
+			]
+		);
+
+		$result = \Newspack\Post_Date::filter_blocks_formatted_date( 'March 17, 2026', get_post( $post_id ) );
+		$this->assertEquals( 'March 17, 2026', $result, 'Blocks formatted date should be unchanged when disabled.' );
+	}
+
 	// ─── Theme Switch Migration ───
 
 	/**

--- a/tests/unit-tests/class-post-date-test.php
+++ b/tests/unit-tests/class-post-date-test.php
@@ -200,10 +200,10 @@ class Test_Post_Date extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test render_block filter does NOT convert modified date blocks to time-ago,
-	 * even when the modified date feature is enabled and the block should display.
+	 * Test render_block filter applies time-ago to modified date blocks
+	 * and wraps with "Updated" label.
 	 */
-	public function test_render_block_time_ago_skips_modified_date() {
+	public function test_render_block_time_ago_applies_to_modified_date() {
 		set_theme_mod( 'post_time_ago', true );
 		set_theme_mod( 'post_time_ago_cut_off', 14 );
 		set_theme_mod( 'post_updated_date', true );
@@ -223,9 +223,8 @@ class Test_Post_Date extends \WP_UnitTestCase {
 		$post = get_post( $post_id );
 
 		$result = \Newspack\Post_Date::filter_post_date_block( $block_content, $block );
-		// Modified date block should be returned unchanged (no time-ago conversion).
-		$this->assertStringContainsString( 'March 11, 2026', $result, 'Modified date block should preserve original text.' );
-		$this->assertStringNotContainsString( 'ago', $result, 'Modified date block should NOT get time-ago treatment.' );
+		$this->assertStringContainsString( 'Updated', $result, 'Modified date block should have Updated label.' );
+		$this->assertStringContainsString( 'ago', $result, 'Modified date block should get time-ago treatment when enabled.' );
 
 		wp_delete_post( $post_id, true );
 	}

--- a/tests/unit-tests/class-post-date-test.php
+++ b/tests/unit-tests/class-post-date-test.php
@@ -1,0 +1,205 @@
+<?php
+/**
+ * Tests for Post Date features.
+ *
+ * @package Newspack\Tests
+ */
+
+namespace Newspack\Tests;
+
+/**
+ * Test class for Post_Date.
+ *
+ * @group post-date
+ */
+class Test_Post_Date extends \WP_UnitTestCase {
+
+	/**
+	 * Post ID for testing.
+	 *
+	 * @var int
+	 */
+	private static $post_id;
+
+	/**
+	 * Setup before class.
+	 */
+	public static function set_up_before_class(): void {
+		parent::set_up_before_class();
+		require_once NEWSPACK_ABSPATH . 'includes/class-post-date.php';
+	}
+
+	/**
+	 * Setup.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		// Reset theme mods for each test.
+		remove_theme_mod( 'post_time_ago' );
+		remove_theme_mod( 'post_time_ago_cut_off' );
+		remove_theme_mod( 'post_updated_date' );
+		remove_theme_mod( 'post_updated_date_threshold' );
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tear_down(): void {
+		remove_theme_mod( 'post_time_ago' );
+		remove_theme_mod( 'post_time_ago_cut_off' );
+		remove_theme_mod( 'post_updated_date' );
+		remove_theme_mod( 'post_updated_date_threshold' );
+		parent::tear_down();
+	}
+
+	// ─── Time Ago: convert_to_time_ago() ───
+
+	/**
+	 * Test time-ago conversion for a recent post (within cutoff).
+	 */
+	public function test_time_ago_within_cutoff() {
+		$two_hours_ago = gmdate( 'Y-m-d H:i:s', time() - 2 * HOUR_IN_SECONDS );
+		$result = \Newspack\Post_Date::convert_to_time_ago( $two_hours_ago, 14 );
+		$this->assertStringContainsString( 'ago', $result, 'Post 2 hours old should show relative date.' );
+	}
+
+	/**
+	 * Test time-ago returns null for a post beyond the cutoff.
+	 */
+	public function test_time_ago_beyond_cutoff() {
+		$twenty_days_ago = gmdate( 'Y-m-d H:i:s', time() - 20 * DAY_IN_SECONDS );
+		$result = \Newspack\Post_Date::convert_to_time_ago( $twenty_days_ago, 14 );
+		$this->assertNull( $result, 'Post beyond cutoff should return null.' );
+	}
+
+	/**
+	 * Test time-ago at exact cutoff boundary returns null (not within cutoff).
+	 */
+	public function test_time_ago_at_boundary() {
+		$exactly_14_days = gmdate( 'Y-m-d H:i:s', time() - 14 * DAY_IN_SECONDS );
+		$result = \Newspack\Post_Date::convert_to_time_ago( $exactly_14_days, 14 );
+		$this->assertNull( $result, 'Post at exact cutoff boundary should return null.' );
+	}
+
+	/**
+	 * Test time-ago with custom cutoff.
+	 */
+	public function test_time_ago_custom_cutoff() {
+		$three_days_ago = gmdate( 'Y-m-d H:i:s', time() - 3 * DAY_IN_SECONDS );
+		$result_within = \Newspack\Post_Date::convert_to_time_ago( $three_days_ago, 7 );
+		$this->assertStringContainsString( 'ago', $result_within, 'Post 3 days old with 7-day cutoff should show relative date.' );
+
+		$result_beyond = \Newspack\Post_Date::convert_to_time_ago( $three_days_ago, 2 );
+		$this->assertNull( $result_beyond, 'Post 3 days old with 2-day cutoff should return null.' );
+	}
+
+	// ─── Time Ago: get_the_date filter (classic theme) ───
+
+	/**
+	 * Test get_the_date filter converts date when feature is enabled.
+	 */
+	public function test_get_the_date_filter_enabled() {
+		set_theme_mod( 'post_time_ago', true );
+		set_theme_mod( 'post_time_ago_cut_off', 14 );
+
+		$post_id = static::factory()->post->create(
+			[
+				'post_date' => gmdate( 'Y-m-d H:i:s', time() - 2 * HOUR_IN_SECONDS ),
+			]
+		);
+
+		\Newspack\Post_Date::init();
+		$date = get_the_date( '', $post_id );
+		$this->assertStringContainsString( 'ago', $date, 'get_the_date should return relative date when feature is on.' );
+
+		wp_delete_post( $post_id, true );
+	}
+
+	/**
+	 * Test get_the_date filter preserves date when feature is disabled.
+	 */
+	public function test_get_the_date_filter_disabled() {
+		set_theme_mod( 'post_time_ago', false );
+
+		$post_id = static::factory()->post->create(
+			[
+				'post_date' => gmdate( 'Y-m-d H:i:s', time() - 2 * HOUR_IN_SECONDS ),
+			]
+		);
+
+		\Newspack\Post_Date::init();
+		$date = get_the_date( '', $post_id );
+		$this->assertStringNotContainsString( 'ago', $date, 'get_the_date should return full date when feature is off.' );
+
+		wp_delete_post( $post_id, true );
+	}
+
+	/**
+	 * Test get_the_date filter skips machine-readable ISO format.
+	 */
+	public function test_get_the_date_skips_iso_format() {
+		set_theme_mod( 'post_time_ago', true );
+		set_theme_mod( 'post_time_ago_cut_off', 14 );
+
+		$post_id = static::factory()->post->create(
+			[
+				'post_date' => gmdate( 'Y-m-d H:i:s', time() - 2 * HOUR_IN_SECONDS ),
+			]
+		);
+
+		\Newspack\Post_Date::init();
+		$date = get_the_date( 'Y-m-d\TH:i:sP', $post_id );
+		$this->assertStringNotContainsString( 'ago', $date, 'ISO format should not be converted to time-ago.' );
+
+		wp_delete_post( $post_id, true );
+	}
+
+	// ─── Time Ago: render_block filter (block theme) ───
+
+	/**
+	 * Test render_block filter converts publish date block.
+	 */
+	public function test_render_block_time_ago_publish_date() {
+		set_theme_mod( 'post_time_ago', true );
+		set_theme_mod( 'post_time_ago_cut_off', 14 );
+
+		$two_hours_ago = gmdate( 'Y-m-d\TH:i:sP', time() - 2 * HOUR_IN_SECONDS );
+		$block_content = '<div class="wp-block-post-date"><time datetime="' . $two_hours_ago . '">March 11, 2026</time></div>';
+		$block = [ 'blockName' => 'core/post-date' ];
+
+		$result = \Newspack\Post_Date::filter_post_date_block( $block_content, $block );
+		$this->assertStringContainsString( 'ago', $result, 'Publish date block should show relative date.' );
+		$this->assertStringContainsString( 'datetime="' . $two_hours_ago . '"', $result, 'datetime attribute should be preserved.' );
+	}
+
+	/**
+	 * Test render_block filter does NOT convert modified date blocks.
+	 */
+	public function test_render_block_time_ago_skips_modified_date() {
+		set_theme_mod( 'post_time_ago', true );
+		set_theme_mod( 'post_time_ago_cut_off', 14 );
+
+		$two_hours_ago = gmdate( 'Y-m-d\TH:i:sP', time() - 2 * HOUR_IN_SECONDS );
+		$block_content = '<div class="wp-block-post-date wp-block-post-date__modified-date"><time datetime="' . $two_hours_ago . '">March 11, 2026</time></div>';
+		$block = [ 'blockName' => 'core/post-date' ];
+
+		$result = \Newspack\Post_Date::filter_post_date_block( $block_content, $block );
+		$this->assertStringNotContainsString( 'ago', $result, 'Modified date block should NOT get time-ago treatment.' );
+	}
+
+	/**
+	 * Test render_block filter preserves date beyond cutoff.
+	 */
+	public function test_render_block_time_ago_beyond_cutoff() {
+		set_theme_mod( 'post_time_ago', true );
+		set_theme_mod( 'post_time_ago_cut_off', 14 );
+
+		$twenty_days_ago = gmdate( 'Y-m-d\TH:i:sP', time() - 20 * DAY_IN_SECONDS );
+		$block_content = '<div class="wp-block-post-date"><time datetime="' . $twenty_days_ago . '">February 19, 2026</time></div>';
+		$block = [ 'blockName' => 'core/post-date' ];
+
+		$result = \Newspack\Post_Date::filter_post_date_block( $block_content, $block );
+		$this->assertStringNotContainsString( 'ago', $result, 'Date beyond cutoff should not be converted.' );
+		$this->assertStringContainsString( 'February 19, 2026', $result, 'Original date text should be preserved.' );
+	}
+}

--- a/tests/unit-tests/class-post-date-test.php
+++ b/tests/unit-tests/class-post-date-test.php
@@ -202,4 +202,195 @@ class Test_Post_Date extends \WP_UnitTestCase {
 		$this->assertStringNotContainsString( 'ago', $result, 'Date beyond cutoff should not be converted.' );
 		$this->assertStringContainsString( 'February 19, 2026', $result, 'Original date text should be preserved.' );
 	}
+
+	// ─── Modified Date: should_display_updated_date() ───
+
+	/**
+	 * Test modified date shows when sitewide on, beyond threshold.
+	 */
+	public function test_modified_date_sitewide_on_beyond_threshold() {
+		set_theme_mod( 'post_updated_date', true );
+		set_theme_mod( 'post_updated_date_threshold', 24 );
+
+		$post_id = static::factory()->post->create(
+			[
+				'post_date'     => gmdate( 'Y-m-d H:i:s', time() - 7 * DAY_IN_SECONDS ),
+				'post_modified' => gmdate( 'Y-m-d H:i:s', time() - 3 * DAY_IN_SECONDS ),
+			] 
+		);
+
+		$this->assertTrue(
+			\Newspack\Post_Date::should_display_updated_date( $post_id ),
+			'Modified date should display when sitewide is on and post was modified beyond threshold.'
+		);
+
+		wp_delete_post( $post_id, true );
+	}
+
+	/**
+	 * Test modified date hidden when sitewide on but within threshold.
+	 */
+	public function test_modified_date_sitewide_on_within_threshold() {
+		set_theme_mod( 'post_updated_date', true );
+		set_theme_mod( 'post_updated_date_threshold', 24 );
+
+		$post_id = static::factory()->post->create(
+			[
+				'post_date'     => gmdate( 'Y-m-d H:i:s', time() - 2 * HOUR_IN_SECONDS ),
+				'post_modified' => gmdate( 'Y-m-d H:i:s', time() - 1 * HOUR_IN_SECONDS ),
+			] 
+		);
+
+		$this->assertFalse(
+			\Newspack\Post_Date::should_display_updated_date( $post_id ),
+			'Modified date should not display when modification is within threshold hours of publish.'
+		);
+
+		wp_delete_post( $post_id, true );
+	}
+
+	/**
+	 * Test modified date hidden when sitewide off and no per-post override.
+	 */
+	public function test_modified_date_sitewide_off_no_override() {
+		set_theme_mod( 'post_updated_date', false );
+
+		$post_id = static::factory()->post->create(
+			[
+				'post_date'     => gmdate( 'Y-m-d H:i:s', time() - 7 * DAY_IN_SECONDS ),
+				'post_modified' => gmdate( 'Y-m-d H:i:s', time() - 3 * DAY_IN_SECONDS ),
+			] 
+		);
+
+		$this->assertFalse(
+			\Newspack\Post_Date::should_display_updated_date( $post_id ),
+			'Modified date should not display when sitewide is off and no per-post override.'
+		);
+
+		wp_delete_post( $post_id, true );
+	}
+
+	/**
+	 * Test per-post show override when sitewide off.
+	 */
+	public function test_modified_date_per_post_show_override() {
+		set_theme_mod( 'post_updated_date', false );
+
+		$post_id = static::factory()->post->create(
+			[
+				'post_date'     => gmdate( 'Y-m-d H:i:s', time() - 7 * DAY_IN_SECONDS ),
+				'post_modified' => gmdate( 'Y-m-d H:i:s', time() - 3 * DAY_IN_SECONDS ),
+			] 
+		);
+		update_post_meta( $post_id, 'newspack_show_updated_date', true );
+
+		$this->assertTrue(
+			\Newspack\Post_Date::should_display_updated_date( $post_id ),
+			'Modified date should display when per-post show override is on.'
+		);
+
+		wp_delete_post( $post_id, true );
+	}
+
+	/**
+	 * Test per-post hide override when sitewide on.
+	 */
+	public function test_modified_date_per_post_hide_override() {
+		set_theme_mod( 'post_updated_date', true );
+		set_theme_mod( 'post_updated_date_threshold', 24 );
+
+		$post_id = static::factory()->post->create(
+			[
+				'post_date'     => gmdate( 'Y-m-d H:i:s', time() - 7 * DAY_IN_SECONDS ),
+				'post_modified' => gmdate( 'Y-m-d H:i:s', time() - 3 * DAY_IN_SECONDS ),
+			] 
+		);
+		update_post_meta( $post_id, 'newspack_hide_updated_date', true );
+
+		$this->assertFalse(
+			\Newspack\Post_Date::should_display_updated_date( $post_id ),
+			'Modified date should not display when per-post hide override is on.'
+		);
+
+		wp_delete_post( $post_id, true );
+	}
+
+	/**
+	 * Test threshold of zero shows modified date immediately.
+	 */
+	public function test_modified_date_threshold_zero() {
+		set_theme_mod( 'post_updated_date', true );
+		set_theme_mod( 'post_updated_date_threshold', 0 );
+
+		$post_id = static::factory()->post->create(
+			[
+				'post_date'     => gmdate( 'Y-m-d H:i:s', time() - 1 * HOUR_IN_SECONDS ),
+				'post_modified' => gmdate( 'Y-m-d H:i:s', time() - 30 * MINUTE_IN_SECONDS ),
+			] 
+		);
+
+		$this->assertTrue(
+			\Newspack\Post_Date::should_display_updated_date( $post_id ),
+			'Modified date should display immediately when threshold is zero.'
+		);
+
+		wp_delete_post( $post_id, true );
+	}
+
+	// ─── Modified Date: render_block filter ───
+
+	/**
+	 * Test render_block hides modified date block when sitewide off.
+	 */
+	public function test_render_block_hides_modified_date_when_off() {
+		set_theme_mod( 'post_updated_date', false );
+
+		$block_content = '<div class="wp-block-post-date wp-block-post-date__modified-date"><time datetime="2026-03-10T10:00:00+00:00">March 10, 2026</time></div>';
+		$block = [ 'blockName' => 'core/post-date' ];
+
+		$post_id = static::factory()->post->create(
+			[
+				'post_date'     => gmdate( 'Y-m-d H:i:s', time() - 7 * DAY_IN_SECONDS ),
+				'post_modified' => gmdate( 'Y-m-d H:i:s', time() - 3 * DAY_IN_SECONDS ),
+			] 
+		);
+
+		global $post;
+		$post = get_post( $post_id );
+
+		$result = \Newspack\Post_Date::filter_post_date_block( $block_content, $block );
+		$this->assertEmpty( $result, 'Modified date block should be hidden when sitewide is off.' );
+
+		wp_delete_post( $post_id, true );
+	}
+
+	// ─── Theme Switch Migration ───
+
+	/**
+	 * Test theme switch copies date settings from old theme to new.
+	 */
+	public function test_theme_switch_migration() {
+		// Simulate old theme having settings.
+		$old_theme_slug = 'newspack-theme';
+		$old_mods = get_option( "theme_mods_$old_theme_slug", [] );
+		$old_mods['post_time_ago'] = true;
+		$old_mods['post_time_ago_cut_off'] = 7;
+		$old_mods['post_updated_date'] = true;
+		$old_mods['post_updated_date_threshold'] = 12;
+		update_option( "theme_mods_$old_theme_slug", $old_mods );
+
+		// Create a mock old WP_Theme object.
+		$old_theme = $this->createMock( \WP_Theme::class );
+		$old_theme->method( 'get_stylesheet' )->willReturn( $old_theme_slug );
+
+		\Newspack\Post_Date::migrate_date_settings( 'Newspack', $old_theme );
+
+		$this->assertTrue( get_theme_mod( 'post_time_ago' ), 'post_time_ago should be migrated.' );
+		$this->assertEquals( 7, get_theme_mod( 'post_time_ago_cut_off' ), 'post_time_ago_cut_off should be migrated.' );
+		$this->assertTrue( get_theme_mod( 'post_updated_date' ), 'post_updated_date should be migrated.' );
+		$this->assertEquals( 12, get_theme_mod( 'post_updated_date_threshold' ), 'post_updated_date_threshold should be migrated.' );
+
+		// Cleanup.
+		delete_option( "theme_mods_$old_theme_slug" );
+	}
 }

--- a/tests/unit-tests/class-post-date-test.php
+++ b/tests/unit-tests/class-post-date-test.php
@@ -7,6 +7,8 @@
 
 namespace Newspack\Tests;
 
+use Newspack\Post_Date;
+
 /**
  * Test class for Post_Date.
  *
@@ -82,7 +84,7 @@ class Test_Post_Date extends \WP_UnitTestCase {
 	 */
 	public function test_time_ago_within_cutoff() {
 		$two_hours_ago = gmdate( 'Y-m-d H:i:s', time() - 2 * HOUR_IN_SECONDS );
-		$result = \Newspack\Post_Date::convert_to_time_ago( $two_hours_ago, 14 );
+		$result = Post_Date::convert_to_time_ago( $two_hours_ago, 14 );
 		$this->assertStringContainsString( 'ago', $result, 'Post 2 hours old should show relative date.' );
 	}
 
@@ -91,7 +93,7 @@ class Test_Post_Date extends \WP_UnitTestCase {
 	 */
 	public function test_time_ago_beyond_cutoff() {
 		$twenty_days_ago = gmdate( 'Y-m-d H:i:s', time() - 20 * DAY_IN_SECONDS );
-		$result = \Newspack\Post_Date::convert_to_time_ago( $twenty_days_ago, 14 );
+		$result = Post_Date::convert_to_time_ago( $twenty_days_ago, 14 );
 		$this->assertNull( $result, 'Post beyond cutoff should return null.' );
 	}
 
@@ -100,7 +102,7 @@ class Test_Post_Date extends \WP_UnitTestCase {
 	 */
 	public function test_time_ago_at_boundary() {
 		$exactly_14_days = gmdate( 'Y-m-d H:i:s', time() - 14 * DAY_IN_SECONDS );
-		$result = \Newspack\Post_Date::convert_to_time_ago( $exactly_14_days, 14 );
+		$result = Post_Date::convert_to_time_ago( $exactly_14_days, 14 );
 		$this->assertNull( $result, 'Post at exact cutoff boundary should return null.' );
 	}
 
@@ -109,10 +111,10 @@ class Test_Post_Date extends \WP_UnitTestCase {
 	 */
 	public function test_time_ago_custom_cutoff() {
 		$three_days_ago = gmdate( 'Y-m-d H:i:s', time() - 3 * DAY_IN_SECONDS );
-		$result_within = \Newspack\Post_Date::convert_to_time_ago( $three_days_ago, 7 );
+		$result_within = Post_Date::convert_to_time_ago( $three_days_ago, 7 );
 		$this->assertStringContainsString( 'ago', $result_within, 'Post 3 days old with 7-day cutoff should show relative date.' );
 
-		$result_beyond = \Newspack\Post_Date::convert_to_time_ago( $three_days_ago, 2 );
+		$result_beyond = Post_Date::convert_to_time_ago( $three_days_ago, 2 );
 		$this->assertNull( $result_beyond, 'Post 3 days old with 2-day cutoff should return null.' );
 	}
 
@@ -122,11 +124,11 @@ class Test_Post_Date extends \WP_UnitTestCase {
 	public function test_time_ago_cutoff_reduced_when_updated_date_enabled() {
 		set_theme_mod( 'post_time_ago_cut_off', 14 );
 
-		$this->assertEquals( 14, \Newspack\Post_Date::get_time_ago_cutoff_days(), 'Cutoff should be 14 days by default.' );
+		$this->assertEquals( 14, Post_Date::get_time_ago_cutoff_days(), 'Cutoff should be 14 days by default.' );
 
 		set_theme_mod( 'post_updated_date', true );
 
-		$this->assertEquals( 1, \Newspack\Post_Date::get_time_ago_cutoff_days(), 'Cutoff should be 1 day when updated date is enabled.' );
+		$this->assertEquals( 1, Post_Date::get_time_ago_cutoff_days(), 'Cutoff should be 1 day when updated date is enabled.' );
 	}
 
 	// ─── Time Ago: get_the_date filter (classic theme) ───
@@ -197,7 +199,7 @@ class Test_Post_Date extends \WP_UnitTestCase {
 		$block_content = '<div class="wp-block-post-date"><time datetime="' . $two_hours_ago . '">March 11, 2026</time></div>';
 		$block = [ 'blockName' => 'core/post-date' ];
 
-		$result = \Newspack\Post_Date::filter_post_date_block( $block_content, $block );
+		$result = Post_Date::filter_post_date_block( $block_content, $block );
 		$this->assertStringContainsString( 'ago', $result, 'Publish date block should show relative date.' );
 		$this->assertStringContainsString( 'datetime="' . $two_hours_ago . '"', $result, 'datetime attribute should be preserved.' );
 	}
@@ -225,7 +227,7 @@ class Test_Post_Date extends \WP_UnitTestCase {
 		global $post;
 		$post = get_post( $post_id );
 
-		$result = \Newspack\Post_Date::filter_post_date_block( $block_content, $block );
+		$result = Post_Date::filter_post_date_block( $block_content, $block );
 		$this->assertStringContainsString( 'Updated', $result, 'Modified date block should have Updated label.' );
 		$this->assertStringContainsString( 'ago', $result, 'Modified date block should get time-ago treatment when enabled.' );
 	}
@@ -241,7 +243,7 @@ class Test_Post_Date extends \WP_UnitTestCase {
 		$block_content = '<div class="wp-block-post-date"><time datetime="' . $twenty_days_ago . '">February 19, 2026</time></div>';
 		$block = [ 'blockName' => 'core/post-date' ];
 
-		$result = \Newspack\Post_Date::filter_post_date_block( $block_content, $block );
+		$result = Post_Date::filter_post_date_block( $block_content, $block );
 		$this->assertStringNotContainsString( 'ago', $result, 'Date beyond cutoff should not be converted.' );
 		$this->assertStringContainsString( 'February 19, 2026', $result, 'Original date text should be preserved.' );
 	}
@@ -261,7 +263,7 @@ class Test_Post_Date extends \WP_UnitTestCase {
 		);
 
 		$this->assertTrue(
-			\Newspack\Post_Date::should_display_updated_date( $post_id ),
+			Post_Date::should_display_updated_date( $post_id ),
 			'Modified date should display when sitewide is on and post was modified beyond threshold.'
 		);
 	}
@@ -279,7 +281,7 @@ class Test_Post_Date extends \WP_UnitTestCase {
 		);
 
 		$this->assertFalse(
-			\Newspack\Post_Date::should_display_updated_date( $post_id ),
+			Post_Date::should_display_updated_date( $post_id ),
 			'Modified date should not display when modification is within threshold hours of publish.'
 		);
 	}
@@ -296,7 +298,7 @@ class Test_Post_Date extends \WP_UnitTestCase {
 		);
 
 		$this->assertFalse(
-			\Newspack\Post_Date::should_display_updated_date( $post_id ),
+			Post_Date::should_display_updated_date( $post_id ),
 			'Modified date should not display when sitewide is off and no per-post override.'
 		);
 	}
@@ -316,7 +318,7 @@ class Test_Post_Date extends \WP_UnitTestCase {
 		update_post_meta( $post_id, 'newspack_show_updated_date', true );
 
 		$this->assertTrue(
-			\Newspack\Post_Date::should_display_updated_date( $post_id ),
+			Post_Date::should_display_updated_date( $post_id ),
 			'Per-post show override should bypass threshold.'
 		);
 	}
@@ -335,7 +337,7 @@ class Test_Post_Date extends \WP_UnitTestCase {
 		update_post_meta( $post_id, 'newspack_hide_updated_date', true );
 
 		$this->assertFalse(
-			\Newspack\Post_Date::should_display_updated_date( $post_id ),
+			Post_Date::should_display_updated_date( $post_id ),
 			'Modified date should not display when per-post hide override is on.'
 		);
 	}
@@ -353,7 +355,7 @@ class Test_Post_Date extends \WP_UnitTestCase {
 		);
 
 		$this->assertTrue(
-			\Newspack\Post_Date::should_display_updated_date( $post_id ),
+			Post_Date::should_display_updated_date( $post_id ),
 			'Modified date should display immediately when threshold is zero.'
 		);
 	}
@@ -377,7 +379,7 @@ class Test_Post_Date extends \WP_UnitTestCase {
 		global $post;
 		$post = get_post( $post_id );
 
-		$result = \Newspack\Post_Date::filter_post_date_block( $block_content, $block );
+		$result = Post_Date::filter_post_date_block( $block_content, $block );
 		$this->assertEmpty( $result, 'Modified date block should be hidden when sitewide is off.' );
 	}
 
@@ -411,7 +413,7 @@ class Test_Post_Date extends \WP_UnitTestCase {
 			],
 		];
 
-		$result = \Newspack\Post_Date::filter_post_date_block( $block_content, $block );
+		$result = Post_Date::filter_post_date_block( $block_content, $block );
 		$this->assertEmpty( $result, 'Modified date block detected via bindings should be hidden when sitewide is off.' );
 	}
 
@@ -435,7 +437,7 @@ class Test_Post_Date extends \WP_UnitTestCase {
 			'attrs'     => [ 'displayType' => 'modified' ],
 		];
 
-		$result = \Newspack\Post_Date::filter_post_date_block( $block_content, $block );
+		$result = Post_Date::filter_post_date_block( $block_content, $block );
 		$this->assertEmpty( $result, 'Modified date block detected via displayType should be hidden when sitewide is off.' );
 	}
 
@@ -458,7 +460,7 @@ class Test_Post_Date extends \WP_UnitTestCase {
 		$block_content = '<div class="wp-block-post-date wp-block-post-date__modified-date"><time datetime="2026-03-14T10:00:00+00:00">March 14, 2026</time></div>';
 		$block         = [ 'blockName' => 'core/post-date' ];
 
-		$result = \Newspack\Post_Date::filter_post_date_block( $block_content, $block );
+		$result = Post_Date::filter_post_date_block( $block_content, $block );
 		$this->assertStringContainsString( 'Updated', $result, 'Modified date should have Updated label even without time-ago.' );
 		$this->assertStringNotContainsString( 'ago', $result, 'Date should not show time-ago when feature is off.' );
 	}
@@ -479,7 +481,7 @@ class Test_Post_Date extends \WP_UnitTestCase {
 			]
 		);
 
-		$result = \Newspack\Post_Date::filter_blocks_formatted_date( 'March 17, 2026', get_post( $post_id ) );
+		$result = Post_Date::filter_blocks_formatted_date( 'March 17, 2026', get_post( $post_id ) );
 		$this->assertStringContainsString( 'ago', $result, 'Blocks formatted date should show relative date when enabled.' );
 	}
 
@@ -496,7 +498,7 @@ class Test_Post_Date extends \WP_UnitTestCase {
 			]
 		);
 
-		$result = \Newspack\Post_Date::filter_blocks_formatted_date( 'March 17, 2026', get_post( $post_id ) );
+		$result = Post_Date::filter_blocks_formatted_date( 'March 17, 2026', get_post( $post_id ) );
 		$this->assertEquals( 'March 17, 2026', $result, 'Blocks formatted date should be unchanged when disabled.' );
 	}
 
@@ -525,7 +527,7 @@ class Test_Post_Date extends \WP_UnitTestCase {
 			}
 		};
 
-		\Newspack\Post_Date::migrate_date_settings( 'Newspack', $old_theme );
+		Post_Date::migrate_date_settings( 'Newspack', $old_theme );
 
 		$this->assertTrue( get_theme_mod( 'post_time_ago' ), 'post_time_ago should be migrated.' );
 		$this->assertEquals( 7, get_theme_mod( 'post_time_ago_cut_off' ), 'post_time_ago_cut_off should be migrated.' );

--- a/tests/unit-tests/class-post-date-test.php
+++ b/tests/unit-tests/class-post-date-test.php
@@ -116,6 +116,19 @@ class Test_Post_Date extends \WP_UnitTestCase {
 		$this->assertNull( $result_beyond, 'Post 3 days old with 2-day cutoff should return null.' );
 	}
 
+	/**
+	 * Test cutoff is reduced to 1 day when updated date is enabled.
+	 */
+	public function test_time_ago_cutoff_reduced_when_updated_date_enabled() {
+		set_theme_mod( 'post_time_ago_cut_off', 14 );
+
+		$this->assertEquals( 14, \Newspack\Post_Date::get_time_ago_cutoff_days(), 'Cutoff should be 14 days by default.' );
+
+		set_theme_mod( 'post_updated_date', true );
+
+		$this->assertEquals( 1, \Newspack\Post_Date::get_time_ago_cutoff_days(), 'Cutoff should be 1 day when updated date is enabled.' );
+	}
+
 	// ─── Time Ago: get_the_date filter (classic theme) ───
 
 	/**

--- a/tests/unit-tests/class-post-date-test.php
+++ b/tests/unit-tests/class-post-date-test.php
@@ -163,9 +163,9 @@ class Test_Post_Date extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test get_the_date filter skips machine-readable ISO format.
+	 * Test get_the_date filter only converts default format, skips explicit formats.
 	 */
-	public function test_get_the_date_skips_iso_format() {
+	public function test_get_the_date_skips_explicit_format() {
 		set_theme_mod( 'post_time_ago', true );
 		set_theme_mod( 'post_time_ago_cut_off', 14 );
 
@@ -175,10 +175,11 @@ class Test_Post_Date extends \WP_UnitTestCase {
 			]
 		);
 
-		$date = get_the_date( 'Y-m-d\TH:i:sP', $post_id );
-		$this->assertStringNotContainsString( 'ago', $date, 'ISO format should not be converted to time-ago.' );
+		$date = get_the_date( 'F j, Y', $post_id );
+		$this->assertStringNotContainsString( 'ago', $date, 'Explicit format should not be converted to time-ago.' );
 
-		wp_delete_post( $post_id, true );
+		$unix = get_the_date( 'U', $post_id );
+		$this->assertTrue( is_numeric( $unix ), 'Unix timestamp format should return a numeric value.' );
 	}
 
 	// ─── Time Ago: render_block filter (block theme) ───
@@ -307,23 +308,23 @@ class Test_Post_Date extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test per-post show override when sitewide off.
+	 * Test per-post show override bypasses threshold.
 	 */
 	public function test_modified_date_per_post_show_override() {
 		set_theme_mod( 'post_updated_date', false );
+		set_theme_mod( 'post_updated_date_threshold', 24 );
 
+		// Modified only 1 hour after publish (within threshold).
 		$post_id = $this->create_post_with_modified_date(
 			gmdate( 'Y-m-d H:i:s', time() - 7 * DAY_IN_SECONDS ),
-			gmdate( 'Y-m-d H:i:s', time() - 3 * DAY_IN_SECONDS )
+			gmdate( 'Y-m-d H:i:s', time() - 7 * DAY_IN_SECONDS + HOUR_IN_SECONDS )
 		);
 		update_post_meta( $post_id, 'newspack_show_updated_date', true );
 
 		$this->assertTrue(
 			\Newspack\Post_Date::should_display_updated_date( $post_id ),
-			'Modified date should display when per-post show override is on.'
+			'Per-post show override should bypass threshold.'
 		);
-
-		wp_delete_post( $post_id, true );
 	}
 
 	/**
@@ -388,26 +389,6 @@ class Test_Post_Date extends \WP_UnitTestCase {
 
 		$result = \Newspack\Post_Date::filter_post_date_block( $block_content, $block );
 		$this->assertEmpty( $result, 'Modified date block should be hidden when sitewide is off.' );
-
-		wp_delete_post( $post_id, true );
-	}
-
-	/**
-	 * Test get_the_date filter skips Unix timestamp format.
-	 */
-	public function test_get_the_date_skips_unix_format() {
-		set_theme_mod( 'post_time_ago', true );
-		set_theme_mod( 'post_time_ago_cut_off', 14 );
-
-		$post_id = static::factory()->post->create(
-			[
-				'post_date' => gmdate( 'Y-m-d H:i:s', time() - 2 * HOUR_IN_SECONDS ),
-			]
-		);
-
-		$date = get_the_date( 'U', $post_id );
-		$this->assertStringNotContainsString( 'ago', $date, 'Unix timestamp format should not be converted to time-ago.' );
-		$this->assertTrue( is_numeric( $date ), 'Unix timestamp format should return a numeric value.' );
 
 		wp_delete_post( $post_id, true );
 	}

--- a/tests/unit-tests/class-post-date-test.php
+++ b/tests/unit-tests/class-post-date-test.php
@@ -248,6 +248,47 @@ class Test_Post_Date extends \WP_UnitTestCase {
 		$this->assertStringContainsString( 'February 19, 2026', $result, 'Original date text should be preserved.' );
 	}
 
+	/**
+	 * Test render_block preserves anchor tag when isLink is enabled.
+	 */
+	public function test_render_block_time_ago_preserves_link() {
+		set_theme_mod( 'post_time_ago', true );
+		set_theme_mod( 'post_time_ago_cut_off', 14 );
+
+		$two_hours_ago = gmdate( 'Y-m-d\TH:i:sP', time() - 2 * HOUR_IN_SECONDS );
+		$block_content = '<div class="wp-block-post-date"><time datetime="' . $two_hours_ago . '"><a href="/2026/03/11/test/">March 11, 2026</a></time></div>';
+		$block         = [ 'blockName' => 'core/post-date' ];
+
+		$result = Post_Date::filter_post_date_block( $block_content, $block );
+		$this->assertStringContainsString( 'ago', $result, 'Linked date should still show time-ago.' );
+		$this->assertStringContainsString( '<a href="/2026/03/11/test/">', $result, 'Anchor tag should be preserved.' );
+		$this->assertStringContainsString( '</a>', $result, 'Anchor closing tag should be preserved.' );
+	}
+
+	/**
+	 * Test render_block preserves anchor tag on modified date with Updated label.
+	 */
+	public function test_render_block_updated_label_preserves_link() {
+		set_theme_mod( 'post_time_ago', false );
+		set_theme_mod( 'post_updated_date', true );
+		set_theme_mod( 'post_updated_date_threshold', 24 );
+
+		$post_id = $this->create_post_with_modified_date(
+			gmdate( 'Y-m-d H:i:s', time() - 7 * DAY_IN_SECONDS ),
+			gmdate( 'Y-m-d H:i:s', time() - 3 * DAY_IN_SECONDS )
+		);
+
+		global $post;
+		$post = get_post( $post_id );
+
+		$block_content = '<div class="wp-block-post-date wp-block-post-date__modified-date"><time datetime="2026-03-15T10:00:00+00:00"><a href="/2026/03/15/test/">March 15, 2026</a></time></div>';
+		$block         = [ 'blockName' => 'core/post-date' ];
+
+		$result = Post_Date::filter_post_date_block( $block_content, $block );
+		$this->assertStringContainsString( 'Updated', $result, 'Modified linked date should have Updated label.' );
+		$this->assertStringContainsString( '<a href="/2026/03/15/test/">', $result, 'Anchor tag should be preserved on modified date.' );
+	}
+
 	// ─── Modified Date: should_display_updated_date() ───
 
 	/**
@@ -457,7 +498,7 @@ class Test_Post_Date extends \WP_UnitTestCase {
 		global $post;
 		$post = get_post( $post_id );
 
-		$block_content = '<div class="wp-block-post-date wp-block-post-date__modified-date"><time datetime="2026-03-14T10:00:00+00:00">March 14, 2026</time></div>';
+		$block_content = '<div class="wp-block-post-date wp-block-post-date__modified-date"><time datetime="2026-03-15T10:00:00+00:00">March 15, 2026</time></div>';
 		$block         = [ 'blockName' => 'core/post-date' ];
 
 		$result = Post_Date::filter_post_date_block( $block_content, $block );

--- a/tests/unit-tests/class-post-date-test.php
+++ b/tests/unit-tests/class-post-date-test.php
@@ -138,7 +138,6 @@ class Test_Post_Date extends \WP_UnitTestCase {
 			]
 		);
 
-		\Newspack\Post_Date::init();
 		$date = get_the_date( '', $post_id );
 		$this->assertStringContainsString( 'ago', $date, 'get_the_date should return relative date when feature is on.' );
 
@@ -157,7 +156,6 @@ class Test_Post_Date extends \WP_UnitTestCase {
 			]
 		);
 
-		\Newspack\Post_Date::init();
 		$date = get_the_date( '', $post_id );
 		$this->assertStringNotContainsString( 'ago', $date, 'get_the_date should return full date when feature is off.' );
 
@@ -177,7 +175,6 @@ class Test_Post_Date extends \WP_UnitTestCase {
 			]
 		);
 
-		\Newspack\Post_Date::init();
 		$date = get_the_date( 'Y-m-d\TH:i:sP', $post_id );
 		$this->assertStringNotContainsString( 'ago', $date, 'ISO format should not be converted to time-ago.' );
 
@@ -203,18 +200,34 @@ class Test_Post_Date extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test render_block filter does NOT convert modified date blocks.
+	 * Test render_block filter does NOT convert modified date blocks to time-ago,
+	 * even when the modified date feature is enabled and the block should display.
 	 */
 	public function test_render_block_time_ago_skips_modified_date() {
 		set_theme_mod( 'post_time_ago', true );
 		set_theme_mod( 'post_time_ago_cut_off', 14 );
+		set_theme_mod( 'post_updated_date', true );
+		set_theme_mod( 'post_updated_date_threshold', 24 );
 
 		$two_hours_ago = gmdate( 'Y-m-d\TH:i:sP', time() - 2 * HOUR_IN_SECONDS );
 		$block_content = '<div class="wp-block-post-date wp-block-post-date__modified-date"><time datetime="' . $two_hours_ago . '">March 11, 2026</time></div>';
-		$block = [ 'blockName' => 'core/post-date' ];
+		$block         = [ 'blockName' => 'core/post-date' ];
+
+		// Create a post with a modified date well beyond threshold.
+		$post_id = $this->create_post_with_modified_date(
+			gmdate( 'Y-m-d H:i:s', time() - 7 * DAY_IN_SECONDS ),
+			gmdate( 'Y-m-d H:i:s', time() - 2 * HOUR_IN_SECONDS )
+		);
+
+		global $post;
+		$post = get_post( $post_id );
 
 		$result = \Newspack\Post_Date::filter_post_date_block( $block_content, $block );
+		// Modified date block should be returned unchanged (no time-ago conversion).
+		$this->assertStringContainsString( 'March 11, 2026', $result, 'Modified date block should preserve original text.' );
 		$this->assertStringNotContainsString( 'ago', $result, 'Modified date block should NOT get time-ago treatment.' );
+
+		wp_delete_post( $post_id, true );
 	}
 
 	/**

--- a/tests/unit-tests/class-post-date-test.php
+++ b/tests/unit-tests/class-post-date-test.php
@@ -393,6 +393,62 @@ class Test_Post_Date extends \WP_UnitTestCase {
 		wp_delete_post( $post_id, true );
 	}
 
+	/**
+	 * Test get_the_date filter skips Unix timestamp format.
+	 */
+	public function test_get_the_date_skips_unix_format() {
+		set_theme_mod( 'post_time_ago', true );
+		set_theme_mod( 'post_time_ago_cut_off', 14 );
+
+		$post_id = static::factory()->post->create(
+			[
+				'post_date' => gmdate( 'Y-m-d H:i:s', time() - 2 * HOUR_IN_SECONDS ),
+			]
+		);
+
+		$date = get_the_date( 'U', $post_id );
+		$this->assertStringNotContainsString( 'ago', $date, 'Unix timestamp format should not be converted to time-ago.' );
+		$this->assertTrue( is_numeric( $date ), 'Unix timestamp format should return a numeric value.' );
+
+		wp_delete_post( $post_id, true );
+	}
+
+	/**
+	 * Test render_block detects modified date via block bindings attributes.
+	 */
+	public function test_render_block_detects_modified_via_bindings() {
+		set_theme_mod( 'post_updated_date', false );
+
+		$post_id = $this->create_post_with_modified_date(
+			gmdate( 'Y-m-d H:i:s', time() - 7 * DAY_IN_SECONDS ),
+			gmdate( 'Y-m-d H:i:s', time() - 3 * DAY_IN_SECONDS )
+		);
+
+		global $post;
+		$post = get_post( $post_id );
+
+		// Block with bindings attrs (no CSS class in content) should still be detected as modified.
+		$block_content = '<div class="wp-block-post-date"><time datetime="2026-03-16T10:00:00+00:00">March 16, 2026</time></div>';
+		$block         = [
+			'blockName' => 'core/post-date',
+			'attrs'     => [
+				'metadata' => [
+					'bindings' => [
+						'datetime' => [
+							'source' => 'core/post-data',
+							'args'   => [ 'field' => 'modified' ],
+						],
+					],
+				],
+			],
+		];
+
+		$result = \Newspack\Post_Date::filter_post_date_block( $block_content, $block );
+		$this->assertEmpty( $result, 'Modified date block detected via bindings should be hidden when sitewide is off.' );
+
+		wp_delete_post( $post_id, true );
+	}
+
 	// ─── Theme Switch Migration ───
 
 	/**

--- a/tests/unit-tests/class-post-date-test.php
+++ b/tests/unit-tests/class-post-date-test.php
@@ -25,10 +25,19 @@ class Test_Post_Date extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Original global $post value, saved in set_up and restored in tear_down.
+	 *
+	 * @var \WP_Post|null
+	 */
+	private $original_post;
+
+	/**
 	 * Setup.
 	 */
 	public function set_up(): void {
 		parent::set_up();
+		global $post;
+		$this->original_post = $post;
 		// Reset theme mods for each test.
 		remove_theme_mod( 'post_time_ago' );
 		remove_theme_mod( 'post_time_ago_cut_off' );
@@ -40,6 +49,8 @@ class Test_Post_Date extends \WP_UnitTestCase {
 	 * Tear down.
 	 */
 	public function tear_down(): void {
+		global $post;
+		$post = $this->original_post; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		remove_theme_mod( 'post_time_ago' );
 		remove_theme_mod( 'post_time_ago_cut_off' );
 		remove_theme_mod( 'post_updated_date' );

--- a/tests/unit-tests/class-post-date-test.php
+++ b/tests/unit-tests/class-post-date-test.php
@@ -15,13 +15,6 @@ namespace Newspack\Tests;
 class Test_Post_Date extends \WP_UnitTestCase {
 
 	/**
-	 * Post ID for testing.
-	 *
-	 * @var int
-	 */
-	private static $post_id;
-
-	/**
 	 * Setup before class.
 	 */
 	public static function set_up_before_class(): void {
@@ -140,8 +133,6 @@ class Test_Post_Date extends \WP_UnitTestCase {
 
 		$date = get_the_date( '', $post_id );
 		$this->assertStringContainsString( 'ago', $date, 'get_the_date should return relative date when feature is on.' );
-
-		wp_delete_post( $post_id, true );
 	}
 
 	/**
@@ -158,8 +149,6 @@ class Test_Post_Date extends \WP_UnitTestCase {
 
 		$date = get_the_date( '', $post_id );
 		$this->assertStringNotContainsString( 'ago', $date, 'get_the_date should return full date when feature is off.' );
-
-		wp_delete_post( $post_id, true );
 	}
 
 	/**
@@ -226,8 +215,6 @@ class Test_Post_Date extends \WP_UnitTestCase {
 		$result = \Newspack\Post_Date::filter_post_date_block( $block_content, $block );
 		$this->assertStringContainsString( 'Updated', $result, 'Modified date block should have Updated label.' );
 		$this->assertStringContainsString( 'ago', $result, 'Modified date block should get time-ago treatment when enabled.' );
-
-		wp_delete_post( $post_id, true );
 	}
 
 	/**
@@ -264,8 +251,6 @@ class Test_Post_Date extends \WP_UnitTestCase {
 			\Newspack\Post_Date::should_display_updated_date( $post_id ),
 			'Modified date should display when sitewide is on and post was modified beyond threshold.'
 		);
-
-		wp_delete_post( $post_id, true );
 	}
 
 	/**
@@ -284,8 +269,6 @@ class Test_Post_Date extends \WP_UnitTestCase {
 			\Newspack\Post_Date::should_display_updated_date( $post_id ),
 			'Modified date should not display when modification is within threshold hours of publish.'
 		);
-
-		wp_delete_post( $post_id, true );
 	}
 
 	/**
@@ -303,8 +286,6 @@ class Test_Post_Date extends \WP_UnitTestCase {
 			\Newspack\Post_Date::should_display_updated_date( $post_id ),
 			'Modified date should not display when sitewide is off and no per-post override.'
 		);
-
-		wp_delete_post( $post_id, true );
 	}
 
 	/**
@@ -344,8 +325,6 @@ class Test_Post_Date extends \WP_UnitTestCase {
 			\Newspack\Post_Date::should_display_updated_date( $post_id ),
 			'Modified date should not display when per-post hide override is on.'
 		);
-
-		wp_delete_post( $post_id, true );
 	}
 
 	/**
@@ -364,8 +343,6 @@ class Test_Post_Date extends \WP_UnitTestCase {
 			\Newspack\Post_Date::should_display_updated_date( $post_id ),
 			'Modified date should display immediately when threshold is zero.'
 		);
-
-		wp_delete_post( $post_id, true );
 	}
 
 	// ─── Modified Date: render_block filter ───
@@ -389,8 +366,6 @@ class Test_Post_Date extends \WP_UnitTestCase {
 
 		$result = \Newspack\Post_Date::filter_post_date_block( $block_content, $block );
 		$this->assertEmpty( $result, 'Modified date block should be hidden when sitewide is off.' );
-
-		wp_delete_post( $post_id, true );
 	}
 
 	/**
@@ -425,8 +400,6 @@ class Test_Post_Date extends \WP_UnitTestCase {
 
 		$result = \Newspack\Post_Date::filter_post_date_block( $block_content, $block );
 		$this->assertEmpty( $result, 'Modified date block detected via bindings should be hidden when sitewide is off.' );
-
-		wp_delete_post( $post_id, true );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Centralizes the "time ago" relative dates and "last updated" date features from the classic theme into the plugin, making them work across both classic and block themes.

**Time-ago relative dates:**
- Converts post dates to "X hours/days ago" format when within a configurable cutoff (default 14 days).
- Works on classic themes via `get_the_date` filter, on block themes via `render_block_core/post-date` filter, and on Newspack Blocks Homepage Posts via `newspack_blocks_formatted_displayed_post_date` filter.
- Client-side JS refreshes stale cached dates and adds localized full-date tooltips on hover.

**Last updated date:**
- Shows "Updated [date]" on posts modified significantly after publication (configurable threshold, default 24 hours).
- Block themes: filters the `core/post-date` modified block, adding the "Updated" label and `data-newspack-modified` attribute for JS signaling.
- Classic themes: renders via `newspack_theme_entry_meta` action hook (zero theme logic duplication).
- Per-post overrides: editor sidebar toggles to show/hide the updated date on individual posts.

**Settings:**
- New "Post Date" section in Newspack > Settings > Advanced Settings with 4 controls.
- Settings stored as theme mods with automatic migration on theme switch.
- When "Show last updated date" is enabled, the time-ago cutoff automatically reduces to 1 day (replicating the classic theme coupling behavior).

**Architecture notes:**
- The plugin owns all business logic. The classic theme was simplified to only render the publish date (`newspack_posted_on()`), while the plugin injects the updated date via a dedicated `newspack_theme_after_posted_on` action hook that fires immediately after the publish date. This means the classic theme HTML structure differs slightly from the old baseline (updated date is a sibling `<span>` rather than nested inside the same one, and the "Updated" label is inside the `<time>` element for better i18n). The visual result is identical.
- More details on architectural decisions and intentional behavioral differences are documented in the Linear issues.

Closes NPPD-1277, NPPD-1278.

Companion PRs:
- https://github.com/Automattic/newspack-theme/pull/2652
- https://github.com/Automattic/newspack-block-theme/pull/428

### How to test the changes in this Pull Request:

**Prerequisites:** Also check out `feat/post-date` on `newspack-theme` and `newspack-block-theme`. Build all three projects.

**Setup:**
1. Create test posts with varied publish/modified dates (e.g., 6h ago / modified 2h ago, 3d ago / modified 1d ago, 20d ago / modified 15d ago, unmodified post).
2. Enable features via WP-CLI or Newspack > Settings > Advanced Settings > Post Date.

**Time-ago (both themes):**
3. Visit a post published within the cutoff period. Verify the date shows in "X hours/days ago" format.
4. Visit a post published beyond the cutoff. Verify the full date is shown.
5. Hover over any date element. Verify a localized full datetime tooltip appears.
6. Visit the homepage. Verify recent posts show time-ago and older posts show full dates.

**Updated date (block theme):**
7. Activate the block theme. Visit a post modified well after publication (beyond the 24h threshold). Verify "Updated [date]" appears.
8. Visit an unmodified post. Verify no updated date appears.
9. Edit a post. Verify the "Updated Date" panel appears in the document sidebar with a hide/show toggle.
10. Toggle the per-post override and verify the frontend reflects the change.

**Updated date (classic theme):**
11. Activate the classic Newspack theme. Repeat steps 7-8. Verify the updated date appears after the publish date.

**24-hour cutoff coupling:**
12. Enable both features. Verify posts older than 1 day show full dates (not time-ago).
13. Disable the updated date feature. Verify the 14-day cutoff is restored (3-day-old posts show "3 days ago").

**Settings:**
14. Go to Newspack > Settings > Advanced Settings > Post Date. Toggle features on/off and change numeric values. Verify changes persist and take effect on the frontend.
15. Switch themes (classic to block and back). Verify all 4 settings are preserved via the migration hook.

**Disabled state:**
16. Disable both features. Verify no time-ago formatting, no updated dates, and no `newspack-relative-time` script in page source.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?