### PR TITLE
feat(block-theme): add block theme support to lite site

### DIFF
--- a/includes/lite-site/class-lite-site.php
+++ b/includes/lite-site/class-lite-site.php
@@ -374,6 +374,12 @@ class Lite_Site {
 	 * @return string The primary color.
 	 */
 	public static function get_primary_color() {
+		if ( function_exists( 'wp_is_block_theme' ) && wp_is_block_theme() ) {
+			$settings = wp_get_global_settings();
+			$palette  = $settings['color']['palette']['custom'] ?? $settings['color']['palette']['theme'] ?? $settings['color']['palette']['default'] ?? [];
+			return $palette[0]['color'] ?? 'currentcolor';
+		}
+
 		if ( ! function_exists( 'newspack_get_primary_color' ) ) {
 			return 'currentcolor';
 		}

--- a/src/blocks/overlay-menu/README.md
+++ b/src/blocks/overlay-menu/README.md
@@ -1,0 +1,91 @@
+# Overlay Menu Block
+
+A Gutenberg block that provides an accessible drawer menu pattern with a trigger button and a sliding content panel.
+
+## Overview
+
+The Overlay Menu is a three-block system: a parent container (`newspack/overlay-menu`) that holds an Overlay Button (`newspack/overlay-menu-trigger`) and a Menu Panel (`newspack/overlay-menu-panel`). The parent is `templateLock="all"` — both child blocks are always present and cannot be removed or reordered. The block is only available in block themes.
+
+Each instance gets a unique `instanceId` derived from its `clientId`. The parent provides this via block context (`newspack-overlay-menu/instanceId`), and both children consume it to link the trigger to the panel via ARIA and to scope body classes and panel IDs on the frontend.
+
+Multiple instances on the same page are fully independent.
+
+## Block attributes
+
+### `newspack/overlay-menu` (parent)
+
+| Attribute | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `instanceId` | string | `""` | Unique identifier scoped to this block instance. Derived from `clientId` on first render and synced to attributes so it survives duplication. Provided to children via context. |
+
+### `newspack/overlay-menu-trigger` (Overlay Button)
+
+| Attribute | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `triggerText` | string | `"Menu"` | Label text on the trigger button. Always present in the DOM; may be visually hidden depending on the active block style. |
+
+**Block styles:**
+
+| Style | Description |
+|-------|-------------|
+| Default | Hamburger icon + label text |
+| Icon only | Icon only; label hidden with `screen-reader-text` |
+| Text only | Label only; no icon |
+
+**Block supports:** `color.text`, `color.background`, `typography.fontSize`, `spacing.padding`, `border.radius`.
+
+### `newspack/overlay-menu-panel` (Menu Panel)
+
+| Attribute | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `slideDirection` | string | `"left"` | Which side the panel slides in from. Accepted values: `"left"`, `"right"`. |
+| `overlayColor` | string | `""` | Color of the scrim backdrop. Supports RGBA for transparency. Read by `view.js` from a `data-overlay-color` attribute on the panel element. |
+| `panelBackgroundColor` | string | `""` | Panel background color. Applied as an inline style. |
+| `panelTextColor` | string | `""` | Panel text color. Applied as an inline style. |
+| `isPreviewOpen` | boolean | `false` | Ephemeral editor-only flag to show the panel in the editor for design purposes. Not persisted on save. |
+
+## Editor behavior
+
+**Preview toggle**: Both the trigger and panel toolbars include a `PanelPreviewToggle` button (shared component at `panel-preview-toggle.js`). Activating it sets `isPreviewOpen` to `true` on the panel block, making the panel visible in the editor without navigating to the frontend.
+
+**Trigger edit**: `triggerText` is edited inline via a plain-text `RichText` field inside the button. The icon is not configurable from the editor.
+
+**Panel colors**: The panel's sidebar uses `ColorGradientSettingsDropdown` for text, background, and overlay color, supporting the theme palette and custom colors including alpha.
+
+## Rendering
+
+**Trigger block**: Client-side only (`save: () => null`). All output is handled in `edit.js`.
+
+**Panel block**: Dynamic block. The PHP render callback (`class-overlay-menu-panel-block.php`) builds the panel wrapper with ARIA attributes (`role="dialog"`, `aria-modal="true"`, `aria-hidden="true"`, `aria-label`), passes `instanceId` from block context, and outputs InnerBlocks content. The `data-overlay-color` attribute on the panel wrapper is used by `view.js` to set the scrim color at runtime.
+
+**Frontend script** (`view.js`, webpack entry `overlay-menu-block`): Creates a self-contained controller per instance (`createFlyoutInstance`). On open, the panel is moved to `document.body` (to avoid stacking context issues from CSS transforms), ARIA states are updated, a focus trap is activated, and a scrim element is created dynamically. Escape closes the menu. Focus returns to the trigger on close.
+
+**CSS note**: Panel and scrim styles are written at root scope (not nested inside the block wrapper selector) because the panel moves to `document.body` on open and loses its ancestor context.
+
+## Availability
+
+Block theme only. Registration in `includes/class-blocks.php` is conditional on `wp_is_block_theme()`.
+
+## Usage with block theme patterns
+
+The block is typically placed in a header template part. Example markup:
+
+```html
+<!-- wp:newspack/overlay-menu -->
+<div class="wp-block-newspack-overlay-menu">
+  <!-- wp:newspack/overlay-menu-trigger {"triggerText":"Menu"} /-->
+  <!-- wp:newspack/overlay-menu-panel {"slideDirection":"left"} -->
+  <div class="wp-block-newspack-overlay-menu-panel">
+    <!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","orientation":"vertical"}} /-->
+  </div>
+  <!-- /wp:newspack/overlay-menu-panel -->
+</div>
+<!-- /wp:newspack/overlay-menu -->
+```
+
+## Related
+
+- [Overlay Menu block source](.) — Parent block, `view.js` frontend controller, and shared `panel-preview-toggle.js` component.
+- [Trigger block source](./trigger/) — Button sub-block with style variations.
+- [Panel block source](./panel/) — Drawer panel sub-block with color controls and PHP renderer.
+- [`includes/class-blocks.php`](../../../includes/class-blocks.php) — Conditional block registration (block theme check).


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The Lite Site uses the classic theme's primary colour as an accent; this PR makes it so it can also pick up the first colour in the palette when a block theme is used. 

Closes NPPD-1424

### How to test the changes in this Pull Request:

1. On a site running the block theme, navigate to WP Admin > Editor > Styles > Colors, click the `...` icon, and "Reset colors":

<img width="445" height="225" alt="CleanShot 2026-04-03 at 17 07 11" src="https://github.com/user-attachments/assets/7886a61e-027f-44f4-a910-3146ba0b9fae" />

2. Enable Lite Site.
3. Visit your Lite Site page (if it doesn't load you may need to go to Settings > Permalinks and click Save without making changes).
4. Confirm the top and bottom borders are picking up the first colour in the default palette.
5. Navigate back to WP Admin > Editor > Styles > Colors, and change the first colour in the palette.
6. Repeat step 4 and confirm the colour is updated.
7. Switch to the Classic theme, and confirm the Lite Site is still picking up the colour set as the primary colour in the Customizer.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->