### PR TITLE
fix(jetpack): disable Image Studio to restore Media Library custom fields

### DIFF
--- a/includes/plugins/class-jetpack.php
+++ b/includes/plugins/class-jetpack.php
@@ -162,8 +162,8 @@ class Jetpack {
 		// Modify the related posts timeframe.
 		add_filter( 'jetpack_relatedposts_filter_date_range', [ __CLASS__, 'restrict_age_of_related_posts' ] );
 
-		// Disable Jetpack Image Studio.
-		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'disable_image_studio' ], 100 );
+		// Disable Jetpack Image Studio as late as possible so dequeues cannot be overridden.
+		add_action( 'admin_print_scripts', [ __CLASS__, 'disable_image_studio' ], 999 );
 	}
 
 	/**
@@ -353,8 +353,8 @@ class Jetpack {
 	 * Disable Jetpack Image Studio scripts and styles.
 	 *
 	 * Image Studio's full-screen AI editor replaces the Media Library attachment
-	 * view, hiding custom fields like photo credits. Dequeuing the assets is
-	 * version-independent and works across Jetpack 15.7+ gating changes.
+	 * view, hiding custom fields like photo credits. Dequeuing the assets using
+	 * the current handles has been tested with Jetpack 15.7+ (handles: image-studio / image-studio-style).
 	 */
 	public static function disable_image_studio() {
 		wp_dequeue_script( 'image-studio' );

--- a/includes/plugins/class-jetpack.php
+++ b/includes/plugins/class-jetpack.php
@@ -161,6 +161,10 @@ class Jetpack {
 
 		// Modify the related posts timeframe.
 		add_filter( 'jetpack_relatedposts_filter_date_range', [ __CLASS__, 'restrict_age_of_related_posts' ] );
+
+		// Disable Jetpack Image Studio — its full-screen AI editor replaces the
+		// Media Library attachment view, hiding custom fields like photo credits.
+		add_filter( 'jetpack_image_studio_enabled', '__return_false' );
 	}
 
 	/**

--- a/includes/plugins/class-jetpack.php
+++ b/includes/plugins/class-jetpack.php
@@ -162,9 +162,8 @@ class Jetpack {
 		// Modify the related posts timeframe.
 		add_filter( 'jetpack_relatedposts_filter_date_range', [ __CLASS__, 'restrict_age_of_related_posts' ] );
 
-		// Disable Jetpack Image Studio — its full-screen AI editor replaces the
-		// Media Library attachment view, hiding custom fields like photo credits.
-		add_filter( 'jetpack_image_studio_enabled', '__return_false' );
+		// Disable Jetpack Image Studio.
+		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'disable_image_studio' ], 100 );
 	}
 
 	/**
@@ -348,6 +347,18 @@ class Jetpack {
 		}
 
 		return $date_range;
+	}
+
+	/**
+	 * Disable Jetpack Image Studio scripts and styles.
+	 *
+	 * Image Studio's full-screen AI editor replaces the Media Library attachment
+	 * view, hiding custom fields like photo credits. Dequeuing the assets is
+	 * version-independent and works across Jetpack 15.7+ gating changes.
+	 */
+	public static function disable_image_studio() {
+		wp_dequeue_script( 'image-studio' );
+		wp_dequeue_style( 'image-studio-style' );
 	}
 }
 Jetpack::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The latest release of Jetpack Image Studio replaces the standard Media Library attachment detail view with a full-screen AI editor ("Big Sky"). This hides custom fields added by other plugins, including Newspack’s photo credit fields (`Credit`, `Credit URL`, `Organization`).

This change disables Jetpack Image Studio by dequeuing its script and stylesheet assets on admin screens, restoring the standard Media Library attachment view and making the photo credit fields accessible again.

Closes `NPPM-2705`.

### How to test the changes in this Pull Request:

**Note:** Full reproduction requires an Atomic site with Jetpack 15.7+ and Big Sky active. Local Docker environments do not include the Big Sky data store required for Image Studio to render fully.

#### Before applying the PR (reproduce the issue)

1. On any Newspack Atomic staging site with Jetpack 15.7+
2. Go to **Media Library** (grid view)
3. Click any image
4. A full-screen **Image Editor Beta** interface appears with AI tools 
5. The photo credit fields (`Credit`, `Credit URL`, `Organization`) are no longer accessible

<img width="1625" height="1179" alt="Screenshot 2026-03-31 at 11 28 34 AM" src="https://github.com/user-attachments/assets/898baeae-862b-472c-b1fa-d386721989cc" />

#### After applying the PR (verify the fix)

1. Go to **Media Library** and click any image
2. The standard attachment detail view appears
3. Photo credit fields are visible and editable
 
<img width="1594" height="857" alt="Screenshot 2026-03-31 at 11 29 36 AM" src="https://github.com/user-attachments/assets/cb8acd24-e579-4191-9e70-b6ee6ec85dd6" />

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
