### PR TITLE
feat(content-gate): add POST method for external IP access checks

### DIFF
--- a/includes/content-gate/class-ip-access-rule.php
+++ b/includes/content-gate/class-ip-access-rule.php
@@ -67,20 +67,34 @@ class IP_Access_Rule {
 	}
 
 	/**
-	 * Register the REST API route for IP checking.
+	 * Register the REST API routes for IP checking.
 	 */
 	public static function register_rest_route() {
 		\register_rest_route(
 			NEWSPACK_API_NAMESPACE,
 			self::REST_ROUTE,
 			[
-				'methods'             => 'GET',
-				'callback'            => [ __CLASS__, 'check_ip_rest' ],
-				'permission_callback' => '__return_true',
-				'args'                => [
-					'institution_id' => [
-						'type'              => 'integer',
-						'sanitize_callback' => 'absint',
+				[
+					'methods'             => 'GET',
+					'callback'            => [ __CLASS__, 'check_ip_rest' ],
+					'permission_callback' => '__return_true',
+					'args'                => [
+						'institution_id' => [
+							'type'              => 'integer',
+							'sanitize_callback' => 'absint',
+						],
+					],
+				],
+				[
+					'methods'             => 'POST',
+					'callback'            => [ __CLASS__, 'check_external_ip_rest' ],
+					'permission_callback' => '__return_true',
+					'args'                => [
+						'ip' => [
+							'type'              => 'string',
+							'required'          => true,
+							'sanitize_callback' => 'sanitize_text_field',
+						],
 					],
 				],
 			]
@@ -134,6 +148,43 @@ class IP_Access_Rule {
 		}
 
 		return new \WP_REST_Response( $data );
+	}
+
+	/**
+	 * REST API callback for external IP queries via POST.
+	 *
+	 * Accepts a JSON body with an `ip` field and checks it against all
+	 * institutional IP ranges. Designed for server-to-server calls from
+	 * external platforms.
+	 *
+	 * Example request:
+	 *
+	 *     POST /wp-json/newspack/v1/institutional-access/check
+	 *     Content-Type: application/json
+	 *
+	 *     {"ip": "127.0.0.1"}
+	 *
+	 * @param \WP_REST_Request $request The REST request.
+	 * @return \WP_REST_Response
+	 */
+	public static function check_external_ip_rest( $request ) {
+		$ip = $request->get_param( 'ip' );
+		if ( ! filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 ) ) {
+			return new \WP_REST_Response(
+				[ 'error' => 'Only IPv4 addresses are supported.' ],
+				400
+			);
+		}
+
+		$override = fn() => $ip;
+		add_filter( 'newspack_visitor_ip', $override );
+
+		/** This filter is documented in self::handle_redirect(). */
+		$result = apply_filters( 'newspack_content_gate_check_ip', false );
+
+		remove_filter( 'newspack_visitor_ip', $override );
+
+		return new \WP_REST_Response( [ 'show_paywall' => ! (bool) $result ] );
 	}
 
 	/**

--- a/includes/content-gate/class-ip-access-rule.php
+++ b/includes/content-gate/class-ip-access-rule.php
@@ -88,7 +88,7 @@ class IP_Access_Rule {
 				[
 					'methods'             => 'POST',
 					'callback'            => [ __CLASS__, 'check_external_ip_rest' ],
-					'permission_callback' => '__return_true',
+					'permission_callback' => [ __CLASS__, 'check_external_ip_permission' ],
 					'args'                => [
 						'ip' => [
 							'type'              => 'string',
@@ -186,6 +186,15 @@ class IP_Access_Rule {
 		remove_filter( 'newspack_visitor_ip', $override );
 
 		return new \WP_REST_Response( [ 'show_paywall' => ! (bool) $result ] );
+	}
+
+	/**
+	 * Permission check for the external IP query endpoint.
+	 *
+	 * @return bool
+	 */
+	public static function check_external_ip_permission() {
+		return current_user_can( 'manage_options' );
 	}
 
 	/**

--- a/includes/content-gate/class-ip-access-rule.php
+++ b/includes/content-gate/class-ip-access-rule.php
@@ -165,14 +165,15 @@ class IP_Access_Rule {
 	 *     {"ip": "127.0.0.1"}
 	 *
 	 * @param \WP_REST_Request $request The REST request.
-	 * @return \WP_REST_Response
+	 * @return \WP_REST_Response|\WP_Error
 	 */
 	public static function check_external_ip_rest( $request ) {
 		$ip = $request->get_param( 'ip' );
 		if ( ! filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 ) ) {
-			return new \WP_REST_Response(
-				[ 'error' => 'Only IPv4 addresses are supported.' ],
-				400
+			return new \WP_Error(
+				'rest_invalid_param',
+				'Only IPv4 addresses are supported.',
+				[ 'status' => 400 ]
 			);
 		}
 

--- a/tests/unit-tests/content-gate/class-ip-access-rule.php
+++ b/tests/unit-tests/content-gate/class-ip-access-rule.php
@@ -273,9 +273,31 @@ class Newspack_Test_IP_Access_Rule extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test POST requires manage_options capability.
+	 */
+	public function test_post_requires_authentication() {
+		$route = '/' . NEWSPACK_API_NAMESPACE . IP_Access_Rule::REST_ROUTE;
+
+		// Unauthenticated request should be forbidden.
+		$request = new WP_REST_Request( 'POST', $route );
+		$request->set_param( 'ip', '10.0.0.1' );
+		$response = rest_do_request( $request );
+		$this->assertSame( 401, $response->get_status() );
+
+		// Non-admin user should be forbidden.
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'subscriber' ] ) );
+		$request = new WP_REST_Request( 'POST', $route );
+		$request->set_param( 'ip', '10.0.0.1' );
+		$response = rest_do_request( $request );
+		$this->assertSame( 403, $response->get_status() );
+	}
+
+	/**
 	 * Test POST returns 400 for missing or invalid ip param.
 	 */
 	public function test_post_requires_valid_ip_param() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
 		$route = '/' . NEWSPACK_API_NAMESPACE . IP_Access_Rule::REST_ROUTE;
 
 		// Missing param (handled by WP REST required arg validation).
@@ -300,6 +322,8 @@ class Newspack_Test_IP_Access_Rule extends WP_UnitTestCase {
 	 * Test POST returns correct show_paywall value.
 	 */
 	public function test_post_show_paywall_response() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
 		$route = '/' . NEWSPACK_API_NAMESPACE . IP_Access_Rule::REST_ROUTE;
 
 		// No match: show paywall.

--- a/tests/unit-tests/content-gate/class-ip-access-rule.php
+++ b/tests/unit-tests/content-gate/class-ip-access-rule.php
@@ -259,4 +259,71 @@ class Newspack_Test_IP_Access_Rule extends WP_UnitTestCase {
 		$this->assertFalse( $data['valid'] );
 		$this->assertArrayNotHasKey( 'institution', $data );
 	}
+
+	/**
+	 * Test the POST route is registered.
+	 */
+	public function test_post_route_registered() {
+		do_action( 'rest_api_init' );
+
+		$routes         = rest_get_server()->get_routes( NEWSPACK_API_NAMESPACE );
+		$expected_route = '/' . NEWSPACK_API_NAMESPACE . IP_Access_Rule::REST_ROUTE;
+		$endpoint       = $routes[ $expected_route ][1];
+		$this->assertArrayHasKey( 'POST', $endpoint['methods'], 'The route should accept POST requests.' );
+	}
+
+	/**
+	 * Test POST returns 400 for missing or invalid ip param.
+	 */
+	public function test_post_requires_valid_ip_param() {
+		$route = '/' . NEWSPACK_API_NAMESPACE . IP_Access_Rule::REST_ROUTE;
+
+		// Missing param (handled by WP REST required arg validation).
+		$request  = new WP_REST_Request( 'POST', $route );
+		$response = rest_do_request( $request );
+		$this->assertSame( 400, $response->get_status() );
+
+		// Invalid IP.
+		$request = new WP_REST_Request( 'POST', $route );
+		$request->set_param( 'ip', 'not-an-ip' );
+		$response = rest_do_request( $request );
+		$this->assertSame( 400, $response->get_status() );
+
+		// IPv6 not supported.
+		$request = new WP_REST_Request( 'POST', $route );
+		$request->set_param( 'ip', '2001:db8::1' );
+		$response = rest_do_request( $request );
+		$this->assertSame( 400, $response->get_status() );
+	}
+
+	/**
+	 * Test POST returns correct show_paywall value.
+	 */
+	public function test_post_show_paywall_response() {
+		$route = '/' . NEWSPACK_API_NAMESPACE . IP_Access_Rule::REST_ROUTE;
+
+		// No match: show paywall.
+		$request = new WP_REST_Request( 'POST', $route );
+		$request->set_param( 'ip', '203.0.113.50' );
+		$response = rest_do_request( $request );
+		$data     = $response->get_data();
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertTrue( $data['show_paywall'] );
+
+		// Match: hide paywall.
+		add_filter(
+			'newspack_content_gate_check_ip',
+			function () {
+				return 123;
+			}
+		);
+		$request = new WP_REST_Request( 'POST', $route );
+		$request->set_param( 'ip', '10.0.0.1' );
+		$response = rest_do_request( $request );
+		$data     = $response->get_data();
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertFalse( $data['show_paywall'] );
+
+		remove_all_filters( 'newspack_content_gate_check_ip' );
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds a POST method to the existing `/newspack/v1/institutional-access/check` endpoint for server-to-server IP access queries. External platforms can send a client IP in the JSON request body and receive a `show_paywall` boolean response, enabling paywall decisions based on institutional IP ranges without browser interaction.

The POST body accepts `{"ip": "<ipv4>"}` and the endpoint reuses the existing `newspack_content_gate_check_ip` filter by temporarily overriding the visitor IP. The `X-Forwarded-For` header approach was ruled out because the Newspack hosting infrastructure replaces that header with the caller's server IP.

Builds on #4593 and #4596.

Closes NPPD-1395.

### How to test the changes in this Pull Request:

1. Enable content gates: `define( 'NEWSPACK_CONTENT_GATES', true );` in `wp-config.php`.
2. Create an institution with an IP range (e.g. `192.168.1.0/24`) via Audience > Access Control > Institutions.
3. Create/activate a content gate with the "Institutional access" rule assigned to that institution.
4. **Matching IP**: `curl -X POST https://your-site.com/wp-json/newspack/v1/institutional-access/check -H "Content-Type: application/json" -d '{"ip": "192.168.1.50"}'` should return `{"show_paywall": false}`.
5. **Non-matching IP**: Same request with `"ip": "10.0.0.1"` should return `{"show_paywall": true}`.
6. **Missing param**: POST with empty body should return `400` with `Missing parameter(s): ip`.
7. **Invalid IP**: POST with `"ip": "not-an-ip"` should return `400` with `Only IPv4 addresses are supported.`.
8. **IPv6**: POST with `"ip": "2001:db8::1"` should return `400` with the same IPv4 message.
9. **GET still works**: Verify `GET /wp-json/newspack/v1/institutional-access/check` returns `{"valid": true, "institution": "..."}` as before.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?