### PR TITLE
feat: require reader to set name when commenting

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -105,9 +105,11 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/reader-activation/sync/class-woocommerce.php';
 		include_once NEWSPACK_ABSPATH . 'includes/reader-activation/sync/class-contact-sync.php';
 		include_once NEWSPACK_ABSPATH . 'includes/reader-activation/sync/class-contact-sync-admin.php';
+		include_once NEWSPACK_ABSPATH . 'includes/reader-activation/class-comment-display-name.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-action-scheduler.php';
 		include_once NEWSPACK_ABSPATH . 'includes/reader-activation/class-integrations.php';
 		\Newspack\Reader_Activation\Integrations::init();
+		\Newspack\Reader_Activation\Comment_Display_Name::init();
 		include_once NEWSPACK_ABSPATH . 'includes/reader-activation/class-promoted-fields.php';
 		include_once NEWSPACK_ABSPATH . 'includes/reader-activation/class-session-hydration.php';
 		include_once NEWSPACK_ABSPATH . 'includes/data-events/class-utils.php';

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -108,8 +108,6 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/reader-activation/class-comment-display-name.php';
 		include_once NEWSPACK_ABSPATH . 'includes/class-action-scheduler.php';
 		include_once NEWSPACK_ABSPATH . 'includes/reader-activation/class-integrations.php';
-		\Newspack\Reader_Activation\Integrations::init();
-		\Newspack\Reader_Activation\Comment_Display_Name::init();
 		include_once NEWSPACK_ABSPATH . 'includes/reader-activation/class-promoted-fields.php';
 		include_once NEWSPACK_ABSPATH . 'includes/reader-activation/class-session-hydration.php';
 		include_once NEWSPACK_ABSPATH . 'includes/data-events/class-utils.php';

--- a/includes/reader-activation/class-comment-display-name.php
+++ b/includes/reader-activation/class-comment-display-name.php
@@ -21,9 +21,8 @@ final class Comment_Display_Name {
 	 * Initialize hooks.
 	 */
 	public static function init() {
-		\add_action( 'comment_form_logged_in_after', [ __CLASS__, 'render_display_name_field' ] );
+		\add_filter( 'comment_form_submit_field', [ __CLASS__, 'render_display_name_field' ] );
 		\add_filter( 'preprocess_comment', [ __CLASS__, 'validate_display_name' ] );
-		\add_action( 'comment_post', [ __CLASS__, 'save_display_name' ] );
 	}
 
 	/**
@@ -43,10 +42,14 @@ final class Comment_Display_Name {
 	}
 
 	/**
-	 * Validate the display name field before a comment is saved.
+	 * Validate and save the display name before a comment is inserted.
+	 *
+	 * Runs on `preprocess_comment` so the updated display name is used as the
+	 * comment author, rather than the stale email-derived name WordPress read
+	 * from the user profile earlier in the request.
 	 *
 	 * @param array $commentdata Comment data.
-	 * @return array Comment data, unchanged.
+	 * @return array Comment data with updated comment_author.
 	 */
 	public static function validate_display_name( $commentdata ) {
 		if ( ! self::should_prompt() ) {
@@ -76,52 +79,43 @@ final class Comment_Display_Name {
 			);
 		}
 
-		return $commentdata;
-	}
-
-	/**
-	 * Save the display name to the user profile after a comment is posted.
-	 *
-	 * @param int $comment_id Comment ID.
-	 */
-	public static function save_display_name( $comment_id ) {
-		if ( ! self::should_prompt() ) {
-			return;
-		}
-
-		$display_name = isset( $_POST['comment_display_name'] ) ? \sanitize_text_field( \wp_unslash( $_POST['comment_display_name'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing
-		if ( empty( $display_name ) ) {
-			return;
-		}
-
-		$user_id   = \get_current_user_id();
+		// Update the user profile.
 		$user_data = [
-			'ID'           => $user_id,
+			'ID'           => $user->ID,
 			'display_name' => $display_name,
 		];
 
-		$name_parts = explode( ' ', $display_name, 2 );
+		$name_parts              = explode( ' ', $display_name, 2 );
 		$user_data['first_name'] = $name_parts[0];
 		$user_data['last_name']  = $name_parts[1] ?? '';
 
 		\wp_update_user( $user_data );
+
+		// Override the comment author so this comment uses the new name.
+		$commentdata['comment_author'] = $display_name;
+
+		return $commentdata;
 	}
 
 	/**
-	 * Render the display name field in the comment form.
+	 * Render the display name field before the comment form submit button.
+	 *
+	 * @param string $submit_field The submit field HTML.
+	 * @return string The submit field HTML, with display name field prepended if needed.
 	 */
-	public static function render_display_name_field() {
+	public static function render_display_name_field( $submit_field ) {
 		if ( ! self::should_prompt() ) {
-			return;
+			return $submit_field;
 		}
-		?>
-		<p class="comment-form-display-name">
-			<label for="comment_display_name">
-				<?php esc_html_e( 'Display name (shown publicly)', 'newspack-plugin' ); ?>
-				<span class="required" aria-hidden="true">*</span>
-			</label>
-			<input id="comment_display_name" name="comment_display_name" type="text" required="required" />
-		</p>
-		<?php
+
+		$field = '<p class="comment-form-display-name">'
+			. '<label for="comment_display_name">'
+			. esc_html__( 'Display name (shown publicly)', 'newspack-plugin' )
+			. ' <span class="required" aria-hidden="true">*</span>'
+			. '</label>'
+			. '<input id="comment_display_name" name="comment_display_name" type="text" required="required" style="display:block;width:100%" />'
+			. '</p>';
+
+		return $field . $submit_field;
 	}
 }

--- a/includes/reader-activation/class-comment-display-name.php
+++ b/includes/reader-activation/class-comment-display-name.php
@@ -119,3 +119,4 @@ final class Comment_Display_Name {
 		return $field . $submit_field;
 	}
 }
+Comment_Display_Name::init();

--- a/includes/reader-activation/class-comment-display-name.php
+++ b/includes/reader-activation/class-comment-display-name.php
@@ -22,6 +22,7 @@ final class Comment_Display_Name {
 	 */
 	public static function init() {
 		\add_action( 'comment_form_logged_in_after', [ __CLASS__, 'render_display_name_field' ] );
+		\add_filter( 'preprocess_comment', [ __CLASS__, 'validate_display_name' ] );
 	}
 
 	/**
@@ -38,6 +39,43 @@ final class Comment_Display_Name {
 			return false;
 		}
 		return Reader_Activation::reader_has_generic_display_name( $user->ID );
+	}
+
+	/**
+	 * Validate the display name field before a comment is saved.
+	 *
+	 * @param array $commentdata Comment data.
+	 * @return array Comment data, unchanged.
+	 */
+	public static function validate_display_name( $commentdata ) {
+		if ( ! self::should_prompt() ) {
+			return $commentdata;
+		}
+
+		$display_name = isset( $_POST['comment_display_name'] ) ? \sanitize_text_field( \wp_unslash( $_POST['comment_display_name'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing
+
+		if ( empty( $display_name ) ) {
+			\wp_die(
+				esc_html__( 'Please enter a display name.', 'newspack-plugin' ),
+				esc_html__( 'Comment Submission Failure', 'newspack-plugin' ),
+				[ 'back_link' => true ]
+			);
+		}
+
+		$user  = \wp_get_current_user();
+		$email = $user->user_email;
+		if (
+			Reader_Activation::generate_user_nicename( $email ) === $display_name ||
+			Reader_Activation::strip_email_domain( $email ) === $display_name
+		) {
+			\wp_die(
+				esc_html__( 'Please choose a display name that is not derived from your email address.', 'newspack-plugin' ),
+				esc_html__( 'Comment Submission Failure', 'newspack-plugin' ),
+				[ 'back_link' => true ]
+			);
+		}
+
+		return $commentdata;
 	}
 
 	/**

--- a/includes/reader-activation/class-comment-display-name.php
+++ b/includes/reader-activation/class-comment-display-name.php
@@ -110,7 +110,7 @@ final class Comment_Display_Name {
 
 		$field = '<p class="comment-form-display-name">'
 			. '<label for="comment_display_name">'
-			. esc_html__( 'Display name (shown publicly)', 'newspack-plugin' )
+			. esc_html__( 'Name', 'newspack-plugin' )
 			. ' <span class="required" aria-hidden="true">*</span>'
 			. '</label>'
 			. '<input id="comment_display_name" name="comment_display_name" type="text" required="required" style="display:block;width:100%" />'

--- a/includes/reader-activation/class-comment-display-name.php
+++ b/includes/reader-activation/class-comment-display-name.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Comment Display Name — requires readers with auto-generated display names
+ * to choose a proper display name before commenting.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Reader_Activation;
+
+use Newspack\Reader_Activation;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Comment Display Name class.
+ */
+final class Comment_Display_Name {
+
+	/**
+	 * Initialize hooks.
+	 */
+	public static function init() {
+		\add_action( 'comment_form_logged_in_after', [ __CLASS__, 'render_display_name_field' ] );
+	}
+
+	/**
+	 * Whether the current user should be prompted for a display name.
+	 *
+	 * @return bool
+	 */
+	private static function should_prompt() {
+		if ( ! \is_user_logged_in() ) {
+			return false;
+		}
+		$user = \wp_get_current_user();
+		if ( ! Reader_Activation::is_user_reader( $user ) ) {
+			return false;
+		}
+		return Reader_Activation::reader_has_generic_display_name( $user->ID );
+	}
+
+	/**
+	 * Render the display name field in the comment form.
+	 */
+	public static function render_display_name_field() {
+		if ( ! self::should_prompt() ) {
+			return;
+		}
+		?>
+		<p class="comment-form-display-name">
+			<label for="comment_display_name">
+				<?php esc_html_e( 'Display name (shown publicly)', 'newspack-plugin' ); ?>
+				<span class="required" aria-hidden="true">*</span>
+			</label>
+			<input id="comment_display_name" name="comment_display_name" type="text" required="required" />
+		</p>
+		<?php
+	}
+}

--- a/includes/reader-activation/class-comment-display-name.php
+++ b/includes/reader-activation/class-comment-display-name.php
@@ -23,6 +23,7 @@ final class Comment_Display_Name {
 	public static function init() {
 		\add_action( 'comment_form_logged_in_after', [ __CLASS__, 'render_display_name_field' ] );
 		\add_filter( 'preprocess_comment', [ __CLASS__, 'validate_display_name' ] );
+		\add_action( 'comment_post', [ __CLASS__, 'save_display_name' ] );
 	}
 
 	/**
@@ -76,6 +77,34 @@ final class Comment_Display_Name {
 		}
 
 		return $commentdata;
+	}
+
+	/**
+	 * Save the display name to the user profile after a comment is posted.
+	 *
+	 * @param int $comment_id Comment ID.
+	 */
+	public static function save_display_name( $comment_id ) {
+		if ( ! self::should_prompt() ) {
+			return;
+		}
+
+		$display_name = isset( $_POST['comment_display_name'] ) ? \sanitize_text_field( \wp_unslash( $_POST['comment_display_name'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		if ( empty( $display_name ) ) {
+			return;
+		}
+
+		$user_id   = \get_current_user_id();
+		$user_data = [
+			'ID'           => $user_id,
+			'display_name' => $display_name,
+		];
+
+		$name_parts = explode( ' ', $display_name, 2 );
+		$user_data['first_name'] = $name_parts[0];
+		$user_data['last_name']  = $name_parts[1] ?? '';
+
+		\wp_update_user( $user_data );
 	}
 
 	/**

--- a/includes/reader-activation/class-integrations.php
+++ b/includes/reader-activation/class-integrations.php
@@ -546,3 +546,4 @@ class Integrations {
 		}
 	}
 }
+Integrations::init();

--- a/tests/unit-tests/comment-display-name.php
+++ b/tests/unit-tests/comment-display-name.php
@@ -181,4 +181,92 @@ class Newspack_Test_Comment_Display_Name extends WP_UnitTestCase {
 
 		wp_delete_user( $admin_id );
 	}
+
+	/**
+	 * Test that save_display_name updates the user profile.
+	 */
+	public function test_save_updates_display_name() {
+		$user_id = $this->create_generic_reader();
+		$_POST['comment_display_name'] = 'Jane Doe';
+
+		$post_id    = $this->factory->post->create();
+		$comment_id = $this->factory->comment->create(
+			[
+				'comment_post_ID' => $post_id,
+				'user_id'         => $user_id,
+			]
+		);
+
+		Comment_Display_Name::save_display_name( $comment_id );
+
+		$user = get_userdata( $user_id );
+		$this->assertEquals( 'Jane Doe', $user->display_name );
+		$this->assertEquals( 'Jane', $user->first_name );
+		$this->assertEquals( 'Doe', $user->last_name );
+		$this->assertFalse( Reader_Activation::reader_has_generic_display_name( $user_id ) );
+
+		wp_delete_user( $user_id );
+		wp_delete_comment( $comment_id, true );
+		unset( $_POST['comment_display_name'] );
+	}
+
+	/**
+	 * Test that save_display_name handles single-word names.
+	 */
+	public function test_save_handles_single_word_name() {
+		$user_id = $this->create_generic_reader();
+		$_POST['comment_display_name'] = 'Madonna';
+
+		$post_id    = $this->factory->post->create();
+		$comment_id = $this->factory->comment->create(
+			[
+				'comment_post_ID' => $post_id,
+				'user_id'         => $user_id,
+			]
+		);
+
+		Comment_Display_Name::save_display_name( $comment_id );
+
+		$user = get_userdata( $user_id );
+		$this->assertEquals( 'Madonna', $user->display_name );
+		$this->assertFalse( Reader_Activation::reader_has_generic_display_name( $user_id ) );
+
+		wp_delete_user( $user_id );
+		wp_delete_comment( $comment_id, true );
+		unset( $_POST['comment_display_name'] );
+	}
+
+	/**
+	 * Test that save_display_name does nothing for non-reader users.
+	 */
+	public function test_save_skips_non_reader() {
+		$admin_id = wp_insert_user(
+			[
+				'user_login'   => 'test-admin-3',
+				'user_pass'    => wp_generate_password(),
+				'user_email'   => 'admin3@example.com',
+				'display_name' => 'admin3',
+				'role'         => 'administrator',
+			]
+		);
+		wp_set_current_user( $admin_id );
+		$_POST['comment_display_name'] = 'New Name';
+
+		$post_id    = $this->factory->post->create();
+		$comment_id = $this->factory->comment->create(
+			[
+				'comment_post_ID' => $post_id,
+				'user_id'         => $admin_id,
+			]
+		);
+
+		Comment_Display_Name::save_display_name( $comment_id );
+
+		$user = get_userdata( $admin_id );
+		$this->assertEquals( 'admin3', $user->display_name );
+
+		wp_delete_user( $admin_id );
+		wp_delete_comment( $comment_id, true );
+		unset( $_POST['comment_display_name'] );
+	}
 }

--- a/tests/unit-tests/comment-display-name.php
+++ b/tests/unit-tests/comment-display-name.php
@@ -99,4 +99,86 @@ class Newspack_Test_Comment_Display_Name extends WP_UnitTestCase {
 
 		$this->assertEmpty( $output );
 	}
+
+	/**
+	 * Test that validation rejects an empty display name.
+	 */
+	public function test_validate_rejects_empty_display_name() {
+		$user_id = $this->create_generic_reader();
+		$_POST['comment_display_name'] = '';
+
+		$commentdata = [
+			'comment_post_ID' => $this->factory->post->create(),
+			'user_id'         => $user_id,
+		];
+
+		$this->expectException( WPDieException::class );
+		Comment_Display_Name::validate_display_name( $commentdata );
+
+		wp_delete_user( $user_id );
+		unset( $_POST['comment_display_name'] );
+	}
+
+	/**
+	 * Test that validation rejects a display name that matches the generic pattern.
+	 */
+	public function test_validate_rejects_generic_display_name() {
+		$user_id = $this->create_generic_reader( 'john.smith@example.com' );
+		$_POST['comment_display_name'] = 'john.smith';
+
+		$commentdata = [
+			'comment_post_ID' => $this->factory->post->create(),
+			'user_id'         => $user_id,
+		];
+
+		$this->expectException( WPDieException::class );
+		Comment_Display_Name::validate_display_name( $commentdata );
+
+		wp_delete_user( $user_id );
+		unset( $_POST['comment_display_name'] );
+	}
+
+	/**
+	 * Test that validation passes with a valid display name.
+	 */
+	public function test_validate_accepts_valid_display_name() {
+		$user_id = $this->create_generic_reader();
+		$_POST['comment_display_name'] = 'Jane Doe';
+
+		$commentdata = [
+			'comment_post_ID' => $this->factory->post->create(),
+			'user_id'         => $user_id,
+		];
+
+		$result = Comment_Display_Name::validate_display_name( $commentdata );
+		$this->assertEquals( $commentdata, $result );
+
+		wp_delete_user( $user_id );
+		unset( $_POST['comment_display_name'] );
+	}
+
+	/**
+	 * Test that validation passes for non-reader users without the field.
+	 */
+	public function test_validate_skips_non_reader() {
+		$admin_id = wp_insert_user(
+			[
+				'user_login' => 'test-admin-2',
+				'user_pass'  => wp_generate_password(),
+				'user_email' => 'admin2@example.com',
+				'role'       => 'administrator',
+			]
+		);
+		wp_set_current_user( $admin_id );
+
+		$commentdata = [
+			'comment_post_ID' => $this->factory->post->create(),
+			'user_id'         => $admin_id,
+		];
+
+		$result = Comment_Display_Name::validate_display_name( $commentdata );
+		$this->assertEquals( $commentdata, $result );
+
+		wp_delete_user( $admin_id );
+	}
 }

--- a/tests/unit-tests/comment-display-name.php
+++ b/tests/unit-tests/comment-display-name.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Tests the Comment Display Name functionality.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Reader_Activation;
+use Newspack\Reader_Activation\Comment_Display_Name;
+
+/**
+ * Tests the Comment Display Name functionality.
+ *
+ * @group comment-display-name
+ */
+class Newspack_Test_Comment_Display_Name extends WP_UnitTestCase {
+
+	/**
+	 * Create a reader with a generic (email-derived) display name.
+	 *
+	 * @param string $email Reader email.
+	 * @return int User ID.
+	 */
+	private function create_generic_reader( $email = 'jane.doe@example.com' ) {
+		$user_id = Reader_Activation::register_reader( $email );
+		wp_set_current_user( $user_id );
+		return $user_id;
+	}
+
+	/**
+	 * Test that the display name field renders for a reader with a generic display name.
+	 */
+	public function test_renders_field_for_generic_display_name() {
+		$user_id = $this->create_generic_reader();
+
+		ob_start();
+		Comment_Display_Name::render_display_name_field();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'name="comment_display_name"', $output );
+		$this->assertStringContainsString( 'required', $output );
+
+		wp_delete_user( $user_id );
+	}
+
+	/**
+	 * Test that the display name field does not render for a reader with a custom display name.
+	 */
+	public function test_does_not_render_for_custom_display_name() {
+		$user_id = $this->create_generic_reader();
+		wp_update_user(
+			[
+				'ID'           => $user_id,
+				'display_name' => 'Jane Doe',
+			] 
+		);
+
+		ob_start();
+		Comment_Display_Name::render_display_name_field();
+		$output = ob_get_clean();
+
+		$this->assertEmpty( $output );
+
+		wp_delete_user( $user_id );
+	}
+
+	/**
+	 * Test that the display name field does not render for non-reader users.
+	 */
+	public function test_does_not_render_for_non_reader() {
+		$admin_id = wp_insert_user(
+			[
+				'user_login' => 'test-admin',
+				'user_pass'  => wp_generate_password(),
+				'user_email' => 'admin@example.com',
+				'role'       => 'administrator',
+			] 
+		);
+		wp_set_current_user( $admin_id );
+
+		ob_start();
+		Comment_Display_Name::render_display_name_field();
+		$output = ob_get_clean();
+
+		$this->assertEmpty( $output );
+
+		wp_delete_user( $admin_id );
+	}
+
+	/**
+	 * Test that the display name field does not render for logged-out users.
+	 */
+	public function test_does_not_render_for_logged_out() {
+		wp_set_current_user( 0 );
+
+		ob_start();
+		Comment_Display_Name::render_display_name_field();
+		$output = ob_get_clean();
+
+		$this->assertEmpty( $output );
+	}
+}

--- a/tests/unit-tests/comment-display-name.php
+++ b/tests/unit-tests/comment-display-name.php
@@ -33,12 +33,11 @@ class Newspack_Test_Comment_Display_Name extends WP_UnitTestCase {
 	public function test_renders_field_for_generic_display_name() {
 		$user_id = $this->create_generic_reader();
 
-		ob_start();
-		Comment_Display_Name::render_display_name_field();
-		$output = ob_get_clean();
+		$output = Comment_Display_Name::render_display_name_field( '<submit />' );
 
 		$this->assertStringContainsString( 'name="comment_display_name"', $output );
 		$this->assertStringContainsString( 'required', $output );
+		$this->assertStringContainsString( '<submit />', $output );
 
 		wp_delete_user( $user_id );
 	}
@@ -52,14 +51,12 @@ class Newspack_Test_Comment_Display_Name extends WP_UnitTestCase {
 			[
 				'ID'           => $user_id,
 				'display_name' => 'Jane Doe',
-			] 
+			]
 		);
 
-		ob_start();
-		Comment_Display_Name::render_display_name_field();
-		$output = ob_get_clean();
+		$output = Comment_Display_Name::render_display_name_field( '<submit />' );
 
-		$this->assertEmpty( $output );
+		$this->assertEquals( '<submit />', $output );
 
 		wp_delete_user( $user_id );
 	}
@@ -74,15 +71,13 @@ class Newspack_Test_Comment_Display_Name extends WP_UnitTestCase {
 				'user_pass'  => wp_generate_password(),
 				'user_email' => 'admin@example.com',
 				'role'       => 'administrator',
-			] 
+			]
 		);
 		wp_set_current_user( $admin_id );
 
-		ob_start();
-		Comment_Display_Name::render_display_name_field();
-		$output = ob_get_clean();
+		$output = Comment_Display_Name::render_display_name_field( '<submit />' );
 
-		$this->assertEmpty( $output );
+		$this->assertEquals( '<submit />', $output );
 
 		wp_delete_user( $admin_id );
 	}
@@ -93,11 +88,9 @@ class Newspack_Test_Comment_Display_Name extends WP_UnitTestCase {
 	public function test_does_not_render_for_logged_out() {
 		wp_set_current_user( 0 );
 
-		ob_start();
-		Comment_Display_Name::render_display_name_field();
-		$output = ob_get_clean();
+		$output = Comment_Display_Name::render_display_name_field( '<submit />' );
 
-		$this->assertEmpty( $output );
+		$this->assertEquals( '<submit />', $output );
 	}
 
 	/**
@@ -139,7 +132,7 @@ class Newspack_Test_Comment_Display_Name extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that validation passes with a valid display name.
+	 * Test that validation passes with a valid display name and sets comment_author.
 	 */
 	public function test_validate_accepts_valid_display_name() {
 		$user_id = $this->create_generic_reader();
@@ -151,7 +144,7 @@ class Newspack_Test_Comment_Display_Name extends WP_UnitTestCase {
 		];
 
 		$result = Comment_Display_Name::validate_display_name( $commentdata );
-		$this->assertEquals( $commentdata, $result );
+		$this->assertEquals( 'Jane Doe', $result['comment_author'] );
 
 		wp_delete_user( $user_id );
 		unset( $_POST['comment_display_name'] );
@@ -183,22 +176,24 @@ class Newspack_Test_Comment_Display_Name extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that save_display_name updates the user profile.
+	 * Test that validation saves the display name to the user profile and updates comment_author.
 	 */
-	public function test_save_updates_display_name() {
+	public function test_validate_saves_display_name() {
 		$user_id = $this->create_generic_reader();
 		$_POST['comment_display_name'] = 'Jane Doe';
 
-		$post_id    = $this->factory->post->create();
-		$comment_id = $this->factory->comment->create(
-			[
-				'comment_post_ID' => $post_id,
-				'user_id'         => $user_id,
-			]
-		);
+		$commentdata = [
+			'comment_post_ID' => $this->factory->post->create(),
+			'user_id'         => $user_id,
+			'comment_author'  => 'jane-doe', // Generic name set by WP before preprocess_comment.
+		];
 
-		Comment_Display_Name::save_display_name( $comment_id );
+		$result = Comment_Display_Name::validate_display_name( $commentdata );
 
+		// Comment author should be updated.
+		$this->assertEquals( 'Jane Doe', $result['comment_author'] );
+
+		// User profile should be updated.
 		$user = get_userdata( $user_id );
 		$this->assertEquals( 'Jane Doe', $user->display_name );
 		$this->assertEquals( 'Jane', $user->first_name );
@@ -206,67 +201,31 @@ class Newspack_Test_Comment_Display_Name extends WP_UnitTestCase {
 		$this->assertFalse( Reader_Activation::reader_has_generic_display_name( $user_id ) );
 
 		wp_delete_user( $user_id );
-		wp_delete_comment( $comment_id, true );
 		unset( $_POST['comment_display_name'] );
 	}
 
 	/**
-	 * Test that save_display_name handles single-word names.
+	 * Test that validation handles single-word display names.
 	 */
-	public function test_save_handles_single_word_name() {
+	public function test_validate_saves_single_word_name() {
 		$user_id = $this->create_generic_reader();
 		$_POST['comment_display_name'] = 'Madonna';
 
-		$post_id    = $this->factory->post->create();
-		$comment_id = $this->factory->comment->create(
-			[
-				'comment_post_ID' => $post_id,
-				'user_id'         => $user_id,
-			]
-		);
+		$commentdata = [
+			'comment_post_ID' => $this->factory->post->create(),
+			'user_id'         => $user_id,
+			'comment_author'  => 'jane-doe',
+		];
 
-		Comment_Display_Name::save_display_name( $comment_id );
+		$result = Comment_Display_Name::validate_display_name( $commentdata );
+
+		$this->assertEquals( 'Madonna', $result['comment_author'] );
 
 		$user = get_userdata( $user_id );
 		$this->assertEquals( 'Madonna', $user->display_name );
 		$this->assertFalse( Reader_Activation::reader_has_generic_display_name( $user_id ) );
 
 		wp_delete_user( $user_id );
-		wp_delete_comment( $comment_id, true );
-		unset( $_POST['comment_display_name'] );
-	}
-
-	/**
-	 * Test that save_display_name does nothing for non-reader users.
-	 */
-	public function test_save_skips_non_reader() {
-		$admin_id = wp_insert_user(
-			[
-				'user_login'   => 'test-admin-3',
-				'user_pass'    => wp_generate_password(),
-				'user_email'   => 'admin3@example.com',
-				'display_name' => 'admin3',
-				'role'         => 'administrator',
-			]
-		);
-		wp_set_current_user( $admin_id );
-		$_POST['comment_display_name'] = 'New Name';
-
-		$post_id    = $this->factory->post->create();
-		$comment_id = $this->factory->comment->create(
-			[
-				'comment_post_ID' => $post_id,
-				'user_id'         => $admin_id,
-			]
-		);
-
-		Comment_Display_Name::save_display_name( $comment_id );
-
-		$user = get_userdata( $admin_id );
-		$this->assertEquals( 'admin3', $user->display_name );
-
-		wp_delete_user( $admin_id );
-		wp_delete_comment( $comment_id, true );
 		unset( $_POST['comment_display_name'] );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Readers may register with just their email. In this case, their name defaults to the email handle. This should be fine for internal purposes, but shouldn't be used as a public display name in comments.

This PR implements a new input in the comment form, requiring a reader to set their display name if it has not yet been set. Once set, the input should no longer render.

<img width="847" height="489" alt="image" src="https://github.com/user-attachments/assets/ea15b2a9-6ff8-4287-b64c-6b1036eaa27f" />

The input placement follows the same standard as when commenting anonymously.

Closes NPPM-2701

### How to test the changes in this Pull Request:

1. Sign in as a reader who already has a display name set
2. Visit an article and confirm there's no new input
3. In a fresh session, register as a new reader using the registration flow from the header "Sign In" button
4. Visit an article and confirm the new input renders as in the image above
5. Confirm you are not able to comment without setting a name first
6. Set a name, post the comment, and confirm that the filled name is set
7. Navigate to My Account, verify the account, and confirm the chosen name is saved in the user
8. Visit another article and confirm the input no longer renders

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->