### PR TITLE
fix(card-settings-group): change default actionType from chevron to none

### DIFF
--- a/packages/components/src/card-settings-group/index.tsx
+++ b/packages/components/src/card-settings-group/index.tsx
@@ -9,7 +9,7 @@ import { Card } from '../';
 import './style.scss';
 
 const CardSettingsGroup = ( {
-	actionType = 'chevron',
+	actionType = 'none',
 	children,
 	icon = null,
 	title = '',

--- a/src/wizards/audience/views/content-gates/edit/index.tsx
+++ b/src/wizards/audience/views/content-gates/edit/index.tsx
@@ -486,7 +486,6 @@ const Edit = ( { match, updateGatesData, slug = AUDIENCE_CONTENT_GATES_WIZARD_SL
 				/>
 				<VStack spacing={ 4 }>
 					<CardSettingsGroup
-						actionType="chevron"
 						title={ sprintf(
 							// translators: %s is the type of content to restrict.
 							__( 'Restrict all %s', 'newspack-plugin' ),
@@ -502,7 +501,6 @@ const Edit = ( { match, updateGatesData, slug = AUDIENCE_CONTENT_GATES_WIZARD_SL
 						onEnable={ () => setContentType( 'all' ) }
 					/>
 					<CardSettingsGroup
-						actionType="chevron"
 						title={ sprintf(
 							// translators: %s is the type of content to restrict.
 							__( 'Choose specific %s', 'newspack-plugin' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Changes the default `actionType` for `CardSettingsGroup` from `"chevron"` to `"none"`, making the chevron opt-in rather than opt-out. The content gates edit view ("What would you like to restrict?") no longer shows chevrons on the "Restrict all posts" and "Choose specific content" cards — chevrons are intentional only on the onboarding/init screen where those cards act as navigation links.

### How to test the changes in this Pull Request:

1. Go to **Audience > Content Gates** with no existing gates — the onboarding screen should show both cards with chevrons (unchanged).
2. Click either card to enter the add-new flow — the "What would you like to restrict?" section should show both cards **without** chevrons.
3. Edit an existing gate — same section should show both cards without chevrons.
4. Confirm the "Registered access" and "Paid access" cards still show toggles as expected (they explicitly pass `actionType="toggle"`).
5. Go to **Audience > Content Gates > Institutions** — the Email domain, IP range, and Reader data cards should still show toggles (they explicitly pass `actionType="toggle"`).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?