### PR TITLE
fix(post-date): preserve classic theme markup and fix archive titles

### DIFF
--- a/includes/class-post-date.php
+++ b/includes/class-post-date.php
@@ -52,7 +52,7 @@ class Post_Date {
 		add_filter( 'newspack_blocks_formatted_displayed_post_date', [ __CLASS__, 'filter_blocks_formatted_date' ], 10, 2 );
 		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'enqueue_scripts' ] );
 		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'enqueue_editor_assets' ] );
-		add_action( 'newspack_theme_after_posted_on', [ __CLASS__, 'render_updated_date_classic' ] );
+		add_action( 'newspack_theme_posted_on', [ __CLASS__, 'render_updated_date_classic' ] );
 	}
 
 	/**
@@ -257,6 +257,12 @@ class Post_Date {
 			return $the_date;
 		}
 
+		// Only convert dates in the loop on singular views to avoid affecting
+		// archive titles (e.g. "Daily Archives: 2 days ago") and other contexts.
+		if ( ! in_the_loop() ) {
+			return $the_date;
+		}
+
 		$time_ago = self::convert_to_time_ago( $post->post_date_gmt, self::get_time_ago_cutoff_days() );
 
 		return null !== $time_ago ? $time_ago : $the_date;
@@ -281,7 +287,7 @@ class Post_Date {
 
 	/**
 	 * Render updated date for classic (non-block) themes.
-	 * Hooked to `newspack_theme_after_posted_on` which fires after `newspack_posted_on()`.
+	 * Hooked to `newspack_theme_posted_on` which fires inside `newspack_posted_on()`.
 	 */
 	public static function render_updated_date_classic() {
 		if ( wp_is_block_theme() || ! is_singular() ) {
@@ -306,13 +312,11 @@ class Post_Date {
 			}
 		}
 
-		/* translators: %s: Modified date. */
-		$label = sprintf( esc_html__( 'Updated %s', 'newspack-plugin' ), $modified_date );
-
 		printf(
-			'<span class="posted-on updated-date" data-newspack-modified><time class="entry-date updated" datetime="%1$s">%2$s</time></span>',
+			'<span class="updated-label">%1$s </span><time class="updated" datetime="%2$s">%3$s</time>',
+			esc_html__( 'Updated', 'newspack-plugin' ),
 			esc_attr( get_the_modified_date( DATE_W3C, $post ) ),
-			wp_kses_post( $label )
+			esc_html( $modified_date )
 		);
 	}
 
@@ -382,17 +386,9 @@ class Post_Date {
 	}
 
 	/**
-	 * Enqueue relative-time script and updated date styles on frontend.
+	 * Enqueue relative-time script on frontend.
 	 */
 	public static function enqueue_scripts() {
-		// Inline styles for the classic theme updated date.
-		// Always enqueue on classic themes since per-post overrides can show the date even when sitewide is off.
-		if ( ! wp_is_block_theme() ) {
-			wp_register_style( 'newspack-post-date', false, [], NEWSPACK_PLUGIN_VERSION );
-			wp_enqueue_style( 'newspack-post-date' );
-			wp_add_inline_style( 'newspack-post-date', '.entry-meta .updated-date { margin-inline-start: 1em; }' );
-		}
-
 		if ( ! get_theme_mod( 'post_time_ago', false ) ) {
 			return;
 		}

--- a/includes/class-post-date.php
+++ b/includes/class-post-date.php
@@ -53,6 +53,8 @@ class Post_Date {
 		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'enqueue_scripts' ] );
 		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'enqueue_editor_assets' ] );
 		add_action( 'newspack_theme_posted_on', [ __CLASS__, 'render_updated_date_classic' ] );
+		add_filter( 'body_class', [ __CLASS__, 'add_body_show_updated' ] );
+		add_filter( 'newspack_theme_include_hidden_updated_time', [ __CLASS__, 'suppress_theme_hidden_updated_time' ] );
 	}
 
 	/**
@@ -318,6 +320,38 @@ class Post_Date {
 			esc_attr( get_the_modified_date( DATE_W3C, $post ) ),
 			esc_html( $modified_date )
 		);
+	}
+
+	/**
+	 * Add 'show-updated' body class when the updated date should display on classic themes.
+	 *
+	 * @param string[] $classes Body CSS classes.
+	 * @return string[]
+	 */
+	public static function add_body_show_updated( $classes ) {
+		if ( wp_is_block_theme() || ! is_singular() ) {
+			return $classes;
+		}
+		if ( self::should_display_updated_date() ) {
+			$classes[] = 'show-updated';
+		}
+		return $classes;
+	}
+
+	/**
+	 * Suppress the theme's hidden <time class="updated"> when the plugin handles it.
+	 *
+	 * @param bool $include Whether to include the hidden updated time.
+	 * @return bool
+	 */
+	public static function suppress_theme_hidden_updated_time( $include ) {
+		if ( wp_is_block_theme() || ! is_singular() ) {
+			return $include;
+		}
+		if ( self::should_display_updated_date() ) {
+			return false;
+		}
+		return $include;
 	}
 
 	/**

--- a/includes/class-post-date.php
+++ b/includes/class-post-date.php
@@ -257,8 +257,8 @@ class Post_Date {
 			return $the_date;
 		}
 
-		// Only convert dates in the loop on singular views to avoid affecting
-		// archive titles (e.g. "Daily Archives: 2 days ago") and other contexts.
+		// Only convert dates in the loop to avoid affecting archive titles
+		// (e.g. "Daily Archives: 2 days ago") and other contexts.
 		if ( ! in_the_loop() ) {
 			return $the_date;
 		}

--- a/src/other-scripts/relative-time/index.js
+++ b/src/other-scripts/relative-time/index.js
@@ -74,7 +74,7 @@
 				el.setAttribute( 'title', new Date( datetime ).toLocaleString( localeTag ) );
 			}
 
-			// Only replace text on publish dates, not modified date blocks.
+			// Skip block-theme modified dates (label is inside <time>). Classic-theme ones are fine.
 			if ( el.closest( '[data-newspack-modified]' ) || el.closest( '.wp-block-post-date__modified-date' ) ) {
 				return;
 			}

--- a/src/other-scripts/relative-time/index.js
+++ b/src/other-scripts/relative-time/index.js
@@ -58,7 +58,9 @@
 			return; // No Intl support.
 		}
 
-		const elements = document.querySelectorAll( '.wp-block-post-date time[datetime], time.entry-date[datetime], .comment-meta time[datetime]' );
+		const elements = document.querySelectorAll(
+			'.wp-block-post-date time[datetime], time.entry-date[datetime], time.updated[datetime], .comment-meta time[datetime]'
+		);
 		const now = Date.now();
 
 		elements.forEach( function ( el ) {

--- a/tests/unit-tests/class-post-date-test.php
+++ b/tests/unit-tests/class-post-date-test.php
@@ -157,8 +157,13 @@ class Test_Post_Date extends \WP_UnitTestCase {
 			]
 		);
 
+		// Simulate being in the loop so the filter applies.
+		$GLOBALS['wp_query']->in_the_loop = true;
+
 		$date = get_the_date( '', $post_id );
 		$this->assertStringContainsString( 'ago', $date, 'get_the_date should return relative date when feature is on.' );
+
+		$GLOBALS['wp_query']->in_the_loop = false;
 	}
 
 	/**

--- a/tests/unit-tests/class-post-date-test.php
+++ b/tests/unit-tests/class-post-date-test.php
@@ -158,12 +158,33 @@ class Test_Post_Date extends \WP_UnitTestCase {
 		);
 
 		// Simulate being in the loop so the filter applies.
-		$GLOBALS['wp_query']->in_the_loop = true;
+		$original_in_the_loop = $GLOBALS['wp_query']->in_the_loop ?? null;
+
+		try {
+			$GLOBALS['wp_query']->in_the_loop = true;
+
+			$date = get_the_date( '', $post_id );
+			$this->assertStringContainsString( 'ago', $date, 'get_the_date should return relative date when feature is on.' );
+		} finally {
+			$GLOBALS['wp_query']->in_the_loop = $original_in_the_loop;
+		}
+	}
+
+	/**
+	 * Test get_the_date filter skips conversion outside the loop (e.g. archive titles).
+	 */
+	public function test_get_the_date_filter_skips_outside_loop() {
+		set_theme_mod( 'post_time_ago', true );
+		set_theme_mod( 'post_time_ago_cut_off', 14 );
+
+		$post_id = static::factory()->post->create(
+			[
+				'post_date' => gmdate( 'Y-m-d H:i:s', time() - 2 * HOUR_IN_SECONDS ),
+			]
+		);
 
 		$date = get_the_date( '', $post_id );
-		$this->assertStringContainsString( 'ago', $date, 'get_the_date should return relative date when feature is on.' );
-
-		$GLOBALS['wp_query']->in_the_loop = false;
+		$this->assertStringNotContainsString( 'ago', $date, 'get_the_date should not convert to time-ago outside the loop.' );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Follow-up to #4579. Addresses review feedback from @laurelfulford about preserving the classic theme's HTML markup for the updated date, and fixes the archive title regression.

- Renamed hook from `newspack_theme_after_posted_on` to `newspack_theme_posted_on` (now fires inside `newspack_posted_on()` in the theme)
- Changed classic theme output to bare inner elements (`<span class="updated-label">` + `<time class="updated">`) matching the old theme markup exactly
- Removed plugin's inline CSS for `.updated-date` (theme provides `.updated-label` styling)
- Added `in_the_loop()` guard to `filter_get_the_date` to prevent archive titles showing relative dates (e.g. "Daily Archives: 2 days ago")
- Added `time.updated[datetime]` to the relative-time JS selector so the updated date gets a hover tooltip on classic themes

**Requires companion theme PR:** Automattic/newspack-theme#2658. Must ship together.

Closes NPPD-1278.

### How to test the changes in this Pull Request:

1. Activate the **classic Newspack theme** (with the companion theme PR) and enable both "Show relative dates" and "Show last updated date" in Newspack > Settings > Advanced Settings > Post Date.
2. Create or find a post modified well after publication (at least 24 hours). Verify the markup is all inside one `.posted-on` span: `<time class="entry-date published">` + `<span class="updated-label">Updated </span>` + `<time class="updated">`.
3. Hover over both dates and verify both show a tooltip with the full date.
4. Visit a daily archive page and verify the title shows the full date, not "X days ago".
5. Switch to the **block theme**. Verify the updated date still renders correctly with `data-newspack-modified` and `wp-block-post-date__modified-date`.
6. Open a post in the block editor. Verify the "Hide/Show last updated date" toggle appears in the Summary panel.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?