### PR TITLE
feat(color-picker): simplify component to use basecontrol

### DIFF
--- a/packages/components/src/color-picker/index.js
+++ b/packages/components/src/color-picker/index.js
@@ -1,7 +1,8 @@
 /**
  * WordPress dependencies.
  */
-import { ColorPicker as ColorPickerComponent } from '@wordpress/components';
+import { BaseControl, ColorPicker as ColorPickerComponent } from '@wordpress/components';
+import { useInstanceId } from '@wordpress/compose';
 import { useState, useRef } from '@wordpress/element';
 
 /**
@@ -26,26 +27,26 @@ const { InteractiveDiv } = utils;
  *
  * @param {Object}             props             - Component props.
  * @param {JSX.Element|string} props.label       - Label for the color picker.
+ * @param {JSX.Element|string} props.help        - Help text for the color picker.
  * @param {string}             [props.color]     - Default color.
  * @param {Function}           props.onChange    - Function to call when the color changes.
  * @param {string}             [props.className] - Additional class name.
  * @return {JSX.Element} ColorPicker component.
  */
-const ColorPicker = ( { label, color = '#fff', onChange, className } ) => {
+const ColorPicker = ( { label, help, color = '#ffffff', onChange, className } ) => {
 	const [ isExpanded, setIsExpanded ] = useState( false );
 	const ref = useRef();
+	const id = useInstanceId( ColorPicker, 'newspack-color-picker' );
 	const colordColor = colord( color );
 	hooks.useOnClickOutside( ref, () => setIsExpanded( false ) );
 	return (
-		<div className={ classnames( 'newspack-color-picker', className ) }>
-			<div className="newspack-color-picker__label">{ label }</div>
-
+		<BaseControl className={ classnames( 'newspack-color-picker', className ) } id={ id } label={ label } help={ help }>
 			<InteractiveDiv
 				className={ 'newspack-color-picker__expander' }
 				onClick={ () => setIsExpanded( ! isExpanded ) }
 				style={ {
 					backgroundColor: color,
-					color: colordColor.contrast() > colordColor.contrast( '#000' ) ? '#fff' : '#000',
+					color: colordColor.contrast() > colordColor.contrast( '#000000' ) ? '#ffffff' : '#000000',
 				} }
 			>
 				{ color }
@@ -54,7 +55,7 @@ const ColorPicker = ( { label, color = '#fff', onChange, className } ) => {
 			<div className="newspack-color-picker__main" ref={ ref }>
 				{ isExpanded && <ColorPickerComponent color={ color } onChange={ hex => onChange( hex ) } enableAlpha={ false } /> }
 			</div>
-		</div>
+		</BaseControl>
 	);
 };
 

--- a/packages/components/src/color-picker/index.js
+++ b/packages/components/src/color-picker/index.js
@@ -42,6 +42,8 @@ const ColorPicker = ( { label, help, color = '#ffffff', onChange, className } ) 
 	return (
 		<BaseControl className={ classnames( 'newspack-color-picker', className ) } id={ id } label={ label } help={ help }>
 			<InteractiveDiv
+				id={ id }
+				aria-expanded={ isExpanded }
 				className={ 'newspack-color-picker__expander' }
 				onClick={ () => setIsExpanded( ! isExpanded ) }
 				style={ {
@@ -53,7 +55,7 @@ const ColorPicker = ( { label, help, color = '#ffffff', onChange, className } ) 
 			</InteractiveDiv>
 
 			<div className="newspack-color-picker__main" ref={ ref }>
-				{ isExpanded && <ColorPickerComponent color={ color } onChange={ hex => onChange( hex ) } enableAlpha={ false } /> }
+				{ isExpanded && <ColorPickerComponent color={ color } onChange={ onChange } enableAlpha={ false } /> }
 			</div>
 		</BaseControl>
 	);

--- a/packages/components/src/color-picker/index.js
+++ b/packages/components/src/color-picker/index.js
@@ -41,11 +41,12 @@ const ColorPicker = ( { label, help, color = '#ffffff', onChange, className } ) 
 	const colordColor = colord( color );
 	hooks.useOnClickOutside( ref, () => setIsExpanded( false ) );
 	return (
-		<BaseControl className={ classnames( 'newspack-color-picker', className ) } help={ help }>
+		<BaseControl id={ id } className={ classnames( 'newspack-color-picker', className ) } help={ help } __nextHasNoMarginBottom>
 			<BaseControl.VisualLabel id={ labelId }>{ label }</BaseControl.VisualLabel>
 			<InteractiveDiv
 				id={ id }
 				aria-labelledby={ labelId }
+				aria-describedby={ help ? `${ id }__help` : undefined }
 				aria-expanded={ isExpanded }
 				className={ 'newspack-color-picker__expander' }
 				onClick={ () => setIsExpanded( ! isExpanded ) }

--- a/packages/components/src/color-picker/index.js
+++ b/packages/components/src/color-picker/index.js
@@ -37,12 +37,15 @@ const ColorPicker = ( { label, help, color = '#ffffff', onChange, className } ) 
 	const [ isExpanded, setIsExpanded ] = useState( false );
 	const ref = useRef();
 	const id = useInstanceId( ColorPicker, 'newspack-color-picker' );
+	const labelId = `${ id }-label`;
 	const colordColor = colord( color );
 	hooks.useOnClickOutside( ref, () => setIsExpanded( false ) );
 	return (
-		<BaseControl className={ classnames( 'newspack-color-picker', className ) } id={ id } label={ label } help={ help }>
+		<BaseControl className={ classnames( 'newspack-color-picker', className ) } help={ help }>
+			<BaseControl.VisualLabel id={ labelId }>{ label }</BaseControl.VisualLabel>
 			<InteractiveDiv
 				id={ id }
+				aria-labelledby={ labelId }
 				aria-expanded={ isExpanded }
 				className={ 'newspack-color-picker__expander' }
 				onClick={ () => setIsExpanded( ! isExpanded ) }

--- a/packages/components/src/color-picker/index.test.js
+++ b/packages/components/src/color-picker/index.test.js
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+import { render, fireEvent } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import ColorPicker from './';
+
+describe( 'ColorPicker', () => {
+	it( 'should render the label', () => {
+		const { getByText } = render( <ColorPicker label="Background color" onChange={ () => {} } /> );
+		expect( getByText( 'Background color' ) ).toBeInTheDocument();
+	} );
+
+	it( 'should render help text', () => {
+		const { getByText } = render( <ColorPicker label="Background color" help="Choose a color" onChange={ () => {} } /> );
+		expect( getByText( 'Choose a color' ) ).toBeInTheDocument();
+	} );
+
+	it( 'should start collapsed', () => {
+		const { getByRole } = render( <ColorPicker label="Background color" onChange={ () => {} } /> );
+		expect( getByRole( 'button' ) ).toHaveAttribute( 'aria-expanded', 'false' );
+	} );
+
+	it( 'should expand when the expander is clicked', () => {
+		const { getByRole } = render( <ColorPicker label="Background color" onChange={ () => {} } /> );
+		const expander = getByRole( 'button' );
+		fireEvent.click( expander );
+		expect( expander ).toHaveAttribute( 'aria-expanded', 'true' );
+	} );
+
+	it( 'should associate label via aria-labelledby', () => {
+		const { getByRole, getByText } = render( <ColorPicker label="Background color" onChange={ () => {} } /> );
+		const expander = getByRole( 'button' );
+		const label = getByText( 'Background color' );
+		expect( expander.getAttribute( 'aria-labelledby' ) ).toBe( label.id );
+	} );
+
+	it( 'should associate help text via aria-describedby when help is provided', () => {
+		const { getByRole, getByText } = render( <ColorPicker label="Background color" help="Choose a color" onChange={ () => {} } /> );
+		const expander = getByRole( 'button' );
+		const help = getByText( 'Choose a color' );
+		expect( expander.getAttribute( 'aria-describedby' ) ).toBe( help.id );
+	} );
+
+	it( 'should not set aria-describedby when no help is provided', () => {
+		const { getByRole } = render( <ColorPicker label="Background color" onChange={ () => {} } /> );
+		expect( getByRole( 'button' ) ).not.toHaveAttribute( 'aria-describedby' );
+	} );
+} );

--- a/packages/components/src/color-picker/style.scss
+++ b/packages/components/src/color-picker/style.scss
@@ -2,31 +2,29 @@
  * Color Picker
  */
 
+@use "~@wordpress/base-styles/colors" as wp-colors;
+@use "~@wordpress/base-styles/variables" as wp-vars;
+
 .newspack-color-picker {
 	position: relative;
-
-	&__label {
-		margin-bottom: 8px;
-	}
-
 	&__expander {
-		box-shadow: inset 0 0 0 1px rgb(0 0 0 / 20%);
-		border-radius: 2px;
-		height: 64px;
-		padding: 12px;
+		box-shadow: inset 0 0 0 1px rgba(wp-colors.$black, 0.54);
+		border-radius: wp-vars.$radius-small;
+		height: wp-vars.$grid-unit-80;
+		padding: wp-vars.$grid-unit-10;
 		text-align: right;
 		text-transform: uppercase;
 
 		&:focus-visible {
 			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
-			border-color: white;
+			border-color: wp-colors.$white;
 		}
 	}
 
 	&__main {
-		background: white;
-		box-shadow: 0 0 8px 4px rgba(black, 0.08);
-		margin: 12px 0;
+		background: wp-colors.$white;
+		box-shadow: wp-vars.$elevation-small;
+		margin: wp-vars.$grid-unit-10 0 0;
 		position: absolute;
 		z-index: 2;
 

--- a/src/wizards/newspack/views/settings/additional-brands/style.scss
+++ b/src/wizards/newspack/views/settings/additional-brands/style.scss
@@ -29,11 +29,4 @@
 		display: flex;
 		align-items: baseline;
 	}
-
-	&__theme-mod-color-picker {
-		.newspack-color-picker__label {
-			display: flex;
-			justify-content: space-between;
-		}
-	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Similar to https://github.com/Automattic/newspack-plugin/pull/4580 we need to stop having "hard coded" labels and start using `BaseControl` for these.

Aslo, I added support for a help text.

### How to test the changes in this Pull Request:

1. Go somewhere we have a color picker (e.g. Newspack > Settings > Theme and brand)
2. Notice the label looks off compared with the other settings
3. Switch to this branch
4. Test if the color picker still works and notice now the labels are in caps

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->