### PR TITLE
fix: address false positives in subscription status alerts on My Account

### DIFF
--- a/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
+++ b/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
@@ -144,7 +144,7 @@ class WooCommerce_Subscriptions {
 	}
 
 	/**
-	 * Get the user's subscription within a grouped or variable subscription product.
+	 * Get the user's active subscription for a product (simple, grouped, or variable).
 	 *
 	 * @param \WC_Product $product Product.
 	 * @param int|null    $user_id User ID. Defaults to the current user.

--- a/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
+++ b/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
@@ -161,16 +161,19 @@ class WooCommerce_Subscriptions {
 			return null;
 		}
 
-		$products           = $product->get_children();
+		$children           = $product->get_children();
 		$user_subscriptions = wcs_get_users_subscriptions( $user_id );
 
-		foreach ( $products as $product ) {
-			$product = wc_get_product( $product );
-			if ( ! $product ) {
+		// Simple products have no children; check their status directly.
+		$product_ids = ! empty( $children ) ? $children : [ $product->get_id() ];
+
+		foreach ( $product_ids as $product_id ) {
+			$product_to_check = wc_get_product( $product_id );
+			if ( ! $product_to_check ) {
 				continue;
 			}
 			foreach ( $user_subscriptions as $subscription ) {
-				if ( $subscription->has_product( $product->get_id() ) && $subscription->has_status( 'active' ) ) {
+				if ( $subscription->has_product( $product_to_check->get_id() ) && $subscription->has_status( 'active' ) ) {
 					return $subscription;
 				}
 			}

--- a/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
+++ b/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
@@ -173,7 +173,7 @@ class WooCommerce_Subscriptions {
 				continue;
 			}
 			foreach ( $user_subscriptions as $subscription ) {
-				if ( $subscription->has_product( $product_to_check->get_id() ) && $subscription->has_status( 'active' ) ) {
+				if ( $subscription->has_product( $product_to_check->get_id() ) && $subscription->has_status( WooCommerce_Connection::ACTIVE_SUBSCRIPTION_STATUSES ) ) {
 					return $subscription;
 				}
 			}

--- a/tests/mocks/wc-mocks.php
+++ b/tests/mocks/wc-mocks.php
@@ -119,6 +119,7 @@ class WC_Customer {
 
 $orders_database = [];
 $subscriptions_database = [];
+$products_database = [];
 
 class WC_Order_Item_Product {
 	private $data = [];
@@ -159,8 +160,18 @@ class WC_Product {
 	}
 }
 
-
-$products_database = [];
+/**
+ * Register a mock product in the global products database.
+ *
+ * @param array $data Product data including 'id', 'children', 'type', 'name', 'price'.
+ * @return WC_Product
+ */
+function wc_create_mock_product( $data = [] ) {
+	global $products_database;
+	$product = new WC_Product( $data );
+	$products_database[ $product->get_id() ] = $product;
+	return $product;
+}
 
 class WC_Order {
 	public $data = [];

--- a/tests/unit-tests/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
+++ b/tests/unit-tests/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
@@ -8,12 +8,24 @@
 use Newspack\WooCommerce_Subscriptions;
 use Newspack\Reader_Activation;
 
+require_once __DIR__ . '/../../../mocks/wc-mocks.php';
+
 /**
  * Test WooCommerce Subscriptions integration functionality.
  *
  * @group WooCommerce_Subscriptions_Integration
  */
 class Newspack_Test_WooCommerce_Subscriptions extends WP_UnitTestCase {
+	/**
+	 * Reset the global mock databases before each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+		global $subscriptions_database, $products_database;
+		$subscriptions_database = [];
+		$products_database      = [];
+	}
+
 	/**
 	 * Test WooCommerce_Subscriptions::is_active.
 	 */
@@ -28,5 +40,124 @@ class Newspack_Test_WooCommerce_Subscriptions extends WP_UnitTestCase {
 	public function test_is_enabled() {
 		$is_enabled = WooCommerce_Subscriptions::is_enabled();
 		$this->assertFalse( $is_enabled, 'WooCommerce Subscriptions integration should not be active if the main WooCommerce plugin is not available.' );
+	}
+
+	/**
+	 * Test get_user_subscription returns an active subscription for a simple product.
+	 */
+	public function test_get_user_subscription_simple_product_active() {
+		$user_id    = $this->factory->user->create();
+		$product_id = 100;
+		$product    = wc_create_mock_product( [ 'id' => $product_id ] );
+
+		wcs_create_subscription(
+			[
+				'customer_id' => $user_id,
+				'status'      => 'active',
+				'products'    => [ $product_id ],
+			]
+		);
+
+		$result = WooCommerce_Subscriptions::get_user_subscription( $product, $user_id );
+		$this->assertInstanceOf( WC_Subscription::class, $result, 'Should find active subscription for a simple product.' );
+	}
+
+	/**
+	 * Test get_user_subscription returns null for a simple product with no subscription.
+	 */
+	public function test_get_user_subscription_simple_product_none() {
+		$user_id = $this->factory->user->create();
+		$product = wc_create_mock_product( [ 'id' => 200 ] );
+
+		$result = WooCommerce_Subscriptions::get_user_subscription( $product, $user_id );
+		$this->assertNull( $result, 'Should return null when the user has no subscription for the product.' );
+	}
+
+	/**
+	 * Test get_user_subscription finds an active subscription on a child product.
+	 */
+	public function test_get_user_subscription_variable_product() {
+		$user_id  = $this->factory->user->create();
+		$child_id = 301;
+
+		wc_create_mock_product( [ 'id' => $child_id ] );
+		$parent = wc_create_mock_product(
+			[
+				'id'       => 300,
+				'type'     => 'variable',
+				'children' => [ $child_id ],
+			]
+		);
+
+		wcs_create_subscription(
+			[
+				'customer_id' => $user_id,
+				'status'      => 'active',
+				'products'    => [ $child_id ],
+			]
+		);
+
+		$result = WooCommerce_Subscriptions::get_user_subscription( $parent, $user_id );
+		$this->assertInstanceOf( WC_Subscription::class, $result, 'Should find active subscription on a child/variation product.' );
+	}
+
+	/**
+	 * Test get_user_subscription treats pending-cancel as active.
+	 */
+	public function test_get_user_subscription_pending_cancel_is_active() {
+		$user_id    = $this->factory->user->create();
+		$product_id = 400;
+		$product    = wc_create_mock_product( [ 'id' => $product_id ] );
+
+		wcs_create_subscription(
+			[
+				'customer_id' => $user_id,
+				'status'      => 'pending-cancel',
+				'products'    => [ $product_id ],
+			]
+		);
+
+		$result = WooCommerce_Subscriptions::get_user_subscription( $product, $user_id );
+		$this->assertInstanceOf( WC_Subscription::class, $result, 'Should treat pending-cancel subscriptions as active.' );
+	}
+
+	/**
+	 * Test get_user_subscription returns null for an expired subscription.
+	 */
+	public function test_get_user_subscription_expired_returns_null() {
+		$user_id    = $this->factory->user->create();
+		$product_id = 500;
+		$product    = wc_create_mock_product( [ 'id' => $product_id ] );
+
+		wcs_create_subscription(
+			[
+				'customer_id' => $user_id,
+				'status'      => 'expired',
+				'products'    => [ $product_id ],
+			]
+		);
+
+		$result = WooCommerce_Subscriptions::get_user_subscription( $product, $user_id );
+		$this->assertNull( $result, 'Should return null for an expired subscription.' );
+	}
+
+	/**
+	 * Test get_user_subscription returns null for a cancelled subscription.
+	 */
+	public function test_get_user_subscription_cancelled_returns_null() {
+		$user_id    = $this->factory->user->create();
+		$product_id = 600;
+		$product    = wc_create_mock_product( [ 'id' => $product_id ] );
+
+		wcs_create_subscription(
+			[
+				'customer_id' => $user_id,
+				'status'      => 'cancelled',
+				'products'    => [ $product_id ],
+			]
+		);
+
+		$result = WooCommerce_Subscriptions::get_user_subscription( $product, $user_id );
+		$this->assertNull( $result, 'Should return null for a cancelled subscription.' );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Relands #4615 (reverted in #4636) with the test mock conflict resolved.

The subscription status check in `get_user_subscription()` has two bugs that cause false-positive "update your payment method" alerts on the My Account page:

1. **Simple products (no children) are silently skipped.** The method calls `$product->get_children()` and iterates only the children. For simple subscription products that have no variations, this returns an empty array and the method never checks the product itself — so active subscriptions on simple products are invisible, triggering an incorrect "inactive" alert.

2. **`pending-cancel` subscriptions are not counted as active.** The method checks `$subscription->has_status( 'active' )`, but subscribers in the `pending-cancel` state (who've cancelled but whose term hasn't expired yet) still have an active subscription. This causes false alerts for subscribers who cancel and renew, or whose subscription is pending cancellation.

**Fix 1:** When `get_children()` returns empty, fall back to checking the product's own ID.

**Fix 2:** Use `WooCommerce_Connection::ACTIVE_SUBSCRIPTION_STATUSES` (the canonical constant that includes `pending-cancel`) instead of the string `'active'`.

**Tests:** The original PR added a `WC_Product` mock and `wc_get_product()` to `wc-mocks.php`, but #4597 had independently added the same definitions to trunk. The squash merge produced duplicate class/function declarations that failed PHPCS lint. This version drops the duplicates and adds only the `wc_create_mock_product()` helper that the new tests need.

Addresses [NPPM-2642](https://linear.app/a8c/issue/NPPM-2642/false-positive-on-inactive-subscriptions-alerts).

### How to test the changes in this Pull Request:

**Setup:**
```bash
ncd newspack-plugin   # or: cd repos/newspack-plugin
n ci-build
```

**1. Verify existing tests pass:**
```bash
n test-php
n test-php --group WooCommerce_Subscriptions_Integration
```

#### Manual testing (browser)

**2a. Test with a simple subscription product:**
1. Create a simple subscription product (no variations) in WooCommerce.
2. Purchase a subscription as a test user.
3. Visit My Account as that user.
4. **Before this fix:** the "update your payment method" alert may appear even though the subscription is active. **After:** no false alert.

**3a. Test with a pending-cancel subscription:**
1. As a subscribed user, cancel a subscription (setting it to `pending-cancel`).
2. Visit My Account.
3. **Before this fix:** the alert appears because `pending-cancel` isn't treated as active. **After:** no false alert while the subscription term is still running.

#### CLI testing using `newspack-workspace` (suitable for agentic use)

**2b. Run the dedicated test group:**
```bash
n test-php --group WooCommerce_Subscriptions_Integration
# Expect: all tests pass
```

**3b. Verify the fix logic directly:**
```bash
# Confirm ACTIVE_SUBSCRIPTION_STATUSES includes pending-cancel
docker exec newspack_dev sh -c "wp eval '
  if ( class_exists( \"Newspack\WooCommerce_Connection\" ) ) {
    print_r( Newspack\WooCommerce_Connection::ACTIVE_SUBSCRIPTION_STATUSES );
  }
' --allow-root"
# Expect: array containing 'active' and 'pending-cancel'
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?