### PR TITLE
fix(reader-activation): clear referrer data when none provided

### DIFF
--- a/src/reader-activation/index.js
+++ b/src/reader-activation/index.js
@@ -350,9 +350,14 @@ function pushActivities() {
  * Store the referrer.
  */
 function setReferrer() {
-	const referrer = document.referrer ? new URL( document.referrer ).hostname : '';
-	if ( referrer && referrer !== window.location.hostname ) {
-		store.set( 'referrer', referrer.replace( 'www.', '' ).trim().toLowerCase() );
+	const normalize = hostname =>
+		hostname
+			.trim()
+			.toLowerCase()
+			.replace( /^www\./, '' );
+	const referrer = document.referrer ? normalize( new URL( document.referrer ).hostname ) : '';
+	if ( referrer && referrer !== normalize( window.location.hostname ) ) {
+		store.set( 'referrer', referrer );
 	} else {
 		store.set( 'referrer', '' );
 	}

--- a/src/reader-activation/index.js
+++ b/src/reader-activation/index.js
@@ -353,6 +353,8 @@ function setReferrer() {
 	const referrer = document.referrer ? new URL( document.referrer ).hostname : '';
 	if ( referrer && referrer !== window.location.hostname ) {
 		store.set( 'referrer', referrer.replace( 'www.', '' ).trim().toLowerCase() );
+	} else {
+		store.set( 'referrer', '' );
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The `setReferrer()` function in the Reader Activation library stores the reader's traffic source hostname in localStorage for use in segment matching. Previously, this value was only written when an external referrer was present — meaning once set, it persisted indefinitely across sessions where the reader arrived via direct navigation, app handoff, or email links (which typically send no `Referer` header).

This caused readers to remain permanently segmented by a stale referrer. For example, a reader who once clicked through from Google would stay in a "Google" segment even when returning via a newsletter link or typing the URL directly. This was observed at scale on Texas Tribune (NPPM-2635), where the workaround was to disable the Google segment entirely.

This PR now clears the stored referrer on:
- Direct navigation (entering the URL in the address bar).
- Navigation that originates outside the browser (clicking a newsletter link).
- Internal navigation (clicking around on the site).

This aligns with our on-page documentation for segmentation by referrer: "Segments using these options will apply only to the first page visited after coming from an external source."

Addresses [NPPM-2643: Readers being segmented by old referrer data](https://linear.app/a8c/issue/NPPM-2643/readers-being-segmented-by-old-referrer-data).

### How to test the changes in this Pull Request:

**Setup:**
1. Build the plugin: `ncd newspack-plugin && n ci-build`
2. Open the site in an incognito/private browser window (to start with clean localStorage).

**Test 1 — Referrer is set on external arrival:**
3. Navigate to the site by clicking a link from an external source (e.g., Google search results, or simulate by setting `document.referrer` in devtools).
4. Open the browser console and check: `localStorage` for a key matching `np_reader_*_referrer`. It should contain the external hostname (e.g., `google.com`).

**Test 2 — Referrer is cleared on direct navigation:**
5. From the same browser, navigate directly to the site by typing the URL in the address bar (no external referrer).
6. After the page loads, check localStorage again. The referrer value should now be empty (`""`).

**Test 3 — Referrer updates on new external source:**
7. Navigate to the site from a different external source (e.g., click a link from a different domain).
8. Check localStorage — the referrer should now reflect the new source, not the old one.

**Test 4 — Segment matching reflects current visit:**
9. Create a segment with a "Sources to match" criterion (e.g., `google.com`).
10. Assign a campaign/prompt to that segment.
11. Visit the site from Google — the prompt should appear.
12. Navigate directly to the site (type the URL) — the prompt should **not** appear on this visit, since the referrer has been cleared.

**Test 5 — Non-referrer segments unaffected:**
13. Verify that segments based on other criteria (articles read, logged-in status, etc.) continue to work as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?