### PR TITLE
fix(memberships): force non-empty message to allow wc_memberships_notice_html to fire

### DIFF
--- a/includes/plugins/wc-memberships/class-memberships.php
+++ b/includes/plugins/wc-memberships/class-memberships.php
@@ -48,6 +48,7 @@ class Memberships {
 
 		// WC Memberships hooks.
 		add_filter( 'wc_memberships_notice_html', [ __CLASS__, 'wc_memberships_notice_html' ], 100, 4 );
+		add_filter( 'wc_memberships_restricted_message', [ __CLASS__, 'wc_memberships_restricted_message' ], 100, 4 );
 		add_filter( 'wc_memberships_restricted_content_excerpt', [ __CLASS__, 'wc_memberships_excerpt' ], 100, 3 );
 		add_filter( 'wc_memberships_message_excerpt_apply_the_content_filter', '__return_false' );
 		add_filter( 'wc_memberships_admin_screen_ids', [ __CLASS__, 'admin_screens' ] );
@@ -532,6 +533,44 @@ class Memberships {
 		}
 		Content_Gate::mark_gate_as_rendered();
 		return Content_Gate::get_inline_gate_html();
+	}
+
+	/**
+	 * Filter WooCommerce Memberships' restricted message before it is rendered.
+	 *
+	 * When all WC Memberships message templates are set to empty strings, the
+	 * `get_message_html()` method skips `get_notice_html()` entirely — which
+	 * means `wc_memberships_notice_html` never fires and Newspack's gate is
+	 * never rendered.  We work around this by returning a non-empty placeholder
+	 * here so that `get_notice_html()` is always called when a Newspack gate is
+	 * configured for a content-restriction context.  The placeholder is then
+	 * replaced by the real gate HTML inside `wc_memberships_notice_html()`.
+	 *
+	 * @param string $message      Restriction message text (may be empty).
+	 * @param object $post         Post object.
+	 * @param string $message_code Message code (e.g. 'content_delayed', 'content_restricted').
+	 * @param array  $args         Additional arguments.
+	 *
+	 * @return string
+	 */
+	public static function wc_memberships_restricted_message( $message, $post, $message_code, $args ) {
+		// Only intervene when the message is empty — a non-empty message means
+		// the publisher configured their own copy and we should leave it alone.
+		if ( '' !== trim( $message ) ) {
+			return $message;
+		}
+		// Only replace for content-restriction contexts (not product discounts etc.).
+		if ( ! str_contains( $message_code, 'content_' ) ) {
+			return $message;
+		}
+		// Only replace when a Newspack gate is configured.
+		if ( ! Content_Gate::has_gate() ) {
+			return $message;
+		}
+		// Return a single non-breaking space so that get_message_html() proceeds
+		// to call get_notice_html() → wc_memberships_notice_html, where the
+		// real gate HTML will be substituted.
+		return '&nbsp;';
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Closes NPPM-2707.

When all WC Memberships message templates are set to empty strings (which is the case when Newspack content gates replace them), the `get_message_html()` method in WC Memberships skips `get_notice_html()` entirely. This means the `wc_memberships_notice_html` filter never fires, so Newspack's content gate is never rendered. The result is that restricted content is truncated but no gate is shown to the reader.

This fix adds a `wc_memberships_restricted_message` filter that returns a non-breaking space (`&nbsp;`) when the message is empty and a Newspack gate is configured. This ensures `get_notice_html()` is called, which fires `wc_memberships_notice_html`, and the gate renders correctly. The placeholder is fully replaced by Newspack's gate HTML in `wc_memberships_notice_html()`.

The filter has three guard clauses to limit its scope:
- Only intervenes when the message is empty (leaves publisher-configured messages alone)
- Only applies to `content_` message codes (not product discounts etc.)
- Only activates when a Newspack gate is configured

### How to test the changes in this Pull Request:

1. Ensure WC Memberships 1.28.1 is installed and active with a membership plan that restricts all posts.
2. Set the WC Memberships message templates to empty strings (this happens automatically when Newspack content gates are configured, or set manually via `update_option('wc_memberships_messages', ['content_restricted_message' => '', ...])`)
3. Configure a Newspack content gate (Audience > Access Control > create a gate restricting all posts with registered access).
4. Log in as a subscriber/reader who does NOT have an active membership in the restricting plan.
5. Visit a restricted post.

**Expected on `release` (bug):** Content is truncated but no gate appears below it.
**Expected on this branch (fix):** Content is truncated and the memberships gate is rendered below.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?