### PR TITLE
feat(image-upload): simplify component to use basecontrol; remove info prop

### DIFF
--- a/packages/components/src/image-upload/index.js
+++ b/packages/components/src/image-upload/index.js
@@ -21,8 +21,6 @@ import './style.scss';
 import classnames from 'classnames';
 
 class ImageUpload extends Component {
-	static instanceCounter = 0;
-
 	/**
 	 * Constructor.
 	 */
@@ -31,9 +29,6 @@ class ImageUpload extends Component {
 		this.state = {
 			frame: false,
 		};
-
-		ImageUpload.instanceCounter += 1;
-		this.baseControlId = this.props.id || `newspack-image-upload-${ ImageUpload.instanceCounter }`;
 	}
 
 	/**
@@ -85,7 +80,8 @@ class ImageUpload extends Component {
 			{ 'newspack-image-upload__image--covering': isCovering }
 		);
 		return (
-			<BaseControl className={ classnames( 'newspack-image-upload', className ) } help={ help } id={ this.baseControlId } label={ label }>
+			<BaseControl __nextHasNoMarginBottom className={ classnames( 'newspack-image-upload', className ) } help={ help }>
+				{ label && <BaseControl.VisualLabel>{ label }</BaseControl.VisualLabel> }
 				<div className={ classes } style={ style }>
 					{ image?.url ? (
 						<>
@@ -100,7 +96,7 @@ class ImageUpload extends Component {
 							</div>
 						</>
 					) : (
-						<Button disabled={ disabled } id={ this.baseControlId } onClick={ this.openModal } variant="tertiary">
+						<Button disabled={ disabled } onClick={ this.openModal } variant="tertiary">
 							{ buttonLabel ? buttonLabel : __( 'Upload', 'newspack-plugin' ) }
 						</Button>
 					) }

--- a/packages/components/src/image-upload/index.js
+++ b/packages/components/src/image-upload/index.js
@@ -85,13 +85,8 @@ class ImageUpload extends Component {
 			{ 'newspack-image-upload__image--covering': isCovering }
 		);
 		return (
-			<BaseControl
-				className={ classnames( 'newspack-image-upload', className ) }
-				help={ help }
-				id={ this.props.id || this.baseControlId }
-				label={ label }
-			>
-				<div className={ classes } style={ { ...style } }>
+			<BaseControl className={ classnames( 'newspack-image-upload', className ) } help={ help } id={ this.baseControlId } label={ label }>
+				<div className={ classes } style={ style }>
 					{ image?.url ? (
 						<>
 							<img data-testid="image-upload" src={ image.url } alt={ __( 'Image preview', 'newspack-plugin' ) } />
@@ -99,19 +94,13 @@ class ImageUpload extends Component {
 								<Button disabled={ disabled } onClick={ this.openModal } variant="tertiary">
 									{ __( 'Replace', 'newspack-plugin' ) }
 								</Button>
-								<span className="sep" />
 								<Button disabled={ disabled } onClick={ () => onChange( null ) } variant="tertiary" isDestructive>
 									{ __( 'Remove', 'newspack-plugin' ) }
 								</Button>
 							</div>
 						</>
 					) : (
-						<Button
-							disabled={ disabled }
-							onClick={ this.openModal }
-							variant="tertiary"
-							style={ { width: 'calc(100% - 2px)', justifyContent: 'center' } }
-						>
+						<Button disabled={ disabled } id={ this.baseControlId } onClick={ this.openModal } variant="tertiary">
 							{ buttonLabel ? buttonLabel : __( 'Upload', 'newspack-plugin' ) }
 						</Button>
 					) }

--- a/packages/components/src/image-upload/index.js
+++ b/packages/components/src/image-upload/index.js
@@ -7,11 +7,12 @@
  */
 import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { BaseControl } from '@wordpress/components';
 
 /**
  * Internal dependencies.
  */
-import { Button, InfoButton } from '../';
+import { Button } from '../';
 import './style.scss';
 
 /**
@@ -20,6 +21,8 @@ import './style.scss';
 import classnames from 'classnames';
 
 class ImageUpload extends Component {
+	static instanceCounter = 0;
+
 	/**
 	 * Constructor.
 	 */
@@ -28,6 +31,9 @@ class ImageUpload extends Component {
 		this.state = {
 			frame: false,
 		};
+
+		ImageUpload.instanceCounter += 1;
+		this.baseControlId = this.props.id || `newspack-image-upload-${ ImageUpload.instanceCounter }`;
 	}
 
 	/**
@@ -72,41 +78,45 @@ class ImageUpload extends Component {
 	 * Render.
 	 */
 	render = () => {
-		const { buttonLabel, className, disabled, help, image, info, isCovering, label, onChange, style = {} } = this.props;
+		const { buttonLabel, className, disabled, help, image, isCovering, label, onChange, style = {} } = this.props;
 		const classes = classnames(
 			'newspack-image-upload__image',
 			{ 'newspack-image-upload__image--has-image': image },
 			{ 'newspack-image-upload__image--covering': isCovering }
 		);
 		return (
-			<div className={ classnames( 'newspack-image-upload', className ) }>
-				<div className="newspack-image-upload__header">
-					{ /* eslint-disable-next-line jsx-a11y/label-has-for, jsx-a11y/label-has-associated-control */ }
-					{ label && <label className="newspack-image-upload__label">{ label }</label> }
-					{ info && <InfoButton text={ info } /> }
-				</div>
+			<BaseControl
+				className={ classnames( 'newspack-image-upload', className ) }
+				help={ help }
+				id={ this.props.id || this.baseControlId }
+				label={ label }
+			>
 				<div className={ classes } style={ { ...style } }>
 					{ image?.url ? (
 						<>
 							<img data-testid="image-upload" src={ image.url } alt={ __( 'Image preview', 'newspack-plugin' ) } />
 							<div className="newspack-image-upload__controls">
-								<Button disabled={ disabled } onClick={ this.openModal } isLink>
+								<Button disabled={ disabled } onClick={ this.openModal } variant="tertiary">
 									{ __( 'Replace', 'newspack-plugin' ) }
 								</Button>
 								<span className="sep" />
-								<Button disabled={ disabled } onClick={ () => onChange( null ) } isLink isDestructive>
+								<Button disabled={ disabled } onClick={ () => onChange( null ) } variant="tertiary" isDestructive>
 									{ __( 'Remove', 'newspack-plugin' ) }
 								</Button>
 							</div>
 						</>
 					) : (
-						<Button disabled={ disabled } onClick={ this.openModal } isLink>
+						<Button
+							disabled={ disabled }
+							onClick={ this.openModal }
+							variant="tertiary"
+							style={ { width: 'calc(100% - 2px)', justifyContent: 'center' } }
+						>
 							{ buttonLabel ? buttonLabel : __( 'Upload', 'newspack-plugin' ) }
 						</Button>
 					) }
 				</div>
-				{ help && <p className="newspack-image-upload__help">{ help }</p> }
-			</div>
+			</BaseControl>
 		);
 	};
 }

--- a/packages/components/src/image-upload/style.scss
+++ b/packages/components/src/image-upload/style.scss
@@ -70,6 +70,6 @@
 		align-items: center;
 		display: flex;
 		flex-direction: column;
-position: absolute;
+		position: absolute;
 	}
 }

--- a/packages/components/src/image-upload/style.scss
+++ b/packages/components/src/image-upload/style.scss
@@ -23,7 +23,7 @@
 			background-size: cover;
 		}
 		&:not(&--has-image) {
-			.newspack-button {
+			.components-button {
 				background: wp-colors.$white !important;
 				border-radius: wp-vars.$radius-small !important;
 				padding: wp-vars.$grid-unit-05 wp-vars.$grid-unit-20 !important;

--- a/packages/components/src/image-upload/style.scss
+++ b/packages/components/src/image-upload/style.scss
@@ -24,19 +24,8 @@
 		}
 		&:not(&--has-image) {
 			.components-button {
-				background: wp-colors.$white !important;
-				border-radius: wp-vars.$radius-small !important;
-				padding: wp-vars.$grid-unit-05 wp-vars.$grid-unit-20 !important;
-
-				&:active,
-				&:focus,
-				&:hover {
-					background: wp-colors.$white !important;
-				}
-
-				&:focus {
-					outline-offset: -3px !important;
-				}
+				justify-content: center;
+				width: calc(100% - 2px);
 			}
 		}
 		&--has-image {
@@ -75,19 +64,12 @@
 				max-height: 100%;
 				max-width: 100%;
 			}
-			.sep {
-				background: transparent;
-				display: block;
-				height: wp-vars.$grid-unit-10;
-				margin: 0;
-				width: 100%;
-			}
 		}
 	}
 	&__controls {
 		align-items: center;
 		display: flex;
 		flex-direction: column;
-		position: absolute;
+position: absolute;
 	}
 }

--- a/packages/components/src/image-upload/style.scss
+++ b/packages/components/src/image-upload/style.scss
@@ -3,40 +3,35 @@
  */
 
 @use "~@wordpress/base-styles/colors" as wp-colors;
+@use "~@wordpress/base-styles/variables" as wp-vars;
 
 .newspack-image-upload {
-	margin: 32px 0;
-	&__header {
-		display: flex;
-	}
-	&__label {
-		margin: 0 0 8px;
-	}
+	margin: wp-vars.$grid-unit-40 0;
 	&__image {
 		align-items: center;
+		background-position: center;
 		background-repeat: no-repeat;
 		background-size: contain;
-		background-position: center;
-		border: 1px dashed wp-colors.$gray-700;
-		border-radius: 2px;
+		border: 1px dashed wp-colors.$gray-600;
+		border-radius: wp-vars.$radius-small;
 		display: flex;
 		justify-content: center;
 		max-width: 100%;
-		min-height: 48px;
+		min-height: wp-vars.$grid-unit-50;
 		position: relative;
 		&--covering {
 			background-size: cover;
 		}
 		&:not(&--has-image) {
 			.newspack-button {
-				background: white !important;
-				border-radius: 2px !important;
-				padding: 4px 16px !important;
+				background: wp-colors.$white !important;
+				border-radius: wp-vars.$radius-small !important;
+				padding: wp-vars.$grid-unit-05 wp-vars.$grid-unit-20 !important;
 
 				&:active,
 				&:focus,
 				&:hover {
-					background: white !important;
+					background: wp-colors.$white !important;
 				}
 
 				&:focus {
@@ -49,8 +44,8 @@
 			overflow: hidden;
 			&::before,
 			&::after {
-				border: 1px solid rgba(black, 0.54);
-				border-radius: 2px;
+				border: 1px solid rgba(wp-colors.$black, 0.54);
+				border-radius: wp-vars.$radius-small;
 				content: "";
 				inset: 0;
 				position: absolute;
@@ -66,7 +61,7 @@
 				position: relative;
 			}
 			&::after {
-				background: rgba(white, 0.9);
+				background: rgba(wp-colors.$white, 0.95);
 				border-color: wp-colors.$gray-700;
 			}
 			&:focus-within,
@@ -83,16 +78,11 @@
 			.sep {
 				background: transparent;
 				display: block;
-				height: 8px;
+				height: wp-vars.$grid-unit-10;
 				margin: 0;
 				width: 100%;
 			}
 		}
-	}
-	&__image + &__help {
-		color: wp-colors.$gray-700;
-		font-size: 12px;
-		margin: 1em 0 0;
 	}
 	&__controls {
 		align-items: center;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR simplifies the `ImageUpload`. Instead of custom label and help text we are leveraging Core's `BaseControl`. This means visually it looks closer to Core's (especially if they end up making tweaks to the label or help text).

I removed the `info` prop. It wasn't being used and I'd rather we use the help text anyway.

I've also update the buttons to use the `tertiary` variant instead of `isLink`.

__Before:__
<img width="1052" height="1616" src="https://github.com/user-attachments/assets/604a8610-436f-406a-bcf3-3847037b6477" />

__After:__
<img width="1080" height="1624" src="https://github.com/user-attachments/assets/68837b98-4835-4133-986b-cb0dc2c0b023" />

### How to test the changes in this Pull Request:

1. Navigation to a page that has image uploads (e.g. Newspack > Settings > Theme and brand)
2. Check how it looks and works now
3. Switch to this branch and refresh page
4. Test if everything still work (upload / remove / replace)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->