### PR TITLE
fix(reader-data): make is_donor read-only only when platform has server-side tracking

### DIFF
--- a/includes/class-donations.php
+++ b/includes/class-donations.php
@@ -672,7 +672,14 @@ class Donations {
 	 * @return bool
 	 */
 	public static function has_server_side_donor_tracking() {
-		return self::is_platform_wc();
+		/**
+		 * Allow third parties to declare server-side donor tracking,
+		 * which will cause is_donor to be enforced as read-only
+		 * at the public API boundary.
+		 *
+		 * @param bool $has_tracking Whether the platform has server-side tracking. Default to whether we're using Woo.
+		 */
+		return apply_filters( 'newspack_has_server_side_donor_tracking', self::is_platform_wc() );
 	}
 
 	/**

--- a/includes/class-donations.php
+++ b/includes/class-donations.php
@@ -662,6 +662,20 @@ class Donations {
 	}
 
 	/**
+	 * Whether the current donation platform has a secure server-side mechanism
+	 * to manage donor status (e.g., via the donation_new data event).
+	 *
+	 * Platforms with server-side tracking can enforce is_donor as read-only
+	 * at the public API boundary. Platforms without it (NRH, other) need
+	 * client-side write access for post-transaction landing page flows.
+	 *
+	 * @return bool
+	 */
+	public static function has_server_side_donor_tracking() {
+		return self::is_platform_wc();
+	}
+
+	/**
 	 * Handle submission of the donation form.
 	 */
 	public static function process_donation_request() {

--- a/includes/reader-activation/class-reader-data.php
+++ b/includes/reader-activation/class-reader-data.php
@@ -78,6 +78,12 @@ final class Reader_Data {
 		// mechanism to manage donor status. Currently only WooCommerce has this
 		// via the donation_new data event. Non-Woo platforms (NRH, other) rely
 		// on client-side writes from the donor landing page.
+		//
+		// Note: when is_donor is NOT read-only, any authenticated reader can
+		// set it via the REST API. This is an intentional trade-off — is_donor
+		// is used for segmentation and analytics, not access control. Consumers
+		// that need to distinguish server-verified from client-asserted donor
+		// status should check Donations::has_server_side_donor_tracking().
 		if ( Donations::has_server_side_donor_tracking() ) {
 			$keys[] = 'is_donor';
 		}

--- a/includes/reader-activation/class-reader-data.php
+++ b/includes/reader-activation/class-reader-data.php
@@ -67,21 +67,32 @@ final class Reader_Data {
 	 * @return string[] Names of read-only keys.
 	 */
 	public static function get_read_only_keys() {
+		$keys = [
+			'active_memberships',
+			'active_subscriptions',
+			'is_former_donor',
+			'newsletter_subscribed_lists',
+		];
+
+		// is_donor is only read-only when the platform has a secure server-side
+		// mechanism to manage donor status. Currently only WooCommerce has this
+		// via the donation_new data event. Non-Woo platforms (NRH, other) rely
+		// on client-side writes from the donor landing page.
+		if ( Donations::has_server_side_donor_tracking() ) {
+			$keys[] = 'is_donor';
+		}
+
 		/**
 		 * Filters the list of read-only reader data keys.
 		 *
+		 * This list is used for both client-side configuration (via wp_localize_script)
+		 * and server-side REST API enforcement. Note that filter callbacks relying on
+		 * page-context conditionals (is_page, get_the_ID, etc.) will only affect the
+		 * client-side path.
+		 *
 		 * @param string[] $keys Names of read-only keys.
 		 */
-		return apply_filters(
-			'newspack_reader_data_read_only_keys',
-			[
-				'active_memberships',
-				'active_subscriptions',
-				'is_former_donor',
-				'is_donor',
-				'newsletter_subscribed_lists',
-			]
-		);
+		return apply_filters( 'newspack_reader_data_read_only_keys', $keys );
 	}
 
 	/**

--- a/tests/unit-tests/reader-data-read-only-keys.php
+++ b/tests/unit-tests/reader-data-read-only-keys.php
@@ -17,10 +17,21 @@ use Newspack\Reader_Data;
 class Newspack_Test_Reader_Data_Read_Only_Keys extends WP_UnitTestCase {
 
 	/**
-	 * Tear down after each test — reset platform to default.
+	 * Filter callback registered during test_filter_can_add_custom_key.
+	 *
+	 * @var callable|null
+	 */
+	private $custom_key_filter = null;
+
+	/**
+	 * Tear down after each test.
 	 */
 	public function tear_down() {
 		Donations::set_platform_slug( 'wc' );
+		if ( $this->custom_key_filter ) {
+			remove_filter( 'newspack_reader_data_read_only_keys', $this->custom_key_filter );
+			$this->custom_key_filter = null;
+		}
 		parent::tear_down();
 	}
 
@@ -112,19 +123,17 @@ class Newspack_Test_Reader_Data_Read_Only_Keys extends WP_UnitTestCase {
 	 * Test that the newspack_reader_data_read_only_keys filter still works.
 	 */
 	public function test_filter_can_add_custom_key() {
-		$add_key = function ( $keys ) {
+		$this->custom_key_filter = function ( $keys ) {
 			$keys[] = 'custom_key';
 			return $keys;
 		};
-		add_filter( 'newspack_reader_data_read_only_keys', $add_key );
+		add_filter( 'newspack_reader_data_read_only_keys', $this->custom_key_filter );
 
 		self::assertContains(
 			'custom_key',
 			Reader_Data::get_read_only_keys(),
 			'Filter should be able to add custom read-only keys.'
 		);
-
-		remove_filter( 'newspack_reader_data_read_only_keys', $add_key );
 	}
 
 	/**

--- a/tests/unit-tests/reader-data-read-only-keys.php
+++ b/tests/unit-tests/reader-data-read-only-keys.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Tests for platform-conditional read-only key enforcement in Reader_Data.
+ *
+ * @package Newspack\Tests
+ * @group reader-data-read-only
+ */
+
+use Newspack\Donations;
+use Newspack\Reader_Data;
+
+/**
+ * Tests for Reader_Data read-only key behavior based on donation platform.
+ *
+ * @group reader-data-read-only
+ */
+class Newspack_Test_Reader_Data_Read_Only_Keys extends WP_UnitTestCase {
+
+	/**
+	 * Tear down after each test — reset platform to default.
+	 */
+	public function tear_down() {
+		Donations::set_platform_slug( 'wc' );
+		parent::tear_down();
+	}
+
+	/**
+	 * Test that has_server_side_donor_tracking() returns true for WooCommerce.
+	 */
+	public function test_has_server_side_donor_tracking_wc() {
+		Donations::set_platform_slug( 'wc' );
+		self::assertTrue(
+			Donations::has_server_side_donor_tracking(),
+			'WooCommerce platform should have server-side donor tracking.'
+		);
+	}
+
+	/**
+	 * Test that has_server_side_donor_tracking() returns false for NRH.
+	 */
+	public function test_has_server_side_donor_tracking_nrh() {
+		Donations::set_platform_slug( 'nrh' );
+		self::assertFalse(
+			Donations::has_server_side_donor_tracking(),
+			'NRH platform should not have server-side donor tracking.'
+		);
+	}
+
+	/**
+	 * Test that has_server_side_donor_tracking() returns false for other.
+	 */
+	public function test_has_server_side_donor_tracking_other() {
+		Donations::set_platform_slug( 'other' );
+		self::assertFalse(
+			Donations::has_server_side_donor_tracking(),
+			'Other platform should not have server-side donor tracking.'
+		);
+	}
+
+	/**
+	 * Test that is_donor is read-only on WooCommerce platform.
+	 */
+	public function test_is_donor_read_only_on_wc() {
+		Donations::set_platform_slug( 'wc' );
+		self::assertContains(
+			'is_donor',
+			Reader_Data::get_read_only_keys(),
+			'is_donor should be read-only on WooCommerce platform.'
+		);
+	}
+
+	/**
+	 * Test that is_donor is writable on NRH platform.
+	 */
+	public function test_is_donor_writable_on_nrh() {
+		Donations::set_platform_slug( 'nrh' );
+		self::assertNotContains(
+			'is_donor',
+			Reader_Data::get_read_only_keys(),
+			'is_donor should be writable on NRH platform.'
+		);
+	}
+
+	/**
+	 * Test that is_donor is writable on other platform.
+	 */
+	public function test_is_donor_writable_on_other() {
+		Donations::set_platform_slug( 'other' );
+		self::assertNotContains(
+			'is_donor',
+			Reader_Data::get_read_only_keys(),
+			'is_donor should be writable on other platform.'
+		);
+	}
+
+	/**
+	 * Test that is_former_donor is always read-only regardless of platform.
+	 *
+	 * @dataProvider platform_provider
+	 * @param string $platform Platform slug.
+	 */
+	public function test_is_former_donor_always_read_only( $platform ) {
+		Donations::set_platform_slug( $platform );
+		self::assertContains(
+			'is_former_donor',
+			Reader_Data::get_read_only_keys(),
+			"is_former_donor should be read-only on {$platform} platform."
+		);
+	}
+
+	/**
+	 * Test that the newspack_reader_data_read_only_keys filter still works.
+	 */
+	public function test_filter_can_add_custom_key() {
+		$add_key = function ( $keys ) {
+			$keys[] = 'custom_key';
+			return $keys;
+		};
+		add_filter( 'newspack_reader_data_read_only_keys', $add_key );
+
+		self::assertContains(
+			'custom_key',
+			Reader_Data::get_read_only_keys(),
+			'Filter should be able to add custom read-only keys.'
+		);
+
+		remove_filter( 'newspack_reader_data_read_only_keys', $add_key );
+	}
+
+	/**
+	 * Data provider for all platform slugs.
+	 *
+	 * @return array[]
+	 */
+	public function platform_provider() {
+		return [
+			'wc'    => [ 'wc' ],
+			'nrh'   => [ 'nrh' ],
+			'other' => [ 'other' ],
+		];
+	}
+}

--- a/tests/unit-tests/reader-data-read-only-keys.php
+++ b/tests/unit-tests/reader-data-read-only-keys.php
@@ -24,6 +24,13 @@ class Newspack_Test_Reader_Data_Read_Only_Keys extends WP_UnitTestCase {
 	private $custom_key_filter = null;
 
 	/**
+	 * Filter callback registered during test_filter_can_override_tracking.
+	 *
+	 * @var callable|null
+	 */
+	private $tracking_filter = null;
+
+	/**
 	 * Tear down after each test.
 	 */
 	public function tear_down() {
@@ -31,6 +38,10 @@ class Newspack_Test_Reader_Data_Read_Only_Keys extends WP_UnitTestCase {
 		if ( $this->custom_key_filter ) {
 			remove_filter( 'newspack_reader_data_read_only_keys', $this->custom_key_filter );
 			$this->custom_key_filter = null;
+		}
+		if ( $this->tracking_filter ) {
+			remove_filter( 'newspack_has_server_side_donor_tracking', $this->tracking_filter );
+			$this->tracking_filter = null;
 		}
 		parent::tear_down();
 	}
@@ -116,6 +127,30 @@ class Newspack_Test_Reader_Data_Read_Only_Keys extends WP_UnitTestCase {
 			'is_former_donor',
 			Reader_Data::get_read_only_keys(),
 			"is_former_donor should be read-only on {$platform} platform."
+		);
+	}
+
+	/**
+	 * Test that a non-WC platform can declare server-side tracking via filter.
+	 */
+	public function test_filter_can_override_tracking() {
+		Donations::set_platform_slug( 'nrh' );
+		self::assertFalse(
+			Donations::has_server_side_donor_tracking(),
+			'NRH should not have server-side tracking by default.'
+		);
+
+		$this->tracking_filter = '__return_true';
+		add_filter( 'newspack_has_server_side_donor_tracking', $this->tracking_filter );
+
+		self::assertTrue(
+			Donations::has_server_side_donor_tracking(),
+			'Filter should allow NRH to declare server-side tracking.'
+		);
+		self::assertContains(
+			'is_donor',
+			Reader_Data::get_read_only_keys(),
+			'is_donor should become read-only when filter declares server-side tracking.'
 		);
 	}
 


### PR DESCRIPTION
### Changes proposed:

The `is_donor` reader data key was made unconditionally read-only in #4532, which broke a [Campaigns feature](https://github.com/Automattic/newspack-popups/pull/1181) that sets `is_donor` client-side on post-transaction landing pages. This mainly affects sites using non-Newspack donation platforms (NRH, other) where there is no server-side path to set the flag.

This PR makes `is_donor` conditionally read-only based on whether the donation platform has server-side donor tracking:

- **WooCommerce sites:** `is_donor` remains read-only. The `donation_new` data event handles it server-side.
- **NRH / other sites:** `is_donor` is writable, allowing the existing client-side landing page flow to work for both anonymous and logged-in readers.

The change introduces `Donations::has_server_side_donor_tracking()`, a capability method that decouples the policy ("does this platform manage donor status server-side?") from the platform identifier. Future platforms with secure server-side handling add themselves to this one method.

Note: when `is_donor` is not read-only, any authenticated reader can set it via the REST API. This is an intentional trade-off documented in the code — `is_donor` is used for segmentation and analytics, not access control. Consumers that need to distinguish server-verified from client-asserted donor status should check `Donations::has_server_side_donor_tracking()`.

Fixes [NPPD-1431: Allow non-Woo integrations to write `is_donor`](https://linear.app/a8c/issue/NPPD-1431/allow-non-woo-integrations-to-write-is-donor).

### How to test:

1. With the donation platform set to **WooCommerce** (default):
   - Confirm `is_donor` is in the read-only keys list: in the browser console, check `newspack_reader_data.read_only_keys` includes `is_donor`.
   - As a logged-in reader, confirm that `window.newspackReaderActivation.store.set('is_donor', true)` throws a read-only error.

2. Switch the donation platform to **NRH** (Audience > Checkout & Payment):
   - Confirm `is_donor` is NOT in `newspack_reader_data.read_only_keys`.
   - As a logged-in reader, confirm that `window.newspackReaderActivation.store.set('is_donor', true)` succeeds without error.
   - Confirm the value persists in localStorage as `np_reader_1_is_donor`.

   > **Note:** If switching via WP-CLI (`wp option update newspack_reader_revenue_platform nrh`), run `wp cache flush` afterward to clear the autoloaded option cache. Switching via the admin UI flushes the cache automatically.  This bit yr. humble dev while he was trying to red/green test, so making a note of it!
