### PR TITLE
feat(handoff): add URL-based handoff with customizable banner text

### DIFF
--- a/includes/api/class-plugins-controller.php
+++ b/includes/api/class-plugins-controller.php
@@ -156,6 +156,31 @@ class Plugins_Controller extends WP_REST_Controller {
 					'methods'             => 'POST',
 					'callback'            => [ $this, 'handoff_to_url' ],
 					'permission_callback' => [ $this, 'handoff_item_permissions_check' ],
+					'args'                => [
+						'destinationUrl'    => [
+							'required'          => true,
+							'type'              => 'string',
+							'sanitize_callback' => 'esc_url_raw',
+							'validate_callback' => [ $this, 'validate_same_site_url' ],
+						],
+						'handoffReturnUrl'  => [
+							'type'              => 'string',
+							'sanitize_callback' => 'esc_url_raw',
+							'validate_callback' => [ $this, 'validate_same_site_url' ],
+						],
+						'bannerText'        => [
+							'type'              => 'string',
+							'sanitize_callback' => 'sanitize_text_field',
+						],
+						'bannerButtonText'  => [
+							'type'              => 'string',
+							'sanitize_callback' => 'sanitize_text_field',
+						],
+						'showOnBlockEditor' => [
+							'type'    => 'boolean',
+							'default' => false,
+						],
+					],
 				],
 			]
 		);
@@ -339,15 +364,6 @@ class Plugins_Controller extends WP_REST_Controller {
 			return new \WP_Error( 'newspack_handoff_missing_url', __( 'destinationUrl is required.', 'newspack-plugin' ), [ 'status' => 400 ] );
 		}
 
-		// Reject external URLs to prevent open-redirect attacks.
-		$parsed_destination = wp_parse_url( $destination_url );
-		if ( ! empty( $parsed_destination['host'] ) ) {
-			$site_host = wp_parse_url( admin_url(), PHP_URL_HOST );
-			if ( $parsed_destination['host'] !== $site_host ) {
-				return new \WP_Error( 'newspack_handoff_invalid_url', __( 'destinationUrl must be a same-site URL.', 'newspack-plugin' ), [ 'status' => 400 ] );
-			}
-		}
-
 		$handoff_return_url   = $request->get_param( 'handoffReturnUrl' );
 		$show_on_block_editor = $request->get_param( 'showOnBlockEditor' );
 		$banner_text          = (string) $request->get_param( 'bannerText' );
@@ -355,10 +371,10 @@ class Plugins_Controller extends WP_REST_Controller {
 
 		update_option( NEWSPACK_HANDOFF, 'url' );
 		update_option( NEWSPACK_HANDOFF_SHOW_ON_BLOCK_EDITOR, (bool) $show_on_block_editor );
-		update_option( NEWSPACK_HANDOFF_BANNER_TEXT, sanitize_text_field( $banner_text ) );
-		update_option( NEWSPACK_HANDOFF_BANNER_BUTTON_TEXT, sanitize_text_field( $banner_button_text ) );
+		update_option( NEWSPACK_HANDOFF_BANNER_TEXT, $banner_text );
+		update_option( NEWSPACK_HANDOFF_BANNER_BUTTON_TEXT, $banner_button_text );
 		if ( ! empty( $handoff_return_url ) ) {
-			update_option( NEWSPACK_HANDOFF_RETURN_URL, esc_url( $handoff_return_url ) );
+			update_option( NEWSPACK_HANDOFF_RETURN_URL, $handoff_return_url );
 		}
 
 		$parsed_url = wp_parse_url( $destination_url );
@@ -369,7 +385,42 @@ class Plugins_Controller extends WP_REST_Controller {
 			}
 		}
 
-		return rest_ensure_response( [ 'HandoffLink' => esc_url_raw( $destination_url ) ] );
+		return rest_ensure_response( [ 'HandoffLink' => $destination_url ] );
+	}
+
+	/**
+	 * Validate that a URL is empty, relative, or a same-site http(s) URL.
+	 *
+	 * Runs before sanitize_callback, so the raw input is checked (e.g. `javascript:` is
+	 * caught here before `esc_url_raw` would silently strip the scheme).
+	 *
+	 * @param mixed            $value   Value being validated.
+	 * @param \WP_REST_Request $request Request object.
+	 * @param string           $param   Parameter name.
+	 * @return true|WP_Error True if valid, WP_Error otherwise.
+	 */
+	public function validate_same_site_url( $value, $request, $param ) {
+		if ( empty( $value ) ) {
+			return true;
+		}
+		$parsed = wp_parse_url( $value );
+		if ( false === $parsed ) {
+			// translators: %s is the parameter name.
+			return new WP_Error( 'rest_invalid_param', sprintf( __( '%s must be a valid URL.', 'newspack-plugin' ), $param ), [ 'status' => 400 ] );
+		}
+		$scheme = isset( $parsed['scheme'] ) ? strtolower( $parsed['scheme'] ) : '';
+		if ( $scheme && ! in_array( $scheme, [ 'http', 'https' ], true ) ) {
+			// translators: %s is the parameter name.
+			return new WP_Error( 'rest_invalid_param', sprintf( __( '%s must be an http(s) URL.', 'newspack-plugin' ), $param ), [ 'status' => 400 ] );
+		}
+		if ( ! empty( $parsed['host'] ) ) {
+			$site_host = wp_parse_url( admin_url(), PHP_URL_HOST );
+			if ( $parsed['host'] !== $site_host ) {
+				// translators: %s is the parameter name.
+				return new WP_Error( 'rest_invalid_param', sprintf( __( '%s must be a same-site URL.', 'newspack-plugin' ), $param ), [ 'status' => 400 ] );
+			}
+		}
+		return true;
 	}
 
 	/**

--- a/includes/api/class-plugins-controller.php
+++ b/includes/api/class-plugins-controller.php
@@ -339,6 +339,15 @@ class Plugins_Controller extends WP_REST_Controller {
 			return new \WP_Error( 'newspack_handoff_missing_url', __( 'destinationUrl is required.', 'newspack-plugin' ), [ 'status' => 400 ] );
 		}
 
+		// Reject external URLs to prevent open-redirect attacks.
+		$parsed_destination = wp_parse_url( $destination_url );
+		if ( ! empty( $parsed_destination['host'] ) ) {
+			$site_host = wp_parse_url( admin_url(), PHP_URL_HOST );
+			if ( $parsed_destination['host'] !== $site_host ) {
+				return new \WP_Error( 'newspack_handoff_invalid_url', __( 'destinationUrl must be a same-site URL.', 'newspack-plugin' ), [ 'status' => 400 ] );
+			}
+		}
+
 		$handoff_return_url   = $request->get_param( 'handoffReturnUrl' );
 		$show_on_block_editor = $request->get_param( 'showOnBlockEditor' );
 		$banner_text          = (string) $request->get_param( 'bannerText' );

--- a/includes/api/class-plugins-controller.php
+++ b/includes/api/class-plugins-controller.php
@@ -359,11 +359,7 @@ class Plugins_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function handoff_to_url( $request ) {
-		$destination_url = $request->get_param( 'destinationUrl' );
-		if ( empty( $destination_url ) ) {
-			return new \WP_Error( 'newspack_handoff_missing_url', __( 'destinationUrl is required.', 'newspack-plugin' ), [ 'status' => 400 ] );
-		}
-
+		$destination_url      = $request->get_param( 'destinationUrl' );
 		$handoff_return_url   = $request->get_param( 'handoffReturnUrl' );
 		$show_on_block_editor = $request->get_param( 'showOnBlockEditor' );
 		$banner_text          = (string) $request->get_param( 'bannerText' );

--- a/includes/api/class-plugins-controller.php
+++ b/includes/api/class-plugins-controller.php
@@ -147,6 +147,19 @@ class Plugins_Controller extends WP_REST_Controller {
 			]
 		);
 
+		// Register newspack/v1/handoff endpoint for URL-based handoff.
+		register_rest_route(
+			$this->namespace,
+			'/handoff',
+			[
+				[
+					'methods'             => 'POST',
+					'callback'            => [ $this, 'handoff_to_url' ],
+					'permission_callback' => [ $this, 'handoff_item_permissions_check' ],
+				],
+			]
+		);
+
 		// Register newspack/v1/plugins/some-plugin/handoff endpoint.
 		register_rest_route(
 			$this->namespace,
@@ -315,6 +328,42 @@ class Plugins_Controller extends WP_REST_Controller {
 	}
 
 	/**
+	 * Handoff to an arbitrary admin URL.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function handoff_to_url( $request ) {
+		$destination_url = $request->get_param( 'destinationUrl' );
+		if ( empty( $destination_url ) ) {
+			return new \WP_Error( 'newspack_handoff_missing_url', __( 'destinationUrl is required.', 'newspack-plugin' ), [ 'status' => 400 ] );
+		}
+
+		$handoff_return_url   = $request->get_param( 'handoffReturnUrl' );
+		$show_on_block_editor = $request->get_param( 'showOnBlockEditor' );
+		$banner_text          = (string) $request->get_param( 'bannerText' );
+		$banner_button_text   = (string) $request->get_param( 'bannerButtonText' );
+
+		update_option( NEWSPACK_HANDOFF, 'url' );
+		update_option( NEWSPACK_HANDOFF_SHOW_ON_BLOCK_EDITOR, (bool) $show_on_block_editor );
+		update_option( NEWSPACK_HANDOFF_BANNER_TEXT, sanitize_text_field( $banner_text ) );
+		update_option( NEWSPACK_HANDOFF_BANNER_BUTTON_TEXT, sanitize_text_field( $banner_button_text ) );
+		if ( ! empty( $handoff_return_url ) ) {
+			update_option( NEWSPACK_HANDOFF_RETURN_URL, esc_url( $handoff_return_url ) );
+		}
+
+		$parsed_url = wp_parse_url( $destination_url );
+		if ( ! empty( $parsed_url['query'] ) ) {
+			wp_parse_str( $parsed_url['query'], $query_params );
+			if ( ! empty( $query_params['page'] ) ) {
+				update_option( NEWSPACK_HANDOFF_DESTINATION_PAGE, sanitize_text_field( $query_params['page'] ) );
+			}
+		}
+
+		return rest_ensure_response( [ 'HandoffLink' => esc_url_raw( $destination_url ) ] );
+	}
+
+	/**
 	 * Handoff to a managed plugin.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
@@ -329,7 +378,9 @@ class Plugins_Controller extends WP_REST_Controller {
 		}
 
 		$show_on_block_editor = $request->get_param( 'showOnBlockEditor' );
-		Handoff_Banner::register_handoff_for_plugin( $slug, (bool) $show_on_block_editor );
+		$banner_text          = (string) $request->get_param( 'bannerText' );
+		$banner_button_text   = (string) $request->get_param( 'bannerButtonText' );
+		Handoff_Banner::register_handoff_for_plugin( $slug, (bool) $show_on_block_editor, $banner_text, $banner_button_text );
 		$managed_plugins = Plugin_Manager::get_managed_plugins();
 
 		$response           = $managed_plugins[ $slug ];

--- a/includes/class-handoff-banner.php
+++ b/includes/class-handoff-banner.php
@@ -12,6 +12,9 @@ defined( 'ABSPATH' ) || exit;
 define( 'NEWSPACK_HANDOFF', 'newspack_handoff' );
 define( 'NEWSPACK_HANDOFF_RETURN_URL', 'newspack_handoff_return_url' );
 define( 'NEWSPACK_HANDOFF_SHOW_ON_BLOCK_EDITOR', 'newspack_handoff_show_on_block_editor' );
+define( 'NEWSPACK_HANDOFF_BANNER_TEXT', 'newspack_handoff_banner_text' );
+define( 'NEWSPACK_HANDOFF_BANNER_BUTTON_TEXT', 'newspack_handoff_banner_button_text' );
+define( 'NEWSPACK_HANDOFF_DESTINATION_PAGE', 'newspack_handoff_destination_page' );
 
 /**
  * Manages the API as a whole.
@@ -25,11 +28,13 @@ class Handoff_Banner {
 		add_action( 'current_screen', [ $this, 'clear_handoff_url' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_styles' ], 1 );
 		add_action( 'enqueue_block_editor_assets', [ $this, 'insert_block_editor_handoff_banner' ] );
-		add_action( 'admin_notices', [ $this, 'insert_handoff_banner' ], -9998 );
+		add_action( 'in_admin_header', [ $this, 'insert_handoff_banner' ] );
+		add_action( 'newspack_before_wizard_content', [ $this, 'insert_handoff_banner_static' ] );
 	}
 
 	/**
-	 * Render element into which Handoff Banner will be rendered.
+	 * Render element into which Handoff Banner will be rendered via JS.
+	 * Used on non-wizard admin pages.
 	 *
 	 * @return void.
 	 */
@@ -38,7 +43,67 @@ class Handoff_Banner {
 			return;
 		}
 
-		printf( "<div id='newspack-handoff-banner' data-primary_button_url='%s'></div>", esc_url( get_option( NEWSPACK_HANDOFF_RETURN_URL ) ) );
+		printf(
+			"<div id='newspack-handoff-banner' data-primary_button_url='%s' data-banner_text='%s' data-banner_button_text='%s'></div>",
+			esc_url( get_option( NEWSPACK_HANDOFF_RETURN_URL ) ),
+			esc_attr( get_option( NEWSPACK_HANDOFF_BANNER_TEXT, '' ) ),
+			esc_attr( get_option( NEWSPACK_HANDOFF_BANNER_BUTTON_TEXT, '' ) )
+		);
+	}
+
+	/**
+	 * Render a fully server-side Handoff Banner.
+	 * Used on Newspack wizard pages where the JS-based banner cannot be used.
+	 *
+	 * @return void.
+	 */
+	public function insert_handoff_banner_static() {
+		if ( ! self::needs_handoff_return_ui() ) {
+			return;
+		}
+
+		$return_url  = esc_url( get_option( NEWSPACK_HANDOFF_RETURN_URL ) );
+		$banner_text = get_option( NEWSPACK_HANDOFF_BANNER_TEXT, '' );
+		$button_text = get_option( NEWSPACK_HANDOFF_BANNER_BUTTON_TEXT, '' );
+
+		if ( empty( $banner_text ) ) {
+			$banner_text = __( 'Return to Newspack after completing configuration', 'newspack-plugin' );
+		}
+		if ( empty( $button_text ) ) {
+			$button_text = __( 'Back to Newspack', 'newspack-plugin' );
+		}
+		?>
+		<div id="newspack-handoff-banner">
+			<div class="newspack-handoff-banner">
+				<div class="newspack-handoff-banner__text"><?php echo esc_html( $banner_text ); ?></div>
+				<div class="newspack-handoff-banner__buttons">
+					<button
+						type="button"
+						class="components-button is-tertiary is-small"
+						onclick="this.closest('#newspack-handoff-banner').remove()"
+					>
+						<?php esc_html_e( 'Dismiss', 'newspack-plugin' ); ?>
+					</button>
+					<a href="<?php echo esc_url( $return_url ); ?>" class="components-button is-primary is-small">
+						<?php echo esc_html( $button_text ); ?>
+					</a>
+				</div>
+			</div>
+		</div>
+		<script>
+		( function() {
+			var el = document.getElementById( 'newspack-handoff-banner' );
+			var wpcontent = document.getElementById( 'wpcontent' );
+			if ( el && wpcontent ) {
+				var paddingLeft = parseInt( window.getComputedStyle( wpcontent ).paddingLeft, 10 );
+				if ( paddingLeft ) {
+					el.style.marginLeft = '-' + paddingLeft + 'px';
+					el.style.width = 'calc(100% + ' + paddingLeft + 'px)';
+				}
+			}
+		} )();
+		</script>
+		<?php
 	}
 
 	/**
@@ -60,9 +125,11 @@ class Handoff_Banner {
 			true
 		);
 
-		$script_info = [
-			'text'       => __( 'Return to Newspack after completing configuration', 'newspack' ),
-			'buttonText' => __( 'Back to Newspack', 'newspack' ),
+		$banner_text        = get_option( NEWSPACK_HANDOFF_BANNER_TEXT, '' );
+		$banner_button_text = get_option( NEWSPACK_HANDOFF_BANNER_BUTTON_TEXT, '' );
+		$script_info        = [
+			'text'       => $banner_text ? $banner_text : __( 'Return to Newspack after completing configuration', 'newspack' ),
+			'buttonText' => $banner_button_text ? $banner_button_text : __( 'Back to Newspack', 'newspack' ),
 			'returnURL'  => esc_url( get_option( NEWSPACK_HANDOFF_RETURN_URL, '' ) ),
 		];
 		wp_localize_script( $handle, 'newspack_handoff', $script_info );
@@ -80,18 +147,24 @@ class Handoff_Banner {
 		wp_register_style(
 			$handle,
 			Newspack::plugin_url() . '/dist/handoff-banner.css',
-			[],
+			[ 'wp-components' ],
 			NEWSPACK_PLUGIN_VERSION
 		);
 		wp_enqueue_style( $handle );
 
+		$screen = get_current_screen();
+		if ( $screen && stristr( $screen->id, 'newspack' ) ) {
+			return;
+		}
+
 		Newspack::load_common_assets();
 
+		$asset = include NEWSPACK_ABSPATH . 'dist/handoff-banner.asset.php';
 		wp_register_script(
 			$handle,
 			Newspack::plugin_url() . '/dist/handoff-banner.js',
-			[ 'wp-element', 'wp-editor', 'wp-components' ],
-			NEWSPACK_PLUGIN_VERSION,
+			$asset['dependencies'],
+			$asset['version'],
 			true
 		);
 		wp_enqueue_script( $handle );
@@ -102,11 +175,15 @@ class Handoff_Banner {
 	 *
 	 * @param  array   $plugin Slug of plugin to be visited.
 	 * @param  boolean $show_on_block_editor Whether to show on block editor.
+	 * @param  string  $banner_text Custom banner body text.
+	 * @param  string  $banner_button_text Custom banner button text.
 	 * @return void
 	 */
-	public static function register_handoff_for_plugin( $plugin, $show_on_block_editor = false ) {
+	public static function register_handoff_for_plugin( $plugin, $show_on_block_editor = false, $banner_text = '', $banner_button_text = '' ) {
 		update_option( NEWSPACK_HANDOFF, $plugin );
 		update_option( NEWSPACK_HANDOFF_SHOW_ON_BLOCK_EDITOR, (bool) $show_on_block_editor );
+		update_option( NEWSPACK_HANDOFF_BANNER_TEXT, sanitize_text_field( $banner_text ) );
+		update_option( NEWSPACK_HANDOFF_BANNER_BUTTON_TEXT, sanitize_text_field( $banner_button_text ) );
 	}
 
 	/**
@@ -115,10 +192,6 @@ class Handoff_Banner {
 	 * @return bool
 	 */
 	public static function needs_handoff_return_ui() {
-		if ( get_option( NEWSPACK_SETUP_COMPLETE, true ) ) {
-			return false;
-		}
-
 		return get_option( NEWSPACK_HANDOFF ) ? true : false;
 	}
 
@@ -139,8 +212,16 @@ class Handoff_Banner {
 	 */
 	public function clear_handoff_url( $current_screen ) {
 		if ( stristr( $current_screen->id, 'newspack' ) ) {
+			$destination_page = get_option( NEWSPACK_HANDOFF_DESTINATION_PAGE, '' );
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			if ( $destination_page && isset( $_GET['page'] ) && sanitize_text_field( wp_unslash( $_GET['page'] ) ) === $destination_page ) {
+				return;
+			}
 			update_option( NEWSPACK_HANDOFF, null );
 			update_option( NEWSPACK_HANDOFF_SHOW_ON_BLOCK_EDITOR, false );
+			update_option( NEWSPACK_HANDOFF_BANNER_TEXT, '' );
+			update_option( NEWSPACK_HANDOFF_BANNER_BUTTON_TEXT, '' );
+			update_option( NEWSPACK_HANDOFF_DESTINATION_PAGE, '' );
 		}
 	}
 }

--- a/includes/class-handoff-banner.php
+++ b/includes/class-handoff-banner.php
@@ -158,6 +158,14 @@ class Handoff_Banner {
 		);
 		wp_enqueue_style( $handle );
 
+		// On Newspack screens the banner is rendered server-side via
+		// insert_handoff_banner_static(); enqueuing the JS would find the same
+		// element id and clobber the server-rendered markup.
+		$screen = get_current_screen();
+		if ( $screen && stristr( $screen->id, 'newspack' ) ) {
+			return;
+		}
+
 		Newspack::load_common_assets();
 
 		$asset = include NEWSPACK_ABSPATH . 'dist/handoff-banner.asset.php';

--- a/includes/class-handoff-banner.php
+++ b/includes/class-handoff-banner.php
@@ -86,7 +86,7 @@ class Handoff_Banner {
 					<button
 						type="button"
 						class="components-button is-tertiary is-small"
-						onclick="this.closest('#newspack-handoff-banner').remove()"
+						data-dismiss
 					>
 						<?php esc_html_e( 'Dismiss', 'newspack-plugin' ); ?>
 					</button>
@@ -99,13 +99,22 @@ class Handoff_Banner {
 		<script>
 		( function() {
 			var el = document.getElementById( 'newspack-handoff-banner' );
+			if ( ! el ) {
+				return;
+			}
 			var wpcontent = document.getElementById( 'wpcontent' );
-			if ( el && wpcontent ) {
+			if ( wpcontent ) {
 				var paddingLeft = parseInt( window.getComputedStyle( wpcontent ).paddingLeft, 10 );
 				if ( paddingLeft ) {
 					el.style.marginLeft = '-' + paddingLeft + 'px';
 					el.style.width = 'calc(100% + ' + paddingLeft + 'px)';
 				}
+			}
+			var dismissBtn = el.querySelector( '[data-dismiss]' );
+			if ( dismissBtn ) {
+				dismissBtn.addEventListener( 'click', function() {
+					el.remove();
+				} );
 			}
 		} )();
 		</script>

--- a/includes/class-handoff-banner.php
+++ b/includes/class-handoff-banner.php
@@ -43,6 +43,12 @@ class Handoff_Banner {
 			return;
 		}
 
+		// On Newspack wizard pages the static banner is rendered via newspack_before_wizard_content.
+		$screen = get_current_screen();
+		if ( $screen && stristr( $screen->id, 'newspack' ) ) {
+			return;
+		}
+
 		printf(
 			"<div id='newspack-handoff-banner' data-primary_button_url='%s' data-banner_text='%s' data-banner_button_text='%s'></div>",
 			esc_url( get_option( NEWSPACK_HANDOFF_RETURN_URL ) ),
@@ -152,11 +158,6 @@ class Handoff_Banner {
 		);
 		wp_enqueue_style( $handle );
 
-		$screen = get_current_screen();
-		if ( $screen && stristr( $screen->id, 'newspack' ) ) {
-			return;
-		}
-
 		Newspack::load_common_assets();
 
 		$asset = include NEWSPACK_ABSPATH . 'dist/handoff-banner.asset.php';
@@ -184,6 +185,7 @@ class Handoff_Banner {
 		update_option( NEWSPACK_HANDOFF_SHOW_ON_BLOCK_EDITOR, (bool) $show_on_block_editor );
 		update_option( NEWSPACK_HANDOFF_BANNER_TEXT, sanitize_text_field( $banner_text ) );
 		update_option( NEWSPACK_HANDOFF_BANNER_BUTTON_TEXT, sanitize_text_field( $banner_button_text ) );
+		update_option( NEWSPACK_HANDOFF_DESTINATION_PAGE, '' );
 	}
 
 	/**
@@ -205,23 +207,52 @@ class Handoff_Banner {
 	}
 
 	/**
-	 * If the current admin page is part of the Newspack dashboard, clear the handoff URL. This ensures the handoff banner won't be shown on Newspack admin pages.
+	 * Clear all handoff-related options.
+	 *
+	 * @return void
+	 */
+	private function clear_all_handoff_options() {
+		update_option( NEWSPACK_HANDOFF, null );
+		update_option( NEWSPACK_HANDOFF_SHOW_ON_BLOCK_EDITOR, false );
+		update_option( NEWSPACK_HANDOFF_BANNER_TEXT, '' );
+		update_option( NEWSPACK_HANDOFF_BANNER_BUTTON_TEXT, '' );
+		update_option( NEWSPACK_HANDOFF_DESTINATION_PAGE, '' );
+	}
+
+	/**
+	 * Clear the handoff state when navigating away from the destination page.
+	 * Clears on any Newspack screen that isn't the destination, and on any
+	 * non-Newspack screen when a destination page was registered (preventing
+	 * the banner from lingering on unrelated admin pages).
 	 *
 	 * @param WP_Screen $current_screen The current screen object.
 	 * @return void
 	 */
 	public function clear_handoff_url( $current_screen ) {
+		if ( ! self::needs_handoff_return_ui() ) {
+			return;
+		}
+
+		$destination_page = get_option( NEWSPACK_HANDOFF_DESTINATION_PAGE, '' );
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$current_page = isset( $_GET['page'] ) ? sanitize_text_field( wp_unslash( $_GET['page'] ) ) : '';
+
+		// Don't clear if we're on the intended destination page.
+		if ( $destination_page && $current_page === $destination_page ) {
+			return;
+		}
+
+		// Clear on any Newspack screen that isn't the destination.
 		if ( stristr( $current_screen->id, 'newspack' ) ) {
-			$destination_page = get_option( NEWSPACK_HANDOFF_DESTINATION_PAGE, '' );
-			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			if ( $destination_page && isset( $_GET['page'] ) && sanitize_text_field( wp_unslash( $_GET['page'] ) ) === $destination_page ) {
-				return;
-			}
-			update_option( NEWSPACK_HANDOFF, null );
-			update_option( NEWSPACK_HANDOFF_SHOW_ON_BLOCK_EDITOR, false );
-			update_option( NEWSPACK_HANDOFF_BANNER_TEXT, '' );
-			update_option( NEWSPACK_HANDOFF_BANNER_BUTTON_TEXT, '' );
-			update_option( NEWSPACK_HANDOFF_DESTINATION_PAGE, '' );
+			$this->clear_all_handoff_options();
+			return;
+		}
+
+		// For URL-based handoffs with a known destination page, also clear on any
+		// non-Newspack page that isn't the destination, to prevent the banner from
+		// persisting across unrelated admin screens.
+		if ( $destination_page ) {
+			$this->clear_all_handoff_options();
 		}
 	}
 }

--- a/includes/class-handoff-banner.php
+++ b/includes/class-handoff-banner.php
@@ -134,8 +134,8 @@ class Handoff_Banner {
 		$banner_text        = get_option( NEWSPACK_HANDOFF_BANNER_TEXT, '' );
 		$banner_button_text = get_option( NEWSPACK_HANDOFF_BANNER_BUTTON_TEXT, '' );
 		$script_info        = [
-			'text'       => $banner_text ? $banner_text : __( 'Return to Newspack after completing configuration', 'newspack' ),
-			'buttonText' => $banner_button_text ? $banner_button_text : __( 'Back to Newspack', 'newspack' ),
+			'text'       => $banner_text ? $banner_text : __( 'Return to Newspack after completing configuration', 'newspack-plugin' ),
+			'buttonText' => $banner_button_text ? $banner_button_text : __( 'Back to Newspack', 'newspack-plugin' ),
 			'returnURL'  => esc_url( get_option( NEWSPACK_HANDOFF_RETURN_URL, '' ) ),
 		];
 		wp_localize_script( $handle, 'newspack_handoff', $script_info );
@@ -220,11 +220,12 @@ class Handoff_Banner {
 	 * @return void
 	 */
 	private function clear_all_handoff_options() {
-		update_option( NEWSPACK_HANDOFF, null );
-		update_option( NEWSPACK_HANDOFF_SHOW_ON_BLOCK_EDITOR, false );
-		update_option( NEWSPACK_HANDOFF_BANNER_TEXT, '' );
-		update_option( NEWSPACK_HANDOFF_BANNER_BUTTON_TEXT, '' );
-		update_option( NEWSPACK_HANDOFF_DESTINATION_PAGE, '' );
+		delete_option( NEWSPACK_HANDOFF );
+		delete_option( NEWSPACK_HANDOFF_SHOW_ON_BLOCK_EDITOR );
+		delete_option( NEWSPACK_HANDOFF_BANNER_TEXT );
+		delete_option( NEWSPACK_HANDOFF_BANNER_BUTTON_TEXT );
+		delete_option( NEWSPACK_HANDOFF_DESTINATION_PAGE );
+		delete_option( NEWSPACK_HANDOFF_RETURN_URL );
 	}
 
 	/**

--- a/includes/class-handoff-banner.php
+++ b/includes/class-handoff-banner.php
@@ -228,10 +228,15 @@ class Handoff_Banner {
 	}
 
 	/**
-	 * Clear the handoff state when navigating away from the destination page.
-	 * Clears on any Newspack screen that isn't the destination, and on any
-	 * non-Newspack screen when a destination page was registered (preventing
-	 * the banner from lingering on unrelated admin pages).
+	 * Clear the handoff state when the user explicitly returns.
+	 *
+	 * The banner is sticky throughout the detour: it survives login redirects
+	 * and sub-page navigation within the destination plugin so the user never
+	 * loses their way back. Two trigger points end the handoff:
+	 *   1. The user reaches the stored return URL (typically via the banner's
+	 *      "Back" button), when one is set.
+	 *   2. The user reaches any Newspack admin screen — fallback for plugin
+	 *      handoffs that don't supply a return URL.
 	 *
 	 * @param WP_Screen $current_screen The current screen object.
 	 * @return void
@@ -241,27 +246,55 @@ class Handoff_Banner {
 			return;
 		}
 
-		$destination_page = get_option( NEWSPACK_HANDOFF_DESTINATION_PAGE, '' );
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$current_page = isset( $_GET['page'] ) ? sanitize_text_field( wp_unslash( $_GET['page'] ) ) : '';
+		$return_url = get_option( NEWSPACK_HANDOFF_RETURN_URL, '' );
 
-		// Don't clear if we're on the intended destination page.
-		if ( $destination_page && $current_page === $destination_page ) {
+		if ( $return_url ) {
+			if ( $this->is_on_return_url( $return_url ) ) {
+				$this->clear_all_handoff_options();
+			}
 			return;
 		}
 
-		// Clear on any Newspack screen that isn't the destination.
-		if ( stristr( $current_screen->id, 'newspack' ) ) {
+		if ( $current_screen && stristr( $current_screen->id, 'newspack' ) ) {
 			$this->clear_all_handoff_options();
-			return;
+		}
+	}
+
+	/**
+	 * Check whether the current admin request matches a stored return URL.
+	 *
+	 * Compares the script filename (e.g. `admin.php`) and every query parameter
+	 * declared in the return URL. Same-site validation is enforced upstream at
+	 * the REST layer, so host is not compared here.
+	 *
+	 * @param string $return_url Stored handoff return URL.
+	 * @return bool
+	 */
+	private function is_on_return_url( $return_url ) {
+		$parsed = wp_parse_url( $return_url );
+		if ( empty( $parsed ) ) {
+			return false;
 		}
 
-		// For URL-based handoffs with a known destination page, also clear on any
-		// non-Newspack page that isn't the destination, to prevent the banner from
-		// persisting across unrelated admin screens.
-		if ( $destination_page ) {
-			$this->clear_all_handoff_options();
+		if ( ! empty( $parsed['path'] ) ) {
+			$current_path = isset( $_SERVER['SCRIPT_NAME'] ) ? sanitize_text_field( wp_unslash( $_SERVER['SCRIPT_NAME'] ) ) : '';
+			if ( basename( $parsed['path'] ) !== basename( $current_path ) ) {
+				return false;
+			}
 		}
+
+		if ( ! empty( $parsed['query'] ) ) {
+			wp_parse_str( $parsed['query'], $return_query );
+			foreach ( $return_query as $key => $value ) {
+				// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				$current_value = isset( $_GET[ $key ] ) ? sanitize_text_field( wp_unslash( $_GET[ $key ] ) ) : '';
+				if ( (string) $current_value !== (string) $value ) {
+					return false;
+				}
+			}
+		}
+
+		return true;
 	}
 }
 new Handoff_Banner();

--- a/includes/wizards/class-wizard.php
+++ b/includes/wizards/class-wizard.php
@@ -118,6 +118,7 @@ abstract class Wizard {
 	 * Render the container for the wizard.
 	 */
 	public function render_wizard() {
+		do_action( 'newspack_before_wizard_content' );
 		?>
 		<div class="newspack-wizard <?php echo esc_attr( $this->slug ); ?>" id="<?php echo esc_attr( $this->slug ); ?>">
 		</div>

--- a/packages/components/src/action-card/index.js
+++ b/packages/components/src/action-card/index.js
@@ -39,6 +39,9 @@ const ActionCard = ( {
 	heading = 2,
 	description,
 	handoff,
+	handoffUrl,
+	bannerText,
+	bannerButtonText,
 	editLink,
 	href,
 	notification,
@@ -187,7 +190,18 @@ const ActionCard = ( {
 						{ actionContent && actionContent }
 						{ actionText &&
 							( handoff ? (
-								<Handoff plugin={ handoff } editLink={ editLink } compact isLink>
+								<Handoff
+									plugin={ handoff }
+									editLink={ editLink }
+									bannerText={ bannerText }
+									bannerButtonText={ bannerButtonText }
+									compact
+									isLink
+								>
+									{ actionText }
+								</Handoff>
+							) : handoffUrl ? (
+								<Handoff url={ handoffUrl } bannerText={ bannerText } bannerButtonText={ bannerButtonText } compact isLink>
 									{ actionText }
 								</Handoff>
 							) : onClick || hasInternalLink ? (

--- a/packages/components/src/handoff/README.md
+++ b/packages/components/src/handoff/README.md
@@ -1,0 +1,93 @@
+# Handoff
+
+Navigates the user to another admin page and displays a return banner at the top of the destination so they can find their way back.
+
+## How it works
+
+1. The user clicks the Handoff button.
+2. A POST request registers the current URL as the return destination and stores optional banner customisations.
+3. The user is redirected to the destination page.
+4. A banner appears at the top of that page with a "Back to Newspack" button (or custom text) that returns them to the origin.
+
+## Usage
+
+### With a URL
+
+Use the `url` prop to hand off to any WordPress admin URL. No plugin needs to be installed.
+
+```jsx
+<Handoff url="/wp-admin/admin.php?page=newspack-dashboard#/">
+    Go to Dashboard
+</Handoff>
+```
+
+### With a managed plugin slug
+
+Use the `plugin` prop to hand off to a Newspack-managed plugin. The button is automatically disabled if the plugin is not installed or inactive.
+
+```jsx
+<Handoff plugin="jetpack">
+    Configure Jetpack
+</Handoff>
+```
+
+Use `editLink` to override the destination to a specific page within the plugin:
+
+```jsx
+<Handoff plugin="wordpress-seo" editLink="/wp-admin/admin.php?page=wpseo_dashboard">
+    Configure Yoast SEO
+</Handoff>
+```
+
+### Via ActionCard
+
+`ActionCard` accepts `handoffUrl` (URL-based) or `handoff` (plugin slug) as convenience props that render a `Handoff` as the action button. `bannerText` and `bannerButtonText` are supported on both:
+
+```jsx
+<ActionCard
+    title="My Feature"
+    actionText="Configure"
+    handoffUrl="/wp-admin/admin.php?page=my-settings"
+    bannerText="Return here once you're done."
+    bannerButtonText="Back to My Feature"
+/>
+
+<ActionCard
+    title="Jetpack"
+    actionText="Configure"
+    handoff="jetpack"
+    editLink="/wp-admin/admin.php?page=jetpack#/settings"
+    bannerText="Return here once you're done."
+    bannerButtonText="Back to My Feature"
+/>
+```
+
+## Props
+
+| Prop | Type | Description |
+|---|---|---|
+| `url` | `string` | Admin URL to hand off to. Use this or `plugin`, not both. |
+| `plugin` | `string` | Slug of a Newspack-managed plugin to hand off to. |
+| `editLink` | `string` | Overrides the destination URL when using `plugin`. |
+| `bannerText` | `string` | Custom body text for the return banner. Defaults to "Return to Newspack after completing configuration". |
+| `bannerButtonText` | `string` | Custom label for the return button. Defaults to "Back to Newspack". |
+| `showOnBlockEditor` | `bool` | Show the return banner inside the block editor. Default `false`. |
+| `useModal` | `bool` | Show a confirmation modal before navigating. |
+| `modalTitle` | `string` | Title for the confirmation modal. |
+| `modalBody` | `string` | Body text for the confirmation modal. |
+| `onReady` | `func` | Called with plugin info once loaded (plugin mode only). |
+| `children` | `node` | Button label. Falls back to "Manage {Plugin Name}" in plugin mode. |
+
+All other props are passed through to the underlying `Button` component (`isPrimary`, `isLink`, `isTertiary`, `className`, etc.).
+
+## Banner customisation
+
+```jsx
+<Handoff
+    url="/wp-admin/admin.php?page=my-settings"
+    bannerText="Finish your configuration, then come back here."
+    bannerButtonText="Back to My Feature"
+>
+    Open Settings
+</Handoff>
+```

--- a/packages/components/src/handoff/index.js
+++ b/packages/components/src/handoff/index.js
@@ -31,8 +31,10 @@ class Handoff extends Component {
 
 	componentDidMount = () => {
 		this._isMounted = true;
-		const { plugin } = this.props;
-		this.retrievePluginInfo( plugin );
+		const { plugin, url } = this.props;
+		if ( plugin && ! url ) {
+			this.retrievePluginInfo( plugin );
+		}
 	};
 
 	componentWillUnmount = () => {
@@ -60,8 +62,25 @@ class Handoff extends Component {
 		return assign( defaults, this.props );
 	};
 
+	goToUrl = () => {
+		const { url, showOnBlockEditor, bannerText, bannerButtonText } = this.props;
+		apiFetch( {
+			path: '/newspack/v1/handoff',
+			method: 'POST',
+			data: {
+				destinationUrl: url,
+				handoffReturnUrl: window && window.location.href,
+				showOnBlockEditor: showOnBlockEditor ? true : false,
+				bannerText,
+				bannerButtonText,
+			},
+		} ).then( response => {
+			window.location.href = response.HandoffLink;
+		} );
+	};
+
 	goToPlugin = plugin => {
-		const { editLink, showOnBlockEditor } = this.props;
+		const { editLink, showOnBlockEditor, bannerText, bannerButtonText } = this.props;
 		apiFetch( {
 			path: '/newspack/v1/plugins/' + plugin + '/handoff',
 			method: 'POST',
@@ -69,6 +88,8 @@ class Handoff extends Component {
 				editLink,
 				handoffReturnUrl: window && window.location.href,
 				showOnBlockEditor: showOnBlockEditor ? true : false,
+				bannerText,
+				bannerButtonText,
 			},
 		} ).then( response => {
 			window.location.href = response.HandoffLink;
@@ -92,30 +113,47 @@ class Handoff extends Component {
 			onReady,
 			// eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars
 			editLink,
+			// eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars
+			bannerText,
+			// eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars
+			bannerButtonText,
+			// eslint-disable-next-line no-unused-vars,@typescript-eslint/no-unused-vars
+			url,
 			...otherProps
 		} = this.props;
 		const { pluginInfo, showModal } = this.state;
 		const { modalBody, modalTitle, primaryButton, primaryModalButton, dismissModalButton } = this.textForPlugin( pluginInfo );
 		const { Configured, Name, Slug, Status } = pluginInfo;
 		const classes = classnames( Configured && 'is-configured', className );
+		const goTo = () => ( url ? this.goToUrl() : this.goToPlugin( Slug ) );
 		return (
 			<Fragment>
-				{ Name && 'active' === Status && (
+				{ url && (
 					<Button
 						className={ classes }
 						isSecondary={ ! otherProps.isPrimary && ! otherProps.isTertiary && ! otherProps.isLink }
 						{ ...otherProps }
-						onClick={ () => ( useModal ? this.setState( { showModal: true } ) : this.goToPlugin( Slug ) ) }
+						onClick={ () => ( useModal ? this.setState( { showModal: true } ) : goTo() ) }
+					>
+						{ children }
+					</Button>
+				) }
+				{ ! url && Name && 'active' === Status && (
+					<Button
+						className={ classes }
+						isSecondary={ ! otherProps.isPrimary && ! otherProps.isTertiary && ! otherProps.isLink }
+						{ ...otherProps }
+						onClick={ () => ( useModal ? this.setState( { showModal: true } ) : goTo() ) }
 					>
 						{ children ? children : primaryButton }
 					</Button>
 				) }
-				{ Name && 'active' !== Status && (
+				{ ! url && Name && 'active' !== Status && (
 					<Button className={ classes } variant="secondary" disabled { ...otherProps }>
 						{ Name + __( ' not installed', 'newspack-plugin' ) }
 					</Button>
 				) }
-				{ ! Name && (
+				{ ! url && ! Name && (
 					<Button
 						className={ classes }
 						isSecondary={ ! otherProps.isPrimary && ! otherProps.isTertiary && ! otherProps.isLink }
@@ -134,7 +172,7 @@ class Handoff extends Component {
 							<Button variant="secondary" onClick={ () => this.setState( { showModal: false } ) }>
 								{ dismissModalButton }
 							</Button>
-							<Button variant="primary" onClick={ () => this.goToPlugin( Slug ) }>
+							<Button variant="primary" onClick={ goTo }>
 								{ primaryModalButton }
 							</Button>
 						</Card>

--- a/packages/components/src/handoff/index.js
+++ b/packages/components/src/handoff/index.js
@@ -133,7 +133,7 @@ class Handoff extends Component {
 						className={ classes }
 						isSecondary={ ! otherProps.isPrimary && ! otherProps.isTertiary && ! otherProps.isLink }
 						{ ...otherProps }
-						onClick={ () => ( useModal ? this.setState( { showModal: true } ) : goTo() ) }
+						onClick={ () => ( useModal && children ? this.setState( { showModal: true } ) : goTo() ) }
 					>
 						{ children ? children : primaryButton }
 					</Button>

--- a/packages/components/src/handoff/index.js
+++ b/packages/components/src/handoff/index.js
@@ -135,7 +135,7 @@ class Handoff extends Component {
 						{ ...otherProps }
 						onClick={ () => ( useModal ? this.setState( { showModal: true } ) : goTo() ) }
 					>
-						{ children }
+						{ children ? children : primaryButton }
 					</Button>
 				) }
 				{ ! url && Name && 'active' === Status && (

--- a/src/wizards/componentsDemo/index.js
+++ b/src/wizards/componentsDemo/index.js
@@ -231,20 +231,18 @@ class ComponentsDemo extends Component {
 					<Card>
 						<h2>{ __( 'Handoff Buttons', 'newspack-plugin' ) }</h2>
 						<Card buttonsCard noBorder>
-							<Handoff
-								modalTitle={ __( 'Manage AMP', 'newspack-plugin' ) }
-								modalBody={ __(
-									'Click to go to the AMP dashboard. There will be a notification bar at the top with a link to return to Newspack.',
-									'newspack-plugin'
-								) }
-								plugin="amp"
-								isTertiary
-							/>
 							<Handoff plugin="jetpack" />
 							<Handoff plugin="google-site-kit" />
 							<Handoff plugin="woocommerce" />
 							<Handoff plugin="wordpress-seo" isPrimary editLink="/wp-admin/admin.php?page=wpseo_dashboard#top#features">
 								{ __( 'Specific Yoast Page', 'newspack-plugin' ) }
+							</Handoff>
+							<Handoff
+								url="/wp-admin/admin.php?page=newspack-dashboard"
+								bannerText={ __( "Return to Components Demo once you're done.", 'newspack-plugin' ) }
+								bannerButtonText={ __( 'Back to Components Demo', 'newspack-plugin' ) }
+							>
+								{ __( 'Go to Dashboard', 'newspack-plugin' ) }
 							</Handoff>
 						</Card>
 					</Card>
@@ -489,6 +487,14 @@ class ComponentsDemo extends Component {
 						actionText={ __( 'Configure', 'newspack-plugin' ) }
 						handoff="jetpack"
 						editLink="admin.php?page=jetpack#/settings"
+					/>
+					<ActionCard
+						title={ __( 'Handoff with URL', 'newspack-plugin' ) }
+						description={ __( 'An example of an action card with URL-based Handoff.', 'newspack-plugin' ) }
+						actionText={ __( 'Go to Dashboard', 'newspack-plugin' ) }
+						handoffUrl="/wp-admin/admin.php?page=newspack-dashboard"
+						bannerText={ __( "Return to Components Demo once you're done.", 'newspack-plugin' ) }
+						bannerButtonText={ __( 'Back to Components Demo', 'newspack-plugin' ) }
 					/>
 					<ActionCard
 						expandable

--- a/src/wizards/handoff-banner/index.js
+++ b/src/wizards/handoff-banner/index.js
@@ -62,8 +62,10 @@ if ( el ) {
 			return false;
 		};
 		if ( ! applyWooCommerceOffset() ) {
+			const timeoutId = setTimeout( () => observer.disconnect(), 5000 );
 			const observer = new MutationObserver( () => {
 				if ( applyWooCommerceOffset() ) {
+					clearTimeout( timeoutId );
 					observer.disconnect();
 				}
 			} );

--- a/src/wizards/handoff-banner/index.js
+++ b/src/wizards/handoff-banner/index.js
@@ -28,7 +28,7 @@ const HandoffBanner = ( {
 			<div className="newspack-handoff-banner">
 				<div className="newspack-handoff-banner__text">{ bodyText }</div>
 				<div className="newspack-handoff-banner__buttons">
-					<Button variant="secondary" isSmall onClick={ () => setVisibility( false ) }>
+					<Button variant="tertiary" isSmall onClick={ () => setVisibility( false ) }>
 						{ dismissButtonText }
 					</Button>
 					<Button variant="primary" isSmall href={ primaryButtonURL }>
@@ -41,10 +41,43 @@ const HandoffBanner = ( {
 };
 
 const el = document.getElementById( 'newspack-handoff-banner' );
-const { primary_button_url: primaryButtonURL } = el.dataset;
-render(
-	createElement( HandoffBanner, {
-		primaryButtonURL,
-	} ),
-	el
-);
+if ( el ) {
+	const wpcontent = document.getElementById( 'wpcontent' );
+	if ( wpcontent ) {
+		const paddingLeft = parseInt( window.getComputedStyle( wpcontent ).paddingLeft, 10 );
+		if ( paddingLeft ) {
+			el.style.marginLeft = `-${ paddingLeft }px`;
+			el.style.width = `calc(100% + ${ paddingLeft }px)`;
+		}
+	}
+
+	const wpbody = document.getElementById( 'wpbody' );
+	if ( wpbody ) {
+		const applyWooCommerceOffset = () => {
+			const wooHeader = document.querySelector( '.woocommerce-layout__header' );
+			if ( wooHeader && wpbody.style.marginTop ) {
+				el.style.marginTop = wpbody.style.marginTop;
+				return true;
+			}
+			return false;
+		};
+		if ( ! applyWooCommerceOffset() ) {
+			const observer = new MutationObserver( () => {
+				if ( applyWooCommerceOffset() ) {
+					observer.disconnect();
+				}
+			} );
+			observer.observe( wpbody, { attributes: true, attributeFilter: [ 'style' ] } );
+		}
+	}
+
+	const { primary_button_url: primaryButtonURL, banner_text: bodyText, banner_button_text: primaryButtonText } = el.dataset;
+	render(
+		createElement( HandoffBanner, {
+			primaryButtonURL,
+			...( bodyText && { bodyText } ),
+			...( primaryButtonText && { primaryButtonText } ),
+		} ),
+		el
+	);
+}

--- a/src/wizards/handoff-banner/style.scss
+++ b/src/wizards/handoff-banner/style.scss
@@ -3,89 +3,45 @@
  */
 
 @use "~@wordpress/base-styles/colors" as wp-colors;
+@use "~@wordpress/base-styles/variables" as wp-vars;
 @use "../../../packages/colors/colors.module" as colors;
 
 #newspack-handoff-banner {
-	// Color
-	--wp-admin-theme-color: var(--newspack-ui-color-primary);
-	--wp-admin-theme-color--rgb: var(--newspack-ui-color-primary-rgb);
-	--wp-admin-theme-color-darker-10: var(--newspack-ui-color-primary);
-	--wp-admin-theme-color-darker-10--rgb: var(--newspack-ui-color-primary-rgb);
-	--wp-admin-theme-color-darker-20: #{colors.$primary-700};
-	--wp-admin-theme-color-darker-20--rgb: #{colors.$primary-700--rgb};
-	--wp-admin-theme-color-lighter-10: #{colors.$primary-000};
-	--wp-admin-theme-color-lighter-10--rgb: #{colors.$primary-000--rgb};
-
-	background: white;
-	border-bottom: 1px solid wp-colors.$gray-300;
-	border-left: 4px solid var(--wp-admin-theme-color);
-	border-top: 1px solid wp-colors.$gray-300;
 	clear: both;
 	display: block;
-	margin: 0 0 0 -10px;
-	padding: 4px 16px;
 	position: relative;
+	z-index: 1000;
 
-	@media screen and ( min-width: 783px ) {
-		margin-left: -20px;
-	}
-
-	// Dismissed
 	&:empty {
 		display: none;
-	}
-
-	// Jetpack
-	.jetpack-pagestyles & {
-		margin-left: 0;
-	}
-
-	// Google Site Kit
-	.site-kit_page_googlesitekit-splash & {
-		margin-bottom: -25px;
 	}
 }
 
 .newspack-handoff-banner {
 	align-items: center;
+	background: colors.$primary-600;
 	box-sizing: border-box;
-	color: wp-colors.$gray-900;
+	color: wp-colors.$white;
+	display: flex;
+	gap: wp-vars.$grid-unit-30;
 	justify-content: space-between;
-	margin: 0;
+	padding: wp-vars.$grid-unit-15 wp-vars.$grid-unit-20;
 	width: 100%;
 
-	@media screen and ( min-width: 600px ) {
-		display: flex;
+	&__text {
+		font-size: wp-vars.$font-size-medium;
+		font-weight: 600;
 	}
 
-	// Text
-	.newspack-handoff-banner__text {
-		align-items: center;
+	&__buttons {
+		--wp-admin-theme-color: #{wp-colors.$white};
+		--wp-components-color-accent: #{wp-colors.$white};
+		--wp-components-color-accent-inverted: #{colors.$primary-600};
+		--wp-admin-theme-color-darker-10: color-mix(in srgb, #{wp-colors.$white} 85%, #{colors.$primary-600});
+		--wp-admin-theme-color-darker-20: color-mix(in srgb, #{wp-colors.$white} 70%, #{colors.$primary-600});
+
 		display: flex;
-		margin: 4px;
-
-		@media screen and ( min-width: 600px ) {
-			&::before {
-				background-image: url("data:image/svg+xml,%3Csvg width='32' height='32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M32 16c0 8.836-7.164 16-16 16-8.837 0-16-7.164-16-16S7.164 0 16 0s16 7.164 16 16zm-10.732.623h1.72v-1.125h-2.823l1.103 1.125zm-3.249-3.31h4.97v-1.125h-6.072l1.102 1.124v.001zm-3.248-3.311h8.217V8.878h-9.32l1.103 1.124zM9.01 8.878l13.977 14.245h-4.66l-5.866-5.98v5.98h-3.45V8.878H9.01z' fill='%2336f' fill-rule='evenodd'/%3E%3C/svg%3E%0A");
-				background-size: 32px 32px;
-				content: "";
-				display: block;
-				flex: 0 0 auto;
-				height: 32px;
-				margin: 0 8px 0 0;
-				width: 32px;
-			}
-		}
-	}
-
-	// Buttons
-	.newspack-handoff-banner__buttons {
-		display: flex;
-		flex-wrap: wrap;
-		gap: 4px;
-
-		@media screen and ( min-width: 600px ) {
-			justify-content: flex-end;
-		}
+		flex-shrink: 0;
+		gap: wp-vars.$grid-unit-10;
 	}
 }

--- a/tests/unit-tests/api-plugins-controller.php
+++ b/tests/unit-tests/api-plugins-controller.php
@@ -97,6 +97,60 @@ class Newspack_Test_Plugins_Controller extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test handoff to URL requires destinationUrl.
+	 */
+	public function test_handoff_to_url_missing_destination() {
+		wp_set_current_user( $this->administrator );
+		$request  = new WP_REST_Request( 'POST', $this->api_namespace . '/handoff' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertEquals( 'newspack_handoff_missing_url', $response->get_data()['code'] );
+	}
+
+	/**
+	 * Test handoff to URL rejects external URLs.
+	 */
+	public function test_handoff_to_url_rejects_external_url() {
+		wp_set_current_user( $this->administrator );
+		$request = new WP_REST_Request( 'POST', $this->api_namespace . '/handoff' );
+		$request->set_param( 'destinationUrl', 'https://evil.example/steal-tokens' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertEquals( 'newspack_handoff_invalid_url', $response->get_data()['code'] );
+	}
+
+	/**
+	 * Test handoff to URL stores options and returns the link.
+	 */
+	public function test_handoff_to_url_success() {
+		wp_set_current_user( $this->administrator );
+		$request = new WP_REST_Request( 'POST', $this->api_namespace . '/handoff' );
+		$request->set_param( 'destinationUrl', '/wp-admin/admin.php?page=newspack-dashboard' );
+		$request->set_param( 'bannerText', 'Come back when done.' );
+		$request->set_param( 'bannerButtonText', 'Back to Plugin' );
+		$request->set_param( 'handoffReturnUrl', 'http://example.org/wp-admin/admin.php?page=newspack-settings' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertArrayHasKey( 'HandoffLink', $response->get_data() );
+
+		$this->assertEquals( 'url', get_option( NEWSPACK_HANDOFF ) );
+		$this->assertEquals( 'Come back when done.', get_option( NEWSPACK_HANDOFF_BANNER_TEXT ) );
+		$this->assertEquals( 'Back to Plugin', get_option( NEWSPACK_HANDOFF_BANNER_BUTTON_TEXT ) );
+		$this->assertEquals( 'newspack-dashboard', get_option( NEWSPACK_HANDOFF_DESTINATION_PAGE ) );
+	}
+
+	/**
+	 * Test handoff to URL is inaccessible without authentication.
+	 */
+	public function test_handoff_to_url_unauthorized() {
+		wp_set_current_user( 0 );
+		$request = new WP_REST_Request( 'POST', $this->api_namespace . '/handoff' );
+		$request->set_param( 'destinationUrl', '/wp-admin/admin.php?page=newspack-dashboard' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	/**
 	 * Test the schema.
 	 */
 	public function test_schema() {

--- a/tests/unit-tests/api-plugins-controller.php
+++ b/tests/unit-tests/api-plugins-controller.php
@@ -104,7 +104,6 @@ class Newspack_Test_Plugins_Controller extends WP_UnitTestCase {
 		$request  = new WP_REST_Request( 'POST', $this->api_namespace . '/handoff' );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 400, $response->get_status() );
-		$this->assertEquals( 'newspack_handoff_missing_url', $response->get_data()['code'] );
 	}
 
 	/**
@@ -116,7 +115,40 @@ class Newspack_Test_Plugins_Controller extends WP_UnitTestCase {
 		$request->set_param( 'destinationUrl', 'https://evil.example/steal-tokens' );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 400, $response->get_status() );
-		$this->assertEquals( 'newspack_handoff_invalid_url', $response->get_data()['code'] );
+	}
+
+	/**
+	 * Test handoff to URL rejects the javascript: scheme.
+	 */
+	public function test_handoff_to_url_rejects_javascript_scheme() {
+		wp_set_current_user( $this->administrator );
+		$request = new WP_REST_Request( 'POST', $this->api_namespace . '/handoff' );
+		$request->set_param( 'destinationUrl', 'javascript:alert(1)' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 400, $response->get_status() );
+	}
+
+	/**
+	 * Test handoff to URL rejects protocol-relative URLs pointing off-site.
+	 */
+	public function test_handoff_to_url_rejects_protocol_relative_url() {
+		wp_set_current_user( $this->administrator );
+		$request = new WP_REST_Request( 'POST', $this->api_namespace . '/handoff' );
+		$request->set_param( 'destinationUrl', '//evil.example/x' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 400, $response->get_status() );
+	}
+
+	/**
+	 * Test handoff to URL rejects external handoffReturnUrl.
+	 */
+	public function test_handoff_to_url_rejects_external_return_url() {
+		wp_set_current_user( $this->administrator );
+		$request = new WP_REST_Request( 'POST', $this->api_namespace . '/handoff' );
+		$request->set_param( 'destinationUrl', '/wp-admin/admin.php?page=newspack-dashboard' );
+		$request->set_param( 'handoffReturnUrl', 'https://evil.example/return' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 400, $response->get_status() );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Context:

The handoff feature appears to have been broken on `trunk` for some time — the return banner doesn't seem to render at all when testing via the Components Demo. On top of that, the old implementation had become quite dated: the JS banner was embedding the **old Newspack logo** as a hardcoded inline SVG in CSS. This PR fixes the breakage, removes the logo entirely, and modernises the banner design and the component's API.

### Changes proposed in this Pull Request:

Extends the Handoff component and ActionCard to support handing off to any arbitrary WordPress admin URL, not just Newspack-managed plugins. Previously, handoff was only possible when a managed plugin slug was available.

Key changes:
- New `url` prop on `Handoff` component for URL-based navigation (no plugin required)
- New `handoffUrl` prop on `ActionCard` as a convenience wrapper
- New `bannerText` and `bannerButtonText` props on both components for customizing the return banner message
- New `POST /newspack/v1/handoff` REST endpoint that stores the destination URL and banner options; validates that the URL is same-site to prevent open-redirect attacks
- New server-side rendered handoff banner (`insert_handoff_banner_static`) for Newspack wizard pages where the JS banner can't render, hooked via a new `newspack_before_wizard_content` action
- Handoff banner redesigned: solid primary-color background, white text, uses WP base-styles variables — old Newspack logo removed
- The `needs_handoff_return_ui()` gate no longer requires setup to be incomplete — the banner now shows whenever a handoff is active
- `clear_handoff_url()` extended to also clear on non-Newspack screens when a destination page was registered, preventing the banner from lingering on unrelated admin pages
- `register_handoff_for_plugin()` now resets `NEWSPACK_HANDOFF_DESTINATION_PAGE` to prevent stale state from a prior URL-based handoff affecting subsequent plugin-based handoffs
- PHPUnit tests added for the new REST endpoint (missing param, external URL rejection, success, unauthorized access)

### How to test the changes in this Pull Request:

1. On **trunk** (before this PR), navigate to **Newspack > Components Demo**, scroll to Handoff Buttons, and click any handoff button — confirm the return banner does **not** appear (verifying the pre-existing breakage).
2. Switch to this branch and rebuild. Navigate to **Newspack > Components Demo** and scroll to the Handoff Buttons section.
3. Click "Go to Dashboard" — you should be redirected to the Newspack Dashboard with a blue return banner at the top reading "Return to Components Demo once you're done."
4. Verify the banner shows a "Dismiss" button and a "Back to Components Demo" button. Click Back — you should return to Components Demo.
5. Repeat step 3, click "Dismiss" — the banner should disappear without navigating away.
6. Scroll to the Action Cards section and find the "Handoff with URL" card. Click "Go to Dashboard" and verify the same banner behavior as above.
7. Navigate to a Newspack wizard page (e.g., Settings). Trigger a handoff programmatically or via the demo and verify the static PHP-rendered banner appears at the top of the wizard page.
8. Test an existing plugin-based handoff (e.g., Jetpack card) — confirm it still works and now accepts custom `bannerText`/`bannerButtonText` when passed.
9. After a handoff to a non-Newspack page, navigate to an unrelated admin page (e.g., Posts) — the banner should clear and no longer be visible.
10. After a handoff, navigate back to a Newspack page — the banner should also be gone.
11. Verify the banner is correctly offset on pages with the WordPress admin sidebar (no overflow or misalignment).
12. On a WooCommerce admin page, trigger a handoff and verify the banner adjusts for the WooCommerce header offset.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?