### PR TITLE
feat(integrations): add content gate metadata

### DIFF
--- a/includes/content-gate/class-user-gate-access.php
+++ b/includes/content-gate/class-user-gate-access.php
@@ -53,7 +53,7 @@ class User_Gate_Access {
 	 *         @type array $rules  Array of rule results with slug, name, value, and passes.
 	 * }
 	 */
-	private static function evaluate_gate_for_user( $gate, $user_id ) {
+	public static function evaluate_gate_for_user( $gate, $user_id ) {
 		$access_rules = Access_Rules::normalize_rules( $gate['custom_access']['access_rules'] ?? [] );
 
 		// Empty rules means the gate does not restrict — matches Content_Restriction_Control behavior.

--- a/includes/reader-activation/sync/class-contact-sync.php
+++ b/includes/reader-activation/sync/class-contact-sync.php
@@ -11,6 +11,7 @@ use Newspack\Reader_Activation;
 use Newspack\Reader_Activation\Integrations;
 use Newspack\Data_Events;
 use Newspack\Logger;
+use Newspack\Reader_Activation\Sync\Metadata;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -130,6 +131,12 @@ class Contact_Sync extends Sync {
 			if ( ! did_action( 'shutdown' ) ) {
 				return true;
 			}
+		}
+
+		// Added logging here to more easily monitor integration sync data. Can be removed once integrations are released.
+		if ( 'legacy' !== Metadata::get_version() ) {
+			Logger::log( sprintf( 'Syncing contact %s for context "%s".', $contact['email'] ?? 'unknown', $context ) );
+			Logger::log( $contact );
 		}
 
 		return self::push_to_integrations( $contact, $context, $existing_contact );

--- a/includes/reader-activation/sync/contact-metadata/class-content-gate.php
+++ b/includes/reader-activation/sync/contact-metadata/class-content-gate.php
@@ -8,6 +8,8 @@
 namespace Newspack\Reader_Activation\Sync\Contact_Metadata;
 
 use Newspack\Reader_Activation\Sync\Contact_Metadata;
+use Newspack\Content_Gate as Content_Gate_CPT;
+use Newspack\User_Gate_Access;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -41,8 +43,8 @@ class Content_Gate extends Contact_Metadata {
 	 */
 	public static function get_fields() {
 		return [
-			'Content_Access'        => 'Content_Access',
-			'Content_Access_Source' => 'Content_Access_Source',
+			'Content_Access'        => 'Content Access',
+			'Content_Access_Source' => 'Content Access Source',
 		];
 	}
 
@@ -52,6 +54,101 @@ class Content_Gate extends Contact_Metadata {
 	 * @return array
 	 */
 	public function get_metadata() {
-		return [];
+		if ( ! $this->user ) {
+			return [];
+		}
+
+		$gates = Content_Gate_CPT::get_gates( Content_Gate_CPT::GATE_CPT, 'publish' );
+		$custom_access_gates = array_filter(
+			$gates,
+			function ( $gate ) {
+				return ! is_wp_error( $gate ) && ! empty( $gate['custom_access']['active'] );
+			}
+		);
+
+		// No custom access gates configured — user is not restricted.
+		if ( empty( $custom_access_gates ) ) {
+			return [
+				'Content_Access'        => 'Yes',
+				'Content_Access_Source' => '',
+			];
+		}
+
+		$sources = $this->get_access_sources( $custom_access_gates );
+
+		return [
+			'Content_Access'        => ! empty( $sources ) ? 'Yes' : 'No',
+			'Content_Access_Source' => ! empty( $sources ) ? implode( ', ', $sources ) : '',
+		];
+	}
+
+	/**
+	 * Get the access source labels for the current user across all custom access gates.
+	 *
+	 * @param array $gates Gates with active custom access.
+	 * @return array Deduplicated source label strings.
+	 */
+	private function get_access_sources( $gates ) {
+		$sources = [];
+
+		foreach ( $gates as $gate ) {
+			$result = User_Gate_Access::evaluate_gate_for_user( $gate, $this->user->ID );
+
+			if ( ! $result['can_bypass'] ) {
+				continue;
+			}
+
+			foreach ( $result['groups'] as $group ) {
+				if ( ! $group['passes'] ) {
+					continue;
+				}
+				foreach ( $group['rules'] as $rule ) {
+					if ( ! $rule['passes'] ) {
+						continue;
+					}
+					$source = self::get_source_label( $rule['slug'], $rule['value'] );
+					if ( ! empty( $source ) ) {
+						$sources[ $source ] = true;
+					}
+				}
+			}
+		}
+
+		return array_keys( $sources );
+	}
+
+	/**
+	 * Map an access rule slug and value to a human-readable source label.
+	 *
+	 * @param string $slug  Rule slug.
+	 * @param mixed  $value Rule value.
+	 * @return string Source label or empty string.
+	 */
+	private static function get_source_label( $slug, $value ) {
+		switch ( $slug ) {
+			case 'subscription':
+				if ( is_array( $value ) && function_exists( 'wc_get_product' ) ) {
+					$names = [];
+					foreach ( $value as $product_id ) {
+						$product = wc_get_product( $product_id );
+						if ( $product ) {
+							$names[] = $product->get_name();
+						}
+					}
+					if ( ! empty( $names ) ) {
+						return implode( ', ', $names );
+					}
+				}
+				return 'Subscription';
+
+			case 'email_domain':
+				return 'domain';
+
+			case 'institution':
+				return 'group';
+
+			default:
+				return '';
+		}
 	}
 }

--- a/includes/reader-activation/sync/contact-metadata/class-content-gate.php
+++ b/includes/reader-activation/sync/contact-metadata/class-content-gate.php
@@ -75,10 +75,10 @@ class Content_Gate extends Contact_Metadata {
 
 		$custom_access_gates = self::get_custom_access_gates();
 
-		// No custom access gates configured — user is not restricted.
+		// No custom access gates configured — nothing to evaluate.
 		if ( empty( $custom_access_gates ) ) {
 			return [
-				'Content_Access'        => 'Yes',
+				'Content_Access'        => '',
 				'Content_Access_Source' => '',
 			];
 		}

--- a/includes/reader-activation/sync/contact-metadata/class-content-gate.php
+++ b/includes/reader-activation/sync/contact-metadata/class-content-gate.php
@@ -8,6 +8,7 @@
 namespace Newspack\Reader_Activation\Sync\Contact_Metadata;
 
 use Newspack\Reader_Activation\Sync\Contact_Metadata;
+use Newspack\Access_Rules;
 use Newspack\Content_Gate as Content_Gate_CPT;
 use Newspack\User_Gate_Access;
 
@@ -17,6 +18,20 @@ defined( 'ABSPATH' ) || exit;
  * Content Gate metadata class.
  */
 class Content_Gate extends Contact_Metadata {
+
+	/**
+	 * Cached custom access gates for the current request.
+	 *
+	 * @var array|null
+	 */
+	private static $custom_access_gates_cache = null;
+
+	/**
+	 * Reset the cached custom access gates.
+	 */
+	public static function reset_cache() {
+		self::$custom_access_gates_cache = null;
+	}
 
 	/**
 	 * Whether or not the metadata fields of this class are available to be synced.
@@ -58,13 +73,7 @@ class Content_Gate extends Contact_Metadata {
 			return [];
 		}
 
-		$gates = Content_Gate_CPT::get_gates( Content_Gate_CPT::GATE_CPT, 'publish' );
-		$custom_access_gates = array_filter(
-			$gates,
-			function ( $gate ) {
-				return ! is_wp_error( $gate ) && ! empty( $gate['custom_access']['active'] );
-			}
-		);
+		$custom_access_gates = self::get_custom_access_gates();
 
 		// No custom access gates configured — user is not restricted.
 		if ( empty( $custom_access_gates ) ) {
@@ -74,30 +83,65 @@ class Content_Gate extends Contact_Metadata {
 			];
 		}
 
-		$sources = $this->get_access_sources( $custom_access_gates );
+		$evaluations = [];
+		foreach ( $custom_access_gates as $gate ) {
+			$evaluations[] = User_Gate_Access::evaluate_gate_for_user( $gate, $this->user->ID );
+		}
 
 		return [
-			'Content_Access'        => ! empty( $sources ) ? 'Yes' : 'No',
-			'Content_Access_Source' => ! empty( $sources ) ? implode( ', ', $sources ) : '',
+			'Content_Access'        => self::has_content_access( $evaluations ) ? 'Yes' : 'No',
+			'Content_Access_Source' => implode( ', ', self::get_access_source_labels( $evaluations, $this->user->ID ) ),
 		];
 	}
 
 	/**
-	 * Get the access source labels for the current user across all custom access gates.
+	 * Get published gates with active custom access, cached for the request.
 	 *
-	 * @param array $gates Gates with active custom access.
-	 * @return array Deduplicated source label strings.
+	 * @return array
 	 */
-	private function get_access_sources( $gates ) {
+	private static function get_custom_access_gates() {
+		if ( null === self::$custom_access_gates_cache ) {
+			$gates                          = Content_Gate_CPT::get_gates( Content_Gate_CPT::GATE_CPT, 'publish' );
+			self::$custom_access_gates_cache = array_filter(
+				$gates,
+				function ( $gate ) {
+					return ! is_wp_error( $gate ) && ! empty( $gate['custom_access']['active'] );
+				}
+			);
+		}
+
+		return self::$custom_access_gates_cache;
+	}
+
+	/**
+	 * Whether any evaluated gate grants the user bypass access.
+	 *
+	 * @param array $evaluations Results from User_Gate_Access::evaluate_gate_for_user().
+	 * @return bool
+	 */
+	private static function has_content_access( $evaluations ) {
+		foreach ( $evaluations as $result ) {
+			if ( $result['can_bypass'] ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Get deduplicated, sorted source labels from gate evaluations.
+	 *
+	 * @param array $evaluations Results from User_Gate_Access::evaluate_gate_for_user().
+	 * @param int   $user_id     User ID.
+	 * @return array Sorted source label strings.
+	 */
+	private static function get_access_source_labels( $evaluations, $user_id ) {
 		$sources = [];
 
-		foreach ( $gates as $gate ) {
-			$result = User_Gate_Access::evaluate_gate_for_user( $gate, $this->user->ID );
-
+		foreach ( $evaluations as $result ) {
 			if ( ! $result['can_bypass'] ) {
 				continue;
 			}
-
 			foreach ( $result['groups'] as $group ) {
 				if ( ! $group['passes'] ) {
 					continue;
@@ -106,49 +150,53 @@ class Content_Gate extends Contact_Metadata {
 					if ( ! $rule['passes'] ) {
 						continue;
 					}
-					$source = self::get_source_label( $rule['slug'], $rule['value'] );
-					if ( ! empty( $source ) ) {
-						$sources[ $source ] = true;
+					foreach ( self::get_source_labels( $rule['slug'], $rule['value'], $user_id ) as $label ) {
+						$sources[ $label ] = true;
 					}
 				}
 			}
 		}
 
-		return array_keys( $sources );
+		$labels = array_keys( $sources );
+		sort( $labels, SORT_NATURAL | SORT_FLAG_CASE );
+		return $labels;
 	}
 
 	/**
-	 * Map an access rule slug and value to a human-readable source label.
+	 * Map an access rule slug and value to source labels.
 	 *
-	 * @param string $slug  Rule slug.
-	 * @param mixed  $value Rule value.
-	 * @return string Source label or empty string.
+	 * @param string $slug    Rule slug.
+	 * @param mixed  $value   Rule value.
+	 * @param int    $user_id User ID.
+	 * @return array Source labels.
 	 */
-	private static function get_source_label( $slug, $value ) {
+	private static function get_source_labels( $slug, $value, $user_id ) {
 		switch ( $slug ) {
 			case 'subscription':
 				if ( is_array( $value ) && function_exists( 'wc_get_product' ) ) {
 					$names = [];
 					foreach ( $value as $product_id ) {
-						$product = wc_get_product( $product_id );
-						if ( $product ) {
-							$names[] = $product->get_name();
+						if ( Access_Rules::has_active_subscription( $user_id, [ $product_id ] ) ) {
+							$product = wc_get_product( $product_id );
+							if ( $product ) {
+								$names[] = $product->get_name();
+							}
 						}
 					}
 					if ( ! empty( $names ) ) {
-						return implode( ', ', $names );
+						return $names;
 					}
 				}
-				return 'Subscription';
+				return [ 'Subscription' ];
 
 			case 'email_domain':
-				return 'domain';
+				return [ 'domain' ];
 
 			case 'institution':
-				return 'group';
+				return [ 'group' ];
 
 			default:
-				return '';
+				return [];
 		}
 	}
 }

--- a/tests/unit-tests/content-gate/class-content-gate-metadata.php
+++ b/tests/unit-tests/content-gate/class-content-gate-metadata.php
@@ -1,0 +1,231 @@
+<?php
+/**
+ * Tests the Content Gate metadata class.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Content_Gate;
+use Newspack\Reader_Activation;
+use Newspack\Reader_Activation\Sync\Contact_Metadata\Content_Gate as Content_Gate_Metadata;
+
+/**
+ * Test Content Gate metadata functionality.
+ *
+ * @group Content_Gate_Metadata
+ */
+class Newspack_Test_Content_Gate_Metadata extends WP_UnitTestCase {
+
+	/**
+	 * Test user ID.
+	 *
+	 * @var int
+	 */
+	private static $user_id;
+
+	/**
+	 * Set up before each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+		self::$user_id = $this->factory->user->create(
+			[
+				'role'       => 'subscriber',
+				'user_email' => 'reader@example.com',
+			]
+		);
+		Reader_Activation::set_reader_verified( self::$user_id );
+	}
+
+	/**
+	 * Helper to create a gate with custom access rules.
+	 *
+	 * @param string $title        Gate title.
+	 * @param array  $access_rules Access rules array.
+	 *
+	 * @return int Gate post ID.
+	 */
+	private function create_gate_with_rules( $title, $access_rules ) {
+		$gate_id = $this->factory->post->create(
+			[
+				'post_type'   => Content_Gate::GATE_CPT,
+				'post_status' => 'publish',
+				'post_title'  => $title,
+			]
+		);
+		update_post_meta(
+			$gate_id,
+			'custom_access',
+			[
+				'active'       => true,
+				'access_rules' => $access_rules,
+			]
+		);
+		return $gate_id;
+	}
+
+	/**
+	 * Helper to get metadata for a user.
+	 *
+	 * @param int $user_id User ID.
+	 * @return array Metadata array.
+	 */
+	private function get_metadata_for_user( $user_id ) {
+		$metadata = new Content_Gate_Metadata( $user_id );
+		return $metadata->get_metadata();
+	}
+
+	/**
+	 * Test that no gates configured returns access with empty source.
+	 */
+	public function test_no_gates_returns_yes() {
+		$result = $this->get_metadata_for_user( self::$user_id );
+
+		$this->assertEquals( 'Yes', $result['Content_Access'], 'No gates means unrestricted access.' );
+		$this->assertEmpty( $result['Content_Access_Source'], 'No gates means no source.' );
+	}
+
+	/**
+	 * Test that invalid user returns empty array.
+	 */
+	public function test_no_user_returns_empty() {
+		$result = $this->get_metadata_for_user( 0 );
+
+		$this->assertEmpty( $result, 'Invalid user should return empty metadata.' );
+	}
+
+	/**
+	 * Test user passing email domain rule.
+	 */
+	public function test_email_domain_pass() {
+		$rules = [
+			[
+				[
+					'slug'  => 'email_domain',
+					'value' => 'example.com',
+				],
+			],
+		];
+		$this->create_gate_with_rules( 'Domain Gate', $rules );
+
+		$result = $this->get_metadata_for_user( self::$user_id );
+
+		$this->assertEquals( 'Yes', $result['Content_Access'], 'User with matching domain should have access.' );
+		$this->assertEquals( 'domain', $result['Content_Access_Source'], 'Source should be "domain" for email domain rule.' );
+	}
+
+	/**
+	 * Test user failing email domain rule.
+	 */
+	public function test_email_domain_fail() {
+		$rules = [
+			[
+				[
+					'slug'  => 'email_domain',
+					'value' => 'other.com',
+				],
+			],
+		];
+		$this->create_gate_with_rules( 'Domain Gate', $rules );
+
+		$result = $this->get_metadata_for_user( self::$user_id );
+
+		$this->assertEquals( 'No', $result['Content_Access'], 'User with non-matching domain should not have access.' );
+		$this->assertEmpty( $result['Content_Access_Source'], 'Source should be empty when access is denied.' );
+	}
+
+	/**
+	 * Test user passes one gate but fails another — access is granted.
+	 */
+	public function test_multiple_gates_pass_one() {
+		$this->create_gate_with_rules(
+			'Failing Gate',
+			[
+				[
+					[
+						'slug'  => 'email_domain',
+						'value' => 'other.com',
+					],
+				],
+			]
+		);
+		$this->create_gate_with_rules(
+			'Passing Gate',
+			[
+				[
+					[
+						'slug'  => 'email_domain',
+						'value' => 'example.com',
+					],
+				],
+			]
+		);
+
+		$result = $this->get_metadata_for_user( self::$user_id );
+
+		$this->assertEquals( 'Yes', $result['Content_Access'], 'User should have access when passing at least one gate.' );
+		$this->assertEquals( 'domain', $result['Content_Access_Source'], 'Source should reflect the passing gate.' );
+	}
+
+	/**
+	 * Test that duplicate sources are deduplicated.
+	 */
+	public function test_sources_deduplicated() {
+		// Two gates with the same email domain rule type.
+		$this->create_gate_with_rules(
+			'Gate A',
+			[
+				[
+					[
+						'slug'  => 'email_domain',
+						'value' => 'example.com',
+					],
+				],
+			]
+		);
+		$this->create_gate_with_rules(
+			'Gate B',
+			[
+				[
+					[
+						'slug'  => 'email_domain',
+						'value' => 'example.com',
+					],
+				],
+			]
+		);
+
+		$result = $this->get_metadata_for_user( self::$user_id );
+
+		$this->assertEquals( 'Yes', $result['Content_Access'] );
+		$this->assertEquals( 'domain', $result['Content_Access_Source'], 'Duplicate sources should be deduplicated.' );
+	}
+
+	/**
+	 * Test OR logic between groups — user passes one group but fails another.
+	 */
+	public function test_or_logic_between_groups() {
+		$rules = [
+			// Group 1: fails.
+			[
+				[
+					'slug'  => 'email_domain',
+					'value' => 'other.com',
+				],
+			],
+			// Group 2: passes.
+			[
+				[
+					'slug'  => 'email_domain',
+					'value' => 'example.com',
+				],
+			],
+		];
+		$this->create_gate_with_rules( 'OR Gate', $rules );
+
+		$result = $this->get_metadata_for_user( self::$user_id );
+
+		$this->assertEquals( 'Yes', $result['Content_Access'], 'User should have access when one group passes (OR logic).' );
+		$this->assertEquals( 'domain', $result['Content_Access_Source'] );
+	}
+}

--- a/tests/unit-tests/content-gate/class-content-gate-metadata.php
+++ b/tests/unit-tests/content-gate/class-content-gate-metadata.php
@@ -77,12 +77,12 @@ class Newspack_Test_Content_Gate_Metadata extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that no gates configured returns access with empty source.
+	 * Test that no gates configured returns empty metadata.
 	 */
-	public function test_no_gates_returns_yes() {
+	public function test_no_gates_returns_empty() {
 		$result = $this->get_metadata_for_user( self::$user_id );
 
-		$this->assertEquals( 'Yes', $result['Content_Access'], 'No gates means unrestricted access.' );
+		$this->assertEmpty( $result['Content_Access'], 'No gates means empty Content_Access.' );
 		$this->assertEmpty( $result['Content_Access_Source'], 'No gates means no source.' );
 	}
 

--- a/tests/unit-tests/content-gate/class-content-gate-metadata.php
+++ b/tests/unit-tests/content-gate/class-content-gate-metadata.php
@@ -28,6 +28,7 @@ class Newspack_Test_Content_Gate_Metadata extends WP_UnitTestCase {
 	 */
 	public function set_up() {
 		parent::set_up();
+		Content_Gate_Metadata::reset_cache();
 		self::$user_id = $this->factory->user->create(
 			[
 				'role'       => 'subscriber',
@@ -199,6 +200,63 @@ class Newspack_Test_Content_Gate_Metadata extends WP_UnitTestCase {
 
 		$this->assertEquals( 'Yes', $result['Content_Access'] );
 		$this->assertEquals( 'domain', $result['Content_Access_Source'], 'Duplicate sources should be deduplicated.' );
+	}
+
+	/**
+	 * Test that an active gate with empty rules grants access with no source.
+	 */
+	public function test_gate_with_empty_rules_returns_yes() {
+		$gate_id = $this->factory->post->create(
+			[
+				'post_type'   => Content_Gate::GATE_CPT,
+				'post_status' => 'publish',
+				'post_title'  => 'Empty Rules Gate',
+			]
+		);
+		update_post_meta(
+			$gate_id,
+			'custom_access',
+			[
+				'active'       => true,
+				'access_rules' => [],
+			]
+		);
+
+		$result = $this->get_metadata_for_user( self::$user_id );
+
+		$this->assertEquals( 'Yes', $result['Content_Access'], 'Gate with empty rules should grant access.' );
+		$this->assertEmpty( $result['Content_Access_Source'], 'Gate with empty rules should have no source.' );
+	}
+
+	/**
+	 * Test institution rule produces "group" source label.
+	 */
+	public function test_institution_rule_source() {
+		$institution_id = $this->factory->post->create(
+			[
+				'post_type'   => 'np_institution',
+				'post_status' => 'publish',
+				'post_title'  => 'Test University',
+			]
+		);
+		update_post_meta( $institution_id, 'np_institution_email_domain', 'example.com' );
+		// Invalidate the institution cache so it picks up the new post.
+		\Newspack\Institution::invalidate_cache();
+
+		$rules = [
+			[
+				[
+					'slug'  => 'institution',
+					'value' => [ $institution_id ],
+				],
+			],
+		];
+		$this->create_gate_with_rules( 'Institution Gate', $rules );
+
+		$result = $this->get_metadata_for_user( self::$user_id );
+
+		$this->assertEquals( 'Yes', $result['Content_Access'], 'User matching institution should have access.' );
+		$this->assertEquals( 'group', $result['Content_Access_Source'], 'Source should be "group" for institution rule.' );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Implements the `Content_Gate` metadata class for reader activation sync, adding two fields that track whether a reader has access to gated content and what grants that access.

- **Content_Access**: `"Yes"`, `"No"`, or empty — whether the reader can bypass any published content gate with custom access rules. Empty when no content gates are configured.
- **Content_Access_Source**: The entity granting access — subscription product name(s), `"domain"` (email domain rule), or `"group"` (institutional access). Empty when Content_Access is `"No"` or empty.

Makes `User_Gate_Access::evaluate_gate_for_user()` public so the metadata class can reuse its detailed per-rule evaluation results.

Fixes `get_access_source_labels` to only include product names the user has actually purchased, rather than all products configured on the gate rule. Uses `Access_Rules::has_active_subscription()` to check each product individually, covering both individual and group subscriptions.

Closes NPPD-1390

## Test plan

1. Enabled the following in `wp-config.php`:
```
define( 'NEWSPACK_LOG_LEVEL', 3 );
define( 'NEWSPACK_CONTENT_GATES', true );
define( 'NEWSPACK_SYNC_METADATA_VERSION', '1.0' );
define( 'NEWSPACK_INTEGRATIONS_SETTINGS_ENABLED', true );
```
2. Navigate to Audience > Integrations > ESP and confirm the Content Access and Content Access Source fields are available in the outgoing metadata section
3. Check them both and save, confirming they persist on reload
4. Create two subscription products (e.g., "Premium Plan" and "Basic Plan")
5. Create a content gate with a subscription access rule that includes both products
6. As a new reader, register to the site
7. Check the logs and verify the contact is synced with `Content_Access = "No"` and `Content_Access_Source` = empty (since the reader has no subscriptions)
8. As the same reader, purchase only one of the two subscription products (e.g., "Basic Plan")
9. Check the logs for another sync entry — verify `Content_Access = "Yes"` and `Content_Access_Source` = only the purchased product name (e.g., `"Basic Plan"`), NOT both products
![Screenshot 2026-03-30 at 13 53 38](https://github.com/user-attachments/assets/0933d140-c82a-4d61-8eab-876738a369ba)
10. Now purchase the second subscription product as well
11. Check the logs — verify `Content_Access_Source` now includes both product names
12. Test with an email domain access rule — verify the source label is `"domain"` when the reader's email matches
13. Test with an institution access rule — verify the source label is `"group"` when the reader matches
14. Verify that when no custom access gates are configured, `Content_Access` is empty with empty source

🤖 Generated with [Claude Code](https://claude.com/claude-code)