### PR TITLE
feat(components): addToolbarBackButton util in newspack-components

### DIFF
--- a/includes/content-gate/class-content-gate.php
+++ b/includes/content-gate/class-content-gate.php
@@ -395,8 +395,8 @@ class Content_Gate {
 			return;
 		}
 		global $pagenow;
-		if ( 'edit.php' === $pagenow && isset( $_GET['post_type'] ) && self::GATE_CPT === $_GET['post_type'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$redirect = \admin_url( 'admin.php?page=newspack-audience#/content-gating' );
+		if ( 'edit.php' === $pagenow && isset( $_GET['post_type'] ) && in_array( $_GET['post_type'], [ self::GATE_CPT, self::GATE_LAYOUT_CPT ], true ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$redirect = Memberships::is_active() ? \admin_url( 'admin.php?page=newspack-audience#/content-gating' ) : \admin_url( 'admin.php?page=newspack-audience-access-control#/' );
 			\wp_safe_redirect( $redirect );
 			exit;
 		}

--- a/packages/components/src/utils/editor-toolbar-back-button.tsx
+++ b/packages/components/src/utils/editor-toolbar-back-button.tsx
@@ -12,11 +12,16 @@ import domReady from '@wordpress/dom-ready';
 import { createRoot } from '@wordpress/element';
 import { arrowUpLeft } from '@wordpress/icons';
 
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
 const WRAPPER_ID = 'newspack-editor-toolbar-wrapper';
 
 const ToolbarButton = ( { href }: { href: string } ) => (
 	<Tooltip text={ __( 'Go back', 'newspack-plugin' ) }>
-		<Button icon={ arrowUpLeft } label={ __( 'Go back', 'newspack-plugin' ) } href={ href } style={ { marginRight: '24px' } } />
+		<Button icon={ arrowUpLeft } label={ __( 'Go back', 'newspack-plugin' ) } href={ href } />
 	</Tooltip>
 );
 

--- a/packages/components/src/utils/editor-toolbar-back-button.tsx
+++ b/packages/components/src/utils/editor-toolbar-back-button.tsx
@@ -16,17 +16,16 @@ const WRAPPER_ID = 'newspack-editor-toolbar-wrapper';
 
 const ToolbarButton = ( { href }: { href: string } ) => (
 	<Tooltip text={ __( 'Go back', 'newspack-plugin' ) }>
-		<Button icon={ arrowUpLeft } href={ href } style={ { marginRight: '24px' } } />
+		<Button icon={ arrowUpLeft } label={ __( 'Go back', 'newspack-plugin' ) } href={ href } style={ { marginRight: '24px' } } />
 	</Tooltip>
 );
 
-export const addToolbarBackButton = ( href: string = '' ) =>
-	subscribe( () => {
-		if ( document.getElementById( WRAPPER_ID ) ) {
-			return;
-		}
-
+export const addToolbarBackButton = ( href: string = '' ) => {
+	const unsubscribe = subscribe( () => {
 		domReady( () => {
+			if ( document.getElementById( WRAPPER_ID ) ) {
+				return;
+			}
 			const toolbar = document.querySelector( '.editor-header__toolbar' );
 			if ( ! toolbar ) {
 				return;
@@ -38,5 +37,7 @@ export const addToolbarBackButton = ( href: string = '' ) =>
 
 			const root = createRoot( wrapper );
 			root.render( <ToolbarButton href={ href } /> );
+			unsubscribe();
 		} );
 	} );
+};

--- a/packages/components/src/utils/editor-toolbar-back-button.tsx
+++ b/packages/components/src/utils/editor-toolbar-back-button.tsx
@@ -1,0 +1,42 @@
+/**
+ * A utility to add a back button to the editor toolbar.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Button, Tooltip } from '@wordpress/components';
+import { subscribe } from '@wordpress/data';
+import domReady from '@wordpress/dom-ready';
+import { createRoot } from '@wordpress/element';
+import { arrowUpLeft } from '@wordpress/icons';
+
+const WRAPPER_ID = 'newspack-editor-toolbar-wrapper';
+
+const ToolbarButton = ( { href }: { href: string } ) => (
+	<Tooltip text={ __( 'Go back', 'newspack-plugin' ) }>
+		<Button icon={ arrowUpLeft } href={ href } style={ { marginRight: '24px' } } />
+	</Tooltip>
+);
+
+export const addToolbarBackButton = ( href: string = '' ) =>
+	subscribe( () => {
+		if ( document.getElementById( WRAPPER_ID ) ) {
+			return;
+		}
+
+		domReady( () => {
+			const toolbar = document.querySelector( '.editor-header__toolbar' );
+			if ( ! toolbar ) {
+				return;
+			}
+
+			const wrapper = document.createElement( 'div' );
+			wrapper.id = WRAPPER_ID;
+			toolbar.prepend( wrapper );
+
+			const root = createRoot( wrapper );
+			root.render( <ToolbarButton href={ href } /> );
+		} );
+	} );

--- a/packages/components/src/utils/index.js
+++ b/packages/components/src/utils/index.js
@@ -3,6 +3,11 @@
  */
 import { ENTER } from '@wordpress/keycodes';
 
+/**
+ * Internal dependencies
+ */
+import { addToolbarBackButton } from './editor-toolbar-back-button';
+
 const InteractiveDiv = ( { style = {}, ...props } ) => (
 	<div
 		tabIndex="0"
@@ -24,4 +29,5 @@ const confirmAction = message => {
 export default {
 	InteractiveDiv,
 	confirmAction,
+	addToolbarBackButton,
 };

--- a/packages/components/src/utils/style.scss
+++ b/packages/components/src/utils/style.scss
@@ -1,0 +1,6 @@
+#newspack-editor-toolbar-wrapper {
+	margin-right: 24px;
+	.is-fullscreen-mode & {
+		display: none;
+	}
+}

--- a/packages/components/src/utils/style.scss
+++ b/packages/components/src/utils/style.scss
@@ -1,5 +1,7 @@
+@use "~@wordpress/base-styles/variables" as wp-vars;
+
 #newspack-editor-toolbar-wrapper {
-	margin-right: 24px;
+	margin-right: wp-vars.$grid-unit-10;
 	.is-fullscreen-mode & {
 		display: none;
 	}

--- a/src/content-gate/editor/editor.js
+++ b/src/content-gate/editor/editor.js
@@ -44,7 +44,14 @@ function GateEdit() {
 	} );
 	const { editPost } = useDispatch( 'core/editor' );
 	useEffect( () => {
-		addToolbarBackButton( '/wp-admin/admin.php?page=newspack-audience-access-control#/' );
+		const unsubscribe = addToolbarBackButton(
+			'/wp-admin/admin.php?page=newspack-audience-access-control#/'
+		);
+		return () => {
+			if ( typeof unsubscribe === 'function' ) {
+				unsubscribe();
+			}
+		};
 	}, [] );
 	useEffect( () => {
 		const wrapper = document.querySelector( '.editor-styles-wrapper' );

--- a/src/content-gate/editor/editor.js
+++ b/src/content-gate/editor/editor.js
@@ -14,6 +14,7 @@ import { registerPlugin } from '@wordpress/plugins';
  * Internal dependencies
  */
 import PositionControl from '../../../packages/components/src/position-control';
+import { addToolbarBackButton } from '../../admin/editor-toolbar-back-button';
 import './editor.scss';
 
 const styles = [
@@ -42,6 +43,9 @@ function GateEdit() {
 		};
 	} );
 	const { editPost } = useDispatch( 'core/editor' );
+	useEffect( () => {
+		addToolbarBackButton( '/wp-admin/admin.php?page=newspack-audience-access-control#/' );
+	}, [] );
 	useEffect( () => {
 		const wrapper = document.querySelector( '.editor-styles-wrapper' );
 		if ( ! wrapper ) {

--- a/src/content-gate/editor/editor.js
+++ b/src/content-gate/editor/editor.js
@@ -14,7 +14,7 @@ import { registerPlugin } from '@wordpress/plugins';
  * Internal dependencies
  */
 import PositionControl from '../../../packages/components/src/position-control';
-import { addToolbarBackButton } from '../../admin/editor-toolbar-back-button';
+import { addToolbarBackButton } from '../../../packages/components/src/utils/editor-toolbar-back-button';
 import './editor.scss';
 
 const styles = [

--- a/src/content-gate/editor/editor.js
+++ b/src/content-gate/editor/editor.js
@@ -14,8 +14,10 @@ import { registerPlugin } from '@wordpress/plugins';
  * Internal dependencies
  */
 import PositionControl from '../../../packages/components/src/position-control';
-import { addToolbarBackButton } from '../../../packages/components/src/utils/editor-toolbar-back-button';
+import utils from '../../../packages/components/src/utils';
 import './editor.scss';
+
+const { addToolbarBackButton } = utils;
 
 const styles = [
 	{ value: 'inline', label: __( 'Inline', 'newspack-plugin' ) },
@@ -44,14 +46,7 @@ function GateEdit() {
 	} );
 	const { editPost } = useDispatch( 'core/editor' );
 	useEffect( () => {
-		const unsubscribe = addToolbarBackButton(
-			'/wp-admin/admin.php?page=newspack-audience-access-control#/'
-		);
-		return () => {
-			if ( typeof unsubscribe === 'function' ) {
-				unsubscribe();
-			}
-		};
+		addToolbarBackButton( 'admin.php?page=newspack-audience-access-control#/' );
 	}, [] );
 	useEffect( () => {
 		const wrapper = document.querySelector( '.editor-styles-wrapper' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a small utility function to the Newspack Components package that adds a back button to the WP block editor toolbar:

<img width="248" height="91" alt="Screenshot 2026-03-31 at 5 19 44 PM" src="https://github.com/user-attachments/assets/ff9391f6-1f9f-40be-b3ea-0d7a339dc5c1" />

The util function relies on DOM manipulation because the WP block editor currently doesn't provide any filters or SlotFill areas to add elements to the editor toolbar. It's in the Components package so that it can be consumed and used in other Newspack repositories.

Also adds a redirect for the `wp-admin/edit.php?post_type=np_gate_layout` link to redirect to the main Access Control wizard page, as the core post list UI shouldn't be accessible for gate layout posts.

Closes NPPD-1393.

### How to test the changes in this Pull Request:

1. Check out this branch
2. Visit **Audience > Access Control** and create a content gate
3. Click the "Customize registered/paid access layout" buttons to edit a gate layout in the block editor
4. Confirm that the back button is added to the top-left of the editor toolbar and that clicking it returns to the main Access Control wizard page
5. Back in the gate layout block editor, enable Fullscreen mode (in the kebab menu at the upper-right corner)
6. Confirm that the Newspack logo in the top-left corner of the full-screen editor also links back to the main Access Control wizard page

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->