### PR TITLE
fix(reader-activation): gate password reset email override on AM enabled

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -96,8 +96,8 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/class-plugin-manager.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-theme-manager.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-admin-plugins-screen.php';
-		include_once NEWSPACK_ABSPATH . 'includes/reader-activation/class-reader-activation-emails.php';
 		include_once NEWSPACK_ABSPATH . 'includes/reader-activation/class-reader-activation.php';
+		include_once NEWSPACK_ABSPATH . 'includes/reader-activation/class-reader-activation-emails.php';
 		include_once NEWSPACK_ABSPATH . 'includes/reader-activation/class-reader-data.php';
 		include_once NEWSPACK_ABSPATH . 'includes/reader-activation/sync/class-sync.php';
 		include_once NEWSPACK_ABSPATH . 'includes/reader-activation/sync/class-metadata.php';

--- a/includes/reader-activation/class-reader-activation-emails.php
+++ b/includes/reader-activation/class-reader-activation-emails.php
@@ -34,10 +34,13 @@ class Reader_Activation_Emails {
 	public static function init() {
 		add_filter( 'newspack_email_configs', [ __CLASS__, 'add_email_configs' ] );
 
-		// Disable the default WC password reset email and replace it with ours.
-		add_filter( 'woocommerce_email_enabled_customer_reset_password', '__return_false' );
-		add_action( 'woocommerce_reset_password_notification', [ __CLASS__, 'send_reset_password_email' ], 10, 2 );
-		add_action( 'woocommerce_customer_reset_password', [ __CLASS__, 'redirect_non_reader' ] );
+		// Only override WC password reset emails when Reader Activation is enabled,
+		// since the My Account handlers that process the reset link require it.
+		if ( Reader_Activation::is_enabled() ) {
+			add_filter( 'woocommerce_email_enabled_customer_reset_password', '__return_false' );
+			add_action( 'woocommerce_reset_password_notification', [ __CLASS__, 'send_reset_password_email' ], 10, 2 );
+			add_action( 'woocommerce_customer_reset_password', [ __CLASS__, 'redirect_non_reader' ] );
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Gates the WooCommerce password reset email override in `Reader_Activation_Emails::init()` behind `Reader_Activation::is_enabled()`, so that when Audience Management is not enabled, WooCommerce's default password reset email and flow are used instead of Newspack's.

## Context

When the AM setup wizard is partially started but never completed (e.g. `newspack_reader_activation_enabled` is not set), the Newspack password reset email is still sent – but the My Account handlers that process the reset link are gated behind `is_enabled()`. This causes a redirect loop: the user clicks the reset link but gets sent back to the password request page.

Fixes [NPPM-2714](https://linear.app/a8c/issue/NPPM-2714).

## How to test

1. Disable AM: `wp option update newspack_reader_activation_enabled ""`
2. Go to `/my-account/lost-password/` and request a password reset
3. Check the email – it should be WooCommerce's default template (not Newspack's)
4. Click the reset link – it should show the "Enter a new password" form (not redirect back to the request page)
5. Re-enable AM: `wp option update newspack_reader_activation_enabled 1`
6. Repeat steps 2–4 – the Newspack email template should be used and the reset flow should still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)