### PR TITLE
fix(campaigns): guard against null taxonomy entries in prompt descriptions

### DIFF
--- a/src/wizards/audience/views/campaigns/utils.js
+++ b/src/wizards/audience/views/campaigns/utils.js
@@ -118,17 +118,20 @@ export const getCardClassName = ( status, forceDisabled = false ) => {
 export const promptDescription = prompt => {
 	const { categories, tags, campaign_groups: campaigns, status } = prompt;
 	const descriptionMessages = [];
-	if ( campaigns.length > 0 ) {
-		const campaignsList = campaigns.map( ( { name } ) => name ).join( ', ' );
+	const validCampaigns = Array.isArray( campaigns ) ? campaigns.filter( Boolean ) : [];
+	const validCategories = Array.isArray( categories ) ? categories.filter( Boolean ) : [];
+	const validTags = Array.isArray( tags ) ? tags.filter( Boolean ) : [];
+	if ( validCampaigns.length > 0 ) {
+		const campaignsList = validCampaigns.map( ( { name } ) => name ).join( ', ' );
 		descriptionMessages.push(
-			( campaigns.length === 1 ? __( 'Campaign: ', 'newspack-plugin' ) : __( 'Campaigns: ', 'newspack-plugin' ) ) + campaignsList
+			( validCampaigns.length === 1 ? __( 'Campaign: ', 'newspack-plugin' ) : __( 'Campaigns: ', 'newspack-plugin' ) ) + campaignsList
 		);
 	}
-	if ( categories.length > 0 ) {
-		descriptionMessages.push( __( 'Categories: ', 'newspack-plugin' ) + categories.map( category => category.name ).join( ', ' ) );
+	if ( validCategories.length > 0 ) {
+		descriptionMessages.push( __( 'Categories: ', 'newspack-plugin' ) + validCategories.map( category => category.name ).join( ', ' ) );
 	}
-	if ( tags.length > 0 ) {
-		descriptionMessages.push( __( 'Tags: ', 'newspack-plugin' ) + tags.map( tag => tag.name ).join( ', ' ) );
+	if ( validTags.length > 0 ) {
+		descriptionMessages.push( __( 'Tags: ', 'newspack-plugin' ) + validTags.map( tag => tag.name ).join( ', ' ) );
 	}
 	if ( 'pending' === status ) {
 		descriptionMessages.push( __( 'Pending review', 'newspack-plugin' ) );

--- a/src/wizards/audience/views/campaigns/utils.js
+++ b/src/wizards/audience/views/campaigns/utils.js
@@ -115,12 +115,14 @@ export const getCardClassName = ( status, forceDisabled = false ) => {
 	return 'newspack-card__is-supported';
 };
 
+const ensureTermArray = terms => ( Array.isArray( terms ) ? terms.filter( Boolean ) : [] );
+
 export const promptDescription = prompt => {
 	const { categories, tags, campaign_groups: campaigns, status } = prompt;
 	const descriptionMessages = [];
-	const validCampaigns = Array.isArray( campaigns ) ? campaigns.filter( Boolean ) : [];
-	const validCategories = Array.isArray( categories ) ? categories.filter( Boolean ) : [];
-	const validTags = Array.isArray( tags ) ? tags.filter( Boolean ) : [];
+	const validCampaigns = ensureTermArray( campaigns );
+	const validCategories = ensureTermArray( categories );
+	const validTags = ensureTermArray( tags );
 	if ( validCampaigns.length > 0 ) {
 		const campaignsList = validCampaigns.map( ( { name } ) => name ).join( ', ' );
 		descriptionMessages.push(
@@ -363,9 +365,9 @@ export const warningForPopup = ( prompts, prompt ) => {
 	const warningMessages = [];
 
 	if ( 'publish' === prompt.status && ( isAboveHeader( prompt ) || isOverlay( prompt ) || isCustomPlacement( prompt ) ) ) {
-		const promptCategories = prompt.categories;
+		const promptCategories = ensureTermArray( prompt.categories );
 		const conflictingPrompts = prompts.filter( conflict => {
-			const conflictCategories = conflict.categories;
+			const conflictCategories = ensureTermArray( conflict.categories );
 
 			// There's a conflict if both campaigns have zero categories, or if they share at least one category.
 			const hasConflictingCategory =

--- a/src/wizards/audience/views/campaigns/utils.test.js
+++ b/src/wizards/audience/views/campaigns/utils.test.js
@@ -1,0 +1,121 @@
+/**
+ * Internal dependencies
+ */
+import { promptDescription, warningForPopup, isOverlay } from './utils';
+
+const placement = 'center';
+
+beforeAll( () => {
+	window.newspackAudienceCampaigns = {
+		overlay_placements: [ placement, 'top', 'bottom' ],
+		custom_placements: {},
+		criteria: [],
+	};
+} );
+
+const overlay = ( overrides = {} ) => ( {
+	id: 100,
+	status: 'publish',
+	title: 'Test prompt',
+	segments: [],
+	categories: [],
+	tags: [],
+	campaign_groups: [],
+	options: { placement, frequency: 'daily' },
+	...overrides,
+} );
+
+const realTag = { term_id: 58, name: 'real-tag' };
+const realCategory = { term_id: 5, name: 'Sports' };
+const otherCategory = { term_id: 6, name: 'News' };
+
+describe( 'promptDescription', () => {
+	it( 'renders a description from valid taxonomy arrays', () => {
+		const result = promptDescription(
+			overlay( {
+				categories: [ realCategory ],
+				tags: [ realTag ],
+				campaign_groups: [ { name: 'Group A' } ],
+			} )
+		);
+		expect( result ).toContain( 'Categories:' );
+		expect( result ).toContain( 'Sports' );
+		expect( result ).toContain( 'Tags:' );
+		expect( result ).toContain( 'real-tag' );
+		expect( result ).toContain( 'Campaign:' );
+		expect( result ).toContain( 'Group A' );
+	} );
+
+	it( 'tolerates a null entry in tags (NPPM-2729 repro)', () => {
+		const result = promptDescription( overlay( { tags: [ realTag, null ] } ) );
+		expect( result ).toContain( 'Tags:' );
+		expect( result ).toContain( 'real-tag' );
+	} );
+
+	it( 'tolerates a null entry in categories', () => {
+		const result = promptDescription( overlay( { categories: [ realCategory, null ] } ) );
+		expect( result ).toContain( 'Categories:' );
+		expect( result ).toContain( 'Sports' );
+	} );
+
+	it( 'tolerates a null entry in campaign_groups', () => {
+		const result = promptDescription( overlay( { campaign_groups: [ { name: 'Group A' }, null ] } ) );
+		expect( result ).toContain( 'Campaign:' );
+		expect( result ).toContain( 'Group A' );
+	} );
+
+	it( 'tolerates tags === null', () => {
+		expect( () => promptDescription( overlay( { tags: null } ) ) ).not.toThrow();
+	} );
+
+	it( 'tolerates categories === null', () => {
+		expect( () => promptDescription( overlay( { categories: null } ) ) ).not.toThrow();
+	} );
+
+	it( 'tolerates campaign_groups === null', () => {
+		expect( () => promptDescription( overlay( { campaign_groups: null } ) ) ).not.toThrow();
+	} );
+} );
+
+describe( 'warningForPopup', () => {
+	it( 'test fixture is correctly set up as an overlay', () => {
+		expect( isOverlay( overlay() ) ).toBe( true );
+	} );
+
+	it( 'returns null when no conflicting prompts share segments and categories', () => {
+		const prompt = overlay( { categories: [ realCategory ] } );
+		const conflict = overlay( { id: 200, categories: [ otherCategory ] } );
+		expect( warningForPopup( [ prompt, conflict ], prompt ) ).toBeNull();
+	} );
+
+	// Null entry in prompt.categories — the outer Array.some hits null.
+	// Conflict has a non-matching category so the outer some iterates past
+	// the real category and into the null.
+	it( 'tolerates a null entry in prompt.categories (NPPM-2729 sibling path)', () => {
+		const prompt = overlay( { categories: [ realCategory, null ] } );
+		const conflict = overlay( { id: 200, categories: [ otherCategory ] } );
+		expect( () => warningForPopup( [ prompt, conflict ], prompt ) ).not.toThrow();
+	} );
+
+	// Null entry in conflict.categories — the inner Array.some hits null.
+	// Place null first so the inner some sees it on its first iteration.
+	it( 'tolerates a null entry in a conflicting prompt categories', () => {
+		const prompt = overlay( { categories: [ realCategory ] } );
+		const conflict = overlay( { id: 200, categories: [ null, otherCategory ] } );
+		expect( () => warningForPopup( [ prompt, conflict ], prompt ) ).not.toThrow();
+	} );
+
+	// Defensive: top-level non-array. prompt.categories must coerce to a usable
+	// array shape so .length / .some don't throw on a primitive.
+	it( 'tolerates categories === null on the prompt', () => {
+		const prompt = overlay( { categories: null } );
+		const conflict = overlay( { id: 200, categories: [ realCategory ] } );
+		expect( () => warningForPopup( [ prompt, conflict ], prompt ) ).not.toThrow();
+	} );
+
+	it( 'tolerates categories === null on a conflicting prompt', () => {
+		const prompt = overlay( { categories: [ realCategory ] } );
+		const conflict = overlay( { id: 200, categories: null } );
+		expect( () => warningForPopup( [ prompt, conflict ], prompt ) ).not.toThrow();
+	} );
+} );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Guards `promptDescription()` and `warningForPopup()` in `utils.js` against null/non-array taxonomy data (tags, categories, campaign_groups) that causes the Campaigns admin page to crash with `TypeError: Cannot read properties of null (reading 'name')`.

Uses `Array.isArray()` + `.filter(Boolean)` to handle both `false` values from PHP's `get_the_tags()`/`get_the_terms()` and null entries from stale object cache.

Fixes [NPPM-2729: Campaigns admin page crashes when tag data contains null entries](https://linear.app/a8c/issue/NPPM-2729/campaigns-admin-page-crashes-when-tag-data-contains-null-entries).

### How to test the changes in this Pull Request:

1. Navigate to **Audience > Campaigns** — the page should load normally.
2. Add a mu-plugin to inject null tags:
   ```php
   add_filter( 'get_the_tags', function( $terms ) {
       if ( is_array( $terms ) ) {
           $terms[] = null;
       }
       return $terms;
   } );
   ```
3. Reload the Campaigns page — it should still render without errors.
4. Check the browser console — no `TypeError` about null `.name`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
