### PR TITLE
feat(components): add CardFeature component

### DIFF
--- a/packages/components/src/card-feature/README.md
+++ b/packages/components/src/card-feature/README.md
@@ -1,0 +1,187 @@
+# CardFeature
+
+A card component for presenting a named feature or setting with a predictable, state-driven interaction model. It handles the primary button, an optional "More" dropdown, and a badge automatically based on the `enabled` and `requirements` props.
+
+## Layout rules
+
+- **Maximum 2 cards per row.** Use `<Grid columns={ 2 }>` — never 3 or more. Cards are designed to be read, not scanned, and 3+ columns makes them too narrow for the content.
+- The icon is always displayed on the **right-hand side**, aligned to the top of the content.
+
+## States
+
+| State | Condition | Button | Dropdown | Badge |
+|---|---|---|---|---|
+| **Unmet requirements** | `requirements` is set | "Enable" — disabled | Hidden | Error badge with `requirements` text |
+| **Disabled** | `!enabled`, no requirements | "Enable" | Hidden | None |
+| **Enabled** | `enabled`, no requirements | "Configure" | Shown if `moreControls` provided | Success badge ("Enabled") |
+
+The card content (title + description) is visually muted (gray text, lighter border) when `requirements` is set.
+
+## Basic usage
+
+```tsx
+import { __ } from '@wordpress/i18n';
+
+<CardFeature
+	title={ __( 'Metered countdown', 'newspack-plugin' ) }
+	description={ __( 'Show a countdown banner letting readers know how many free views they have left.', 'newspack-plugin' ) }
+	enabled={ isEnabled }
+	onEnable={ () => setEnabled( true ) }
+	onConfigure={ () => history.push( '/settings/countdown' ) }
+	moreControls={ [
+		{ title: __( 'Disable', 'newspack-plugin' ), onClick: () => setEnabled( false ) },
+	] }
+/>
+```
+
+## With unmet requirements
+
+When `requirements` is set the button is disabled and an error badge displays the string. The title and description are visually muted.
+
+```tsx
+import { __ } from '@wordpress/i18n';
+
+<CardFeature
+	title={ __( 'Metered countdown', 'newspack-plugin' ) }
+	description={ __( 'Show a countdown banner letting readers know how many free views they have left.', 'newspack-plugin' ) }
+	enabled={ isEnabled }
+	requirements={ __( 'Requires metering', 'newspack-plugin' ) }
+	onEnable={ () => setEnabled( true ) }
+	onConfigure={ () => history.push( '/settings/countdown' ) }
+	moreControls={ [
+		{ title: __( 'Disable', 'newspack-plugin' ), onClick: () => setEnabled( false ) },
+	] }
+/>
+```
+
+## With a custom icon
+
+The `icon` prop accepts an object, not a bare node. Pass `node` for the icon element, `fill` to control the SVG colour (applied via `currentColor`), `backgroundColor` for a container background, and `radius` for the corner treatment.
+
+The icon container is always **40 × 40 px** with the SVG at **24 × 24 px**. `radius` only applies when `backgroundColor` is set.
+
+```tsx
+import { __ } from '@wordpress/i18n';
+import { Icon, starFilled } from '@wordpress/icons';
+
+// Icon with fill only
+<CardFeature
+	title={ __( 'Content gifting', 'newspack-plugin' ) }
+	description={ __( 'Let subscribers share gated articles with non-subscribers.', 'newspack-plugin' ) }
+	icon={ { node: <Icon icon={ starFilled } />, fill: '#003da5' } }
+	enabled={ isEnabled }
+	onEnable={ handleEnable }
+	onConfigure={ handleConfigure }
+	moreControls={ [ { title: __( 'Disable', 'newspack-plugin' ), onClick: handleDisable } ] }
+/>
+
+// Icon with circular background
+<CardFeature
+	title={ __( 'Content gifting', 'newspack-plugin' ) }
+	description={ __( 'Let subscribers share gated articles with non-subscribers.', 'newspack-plugin' ) }
+	icon={ { node: <Icon icon={ starFilled } />, fill: '#003da5', backgroundColor: '#dfe7f4', radius: 'full' } }
+	enabled={ isEnabled }
+	onEnable={ handleEnable }
+	onConfigure={ handleConfigure }
+	moreControls={ [ { title: __( 'Disable', 'newspack-plugin' ), onClick: handleDisable } ] }
+/>
+```
+
+## With custom button labels
+
+Override `enableLabel` and `configureLabel` to match the context of the feature.
+
+```tsx
+import { __ } from '@wordpress/i18n';
+
+<CardFeature
+	title={ __( 'Apple News', 'newspack-plugin' ) }
+	description={ __( 'Automatically publish articles to Apple News.', 'newspack-plugin' ) }
+	enabled={ isEnabled }
+	enableLabel={ __( 'Connect', 'newspack-plugin' ) }
+	configureLabel={ __( 'Manage connection', 'newspack-plugin' ) }
+	onEnable={ handleConnect }
+	onConfigure={ () => history.push( '/settings/apple-news' ) }
+	moreControls={ [ { title: __( 'Disconnect', 'newspack-plugin' ), onClick: handleDisconnect } ] }
+/>
+```
+
+## With a custom badge
+
+Override `badgeText` and `badgeLevel` to change the badge shown when the feature is enabled. Available levels: `default`, `info`, `success`, `warning`, `error`.
+
+```tsx
+import { __ } from '@wordpress/i18n';
+
+<CardFeature
+	title={ __( 'Stripe', 'newspack-plugin' ) }
+	description={ __( 'Accept payments via Stripe.', 'newspack-plugin' ) }
+	enabled={ isEnabled }
+	badgeText={ __( 'Live mode', 'newspack-plugin' ) }
+	badgeLevel="info"
+	onEnable={ handleEnable }
+	onConfigure={ () => history.push( '/settings/stripe' ) }
+	moreControls={ [ { title: __( 'Disable', 'newspack-plugin' ), onClick: handleDisable } ] }
+/>
+```
+
+## With multiple "More" controls
+
+`moreControls` accepts any number of items, each with a `title`, `onClick`, and an optional `icon`.
+
+```tsx
+import { __ } from '@wordpress/i18n';
+
+<CardFeature
+	title={ __( 'Newsletters', 'newspack-plugin' ) }
+	description={ __( 'Send newsletters directly from the WordPress editor.', 'newspack-plugin' ) }
+	enabled={ isEnabled }
+	onEnable={ handleEnable }
+	onConfigure={ () => history.push( '/settings/newsletters' ) }
+	moreControls={ [
+		{ title: __( 'Edit', 'newspack-plugin' ), onClick: handleEdit },
+		{ title: __( 'Preview', 'newspack-plugin' ), onClick: handlePreview },
+		{ title: __( 'Disable', 'newspack-plugin' ), onClick: handleDisable },
+	] }
+/>
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `title` | `string` | — | Card heading (**required**) |
+| `description` | `string` | — | Supporting text below the title |
+| `icon` | `CardFeatureIcon` | — | Icon displayed on the right. See `CardFeatureIcon` below. |
+| `enabled` | `boolean` | `false` | Whether the feature is currently enabled |
+| `requirements` | `string` | — | When set, enters the unmet-requirements state; value is used as the error badge text |
+| `enableLabel` | `string` | `"Enable"` | Primary button label when not enabled |
+| `configureLabel` | `string` | `"Configure"` | Primary button label when enabled |
+| `onEnable` | `() => void` | — | Called when the primary button is clicked and the feature is not enabled |
+| `onConfigure` | `() => void` | — | Called when the primary button is clicked and the feature is enabled |
+| `moreControls` | `MoreControl[]` | — | Items for the "More" dropdown, shown only when enabled |
+| `badgeText` | `string` | `"Enabled"` | Badge text shown when enabled |
+| `badgeLevel` | `BadgeLevel` | `"success"` | Badge level shown when enabled |
+| `className` | `string` | — | Additional class name applied to the card element |
+
+### `CardFeatureIcon`
+
+```ts
+type CardFeatureIcon = {
+	node: React.ReactNode;       // The icon element to render
+	fill?: string;               // SVG fill colour (applied via currentColor)
+	backgroundColor?: string;    // Background colour of the 40×40 container
+	radius?: 'small' | 'full';   // 'small' = 2px ($radius-small), 'full' = 50% ($radius-round)
+	                             // Only applied when backgroundColor is set.
+};
+```
+
+### `MoreControl`
+
+```ts
+type MoreControl = {
+	title: string;
+	onClick: () => void;
+	icon?: React.ReactNode;
+};
+```

--- a/packages/components/src/card-feature/index.tsx
+++ b/packages/components/src/card-feature/index.tsx
@@ -1,0 +1,168 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { DropdownMenu, __experimentalHStack as HStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import { moreVertical } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import Badge from '../badge';
+import Button from '../button';
+import Card from '../card';
+import './style.scss';
+
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+type BadgeLevel = 'default' | 'info' | 'success' | 'warning' | 'error';
+
+type CardFeatureIcon = {
+	/** The icon node to render (e.g. a WordPress <Icon> component). */
+	node: React.ReactNode;
+	/** SVG fill colour, applied via currentColor. */
+	fill?: string;
+	/** Background colour for the icon container. */
+	backgroundColor?: string;
+	/**
+	 * Border-radius of the icon container.
+	 * 'small' uses $radius-small (2px), 'full' uses $radius-round (50%).
+	 * Only relevant when backgroundColor is set.
+	 */
+	radius?: 'small' | 'full';
+};
+
+type MoreControl = {
+	title: string;
+	onClick: () => void;
+	icon?: React.ReactNode;
+};
+
+type CardFeatureProps = {
+	title: string;
+	description?: string;
+	/** Icon displayed on the right-hand side of the title and description. */
+	icon?: CardFeatureIcon;
+	/** Whether the feature is currently enabled. */
+	enabled?: boolean;
+	/**
+	 * When set, the card enters the "unmet requirements" state: the primary
+	 * button is disabled and an error badge displays this string.
+	 */
+	requirements?: string;
+	/** Primary button label when not enabled. Default: "Enable". */
+	enableLabel?: string;
+	/** Primary button label when enabled. Default: "Configure". */
+	configureLabel?: string;
+	/** Called when the primary button is clicked and the feature is not enabled. */
+	onEnable?: () => void;
+	/** Called when the primary button is clicked and the feature is enabled. */
+	onConfigure?: () => void;
+	/** Controls rendered inside the "More" dropdown, shown only when enabled. */
+	moreControls?: MoreControl[];
+	/** Badge text shown when enabled. Default: "Enabled". */
+	badgeText?: string;
+	/** Badge level shown when enabled. Default: "success". */
+	badgeLevel?: BadgeLevel;
+	className?: string;
+};
+
+/**
+ * CardFeature component.
+ *
+ * A card for presenting a named feature or setting with a predictable
+ * action model: a primary button, an optional "More" dropdown when enabled,
+ * and an automatic badge reflecting the current state.
+ */
+const CardFeature = ( {
+	title,
+	description,
+	icon,
+	enabled = false,
+	requirements,
+	enableLabel,
+	configureLabel,
+	onEnable,
+	onConfigure,
+	moreControls,
+	badgeText,
+	badgeLevel = 'success',
+	className,
+}: CardFeatureProps ) => {
+	const isMuted = !! requirements;
+	const classes = classnames( 'newspack-card-feature', className, {
+		'newspack-card-feature--muted': isMuted,
+	} );
+
+	let badge: { text: string; level: BadgeLevel } | undefined;
+	if ( requirements ) {
+		badge = { text: requirements, level: 'error' };
+	} else if ( enabled ) {
+		badge = { text: badgeText ?? __( 'Enabled', 'newspack-plugin' ), level: badgeLevel };
+	}
+
+	const buttonLabel =
+		enabled && ! requirements ? configureLabel ?? __( 'Configure', 'newspack-plugin' ) : enableLabel ?? __( 'Enable', 'newspack-plugin' );
+
+	const handleButtonClick = () => {
+		if ( enabled && ! requirements ) {
+			onConfigure?.();
+		} else {
+			onEnable?.();
+		}
+	};
+
+	const iconClasses = icon
+		? classnames( 'newspack-card-feature__icon', {
+				'newspack-card-feature__icon--radius-small': !! icon.backgroundColor && icon.radius !== 'full',
+				'newspack-card-feature__icon--radius-full': icon.radius === 'full',
+		  } )
+		: undefined;
+
+	return (
+		<Card
+			className={ classes }
+			__experimentalCoreCard
+			__experimentalCoreProps={ {
+				headerStyle: { padding: 32 },
+				header: (
+					<>
+						<HStack alignment="top" spacing={ 4 }>
+							<div className="newspack-card-feature__content">
+								<h2 className="newspack-card-feature__title">{ title }</h2>
+								{ description && <p className="newspack-card-feature__description">{ description }</p> }
+							</div>
+							{ icon && (
+								<div
+									className={ iconClasses }
+									style={ {
+										backgroundColor: icon.backgroundColor,
+										color: icon.fill,
+									} }
+								>
+									{ icon.node }
+								</div>
+							) }
+						</HStack>
+						<HStack alignment="edge">
+							<HStack expanded={ false } spacing="8px">
+								<Button variant="secondary" disabled={ isMuted } onClick={ handleButtonClick }>
+									{ buttonLabel }
+								</Button>
+								{ enabled && ! requirements && !! moreControls?.length && (
+									<DropdownMenu icon={ moreVertical } label={ __( 'More', 'newspack-plugin' ) } controls={ moreControls } />
+								) }
+							</HStack>
+							{ badge && <Badge text={ badge.text } level={ badge.level } /> }
+						</HStack>
+					</>
+				),
+			} }
+		/>
+	);
+};
+
+export default CardFeature;

--- a/packages/components/src/card-feature/index.tsx
+++ b/packages/components/src/card-feature/index.tsx
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -12,11 +17,6 @@ import Badge from '../badge';
 import Button from '../button';
 import Card from '../card';
 import './style.scss';
-
-/**
- * External dependencies
- */
-import classnames from 'classnames';
 
 type BadgeLevel = 'default' | 'info' | 'success' | 'warning' | 'error';
 

--- a/packages/components/src/card-feature/style.scss
+++ b/packages/components/src/card-feature/style.scss
@@ -49,9 +49,6 @@
 	}
 
 	// Unmet requirements state: lighter border, muted content.
-	// Use doubled base class (.newspack-card-feature.newspack-card-feature--muted) to
-	// produce specificity (0,3,0) and beat the .newspack-wizard .newspack-card--core__header-content h2
-	// rule in style-core.scss which compiles to (0,2,1).
 	&.newspack-card-feature--muted {
 		border-color: wp-colors.$gray-100;
 		box-shadow: wp-colors.$gray-100 0 0 0 1px;

--- a/packages/components/src/card-feature/style.scss
+++ b/packages/components/src/card-feature/style.scss
@@ -1,0 +1,64 @@
+/**
+ * CardFeature
+ */
+
+@use "~@wordpress/base-styles/colors" as wp-colors;
+@use "~@wordpress/base-styles/variables" as wp;
+
+.newspack-card-feature {
+	.newspack-card--core__header-content {
+		grid-gap: 16px;
+	}
+
+	&__content {
+		flex: 1;
+		min-width: 0; // prevent flex blowout on long words
+	}
+
+	&__title {
+		font-size: wp.$font-size-x-large;
+		line-height: wp.$font-line-height-x-large;
+		text-align: left;
+	}
+
+	&__description {
+		text-align: left;
+	}
+
+	&__icon {
+		align-items: center;
+		display: flex;
+		flex: 0 0 40px;
+		height: 40px;
+		justify-content: center;
+
+		svg {
+			display: block;
+			fill: currentcolor;
+			height: 24px;
+			width: 24px;
+		}
+
+		&--radius-small {
+			border-radius: wp.$radius-small;
+		}
+
+		&--radius-full {
+			border-radius: wp.$radius-round;
+		}
+	}
+
+	// Unmet requirements state: lighter border, muted content.
+	// Use doubled base class (.newspack-card-feature.newspack-card-feature--muted) to
+	// produce specificity (0,3,0) and beat the .newspack-wizard .newspack-card--core__header-content h2
+	// rule in style-core.scss which compiles to (0,2,1).
+	&.newspack-card-feature--muted {
+		border-color: wp-colors.$gray-100;
+		box-shadow: wp-colors.$gray-100 0 0 0 1px;
+
+		.newspack-card-feature__title,
+		.newspack-card-feature__description {
+			color: wp-colors.$gray-700;
+		}
+	}
+}

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -8,6 +8,7 @@ export { default as Button } from './button';
 export { default as ButtonCard } from './button-card';
 export { default as BoxContrast } from './box-contrast';
 export { default as Card } from './card';
+export { default as CardFeature } from './card-feature';
 export { default as CardSettingsGroup } from './card-settings-group';
 export { default as CardSortableList } from './card-sortable-list';
 export { default as CategoryAutocomplete } from './category-autocomplete';

--- a/src/wizards/audience/views/content-gates/content-gates.tsx
+++ b/src/wizards/audience/views/content-gates/content-gates.tsx
@@ -155,7 +155,7 @@ const ContentGates = ( { updateGatesData }: { updateGatesData: ( gates: Gate[] )
 						'newspack-plugin'
 					) }
 					enabled={ !! config.countdown_banner?.enabled }
-					requirements={ ! hasMetering ? __( 'Requires gate with metering', 'newspack-plugin' ) : undefined }
+					requirements={ ! hasMetering ? __( 'Requires metering', 'newspack-plugin' ) : undefined }
 					toggleEnabled={ toggleCountdownBanner.current }
 					href={ '/settings/countdown-banner' }
 				/>

--- a/src/wizards/audience/views/content-gates/settings-card.tsx
+++ b/src/wizards/audience/views/content-gates/settings-card.tsx
@@ -7,20 +7,13 @@
  * WordPress dependencies.
  */
 import { __ } from '@wordpress/i18n';
-import { DropdownMenu, __experimentalHStack as HStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
-import { moreVertical } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
-import { Button, Card, Router } from '../../../../../packages/components/src';
+import { CardFeature, Router } from '../../../../../packages/components/src';
 
 const { useHistory } = Router;
-
-/**
- * External dependencies
- */
-import classNames from 'classnames';
 
 type SettingsCardProps = {
 	title: string;
@@ -33,51 +26,21 @@ type SettingsCardProps = {
 
 const SettingsCard = ( { title, description, enabled, requirements, toggleEnabled = () => {}, href = '' }: SettingsCardProps ) => {
 	const history = useHistory();
-	const classes = classNames( 'newspack-content-gates__settings-card', {
-		'newspack-content-gates__settings-card--enabled': enabled && ! requirements,
-		'newspack-content-gates__settings-card--disabled': ! enabled || !! requirements,
-	} );
-	const status = enabled ? __( 'Enabled', 'newspack-plugin' ) : __( 'Disabled', 'newspack-plugin' );
-	const handleClick = () => {
-		if ( ! enabled ) {
-			toggleEnabled();
-		} else {
-			history.push( href );
-		}
-	};
+
 	return (
-		<Card
-			className={ classes }
-			__experimentalCoreCard
-			__experimentalCoreProps={ {
-				headerStyle: { padding: 32 },
-				header: (
-					<>
-						<h2>{ title }</h2>
-						{ description && <p className="newspack-content-gates__settings-card__description">{ description }</p> }
-						<HStack alignment="edge">
-							<HStack expanded={ false } justify="flex-start" spacing="8px" className="newspack-content-gates__settings-card__buttons">
-								<Button variant="secondary" disabled={ !! requirements } onClick={ handleClick }>
-									{ ! enabled || requirements ? __( 'Enable', 'newspack-plugin' ) : __( 'Configure', 'newspack-plugin' ) }
-								</Button>
-								{ enabled && ! requirements && (
-									<DropdownMenu
-										icon={ moreVertical }
-										label={ __( 'More', 'newspack-plugin' ) }
-										controls={ [
-											{
-												title: __( 'Disable', 'newspack-plugin' ),
-												onClick: toggleEnabled,
-											},
-										] }
-									/>
-								) }
-							</HStack>
-							<p className="newspack-content-gates__settings-card__status">{ requirements || status }</p>
-						</HStack>
-					</>
-				),
-			} }
+		<CardFeature
+			title={ title }
+			description={ description }
+			enabled={ enabled }
+			requirements={ requirements }
+			onEnable={ toggleEnabled }
+			onConfigure={ () => history.push( href ) }
+			moreControls={ [
+				{
+					title: __( 'Disable', 'newspack-plugin' ),
+					onClick: toggleEnabled,
+				},
+			] }
 		/>
 	);
 };

--- a/src/wizards/audience/views/content-gates/style.scss
+++ b/src/wizards/audience/views/content-gates/style.scss
@@ -52,44 +52,6 @@
 		&__other-settings {
 			margin-bottom: 32px;
 		}
-		&__settings-card {
-			p.newspack-content-gates__settings-card__description {
-				margin-bottom: 16px;
-			}
-			&__status {
-				color: var(--newspack-ui-color-error-60);
-				font-size: wp.$font-size-small;
-				text-transform: uppercase;
-				&::before {
-					background-color: var(--newspack-ui-color-error-60);
-					border-radius: 50%;
-					content: '';
-					display: inline-block;
-					height: 8px;
-					margin-right: 8px;
-					width: 8px;
-				}
-			}
-			&--enabled {
-				.newspack-content-gates__settings-card__status {
-					color: var(--newspack-ui-color-success-60);
-					&::before {
-						background-color: var(--newspack-ui-color-success-60);
-					}
-				}
-			}
-			&--disabled {
-				box-shadow: rgba(wp-colors.$black, 0.06) 0 0 0 1px;
-
-				:not(:has(.components-button.is-secondary[disabled])) .newspack-content-gates__settings-card__status {
-					color: var(--newspack-ui-color-neutral-60);
-					&::before {
-						background-color: var(--newspack-ui-color-neutral-60);
-					}
-				}
-			}
-		}
-
 		.components-form-token-field {
 			position: relative;
 			&__suggestions-list {

--- a/src/wizards/componentsDemo/index.js
+++ b/src/wizards/componentsDemo/index.js
@@ -25,6 +25,7 @@ import {
 	Button,
 	ButtonCard,
 	Card,
+	CardFeature,
 	CardSettingsGroup,
 	ColorPicker,
 	Footer,
@@ -72,6 +73,8 @@ class ComponentsDemo extends Component {
 				{ id: 5, title: 'Draggable Item 5' },
 			],
 			settingsGroupCardActive: false,
+			cardFeatureEnabled: false,
+			cardFeatureCustomEnabled: false,
 		};
 		this.dragWrapperRef = createRef();
 	}
@@ -918,6 +921,121 @@ class ComponentsDemo extends Component {
 						<BoxContrast hexColor="#51f1ff" isInverted>
 							#51f1ff / Inverted
 						</BoxContrast>
+					</Card>
+					<Card>
+						<h2>{ __( 'CardFeature', 'newspack-plugin' ) }</h2>
+						<p>
+							{ __(
+								'A state-driven feature card with a predictable action model. The button, dropdown, and badge are all derived from the enabled and requirements props.',
+								'newspack-plugin'
+							) }
+						</p>
+						<h3>{ __( 'States', 'newspack-plugin' ) }</h3>
+						<Grid columns={ 2 } gutter={ 16 }>
+							<CardFeature
+								title={ __( 'Metered countdown', 'newspack-plugin' ) }
+								description={ __(
+									'Show a countdown banner letting readers know how many free views they have left.',
+									'newspack-plugin'
+								) }
+								requirements={ __( 'Requires metering', 'newspack-plugin' ) }
+								onEnable={ () => {} }
+								onConfigure={ () => {} }
+							/>
+							<CardFeature
+								title={ __( 'Metered countdown', 'newspack-plugin' ) }
+								description={ __(
+									'Show a countdown banner letting readers know how many free views they have left.',
+									'newspack-plugin'
+								) }
+								enabled={ true }
+								onEnable={ () => {} }
+								onConfigure={ () => {} }
+								moreControls={ [ { title: __( 'Disable', 'newspack-plugin' ), onClick: () => {} } ] }
+							/>
+						</Grid>
+						<h3>{ __( 'Interactive toggle', 'newspack-plugin' ) }</h3>
+						<Grid columns={ 2 } gutter={ 16 }>
+							<CardFeature
+								title={ __( 'Metered countdown', 'newspack-plugin' ) }
+								description={ __(
+									'Show a countdown banner letting readers know how many free views they have left.',
+									'newspack-plugin'
+								) }
+								enabled={ this.state.cardFeatureEnabled }
+								onEnable={ () => this.setState( { cardFeatureEnabled: true } ) }
+								onConfigure={ () => {} }
+								moreControls={ [
+									{ title: __( 'Disable', 'newspack-plugin' ), onClick: () => this.setState( { cardFeatureEnabled: false } ) },
+								] }
+							/>
+						</Grid>
+						<h3>{ __( 'With a custom icon', 'newspack-plugin' ) }</h3>
+						<Grid columns={ 2 } gutter={ 16 }>
+							<CardFeature
+								title={ __( 'Content gifting', 'newspack-plugin' ) }
+								description={ __( 'Let subscribers share gated articles with non-subscribers.', 'newspack-plugin' ) }
+								icon={ { node: <Icon icon={ settings } />, fill: '#757575', backgroundColor: '#f0f0f0' } }
+								enabled={ false }
+								onEnable={ () => {} }
+								onConfigure={ () => {} }
+							/>
+							<CardFeature
+								title={ __( 'Content gifting', 'newspack-plugin' ) }
+								description={ __( 'Let subscribers share gated articles with non-subscribers.', 'newspack-plugin' ) }
+								icon={ { node: <Icon icon={ settings } />, fill: '#003da5', backgroundColor: '#dfe7f4', radius: 'full' } }
+								enabled={ true }
+								onEnable={ () => {} }
+								onConfigure={ () => {} }
+								moreControls={ [ { title: __( 'Disable', 'newspack-plugin' ), onClick: () => {} } ] }
+							/>
+						</Grid>
+						<h3>{ __( 'With custom button labels', 'newspack-plugin' ) }</h3>
+						<Grid columns={ 2 } gutter={ 16 }>
+							<CardFeature
+								title={ __( 'Apple News', 'newspack-plugin' ) }
+								description={ __( 'Automatically publish articles to Apple News.', 'newspack-plugin' ) }
+								enabled={ this.state.cardFeatureCustomEnabled }
+								enableLabel={ __( 'Connect', 'newspack-plugin' ) }
+								configureLabel={ __( 'Manage connection', 'newspack-plugin' ) }
+								onEnable={ () => this.setState( { cardFeatureCustomEnabled: true } ) }
+								onConfigure={ () => {} }
+								moreControls={ [
+									{
+										title: __( 'Disconnect', 'newspack-plugin' ),
+										onClick: () => this.setState( { cardFeatureCustomEnabled: false } ),
+									},
+								] }
+							/>
+						</Grid>
+						<h3>{ __( 'With a custom badge', 'newspack-plugin' ) }</h3>
+						<Grid columns={ 2 } gutter={ 16 }>
+							<CardFeature
+								title={ __( 'Stripe', 'newspack-plugin' ) }
+								description={ __( 'Accept payments via Stripe.', 'newspack-plugin' ) }
+								enabled={ true }
+								badgeText={ __( 'Live mode', 'newspack-plugin' ) }
+								badgeLevel="info"
+								onEnable={ () => {} }
+								onConfigure={ () => {} }
+								moreControls={ [ { title: __( 'Disable', 'newspack-plugin' ), onClick: () => {} } ] }
+							/>
+						</Grid>
+						<h3>{ __( 'With multiple dropdown controls', 'newspack-plugin' ) }</h3>
+						<Grid columns={ 2 } gutter={ 16 }>
+							<CardFeature
+								title={ __( 'Newsletters', 'newspack-plugin' ) }
+								description={ __( 'Send newsletters directly from the WordPress editor.', 'newspack-plugin' ) }
+								enabled={ true }
+								onEnable={ () => {} }
+								onConfigure={ () => {} }
+								moreControls={ [
+									{ title: __( 'Edit', 'newspack-plugin' ), onClick: () => {} },
+									{ title: __( 'Preview', 'newspack-plugin' ), onClick: () => {} },
+									{ title: __( 'Disable', 'newspack-plugin' ), onClick: () => {} },
+								] }
+							/>
+						</Grid>
 					</Card>
 					<Card>
 						<h2>{ __( 'Newspack Icons', 'newspack-plugin' ) }</h2>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds a new `CardFeature` component to `packages/components/src/card-feature/` for presenting a named feature or setting with a predictable, state-driven interaction model.

The component automatically derives its button label, dropdown visibility, and badge from two props: `enabled` and `requirements`. There are three states:

- **Unmet requirements** (`requirements` set): button is disabled, an error badge displays the requirements text, and the card content is visually muted (gray text, lighter border).
- **Disabled** (`!enabled`, no requirements): "Enable" button shown, no badge, no dropdown.
- **Enabled** (`enabled`, no requirements): "Configure" button shown, success badge ("Enabled"), optional "More" dropdown with `moreControls` items.

The icon prop accepts a `CardFeatureIcon` object with `node`, `fill` (applied via `currentColor`), `backgroundColor`, and `radius` (`small` | `full`). The icon is displayed on the right-hand side and is always 40×40 px with a 24×24 px SVG. The component is designed for a maximum of 2 per row.

`SettingsCard` in the Audience wizard is refactored to use `CardFeature`, replacing a custom dot-based status indicator with the standard `Badge` component. The requirements string "Requires gate with metering" is also shortened to "Requires metering" throughout.

A full demo section is added to the ComponentsDemo wizard covering all states, interactive toggle, custom icon, custom button labels, custom badge, and multiple dropdown controls. A `README.md` documents all props and usage examples.

### How to test the changes in this Pull Request:

1. Navigate to **Audience → Access control** in wp-admin. Verify the two settings cards ("Metered countdown" and "Content gifting") render correctly with the new `CardFeature` layout — badge instead of dot indicator, "More" dropdown when enabled.
2. With no metered gate configured, verify the "Metered countdown" card shows "Requires metering" in an error badge and has a disabled "Enable" button with muted title/description.
3. Enable metering on a gate, return to the Access control screen, and verify "Metered countdown" can be enabled. Confirm the badge changes to "Enabled" (success level) and the "More" dropdown with "Disable" appears.
4. Click "Configure" on an enabled settings card and verify navigation to the settings route.
5. Click "Disable" in the "More" dropdown and verify the card returns to the disabled state.
6. Navigate to the **Components demo** page. Locate the "CardFeature" section and verify all sub-sections render correctly: States, Interactive toggle, Custom icon, Custom button labels, Custom badge, and Multiple dropdown controls.
7. In the "Interactive toggle" demo, click "Enable" and verify the badge and button update. Open the "More" dropdown and click "Disable" to verify the toggle works in both directions.
8. Verify icon rendering in the "Custom icon" demos: one with a plain fill, one with a circular background (`radius: 'full'`).
9. In the "Multiple dropdown controls" demo, open the "More" dropdown and verify three items appear: Edit, Preview, Disable.
10. Inspect the muted card (unmet requirements) and verify the border uses `$gray-100` and the title/description text is `$gray-700`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?