### PR TITLE
feat(integrations): implement profile metadata (identity, registration, engagement)

### DIFF
--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -2437,8 +2437,6 @@ final class Reader_Activation {
 		 */
 		$metadata = apply_filters( 'newspack_register_reader_metadata', $metadata, $user_id, $existing_user );
 
-
-
 		// Note the user's login method for later use.
 		if ( isset( $metadata['registration_method'] ) ) {
 			\update_user_meta( $user_id, self::REGISTRATION_METHOD, $metadata['registration_method'] );

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -35,6 +35,9 @@ final class Reader_Activation {
 	const WITHOUT_PASSWORD                  = 'np_reader_without_password';
 	const REGISTRATION_METHOD               = 'np_reader_registration_method';
 	const REGISTRATION_PAGE                 = 'np_reader_registration_page';
+	const REGISTRATION_UTM_SOURCE           = 'np_reader_registration_utm_source';
+	const REGISTRATION_UTM_MEDIUM           = 'np_reader_registration_utm_medium';
+	const REGISTRATION_UTM_CAMPAIGN         = 'np_reader_registration_utm_campaign';
 	const CONNECTED_ACCOUNT                 = 'np_reader_connected_account';
 	const READER_SAVED_GENERIC_DISPLAY_NAME = 'np_reader_saved_generic_display_name';
 
@@ -2104,6 +2107,18 @@ final class Reader_Activation {
 		$redirect_url     = isset( $_POST['redirect_url'] ) ? \esc_url_raw( $_POST['redirect_url'] ) : '';
 		// phpcs:enable
 
+		// Capture UTM params before reconstructing the URL (which drops query params).
+		$registration_utm = [];
+		if ( ! empty( $current_page_url['query'] ) ) {
+			$query_params = [];
+			\wp_parse_str( $current_page_url['query'], $query_params );
+			foreach ( [ 'utm_source', 'utm_medium', 'utm_campaign' ] as $utm_param ) {
+				if ( ! empty( $query_params[ $utm_param ] ) ) {
+					$registration_utm[ $utm_param ] = \sanitize_text_field( $query_params[ $utm_param ] );
+				}
+			}
+		}
+
 		if ( ! empty( $current_page_url['path'] ) ) {
 			$current_page_url = \esc_url( \home_url( $current_page_url['path'] ) );
 		}
@@ -2209,6 +2224,9 @@ final class Reader_Activation {
 				}
 				if ( ! empty( $current_page_url ) ) {
 					$metadata['current_page_url'] = $current_page_url;
+				}
+				if ( ! empty( $registration_utm ) ) {
+					$metadata['registration_utm'] = $registration_utm;
 				}
 
 				$user_id = self::register_reader( $email, '', true, $metadata );
@@ -2419,6 +2437,8 @@ final class Reader_Activation {
 		 */
 		$metadata = apply_filters( 'newspack_register_reader_metadata', $metadata, $user_id, $existing_user );
 
+
+
 		// Note the user's login method for later use.
 		if ( isset( $metadata['registration_method'] ) ) {
 			\update_user_meta( $user_id, self::REGISTRATION_METHOD, $metadata['registration_method'] );
@@ -2429,6 +2449,33 @@ final class Reader_Activation {
 
 		if ( isset( $metadata['current_page_url'] ) ) {
 			\update_user_meta( $user_id, self::REGISTRATION_PAGE, $metadata['current_page_url'] );
+		}
+
+		// Save registration UTM params.
+		$utm_keys = [
+			'utm_source'   => self::REGISTRATION_UTM_SOURCE,
+			'utm_medium'   => self::REGISTRATION_UTM_MEDIUM,
+			'utm_campaign' => self::REGISTRATION_UTM_CAMPAIGN,
+		];
+		// Prefer explicitly passed UTM params (from process_auth_form).
+		$registration_utm = $metadata['registration_utm'] ?? [];
+		// Fallback: parse from the registration page URL if it has query params.
+		if ( empty( $registration_utm ) && ! empty( $metadata['current_page_url'] ) ) {
+			$parsed = \wp_parse_url( $metadata['current_page_url'] );
+			if ( ! empty( $parsed['query'] ) ) {
+				$query_params = [];
+				\wp_parse_str( $parsed['query'], $query_params );
+				foreach ( $utm_keys as $param => $meta_key ) {
+					if ( ! empty( $query_params[ $param ] ) ) {
+						$registration_utm[ $param ] = $query_params[ $param ];
+					}
+				}
+			}
+		}
+		foreach ( $utm_keys as $param => $meta_key ) {
+			if ( ! empty( $registration_utm[ $param ] ) ) {
+				\update_user_meta( $user_id, $meta_key, \sanitize_text_field( $registration_utm[ $param ] ) );
+			}
 		}
 
 		/**

--- a/includes/reader-activation/sync/class-contact-metadata.php
+++ b/includes/reader-activation/sync/class-contact-metadata.php
@@ -128,9 +128,9 @@ abstract class Contact_Metadata {
 	}
 
 	/**
-	 * Format a date string to MM/DD/YYYY.
+	 * Format a date string.
 	 *
-	 * @param string $date_string Date string from WooCommerce.
+	 * @param string $date_string Date string.
 	 * @return string Formatted date or empty string.
 	 */
 	protected function format_date( $date_string ) {

--- a/includes/reader-activation/sync/class-contact-sync.php
+++ b/includes/reader-activation/sync/class-contact-sync.php
@@ -133,12 +133,6 @@ class Contact_Sync extends Sync {
 			}
 		}
 
-		// Added logging here to more easily monitor integration sync data. Can be removed once integrations are released.
-		if ( 'legacy' !== Metadata::get_version() ) {
-			Logger::log( sprintf( 'Syncing contact %s for context "%s".', $contact['email'] ?? 'unknown', $context ) );
-			Logger::log( $contact );
-		}
-
 		return self::push_to_integrations( $contact, $context, $existing_contact );
 	}
 
@@ -178,7 +172,14 @@ class Contact_Sync extends Sync {
 
 		foreach ( $integrations as $integration_id => $integration ) {
 			$integration_contact = $integration->prepare_contact( $contact );
-			$result              = $integration->push_contact_data( $integration_contact, $context, $existing_contact );
+
+			// Added logging here to more easily monitor integration sync data. Can be removed once integrations are released.
+			if ( 'legacy' !== Metadata::get_version() ) {
+				Logger::log( sprintf( 'Syncing contact %s for integration %s with context "%s".', $integration_contact['email'] ?? 'unknown', $integration_id, $context ) );
+				Logger::log( $integration_contact );
+			}
+
+			$result = $integration->push_contact_data( $integration_contact, $context, $existing_contact );
 			if ( \is_wp_error( $result ) ) {
 				/**
 				 * Fires when a contact sync fails on the original attempt (before retries).

--- a/includes/reader-activation/sync/class-metadata.php
+++ b/includes/reader-activation/sync/class-metadata.php
@@ -50,11 +50,12 @@ class Metadata {
 			];
 		} else {
 			$classes = [
-				'Profile',
+				'Identity',
+				'Registration',
+				'Engagement',
 				'Subscription',
 				'Donation',
 				'Content_Gate',
-				'Financial',
 			];
 		}
 

--- a/includes/reader-activation/sync/contact-metadata/class-engagement.php
+++ b/includes/reader-activation/sync/contact-metadata/class-engagement.php
@@ -51,7 +51,6 @@ class Engagement extends Contact_Metadata {
 		return [
 			'First_Visit_Date'     => 'First Visit Date',
 			'Last_Active'          => 'Last Active',
-			'Articles_Read'        => 'Articles Read',
 			'Paywall_Hits'         => 'Paywall Hits',
 			'Favorite_Categories'  => 'Favorite Categories',
 			'Payment_Page'         => 'Payment Page',
@@ -77,7 +76,6 @@ class Engagement extends Contact_Metadata {
 		return [
 			'First_Visit_Date'     => $this->format_reader_data_timestamp( 'first_visit_date' ),
 			'Last_Active'          => $this->format_reader_data_timestamp( 'last_active' ),
-			'Articles_Read'        => $this->get_reader_data_int( 'articles_read' ),
 			'Paywall_Hits'         => $this->get_reader_data_int( 'paywall_hits' ),
 			'Favorite_Categories'  => $this->get_favorite_categories(),
 			'Payment_Page'         => $this->get_payment_page( $order ),
@@ -121,6 +119,9 @@ class Engagement extends Contact_Metadata {
 	 */
 	private function get_favorite_categories() {
 		$category_ids = Reader_Data::get_data( $this->user->ID, 'favorite_categories' );
+		if ( is_string( $category_ids ) ) {
+			$category_ids = json_decode( $category_ids, true );
+		}
 		if ( empty( $category_ids ) || ! is_array( $category_ids ) ) {
 			return '';
 		}

--- a/includes/reader-activation/sync/contact-metadata/class-engagement.php
+++ b/includes/reader-activation/sync/contact-metadata/class-engagement.php
@@ -7,6 +7,7 @@
 
 namespace Newspack\Reader_Activation\Sync\Contact_Metadata;
 
+use Newspack\Reader_Data;
 use Newspack\Reader_Activation\Sync\Contact_Metadata;
 
 defined( 'ABSPATH' ) || exit;
@@ -15,6 +16,13 @@ defined( 'ABSPATH' ) || exit;
  * Engagement metadata class.
  */
 class Engagement extends Contact_Metadata {
+
+	/**
+	 * Cache for the latest completed order.
+	 *
+	 * @var \WC_Order|null|false False means unresolved.
+	 */
+	private $latest_order_cache = false;
 
 	/**
 	 * Whether or not the metadata fields of this class are available to be synced.
@@ -60,6 +68,139 @@ class Engagement extends Contact_Metadata {
 	 * @return array
 	 */
 	public function get_metadata() {
-		return [];
+		if ( ! $this->user ) {
+			return [];
+		}
+
+		$order = $this->get_latest_order();
+
+		return [
+			'First_Visit_Date'     => $this->format_reader_data_timestamp( 'first_visit_date' ),
+			'Last_Active'          => $this->format_reader_data_timestamp( 'last_active' ),
+			'Articles_Read'        => $this->get_reader_data_int( 'articles_read' ),
+			'Paywall_Hits'         => $this->get_reader_data_int( 'paywall_hits' ),
+			'Favorite_Categories'  => $this->get_favorite_categories(),
+			'Payment_Page'         => $this->get_payment_page( $order ),
+			'Payment_UTM_Source'   => $this->get_order_utm( $order, 'source' ),
+			'Payment_UTM_Medium'   => $this->get_order_utm( $order, 'medium' ),
+			'Payment_UTM_Campaign' => $this->get_order_utm( $order, 'campaign' ),
+			'Total_Paid'           => $this->customer ? $this->customer->get_total_spent() : '',
+		];
+	}
+
+	/**
+	 * Format a reader data store timestamp (JS milliseconds) into a date string.
+	 *
+	 * @param string $key Reader data store key.
+	 * @return string Formatted date or empty string.
+	 */
+	private function format_reader_data_timestamp( $key ) {
+		$value = Reader_Data::get_data( $this->user->ID, $key );
+		if ( empty( $value ) || ! is_numeric( $value ) ) {
+			return '';
+		}
+		// Reader data timestamps are JS milliseconds.
+		return $this->format_date( gmdate( 'Y-m-d H:i:s', intval( $value ) / 1000 ) );
+	}
+
+	/**
+	 * Get an integer value from the reader data store.
+	 *
+	 * @param string $key Reader data store key.
+	 * @return int
+	 */
+	private function get_reader_data_int( $key ) {
+		$value = Reader_Data::get_data( $this->user->ID, $key );
+		return is_numeric( $value ) ? (int) $value : 0;
+	}
+
+	/**
+	 * Get favorite categories as a comma-separated string of category names.
+	 *
+	 * @return string
+	 */
+	private function get_favorite_categories() {
+		$category_ids = Reader_Data::get_data( $this->user->ID, 'favorite_categories' );
+		if ( empty( $category_ids ) || ! is_array( $category_ids ) ) {
+			return '';
+		}
+		$names = [];
+		foreach ( $category_ids as $cat_id ) {
+			$term = \get_term( (int) $cat_id, 'category' );
+			if ( $term && ! \is_wp_error( $term ) ) {
+				$names[] = $term->name;
+			}
+		}
+		return implode( ',', $names );
+	}
+
+	/**
+	 * Get the most recent completed order for the current user.
+	 *
+	 * @return \WC_Order|null
+	 */
+	private function get_latest_order() {
+		if ( false !== $this->latest_order_cache ) {
+			return $this->latest_order_cache;
+		}
+
+		$this->latest_order_cache = null;
+
+		if ( ! $this->user || ! function_exists( 'wc_get_orders' ) ) {
+			return null;
+		}
+
+		$orders = \wc_get_orders(
+			[
+				'customer_id' => $this->user->ID,
+				'status'      => [ 'wc-completed' ],
+				'limit'       => 1,
+				'order'       => 'DESC',
+				'orderby'     => 'date',
+				'return'      => 'objects',
+			]
+		);
+
+		if ( ! empty( $orders ) ) {
+			$this->latest_order_cache = $orders[0];
+		}
+
+		return $this->latest_order_cache;
+	}
+
+	/**
+	 * Get the payment page URL from an order.
+	 *
+	 * @param \WC_Order|null $order Order object.
+	 * @return string
+	 */
+	private function get_payment_page( $order ) {
+		if ( ! $order ) {
+			return '';
+		}
+		$referer = $order->get_meta( '_newspack_referer' );
+		if ( ! empty( $referer ) ) {
+			return $referer;
+		}
+		return function_exists( 'wc_get_checkout_url' ) ? \wc_get_checkout_url() : '';
+	}
+
+	/**
+	 * Extract a UTM parameter from an order.
+	 *
+	 * @param \WC_Order|null $order Order object.
+	 * @param string         $param UTM parameter name (e.g. 'source', 'medium', 'campaign').
+	 * @return string
+	 */
+	private function get_order_utm( $order, $param ) {
+		if ( ! $order ) {
+			return '';
+		}
+		$utm = $order->get_meta( 'utm' );
+		if ( ! empty( $utm ) && is_array( $utm ) && isset( $utm[ $param ] ) ) {
+			return $utm[ $param ];
+		}
+		$value = $order->get_meta( 'utm_' . $param );
+		return ! empty( $value ) ? $value : '';
 	}
 }

--- a/includes/reader-activation/sync/contact-metadata/class-identity.php
+++ b/includes/reader-activation/sync/contact-metadata/class-identity.php
@@ -70,7 +70,7 @@ class Identity extends Contact_Metadata {
 			'email'             => $this->user->user_email,
 			'Account'           => (string) $this->user->ID,
 			'User_Role'         => ! empty( $roles ) ? reset( $roles ) : '',
-			'verified'          => (bool) \get_user_meta( $this->user->ID, Reader_Activation::EMAIL_VERIFIED, true ),
+			'verified'          => (bool) Reader_Activation::is_reader_verified( $this->user ),
 			'Connected_Account' => (string) \get_user_meta( $this->user->ID, Reader_Activation::CONNECTED_ACCOUNT, true ),
 		];
 	}

--- a/includes/reader-activation/sync/contact-metadata/class-identity.php
+++ b/includes/reader-activation/sync/contact-metadata/class-identity.php
@@ -7,6 +7,7 @@
 
 namespace Newspack\Reader_Activation\Sync\Contact_Metadata;
 
+use Newspack\Reader_Activation;
 use Newspack\Reader_Activation\Sync\Contact_Metadata;
 
 defined( 'ABSPATH' ) || exit;
@@ -57,6 +58,20 @@ class Identity extends Contact_Metadata {
 	 * @return array
 	 */
 	public function get_metadata() {
-		return [];
+		if ( ! $this->user ) {
+			return [];
+		}
+
+		$roles = $this->user->roles;
+
+		return [
+			'first_name'        => $this->user->first_name,
+			'last_name'         => $this->user->last_name,
+			'email'             => $this->user->user_email,
+			'Account'           => (string) $this->user->ID,
+			'User_Role'         => ! empty( $roles ) ? reset( $roles ) : '',
+			'verified'          => (bool) \get_user_meta( $this->user->ID, Reader_Activation::EMAIL_VERIFIED, true ),
+			'Connected_Account' => (string) \get_user_meta( $this->user->ID, Reader_Activation::CONNECTED_ACCOUNT, true ),
+		];
 	}
 }

--- a/includes/reader-activation/sync/contact-metadata/class-registration.php
+++ b/includes/reader-activation/sync/contact-metadata/class-registration.php
@@ -72,22 +72,20 @@ class Registration extends Contact_Metadata {
 	}
 
 	/**
-	 * Extract a UTM parameter from the registration page URL.
+	 * Get a registration UTM parameter from user meta.
 	 *
 	 * @param string $param UTM parameter name (e.g. 'utm_source').
 	 * @return string UTM value or empty string.
 	 */
 	private function get_registration_utm( $param ) {
-		$page = \get_user_meta( $this->user->ID, Reader_Activation::REGISTRATION_PAGE, true );
-		if ( empty( $page ) ) {
+		$meta_keys = [
+			'utm_source'   => Reader_Activation::REGISTRATION_UTM_SOURCE,
+			'utm_medium'   => Reader_Activation::REGISTRATION_UTM_MEDIUM,
+			'utm_campaign' => Reader_Activation::REGISTRATION_UTM_CAMPAIGN,
+		];
+		if ( ! isset( $meta_keys[ $param ] ) ) {
 			return '';
 		}
-		$parsed = \wp_parse_url( $page );
-		if ( empty( $parsed['query'] ) ) {
-			return '';
-		}
-		$params = [];
-		\wp_parse_str( $parsed['query'], $params );
-		return isset( $params[ $param ] ) ? \sanitize_text_field( $params[ $param ] ) : '';
+		return (string) \get_user_meta( $this->user->ID, $meta_keys[ $param ], true );
 	}
 }

--- a/includes/reader-activation/sync/contact-metadata/class-registration.php
+++ b/includes/reader-activation/sync/contact-metadata/class-registration.php
@@ -86,6 +86,22 @@ class Registration extends Contact_Metadata {
 		if ( ! isset( $meta_keys[ $param ] ) ) {
 			return '';
 		}
-		return (string) \get_user_meta( $this->user->ID, $meta_keys[ $param ], true );
+		$value = (string) \get_user_meta( $this->user->ID, $meta_keys[ $param ], true );
+		if ( ! empty( $value ) ) {
+			return $value;
+		}
+		// Fallback: parse UTM from the stored registration page URL for readers registered before UTM meta was saved.
+		$registration_page = (string) \get_user_meta( $this->user->ID, Reader_Activation::REGISTRATION_PAGE, true );
+		if ( ! empty( $registration_page ) ) {
+			$parsed = \wp_parse_url( $registration_page );
+			if ( ! empty( $parsed['query'] ) ) {
+				$query_params = [];
+				\wp_parse_str( $parsed['query'], $query_params );
+				if ( ! empty( $query_params[ $param ] ) ) {
+					return \sanitize_text_field( $query_params[ $param ] );
+				}
+			}
+		}
+		return '';
 	}
 }

--- a/includes/reader-activation/sync/contact-metadata/class-registration.php
+++ b/includes/reader-activation/sync/contact-metadata/class-registration.php
@@ -7,6 +7,7 @@
 
 namespace Newspack\Reader_Activation\Sync\Contact_Metadata;
 
+use Newspack\Reader_Activation;
 use Newspack\Reader_Activation\Sync\Contact_Metadata;
 
 defined( 'ABSPATH' ) || exit;
@@ -56,6 +57,37 @@ class Registration extends Contact_Metadata {
 	 * @return array
 	 */
 	public function get_metadata() {
-		return [];
+		if ( ! $this->user ) {
+			return [];
+		}
+
+		return [
+			'Registration_Date'         => $this->format_date( $this->user->user_registered ),
+			'Registration_Page'         => (string) \get_user_meta( $this->user->ID, Reader_Activation::REGISTRATION_PAGE, true ),
+			'Registration_Strategy'     => (string) \get_user_meta( $this->user->ID, Reader_Activation::REGISTRATION_METHOD, true ),
+			'Registration_UTM_Source'   => $this->get_registration_utm( 'utm_source' ),
+			'Registration_UTM_Medium'   => $this->get_registration_utm( 'utm_medium' ),
+			'Registration_UTM_Campaign' => $this->get_registration_utm( 'utm_campaign' ),
+		];
+	}
+
+	/**
+	 * Extract a UTM parameter from the registration page URL.
+	 *
+	 * @param string $param UTM parameter name (e.g. 'utm_source').
+	 * @return string UTM value or empty string.
+	 */
+	private function get_registration_utm( $param ) {
+		$page = \get_user_meta( $this->user->ID, Reader_Activation::REGISTRATION_PAGE, true );
+		if ( empty( $page ) ) {
+			return '';
+		}
+		$parsed = \wp_parse_url( $page );
+		if ( empty( $parsed['query'] ) ) {
+			return '';
+		}
+		$params = [];
+		\wp_parse_str( $parsed['query'], $params );
+		return isset( $params[ $param ] ) ? \sanitize_text_field( $params[ $param ] ) : '';
 	}
 }

--- a/src/blocks/reader-registration/index.php
+++ b/src/blocks/reader-registration/index.php
@@ -512,11 +512,11 @@ function process_form() {
 	}
 
 	// reCAPTCHA test.
-	$current_page_url = \wp_parse_url( \wp_get_raw_referer() );
-	if ( ! empty( $current_page_url['path'] ) ) {
-		$current_page_url = \esc_url( \home_url( $current_page_url['path'] ) );
-	}
-	if ( apply_filters( 'newspack_recaptcha_verify_captcha', Recaptcha::can_use_captcha(), $current_page_url, 'registration_block' ) ) {
+	$raw_referer      = \wp_get_raw_referer();
+	$parsed_referer   = \wp_parse_url( $raw_referer );
+	$current_page_url = ! empty( $parsed_referer['path'] ) ? \esc_url( $raw_referer ) : $raw_referer;
+	$recaptcha_url    = ! empty( $parsed_referer['path'] ) ? \esc_url( \home_url( $parsed_referer['path'] ) ) : $current_page_url;
+	if ( apply_filters( 'newspack_recaptcha_verify_captcha', Recaptcha::can_use_captcha(), $recaptcha_url, 'registration_block' ) ) {
 		$captcha_result = Recaptcha::verify_captcha();
 		if ( \is_wp_error( $captcha_result ) ) {
 			return send_form_response( $captcha_result );

--- a/tests/unit-tests/class-test-engagement-metadata.php
+++ b/tests/unit-tests/class-test-engagement-metadata.php
@@ -97,23 +97,6 @@ class Test_Engagement_Metadata extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test articles read count.
-	 */
-	public function test_articles_read() {
-		$this->set_reader_data( 'articles_read', 5 );
-		$metadata = ( new Engagement( self::$user_id ) )->get_metadata();
-		$this->assertSame( 5, $metadata['Articles_Read'] );
-	}
-
-	/**
-	 * Test articles read defaults to zero.
-	 */
-	public function test_articles_read_default_zero() {
-		$metadata = ( new Engagement( self::$user_id ) )->get_metadata();
-		$this->assertSame( 0, $metadata['Articles_Read'] );
-	}
-
-	/**
 	 * Test paywall hits count.
 	 */
 	public function test_paywall_hits() {
@@ -123,7 +106,7 @@ class Test_Engagement_Metadata extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test favorite categories converted to comma-separated names.
+	 * Test favorite categories converted to comma-separated names from PHP array.
 	 */
 	public function test_favorite_categories() {
 		$cat1 = self::factory()->category->create( [ 'name' => 'Politics' ] );
@@ -132,6 +115,18 @@ class Test_Engagement_Metadata extends WP_UnitTestCase {
 
 		$metadata = ( new Engagement( self::$user_id ) )->get_metadata();
 		$this->assertSame( 'Politics,Climate', $metadata['Favorite_Categories'] );
+	}
+
+	/**
+	 * Test favorite categories from JSON string (as stored by Reader_Data::update_item).
+	 */
+	public function test_favorite_categories_from_json_string() {
+		$cat1 = self::factory()->category->create( [ 'name' => 'Sports' ] );
+		$cat2 = self::factory()->category->create( [ 'name' => 'Tech' ] );
+		$this->set_reader_data( 'favorite_categories', wp_json_encode( [ $cat1, $cat2 ] ) );
+
+		$metadata = ( new Engagement( self::$user_id ) )->get_metadata();
+		$this->assertSame( 'Sports,Tech', $metadata['Favorite_Categories'] );
 	}
 
 	/**

--- a/tests/unit-tests/class-test-engagement-metadata.php
+++ b/tests/unit-tests/class-test-engagement-metadata.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * Tests Engagement contact metadata.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Reader_Data;
+use Newspack\Reader_Activation\Sync\Contact_Metadata\Engagement;
+
+/**
+ * Test the Engagement metadata class.
+ *
+ * @group Engagement_Metadata
+ */
+class Test_Engagement_Metadata extends WP_UnitTestCase {
+
+	/**
+	 * User ID for tests.
+	 *
+	 * @var int
+	 */
+	private static $user_id;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+		self::$user_id = self::factory()->user->create(
+			[
+				'role'       => 'subscriber',
+				'user_email' => 'reader@example.com',
+			]
+		);
+	}
+
+	/**
+	 * Clean up after each test.
+	 */
+	public function tear_down() {
+		$keys = [ 'first_visit_date', 'last_active', 'articles_read', 'paywall_hits', 'favorite_categories' ];
+		foreach ( $keys as $key ) {
+			delete_user_meta( self::$user_id, Reader_Data::get_meta_key_name( $key ) );
+		}
+		delete_user_meta( self::$user_id, 'newspack_reader_data_keys' );
+		parent::tear_down();
+	}
+
+	/**
+	 * Helper to set a reader data store item for the test user.
+	 *
+	 * @param string $key   Reader data key.
+	 * @param mixed  $value Value to store.
+	 */
+	private function set_reader_data( $key, $value ) {
+		$meta_key = Reader_Data::get_meta_key_name( $key );
+		update_user_meta( self::$user_id, $meta_key, $value );
+
+		// Update the keys registry.
+		$keys = get_user_meta( self::$user_id, 'newspack_reader_data_keys', true );
+		if ( ! is_array( $keys ) ) {
+			$keys = [];
+		}
+		if ( ! in_array( $key, $keys, true ) ) {
+			$keys[] = $key;
+			update_user_meta( self::$user_id, 'newspack_reader_data_keys', $keys );
+		}
+	}
+
+	/**
+	 * Test first visit date conversion from JS timestamp.
+	 */
+	public function test_first_visit_date() {
+		// JS timestamp: 1750000200000 ms = 2025-06-15 15:10:00 UTC.
+		$this->set_reader_data( 'first_visit_date', 1750000200000 );
+		$metadata = ( new Engagement( self::$user_id ) )->get_metadata();
+		$this->assertSame( '2025-06-15 15:10:00', $metadata['First_Visit_Date'] );
+	}
+
+	/**
+	 * Test last active conversion from JS timestamp.
+	 */
+	public function test_last_active() {
+		$this->set_reader_data( 'last_active', 1750000200000 );
+		$metadata = ( new Engagement( self::$user_id ) )->get_metadata();
+		$this->assertSame( '2025-06-15 15:10:00', $metadata['Last_Active'] );
+	}
+
+	/**
+	 * Test timestamps are empty when unset.
+	 */
+	public function test_timestamps_empty_when_unset() {
+		$metadata = ( new Engagement( self::$user_id ) )->get_metadata();
+		$this->assertSame( '', $metadata['First_Visit_Date'] );
+		$this->assertSame( '', $metadata['Last_Active'] );
+	}
+
+	/**
+	 * Test articles read count.
+	 */
+	public function test_articles_read() {
+		$this->set_reader_data( 'articles_read', 5 );
+		$metadata = ( new Engagement( self::$user_id ) )->get_metadata();
+		$this->assertSame( 5, $metadata['Articles_Read'] );
+	}
+
+	/**
+	 * Test articles read defaults to zero.
+	 */
+	public function test_articles_read_default_zero() {
+		$metadata = ( new Engagement( self::$user_id ) )->get_metadata();
+		$this->assertSame( 0, $metadata['Articles_Read'] );
+	}
+
+	/**
+	 * Test paywall hits count.
+	 */
+	public function test_paywall_hits() {
+		$this->set_reader_data( 'paywall_hits', 3 );
+		$metadata = ( new Engagement( self::$user_id ) )->get_metadata();
+		$this->assertSame( 3, $metadata['Paywall_Hits'] );
+	}
+
+	/**
+	 * Test favorite categories converted to comma-separated names.
+	 */
+	public function test_favorite_categories() {
+		$cat1 = self::factory()->category->create( [ 'name' => 'Politics' ] );
+		$cat2 = self::factory()->category->create( [ 'name' => 'Climate' ] );
+		$this->set_reader_data( 'favorite_categories', [ $cat1, $cat2 ] );
+
+		$metadata = ( new Engagement( self::$user_id ) )->get_metadata();
+		$this->assertSame( 'Politics,Climate', $metadata['Favorite_Categories'] );
+	}
+
+	/**
+	 * Test favorite categories empty when unset.
+	 */
+	public function test_favorite_categories_empty() {
+		$metadata = ( new Engagement( self::$user_id ) )->get_metadata();
+		$this->assertSame( '', $metadata['Favorite_Categories'] );
+	}
+
+	/**
+	 * Test payment fields empty without WooCommerce orders.
+	 */
+	public function test_payment_fields_empty_without_woocommerce_orders() {
+		$metadata = ( new Engagement( self::$user_id ) )->get_metadata();
+		$this->assertSame( '', $metadata['Payment_Page'] );
+		$this->assertSame( '', $metadata['Payment_UTM_Source'] );
+		$this->assertSame( '', $metadata['Payment_UTM_Medium'] );
+		$this->assertSame( '', $metadata['Payment_UTM_Campaign'] );
+	}
+
+	/**
+	 * Test total paid empty without WooCommerce.
+	 */
+	public function test_total_paid_empty_without_woocommerce() {
+		$metadata = ( new Engagement( self::$user_id ) )->get_metadata();
+		$this->assertSame( '', $metadata['Total_Paid'] );
+	}
+
+	/**
+	 * Test returns empty without user.
+	 */
+	public function test_returns_empty_without_user() {
+		$metadata = ( new Engagement( 0 ) )->get_metadata();
+		$this->assertSame( [], $metadata );
+	}
+}

--- a/tests/unit-tests/class-test-identity-metadata.php
+++ b/tests/unit-tests/class-test-identity-metadata.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Tests Identity contact metadata.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Reader_Activation;
+use Newspack\Reader_Activation\Sync\Contact_Metadata\Identity;
+
+/**
+ * Test the Identity metadata class.
+ *
+ * @group Identity_Metadata
+ */
+class Test_Identity_Metadata extends WP_UnitTestCase {
+
+	/**
+	 * User ID for tests.
+	 *
+	 * @var int
+	 */
+	private static $user_id;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+		self::$user_id = self::factory()->user->create(
+			[
+				'role'       => 'subscriber',
+				'user_email' => 'reader@example.com',
+				'first_name' => 'Jane',
+				'last_name'  => 'Doe',
+			]
+		);
+	}
+
+	/**
+	 * Clean up after each test.
+	 */
+	public function tear_down() {
+		delete_user_meta( self::$user_id, Reader_Activation::EMAIL_VERIFIED );
+		delete_user_meta( self::$user_id, Reader_Activation::CONNECTED_ACCOUNT );
+		parent::tear_down();
+	}
+
+	/**
+	 * Test basic identity fields.
+	 */
+	public function test_basic_identity_fields() {
+		$metadata = ( new Identity( self::$user_id ) )->get_metadata();
+		$this->assertSame( 'Jane', $metadata['first_name'] );
+		$this->assertSame( 'Doe', $metadata['last_name'] );
+		$this->assertSame( 'reader@example.com', $metadata['email'] );
+		$this->assertSame( (string) self::$user_id, $metadata['Account'] );
+		$this->assertSame( 'subscriber', $metadata['User_Role'] );
+	}
+
+	/**
+	 * Test verified is false by default.
+	 */
+	public function test_verified_false_by_default() {
+		$metadata = ( new Identity( self::$user_id ) )->get_metadata();
+		$this->assertFalse( $metadata['verified'] );
+	}
+
+	/**
+	 * Test verified is true when set.
+	 */
+	public function test_verified_true_when_set() {
+		update_user_meta( self::$user_id, Reader_Activation::EMAIL_VERIFIED, true );
+		$metadata = ( new Identity( self::$user_id ) )->get_metadata();
+		$this->assertTrue( $metadata['verified'] );
+	}
+
+	/**
+	 * Test connected account is empty by default.
+	 */
+	public function test_connected_account_empty_by_default() {
+		$metadata = ( new Identity( self::$user_id ) )->get_metadata();
+		$this->assertSame( '', $metadata['Connected_Account'] );
+	}
+
+	/**
+	 * Test connected account when set.
+	 */
+	public function test_connected_account_when_set() {
+		update_user_meta( self::$user_id, Reader_Activation::CONNECTED_ACCOUNT, 'google' );
+		$metadata = ( new Identity( self::$user_id ) )->get_metadata();
+		$this->assertSame( 'google', $metadata['Connected_Account'] );
+	}
+
+	/**
+	 * Test returns empty without user.
+	 */
+	public function test_returns_empty_without_user() {
+		$metadata = ( new Identity( 0 ) )->get_metadata();
+		$this->assertSame( [], $metadata );
+	}
+}

--- a/tests/unit-tests/class-test-registration-metadata.php
+++ b/tests/unit-tests/class-test-registration-metadata.php
@@ -41,6 +41,9 @@ class Test_Registration_Metadata extends WP_UnitTestCase {
 	public function tear_down() {
 		delete_user_meta( self::$user_id, Reader_Activation::REGISTRATION_PAGE );
 		delete_user_meta( self::$user_id, Reader_Activation::REGISTRATION_METHOD );
+		delete_user_meta( self::$user_id, Reader_Activation::REGISTRATION_UTM_SOURCE );
+		delete_user_meta( self::$user_id, Reader_Activation::REGISTRATION_UTM_MEDIUM );
+		delete_user_meta( self::$user_id, Reader_Activation::REGISTRATION_UTM_CAMPAIGN );
 		parent::tear_down();
 	}
 
@@ -73,14 +76,12 @@ class Test_Registration_Metadata extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test UTM extraction from registration page URL.
+	 * Test UTM values from user meta.
 	 */
-	public function test_utm_extraction_from_registration_page() {
-		update_user_meta(
-			self::$user_id,
-			Reader_Activation::REGISTRATION_PAGE,
-			'https://example.com/signup?utm_source=facebook&utm_medium=social&utm_campaign=spring2024'
-		);
+	public function test_utm_from_user_meta() {
+		update_user_meta( self::$user_id, Reader_Activation::REGISTRATION_UTM_SOURCE, 'facebook' );
+		update_user_meta( self::$user_id, Reader_Activation::REGISTRATION_UTM_MEDIUM, 'social' );
+		update_user_meta( self::$user_id, Reader_Activation::REGISTRATION_UTM_CAMPAIGN, 'spring2024' );
 		$metadata = ( new Registration( self::$user_id ) )->get_metadata();
 		$this->assertSame( 'facebook', $metadata['Registration_UTM_Source'] );
 		$this->assertSame( 'social', $metadata['Registration_UTM_Medium'] );
@@ -88,22 +89,13 @@ class Test_Registration_Metadata extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test UTM empty when no query params in URL.
+	 * Test UTM empty when not set.
 	 */
-	public function test_utm_empty_when_no_query_params() {
-		update_user_meta( self::$user_id, Reader_Activation::REGISTRATION_PAGE, 'https://example.com/signup' );
+	public function test_utm_empty_when_not_set() {
 		$metadata = ( new Registration( self::$user_id ) )->get_metadata();
 		$this->assertSame( '', $metadata['Registration_UTM_Source'] );
 		$this->assertSame( '', $metadata['Registration_UTM_Medium'] );
 		$this->assertSame( '', $metadata['Registration_UTM_Campaign'] );
-	}
-
-	/**
-	 * Test UTM empty when no registration page is set.
-	 */
-	public function test_utm_empty_when_no_registration_page() {
-		$metadata = ( new Registration( self::$user_id ) )->get_metadata();
-		$this->assertSame( '', $metadata['Registration_UTM_Source'] );
 	}
 
 	/**

--- a/tests/unit-tests/class-test-registration-metadata.php
+++ b/tests/unit-tests/class-test-registration-metadata.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Tests Registration contact metadata.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Reader_Activation;
+use Newspack\Reader_Activation\Sync\Contact_Metadata\Registration;
+
+/**
+ * Test the Registration metadata class.
+ *
+ * @group Registration_Metadata
+ */
+class Test_Registration_Metadata extends WP_UnitTestCase {
+
+	/**
+	 * User ID for tests.
+	 *
+	 * @var int
+	 */
+	private static $user_id;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+		self::$user_id = self::factory()->user->create(
+			[
+				'role'       => 'subscriber',
+				'user_email' => 'reader@example.com',
+			]
+		);
+	}
+
+	/**
+	 * Clean up after each test.
+	 */
+	public function tear_down() {
+		delete_user_meta( self::$user_id, Reader_Activation::REGISTRATION_PAGE );
+		delete_user_meta( self::$user_id, Reader_Activation::REGISTRATION_METHOD );
+		parent::tear_down();
+	}
+
+	/**
+	 * Test registration date is formatted correctly.
+	 */
+	public function test_registration_date_formatted() {
+		$metadata = ( new Registration( self::$user_id ) )->get_metadata();
+		$this->assertNotEmpty( $metadata['Registration_Date'] );
+		// Should match Y-m-d H:i:s format.
+		$this->assertMatchesRegularExpression( '/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/', $metadata['Registration_Date'] );
+	}
+
+	/**
+	 * Test registration page from user meta.
+	 */
+	public function test_registration_page() {
+		update_user_meta( self::$user_id, Reader_Activation::REGISTRATION_PAGE, 'https://example.com/newsletter' );
+		$metadata = ( new Registration( self::$user_id ) )->get_metadata();
+		$this->assertSame( 'https://example.com/newsletter', $metadata['Registration_Page'] );
+	}
+
+	/**
+	 * Test registration strategy from user meta.
+	 */
+	public function test_registration_strategy() {
+		update_user_meta( self::$user_id, Reader_Activation::REGISTRATION_METHOD, 'newsletter' );
+		$metadata = ( new Registration( self::$user_id ) )->get_metadata();
+		$this->assertSame( 'newsletter', $metadata['Registration_Strategy'] );
+	}
+
+	/**
+	 * Test UTM extraction from registration page URL.
+	 */
+	public function test_utm_extraction_from_registration_page() {
+		update_user_meta(
+			self::$user_id,
+			Reader_Activation::REGISTRATION_PAGE,
+			'https://example.com/signup?utm_source=facebook&utm_medium=social&utm_campaign=spring2024'
+		);
+		$metadata = ( new Registration( self::$user_id ) )->get_metadata();
+		$this->assertSame( 'facebook', $metadata['Registration_UTM_Source'] );
+		$this->assertSame( 'social', $metadata['Registration_UTM_Medium'] );
+		$this->assertSame( 'spring2024', $metadata['Registration_UTM_Campaign'] );
+	}
+
+	/**
+	 * Test UTM empty when no query params in URL.
+	 */
+	public function test_utm_empty_when_no_query_params() {
+		update_user_meta( self::$user_id, Reader_Activation::REGISTRATION_PAGE, 'https://example.com/signup' );
+		$metadata = ( new Registration( self::$user_id ) )->get_metadata();
+		$this->assertSame( '', $metadata['Registration_UTM_Source'] );
+		$this->assertSame( '', $metadata['Registration_UTM_Medium'] );
+		$this->assertSame( '', $metadata['Registration_UTM_Campaign'] );
+	}
+
+	/**
+	 * Test UTM empty when no registration page is set.
+	 */
+	public function test_utm_empty_when_no_registration_page() {
+		$metadata = ( new Registration( self::$user_id ) )->get_metadata();
+		$this->assertSame( '', $metadata['Registration_UTM_Source'] );
+	}
+
+	/**
+	 * Test empty fields by default.
+	 */
+	public function test_empty_fields_by_default() {
+		$metadata = ( new Registration( self::$user_id ) )->get_metadata();
+		$this->assertSame( '', $metadata['Registration_Page'] );
+		$this->assertSame( '', $metadata['Registration_Strategy'] );
+	}
+
+	/**
+	 * Test returns empty without user.
+	 */
+	public function test_returns_empty_without_user() {
+		$metadata = ( new Registration( 0 ) )->get_metadata();
+		$this->assertSame( [], $metadata );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Implements `get_metadata()` for the three profile contact metadata classes that were previously returning empty arrays: **Identity**, **Registration**, and **Engagement**.

**Identity** (7 fields):
- `first_name`, `last_name`, `email` — from WordPress user data
- `Account` — WordPress user ID
- `User_Role` — first WordPress role assigned to the user
- `verified` — whether the reader has verified their email (from `np_reader_email_verified` user meta)
- `Connected_Account` — SSO provider used to register, if any (from `np_reader_connected_account` user meta)

**Registration** (6 fields):
- `Registration_Date` — account creation date, formatted as `Y-m-d H:i:s`
- `Registration_Page` — URL where the reader registered (from user meta)
- `Registration_Strategy` — how the reader registered: newsletter, checkout, registration-wall, etc. (from user meta)
- `Registration_UTM_Source`, `Registration_UTM_Medium`, `Registration_UTM_Campaign` — parsed from the registration page URL query parameters

**Engagement** (10 fields):
- `First_Visit_Date`, `Last_Active` — from the Reader Data store (JS millisecond timestamps converted to `Y-m-d H:i:s`)
- `Paywall_Hits` — integer count from the Reader Data store
- `Favorite_Categories` — category IDs from the Reader Data store, converted to a comma-separated string of category names
- `Payment_Page` — URL of the most recent checkout page (from the latest completed WC order's `_newspack_referer` meta)
- `Payment_UTM_Source`, `Payment_UTM_Medium`, `Payment_UTM_Campaign` — UTM data from the latest completed WC order
- `Total_Paid` — lifetime total spent via `WC_Customer::get_total_spent()`

Closes https://linear.app/a8c/issue/NPPD-1389/implement-profile-fields-identity-engagement-registration

### How to test the changes in this Pull Request:

1. Enable the new metadata system in `wp-config.php`:
   ```php
   define( 'NEWSPACK_LOG_LEVEL', 3 );
   define( 'NEWSPACK_SYNC_METADATA_VERSION', '1.0' );
   define( 'NEWSPACK_INTEGRATIONS_SETTINGS_ENABLED', true );
   ```
2. Navigate to **Audience > Integrations > ESP** and confirm the Identity, Registration, and Engagement fields appear in the outgoing metadata section
3. Check all fields and save, confirm they persist on reload
4. Register a new reader on a page with UTM parameters (e.g. `?utm_source=test&utm_medium=email&utm_campaign=spring`)
5. Check the logs — verify registration metadata includes the date, page, strategy, and UTM values
6. As that reader, browse several articles and trigger a paywall hit
7. Make a WooCommerce subscription or donation purchase
8. Verify that engagement fields (`First_Visit_Date`, `Last_Active`, `Paywall_Hits`, `Favorite_Categories`, `Payment_Page`, `Payment_UTM_*`, and `Total_Paid`) are synced
9. Run the unit tests:
   ```bash
   n test-php --group=Identity_Metadata,Registration_Metadata,Engagement_Metadata
   ```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?