### PR TITLE
feat(reader-registration): add inline style, hide-oauth toggle, and update content gate patterns

### DIFF
--- a/includes/content-gate/block-patterns/pay-wall-one-tier-metering-wide.php
+++ b/includes/content-gate/block-patterns/pay-wall-one-tier-metering-wide.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Memberships Paywall with One Tier and Metering Pattern.
+ * Memberships Paywall with One Tier and Metering Pattern (Wide/Block Theme Layout).
  *
  * @package Newspack
  */
@@ -45,8 +45,8 @@ if ( $product_id ) {
 }
 
 ?>
-<!-- wp:group {"metadata":{"name":"<?php esc_html_e( 'Subscription', 'newspack-plugin' ); ?>"},"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}},"border":{"radius":{"topLeft":"8px","topRight":"8px","bottomLeft":"8px","bottomRight":"8px"},"width":"1px"}},"borderColor":"base-3","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignwide has-border-color has-base-3-border-color" style="border-width:1px;border-top-left-radius:8px;border-top-right-radius:8px;border-bottom-left-radius:8px;border-bottom-right-radius:8px;padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)">
+<!-- wp:group {"metadata":{"name":"<?php esc_html_e( 'Subscription', 'newspack-plugin' ); ?>"},"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|80","bottom":"var:preset|spacing|80","left":"var:preset|spacing|80","right":"var:preset|spacing|80"}},"border":{"radius":{"topLeft":"8px","topRight":"8px","bottomLeft":"8px","bottomRight":"8px"},"width":"1px"}},"borderColor":"base-3","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignwide has-border-color has-base-3-border-color" style="border-width:1px;border-top-left-radius:8px;border-top-right-radius:8px;border-bottom-left-radius:8px;border-bottom-right-radius:8px;padding-top:var(--wp--preset--spacing--80);padding-right:var(--wp--preset--spacing--80);padding-bottom:var(--wp--preset--spacing--80);padding-left:var(--wp--preset--spacing--80)">
 	<!-- wp:heading {"textAlign":"center","level":3,"metadata":{"name":"<?php esc_html_e( 'Title', 'newspack-plugin' ); ?>"}} -->
 	<h3 class="wp-block-heading has-text-align-center">
 		<?php esc_html_e( 'Unlock the full article', 'newspack' ); ?>
@@ -59,8 +59,8 @@ if ( $product_id ) {
 	</p>
 	<!-- /wp:paragraph -->
 
-	<!-- wp:columns {"metadata":{"name":"<?php esc_html_e( 'Content', 'newspack-plugin' ); ?>"},"className":"is-style-borders","style":{"spacing":{"margin":{"top":"var:preset|spacing|50","bottom":"0"}}}} -->
-	<div class="wp-block-columns is-style-borders" style="margin-top:var(--wp--preset--spacing--50);margin-bottom:0">
+	<!-- wp:columns {"metadata":{"name":"<?php esc_html_e( 'Content', 'newspack-plugin' ); ?>"},"className":"is-style-borders","style":{"spacing":{"margin":{"top":"var:preset|spacing|80","bottom":"0"}}}} -->
+	<div class="wp-block-columns is-style-borders" style="margin-top:var(--wp--preset--spacing--80);margin-bottom:0">
 		<!-- wp:column -->
 		<div class="wp-block-column">
 			<!-- wp:paragraph {"align":"center"} -->

--- a/includes/content-gate/block-patterns/pay-wall-one-tier-metering.php
+++ b/includes/content-gate/block-patterns/pay-wall-one-tier-metering.php
@@ -59,8 +59,8 @@ if ( $product_id ) {
 	</p>
 	<!-- /wp:paragraph -->
 
-	<!-- wp:columns {"metadata":{"name":"<?php esc_html_e( 'Content', 'newspack-plugin' ); ?>"},"className":"is-style-borders","style":{"spacing":{"margin":{"top":"var:preset|spacing|80","bottom":"var:preset|spacing|80"}}}} -->
-	<div class="wp-block-columns is-style-borders" style="margin-top:var(--wp--preset--spacing--80);margin-bottom:var(--wp--preset--spacing--80)">
+	<!-- wp:columns {"metadata":{"name":"<?php esc_html_e( 'Content', 'newspack-plugin' ); ?>"},"className":"is-style-borders","style":{"spacing":{"margin":{"top":"var:preset|spacing|80","bottom":"0"}}}} -->
+	<div class="wp-block-columns is-style-borders" style="margin-top:var(--wp--preset--spacing--80);margin-bottom:0">
 		<!-- wp:column -->
 		<div class="wp-block-column">
 			<!-- wp:paragraph {"align":"center"} -->

--- a/includes/content-gate/block-patterns/pay-wall-one-tier-metering.php
+++ b/includes/content-gate/block-patterns/pay-wall-one-tier-metering.php
@@ -63,70 +63,45 @@ if ( $product_id ) {
 	<div class="wp-block-columns is-style-borders" style="margin-top:var(--wp--preset--spacing--80);margin-bottom:var(--wp--preset--spacing--80)">
 		<!-- wp:column -->
 		<div class="wp-block-column">
-			<!-- wp:group {"style":{"dimensions":{"minHeight":"100%"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch","verticalAlignment":"space-between"}} -->
-			<div class="wp-block-group" style="min-height:100%">
-				<!-- wp:paragraph {"align":"center"} -->
-				<p class="has-text-align-center">
-					<?php
-					printf(
-						wp_kses_post(
-							/* translators: 1: number of free articles, 2: period label such as "month" or "week". */
-							_n(
-								'Get %1$s free article every %2$s with a free account.',
-								'Get %1$s free articles every %2$s with a free account.',
-								$metering_count,
-								'newspack'
-							)
-						),
-						'<strong>' . esc_html( $metering_count ) . '</strong>',
-						esc_html( $metering_period )
-					);
-					?>
-				</p>
-				<!-- /wp:paragraph -->
+			<!-- wp:paragraph {"align":"center"} -->
+			<p class="has-text-align-center">
+				<?php
+				printf(
+					wp_kses_post(
+						/* translators: 1: number of free articles, 2: period label such as "month" or "week". */
+						_n(
+							'Get %1$s free article every %2$s with a free account.',
+							'Get %1$s free articles every %2$s with a free account.',
+							$metering_count,
+							'newspack'
+						)
+					),
+					'<strong>' . esc_html( $metering_count ) . '</strong>',
+					esc_html( $metering_period )
+				);
+				?>
+			</p>
+			<!-- /wp:paragraph -->
 
-				<!-- wp:buttons -->
-				<div class="wp-block-buttons">
-					<!-- wp:button {"width":100,"className":"is-style-outline"} -->
-					<div class="wp-block-button has-custom-width wp-block-button__width-100 is-style-outline">
-						<a class="wp-block-button__link wp-element-button" href="#register_modal"><?php esc_html_e( 'Create a free account', 'newspack' ); ?></a>
-					</div>
-					<!-- /wp:button -->
-				</div>
-				<!-- /wp:buttons -->
-			</div>
-			<!-- /wp:group -->
+			<!-- wp:newspack/reader-registration {"newsletterSubscription":false,"hideOauth":true,"className":"is-style-inline"} -->
+			<div class="wp-block-newspack-reader-registration is-style-inline"></div>
+			<!-- /wp:newspack/reader-registration -->
 		</div>
 		<!-- /wp:column -->
 
 		<!-- wp:column -->
 		<div class="wp-block-column">
-			<!-- wp:group {"style":{"dimensions":{"minHeight":"100%"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch","verticalAlignment":"space-between"}} -->
-			<div class="wp-block-group" style="min-height:100%">
-				<!-- wp:paragraph {"align":"center"} -->
-				<p class="has-text-align-center">
-					<?php esc_html_e( 'Support our journalism and get unlimited access to our full archive.', 'newspack' ); ?>
-				</p>
-				<!-- /wp:paragraph -->
+			<!-- wp:paragraph {"align":"center"} -->
+			<p class="has-text-align-center">
+				<?php esc_html_e( 'Support our journalism and get unlimited access to our full archive.', 'newspack' ); ?>
+			</p>
+			<!-- /wp:paragraph -->
 
-				<!-- wp:newspack-blocks/checkout-button <?php echo wp_json_encode( $checkout_attrs ); ?> /-->
-			</div>
-			<!-- /wp:group -->
+			<!-- wp:newspack-blocks/checkout-button <?php echo wp_json_encode( $checkout_attrs ); ?> /-->
 		</div>
 		<!-- /wp:column -->
 	</div>
 	<!-- /wp:columns -->
 
-	<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
-	<div class="wp-block-buttons">
-		<!-- wp:button {"backgroundColor":"base","textColor":"contrast","style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast"}}}}} -->
-		<div class="wp-block-button">
-			<a class="wp-block-button__link has-contrast-color has-base-background-color has-text-color has-background has-link-color wp-element-button" href="#signin_modal">
-				<?php esc_html_e( 'Sign in to an existing account', 'newspack' ); ?>
-			</a>
-		</div>
-		<!-- /wp:button -->
-	</div>
-	<!-- /wp:buttons -->
 </div>
 <!-- /wp:group -->

--- a/includes/content-gate/block-patterns/registration-wall.php
+++ b/includes/content-gate/block-patterns/registration-wall.php
@@ -26,7 +26,7 @@
 
 	<!-- wp:group {"metadata":{"name":"<?php esc_html_e( 'Form', 'newspack-plugin' ); ?>"},"layout":{"type":"constrained","contentSize":"410px"}} -->
 	<div class="wp-block-group">
-		<!-- wp:newspack/reader-registration -->
+		<!-- wp:newspack/reader-registration {"newsletterSubscription":false} -->
 		<div class="wp-block-newspack-reader-registration"></div>
 		<!-- /wp:newspack/reader-registration -->
 	</div>

--- a/includes/content-gate/class-block-patterns.php
+++ b/includes/content-gate/class-block-patterns.php
@@ -51,15 +51,16 @@ class Block_Patterns {
 	 */
 	public static function get_block_patterns() {
 		return [
-			'registration-banner'        => __( 'Registration Banner', 'newspack' ),
-			'registration-wall'          => __( 'Registration Wall', 'newspack' ),
-			'donation-wall'              => __( 'Donation Wall', 'newspack' ),
-			'pay-wall-one-tier'          => __( 'Paywall with One Tier', 'newspack' ),
-			'pay-wall-one-tier-metering' => __( 'Paywall with One Tier and Metering', 'newspack' ),
-			'pay-wall-two-tiers'         => __( 'Paywall with Two Tiers', 'newspack' ),
-			'pay-wall-two-tiers-alt'     => __( 'Paywall with Two Tiers (Alt)', 'newspack' ),
-			'pay-wall-three-tiers'       => __( 'Paywall with Three Tiers', 'newspack' ),
-			'pay-wall-three-tiers-alt'   => __( 'Paywall with Three Tiers (Alt)', 'newspack' ),
+			'registration-banner'             => __( 'Registration Banner', 'newspack' ),
+			'registration-wall'               => __( 'Registration Wall', 'newspack' ),
+			'donation-wall'                   => __( 'Donation Wall', 'newspack' ),
+			'pay-wall-one-tier'               => __( 'Paywall with One Tier', 'newspack' ),
+			'pay-wall-one-tier-metering'      => __( 'Paywall with One Tier and Metering', 'newspack' ),
+			'pay-wall-one-tier-metering-wide' => __( 'Paywall with One Tier and Metering (Wide)', 'newspack' ),
+			'pay-wall-two-tiers'              => __( 'Paywall with Two Tiers', 'newspack' ),
+			'pay-wall-two-tiers-alt'          => __( 'Paywall with Two Tiers (Alt)', 'newspack' ),
+			'pay-wall-three-tiers'            => __( 'Paywall with Three Tiers', 'newspack' ),
+			'pay-wall-three-tiers-alt'        => __( 'Paywall with Three Tiers (Alt)', 'newspack' ),
 		];
 	}
 

--- a/src/blocks/reader-registration/block.json
+++ b/src/blocks/reader-registration/block.json
@@ -52,6 +52,10 @@
 		"listsCheckboxes": {
 			"type": "object",
 			"default": {}
+		},
+		"hideOauth": {
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"supports": {

--- a/src/blocks/reader-registration/edit.js
+++ b/src/blocks/reader-registration/edit.js
@@ -29,6 +29,7 @@ const editedStateOptions = [
 	{ label: __( 'Registration Success', 'newspack-plugin' ), value: 'registration' },
 ];
 export default function ReaderRegistrationEdit( {
+	isSelected,
 	setAttributes,
 	attributes: {
 		title,
@@ -42,6 +43,7 @@ export default function ReaderRegistrationEdit( {
 		newsletterLabel,
 		lists,
 		listsCheckboxes,
+		hideOauth,
 	},
 } ) {
 	const blockProps = useBlockProps();
@@ -116,6 +118,13 @@ export default function ReaderRegistrationEdit( {
 						disabled={ inFlight }
 						onChange={ value => setAttributes( { placeholder: value } ) }
 					/>
+					{ newspack_blocks.has_google_oauth && (
+						<ToggleControl
+							label={ __( 'Show Google sign-in button', 'newspack-plugin' ) }
+							checked={ ! hideOauth }
+							onChange={ () => setAttributes( { hideOauth: ! hideOauth } ) }
+						/>
+					) }
 				</PanelBody>
 				{ newspack_blocks.has_newsletters && (
 					<PanelBody title={ __( 'Newsletter Subscription', 'newspack-plugin' ) }>
@@ -231,23 +240,27 @@ export default function ReaderRegistrationEdit( {
 				{ editedState === 'initial' && (
 					<div className="newspack-registration newspack-ui">
 						<form onSubmit={ ev => ev.preventDefault() }>
-							<div className="newspack-registration__header">
+							{ ( isSelected || title ) && (
+								<div className="newspack-registration__header">
+									<RichText
+										onChange={ value => setAttributes( { title: value } ) }
+										placeholder={ __( 'Add title', 'newspack-plugin' ) }
+										value={ title }
+										allowedFormats={ [] }
+										tagName="h3"
+										className="newspack-registration__title"
+									/>
+								</div>
+							) }
+							{ ( isSelected || description ) && (
 								<RichText
-									onChange={ value => setAttributes( { title: value } ) }
-									placeholder={ __( 'Add title', 'newspack-plugin' ) }
-									value={ title }
-									allowedFormats={ [] }
-									tagName="h3"
-									className="newspack-registration__title"
+									onChange={ value => setAttributes( { description: value } ) }
+									placeholder={ __( 'Add description', 'newspack-plugin' ) }
+									value={ description }
+									tagName="p"
+									className="newspack-registration__description"
 								/>
-							</div>
-							<RichText
-								onChange={ value => setAttributes( { description: value } ) }
-								placeholder={ __( 'Add description', 'newspack-plugin' ) }
-								value={ description }
-								tagName="p"
-								className="newspack-registration__description"
-							/>
+							) }
 							<div className="newspack-registration__form-content">
 								{ ! shouldHideSubscribeInput() && newsletterSubscription && lists.length ? (
 									<>
@@ -280,7 +293,7 @@ export default function ReaderRegistrationEdit( {
 									</>
 								) : null }
 								<div className="newspack-registration__main">
-									{ newspack_blocks.has_google_oauth && (
+									{ newspack_blocks.has_google_oauth && ! hideOauth && (
 										<div className="newspack-ui">
 											<button className="newspack-ui__button newspack-ui__button--wide newspack-ui__button--secondary newspack-ui__button--google-oauth">
 												<span

--- a/src/blocks/reader-registration/index.php
+++ b/src/blocks/reader-registration/index.php
@@ -32,6 +32,14 @@ function register_block() {
 	if ( ! Reader_Activation::is_enabled() ) {
 		return;
 	}
+
+	\register_block_style(
+		'newspack/reader-registration',
+		[
+			'name'  => 'inline',
+			'label' => __( 'Inline', 'newspack-plugin' ),
+		]
+	);
 }
 add_action( 'init', __NAMESPACE__ . '\\register_block' );
 
@@ -364,7 +372,9 @@ function render_block( $attrs, $content ) {
 					?>
 					<div class="newspack-registration__main">
 						<div>
-							<?php Reader_Activation::render_third_party_auth(); ?>
+							<?php if ( empty( $attrs['hideOauth'] ) ) : ?>
+								<?php Reader_Activation::render_third_party_auth(); ?>
+							<?php endif; ?>
 							<div class="newspack-registration__inputs">
 								<input
 								<?php

--- a/src/blocks/reader-registration/style.scss
+++ b/src/blocks/reader-registration/style.scss
@@ -281,7 +281,7 @@
 }
 
 .newspack-registration.is-style-inline,
-.is-style-inline .newspack-registration {
+.wp-block-newspack-reader-registration.is-style-inline .newspack-registration {
 	.newspack-registration__inputs {
 		gap: var(--newspack-ui-spacer-2);
 		grid-template-columns: 1fr auto;

--- a/src/blocks/reader-registration/style.scss
+++ b/src/blocks/reader-registration/style.scss
@@ -280,6 +280,14 @@
 	}
 }
 
+.newspack-registration.is-style-inline,
+.is-style-inline .newspack-registration {
+	.newspack-registration__inputs {
+		gap: var(--newspack-ui-spacer-2);
+		grid-template-columns: 1fr auto;
+	}
+}
+
 /* Sepcific styles to apply to Reader Registration when part of a Prompt */
 .newspack-popup__content {
 	.newspack-registration__header {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Related to #4569.

Adds two enhancements to the Reader Registration block and updates content gate patterns to use them:

- **Inline block style**: A new "Inline" style that forces the email input and submit button onto a single row at all container widths.
- **Hide OAuth toggle**: A "Show Google sign-in button" toggle in Form settings (enabled by default, so existing blocks are unaffected). Allows hiding the Google OAuth button independently of the block style.
- **Editor UX**: Title and description fields now only render in the editor preview when they have content or the block is selected, matching the PHP render behavior and preventing layout inflation in the editor.
- **`registration-wall` pattern**: Newsletter subscription is now disabled by default.
- **`pay-wall-one-tier-metering` pattern**: Replaces the "Create a free account" button and "Sign in" link with the Reader Registration block (inline style, no OAuth, no newsletter). Padding reduced from `spacing|80` to `spacing|50` for a more compact layout suited to classic/narrow contexts.
- **`pay-wall-one-tier-metering-wide` pattern (new)**: Duplicate of the metering pattern with the original `spacing|80` padding, intended for wide/full-width layouts such as the Block Theme.

### How to test the changes in this Pull Request:

1. Add a **Reader Registration** block to a page.
2. Confirm the block renders normally with Google OAuth (if configured) and email input stacked vertically by default.
3. In the block sidebar → Styles panel, select **Inline**. Confirm the email input and submit button move to a single row.
4. In Form settings, uncheck **Show Google sign-in button**. Confirm the Google OAuth button disappears both in the editor preview and on the frontend.
5. Re-enable the Google sign-in button, then switch back to the Default style. Confirm OAuth reappears.
6. Leave the title and description empty. Deselect the block. Confirm neither placeholder appears in the editor preview. Click the block — confirm both fields reappear for editing.
7. Add a title and description. Deselect the block. Confirm they render in the preview and on the frontend.
8. Insert the **Registration Wall** content gate pattern. Confirm the Reader Registration block inside it has newsletter subscription disabled.
9. Insert the **Paywall – One Tier with Metering** pattern. Confirm it uses compact padding, the left column shows the Reader Registration block (inline, no OAuth, no newsletter), and the "Sign in to an existing account" link is gone.
10. Insert the **Paywall – One Tier with Metering (Wide)** pattern. Confirm it is identical to the above but with larger padding (`spacing|80`), suitable for wide layouts.
11. On the frontend with either metering pattern, submit the registration form and confirm it works correctly.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?