### PR TITLE
feat(integrations): add My Account menu hook to integration abstraction

### DIFF
--- a/includes/reader-activation/class-integrations.php
+++ b/includes/reader-activation/class-integrations.php
@@ -517,6 +517,9 @@ class Integrations {
 				continue;
 			}
 			$slug = sanitize_key( $item['slug'] );
+			if ( '' === $slug ) {
+				continue;
+			}
 			if ( isset( self::$my_account_endpoints[ $slug ] ) ) {
 				// First registration wins; skip collisions.
 				continue;
@@ -571,6 +574,11 @@ class Integrations {
 		// Collect items with positions so we can insert in order.
 		$to_insert = [];
 		foreach ( self::$my_account_endpoints as $slug => $integration_id ) {
+			// Skip if an item with this slug already exists (e.g., a core
+			// WooCommerce endpoint) to avoid overwriting or dropping entries.
+			if ( isset( $items[ $slug ] ) ) {
+				continue;
+			}
 			$integration = self::get_integration( $integration_id );
 			if ( ! $integration ) {
 				continue;

--- a/includes/reader-activation/class-integrations.php
+++ b/includes/reader-activation/class-integrations.php
@@ -56,6 +56,22 @@ class Integrations {
 	private static $handler_map = [];
 
 	/**
+	 * Map of My Account endpoint slug to integration ID.
+	 *
+	 * Populated during `register_my_account_endpoints()` for integrations
+	 * whose `get_my_account_menu_item()` returns a menu item declaration.
+	 *
+	 * @var array<string, string>
+	 */
+	private static $my_account_endpoints = [];
+
+	/**
+	 * Option storing the last set of registered My Account endpoint slugs,
+	 * used to trigger a rewrite rules flush when the set changes.
+	 */
+	const MY_ACCOUNT_ENDPOINTS_OPTION = 'newspack_integration_my_account_endpoints';
+
+	/**
 	 * Option name for storing enabled integrations.
 	 *
 	 * @var string
@@ -71,6 +87,9 @@ class Integrations {
 		require_once __DIR__ . '/integrations/class-contact-pull.php';
 
 		add_action( 'init', [ __CLASS__, 'register_integrations' ], 5 );
+		add_action( 'init', [ __CLASS__, 'register_my_account_endpoints' ], 6 );
+		add_filter( 'woocommerce_account_menu_items', [ __CLASS__, 'filter_my_account_menu_items' ] );
+		add_filter( 'query_vars', [ __CLASS__, 'filter_my_account_query_vars' ] );
 		add_action( 'init', [ __CLASS__, 'schedule_health_check' ] );
 		add_action( self::HEALTH_CHECK_CRON_HOOK, [ __CLASS__, 'run_health_checks' ] );
 		add_filter( 'newspack_data_events_handler_action_group', [ __CLASS__, 'filter_handler_action_group' ], 10, 3 );
@@ -480,6 +499,153 @@ class Integrations {
 		}
 
 		$integration->{ $entry['method'] }( $timestamp, $data, $client_id );
+	}
+
+	/**
+	 * Register WooCommerce My Account endpoints for active integrations.
+	 *
+	 * Iterates active integrations, collects their declared menu items,
+	 * registers rewrite endpoints and per-slug render hooks, and flushes
+	 * rewrite rules when the set of registered slugs changes.
+	 */
+	public static function register_my_account_endpoints() {
+		self::$my_account_endpoints = [];
+
+		foreach ( self::get_active_integrations() as $integration ) {
+			$item = $integration->get_my_account_menu_item();
+			if ( ! is_array( $item ) || empty( $item['slug'] ) || empty( $item['label'] ) ) {
+				continue;
+			}
+			$slug = sanitize_key( $item['slug'] );
+			if ( isset( self::$my_account_endpoints[ $slug ] ) ) {
+				// First registration wins; skip collisions.
+				continue;
+			}
+			self::$my_account_endpoints[ $slug ] = $integration->get_id();
+
+			add_rewrite_endpoint( $slug, EP_PAGES );
+
+			add_action(
+				'woocommerce_account_' . $slug . '_endpoint',
+				function( $value ) use ( $slug ) {
+					$integration_id = self::$my_account_endpoints[ $slug ] ?? null;
+					if ( ! $integration_id ) {
+						return;
+					}
+					$integration = self::get_integration( $integration_id );
+					if ( ! $integration ) {
+						return;
+					}
+					$integration->render_my_account_page( $value );
+				}
+			);
+		}
+
+		// Flush rewrite rules only when the set of slugs changes.
+		$current = array_keys( self::$my_account_endpoints );
+		sort( $current );
+		$previous = get_option( self::MY_ACCOUNT_ENDPOINTS_OPTION, [] );
+		if ( ! is_array( $previous ) ) {
+			$previous = [];
+		}
+		sort( $previous );
+		if ( $current !== $previous ) {
+			// Intentional: only fires when the set of integration-declared
+			// endpoints changes, which is rare (enable/disable/install).
+			flush_rewrite_rules( false ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.flush_rewrite_rules_flush_rewrite_rules
+			update_option( self::MY_ACCOUNT_ENDPOINTS_OPTION, $current );
+		}
+	}
+
+	/**
+	 * Inject integration menu items into the WooCommerce My Account menu.
+	 *
+	 * @param array $items Existing menu items.
+	 * @return array
+	 */
+	public static function filter_my_account_menu_items( $items ) {
+		if ( empty( self::$my_account_endpoints ) ) {
+			return $items;
+		}
+
+		// Collect items with positions so we can insert in order.
+		$to_insert = [];
+		foreach ( self::$my_account_endpoints as $slug => $integration_id ) {
+			$integration = self::get_integration( $integration_id );
+			if ( ! $integration ) {
+				continue;
+			}
+			$item = $integration->get_my_account_menu_item();
+			if ( ! is_array( $item ) || empty( $item['label'] ) ) {
+				continue;
+			}
+			$to_insert[] = [
+				'slug'     => $slug,
+				'label'    => $item['label'],
+				'position' => isset( $item['position'] ) ? (int) $item['position'] : null,
+			];
+		}
+
+		if ( empty( $to_insert ) ) {
+			return $items;
+		}
+
+		// Separate positioned vs. appended.
+		$positioned = [];
+		$appended   = [];
+		foreach ( $to_insert as $entry ) {
+			if ( null !== $entry['position'] ) {
+				$positioned[] = $entry;
+			} else {
+				$appended[ $entry['slug'] ] = $entry['label'];
+			}
+		}
+
+		// Sort positioned by position ascending for stable inserts.
+		usort(
+			$positioned,
+			function( $a, $b ) {
+				return $a['position'] <=> $b['position'];
+			}
+		);
+
+		// Insert positioned entries by converting to an indexed sequence.
+		if ( ! empty( $positioned ) ) {
+			$keys   = array_keys( $items );
+			$values = array_values( $items );
+			foreach ( $positioned as $entry ) {
+				$pos = max( 0, min( count( $keys ), $entry['position'] ) );
+				array_splice( $keys, $pos, 0, [ $entry['slug'] ] );
+				array_splice( $values, $pos, 0, [ $entry['label'] ] );
+			}
+			$items = array_combine( $keys, $values );
+		}
+
+		// Append the rest, preserving customer-logout at the bottom if present.
+		if ( ! empty( $appended ) ) {
+			if ( isset( $items['customer-logout'] ) ) {
+				$logout = $items['customer-logout'];
+				unset( $items['customer-logout'] );
+				$items = array_merge( $items, $appended, [ 'customer-logout' => $logout ] );
+			} else {
+				$items = array_merge( $items, $appended );
+			}
+		}
+
+		return $items;
+	}
+
+	/**
+	 * Register query vars for integration My Account endpoints.
+	 *
+	 * @param array $vars Existing query vars.
+	 * @return array
+	 */
+	public static function filter_my_account_query_vars( $vars ) {
+		foreach ( array_keys( self::$my_account_endpoints ) as $slug ) {
+			$vars[] = $slug;
+		}
+		return $vars;
 	}
 
 	/**

--- a/includes/reader-activation/integrations/class-integration.php
+++ b/includes/reader-activation/integrations/class-integration.php
@@ -217,6 +217,33 @@ abstract class Integration {
 	}
 
 	/**
+	 * Declare a WooCommerce My Account menu item for this integration.
+	 *
+	 * Return null (default) to opt out. Otherwise return:
+	 *   [
+	 *     'slug'     => 'newsletters',          // endpoint slug, unique across integrations.
+	 *     'label'    => __( 'Newsletters', 'newspack-plugin' ),
+	 *     'position' => 25,                     // optional, menu sort order.
+	 *   ]
+	 *
+	 * @return array|null
+	 */
+	public function get_my_account_menu_item() {
+		return null;
+	}
+
+	/**
+	 * Render the My Account page body for this integration.
+	 *
+	 * Called inside the WooCommerce account template when the endpoint
+	 * declared by get_my_account_menu_item() is the current view. Echo
+	 * markup directly. Default is a no-op.
+	 *
+	 * @param mixed $value The endpoint query var value (usually empty).
+	 */
+	public function render_my_account_page( $value ) {}
+
+	/**
 	 * Get incoming available contact fields from the integration.
 	 *
 	 * This method should be implemented by child classes to return

--- a/tests/unit-tests/integrations/class-sample-integration.php
+++ b/tests/unit-tests/integrations/class-sample-integration.php
@@ -19,6 +19,20 @@ class Sample_Integration extends Integration {
 	public static $handler_args = null;
 
 	/**
+	 * Menu item declaration returned by get_my_account_menu_item().
+	 *
+	 * @var array|null
+	 */
+	public $my_account_menu_item = null;
+
+	/**
+	 * Captured render_my_account_page() calls.
+	 *
+	 * @var array
+	 */
+	public $my_account_render_calls = [];
+
+	/**
 	 * Register settings fields (test implementation).
 	 */
 	public function register_settings_fields() {
@@ -98,5 +112,23 @@ class Sample_Integration extends Integration {
 	 */
 	public function get_available_incoming_fields() {
 		return [];
+	}
+
+	/**
+	 * Return the configured My Account menu item (test override).
+	 *
+	 * @return array|null
+	 */
+	public function get_my_account_menu_item() {
+		return $this->my_account_menu_item;
+	}
+
+	/**
+	 * Capture render_my_account_page() calls (test override).
+	 *
+	 * @param mixed $value Endpoint query var value.
+	 */
+	public function render_my_account_page( $value ) {
+		$this->my_account_render_calls[] = $value;
 	}
 }

--- a/tests/unit-tests/integrations/class-test-integrations.php
+++ b/tests/unit-tests/integrations/class-test-integrations.php
@@ -1005,4 +1005,196 @@ class Test_Integrations extends \WP_UnitTestCase {
 		$group = Data_Events::get_handler_action_group( Sample_Integration::class, $action_name );
 		$this->assertSame( 'newspack-integration-filtered-id', $group );
 	}
+
+	/**
+	 * Register an active Sample_Integration with the given ID and menu item.
+	 *
+	 * @param string     $id   Integration ID.
+	 * @param array|null $item Menu item declaration or null.
+	 * @return Sample_Integration
+	 */
+	private function register_active_integration_with_menu( $id, $item ) {
+		$integration                       = new Sample_Integration( $id, ucfirst( $id ) );
+		$integration->my_account_menu_item = $item;
+		Integrations::register( $integration );
+		Integrations::enable( $id );
+		return $integration;
+	}
+
+	/**
+	 * Reset the private $my_account_endpoints map between tests.
+	 */
+	private function reset_my_account_endpoints() {
+		$reflection = new \ReflectionClass( Integrations::class );
+		$property   = $reflection->getProperty( 'my_account_endpoints' );
+		$property->setAccessible( true );
+		$property->setValue( null, [] );
+	}
+
+	/**
+	 * Test that register_my_account_endpoints() collects declared menu items
+	 * only from integrations that opt in, ignoring invalid and opted-out ones.
+	 */
+	public function test_my_account_collects_declared_menu_items() {
+		delete_option( Integrations::MY_ACCOUNT_ENDPOINTS_OPTION );
+		$this->reset_my_account_endpoints();
+
+		$this->register_active_integration_with_menu(
+			'alpha',
+			[
+				'slug'  => 'alpha-page',
+				'label' => 'Alpha',
+			]
+		);
+		$this->register_active_integration_with_menu( 'beta', null ); // opted out.
+		$this->register_active_integration_with_menu(
+			'gamma',
+			[
+				'slug'  => '',
+				'label' => 'Gamma',
+			] // invalid slug.
+		);
+		$this->register_active_integration_with_menu(
+			'delta',
+			[
+				'slug'  => 'delta-page',
+				'label' => '',
+			] // invalid label.
+		);
+
+		Integrations::register_my_account_endpoints();
+
+		$reflection = new \ReflectionClass( Integrations::class );
+		$property   = $reflection->getProperty( 'my_account_endpoints' );
+		$property->setAccessible( true );
+		$map = $property->getValue();
+
+		$this->assertSame( [ 'alpha-page' => 'alpha' ], $map );
+	}
+
+	/**
+	 * Test that duplicate slugs across integrations keep the first registration.
+	 */
+	public function test_my_account_collision_first_registration_wins() {
+		delete_option( Integrations::MY_ACCOUNT_ENDPOINTS_OPTION );
+		$this->reset_my_account_endpoints();
+
+		$this->register_active_integration_with_menu(
+			'first',
+			[
+				'slug'  => 'shared',
+				'label' => 'First',
+			]
+		);
+		$this->register_active_integration_with_menu(
+			'second',
+			[
+				'slug'  => 'shared',
+				'label' => 'Second',
+			]
+		);
+
+		Integrations::register_my_account_endpoints();
+
+		$reflection = new \ReflectionClass( Integrations::class );
+		$property   = $reflection->getProperty( 'my_account_endpoints' );
+		$property->setAccessible( true );
+		$map = $property->getValue();
+
+		$this->assertSame( [ 'shared' => 'first' ], $map );
+	}
+
+	/**
+	 * Test menu insertion: positioned items sort by position, unpositioned
+	 * items append above customer-logout, and existing slugs are not overwritten.
+	 */
+	public function test_my_account_menu_insertion_ordering_and_logout_handling() {
+		delete_option( Integrations::MY_ACCOUNT_ENDPOINTS_OPTION );
+		$this->reset_my_account_endpoints();
+
+		$this->register_active_integration_with_menu(
+			'positioned',
+			[
+				'slug'     => 'newsletters',
+				'label'    => 'Newsletters',
+				'position' => 1,
+			]
+		);
+		$this->register_active_integration_with_menu(
+			'appended',
+			[
+				'slug'  => 'preferences',
+				'label' => 'Preferences',
+			]
+		);
+		$this->register_active_integration_with_menu(
+			'collides',
+			[
+				'slug'  => 'orders',
+				'label' => 'Should Not Overwrite',
+			]
+		);
+
+		Integrations::register_my_account_endpoints();
+
+		$initial = [
+			'dashboard'       => 'Dashboard',
+			'orders'          => 'Orders',
+			'customer-logout' => 'Logout',
+		];
+
+		$result = Integrations::filter_my_account_menu_items( $initial );
+		$keys   = array_keys( $result );
+
+		// "orders" must keep its original label (collision skipped).
+		$this->assertSame( 'Orders', $result['orders'] );
+		// Positioned "newsletters" inserted at index 1.
+		$this->assertSame( 'newsletters', $keys[1] );
+		// "preferences" appended above logout.
+		$this->assertSame( 'customer-logout', end( $keys ) );
+		$this->assertContains( 'preferences', $keys );
+		$logout_index      = array_search( 'customer-logout', $keys, true );
+		$preferences_index = array_search( 'preferences', $keys, true );
+		$this->assertLessThan( $logout_index, $preferences_index );
+	}
+
+	/**
+	 * Test that the flush-change-detection option is updated only when the
+	 * set of endpoint slugs actually changes.
+	 */
+	public function test_my_account_endpoints_option_tracks_changes() {
+		delete_option( Integrations::MY_ACCOUNT_ENDPOINTS_OPTION );
+		$this->reset_my_account_endpoints();
+
+		$this->register_active_integration_with_menu(
+			'one',
+			[
+				'slug'  => 'one-page',
+				'label' => 'One',
+			]
+		);
+
+		Integrations::register_my_account_endpoints();
+		$this->assertSame( [ 'one-page' ], get_option( Integrations::MY_ACCOUNT_ENDPOINTS_OPTION ) );
+
+		// No change: running again must keep the option stable.
+		Integrations::register_my_account_endpoints();
+		$this->assertSame( [ 'one-page' ], get_option( Integrations::MY_ACCOUNT_ENDPOINTS_OPTION ) );
+
+		// Add a second integration: option must now include both, sorted.
+		$this->register_active_integration_with_menu(
+			'two',
+			[
+				'slug'  => 'two-page',
+				'label' => 'Two',
+			]
+		);
+		Integrations::register_my_account_endpoints();
+		$this->assertSame( [ 'one-page', 'two-page' ], get_option( Integrations::MY_ACCOUNT_ENDPOINTS_OPTION ) );
+
+		// Disable 'one': option must shrink back to just 'two-page'.
+		Integrations::disable( 'one' );
+		Integrations::register_my_account_endpoints();
+		$this->assertSame( [ 'two-page' ], get_option( Integrations::MY_ACCOUNT_ENDPOINTS_OPTION ) );
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Extends the reader-activation `Integration` abstraction so any integration can declare a WooCommerce **My Account** page with a single pair of method overrides, instead of wiring rewrite endpoints, menu filters, and render hooks by hand.

An integration now opts in by overriding two new methods:

- `get_my_account_menu_item()` — returns `[ 'slug', 'label', 'position' ]` (or `null` to opt out).
- `render_my_account_page( $value )` — echoes the page body for that endpoint.

The `Integrations` registry handles the WooCommerce plumbing for every active integration that opts in: it registers the rewrite endpoint, injects the label into the My Account sidebar (respecting `position` and keeping `customer-logout` last), registers the query var, and dispatches the per-endpoint render hook back to the right integration instance. Rewrite rules are flushed automatically — and only — when the set of integration-declared endpoints actually changes, tracked via the `newspack_integration_my_account_endpoints` option.

Both new methods on the abstract class have safe no-op defaults, so existing integrations are untouched.

### How to test the changes in this Pull Request:

1. In an env with WooCommerce enabled (`n setup --env <name> --woocommerce --yes`), confirm `/my-account/` loads normally with no extra items — no active integration opts in by default, so the menu is unchanged.
2. Temporarily override `get_my_account_menu_item()` in `class-esp.php` to return `[ 'slug' => 'esp_integration', 'label' => 'ESP Integration', 'position' => 2 ]`, and `render_my_account_page()` to echo a marker string.
3. Reload `/my-account/` once (the `init` diff triggers a rewrite flush). Confirm a new "Newsletters" link appears in the sidebar at position 2 and `customer-logout` is still last.
4. Click the item: `/my-account/newsletters/` should load the WooCommerce account template with the marker string rendered in the content area.
5. Remove the `position` key and reload — confirm the item is appended above `customer-logout` instead.
6. Remove the override entirely and reload `/my-account/` once — confirm the item disappears and `/my-account/newsletters/` 404s (endpoint was removed and rewrite rules re-flushed automatically).
7. Re-add the override and reload once — confirm the item returns without any manual permalink flush.
8. Register two integrations declaring the same slug — confirm only the first wins and no PHP warnings are emitted.
9. Run `vendor/bin/phpcs includes/reader-activation/class-integrations.php includes/reader-activation/integrations/class-integration.php` — expect zero errors.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?