### PR TITLE
feat(content-gate): institutional access redirect and loading UX

### DIFF
--- a/includes/content-gate/class-institution.php
+++ b/includes/content-gate/class-institution.php
@@ -270,9 +270,9 @@ class Institution {
 	 * Check visitor's IP against all institutional IP ranges.
 	 * Hooked to newspack_content_gate_check_ip filter.
 	 *
-	 * @param bool $valid_ip Current validation result.
+	 * @param bool|int $valid_ip Current validation result.
 	 *
-	 * @return bool Whether the IP matches any institutional IP range.
+	 * @return bool|int The matching institution post ID, or the original value.
 	 */
 	public static function check_ip( $valid_ip ) {
 		if ( $valid_ip ) {
@@ -285,9 +285,9 @@ class Institution {
 		}
 
 		$institutions = self::get_cached_institutions();
-		foreach ( $institutions as $rules ) {
+		foreach ( $institutions as $inst_id => $rules ) {
 			if ( ! empty( $rules['ip_range'] ) && IP_Access_Rule::ip_matches_ranges( $visitor_ip, $rules['ip_range'] ) ) {
-				return true;
+				return $inst_id;
 			}
 		}
 

--- a/includes/content-gate/class-ip-access-rule.php
+++ b/includes/content-gate/class-ip-access-rule.php
@@ -7,6 +7,9 @@
 
 namespace Newspack\Content_Gate;
 
+use Newspack\Newspack;
+use Newspack\Newspack_UI;
+
 /**
  * IP Access Rule class.
  */
@@ -23,11 +26,23 @@ class IP_Access_Rule {
 	const ENDPOINT = 'institutional-access';
 
 	/**
+	 * The query parameter name for the IP check result.
+	 */
+	const RESULT_PARAM = 'institutional-access-result';
+
+	/**
+	 * The REST API route for the IP check.
+	 */
+	const REST_ROUTE = 'institutional-access/check';
+
+	/**
 	 * Initialize hooks.
 	 */
 	public static function init() {
 		add_action( 'init', [ __CLASS__, 'add_rewrite_rule' ] );
+		add_action( 'rest_api_init', [ __CLASS__, 'register_rest_route' ] );
 		add_action( 'template_redirect', [ __CLASS__, 'handle_redirect' ] );
+		add_action( 'template_redirect', [ __CLASS__, 'handle_result_notice' ] );
 	}
 
 	/**
@@ -45,7 +60,54 @@ class IP_Access_Rule {
 	}
 
 	/**
-	 * Handle the institutional access redirect.
+	 * Register the REST API route for IP checking.
+	 */
+	public static function register_rest_route() {
+		\register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			self::REST_ROUTE,
+			[
+				'methods'             => 'GET',
+				'callback'            => [ __CLASS__, 'check_ip_rest' ],
+				'permission_callback' => '__return_true',
+			]
+		);
+	}
+
+	/**
+	 * REST API callback: check the visitor's IP and set the cookie if valid.
+	 *
+	 * @return \WP_REST_Response
+	 */
+	public static function check_ip_rest() {
+		if ( function_exists( 'batcache_cancel' ) ) {
+			batcache_cancel();
+		}
+		nocache_headers();
+
+		/** This filter is documented in handle_redirect(). */
+		$result = apply_filters( 'newspack_content_gate_check_ip', false );
+
+		if ( $result ) {
+			setcookie( self::COOKIE_NAME, '1', time() + MONTH_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN ); // phpcs:ignore
+		}
+
+		$data = [ 'valid' => (bool) $result ];
+		if ( is_int( $result ) ) {
+			$data['institution'] = get_the_title( $result );
+		}
+
+		return new \WP_REST_Response( $data );
+	}
+
+	/**
+	 * Handle the institutional access check.
+	 *
+	 * For `?institutional-access=1` on any URL: performs the IP check server-side,
+	 * then redirects back to the same URL with a result parameter.
+	 *
+	 * For the dedicated `/institutional-access` endpoint: renders a loading page
+	 * that performs the check via the REST API and redirects on completion.
 	 */
 	public static function handle_redirect() {
 		if ( ! get_query_var( self::ENDPOINT ) ) {
@@ -58,20 +120,224 @@ class IP_Access_Rule {
 		}
 		nocache_headers();
 
+		// Check if this is the dedicated endpoint or a query param on a regular URL.
+		$request_path = wp_parse_url( $_SERVER['REQUEST_URI'], PHP_URL_PATH ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
+		$is_dedicated = (bool) preg_match( '#^/?' . preg_quote( self::ENDPOINT, '#' ) . '/?$#', trim( $request_path, '/' ) );
+
+		if ( $is_dedicated ) {
+			self::render_loading_page();
+			exit;
+		}
+
+		// Query param on a regular URL: server-side check and redirect.
 		/**
 		 * Filter whether the current IP is valid for content gate access.
 		 *
-		 * @param bool $valid_ip Whether the IP is valid. Default false.
+		 * @param bool|int $valid_ip Whether the IP is valid, or institution post ID. Default false.
 		 */
-		$valid_ip = apply_filters( 'newspack_content_gate_check_ip', false );
+		$result = apply_filters( 'newspack_content_gate_check_ip', false );
 
-		if ( $valid_ip ) {
+		if ( $result ) {
 			setcookie( self::COOKIE_NAME, '1', time() + MONTH_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN ); // phpcs:ignore
 		}
 
-		wp_safe_redirect( home_url( '/' ) );
+		$redirect_url = self::get_redirect_url();
+		$redirect_url = add_query_arg( self::RESULT_PARAM, $result ? 'success' : 'failure', $redirect_url );
+		if ( is_int( $result ) ) {
+			$redirect_url = add_query_arg( 'institution', rawurlencode( get_the_title( $result ) ), $redirect_url );
+		}
+		wp_safe_redirect( $redirect_url );
 		exit;
 	}
+
+	/**
+	 * Display a snackbar notice based on the IP check result parameter.
+	 */
+	public static function handle_result_notice() {
+		if ( empty( $_GET[ self::RESULT_PARAM ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return;
+		}
+
+		$result = sanitize_text_field( wp_unslash( $_GET[ self::RESULT_PARAM ] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		if ( 'success' === $result ) {
+			$institution = ! empty( $_GET['institution'] ) ? sanitize_text_field( wp_unslash( $_GET['institution'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$message     = $institution
+				/* translators: %s: institution name */
+				? sprintf( __( 'Access granted via %s.', 'newspack-plugin' ), '<strong>' . esc_html( $institution ) . '</strong>' )
+				: __( 'Access confirmed.', 'newspack-plugin' );
+			Newspack_UI::add_notice(
+				$message,
+				[
+					'type'     => 'success',
+					'autohide' => true,
+				]
+			);
+		} elseif ( 'failure' === $result ) {
+			Newspack_UI::add_notice(
+				__( "We couldn't verify your location. Make sure you're on your organization's network and try again.", 'newspack-plugin' ),
+				[
+					'type'     => 'warning',
+					'autohide' => false,
+				]
+			);
+		}
+	}
+
+	/**
+	 * Get the URL to redirect to after the IP check (for query param usage).
+	 *
+	 * Rebuilds the current URL without the institutional-access parameter.
+	 *
+	 * @return string The redirect URL.
+	 */
+	private static function get_redirect_url() {
+		$request_path = wp_parse_url( $_SERVER['REQUEST_URI'], PHP_URL_PATH ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
+		$url          = home_url( $request_path );
+
+		// Rebuild query string without the institutional-access param.
+		$query = $_GET; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		unset( $query[ self::ENDPOINT ] );
+		if ( ! empty( $query ) ) {
+			$url = add_query_arg( $query, $url );
+		}
+
+		return $url;
+	}
+
+	/**
+	 * Get the URL to redirect to from the dedicated endpoint.
+	 *
+	 * Checks redirect_to param, then Referer header, then falls back to homepage.
+	 *
+	 * @return string The redirect URL.
+	 */
+	private static function get_dedicated_redirect_url() {
+		$home = home_url( '/' );
+
+		if ( ! empty( $_GET['redirect_to'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput
+			$url = esc_url_raw( wp_unslash( $_GET['redirect_to'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput
+			if ( wp_validate_redirect( $url, $home ) !== $home || $url === $home ) {
+				return $url;
+			}
+		}
+
+		$referer = wp_get_referer();
+		if ( $referer && wp_validate_redirect( $referer, $home ) !== $home ) {
+			return $referer;
+		}
+
+		return $home;
+	}
+
+	/**
+	 * Render the loading page for the dedicated /institutional-access endpoint.
+	 *
+	 * Outputs a standalone HTML page with a loading spinner that performs
+	 * the IP check via the REST API and redirects on completion.
+	 */
+	private static function render_loading_page() {
+		$redirect_url = self::get_dedicated_redirect_url();
+		$rest_url     = rest_url( NEWSPACK_API_NAMESPACE . '/' . self::REST_ROUTE );
+		$result_param = self::RESULT_PARAM;
+		$site_name    = get_bloginfo( 'name' );
+		$timeout_ms   = 10000;
+		?>
+		<!DOCTYPE html>
+		<html <?php language_attributes(); ?>>
+		<head>
+			<meta charset="<?php bloginfo( 'charset' ); ?>">
+			<meta name="viewport" content="width=device-width, initial-scale=1">
+			<meta name="robots" content="noindex, nofollow">
+			<title><?php echo esc_html( $site_name ); ?> — <?php esc_html_e( 'Verifying access', 'newspack-plugin' ); ?></title>
+			<?php wp_head(); ?>
+			<style>
+				.newspack-ui__ip-check__actions { display: none; }
+				.newspack-ui__ip-check--error .newspack-ui__spinner > span { display: none; }
+				.newspack-ui__ip-check--error .newspack-ui__ip-check__actions { display: flex; gap: var(--newspack-ui-spacer-2); justify-content: center; }
+			</style>
+		</head>
+		<body>
+			<div class="newspack-ui" id="ip-check">
+				<div class="newspack-ui__spinner">
+					<span></span>
+					<p class="newspack-ui__font--m" id="ip-check-message"><?php esc_html_e( 'Verifying your access…', 'newspack-plugin' ); ?></p>
+					<p class="newspack-ui__font--xs" id="ip-check-detail" style="color: var(--newspack-ui-color-neutral-50);"><?php esc_html_e( "You'll be redirected in a few seconds.", 'newspack-plugin' ); ?></p>
+					<div class="newspack-ui__ip-check__actions" id="ip-check-actions">
+						<button class="newspack-ui__button newspack-ui__button--primary newspack-ui__button--small" onclick="location.reload()"><?php esc_html_e( 'Try again', 'newspack-plugin' ); ?></button>
+						<a class="newspack-ui__button newspack-ui__button--outline newspack-ui__button--small" href="<?php echo esc_url( $redirect_url ); ?>"><?php esc_html_e( 'Continue to site', 'newspack-plugin' ); ?></a>
+					</div>
+				</div>
+			</div>
+			<script>
+			(function() {
+				var container = document.getElementById( 'ip-check' );
+				var messageEl = document.getElementById( 'ip-check-message' );
+				var detailEl  = document.getElementById( 'ip-check-detail' );
+				var redirectUrl = <?php echo wp_json_encode( $redirect_url ); ?>;
+				var resultParam = <?php echo wp_json_encode( $result_param ); ?>;
+
+				var controller = new AbortController();
+				var timer = setTimeout( function() {
+					controller.abort();
+					showError(
+						<?php echo wp_json_encode( __( 'Verification timed out.', 'newspack-plugin' ) ); ?>,
+						<?php echo wp_json_encode( __( 'Please check your connection and try again.', 'newspack-plugin' ) ); ?>
+					);
+				}, <?php echo (int) $timeout_ms; ?> );
+
+				var minDelay = new Promise( function( resolve ) { setTimeout( resolve, 1000 ); } );
+
+				Promise.all( [
+					fetch( <?php echo wp_json_encode( $rest_url ); ?>, {
+						credentials: 'same-origin',
+						signal: controller.signal
+					} ).then( function( response ) { return response.json(); } ),
+					minDelay
+				] )
+				.then( function( results ) { var data = results[0];
+					clearTimeout( timer );
+					if ( data.valid ) {
+						messageEl.textContent = data.institution
+							? <?php echo wp_json_encode( __( 'Access granted via ', 'newspack-plugin' ) ); ?> + data.institution + '.'
+							: <?php echo wp_json_encode( __( 'Access confirmed.', 'newspack-plugin' ) ); ?>;
+						detailEl.textContent = <?php echo wp_json_encode( __( 'Redirecting…', 'newspack-plugin' ) ); ?>;
+						setTimeout( function() {
+							var url = new URL( redirectUrl, location.origin );
+							url.searchParams.set( resultParam, 'success' );
+							if ( data.institution ) {
+								url.searchParams.set( 'institution', data.institution );
+							}
+							location.href = url.toString();
+						}, 1500 );
+					} else {
+						showError(
+							<?php echo wp_json_encode( __( "We couldn't verify your location.", 'newspack-plugin' ) ); ?>,
+							<?php echo wp_json_encode( __( "Make sure you're on your organization's network and try again.", 'newspack-plugin' ) ); ?>
+						);
+					}
+				} )
+				.catch( function() {
+					clearTimeout( timer );
+					showError(
+						<?php echo wp_json_encode( __( 'Verification failed.', 'newspack-plugin' ) ); ?>,
+						<?php echo wp_json_encode( __( 'An error occurred. Please try again.', 'newspack-plugin' ) ); ?>
+					);
+				} );
+
+				function showError( message, detail ) {
+					container.classList.add( 'newspack-ui__ip-check--error' );
+					messageEl.textContent = message;
+					detailEl.textContent = detail;
+				}
+			})();
+			</script>
+			<?php wp_footer(); ?>
+		</body>
+		</html>
+		<?php
+	}
+
 	/**
 	 * Check if an IP address matches any of the given ranges.
 	 *

--- a/includes/content-gate/class-ip-access-rule.php
+++ b/includes/content-gate/class-ip-access-rule.php
@@ -170,8 +170,8 @@ class IP_Access_Rule {
 			$institution = ! empty( $_GET['institution'] ) ? sanitize_text_field( wp_unslash( $_GET['institution'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			$message     = $institution
 				/* translators: %s: institution name */
-				? sprintf( __( 'Access granted via %s.', 'newspack-plugin' ), '<strong>' . esc_html( $institution ) . '</strong>' )
-				: __( 'Access confirmed.', 'newspack-plugin' );
+				? sprintf( __( 'Connected to %s.', 'newspack-plugin' ), '<strong>' . esc_html( $institution ) . '</strong>' )
+				: __( 'Connected to your organization.', 'newspack-plugin' );
 			Newspack_UI::add_notice(
 				$message,
 				[
@@ -305,8 +305,8 @@ class IP_Access_Rule {
 					clearTimeout( timer );
 					if ( data.valid ) {
 						messageEl.textContent = data.institution
-							? <?php echo wp_json_encode( __( 'Access granted via ', 'newspack-plugin' ) ); ?> + data.institution + '.'
-							: <?php echo wp_json_encode( __( 'Access confirmed.', 'newspack-plugin' ) ); ?>;
+							? <?php echo wp_json_encode( __( 'Connected to ', 'newspack-plugin' ) ); ?> + data.institution + '.'
+							: <?php echo wp_json_encode( __( 'Connected to your organization.', 'newspack-plugin' ) ); ?>;
 						detailEl.textContent = <?php echo wp_json_encode( __( 'Redirecting…', 'newspack-plugin' ) ); ?>;
 						setTimeout( function() {
 							var url = new URL( redirectUrl, location.origin );

--- a/includes/content-gate/class-ip-access-rule.php
+++ b/includes/content-gate/class-ip-access-rule.php
@@ -243,7 +243,7 @@ class IP_Access_Rule {
 	 */
 	private static function render_loading_page() {
 		$redirect_url = self::get_dedicated_redirect_url();
-		$rest_url     = rest_url( NEWSPACK_API_NAMESPACE . '/' . self::REST_ROUTE );
+		$rest_url     = rest_url( NEWSPACK_API_NAMESPACE . self::REST_ROUTE );
 		$result_param = self::RESULT_PARAM;
 		$site_name    = get_bloginfo( 'name' );
 		$timeout_ms   = 10000;

--- a/includes/content-gate/class-ip-access-rule.php
+++ b/includes/content-gate/class-ip-access-rule.php
@@ -7,7 +7,6 @@
 
 namespace Newspack\Content_Gate;
 
-use Newspack\Newspack;
 use Newspack\Newspack_UI;
 
 /**
@@ -33,7 +32,7 @@ class IP_Access_Rule {
 	/**
 	 * The REST API route for the IP check.
 	 */
-	const REST_ROUTE = 'institutional-access/check';
+	const REST_ROUTE = '/institutional-access/check';
 
 	/**
 	 * Initialize hooks.
@@ -157,6 +156,12 @@ class IP_Access_Rule {
 		if ( empty( $_GET[ self::RESULT_PARAM ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			return;
 		}
+
+		// Prevent this response from being cached so other users don't see the snackbar.
+		if ( function_exists( 'batcache_cancel' ) ) {
+			batcache_cancel();
+		}
+		nocache_headers();
 
 		$result = sanitize_text_field( wp_unslash( $_GET[ self::RESULT_PARAM ] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 

--- a/includes/content-gate/class-ip-access-rule.php
+++ b/includes/content-gate/class-ip-access-rule.php
@@ -102,14 +102,15 @@ class IP_Access_Rule {
 	/**
 	 * Handle the institutional access check.
 	 *
-	 * For `?institutional-access=1` on any URL: performs the IP check server-side,
-	 * then redirects back to the same URL with a result parameter.
+	 * For `?institutional-access=1` or `?institutional-access` on any URL:
+	 * performs the IP check server-side, then redirects back to the same URL
+	 * with a result parameter.
 	 *
 	 * For the dedicated `/institutional-access` endpoint: renders a loading page
 	 * that performs the check via the REST API and redirects on completion.
 	 */
 	public static function handle_redirect() {
-		if ( ! get_query_var( self::ENDPOINT ) ) {
+		if ( ! get_query_var( self::ENDPOINT ) && ! isset( $_GET[ self::ENDPOINT ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			return;
 		}
 

--- a/tests/unit-tests/content-gate/class-institution.php
+++ b/tests/unit-tests/content-gate/class-institution.php
@@ -392,7 +392,7 @@ class Newspack_Test_Institution extends WP_UnitTestCase {
 		delete_transient( Institution::TRANSIENT_KEY );
 
 		$_SERVER['REMOTE_ADDR'] = '192.168.1.50'; // phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__REMOTE_ADDR__
-		$this->assertTrue( Institution::check_ip( false ) );
+		$this->assertSame( $inst_id, Institution::check_ip( false ) );
 
 		$_SERVER['REMOTE_ADDR'] = '10.0.0.1'; // phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__REMOTE_ADDR__
 		delete_transient( Institution::TRANSIENT_KEY );

--- a/tests/unit-tests/content-gate/class-ip-access-rule.php
+++ b/tests/unit-tests/content-gate/class-ip-access-rule.php
@@ -60,4 +60,126 @@ class Newspack_Test_IP_Access_Rule extends WP_UnitTestCase {
 	public function test_invalid_ip_returns_false() {
 		$this->assertFalse( IP_Access_Rule::ip_matches_ranges( 'not-an-ip', '10.0.0.0/8' ) );
 	}
+
+	/**
+	 * Test that the REST route is registered.
+	 */
+	public function test_rest_route_registered() {
+		do_action( 'rest_api_init' );
+
+		$routes         = rest_get_server()->get_routes( NEWSPACK_API_NAMESPACE );
+		$expected_route = '/' . NEWSPACK_API_NAMESPACE . IP_Access_Rule::REST_ROUTE;
+		$this->assertArrayHasKey( $expected_route, $routes, 'The institutional access REST route should be registered.' );
+
+		$endpoint = $routes[ $expected_route ][0];
+		$this->assertArrayHasKey( 'GET', $endpoint['methods'], 'The route should accept GET requests.' );
+	}
+
+	/**
+	 * Test the REST endpoint returns the expected JSON shape.
+	 */
+	public function test_rest_endpoint_response_shape() {
+		$request  = new WP_REST_Request( 'GET', '/' . NEWSPACK_API_NAMESPACE . IP_Access_Rule::REST_ROUTE );
+		$response = rest_do_request( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertArrayHasKey( 'valid', $data, 'Response should contain a "valid" key.' );
+		$this->assertIsBool( $data['valid'] );
+	}
+
+	/**
+	 * Test the REST endpoint returns institution name when IP matches.
+	 */
+	public function test_rest_endpoint_with_institution() {
+		// Hook a filter that returns an institution post ID.
+		$inst_id = self::factory()->post->create( [ 'post_title' => 'Test Library' ] );
+		add_filter(
+			'newspack_content_gate_check_ip',
+			function () use ( $inst_id ) {
+				return $inst_id;
+			}
+		);
+
+		$request  = new WP_REST_Request( 'GET', '/' . NEWSPACK_API_NAMESPACE . IP_Access_Rule::REST_ROUTE );
+		$response = @rest_do_request( $request ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- setcookie/nocache_headers cannot send headers in tests.
+		$data = $response->get_data();
+
+		$this->assertTrue( $data['valid'] );
+		$this->assertSame( 'Test Library', $data['institution'] );
+
+		remove_all_filters( 'newspack_content_gate_check_ip' );
+		wp_delete_post( $inst_id, true );
+	}
+
+	/**
+	 * Test get_redirect_url rebuilds the URL without the institutional-access param.
+	 */
+	public function test_redirect_url_strips_endpoint_param() {
+		$original_uri           = isset( $_SERVER['REQUEST_URI'] ) ? $_SERVER['REQUEST_URI'] : null; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
+		$original_get           = $_GET; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$_SERVER['REQUEST_URI'] = '/some-article/?institutional-access=1&foo=bar';
+		$_GET                   = [
+			IP_Access_Rule::ENDPOINT => '1',
+			'foo'                    => 'bar',
+		];
+
+		$method = new ReflectionMethod( IP_Access_Rule::class, 'get_redirect_url' );
+		$method->setAccessible( true );
+		$url = $method->invoke( null );
+
+		$this->assertStringContainsString( '/some-article/', $url );
+		$this->assertStringContainsString( 'foo=bar', $url );
+		$this->assertStringNotContainsString( 'institutional-access', $url );
+
+		if ( null === $original_uri ) {
+			unset( $_SERVER['REQUEST_URI'] );
+		} else {
+			$_SERVER['REQUEST_URI'] = $original_uri;
+		}
+		$_GET = $original_get;
+	}
+
+	/**
+	 * Test get_dedicated_redirect_url uses redirect_to param.
+	 */
+	public function test_dedicated_redirect_url_uses_redirect_to() {
+		$_GET = [ 'redirect_to' => home_url( '/target-page/' ) ];
+
+		$method = new ReflectionMethod( IP_Access_Rule::class, 'get_dedicated_redirect_url' );
+		$method->setAccessible( true );
+		$url = $method->invoke( null );
+
+		$this->assertSame( home_url( '/target-page/' ), $url );
+
+		$_GET = [];
+	}
+
+	/**
+	 * Test get_dedicated_redirect_url rejects external URLs.
+	 */
+	public function test_dedicated_redirect_url_rejects_external() {
+		$_GET = [ 'redirect_to' => 'https://evil.com/steal' ];
+
+		$method = new ReflectionMethod( IP_Access_Rule::class, 'get_dedicated_redirect_url' );
+		$method->setAccessible( true );
+		$url = $method->invoke( null );
+
+		$this->assertSame( home_url( '/' ), $url );
+
+		$_GET = [];
+	}
+
+	/**
+	 * Test get_dedicated_redirect_url falls back to homepage.
+	 */
+	public function test_dedicated_redirect_url_fallback() {
+		$_GET = [];
+
+		$method = new ReflectionMethod( IP_Access_Rule::class, 'get_dedicated_redirect_url' );
+		$method->setAccessible( true );
+		$url = $method->invoke( null );
+
+		$this->assertSame( home_url( '/' ), $url );
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds redirect-back behavior and user-facing feedback to the institutional access IP check.

Publishers can now append `?institutional-access=1` to any page URL and have readers redirected back to that page after the IP verification, with a snackbar showing the result.

The dedicated `/institutional-access` endpoint now renders a loading page with a spinner that performs the check via a new REST API endpoint, then redirects on success or shows an actionable error on failure. A `redirect_to` query parameter is also supported for custom redirect targets.

### Loading state

<img width="444" height="320" alt="image" src="https://github.com/user-attachments/assets/eec526bf-9fcb-49d1-b329-cd87968c5a43" />

### 10-second timeout error

<img width="425" height="281" alt="image" src="https://github.com/user-attachments/assets/9f496451-3f0e-49cc-8c9b-4da13b6a5a3f" />

### No match error

<img width="536" height="267" alt="image" src="https://github.com/user-attachments/assets/c26bc644-783d-4fda-ba5b-7f98c0fdce58" />

### Success

<img width="414" height="266" alt="image" src="https://github.com/user-attachments/assets/49187db4-e8bf-435b-8ce1-2dc9732fef1b" />

### Redirection notice

<img width="377" height="149" alt="image" src="https://github.com/user-attachments/assets/a7e57dd5-13e3-420a-bcac-b6f179845910" />

Closes NPPD-1381.

### How to test the changes in this Pull Request:

1. Create an institution with an IP range that matches your local IP (e.g., `172.0.0.0/8` or your specific IP).
2. Assign the institution to a content gate with an `institution` access rule.
3. **Query param on any URL**: Visit a gated article with `?institutional-access=1` appended. Verify you are redirected back to the same article (without the param) and a success snackbar appears with the institution name.
4. **Query param — failure case**: Remove your IP from the institution's range and repeat step 3. Verify the snackbar shows a warning message that persists until dismissed.
5. **Dedicated endpoint**: Visit `/institutional-access/`. Verify a loading page appears with a spinner and "Verifying your access…" text. After ~1 second, it should show the institution name and redirect to the homepage with a success snackbar.
6. **Dedicated endpoint with `redirect_to`**: Visit `/institutional-access/?redirect_to=/some-article/`. Verify the redirect goes to the specified article after the check.
7. **Dedicated endpoint — failure case**: Remove your IP from the institution's range and visit `/institutional-access/`. Verify the loading page shows an error with "Try again" and "Continue to site" buttons.
8. **Open redirect protection**: Visit `/institutional-access/?redirect_to=https://evil.com`. Verify you are redirected to the homepage, not the external URL.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?