### PR TITLE
fix(my-account): limit notice/success snackbar overrides to My Account

### DIFF
--- a/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php
+++ b/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php
@@ -153,6 +153,22 @@ class My_Account_UI_V1 {
 	}
 
 	/**
+	 * Whether to override WooCommerce notice templates with snackbar versions.
+	 *
+	 * Only applies on My Account pages after the main query has run. Currently
+	 * the same condition governs error, notice, and success templates. If a
+	 * future case needs more granular handling, this is the place to diverge.
+	 *
+	 * @return bool
+	 */
+	private static function should_override_notice_template() {
+		return function_exists( 'is_account_page' )
+			&& function_exists( 'did_action' )
+			&& \did_action( 'wp' )
+			&& \is_account_page();
+	}
+
+	/**
 	 * WC's page templates hijacking.
 	 *
 	 * @param string $template      Template path.
@@ -185,22 +201,20 @@ class My_Account_UI_V1 {
 			case 'order/order-again.php':
 				return __DIR__ . '/templates/v1/order-again.php';
 			case 'notices/error.php':
-				// Only override error notices on My Account pages to avoid breaking checkout validation.
-				// Guard is_account_page() to avoid running before the main query.
-				if ( function_exists( 'is_account_page' ) && function_exists( 'did_action' ) && \did_action( 'wp' ) && \is_account_page() ) {
-					return __DIR__ . '/templates/v1/notices/error.php';
+				if ( ! self::should_override_notice_template() ) {
+					return $template;
 				}
-				return $template;
+				return __DIR__ . '/templates/v1/notices/error.php';
 			case 'notices/notice.php':
-				if ( function_exists( 'is_account_page' ) && function_exists( 'did_action' ) && \did_action( 'wp' ) && \is_account_page() ) {
-					return __DIR__ . '/templates/v1/notices/notice.php';
+				if ( ! self::should_override_notice_template() ) {
+					return $template;
 				}
-				return $template;
+				return __DIR__ . '/templates/v1/notices/notice.php';
 			case 'notices/success.php':
-				if ( function_exists( 'is_account_page' ) && function_exists( 'did_action' ) && \did_action( 'wp' ) && \is_account_page() ) {
-					return __DIR__ . '/templates/v1/notices/success.php';
+				if ( ! self::should_override_notice_template() ) {
+					return $template;
 				}
-				return $template;
+				return __DIR__ . '/templates/v1/notices/success.php';
 			default:
 				return $template;
 		}

--- a/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php
+++ b/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php
@@ -192,9 +192,15 @@ class My_Account_UI_V1 {
 				}
 				return $template;
 			case 'notices/notice.php':
-				return __DIR__ . '/templates/v1/notices/notice.php';
+				if ( function_exists( 'is_account_page' ) && function_exists( 'did_action' ) && \did_action( 'wp' ) && \is_account_page() ) {
+					return __DIR__ . '/templates/v1/notices/notice.php';
+				}
+				return $template;
 			case 'notices/success.php':
-				return __DIR__ . '/templates/v1/notices/success.php';
+				if ( function_exists( 'is_account_page' ) && function_exists( 'did_action' ) && \did_action( 'wp' ) && \is_account_page() ) {
+					return __DIR__ . '/templates/v1/notices/success.php';
+				}
+				return $template;
 			default:
 				return $template;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The `wc_get_template` filter in `My_Account_UI_V1` was overriding WooCommerce's `notices/notice.php` and `notices/success.php` templates globally on all pages, not just My Account. This caused native WooCommerce notices — such as the checkout coupon prompt ("Have a coupon? Click here to enter your code") — to be rendered as Newspack snackbars with auto-hide behavior, making them disappear before readers could interact with them.

The `notices/error.php` case already had an `is_account_page()` guard to prevent this. This PR adds the same guard to `notices/notice.php` and `notices/success.php`, so the snackbar treatment is only applied on My Account pages where it was intended.

Closes NPPM-2711.

### How to test the changes in this Pull Request:

**Setup (fresh Newspack staging site):**
1. Ensure WooCommerce is active with at least one purchasable product.
2. Enable coupons: WooCommerce > Settings > General > check "Enable the use of coupon codes".
3. Create a test coupon: Marketing > Coupons > Add coupon (any code/discount).
4. Ensure you have a checkout page with the `[woocommerce_checkout]` shortcode (WooCommerce creates one by default).

**Test 1 — Coupon notice on checkout (the reported bug):**
5. As a logged-in reader, add a product to the cart.
6. Navigate to the checkout page.
7. **Before this PR:** The "Have a coupon? Click here to enter your code" notice appears as a snackbar in the top-right corner and auto-hides after 8 seconds, leaving no way to enter a coupon.
8. **After this PR:** The coupon notice renders as a standard WooCommerce inline notice at the top of the checkout form and persists until interacted with.

**Test 2 — My Account snackbar behavior is preserved:**
9. Navigate to My Account.
10. Perform an action that triggers a WooCommerce notice (e.g., update account details).
11. Verify the notice still renders as a snackbar in the top-right corner (not an inline banner).

**Test 3 — Success notices on non-My-Account pages:**
12. On a shop or product page, trigger a WooCommerce success notice (e.g., add a product to the cart with "Added to cart" notices enabled).
13. Verify it renders as a standard WooCommerce inline notice, not a snackbar.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?