### PR TITLE
feat(block-theme): move co-authors RSS feed code to the Newspack Plugin

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -224,7 +224,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/co-authors-plus/class-guest-contributor-role.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/co-authors-plus/class-nicename-change.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/co-authors-plus/class-nicename-change-ui.php';
-		include_once NEWSPACK_ABSPATH . 'includes/plugins/co-authors-plus/class-rss-feed.php';
+		include_once NEWSPACK_ABSPATH . 'includes/plugins/co-authors-plus/class-co-authors-plus-rss-feed.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/co-authors-plus/class-search-authors-limit.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/wc-memberships/class-memberships.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-woocommerce.php';

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -224,6 +224,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/co-authors-plus/class-guest-contributor-role.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/co-authors-plus/class-nicename-change.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/co-authors-plus/class-nicename-change-ui.php';
+		include_once NEWSPACK_ABSPATH . 'includes/plugins/co-authors-plus/class-rss-feed.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/co-authors-plus/class-search-authors-limit.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/wc-memberships/class-memberships.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-woocommerce.php';

--- a/includes/plugins/co-authors-plus/class-co-authors-plus-rss-feed.php
+++ b/includes/plugins/co-authors-plus/class-co-authors-plus-rss-feed.php
@@ -42,7 +42,8 @@ class Co_Authors_Plus_RSS_Feed {
 		if ( empty( $coauthors ) ) {
 			return $the_author;
 		}
-		return implode( ', ', array_map( fn( $author ) => wp_strip_all_tags( html_entity_decode( $author->display_name ) ), $coauthors ) );
+		$names = array_map( fn( $author ) => wp_strip_all_tags( html_entity_decode( $author->display_name ) ), $coauthors );
+		return wp_sprintf_l( '%l', $names );
 	}
 }
 Co_Authors_Plus_RSS_Feed::init();

--- a/includes/plugins/co-authors-plus/class-co-authors-plus-rss-feed.php
+++ b/includes/plugins/co-authors-plus/class-co-authors-plus-rss-feed.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Adds co-author support to RSS and other feeds.
  */
-class RSS_Feed {
+class Co_Authors_Plus_RSS_Feed {
 
 	/**
 	 * Initialize hooks.
@@ -45,4 +45,4 @@ class RSS_Feed {
 		return implode( ', ', array_map( fn( $author ) => wp_strip_all_tags( html_entity_decode( $author->display_name ) ), $coauthors ) );
 	}
 }
-RSS_Feed::init();
+Co_Authors_Plus_RSS_Feed::init();

--- a/includes/plugins/co-authors-plus/class-rss-feed.php
+++ b/includes/plugins/co-authors-plus/class-rss-feed.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Co-Authors Plus RSS feed integration.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Adds co-author support to RSS and other feeds.
+ */
+class RSS_Feed {
+
+	/**
+	 * Initialize hooks.
+	 */
+	public static function init() {
+		add_filter( 'the_author', [ __CLASS__, 'coauthors_in_rss' ] );
+	}
+
+	/**
+	 * Filter the_author to include all co-authors in RSS and other feeds.
+	 *
+	 * /wp-includes/feed-rss2.php uses the_author(), so we selectively filter
+	 * the_author value to include all co-authors when inside a feed.
+	 *
+	 * @param string $the_author The post author's display name.
+	 * @return string The co-authors' display names, or the original author if not in a feed.
+	 */
+	public static function coauthors_in_rss( $the_author ) {
+		if ( ! is_feed() || ! function_exists( 'coauthors' ) ) {
+			return $the_author;
+		}
+		return coauthors( null, null, null, null, false );
+	}
+}
+RSS_Feed::init();

--- a/includes/plugins/co-authors-plus/class-rss-feed.php
+++ b/includes/plugins/co-authors-plus/class-rss-feed.php
@@ -31,10 +31,18 @@ class RSS_Feed {
 	 * @return string The co-authors' display names, or the original author if not in a feed.
 	 */
 	public static function coauthors_in_rss( $the_author ) {
-		if ( ! is_feed() || ! function_exists( 'coauthors' ) ) {
+		if ( ! is_feed() || ! function_exists( 'get_coauthors' ) ) {
 			return $the_author;
 		}
-		return coauthors( null, null, null, null, false );
+		$post_id = get_the_ID();
+		if ( ! $post_id ) {
+			return $the_author;
+		}
+		$coauthors = get_coauthors( $post_id );
+		if ( empty( $coauthors ) ) {
+			return $the_author;
+		}
+		return implode( ', ', array_map( fn( $author ) => wp_strip_all_tags( html_entity_decode( $author->display_name ) ), $coauthors ) );
 	}
 }
 RSS_Feed::init();

--- a/tests/mocks/co-authors-plus-mocks.php
+++ b/tests/mocks/co-authors-plus-mocks.php
@@ -1,0 +1,7 @@
+<?php // phpcs:disable Squiz.Commenting.FunctionComment.Missing, Squiz.Commenting.FileComment.Missing
+
+if ( ! function_exists( 'get_coauthors' ) ) {
+	function get_coauthors( $post_id = 0 ) {
+		return $GLOBALS['_test_cap_coauthors'] ?? [];
+	}
+}

--- a/tests/unit-tests/plugins/co-authors-plus-rss-feed.php
+++ b/tests/unit-tests/plugins/co-authors-plus-rss-feed.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Tests for the RSS_Feed Co-Authors Plus integration.
+ *
+ * @package Newspack\Tests
+ */
+
+// Mock get_coauthors() to simulate Co-Authors Plus being active.
+// Uses a global so individual tests can control the return value.
+// The `function_exists( 'get_coauthors' )` guard in RSS_Feed cannot be
+// exercised once this mock is defined, but that branch is trivially correct.
+require_once __DIR__ . '/../../mocks/co-authors-plus-mocks.php';
+
+/**
+ * Tests the RSS_Feed co-authors integration.
+ */
+class Newspack_Test_CAP_RSS_Feed extends WP_UnitTestCase {
+
+	/**
+	 * Reset state before each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$GLOBALS['_test_cap_coauthors'] = [];
+		global $wp_query;
+		$wp_query->is_feed = false;
+	}
+
+	/**
+	 * Clean up after each test.
+	 */
+	public function tear_down() {
+		parent::tear_down();
+		unset( $GLOBALS['_test_cap_coauthors'] );
+		global $wp_query;
+		$wp_query->is_feed = false;
+		wp_reset_postdata();
+	}
+
+	/**
+	 * Build a mock coauthor object.
+	 *
+	 * @param string $display_name Display name.
+	 * @return object
+	 */
+	private function make_coauthor( $display_name ) {
+		return (object) [ 'display_name' => $display_name ];
+	}
+
+	/**
+	 * Apply the the_author filter with a controlled feed context.
+	 *
+	 * @param bool $is_feed Whether to simulate a feed request.
+	 * @param int  $post_id Optional post ID to set up loop context.
+	 * @return string Filtered author string.
+	 */
+	private function filter_author( $is_feed, $post_id = null ) {
+		global $wp_query, $post;
+		if ( $post_id ) {
+			$post = get_post( $post_id ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			setup_postdata( $post );
+		}
+		$wp_query->is_feed = $is_feed;
+		return apply_filters( 'the_author', 'Original Author' );
+	}
+
+	/**
+	 * Returns the original author outside of a feed context.
+	 */
+	public function test_returns_original_author_outside_feed() {
+		$post_id = $this->factory->post->create();
+		$GLOBALS['_test_cap_coauthors'] = [ $this->make_coauthor( 'Jane Smith' ) ];
+
+		$this->assertSame( 'Original Author', $this->filter_author( false, $post_id ) );
+	}
+
+	/**
+	 * Returns the original author when get_coauthors returns an empty array.
+	 */
+	public function test_returns_original_author_when_no_coauthors() {
+		$post_id = $this->factory->post->create();
+		$GLOBALS['_test_cap_coauthors'] = [];
+
+		$this->assertSame( 'Original Author', $this->filter_author( true, $post_id ) );
+	}
+
+	/**
+	 * Returns a comma-separated list of co-author display names in a feed.
+	 */
+	public function test_returns_combined_coauthor_names_in_feed() {
+		$post_id = $this->factory->post->create();
+		$GLOBALS['_test_cap_coauthors'] = [
+			$this->make_coauthor( 'Jane Smith' ),
+			$this->make_coauthor( 'John Doe' ),
+		];
+
+		$this->assertSame( 'Jane Smith, John Doe', $this->filter_author( true, $post_id ) );
+	}
+
+	/**
+	 * Strips HTML tags and decodes entities from display names.
+	 */
+	public function test_strips_html_and_decodes_entities_in_feed() {
+		$post_id = $this->factory->post->create();
+		$GLOBALS['_test_cap_coauthors'] = [ $this->make_coauthor( '<b>Jane &amp; Smith</b>' ) ];
+
+		$this->assertSame( 'Jane & Smith', $this->filter_author( true, $post_id ) );
+	}
+}

--- a/tests/unit-tests/plugins/co-authors-plus-rss-feed.php
+++ b/tests/unit-tests/plugins/co-authors-plus-rss-feed.php
@@ -1,18 +1,18 @@
 <?php
 /**
- * Tests for the RSS_Feed Co-Authors Plus integration.
+ * Tests for the Co_Authors_Plus_RSS_Feed integration.
  *
  * @package Newspack\Tests
  */
 
 // Mock get_coauthors() to simulate Co-Authors Plus being active.
 // Uses a global so individual tests can control the return value.
-// The `function_exists( 'get_coauthors' )` guard in RSS_Feed cannot be
+// The `function_exists( 'get_coauthors' )` guard in Co_Authors_Plus_RSS_Feed cannot be
 // exercised once this mock is defined, but that branch is trivially correct.
 require_once __DIR__ . '/../../mocks/co-authors-plus-mocks.php';
 
 /**
- * Tests the RSS_Feed co-authors integration.
+ * Tests the Co_Authors_Plus_RSS_Feed integration.
  */
 class Newspack_Test_CAP_RSS_Feed extends WP_UnitTestCase {
 

--- a/tests/unit-tests/plugins/co-authors-plus-rss-feed.php
+++ b/tests/unit-tests/plugins/co-authors-plus-rss-feed.php
@@ -85,7 +85,7 @@ class Newspack_Test_CAP_RSS_Feed extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Returns a comma-separated list of co-author display names in a feed.
+	 * Joins two co-authors with "and" in a feed.
 	 */
 	public function test_returns_combined_coauthor_names_in_feed() {
 		$post_id = $this->factory->post->create();
@@ -94,7 +94,21 @@ class Newspack_Test_CAP_RSS_Feed extends WP_UnitTestCase {
 			$this->make_coauthor( 'John Doe' ),
 		];
 
-		$this->assertSame( 'Jane Smith, John Doe', $this->filter_author( true, $post_id ) );
+		$this->assertSame( 'Jane Smith and John Doe', $this->filter_author( true, $post_id ) );
+	}
+
+	/**
+	 * Joins three or more co-authors with commas and an Oxford comma before "and".
+	 */
+	public function test_returns_oxford_comma_separated_coauthor_names_in_feed() {
+		$post_id = $this->factory->post->create();
+		$GLOBALS['_test_cap_coauthors'] = [
+			$this->make_coauthor( 'Alice' ),
+			$this->make_coauthor( 'Bob' ),
+			$this->make_coauthor( 'Carol' ),
+		];
+
+		$this->assertSame( 'Alice, Bob, and Carol', $this->filter_author( true, $post_id ) );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR and https://github.com/Automattic/newspack-theme/pull/2671 remove functionality that adds Co-Authors to the RSS feed from the classic theme, and adds it to the Newspack Plugin. This makes it available regardless of theme used. 

Closes NPPD-1345

### How to test the changes in this Pull Request:

1. Apply this PR and https://github.com/Automattic/newspack-theme/pull/2671
2. Set up some posts with a few different options: multiple authors, or guest authors.
3. View the site's RSS feed (/feed in Chrome to view; the same downloads it in Firefox, which also works!) and search for `<dc:creator>` in the posts you created.
4. Confirm that your bylines are respected (guest authors, multiple authors).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->