### PR TITLE
fix(access-control): fix incorrect class name

### DIFF
--- a/includes/content-gate/class-metering.php
+++ b/includes/content-gate/class-metering.php
@@ -254,7 +254,7 @@ class Metering {
 				'post_id'            => get_the_ID(),
 				'article_view'       => self::$article_view,
 				'excerpt'            => apply_filters( 'newspack_gate_content', Content_Gate::get_restricted_post_excerpt( get_post() ) ),
-				'other_settings'     => Content_Gate_Settings::get_settings(),
+				'other_settings'     => Content_Gate_Advanced_Settings::get_settings(),
 			]
 		);
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an incorrect class name leftover from #4613. The class underwent a couple of name changes and this one got left behind.

### How to test the changes in this Pull Request:

1. Confirm that all instances of `Content_Gate_Settings` and `Content_Gate_Global_Settings` are now `Content_Gate_Advanced_Settings`.
2. Confirm no fatal error on front-end metered pages.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->