### PR TITLE
feat(reader-data): store sync reconciliation

### DIFF
--- a/src/reader-activation/article-view.js
+++ b/src/reader-activation/article-view.js
@@ -4,14 +4,70 @@
 
 export default function setupArticleViewsAggregates( ras ) {
 	// Merge strategies for rehydration.
+
+	/**
+	 * articles_read — cumulative count. Take the higher value since both
+	 * server and client increment independently and the true count can
+	 * only be equal or greater than either.
+	 */
 	ras.store.register( 'articles_read', {
 		merge: ( server, client ) => Math.max( server || 0, client || 0 ),
 	} );
+
+	/**
+	 * paywall_hits — cumulative count, same reasoning as articles_read.
+	 */
 	ras.store.register( 'paywall_hits', {
 		merge: ( server, client ) => Math.max( server || 0, client || 0 ),
 	} );
+
+	/**
+	 * article_view_per_week — object keyed by week-boundary timestamps,
+	 * each value is a { post_id: true } map. Deep-union both sources so
+	 * reading history from different sessions/devices is combined.
+	 */
+	ras.store.register( 'article_view_per_week', {
+		merge: ( server, client ) => {
+			const merged = { ...server };
+			for ( const period of Object.keys( client || {} ) ) {
+				merged[ period ] = { ...merged[ period ], ...client[ period ] };
+			}
+			return merged;
+		},
+	} );
+
+	/**
+	 * article_view_per_month — same structure and reasoning as per_week,
+	 * keyed by month-boundary timestamps.
+	 */
+	ras.store.register( 'article_view_per_month', {
+		merge: ( server, client ) => {
+			const merged = { ...server };
+			for ( const period of Object.keys( client || {} ) ) {
+				merged[ period ] = { ...merged[ period ], ...client[ period ] };
+			}
+			return merged;
+		},
+	} );
+
+	/**
+	 * favorite_categories — ranked array of category IDs. Union both
+	 * sources with client-first ordering since the client has the most
+	 * recent activity data. Server-only categories are appended to
+	 * preserve cross-session engagement. Capped at 5.
+	 */
 	ras.store.register( 'favorite_categories', {
-		merge: ( server, client ) => client || server || [],
+		merge: ( server, client ) => {
+			const clientCats = client || [];
+			const serverCats = server || [];
+			const merged = [ ...clientCats ];
+			for ( const cat of serverCats ) {
+				if ( ! merged.includes( cat ) ) {
+					merged.push( cat );
+				}
+			}
+			return merged.slice( 0, 5 );
+		},
 	} );
 
 	ras.on( 'activity', ( { detail: { action, data, timestamp } } ) => {

--- a/src/reader-activation/article-view.js
+++ b/src/reader-activation/article-view.js
@@ -3,6 +3,17 @@
  */
 
 export default function setupArticleViewsAggregates( ras ) {
+	// Merge strategies for rehydration.
+	ras.store.register( 'articles_read', {
+		merge: ( server, client ) => Math.max( server || 0, client || 0 ),
+	} );
+	ras.store.register( 'paywall_hits', {
+		merge: ( server, client ) => Math.max( server || 0, client || 0 ),
+	} );
+	ras.store.register( 'favorite_categories', {
+		merge: ( server, client ) => client || server || [],
+	} );
+
 	ras.on( 'activity', ( { detail: { action, data, timestamp } } ) => {
 		if ( action !== 'article_view' ) {
 			return;

--- a/src/reader-activation/article-view.js
+++ b/src/reader-activation/article-view.js
@@ -28,7 +28,7 @@ export default function setupArticleViewsAggregates( ras ) {
 	 */
 	ras.store.register( 'article_view_per_week', {
 		merge: ( server, client ) => {
-			const merged = { ...server };
+			const merged = { ...( server || {} ) };
 			for ( const period of Object.keys( client || {} ) ) {
 				merged[ period ] = { ...merged[ period ], ...client[ period ] };
 			}
@@ -42,7 +42,7 @@ export default function setupArticleViewsAggregates( ras ) {
 	 */
 	ras.store.register( 'article_view_per_month', {
 		merge: ( server, client ) => {
-			const merged = { ...server };
+			const merged = { ...( server || {} ) };
 			for ( const period of Object.keys( client || {} ) ) {
 				merged[ period ] = { ...merged[ period ], ...client[ period ] };
 			}

--- a/src/reader-activation/article-view.test.js
+++ b/src/reader-activation/article-view.test.js
@@ -14,27 +14,20 @@ describe( 'setupArticleViewsAggregates', () => {
 	} );
 
 	describe( 'merge strategies', () => {
-		it( 'should register a merge strategy for articles_read', () => {
-			expect( mock.ras.store.register ).toHaveBeenCalledWith( 'articles_read', {
-				merge: expect.any( Function ),
-			} );
-		} );
+		function getMerge( key ) {
+			const call = mock.ras.store.register.mock.calls.find( ( [ k ] ) => k === key );
+			return call[ 1 ].merge;
+		}
 
-		it( 'should register a merge strategy for paywall_hits', () => {
-			expect( mock.ras.store.register ).toHaveBeenCalledWith( 'paywall_hits', {
-				merge: expect.any( Function ),
-			} );
-		} );
-
-		it( 'should register a merge strategy for favorite_categories', () => {
-			expect( mock.ras.store.register ).toHaveBeenCalledWith( 'favorite_categories', {
-				merge: expect.any( Function ),
-			} );
+		it( 'should register merge strategies for all tracked keys', () => {
+			const keys = [ 'articles_read', 'paywall_hits', 'article_view_per_week', 'article_view_per_month', 'favorite_categories' ];
+			for ( const key of keys ) {
+				expect( mock.ras.store.register ).toHaveBeenCalledWith( key, { merge: expect.any( Function ) } );
+			}
 		} );
 
 		it( 'articles_read merge should take the max', () => {
-			const call = mock.ras.store.register.mock.calls.find( ( [ key ] ) => key === 'articles_read' );
-			const merge = call[ 1 ].merge;
+			const merge = getMerge( 'articles_read' );
 			expect( merge( 5, 10 ) ).toBe( 10 );
 			expect( merge( 10, 5 ) ).toBe( 10 );
 			expect( merge( 0, 5 ) ).toBe( 5 );
@@ -42,16 +35,53 @@ describe( 'setupArticleViewsAggregates', () => {
 		} );
 
 		it( 'paywall_hits merge should take the max', () => {
-			const call = mock.ras.store.register.mock.calls.find( ( [ key ] ) => key === 'paywall_hits' );
-			const merge = call[ 1 ].merge;
+			const merge = getMerge( 'paywall_hits' );
 			expect( merge( 3, 7 ) ).toBe( 7 );
 			expect( merge( 7, 3 ) ).toBe( 7 );
 		} );
 
-		it( 'favorite_categories merge should prefer client', () => {
-			const call = mock.ras.store.register.mock.calls.find( ( [ key ] ) => key === 'favorite_categories' );
-			const merge = call[ 1 ].merge;
-			expect( merge( [ 1, 2 ], [ 3, 4 ] ) ).toEqual( [ 3, 4 ] );
+		it( 'article_view_per_week merge should deep-union periods and post IDs', () => {
+			const merge = getMerge( 'article_view_per_week' );
+			const server = { 100: { 1: true, 2: true }, 200: { 3: true } };
+			const client = { 100: { 2: true, 4: true }, 300: { 5: true } };
+			expect( merge( server, client ) ).toEqual( {
+				100: { 1: true, 2: true, 4: true },
+				200: { 3: true },
+				300: { 5: true },
+			} );
+		} );
+
+		it( 'article_view_per_month merge should deep-union periods and post IDs', () => {
+			const merge = getMerge( 'article_view_per_month' );
+			const server = { 100: { 1: true } };
+			const client = { 100: { 2: true } };
+			expect( merge( server, client ) ).toEqual( { 100: { 1: true, 2: true } } );
+		} );
+
+		it( 'article_view_per_week merge should handle null values', () => {
+			const merge = getMerge( 'article_view_per_week' );
+			const data = { 100: { 1: true } };
+			expect( merge( data, null ) ).toEqual( data );
+			expect( merge( null, data ) ).toEqual( data );
+		} );
+
+		it( 'favorite_categories merge should union with client-first ordering', () => {
+			const merge = getMerge( 'favorite_categories' );
+			expect( merge( [ 1, 2, 3 ], [ 4, 5 ] ) ).toEqual( [ 4, 5, 1, 2, 3 ] );
+		} );
+
+		it( 'favorite_categories merge should deduplicate', () => {
+			const merge = getMerge( 'favorite_categories' );
+			expect( merge( [ 1, 2, 3 ], [ 2, 3, 4 ] ) ).toEqual( [ 2, 3, 4, 1 ] );
+		} );
+
+		it( 'favorite_categories merge should cap at 5', () => {
+			const merge = getMerge( 'favorite_categories' );
+			expect( merge( [ 1, 2, 3 ], [ 4, 5, 6, 7 ] ) ).toHaveLength( 5 );
+		} );
+
+		it( 'favorite_categories merge should handle null values', () => {
+			const merge = getMerge( 'favorite_categories' );
 			expect( merge( [ 1, 2 ], null ) ).toEqual( [ 1, 2 ] );
 			expect( merge( null, null ) ).toEqual( [] );
 		} );

--- a/src/reader-activation/article-view.test.js
+++ b/src/reader-activation/article-view.test.js
@@ -13,6 +13,50 @@ describe( 'setupArticleViewsAggregates', () => {
 		mock.reset();
 	} );
 
+	describe( 'merge strategies', () => {
+		it( 'should register a merge strategy for articles_read', () => {
+			expect( mock.ras.store.register ).toHaveBeenCalledWith( 'articles_read', {
+				merge: expect.any( Function ),
+			} );
+		} );
+
+		it( 'should register a merge strategy for paywall_hits', () => {
+			expect( mock.ras.store.register ).toHaveBeenCalledWith( 'paywall_hits', {
+				merge: expect.any( Function ),
+			} );
+		} );
+
+		it( 'should register a merge strategy for favorite_categories', () => {
+			expect( mock.ras.store.register ).toHaveBeenCalledWith( 'favorite_categories', {
+				merge: expect.any( Function ),
+			} );
+		} );
+
+		it( 'articles_read merge should take the max', () => {
+			const call = mock.ras.store.register.mock.calls.find( ( [ key ] ) => key === 'articles_read' );
+			const merge = call[ 1 ].merge;
+			expect( merge( 5, 10 ) ).toBe( 10 );
+			expect( merge( 10, 5 ) ).toBe( 10 );
+			expect( merge( 0, 5 ) ).toBe( 5 );
+			expect( merge( null, 5 ) ).toBe( 5 );
+		} );
+
+		it( 'paywall_hits merge should take the max', () => {
+			const call = mock.ras.store.register.mock.calls.find( ( [ key ] ) => key === 'paywall_hits' );
+			const merge = call[ 1 ].merge;
+			expect( merge( 3, 7 ) ).toBe( 7 );
+			expect( merge( 7, 3 ) ).toBe( 7 );
+		} );
+
+		it( 'favorite_categories merge should prefer client', () => {
+			const call = mock.ras.store.register.mock.calls.find( ( [ key ] ) => key === 'favorite_categories' );
+			const merge = call[ 1 ].merge;
+			expect( merge( [ 1, 2 ], [ 3, 4 ] ) ).toEqual( [ 3, 4 ] );
+			expect( merge( [ 1, 2 ], null ) ).toEqual( [ 1, 2 ] );
+			expect( merge( null, null ) ).toEqual( [] );
+		} );
+	} );
+
 	function simulateArticleView( data, timestamp = Date.now() ) {
 		mock.trigger( 'activity', { action: 'article_view', data, timestamp } );
 	}

--- a/src/reader-activation/article-view.test.js
+++ b/src/reader-activation/article-view.test.js
@@ -1,3 +1,5 @@
+// @jest-environment jsdom
+
 import setupArticleViewsAggregates from './article-view';
 import { createMockRAS } from './mocks/ras';
 

--- a/src/reader-activation/engagement.js
+++ b/src/reader-activation/engagement.js
@@ -1,5 +1,3 @@
-/* globals newspack_reader_data */
-
 /**
  * Set up general reader engagement fields.
  *
@@ -7,13 +5,20 @@
  */
 export default function setupEngagement( ras ) {
 	// first_visit_date — preserve the oldest known value (server or client).
-	const serverFirstVisit = newspack_reader_data?.items?.first_visit_date;
-	const serverValue = serverFirstVisit ? JSON.parse( serverFirstVisit ) : null;
-	const clientValue = ras.store.get( 'first_visit_date' );
-	const candidates = [ serverValue, clientValue ].filter( Boolean );
-	const firstVisit = candidates.length ? Math.min( ...candidates ) : Date.now();
-	ras.store.set( 'first_visit_date', firstVisit );
+	ras.store.register( 'first_visit_date', {
+		merge: ( server, client ) => {
+			const candidates = [ server, client ].filter( Boolean );
+			return candidates.length ? Math.min( ...candidates ) : Date.now();
+		},
+	} );
+	// Set default if this is the first visit ever.
+	if ( ! ras.store.get( 'first_visit_date' ) ) {
+		ras.store.set( 'first_visit_date', Date.now() );
+	}
 
-	// last_active — Date reader was last seen on site.
+	// last_active — most recent timestamp wins.
+	ras.store.register( 'last_active', {
+		merge: ( server, client ) => Math.max( server || 0, client || 0 ),
+	} );
 	ras.store.set( 'last_active', Date.now() );
 }

--- a/src/reader-activation/engagement.js
+++ b/src/reader-activation/engagement.js
@@ -7,7 +7,7 @@ export default function setupEngagement( ras ) {
 	// first_visit_date — preserve the oldest known value (server or client).
 	ras.store.register( 'first_visit_date', {
 		merge: ( server, client ) => {
-			const candidates = [ server, client ].filter( Boolean );
+			const candidates = [ server, client ].filter( v => v !== null && v !== undefined );
 			return candidates.length ? Math.min( ...candidates ) : Date.now();
 		},
 	} );

--- a/src/reader-activation/engagement.test.js
+++ b/src/reader-activation/engagement.test.js
@@ -6,50 +6,79 @@ describe( 'setupEngagement', () => {
 
 	beforeEach( () => {
 		mock = createMockRAS();
-		window.newspack_reader_data = {};
 	} );
 
 	afterEach( () => {
 		mock.reset();
-		delete window.newspack_reader_data;
 	} );
 
-	it( 'should set first_visit_date on first call', () => {
+	it( 'should register a merge strategy for first_visit_date', () => {
 		setupEngagement( mock.ras );
-		expect( mock.ras.store.set ).toHaveBeenCalledWith( 'first_visit_date', expect.any( Number ) );
+		expect( mock.ras.store.register ).toHaveBeenCalledWith( 'first_visit_date', {
+			merge: expect.any( Function ),
+		} );
 	} );
 
-	it( 'should preserve existing client first_visit_date when no server value', () => {
+	it( 'should register a merge strategy for last_active', () => {
+		setupEngagement( mock.ras );
+		expect( mock.ras.store.register ).toHaveBeenCalledWith( 'last_active', {
+			merge: expect.any( Function ),
+		} );
+	} );
+
+	describe( 'first_visit_date merge', () => {
+		function getFirstVisitMerge() {
+			setupEngagement( mock.ras );
+			const call = mock.ras.store.register.mock.calls.find( ( [ key ] ) => key === 'first_visit_date' );
+			return call[ 1 ].merge;
+		}
+
+		it( 'should return the older of two values', () => {
+			const merge = getFirstVisitMerge();
+			expect( merge( 1000, 9999 ) ).toBe( 1000 );
+			expect( merge( 9999, 1000 ) ).toBe( 1000 );
+		} );
+
+		it( 'should return the existing value when only one is present', () => {
+			const merge = getFirstVisitMerge();
+			expect( merge( 1000, null ) ).toBe( 1000 );
+			expect( merge( null, 1000 ) ).toBe( 1000 );
+		} );
+
+		it( 'should return Date.now() when neither value exists', () => {
+			const merge = getFirstVisitMerge();
+			const before = Date.now();
+			const result = merge( null, null );
+			const after = Date.now();
+			expect( result ).toBeGreaterThanOrEqual( before );
+			expect( result ).toBeLessThanOrEqual( after );
+		} );
+	} );
+
+	describe( 'last_active merge', () => {
+		function getLastActiveMerge() {
+			setupEngagement( mock.ras );
+			const call = mock.ras.store.register.mock.calls.find( ( [ key ] ) => key === 'last_active' );
+			return call[ 1 ].merge;
+		}
+
+		it( 'should return the newer of two values', () => {
+			const merge = getLastActiveMerge();
+			expect( merge( 1000, 9999 ) ).toBe( 9999 );
+			expect( merge( 9999, 1000 ) ).toBe( 9999 );
+		} );
+	} );
+
+	it( 'should set first_visit_date default on first visit', () => {
+		setupEngagement( mock.ras );
+		const before = Date.now();
+		expect( mock.storeData.first_visit_date ).toBeGreaterThanOrEqual( before - 10 );
+	} );
+
+	it( 'should not overwrite existing client first_visit_date', () => {
 		mock.storeData.first_visit_date = 1000;
 		setupEngagement( mock.ras );
 		expect( mock.storeData.first_visit_date ).toBe( 1000 );
-	} );
-
-	it( 'should prefer older server value over newer client value', () => {
-		const oldServerValue = 1000;
-		const newClientValue = 9999;
-		mock.storeData.first_visit_date = newClientValue;
-		window.newspack_reader_data = {
-			items: { first_visit_date: JSON.stringify( oldServerValue ) },
-		};
-		setupEngagement( mock.ras );
-		expect( mock.storeData.first_visit_date ).toBe( oldServerValue );
-	} );
-
-	it( 'should prefer older client value over newer server value', () => {
-		const oldClientValue = 1000;
-		const newServerValue = 9999;
-		mock.storeData.first_visit_date = oldClientValue;
-		window.newspack_reader_data = {
-			items: { first_visit_date: JSON.stringify( newServerValue ) },
-		};
-		setupEngagement( mock.ras );
-		expect( mock.storeData.first_visit_date ).toBe( oldClientValue );
-	} );
-
-	it( 'should always set last_active', () => {
-		setupEngagement( mock.ras );
-		expect( mock.ras.store.set ).toHaveBeenCalledWith( 'last_active', expect.any( Number ) );
 	} );
 
 	it( 'should set last_active to a recent timestamp', () => {

--- a/src/reader-activation/engagement.test.js
+++ b/src/reader-activation/engagement.test.js
@@ -1,3 +1,5 @@
+// @jest-environment jsdom
+
 import setupEngagement from './engagement';
 import { createMockRAS } from './mocks/ras';
 

--- a/src/reader-activation/index.js
+++ b/src/reader-activation/index.js
@@ -494,6 +494,7 @@ function init() {
 	fixClientID();
 	setupArticleViewsAggregates( readerActivation );
 	setupEngagement( readerActivation );
+	store.rehydrate();
 	attachAuthCookiesListener();
 	attachNewsletterFormListener();
 	pushActivities();

--- a/src/reader-activation/index.js
+++ b/src/reader-activation/index.js
@@ -494,7 +494,6 @@ function init() {
 	fixClientID();
 	setupArticleViewsAggregates( readerActivation );
 	setupEngagement( readerActivation );
-	store.rehydrate();
 	attachAuthCookiesListener();
 	attachNewsletterFormListener();
 	pushActivities();
@@ -505,6 +504,10 @@ function init() {
 	window.newspackRAS = window.newspackRAS || [];
 	window.newspackRAS.forEach( arg => handlePush( arg ) );
 	window.newspackRAS.push = handlePush;
+
+	// Rehydrate after all synchronous strategy registrations, including
+	// those from third parties via newspackRAS.push().
+	store.rehydrate();
 
 	window.newspackRASInitialized = true;
 }

--- a/src/reader-activation/mocks/ras.js
+++ b/src/reader-activation/mocks/ras.js
@@ -14,6 +14,7 @@ export function createMockRAS() {
 			set: jest.fn( ( key, value ) => {
 				storeData[ key ] = value;
 			} ),
+			register: jest.fn(),
 		},
 		on: jest.fn( ( event, callback ) => {
 			handlers[ event ] = callback;

--- a/src/reader-activation/store.js
+++ b/src/reader-activation/store.js
@@ -24,6 +24,30 @@ const config = {
 };
 
 /**
+ * Registry of merge strategies for rehydration.
+ *
+ * @type {Map<string, Function>}
+ */
+const mergeStrategies = new Map();
+
+/**
+ * Rehydrate a single item from server data, using the registered merge
+ * strategy if one exists. Falls back to a direct overwrite.
+ *
+ * @param {string} key         Store key.
+ * @param {any}    serverValue Decoded value from the server.
+ */
+function rehydrateItem( key, serverValue ) {
+	const merge = mergeStrategies.get( key );
+	if ( merge ) {
+		const clientValue = _get( key );
+		_set( key, merge( serverValue, clientValue ) );
+	} else {
+		_set( key, serverValue );
+	}
+}
+
+/**
  * Initialize sync interval.
  *
  * @param {string[]} queue Store items keys to sync.
@@ -268,7 +292,7 @@ export default function Store() {
 			const unsyncedKeys = _get( 'unsynced', true ) || [];
 			for ( const key of Object.keys( items ) ) {
 				if ( ! unsyncedKeys.includes( key ) ) {
-					_set( key, decode( items[ key ] ) );
+					rehydrateItem( key, decode( items[ key ] ) );
 				}
 			}
 		}
@@ -281,15 +305,19 @@ export default function Store() {
 		}
 	} );
 
-	// Rehydrate items from server. No need to rehydrate for temporary sessions.
-	if ( newspack_reader_data?.items && ! newspack_reader_data?.is_temporary ) {
-		const keys = Object.keys( newspack_reader_data.items );
-		for ( const key of keys ) {
-			// Do not overwrite items that were pending sync.
-			if ( unsynced.includes( key ) ) {
-				continue;
+	/**
+	 * Rehydrate items from server data. Called explicitly after merge
+	 * strategies have been registered via store.register().
+	 */
+	function rehydrate() {
+		if ( ! newspack_reader_data?.items || newspack_reader_data?.is_temporary ) {
+			return;
+		}
+		const unsyncedKeys = _get( 'unsynced', true ) || [];
+		for ( const key of Object.keys( newspack_reader_data.items ) ) {
+			if ( ! unsyncedKeys.includes( key ) ) {
+				rehydrateItem( key, decode( newspack_reader_data.items[ key ] ) );
 			}
-			_set( key, decode( newspack_reader_data.items[ key ] ) );
 		}
 	}
 
@@ -394,5 +422,24 @@ export default function Store() {
 
 			_set( key, collection );
 		},
+		/**
+		 * Register a merge strategy for a store key. The merge function is
+		 * called during rehydration to reconcile server and client values.
+		 *
+		 * @param {string}   key           Store key.
+		 * @param {Object}   options       Options.
+		 * @param {Function} options.merge Merge function: (serverValue, clientValue) => resolvedValue.
+		 */
+		register: ( key, { merge } ) => {
+			if ( typeof merge !== 'function' ) {
+				throw new Error( 'merge must be a function.' );
+			}
+			mergeStrategies.set( key, merge );
+		},
+		/**
+		 * Rehydrate items from server data. Must be called after all merge
+		 * strategies have been registered.
+		 */
+		rehydrate,
 	};
 }

--- a/src/reader-activation/store.js
+++ b/src/reader-activation/store.js
@@ -430,9 +430,9 @@ export default function Store() {
 		 * @param {Object}   options       Options.
 		 * @param {Function} options.merge Merge function: (serverValue, clientValue) => resolvedValue.
 		 */
-		register: ( key, { merge } ) => {
+		register: ( key, { merge } = {} ) => {
 			if ( typeof merge !== 'function' ) {
-				throw new Error( 'merge must be a function.' );
+				throw new Error( `Store key '${ key }' requires a merge function.` );
 			}
 			mergeStrategies.set( key, merge );
 		},

--- a/src/reader-activation/store.js
+++ b/src/reader-activation/store.js
@@ -298,8 +298,11 @@ export default function Store() {
 	} );
 
 	/**
-	 * Rehydrate items from server data. Called explicitly after merge
+	 * Rehydrate items from server data. Must be called after all merge
 	 * strategies have been registered via store.register().
+	 *
+	 * Merge strategies must be registered synchronously before this
+	 * method runs — async registration is not supported.
 	 *
 	 * @param {Object} items Items to rehydrate. Defaults to newspack_reader_data.items.
 	 */

--- a/src/reader-activation/store.js
+++ b/src/reader-activation/store.js
@@ -434,6 +434,10 @@ export default function Store() {
 			if ( typeof merge !== 'function' ) {
 				throw new Error( `Store key '${ key }' requires a merge function.` );
 			}
+			if ( mergeStrategies.has( key ) ) {
+				// eslint-disable-next-line no-console
+				console.warn( `Store key '${ key }' already has a merge strategy registered. Overwriting.` );
+			}
 			mergeStrategies.set( key, merge );
 		},
 		/**

--- a/src/reader-activation/store.js
+++ b/src/reader-activation/store.js
@@ -288,8 +288,8 @@ export default function Store() {
 		// Rehydrate items from server if provided.
 		const items = detail?.reader_data_items || {};
 		newspack_reader_data.items = items;
+		const unsyncedKeys = _get( 'unsynced', true ) || [];
 		if ( ! newspack_reader_data?.is_temporary ) {
-			const unsyncedKeys = _get( 'unsynced', true ) || [];
 			for ( const key of Object.keys( items ) ) {
 				if ( ! unsyncedKeys.includes( key ) ) {
 					rehydrateItem( key, decode( items[ key ] ) );
@@ -297,8 +297,7 @@ export default function Store() {
 			}
 		}
 		// Re-queue unsynced items.
-		const pending = _get( 'unsynced', true ) || [];
-		for ( const key of pending ) {
+		for ( const key of unsyncedKeys ) {
 			if ( ! syncQueue.includes( key ) ) {
 				syncQueue.push( key );
 			}

--- a/src/reader-activation/store.js
+++ b/src/reader-activation/store.js
@@ -285,21 +285,11 @@ export default function Store() {
 	// When session hydration provides a nonce, rehydrate server items
 	// and re-queue any unsynced items.
 	on( EVENTS.session, ( { detail } ) => {
-		// Rehydrate items from server if provided.
 		const items = detail?.reader_data_items || {};
 		newspack_reader_data.items = items;
-		const unsyncedKeys = _get( 'unsynced', true ) || [];
-		if ( ! newspack_reader_data?.is_temporary ) {
-			for ( const key of Object.keys( items ) ) {
-				// Skip unsynced items unless they have a merge strategy,
-				// which is the authority on how to reconcile values.
-				if ( unsyncedKeys.includes( key ) && ! mergeStrategies.has( key ) ) {
-					continue;
-				}
-				rehydrateItem( key, decode( items[ key ] ) );
-			}
-		}
+		rehydrate( items );
 		// Re-queue unsynced items.
+		const unsyncedKeys = _get( 'unsynced', true ) || [];
 		for ( const key of unsyncedKeys ) {
 			if ( ! syncQueue.includes( key ) ) {
 				syncQueue.push( key );
@@ -310,19 +300,21 @@ export default function Store() {
 	/**
 	 * Rehydrate items from server data. Called explicitly after merge
 	 * strategies have been registered via store.register().
+	 *
+	 * @param {Object} items Items to rehydrate. Defaults to newspack_reader_data.items.
 	 */
-	function rehydrate() {
-		if ( ! newspack_reader_data?.items || newspack_reader_data?.is_temporary ) {
+	function rehydrate( items = newspack_reader_data?.items ) {
+		if ( ! items || newspack_reader_data?.is_temporary ) {
 			return;
 		}
 		const unsyncedKeys = _get( 'unsynced', true ) || [];
-		for ( const key of Object.keys( newspack_reader_data.items ) ) {
+		for ( const key of Object.keys( items ) ) {
 			// Skip unsynced items unless they have a merge strategy,
 			// which is the authority on how to reconcile values.
 			if ( unsyncedKeys.includes( key ) && ! mergeStrategies.has( key ) ) {
 				continue;
 			}
-			rehydrateItem( key, decode( newspack_reader_data.items[ key ] ) );
+			rehydrateItem( key, decode( items[ key ] ) );
 		}
 	}
 

--- a/src/reader-activation/store.js
+++ b/src/reader-activation/store.js
@@ -291,9 +291,12 @@ export default function Store() {
 		const unsyncedKeys = _get( 'unsynced', true ) || [];
 		if ( ! newspack_reader_data?.is_temporary ) {
 			for ( const key of Object.keys( items ) ) {
-				if ( ! unsyncedKeys.includes( key ) ) {
-					rehydrateItem( key, decode( items[ key ] ) );
+				// Skip unsynced items unless they have a merge strategy,
+				// which is the authority on how to reconcile values.
+				if ( unsyncedKeys.includes( key ) && ! mergeStrategies.has( key ) ) {
+					continue;
 				}
+				rehydrateItem( key, decode( items[ key ] ) );
 			}
 		}
 		// Re-queue unsynced items.
@@ -314,9 +317,12 @@ export default function Store() {
 		}
 		const unsyncedKeys = _get( 'unsynced', true ) || [];
 		for ( const key of Object.keys( newspack_reader_data.items ) ) {
-			if ( ! unsyncedKeys.includes( key ) ) {
-				rehydrateItem( key, decode( newspack_reader_data.items[ key ] ) );
+			// Skip unsynced items unless they have a merge strategy,
+			// which is the authority on how to reconcile values.
+			if ( unsyncedKeys.includes( key ) && ! mergeStrategies.has( key ) ) {
+				continue;
 			}
+			rehydrateItem( key, decode( newspack_reader_data.items[ key ] ) );
 		}
 	}
 

--- a/src/reader-activation/store.test.js
+++ b/src/reader-activation/store.test.js
@@ -1,3 +1,5 @@
+// @jest-environment jsdom
+
 import Store from './store';
 
 describe( 'Store', () => {

--- a/src/reader-activation/store.test.js
+++ b/src/reader-activation/store.test.js
@@ -94,6 +94,7 @@ describe( 'Store', () => {
 			},
 		};
 		const store = Store();
+		store.rehydrate();
 		expect( store.get( 'foo' ) ).toEqual( 'bar' );
 	} );
 	describe( 'getAll', () => {
@@ -133,6 +134,7 @@ describe( 'Store', () => {
 				},
 			};
 			const store = Store();
+			store.rehydrate();
 			const all = store.getAll();
 			expect( all.is_donor ).toEqual( true );
 			expect( all.active_memberships ).toEqual( [ 1, 2 ] );
@@ -164,6 +166,7 @@ describe( 'Store', () => {
 				},
 			};
 			const store = Store();
+			store.rehydrate();
 			expect( store.get( 'is_donor' ) ).toEqual( true );
 		} );
 		it( 'should not affect non-read-only keys', () => {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds a merge strategy registry to the reader data store so features can declare how their items should be reconciled during server/client rehydration.

There are currently two behaviors during rehydration: items in the unsynced queue are synced to the server (client wins), while all other items are overwritten with server values (server wins).

Neither behavior is correct for fields like `first_visit_date` (#4594), which needs a "keep oldest" strategy — a fresh session creates a new unsynced value that would overwrite the older server value upon authentication.

- `store.register( key, { merge } )`: register a `merge( serverValue, clientValue )` function that the store calls during rehydration instead of picking one side.
- `store.rehydrate( items )`: explicit rehydration method called after all synchronous strategy registrations, including third-party code via `newspackRAS.push()`.
- Items with a registered merge strategy are always reconciled through the merge function.
- Items without a registered strategy preserve the existing behavior.

#### Registered strategies

| Key | Strategy | Reasoning |
| --- | --- | --- |
| `first_visit_date` | `Math.min` |  Preserve the oldest known timestamp |
| `last_active` | `Math.max` | Most recent activity wins |
| `articles_read` | `Math.max` | `Cumulative counter — true count ≥ either value` |
| `paywall_hits` | `Math.max` | Same as above |
| `article_view_per_week` | Deep union | Combine reading history across sessions/devices |
| `article_view_per_month` | Deep union | Same as above |
| `favorite_categories` | Client-first union | Client has most recent ranking; server categories appended until cap 5 |

### How to test the changes in this Pull Request:

1. On a fresh session, register as a reader and navigate around a few articles
2. Open devtools and take a snapshot of your localStorage (all the keys listed above)
3. Close the browser and start another fresh session
4. Navigate the site anonymously, and make sure to visit articles you haven't before
5. Authenticate as the same reader and open devtools
6. Confirm that each item above has the described logic applied:
    1. `first_visit_date` updated with the server value
    2. `last_active` preserved with the latest/client value
    3. `articles_read` preserved the highest value
    4. `article_view_per_week` and `article_view_per_month` merged client and server values
    5. `favorite_categories` also merged

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->