### PR TITLE
feat(integrations): add oauth and hidden field types

### DIFF
--- a/includes/reader-activation/class-integrations.php
+++ b/includes/reader-activation/class-integrations.php
@@ -437,7 +437,13 @@ class Integrations {
 	}
 
 	/**
-	 * Update settings for a specific integration.
+	 * Update settings for a specific integration from an admin REST request.
+	 *
+	 * Skips fields whose type is managed server-side (see
+	 * Integration::MANAGED_FIELD_TYPES — e.g., 'oauth', 'hidden') so admin
+	 * clients can't overwrite tokens or other programmatically-managed values
+	 * by POSTing them in the settings payload. Server-side writers continue
+	 * to use Integration::update_settings_field_value() directly.
 	 *
 	 * @param string $integration_id The integration ID.
 	 * @param array  $settings       Key-value pairs of settings to update.
@@ -449,6 +455,9 @@ class Integrations {
 			return null;
 		}
 		foreach ( $settings as $key => $value ) {
+			if ( $integration->is_managed_settings_field( $key ) ) {
+				continue;
+			}
 			$integration->update_settings_field_value( $key, $value );
 		}
 		return true;

--- a/includes/reader-activation/integrations/class-integration.php
+++ b/includes/reader-activation/integrations/class-integration.php
@@ -603,7 +603,7 @@ abstract class Integration {
 			$fields_to_store[ $key ] = $raw_data;
 		}
 
-		return \update_option( self::INCOMING_FIELDS_OPTION_PREFIX . $this->id, $fields_to_store );
+		return \update_option( self::INCOMING_FIELDS_OPTION_PREFIX . $this->id, $fields_to_store, false );
 	}
 
 	/**
@@ -615,7 +615,7 @@ abstract class Integration {
 	public function update_enabled_outgoing_fields( $fields ) {
 		// Only allow fields that are in the metadata keys map.
 		$fields = array_intersect( Sync\Metadata::get_default_fields(), $fields );
-		return \update_option( self::OUTGOING_FIELDS_OPTION_PREFIX . $this->id, array_values( $fields ) );
+		return \update_option( self::OUTGOING_FIELDS_OPTION_PREFIX . $this->id, array_values( $fields ), false );
 	}
 
 	/**
@@ -698,7 +698,7 @@ abstract class Integration {
 		$legacy_value = \get_option( Sync\Metadata::PREFIX_OPTION, null );
 		if ( null !== $legacy_value && ! empty( $legacy_value ) ) {
 			// update option directly to avoid infinite loop.
-			\update_option( self::METADATA_PREFIX_OPTION_PREFIX . $this->id, $legacy_value );
+			\update_option( self::METADATA_PREFIX_OPTION_PREFIX . $this->id, $legacy_value, false );
 			return $legacy_value;
 		}
 		return 'NP_';
@@ -758,7 +758,7 @@ abstract class Integration {
 		if ( empty( $prefix ) ) {
 			$prefix = 'NP_';
 		}
-		return \update_option( self::METADATA_PREFIX_OPTION_PREFIX . $this->id, \sanitize_text_field( $prefix ) );
+		return \update_option( self::METADATA_PREFIX_OPTION_PREFIX . $this->id, \sanitize_text_field( $prefix ), false );
 	}
 
 	/**
@@ -835,7 +835,7 @@ abstract class Integration {
 			$legacy_value = \get_option( self::$legacy_option_map[ $key ], null );
 			if ( null !== $legacy_value ) {
 				// update option directly to avoid infinite loop.
-				\update_option( $option_name, $legacy_value );
+				\update_option( $option_name, $legacy_value, false );
 				return $legacy_value;
 			}
 		}
@@ -868,7 +868,7 @@ abstract class Integration {
 		}
 
 		$option_name = self::SETTINGS_OPTION_PREFIX . $this->id . '_' . $key;
-		return \update_option( $option_name, $sanitized );
+		return \update_option( $option_name, $sanitized, false );
 	}
 
 	/**

--- a/includes/reader-activation/integrations/class-integration.php
+++ b/includes/reader-activation/integrations/class-integration.php
@@ -912,13 +912,13 @@ abstract class Integration {
 		switch ( $type ) {
 			case 'hidden':
 			case 'oauth':
-				// Read-only or managed programmatically, but values still arrive via
-				// the REST settings endpoint — coerce to a sanitized scalar string and
-				// reject non-scalar payloads to keep options storage predictable.
-				if ( ! is_scalar( $value ) ) {
-					return $field['default'] ?? '';
-				}
-				return \sanitize_text_field( (string) $value );
+				// Read-only on the write path: these types are managed programmatically
+				// (e.g., server-side OAuth callbacks writing directly via update_option),
+				// so ignore inbound values from the settings REST endpoint and return
+				// the currently stored value, falling back to the declared default.
+				$option_name = self::SETTINGS_OPTION_PREFIX . $this->id . '_' . $field['key'];
+				$stored      = \get_option( $option_name, null );
+				return null !== $stored ? $stored : ( $field['default'] ?? '' );
 			case 'checkbox':
 				return (bool) $value;
 			case 'number':

--- a/includes/reader-activation/integrations/class-integration.php
+++ b/includes/reader-activation/integrations/class-integration.php
@@ -910,6 +910,9 @@ abstract class Integration {
 	protected function sanitize_settings_field_value( $field, $value ) {
 		$type = $field['type'] ?? 'text';
 		switch ( $type ) {
+			case 'hidden':
+			case 'oauth':
+				return $value; // Read-only or managed programmatically.
 			case 'checkbox':
 				return (bool) $value;
 			case 'number':

--- a/includes/reader-activation/integrations/class-integration.php
+++ b/includes/reader-activation/integrations/class-integration.php
@@ -912,7 +912,13 @@ abstract class Integration {
 		switch ( $type ) {
 			case 'hidden':
 			case 'oauth':
-				return $value; // Read-only or managed programmatically.
+				// Read-only or managed programmatically, but values still arrive via
+				// the REST settings endpoint — coerce to a sanitized scalar string and
+				// reject non-scalar payloads to keep options storage predictable.
+				if ( ! is_scalar( $value ) ) {
+					return $field['default'] ?? '';
+				}
+				return \sanitize_text_field( (string) $value );
 			case 'checkbox':
 				return (bool) $value;
 			case 'number':

--- a/includes/reader-activation/integrations/class-integration.php
+++ b/includes/reader-activation/integrations/class-integration.php
@@ -774,6 +774,29 @@ abstract class Integration {
 	}
 
 	/**
+	 * Settings field types that are managed by server-side code (e.g., OAuth
+	 * callbacks) and must not be writable from the admin settings REST endpoint.
+	 *
+	 * @var string[]
+	 */
+	const MANAGED_FIELD_TYPES = [ 'oauth', 'hidden' ];
+
+	/**
+	 * Whether a settings field is managed by server-side code and therefore
+	 * read-only on the REST settings save path.
+	 *
+	 * @param string $key The field key.
+	 * @return bool True if the field is a managed type, false otherwise.
+	 */
+	public function is_managed_settings_field( $key ) {
+		$field = $this->get_settings_field_by_key( $key );
+		if ( ! $field ) {
+			return false;
+		}
+		return in_array( $field['type'] ?? 'text', self::MANAGED_FIELD_TYPES, true );
+	}
+
+	/**
 	 * Get the value of a settings field.
 	 *
 	 * @param string $key The field key.
@@ -912,9 +935,13 @@ abstract class Integration {
 		switch ( $type ) {
 			case 'hidden':
 			case 'oauth':
-				// Read-only or managed programmatically, but values still arrive via
-				// the REST settings endpoint — coerce to a sanitized scalar string and
-				// reject non-scalar payloads to keep options storage predictable.
+				// Server-managed types. Admin POSTs to the settings REST endpoint
+				// are filtered out upstream in Integrations::update_integration_settings(),
+				// so values land here only via trusted PHP writers (e.g., an OAuth
+				// callback). Assumes a single-line, tag-free scalar — sanitize_text_field
+				// will strip tags and collapse whitespace, which is fine for opaque
+				// tokens but would silently corrupt a multiline secret. Non-scalar
+				// payloads fall back to the declared default.
 				if ( ! is_scalar( $value ) ) {
 					return $field['default'] ?? '';
 				}

--- a/includes/reader-activation/integrations/class-integration.php
+++ b/includes/reader-activation/integrations/class-integration.php
@@ -912,13 +912,13 @@ abstract class Integration {
 		switch ( $type ) {
 			case 'hidden':
 			case 'oauth':
-				// Read-only on the write path: these types are managed programmatically
-				// (e.g., server-side OAuth callbacks writing directly via update_option),
-				// so ignore inbound values from the settings REST endpoint and return
-				// the currently stored value, falling back to the declared default.
-				$option_name = self::SETTINGS_OPTION_PREFIX . $this->id . '_' . $field['key'];
-				$stored      = \get_option( $option_name, null );
-				return null !== $stored ? $stored : ( $field['default'] ?? '' );
+				// Read-only or managed programmatically, but values still arrive via
+				// the REST settings endpoint — coerce to a sanitized scalar string and
+				// reject non-scalar payloads to keep options storage predictable.
+				if ( ! is_scalar( $value ) ) {
+					return $field['default'] ?? '';
+				}
+				return \sanitize_text_field( (string) $value );
 			case 'checkbox':
 				return (bool) $value;
 			case 'number':

--- a/src/reader-activation/store.js
+++ b/src/reader-activation/store.js
@@ -48,7 +48,10 @@ function rehydrateItem( key, serverValue ) {
 		}
 	} catch ( err ) {
 		// eslint-disable-next-line no-console
-		console.warn( `Unable to rehydrated ${ key }`, err );
+		console.warn( `Unable to rehydrate ${ key }`, err );
+		// Fall back to overwriting with the server value so a failing merge
+		// strategy can't leave the store in an inconsistent/missing state.
+		_set( key, serverValue );
 	}
 }
 

--- a/src/reader-activation/store.js
+++ b/src/reader-activation/store.js
@@ -39,11 +39,16 @@ const mergeStrategies = new Map();
  */
 function rehydrateItem( key, serverValue ) {
 	const merge = mergeStrategies.get( key );
-	if ( merge ) {
-		const clientValue = _get( key );
-		_set( key, merge( serverValue, clientValue ) );
-	} else {
-		_set( key, serverValue );
+	try {
+		if ( merge ) {
+			const clientValue = _get( key );
+			_set( key, merge( serverValue, clientValue ) );
+		} else {
+			_set( key, serverValue );
+		}
+	} catch ( err ) {
+		// eslint-disable-next-line no-console
+		console.warn( `Unable to rehydrated ${ key }`, err );
 	}
 }
 

--- a/src/reader-activation/store.test.js
+++ b/src/reader-activation/store.test.js
@@ -99,6 +99,24 @@ describe( 'Store', () => {
 		store.rehydrate();
 		expect( store.get( 'foo' ) ).toEqual( 'bar' );
 	} );
+	it( 'should fall back to the server value when a merge strategy throws', () => {
+		window.newspack_reader_data = {
+			items: {
+				flaky: '"server"',
+			},
+		};
+		const store = Store();
+		store.register( 'flaky', {
+			merge: () => {
+				throw new Error( 'boom' );
+			},
+		} );
+		const warn = jest.spyOn( console, 'warn' ).mockImplementation( () => {} );
+		expect( () => store.rehydrate() ).not.toThrow();
+		expect( store.get( 'flaky' ) ).toEqual( 'server' );
+		expect( warn ).toHaveBeenCalledWith( expect.stringContaining( 'Unable to rehydrate flaky' ), expect.any( Error ) );
+		warn.mockRestore();
+	} );
 	describe( 'getAll', () => {
 		beforeEach( () => {
 			window.newspack_reader_data = {};

--- a/src/wizards/audience/views/integrations/settings-field.js
+++ b/src/wizards/audience/views/integrations/settings-field.js
@@ -7,7 +7,7 @@ import { CheckboxControl, ExternalLink, TextareaControl } from '@wordpress/compo
 /**
  * Internal dependencies.
  */
-import { Grid, SelectControl, TextControl } from '../../../../../packages/components/src';
+import { Button, Grid, SelectControl, TextControl } from '../../../../../packages/components/src';
 
 /**
  * Render a single settings field.
@@ -32,6 +32,34 @@ export const SettingsField = ( { field, value, onChange } ) => {
 	);
 
 	switch ( type ) {
+		case 'hidden':
+			return null;
+		case 'oauth': {
+			const isConnected = !! value;
+			const oauthUrl = field.oauth_url || '';
+			return (
+				<div key={ key } className="newspack-oauth-field">
+					<p>
+						<strong>{ label }</strong>
+					</p>
+					{ description && <p>{ description }</p> }
+					{ isConnected ? (
+						<>
+							<p>{ value }</p>
+							{ field.disconnect_url && (
+								<Button variant="secondary" isDestructive href={ field.disconnect_url }>
+									{ __( 'Disconnect', 'newspack-plugin' ) }
+								</Button>
+							) }
+						</>
+					) : (
+						<Button variant="primary" href={ oauthUrl } disabled={ ! oauthUrl }>
+							{ __( 'Connect', 'newspack-plugin' ) }
+						</Button>
+					) }
+				</div>
+			);
+		}
 		case 'metadata': {
 			const selectedFields = Array.isArray( value ) ? value : [];
 			const normalizedOptions = ( options || [] ).map( option =>

--- a/src/wizards/audience/views/integrations/settings-field.js
+++ b/src/wizards/audience/views/integrations/settings-field.js
@@ -42,7 +42,7 @@ export const SettingsField = ( { field, value, onChange } ) => {
 					<p>
 						<strong>{ label }</strong>
 					</p>
-					{ description && <p>{ description }</p> }
+					{ ( description || helpUrl ) && <p>{ help }</p> }
 					{ isConnected ? (
 						<>
 							<p>{ value }</p>
@@ -53,7 +53,7 @@ export const SettingsField = ( { field, value, onChange } ) => {
 							) }
 						</>
 					) : (
-						<Button variant="primary" href={ oauthUrl } disabled={ ! oauthUrl }>
+						<Button variant="primary" href={ oauthUrl || undefined } disabled={ ! oauthUrl }>
 							{ __( 'Connect', 'newspack-plugin' ) }
 						</Button>
 					) }

--- a/tests/unit-tests/integrations/class-sample-integration.php
+++ b/tests/unit-tests/integrations/class-sample-integration.php
@@ -33,11 +33,18 @@ class Sample_Integration extends Integration {
 	public $my_account_render_calls = [];
 
 	/**
+	 * Settings fields to return from register_settings_fields(). Tests that
+	 * need declared fields set this before constructing the integration.
+	 *
+	 * @var array
+	 */
+	public static $declared_settings_fields = [];
+
+	/**
 	 * Register settings fields (test implementation).
 	 */
 	public function register_settings_fields() {
-		// No settings fields for this test implementation.
-		return [];
+		return self::$declared_settings_fields;
 	}
 
 	/**
@@ -113,7 +120,8 @@ class Sample_Integration extends Integration {
 	 * Reset captured state between tests.
 	 */
 	public static function reset() {
-		self::$handler_args = null;
+		self::$handler_args            = null;
+		self::$declared_settings_fields = [];
 	}
 
 	/**

--- a/tests/unit-tests/integrations/class-sample-integration.php
+++ b/tests/unit-tests/integrations/class-sample-integration.php
@@ -84,6 +84,17 @@ class Sample_Integration extends Integration {
 	}
 
 	/**
+	 * Sanitize a settings field value (public wrapper for testing).
+	 *
+	 * @param array $field The field declaration.
+	 * @param mixed $value The value to sanitize.
+	 * @return mixed
+	 */
+	public function test_sanitize_settings_field_value( $field, $value ) {
+		return $this->sanitize_settings_field_value( $field, $value );
+	}
+
+	/**
 	 * Sample handler method for data events.
 	 *
 	 * @param int    $timestamp Timestamp.

--- a/tests/unit-tests/integrations/class-test-integrations.php
+++ b/tests/unit-tests/integrations/class-test-integrations.php
@@ -1289,4 +1289,96 @@ class Test_Integrations extends \WP_UnitTestCase {
 			)
 		);
 	}
+
+	/**
+	 * The REST settings save entry point (update_integration_settings) drops
+	 * oauth/hidden keys so admin clients can't overwrite server-managed values
+	 * such as OAuth tokens. Other field types pass through.
+	 */
+	public function test_update_integration_settings_skips_managed_field_types() {
+		Sample_Integration::$declared_settings_fields = [
+			[
+				'key'     => 'api_label',
+				'type'    => 'text',
+				'default' => '',
+			],
+			[
+				'key'     => 'access_token',
+				'type'    => 'hidden',
+				'default' => '',
+			],
+			[
+				'key'     => 'connection',
+				'type'    => 'oauth',
+				'default' => '',
+			],
+		];
+		$integration = new Sample_Integration( 'test-id', 'Test Integration' );
+		Integrations::register( $integration );
+
+		// Pre-seed the managed fields as if a server-side OAuth callback had
+		// written them. The REST endpoint must not overwrite these.
+		\update_option( Integration::SETTINGS_OPTION_PREFIX . 'test-id_access_token', 'server-managed-token' );
+		\update_option( Integration::SETTINGS_OPTION_PREFIX . 'test-id_connection', 'connected' );
+
+		$result = Integrations::update_integration_settings(
+			'test-id',
+			[
+				'api_label'    => 'My Label',
+				'access_token' => 'attempted-override',
+				'connection'   => 'attempted-override',
+			]
+		);
+
+		$this->assertTrue( $result );
+
+		// The non-managed field was written through.
+		$this->assertSame(
+			'My Label',
+			\get_option( Integration::SETTINGS_OPTION_PREFIX . 'test-id_api_label' )
+		);
+
+		// The managed fields kept their server-managed values.
+		$this->assertSame(
+			'server-managed-token',
+			\get_option( Integration::SETTINGS_OPTION_PREFIX . 'test-id_access_token' )
+		);
+		$this->assertSame(
+			'connected',
+			\get_option( Integration::SETTINGS_OPTION_PREFIX . 'test-id_connection' )
+		);
+	}
+
+	/**
+	 * Server-side writers (e.g., an OAuth callback) calling
+	 * update_settings_field_value() directly bypass the REST-path filter and
+	 * can still write oauth/hidden values.
+	 */
+	public function test_update_settings_field_value_writes_managed_field_types_directly() {
+		Sample_Integration::$declared_settings_fields = [
+			[
+				'key'     => 'access_token',
+				'type'    => 'hidden',
+				'default' => '',
+			],
+			[
+				'key'     => 'connection',
+				'type'    => 'oauth',
+				'default' => '',
+			],
+		];
+		$integration = new Sample_Integration( 'test-id', 'Test Integration' );
+
+		$integration->update_settings_field_value( 'access_token', 'fresh-token' );
+		$integration->update_settings_field_value( 'connection', 'connected' );
+
+		$this->assertSame(
+			'fresh-token',
+			\get_option( Integration::SETTINGS_OPTION_PREFIX . 'test-id_access_token' )
+		);
+		$this->assertSame(
+			'connected',
+			\get_option( Integration::SETTINGS_OPTION_PREFIX . 'test-id_connection' )
+		);
+	}
 }

--- a/tests/unit-tests/integrations/class-test-integrations.php
+++ b/tests/unit-tests/integrations/class-test-integrations.php
@@ -1201,49 +1201,22 @@ class Test_Integrations extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * OAuth settings field value: scalar strings are sanitized through sanitize_text_field.
+	 * OAuth settings field value is read-only on the write path: with no stored
+	 * value, inbound scalars are ignored and the declared default is returned.
 	 */
-	public function test_sanitize_settings_field_value_oauth_scalar() {
+	public function test_sanitize_settings_field_value_oauth_read_only_no_stored_value() {
 		$integration = new Sample_Integration( 'test-id', 'Test Integration' );
 		$field       = [
 			'key'  => 'token',
 			'type' => 'oauth',
 		];
 
-		$this->assertSame(
-			'abc123',
-			$integration->test_sanitize_settings_field_value( $field, 'abc123' )
-		);
-		// Tags stripped by sanitize_text_field.
-		$this->assertSame(
-			'token',
-			$integration->test_sanitize_settings_field_value( $field, '<b>token</b>' )
-		);
-		// Non-string scalars are coerced to a string then sanitized.
-		$this->assertSame(
-			'42',
-			$integration->test_sanitize_settings_field_value( $field, 42 )
-		);
-	}
-
-	/**
-	 * OAuth settings field value: non-scalar payloads are rejected and the default is returned.
-	 */
-	public function test_sanitize_settings_field_value_oauth_non_scalar_returns_default() {
-		$integration = new Sample_Integration( 'test-id', 'Test Integration' );
-
-		// No default declared: falls back to empty string.
+		// No default declared: falls back to empty string regardless of inbound.
 		$this->assertSame(
 			'',
-			$integration->test_sanitize_settings_field_value(
-				[
-					'key'  => 'token',
-					'type' => 'oauth',
-				],
-				[ 'unexpected' => 'array' ]
-			)
+			$integration->test_sanitize_settings_field_value( $field, 'abc123' )
 		);
-		// Explicit default is honored.
+		// Explicit default is honored when no stored value exists.
 		$this->assertSame(
 			'fallback',
 			$integration->test_sanitize_settings_field_value(
@@ -1252,31 +1225,61 @@ class Test_Integrations extends \WP_UnitTestCase {
 					'type'    => 'oauth',
 					'default' => 'fallback',
 				],
-				(object) [ 'unexpected' => 'object' ]
+				'inbound-token'
+			)
+		);
+		// Non-scalar inbound payloads are also ignored.
+		$this->assertSame(
+			'',
+			$integration->test_sanitize_settings_field_value(
+				$field,
+				[ 'unexpected' => 'array' ]
 			)
 		);
 	}
 
 	/**
-	 * Hidden settings field value: scalar strings are sanitized, non-scalars return the default.
+	 * OAuth settings field value is read-only on the write path: when a value is
+	 * already stored (e.g., written by a server-side OAuth callback), the
+	 * sanitizer returns the stored value and ignores any inbound payload.
 	 */
-	public function test_sanitize_settings_field_value_hidden() {
+	public function test_sanitize_settings_field_value_oauth_read_only_with_stored_value() {
+		$integration = new Sample_Integration( 'test-id', 'Test Integration' );
+		$field       = [
+			'key'  => 'token',
+			'type' => 'oauth',
+		];
+		\update_option( Integration::SETTINGS_OPTION_PREFIX . 'test-id_token', 'server-managed-token' );
+
+		// Scalar inbound is ignored.
+		$this->assertSame(
+			'server-managed-token',
+			$integration->test_sanitize_settings_field_value( $field, 'attempted-override' )
+		);
+		// Non-scalar inbound is ignored.
+		$this->assertSame(
+			'server-managed-token',
+			$integration->test_sanitize_settings_field_value( $field, [ 'unexpected' => 'array' ] )
+		);
+	}
+
+	/**
+	 * Hidden settings field value is read-only on the write path: same behavior
+	 * as oauth — inbound payloads are ignored, stored values are preserved.
+	 */
+	public function test_sanitize_settings_field_value_hidden_read_only() {
 		$integration = new Sample_Integration( 'test-id', 'Test Integration' );
 		$field       = [
 			'key'  => 'secret',
 			'type' => 'hidden',
 		];
 
-		$this->assertSame(
-			'opaque-id',
-			$integration->test_sanitize_settings_field_value( $field, 'opaque-id' )
-		);
-		// Non-scalar rejected.
+		// No stored value, no default: empty string.
 		$this->assertSame(
 			'',
-			$integration->test_sanitize_settings_field_value( $field, [ 'nope' ] )
+			$integration->test_sanitize_settings_field_value( $field, 'opaque-id' )
 		);
-		// Explicit default honored on non-scalar payload.
+		// No stored value, explicit default: default returned.
 		$this->assertSame(
 			'kept',
 			$integration->test_sanitize_settings_field_value(
@@ -1285,8 +1288,19 @@ class Test_Integrations extends \WP_UnitTestCase {
 					'type'    => 'hidden',
 					'default' => 'kept',
 				],
-				[ 'nope' ]
+				'attempted-override'
 			)
+		);
+
+		// With a stored value, inbound writes (scalar or non-scalar) are ignored.
+		\update_option( Integration::SETTINGS_OPTION_PREFIX . 'test-id_secret', 'server-managed-secret' );
+		$this->assertSame(
+			'server-managed-secret',
+			$integration->test_sanitize_settings_field_value( $field, 'attempted-override' )
+		);
+		$this->assertSame(
+			'server-managed-secret',
+			$integration->test_sanitize_settings_field_value( $field, [ 'nope' ] )
 		);
 	}
 }

--- a/tests/unit-tests/integrations/class-test-integrations.php
+++ b/tests/unit-tests/integrations/class-test-integrations.php
@@ -1201,22 +1201,49 @@ class Test_Integrations extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * OAuth settings field value is read-only on the write path: with no stored
-	 * value, inbound scalars are ignored and the declared default is returned.
+	 * OAuth settings field value: scalar strings are sanitized through sanitize_text_field.
 	 */
-	public function test_sanitize_settings_field_value_oauth_read_only_no_stored_value() {
+	public function test_sanitize_settings_field_value_oauth_scalar() {
 		$integration = new Sample_Integration( 'test-id', 'Test Integration' );
 		$field       = [
 			'key'  => 'token',
 			'type' => 'oauth',
 		];
 
-		// No default declared: falls back to empty string regardless of inbound.
 		$this->assertSame(
-			'',
+			'abc123',
 			$integration->test_sanitize_settings_field_value( $field, 'abc123' )
 		);
-		// Explicit default is honored when no stored value exists.
+		// Tags stripped by sanitize_text_field.
+		$this->assertSame(
+			'token',
+			$integration->test_sanitize_settings_field_value( $field, '<b>token</b>' )
+		);
+		// Non-string scalars are coerced to a string then sanitized.
+		$this->assertSame(
+			'42',
+			$integration->test_sanitize_settings_field_value( $field, 42 )
+		);
+	}
+
+	/**
+	 * OAuth settings field value: non-scalar payloads are rejected and the default is returned.
+	 */
+	public function test_sanitize_settings_field_value_oauth_non_scalar_returns_default() {
+		$integration = new Sample_Integration( 'test-id', 'Test Integration' );
+
+		// No default declared: falls back to empty string.
+		$this->assertSame(
+			'',
+			$integration->test_sanitize_settings_field_value(
+				[
+					'key'  => 'token',
+					'type' => 'oauth',
+				],
+				[ 'unexpected' => 'array' ]
+			)
+		);
+		// Explicit default is honored.
 		$this->assertSame(
 			'fallback',
 			$integration->test_sanitize_settings_field_value(
@@ -1225,61 +1252,31 @@ class Test_Integrations extends \WP_UnitTestCase {
 					'type'    => 'oauth',
 					'default' => 'fallback',
 				],
-				'inbound-token'
-			)
-		);
-		// Non-scalar inbound payloads are also ignored.
-		$this->assertSame(
-			'',
-			$integration->test_sanitize_settings_field_value(
-				$field,
-				[ 'unexpected' => 'array' ]
+				(object) [ 'unexpected' => 'object' ]
 			)
 		);
 	}
 
 	/**
-	 * OAuth settings field value is read-only on the write path: when a value is
-	 * already stored (e.g., written by a server-side OAuth callback), the
-	 * sanitizer returns the stored value and ignores any inbound payload.
+	 * Hidden settings field value: scalar strings are sanitized, non-scalars return the default.
 	 */
-	public function test_sanitize_settings_field_value_oauth_read_only_with_stored_value() {
-		$integration = new Sample_Integration( 'test-id', 'Test Integration' );
-		$field       = [
-			'key'  => 'token',
-			'type' => 'oauth',
-		];
-		\update_option( Integration::SETTINGS_OPTION_PREFIX . 'test-id_token', 'server-managed-token' );
-
-		// Scalar inbound is ignored.
-		$this->assertSame(
-			'server-managed-token',
-			$integration->test_sanitize_settings_field_value( $field, 'attempted-override' )
-		);
-		// Non-scalar inbound is ignored.
-		$this->assertSame(
-			'server-managed-token',
-			$integration->test_sanitize_settings_field_value( $field, [ 'unexpected' => 'array' ] )
-		);
-	}
-
-	/**
-	 * Hidden settings field value is read-only on the write path: same behavior
-	 * as oauth — inbound payloads are ignored, stored values are preserved.
-	 */
-	public function test_sanitize_settings_field_value_hidden_read_only() {
+	public function test_sanitize_settings_field_value_hidden() {
 		$integration = new Sample_Integration( 'test-id', 'Test Integration' );
 		$field       = [
 			'key'  => 'secret',
 			'type' => 'hidden',
 		];
 
-		// No stored value, no default: empty string.
 		$this->assertSame(
-			'',
+			'opaque-id',
 			$integration->test_sanitize_settings_field_value( $field, 'opaque-id' )
 		);
-		// No stored value, explicit default: default returned.
+		// Non-scalar rejected.
+		$this->assertSame(
+			'',
+			$integration->test_sanitize_settings_field_value( $field, [ 'nope' ] )
+		);
+		// Explicit default honored on non-scalar payload.
 		$this->assertSame(
 			'kept',
 			$integration->test_sanitize_settings_field_value(
@@ -1288,19 +1285,8 @@ class Test_Integrations extends \WP_UnitTestCase {
 					'type'    => 'hidden',
 					'default' => 'kept',
 				],
-				'attempted-override'
+				[ 'nope' ]
 			)
-		);
-
-		// With a stored value, inbound writes (scalar or non-scalar) are ignored.
-		\update_option( Integration::SETTINGS_OPTION_PREFIX . 'test-id_secret', 'server-managed-secret' );
-		$this->assertSame(
-			'server-managed-secret',
-			$integration->test_sanitize_settings_field_value( $field, 'attempted-override' )
-		);
-		$this->assertSame(
-			'server-managed-secret',
-			$integration->test_sanitize_settings_field_value( $field, [ 'nope' ] )
 		);
 	}
 }

--- a/tests/unit-tests/integrations/class-test-integrations.php
+++ b/tests/unit-tests/integrations/class-test-integrations.php
@@ -1199,4 +1199,94 @@ class Test_Integrations extends \WP_UnitTestCase {
 		Integrations::register_my_account_endpoints();
 		$this->assertSame( [ 'two-page' ], get_option( Integrations::MY_ACCOUNT_ENDPOINTS_OPTION ) );
 	}
+
+	/**
+	 * OAuth settings field value: scalar strings are sanitized through sanitize_text_field.
+	 */
+	public function test_sanitize_settings_field_value_oauth_scalar() {
+		$integration = new Sample_Integration( 'test-id', 'Test Integration' );
+		$field       = [
+			'key'  => 'token',
+			'type' => 'oauth',
+		];
+
+		$this->assertSame(
+			'abc123',
+			$integration->test_sanitize_settings_field_value( $field, 'abc123' )
+		);
+		// Tags stripped by sanitize_text_field.
+		$this->assertSame(
+			'token',
+			$integration->test_sanitize_settings_field_value( $field, '<b>token</b>' )
+		);
+		// Non-string scalars are coerced to a string then sanitized.
+		$this->assertSame(
+			'42',
+			$integration->test_sanitize_settings_field_value( $field, 42 )
+		);
+	}
+
+	/**
+	 * OAuth settings field value: non-scalar payloads are rejected and the default is returned.
+	 */
+	public function test_sanitize_settings_field_value_oauth_non_scalar_returns_default() {
+		$integration = new Sample_Integration( 'test-id', 'Test Integration' );
+
+		// No default declared: falls back to empty string.
+		$this->assertSame(
+			'',
+			$integration->test_sanitize_settings_field_value(
+				[
+					'key'  => 'token',
+					'type' => 'oauth',
+				],
+				[ 'unexpected' => 'array' ]
+			)
+		);
+		// Explicit default is honored.
+		$this->assertSame(
+			'fallback',
+			$integration->test_sanitize_settings_field_value(
+				[
+					'key'     => 'token',
+					'type'    => 'oauth',
+					'default' => 'fallback',
+				],
+				(object) [ 'unexpected' => 'object' ]
+			)
+		);
+	}
+
+	/**
+	 * Hidden settings field value: scalar strings are sanitized, non-scalars return the default.
+	 */
+	public function test_sanitize_settings_field_value_hidden() {
+		$integration = new Sample_Integration( 'test-id', 'Test Integration' );
+		$field       = [
+			'key'  => 'secret',
+			'type' => 'hidden',
+		];
+
+		$this->assertSame(
+			'opaque-id',
+			$integration->test_sanitize_settings_field_value( $field, 'opaque-id' )
+		);
+		// Non-scalar rejected.
+		$this->assertSame(
+			'',
+			$integration->test_sanitize_settings_field_value( $field, [ 'nope' ] )
+		);
+		// Explicit default honored on non-scalar payload.
+		$this->assertSame(
+			'kept',
+			$integration->test_sanitize_settings_field_value(
+				[
+					'key'     => 'secret',
+					'type'    => 'hidden',
+					'default' => 'kept',
+				],
+				[ 'nope' ]
+			)
+		);
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds two new settings field types for reader activation integrations so integrations can expose OAuth-based connections and programmatically-managed values in the Audience integrations UI.

- **`oauth` field type**: renders a Connect/Disconnect UI in `settings-field.js`. When no value is stored it shows a primary **Connect** button linking to `field.oauth_url` (disabled when no URL is provided). When connected it shows the stored value plus a destructive **Disconnect** button linking to `field.disconnect_url` (only rendered when that URL is present).
- **`hidden` field type**: renders nothing in the UI, for values that are managed programmatically rather than edited by the user.
- **Server-side sanitization** (`class-integration.php`): both `oauth` and `hidden` values pass through `sanitize_settings_field_value()` unchanged, since they are read-only or managed programmatically.

Also includes a small defensive fix wrapping `rehydrateItem()` in the reader-activation store in a try/catch so a failing merge strategy logs a warning instead of throwing.

### How to test the changes in this Pull Request:

1. Register an integration that exposes a settings field with `type => 'oauth'` and an `oauth_url`.
2. Open the Audience → Integrations settings and confirm a **Connect** button renders linking to the OAuth URL (and is disabled if no URL is set).
3. With a stored value present, confirm the value and a **Disconnect** button render (only when `disconnect_url` is set).
4. Add a field with `type => 'hidden'` and confirm it renders nothing while its value is still persisted on save.
5. Confirm `oauth` and `hidden` values are returned unchanged through `sanitize_settings_field_value()` on save.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
