### PR TITLE
feat(components): update CardFeature button size and variant

### DIFF
--- a/packages/components/src/card-feature/index.tsx
+++ b/packages/components/src/card-feature/index.tsx
@@ -104,11 +104,11 @@ const CardFeature = ( {
 		badge = { text: badgeText ?? __( 'Enabled', 'newspack-plugin' ), level: badgeLevel };
 	}
 
-	const buttonLabel =
-		enabled && ! requirements ? configureLabel ?? __( 'Configure', 'newspack-plugin' ) : enableLabel ?? __( 'Enable', 'newspack-plugin' );
+	const isConfigureState = enabled && ! requirements;
+	const buttonLabel = isConfigureState ? configureLabel ?? __( 'Configure', 'newspack-plugin' ) : enableLabel ?? __( 'Enable', 'newspack-plugin' );
 
 	const handleButtonClick = () => {
-		if ( enabled && ! requirements ) {
+		if ( isConfigureState ) {
 			onConfigure?.();
 		} else {
 			onEnable?.();
@@ -150,15 +150,20 @@ const CardFeature = ( {
 						<HStack alignment="edge">
 							<HStack expanded={ false } spacing="8px">
 								<Button
-									variant={ enabled && ! requirements ? 'tertiary' : 'secondary' }
+									variant={ isConfigureState ? 'tertiary' : 'secondary' }
 									disabled={ isMuted }
 									onClick={ handleButtonClick }
 									size="compact"
 								>
 									{ buttonLabel }
 								</Button>
-								{ enabled && ! requirements && !! moreControls?.length && (
-									<DropdownMenu icon={ moreVertical } label={ __( 'More', 'newspack-plugin' ) } controls={ moreControls } />
+								{ isConfigureState && !! moreControls?.length && (
+									<DropdownMenu
+										icon={ moreVertical }
+										label={ __( 'More', 'newspack-plugin' ) }
+										controls={ moreControls }
+										toggleProps={ { size: 'compact' } }
+									/>
 								) }
 							</HStack>
 							{ badge && <Badge text={ badge.text } level={ badge.level } /> }

--- a/packages/components/src/card-feature/index.tsx
+++ b/packages/components/src/card-feature/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import type { ComponentType } from 'react';
 import classnames from 'classnames';
 
 /**
@@ -38,7 +39,7 @@ type CardFeatureIcon = {
 type MoreControl = {
 	title: string;
 	onClick: () => void;
-	icon?: React.ReactNode;
+	icon?: ComponentType< { size?: number } > | JSX.Element;
 };
 
 type CardFeatureProps = {
@@ -149,7 +150,12 @@ const CardFeature = ( {
 						</HStack>
 						<HStack alignment="edge">
 							<HStack expanded={ false } spacing="8px">
-								<Button variant="secondary" disabled={ isMuted } onClick={ handleButtonClick }>
+								<Button
+									variant={ enabled && ! requirements ? 'tertiary' : 'secondary' }
+									disabled={ isMuted }
+									onClick={ handleButtonClick }
+									size="compact"
+								>
 									{ buttonLabel }
 								</Button>
 								{ enabled && ! requirements && !! moreControls?.length && (

--- a/packages/components/src/card-feature/index.tsx
+++ b/packages/components/src/card-feature/index.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import type { ComponentType } from 'react';
 import classnames from 'classnames';
 
 /**
@@ -39,7 +38,7 @@ type CardFeatureIcon = {
 type MoreControl = {
 	title: string;
 	onClick: () => void;
-	icon?: ComponentType< { size?: number } > | JSX.Element;
+	icon?: React.ReactNode;
 };
 
 type CardFeatureProps = {

--- a/packages/components/src/card-feature/style.scss
+++ b/packages/components/src/card-feature/style.scss
@@ -3,7 +3,7 @@
  */
 
 @use "~@wordpress/base-styles/colors" as wp-colors;
-@use "~@wordpress/base-styles/variables" as wp;
+@use "~@wordpress/base-styles/variables" as wp-vars;
 
 .newspack-card-feature {
 	.newspack-card--core__header-content {
@@ -16,8 +16,8 @@
 	}
 
 	&__title {
-		font-size: wp.$font-size-x-large;
-		line-height: wp.$font-line-height-x-large;
+		font-size: wp-vars.$font-size-x-large;
+		line-height: wp-vars.$font-line-height-x-large;
 		text-align: left;
 	}
 
@@ -40,11 +40,11 @@
 		}
 
 		&--radius-small {
-			border-radius: wp.$radius-small;
+			border-radius: wp-vars.$radius-small;
 		}
 
 		&--radius-full {
-			border-radius: wp.$radius-round;
+			border-radius: wp-vars.$radius-round;
 		}
 	}
 
@@ -57,5 +57,11 @@
 		.newspack-card-feature__description {
 			color: wp-colors.$gray-700;
 		}
+	}
+
+	.components-dropdown-menu__toggle {
+		height: wp-vars.$grid-unit-40;
+		min-width: wp-vars.$grid-unit-40;
+		padding: wp-vars.$grid-unit-05;
 	}
 }

--- a/packages/components/src/card-feature/style.scss
+++ b/packages/components/src/card-feature/style.scss
@@ -58,10 +58,4 @@
 			color: wp-colors.$gray-700;
 		}
 	}
-
-	.components-dropdown-menu__toggle {
-		height: wp-vars.$grid-unit-40;
-		min-width: wp-vars.$grid-unit-40;
-		padding: wp-vars.$grid-unit-05;
-	}
 }

--- a/packages/components/src/section-header/style.scss
+++ b/packages/components/src/section-header/style.scss
@@ -3,7 +3,7 @@
  */
 
 @use "~@wordpress/base-styles/colors" as wp-colors;
-@use "~@wordpress/base-styles/variables" as wp;
+@use "~@wordpress/base-styles/variables" as wp-vars;
 @use "../../../colors/colors.module" as colors;
 
 .newspack-section-header {
@@ -87,9 +87,9 @@
 		gap: 8px;
 
 		h2 {
-			font-size: wp.$font-size-x-large;
-			font-weight: wp.$font-weight-medium;
-			line-height: wp.$font-line-height-x-large;
+			font-size: wp-vars.$font-size-x-large;
+			font-weight: wp-vars.$font-weight-medium;
+			line-height: wp-vars.$font-line-height-x-large;
 		}
 
 		.newspack-section-header__menu,
@@ -159,9 +159,9 @@
 			}
 		}
 		h1 {
-			font-size: wp.$font-size-x-large;
-			font-weight: wp.$font-weight-medium;
-			line-height: wp.$font-line-height-x-large;
+			font-size: wp-vars.$font-size-x-large;
+			font-weight: wp-vars.$font-weight-medium;
+			line-height: wp-vars.$font-line-height-x-large;
 		}
 	}
 }

--- a/src/wizards/audience/views/content-gates/content-gate-settings.tsx
+++ b/src/wizards/audience/views/content-gates/content-gate-settings.tsx
@@ -199,7 +199,7 @@ export default function ContentGateSettings( {
 								) }
 								{ ! gate.registration?.active && <p>{ __( 'N/A', 'newspack-plugin' ) }</p> }
 								{ gate.registration?.active && gate.registration.gate_layout_id && (
-									<Button variant="secondary" href={ getEditGateLayoutUrl( gate.id, 'registration' ) }>
+									<Button variant="secondary" href={ getEditGateLayoutUrl( gate.id, 'registration' ) } size="compact">
 										{ __( 'Customize registered access layout', 'newspack-plugin' ) }
 									</Button>
 								) }
@@ -246,7 +246,7 @@ export default function ContentGateSettings( {
 								gate.custom_access.access_rules?.length > 0 &&
 								gate.custom_access.gate_layout_id &&
 								! isNewsletter && (
-									<Button variant="secondary" href={ getEditGateLayoutUrl( gate.id, 'custom_access' ) }>
+									<Button variant="secondary" href={ getEditGateLayoutUrl( gate.id, 'custom_access' ) } size="compact">
 										{ __( 'Customize paid access layout', 'newspack-plugin' ) }
 									</Button>
 								) }

--- a/src/wizards/audience/views/content-gates/style.scss
+++ b/src/wizards/audience/views/content-gates/style.scss
@@ -3,7 +3,7 @@
  */
 
 @use "~@wordpress/base-styles/colors" as wp-colors;
-@use "~@wordpress/base-styles/variables" as wp;
+@use "~@wordpress/base-styles/variables" as wp-vars;
 
 .audience_page_newspack-audience-access-control,
 .newspack-premium-newsletters {
@@ -26,9 +26,9 @@
 			}
 			&__settings {
 				h4 {
-					font-size: wp.$font-size-small;
-					font-weight: wp.$font-weight-medium;
-					line-height: wp.$font-line-height-small;
+					font-size: wp-vars.$font-size-small;
+					font-weight: wp-vars.$font-weight-medium;
+					line-height: wp-vars.$font-line-height-small;
 					margin-bottom: 8px;
 					text-transform: uppercase;
 				}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Updates button sizing to use the medium (compact) size across integration cards and related screens.

- `CardFeature`: primary button uses `size="compact"` (32px height); variant is conditionally `tertiary` when enabled (Configure state) or `secondary` when not yet enabled or requirements are unmet (Enable state). The "More" dropdown toggle is also sized to match (32×32px).
- `ContentGateSettings`: two layout-customization buttons updated to `size="compact"` for consistency.
- Renames the `@wordpress/base-styles/variables` SCSS alias from `wp` to `wp-vars` across affected files for clarity.

Note: `CardFeature` is part of the shared `npm-packages` contract. This is a visual-only change — no API or props changes — so consumers require no code updates, but will see the updated button appearance.

Closes DSGNEWS-141.

### How to test the changes in this Pull Request:

1. Navigate to the Integrations screen (Newspack > Integrations).
2. Find a feature card in its default (not enabled) state. Verify the primary button reads "Enable", uses the `secondary` variant, and is compact (32px height).
3. Enable a feature. Verify the primary button reads "Configure", uses the `tertiary` variant (less prominent), and remains compact.
4. Find a feature card with unmet requirements (error badge). Verify the button is disabled, uses the `secondary` variant, and is compact.
5. On a card with the "More" dropdown visible (enabled, no requirements), verify the dropdown toggle button is visually the same height as the primary button.
6. Navigate to Audience > Access Control, open a content gate's settings. Verify the "Customize registered access layout" and "Customize paid access layout" buttons are also compact.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?