### PR TITLE
fix(indesign): exclude rich media blocks from export output

### DIFF
--- a/includes/optional-modules/indesign-export/class-indesign-converter.php
+++ b/includes/optional-modules/indesign-export/class-indesign-converter.php
@@ -190,10 +190,13 @@ class InDesign_Converter {
 		// the InDesign output. Strip recursively so nested occurrences inside
 		// container blocks (core/group, core/columns, etc.) are also removed.
 		// Publishers can extend this list via the filter for custom block types.
-		$excluded_block_types = apply_filters(
+		// Normalize the filter result to an array of strings in case a callback
+		// returns a non-array or mixed-type value.
+		$excluded_block_types = (array) apply_filters(
 			'newspack_indesign_export_excluded_blocks',
 			self::EXCLUDED_BLOCK_TYPES
 		);
+		$excluded_block_types = array_values( array_filter( $excluded_block_types, 'is_string' ) );
 
 		$blocks  = $this->strip_excluded_blocks( parse_blocks( $content ), $excluded_block_types );
 		$content = '';
@@ -256,11 +259,12 @@ class InDesign_Converter {
 	/**
 	 * Check whether a block name should be excluded from export.
 	 *
-	 * Handles both the explicit exclusion list and legacy core-embed/* block
-	 * names used in content created before WordPress 5.6.
+	 * Legacy core-embed/* block names (pre-WP 5.6) follow the same exclusion
+	 * state as core/embed — if core/embed is in the filtered list, its legacy
+	 * variants are excluded too.
 	 *
 	 * @param string   $block_name           Block type name.
-	 * @param string[] $excluded_block_types Explicit list of excluded block types.
+	 * @param string[] $excluded_block_types Filtered list of excluded block types.
 	 *
 	 * @return bool True if the block should be excluded.
 	 */
@@ -272,8 +276,11 @@ class InDesign_Converter {
 		if ( in_array( $block_name, $excluded_block_types, true ) ) {
 			return true;
 		}
-		// Legacy embed block names (pre-WP 5.6) use the core-embed/* namespace.
-		if ( 0 === strpos( $block_name, 'core-embed/' ) ) {
+		// Legacy core-embed/* variants follow core/embed's exclusion state.
+		if (
+			in_array( 'core/embed', $excluded_block_types, true )
+			&& 0 === strpos( $block_name, 'core-embed/' )
+		) {
 			return true;
 		}
 		return false;

--- a/includes/optional-modules/indesign-export/class-indesign-converter.php
+++ b/includes/optional-modules/indesign-export/class-indesign-converter.php
@@ -172,9 +172,22 @@ class InDesign_Converter {
 	 * @return string Content with processed blocks.
 	 */
 	private function process_blocks( $content ) {
-		$blocks = parse_blocks( $content );
+		// Rich media blocks have no print equivalent. Exclude them entirely to
+		// prevent raw HTML (e.g. <object> tags, embed URLs) from leaking into
+		// the InDesign output.
+		$excluded_block_types = [
+			'core/file',
+			'core/embed',
+			'core/video',
+			'core/audio',
+		];
+
+		$blocks  = parse_blocks( $content );
 		$content = '';
 		foreach ( $blocks as $block ) {
+			if ( in_array( $block['blockName'], $excluded_block_types, true ) ) {
+				continue;
+			}
 			$tag = $this->get_block_tag( $block );
 			if ( ! empty( $tag ) ) {
 				$content .= $tag . $this->get_transformed_text( preg_replace( '/^<[^>]+>(.*)<\/[^>]+>$/s', '$1', trim( $block['innerHTML'] ) ) );

--- a/includes/optional-modules/indesign-export/class-indesign-converter.php
+++ b/includes/optional-modules/indesign-export/class-indesign-converter.php
@@ -15,6 +15,19 @@ defined( 'ABSPATH' ) || exit;
 class InDesign_Converter {
 
 	/**
+	 * Block types with no print equivalent, excluded from InDesign export by default.
+	 * Filterable via the newspack_indesign_export_excluded_blocks filter.
+	 *
+	 * @var string[]
+	 */
+	const EXCLUDED_BLOCK_TYPES = [
+		'core/file',
+		'core/embed',
+		'core/video',
+		'core/audio',
+	];
+
+	/**
 	 * Default InDesign styles configuration.
 	 *
 	 * @var array
@@ -176,12 +189,11 @@ class InDesign_Converter {
 		// prevent raw HTML (e.g. <object> tags, embed URLs) from leaking into
 		// the InDesign output. Strip recursively so nested occurrences inside
 		// container blocks (core/group, core/columns, etc.) are also removed.
-		$excluded_block_types = [
-			'core/file',
-			'core/embed',
-			'core/video',
-			'core/audio',
-		];
+		// Publishers can extend this list via the filter for custom block types.
+		$excluded_block_types = apply_filters(
+			'newspack_indesign_export_excluded_blocks',
+			self::EXCLUDED_BLOCK_TYPES
+		);
 
 		$blocks  = $this->strip_excluded_blocks( parse_blocks( $content ), $excluded_block_types );
 		$content = '';
@@ -211,7 +223,7 @@ class InDesign_Converter {
 	private function strip_excluded_blocks( $blocks, $excluded_block_types ) {
 		$filtered = [];
 		foreach ( $blocks as $block ) {
-			if ( in_array( $block['blockName'], $excluded_block_types, true ) ) {
+			if ( $this->is_excluded_block( $block['blockName'], $excluded_block_types ) ) {
 				continue;
 			}
 			if ( ! empty( $block['innerBlocks'] ) ) {
@@ -222,8 +234,12 @@ class InDesign_Converter {
 					if ( is_string( $chunk ) ) {
 						$new_inner_content[] = $chunk;
 					} else {
+						if ( ! isset( $block['innerBlocks'][ $inner_index ] ) ) {
+							$inner_index++;
+							continue;
+						}
 						$inner_block = $block['innerBlocks'][ $inner_index++ ];
-						if ( ! in_array( $inner_block['blockName'], $excluded_block_types, true ) ) {
+						if ( ! $this->is_excluded_block( $inner_block['blockName'], $excluded_block_types ) ) {
 							$new_inner_blocks[]  = $inner_block;
 							$new_inner_content[] = null;
 						}
@@ -235,6 +251,32 @@ class InDesign_Converter {
 			$filtered[] = $block;
 		}
 		return $filtered;
+	}
+
+	/**
+	 * Check whether a block name should be excluded from export.
+	 *
+	 * Handles both the explicit exclusion list and legacy core-embed/* block
+	 * names used in content created before WordPress 5.6.
+	 *
+	 * @param string   $block_name           Block type name.
+	 * @param string[] $excluded_block_types Explicit list of excluded block types.
+	 *
+	 * @return bool True if the block should be excluded.
+	 */
+	private function is_excluded_block( $block_name, $excluded_block_types ) {
+		// parse_blocks() returns null blockName for freeform/whitespace chunks.
+		if ( ! is_string( $block_name ) || '' === $block_name ) {
+			return false;
+		}
+		if ( in_array( $block_name, $excluded_block_types, true ) ) {
+			return true;
+		}
+		// Legacy embed block names (pre-WP 5.6) use the core-embed/* namespace.
+		if ( 0 === strpos( $block_name, 'core-embed/' ) ) {
+			return true;
+		}
+		return false;
 	}
 
 	/**

--- a/includes/optional-modules/indesign-export/class-indesign-converter.php
+++ b/includes/optional-modules/indesign-export/class-indesign-converter.php
@@ -174,7 +174,8 @@ class InDesign_Converter {
 	private function process_blocks( $content ) {
 		// Rich media blocks have no print equivalent. Exclude them entirely to
 		// prevent raw HTML (e.g. <object> tags, embed URLs) from leaking into
-		// the InDesign output.
+		// the InDesign output. Strip recursively so nested occurrences inside
+		// container blocks (core/group, core/columns, etc.) are also removed.
 		$excluded_block_types = [
 			'core/file',
 			'core/embed',
@@ -182,12 +183,9 @@ class InDesign_Converter {
 			'core/audio',
 		];
 
-		$blocks  = parse_blocks( $content );
+		$blocks  = $this->strip_excluded_blocks( parse_blocks( $content ), $excluded_block_types );
 		$content = '';
 		foreach ( $blocks as $block ) {
-			if ( in_array( $block['blockName'], $excluded_block_types, true ) ) {
-				continue;
-			}
 			$tag = $this->get_block_tag( $block );
 			if ( ! empty( $tag ) ) {
 				$content .= $tag . $this->get_transformed_text( preg_replace( '/^<[^>]+>(.*)<\/[^>]+>$/s', '$1', trim( $block['innerHTML'] ) ) );
@@ -196,6 +194,47 @@ class InDesign_Converter {
 			}
 		}
 		return $content;
+	}
+
+	/**
+	 * Recursively remove excluded block types from a block tree.
+	 *
+	 * Strips both the top-level block and any occurrences nested inside
+	 * container blocks (core/group, core/columns, etc.) by filtering
+	 * innerBlocks and the corresponding innerContent null placeholders.
+	 *
+	 * @param array $blocks               Block list to filter.
+	 * @param array $excluded_block_types Block type names to remove.
+	 *
+	 * @return array Filtered block list.
+	 */
+	private function strip_excluded_blocks( $blocks, $excluded_block_types ) {
+		$filtered = [];
+		foreach ( $blocks as $block ) {
+			if ( in_array( $block['blockName'], $excluded_block_types, true ) ) {
+				continue;
+			}
+			if ( ! empty( $block['innerBlocks'] ) ) {
+				$new_inner_blocks  = [];
+				$new_inner_content = [];
+				$inner_index       = 0;
+				foreach ( $block['innerContent'] as $chunk ) {
+					if ( is_string( $chunk ) ) {
+						$new_inner_content[] = $chunk;
+					} else {
+						$inner_block = $block['innerBlocks'][ $inner_index++ ];
+						if ( ! in_array( $inner_block['blockName'], $excluded_block_types, true ) ) {
+							$new_inner_blocks[]  = $inner_block;
+							$new_inner_content[] = null;
+						}
+					}
+				}
+				$block['innerBlocks']  = $this->strip_excluded_blocks( $new_inner_blocks, $excluded_block_types );
+				$block['innerContent'] = $new_inner_content;
+			}
+			$filtered[] = $block;
+		}
+		return $filtered;
 	}
 
 	/**

--- a/tests/unit-tests/indesign-exporter/indesign-exporter.php
+++ b/tests/unit-tests/indesign-exporter/indesign-exporter.php
@@ -415,7 +415,7 @@ class Newspack_Test_InDesign_Exporter extends WP_UnitTestCase {
 	/**
 	 * Test that core/embed blocks are excluded from export when nested inside a columns block.
 	 *
-	 * core/columns has a different innerContent shape from core/group (it contains
+	 * The core/columns block has a different innerContent shape from core/group (it contains
 	 * core/column children which in turn contain the embed), exercising the recursive
 	 * strip logic through two container levels.
 	 */

--- a/tests/unit-tests/indesign-exporter/indesign-exporter.php
+++ b/tests/unit-tests/indesign-exporter/indesign-exporter.php
@@ -367,6 +367,124 @@ class Newspack_Test_InDesign_Exporter extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that core/video blocks are excluded from export.
+	 *
+	 * Video embeds have no print equivalent and their raw markup must not
+	 * appear in the InDesign output.
+	 */
+	public function test_video_block_excluded() {
+		$post_id = $this->factory->post->create(
+			[
+				'post_title'   => 'Test Post',
+				'post_content' => '<!-- wp:paragraph --><p>Before the video.</p><!-- /wp:paragraph --><!-- wp:video {"id":1} --><figure class="wp-block-video"><video controls src="https://example.com/video.mp4"></video></figure><!-- /wp:video --><!-- wp:paragraph --><p>After the video.</p><!-- /wp:paragraph -->',
+			]
+		);
+
+		$converter = new InDesign_Converter();
+		$content   = $converter->convert_post( $post_id );
+
+		$this->assertStringContainsString( 'Before the video.', $content );
+		$this->assertStringContainsString( 'After the video.', $content );
+		$this->assertStringNotContainsString( 'video.mp4', $content );
+		$this->assertStringNotContainsString( '<video', $content );
+	}
+
+	/**
+	 * Test that core/audio blocks are excluded from export.
+	 *
+	 * Audio embeds have no print equivalent and their raw markup must not
+	 * appear in the InDesign output.
+	 */
+	public function test_audio_block_excluded() {
+		$post_id = $this->factory->post->create(
+			[
+				'post_title'   => 'Test Post',
+				'post_content' => '<!-- wp:paragraph --><p>Before the audio.</p><!-- /wp:paragraph --><!-- wp:audio {"id":1} --><figure class="wp-block-audio"><audio controls src="https://example.com/audio.mp3"></audio></figure><!-- /wp:audio --><!-- wp:paragraph --><p>After the audio.</p><!-- /wp:paragraph -->',
+			]
+		);
+
+		$converter = new InDesign_Converter();
+		$content   = $converter->convert_post( $post_id );
+
+		$this->assertStringContainsString( 'Before the audio.', $content );
+		$this->assertStringContainsString( 'After the audio.', $content );
+		$this->assertStringNotContainsString( 'audio.mp3', $content );
+		$this->assertStringNotContainsString( '<audio', $content );
+	}
+
+	/**
+	 * Test that core/embed blocks are excluded from export when nested inside a columns block.
+	 *
+	 * core/columns has a different innerContent shape from core/group (it contains
+	 * core/column children which in turn contain the embed), exercising the recursive
+	 * strip logic through two container levels.
+	 */
+	public function test_embed_block_excluded_when_nested_in_columns() {
+		$post_id = $this->factory->post->create(
+			[
+				'post_title'   => 'Test Post',
+				'post_content' => '<!-- wp:paragraph --><p>Before the columns.</p><!-- /wp:paragraph --><!-- wp:columns --><div class="wp-block-columns"><!-- wp:column --><div class="wp-block-column"><!-- wp:embed {"url":"https://www.youtube.com/watch?v=xyz789","type":"video","providerNameSlug":"youtube"} --><figure class="wp-block-embed is-type-video is-provider-youtube"><div class="wp-block-embed__wrapper">' . "\n" . 'https://www.youtube.com/watch?v=xyz789' . "\n" . '</div></figure><!-- /wp:embed --></div><!-- /wp:column --><!-- wp:column --><div class="wp-block-column"><!-- wp:paragraph --><p>Text in second column.</p><!-- /wp:paragraph --></div><!-- /wp:column --></div><!-- /wp:columns --><!-- wp:paragraph --><p>After the columns.</p><!-- /wp:paragraph -->',
+			]
+		);
+
+		$converter = new InDesign_Converter();
+		$content   = $converter->convert_post( $post_id );
+
+		$this->assertStringContainsString( 'Before the columns.', $content );
+		$this->assertStringContainsString( 'After the columns.', $content );
+		$this->assertStringNotContainsString( 'youtube.com', $content );
+		$this->assertStringNotContainsString( 'xyz789', $content );
+	}
+
+	/**
+	 * Test that two consecutive excluded blocks inside a container are both removed.
+	 *
+	 * This exercises the $inner_index increment path in strip_excluded_blocks() where
+	 * two null placeholders in innerContent map to two consecutive excluded innerBlocks
+	 * entries — ensuring the index stays in sync after the first block is skipped.
+	 */
+	public function test_two_excluded_siblings_in_container() {
+		$post_id = $this->factory->post->create(
+			[
+				'post_title'   => 'Test Post',
+				'post_content' => '<!-- wp:paragraph --><p>Before the group.</p><!-- /wp:paragraph --><!-- wp:group --><div class="wp-block-group"><!-- wp:embed {"url":"https://www.youtube.com/watch?v=first","type":"video","providerNameSlug":"youtube"} --><figure class="wp-block-embed is-type-video is-provider-youtube"><div class="wp-block-embed__wrapper">' . "\n" . 'https://www.youtube.com/watch?v=first' . "\n" . '</div></figure><!-- /wp:embed --><!-- wp:embed {"url":"https://www.youtube.com/watch?v=second","type":"video","providerNameSlug":"youtube"} --><figure class="wp-block-embed is-type-video is-provider-youtube"><div class="wp-block-embed__wrapper">' . "\n" . 'https://www.youtube.com/watch?v=second' . "\n" . '</div></figure><!-- /wp:embed --><!-- wp:paragraph --><p>After both embeds.</p><!-- /wp:paragraph --></div><!-- /wp:group --><!-- wp:paragraph --><p>After the group.</p><!-- /wp:paragraph -->',
+			]
+		);
+
+		$converter = new InDesign_Converter();
+		$content   = $converter->convert_post( $post_id );
+
+		$this->assertStringContainsString( 'Before the group.', $content );
+		$this->assertStringContainsString( 'After both embeds.', $content );
+		$this->assertStringContainsString( 'After the group.', $content );
+		$this->assertStringNotContainsString( 'first', $content );
+		$this->assertStringNotContainsString( 'second', $content );
+	}
+
+	/**
+	 * Test that legacy core-embed/* blocks (pre-WP 5.6) are excluded from export.
+	 *
+	 * WordPress 5.6 unified embed blocks under core/embed. Older content may still
+	 * contain core-embed/youtube, core-embed/vimeo, etc. These must also be excluded.
+	 */
+	public function test_legacy_core_embed_block_excluded() {
+		$post_id = $this->factory->post->create(
+			[
+				'post_title'   => 'Test Post',
+				'post_content' => '<!-- wp:paragraph --><p>Before the embed.</p><!-- /wp:paragraph --><!-- wp:core-embed/youtube {"url":"https://www.youtube.com/watch?v=legacy123"} --><figure class="wp-block-embed-youtube"><div class="wp-block-embed__wrapper">' . "\n" . 'https://www.youtube.com/watch?v=legacy123' . "\n" . '</div></figure><!-- /wp:core-embed/youtube --><!-- wp:paragraph --><p>After the embed.</p><!-- /wp:paragraph -->',
+			]
+		);
+
+		$converter = new InDesign_Converter();
+		$content   = $converter->convert_post( $post_id );
+
+		$this->assertStringContainsString( 'Before the embed.', $content );
+		$this->assertStringContainsString( 'After the embed.', $content );
+		$this->assertStringNotContainsString( 'youtube.com', $content );
+		$this->assertStringNotContainsString( 'legacy123', $content );
+	}
+
+	/**
 	 * Test image caption and credit special characters.
 	 */
 	public function test_image_caption_and_credit_special_characters() {

--- a/tests/unit-tests/indesign-exporter/indesign-exporter.php
+++ b/tests/unit-tests/indesign-exporter/indesign-exporter.php
@@ -279,6 +279,53 @@ class Newspack_Test_InDesign_Exporter extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that core/file blocks are excluded from export.
+	 *
+	 * PDF embeds have no print equivalent and their raw markup (<object> tags,
+	 * download links) must not appear in the InDesign output.
+	 */
+	public function test_file_block_excluded() {
+		$post_id = $this->factory->post->create(
+			[
+				'post_title'   => 'Test Post',
+				'post_content' => '<!-- wp:paragraph --><p>Before the file.</p><!-- /wp:paragraph --><!-- wp:file {"id":1,"href":"https://example.com/document.pdf"} --><div class="wp-block-file"><object class="wp-block-file__embed" data="https://example.com/document.pdf" type="application/pdf" style="width:100%;height:600px"></object><a href="https://example.com/document.pdf" class="wp-block-file__button">Download</a></div><!-- /wp:file --><!-- wp:paragraph --><p>After the file.</p><!-- /wp:paragraph -->',
+			]
+		);
+
+		$converter = new InDesign_Converter();
+		$content   = $converter->convert_post( $post_id );
+
+		$this->assertStringContainsString( 'Before the file.', $content );
+		$this->assertStringContainsString( 'After the file.', $content );
+		$this->assertStringNotContainsString( '<object', $content );
+		$this->assertStringNotContainsString( 'document.pdf', $content );
+		$this->assertStringNotContainsString( 'Download', $content );
+	}
+
+	/**
+	 * Test that core/embed blocks are excluded from export.
+	 *
+	 * Rich media embeds (YouTube, etc.) have no print equivalent and their
+	 * raw URLs must not appear in the InDesign output.
+	 */
+	public function test_embed_block_excluded() {
+		$post_id = $this->factory->post->create(
+			[
+				'post_title'   => 'Test Post',
+				'post_content' => '<!-- wp:paragraph --><p>Before the embed.</p><!-- /wp:paragraph --><!-- wp:embed {"url":"https://www.youtube.com/watch?v=abc123","type":"video","providerNameSlug":"youtube"} --><figure class="wp-block-embed is-type-video is-provider-youtube"><div class="wp-block-embed__wrapper">' . "\n" . 'https://www.youtube.com/watch?v=abc123' . "\n" . '</div></figure><!-- /wp:embed --><!-- wp:paragraph --><p>After the embed.</p><!-- /wp:paragraph -->',
+			]
+		);
+
+		$converter = new InDesign_Converter();
+		$content   = $converter->convert_post( $post_id );
+
+		$this->assertStringContainsString( 'Before the embed.', $content );
+		$this->assertStringContainsString( 'After the embed.', $content );
+		$this->assertStringNotContainsString( 'youtube.com', $content );
+		$this->assertStringNotContainsString( 'abc123', $content );
+	}
+
+	/**
 	 * Test image caption and credit special characters.
 	 */
 	public function test_image_caption_and_credit_special_characters() {

--- a/tests/unit-tests/indesign-exporter/indesign-exporter.php
+++ b/tests/unit-tests/indesign-exporter/indesign-exporter.php
@@ -326,6 +326,47 @@ class Newspack_Test_InDesign_Exporter extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that core/file blocks are excluded from export when nested inside a group block.
+	 */
+	public function test_file_block_excluded_when_nested_in_group() {
+		$post_id = $this->factory->post->create(
+			[
+				'post_title'   => 'Test Post',
+				'post_content' => '<!-- wp:paragraph --><p>Before the group.</p><!-- /wp:paragraph --><!-- wp:group --><div class="wp-block-group"><!-- wp:file {"id":1,"href":"https://example.com/document.pdf"} --><div class="wp-block-file"><object class="wp-block-file__embed" data="https://example.com/document.pdf" type="application/pdf" style="width:100%;height:600px"></object><a href="https://example.com/document.pdf" class="wp-block-file__button">Download</a></div><!-- /wp:file --></div><!-- /wp:group --><!-- wp:paragraph --><p>After the group.</p><!-- /wp:paragraph -->',
+			]
+		);
+
+		$converter = new InDesign_Converter();
+		$content   = $converter->convert_post( $post_id );
+
+		$this->assertStringContainsString( 'Before the group.', $content );
+		$this->assertStringContainsString( 'After the group.', $content );
+		$this->assertStringNotContainsString( '<object', $content );
+		$this->assertStringNotContainsString( 'document.pdf', $content );
+		$this->assertStringNotContainsString( 'Download', $content );
+	}
+
+	/**
+	 * Test that core/embed blocks are excluded from export when nested inside a group block.
+	 */
+	public function test_embed_block_excluded_when_nested_in_group() {
+		$post_id = $this->factory->post->create(
+			[
+				'post_title'   => 'Test Post',
+				'post_content' => '<!-- wp:paragraph --><p>Before the group.</p><!-- /wp:paragraph --><!-- wp:group --><div class="wp-block-group"><!-- wp:embed {"url":"https://www.youtube.com/watch?v=abc123","type":"video","providerNameSlug":"youtube"} --><figure class="wp-block-embed is-type-video is-provider-youtube"><div class="wp-block-embed__wrapper">' . "\n" . 'https://www.youtube.com/watch?v=abc123' . "\n" . '</div></figure><!-- /wp:embed --></div><!-- /wp:group --><!-- wp:paragraph --><p>After the group.</p><!-- /wp:paragraph -->',
+			]
+		);
+
+		$converter = new InDesign_Converter();
+		$content   = $converter->convert_post( $post_id );
+
+		$this->assertStringContainsString( 'Before the group.', $content );
+		$this->assertStringContainsString( 'After the group.', $content );
+		$this->assertStringNotContainsString( 'youtube.com', $content );
+		$this->assertStringNotContainsString( 'abc123', $content );
+	}
+
+	/**
 	 * Test image caption and credit special characters.
 	 */
 	public function test_image_caption_and_credit_special_characters() {

--- a/tests/unit-tests/indesign-exporter/indesign-exporter.php
+++ b/tests/unit-tests/indesign-exporter/indesign-exporter.php
@@ -485,6 +485,92 @@ class Newspack_Test_InDesign_Exporter extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that a custom block type added via the filter is excluded from export.
+	 *
+	 * Verifies the `newspack_indesign_export_excluded_blocks` filter is an effective
+	 * extension point for publishers with custom rich-media blocks.
+	 */
+	public function test_custom_block_excluded_via_filter() {
+		$callback = function ( $types ) {
+			$types[] = 'my-plugin/custom-embed';
+			return $types;
+		};
+		add_filter( 'newspack_indesign_export_excluded_blocks', $callback );
+
+		$post_id = $this->factory->post->create(
+			[
+				'post_title'   => 'Test Post',
+				'post_content' => '<!-- wp:paragraph --><p>Before the custom block.</p><!-- /wp:paragraph --><!-- wp:my-plugin/custom-embed --><div>CUSTOM_EMBED_MARKER</div><!-- /wp:my-plugin/custom-embed --><!-- wp:paragraph --><p>After the custom block.</p><!-- /wp:paragraph -->',
+			]
+		);
+
+		$converter = new InDesign_Converter();
+		$content   = $converter->convert_post( $post_id );
+
+		remove_filter( 'newspack_indesign_export_excluded_blocks', $callback );
+
+		$this->assertStringContainsString( 'Before the custom block.', $content );
+		$this->assertStringContainsString( 'After the custom block.', $content );
+		$this->assertStringNotContainsString( 'CUSTOM_EMBED_MARKER', $content );
+	}
+
+	/**
+	 * Test that a misbehaving filter callback does not break the export.
+	 *
+	 * The filter result is normalized to an array of strings, so a callback
+	 * returning null, a string, or any non-array type must not cause a TypeError.
+	 */
+	public function test_filter_returning_non_array_does_not_break_export() {
+		$callback = function () {
+			return null;
+		};
+		add_filter( 'newspack_indesign_export_excluded_blocks', $callback );
+
+		$post_id = $this->factory->post->create(
+			[
+				'post_title'   => 'Test Post',
+				'post_content' => '<!-- wp:paragraph --><p>Content survives a bad filter.</p><!-- /wp:paragraph -->',
+			]
+		);
+
+		$converter = new InDesign_Converter();
+		$content   = $converter->convert_post( $post_id );
+
+		remove_filter( 'newspack_indesign_export_excluded_blocks', $callback );
+
+		$this->assertStringContainsString( 'Content survives a bad filter.', $content );
+	}
+
+	/**
+	 * Test that legacy core-embed/* blocks follow the core/embed filter state.
+	 *
+	 * When a publisher removes core/embed from the filter to allow embed content
+	 * in exports, legacy core-embed/* blocks should also be allowed for consistency.
+	 */
+	public function test_legacy_core_embed_follows_core_embed_filter() {
+		$callback = function ( $types ) {
+			return array_values( array_diff( $types, [ 'core/embed' ] ) );
+		};
+		add_filter( 'newspack_indesign_export_excluded_blocks', $callback );
+
+		$post_id = $this->factory->post->create(
+			[
+				'post_title'   => 'Test Post',
+				'post_content' => '<!-- wp:paragraph --><p>Before the embed.</p><!-- /wp:paragraph --><!-- wp:core-embed/youtube {"url":"https://www.youtube.com/watch?v=legacy123"} --><figure class="wp-block-embed-youtube"><div class="wp-block-embed__wrapper">' . "\n" . 'https://www.youtube.com/watch?v=legacy123' . "\n" . '</div></figure><!-- /wp:core-embed/youtube --><!-- wp:paragraph --><p>After the embed.</p><!-- /wp:paragraph -->',
+			]
+		);
+
+		$converter = new InDesign_Converter();
+		$content   = $converter->convert_post( $post_id );
+
+		remove_filter( 'newspack_indesign_export_excluded_blocks', $callback );
+
+		$this->assertStringContainsString( 'Before the embed.', $content );
+		$this->assertStringContainsString( 'After the embed.', $content );
+		$this->assertStringContainsString( 'legacy123', $content );
+	}
+
+	/**
 	 * Test image caption and credit special characters.
 	 */
 	public function test_image_caption_and_credit_special_characters() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

When a post contains a `core/file` block (PDF embed) or `core/embed` block (YouTube, etc.), the InDesign export was including raw HTML markup in the output — such as `<object>` tags, download link text, and bare embed URLs — instead of skipping those blocks entirely. This resulted in import errors and corrupted print output for publishers using the InDesign export tool.

Rich media blocks have no print equivalent and should be excluded from the export. This fix adds an explicit exclusion list in `process_blocks()` for `core/file`, `core/embed`, `core/video`, and `core/audio`.

These blocks are now skipped before serialization, ensuring that only printable content is exported while leaving surrounding content intact.

Closes `NPPM-2677`.

### How to test the changes in this Pull Request:

**Reproduce the problem (without this PR):**

1. Enable the InDesign export optional module: `wp newspack optional-modules enable indesign-export`
2. Create a post containing a paragraph, a PDF file block (`core/file`), and another paragraph after it.
3. From the Posts list, click **Export as Adobe InDesign** in the row actions for that post.
4. Open the downloaded `.txt` file — observe that `<object>` tags, the PDF filename, and "Download" text appear between the two paragraphs in the export output.

**Verify the fix (with this PR):**

5. Export the same post again.
6. Open the downloaded `.txt` file — the two paragraphs should appear cleanly with no `<object>` tag, PDF filename, or "Download" text between them.
7. Repeat with a post containing a YouTube embed block (`core/embed`) — the YouTube URL should not appear in the export.
8. Test a post with only standard content (paragraphs, headings, blockquotes, lists) — verify all content is present and unchanged.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

