### PR TITLE
feat: add block theme support to lite site

### DIFF
--- a/includes/lite-site/class-lite-site.php
+++ b/includes/lite-site/class-lite-site.php
@@ -374,6 +374,12 @@ class Lite_Site {
 	 * @return string The primary color.
 	 */
 	public static function get_primary_color() {
+		if ( function_exists( 'wp_is_block_theme' ) && wp_is_block_theme() ) {
+			$settings = wp_get_global_settings();
+			$palette  = $settings['color']['palette']['custom'] ?? $settings['color']['palette']['theme'] ?? $settings['color']['palette']['default'] ?? [];
+			return $palette[0]['color'] ?? 'currentcolor';
+		}
+
 		if ( ! function_exists( 'newspack_get_primary_color' ) ) {
 			return 'currentcolor';
 		}

--- a/includes/lite-site/class-lite-site.php
+++ b/includes/lite-site/class-lite-site.php
@@ -374,10 +374,16 @@ class Lite_Site {
 	 * @return string The primary color.
 	 */
 	public static function get_primary_color() {
-		if ( function_exists( 'wp_is_block_theme' ) && wp_is_block_theme() ) {
+		if ( wp_is_block_theme() ) {
 			$settings = wp_get_global_settings();
 			$palettes = $settings['color']['palette'] ?? [];
-			$palette  = ! empty( $palettes['custom'] ) ? $palettes['custom'] : ( ! empty( $palettes['theme'] ) ? $palettes['theme'] : ( $palettes['default'] ?? [] ) );
+			$palette  = [];
+			foreach ( [ 'custom', 'theme', 'default' ] as $origin ) {
+				if ( ! empty( $palettes[ $origin ] ) ) {
+					$palette = $palettes[ $origin ];
+					break;
+				}
+			}
 			return $palette[0]['color'] ?? 'currentcolor';
 		}
 

--- a/includes/lite-site/class-lite-site.php
+++ b/includes/lite-site/class-lite-site.php
@@ -376,7 +376,8 @@ class Lite_Site {
 	public static function get_primary_color() {
 		if ( function_exists( 'wp_is_block_theme' ) && wp_is_block_theme() ) {
 			$settings = wp_get_global_settings();
-			$palette  = $settings['color']['palette']['custom'] ?? $settings['color']['palette']['theme'] ?? $settings['color']['palette']['default'] ?? [];
+			$palettes = $settings['color']['palette'] ?? [];
+			$palette  = ! empty( $palettes['custom'] ) ? $palettes['custom'] : ( ! empty( $palettes['theme'] ) ? $palettes['theme'] : ( $palettes['default'] ?? [] ) );
 			return $palette[0]['color'] ?? 'currentcolor';
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The Lite Site uses the classic theme's primary colour as an accent; this PR makes it so it can also pick up the first colour in the palette when a block theme is used. 

Closes NPPD-1424

### How to test the changes in this Pull Request:

1. If you have custom colours set, navigate to WP Admin > Editor > Styles > Colors, click the `...` icon, and "Reset colors":

<img width="445" height="225" alt="CleanShot 2026-04-03 at 17 07 11" src="https://github.com/user-attachments/assets/7886a61e-027f-44f4-a910-3146ba0b9fae" />

2. Enable Lite Site.
3. Visit your Lite Site page (if it doesn't load you may need to go to Settings > Permalinks and click Save without making changes).
4. Confirm the top and bottom borders are picking up the first colour in the default palette.
5. Navigate back to WP Admin > Editor > Styles > Colors, and change the first colour in the palette.
6. Repeat step 4 and confirm the colour is updated.
7. Switch to the Classic theme, and confirm the Lite Site is still picking up the colour set as the primary colour in the Customizer.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->