### PR TITLE
ci(test-php): cache WP test suite and fetch from GitHub mirror

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -19,4 +19,63 @@ jobs:
     uses: Automattic/newspack-scripts/.github/workflows/reusable-lint-php.yml@trunk
 
   test-php:
-    uses: Automattic/newspack-scripts/.github/workflows/reusable-test-php.yml@trunk
+    name: Run PHP tests
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: yes
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
+    env:
+      WP_TESTS_DIR: /tmp/wordpress-tests-lib
+      WP_CORE_DIR: /tmp/wordpress/
+      WP_VERSION: latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          tools: composer
+          extensions: mysqli
+          coverage: pcov
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y default-mysql-client
+
+      - name: Install Composer dependencies
+        run: composer update
+
+      - name: Cache WordPress test suite and core
+        id: cache-wp-tests
+        uses: actions/cache@v4
+        with:
+          path: |
+            /tmp/wordpress-tests-lib
+            /tmp/wordpress
+          key: wp-tests-${{ env.WP_VERSION }}-${{ hashFiles('bin/install-wp-tests.sh') }}
+
+      - name: Setup WordPress test environment
+        run: bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 ${{ env.WP_VERSION }}
+
+      - name: Run tests with coverage
+        run: vendor/bin/phpunit --coverage-clover coverage.xml
+
+      - name: Upload coverage to Codecov
+        if: ${{ env.CODECOV_TOKEN != '' }}
+        uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.xml
+          fail_ci_if_error: false

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -105,14 +105,32 @@ install_test_suite() {
 
 	# set up testing suite if it doesn't yet exist
 	if [ ! -d $WP_TESTS_DIR ]; then
-		# set up testing suite
+		# Download the WordPress PHPUnit test suite from the GitHub mirror instead of SVN.
+		# develop.svn.wordpress.org is flaky; the GitHub mirror at WordPress/wordpress-develop
+		# is orders of magnitude more reliable.
+		local GH_REF
+		case "$WP_TESTS_TAG" in
+			trunk) GH_REF="refs/heads/trunk" ;;
+			tags/*) GH_REF="refs/tags/${WP_TESTS_TAG#tags/}" ;;
+			branches/*) GH_REF="refs/heads/${WP_TESTS_TAG#branches/}-branch" ;;
+			*) echo "Unexpected WP_TESTS_TAG: $WP_TESTS_TAG"; exit 1 ;;
+		esac
+
 		mkdir -p $WP_TESTS_DIR
-		svn co --ignore-externals --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
-		svn co --ignore-externals --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ $WP_TESTS_DIR/data
+		local WPD_TARBALL="$TMPDIR/wordpress-develop.tar.gz"
+		local WPD_EXTRACT="$TMPDIR/wordpress-develop-extract"
+		rm -rf "$WPD_EXTRACT"
+		mkdir -p "$WPD_EXTRACT"
+		download "https://github.com/WordPress/wordpress-develop/archive/${GH_REF}.tar.gz" "$WPD_TARBALL"
+		tar --strip-components=1 -xzmf "$WPD_TARBALL" -C "$WPD_EXTRACT"
+		cp -R "$WPD_EXTRACT/tests/phpunit/includes" "$WP_TESTS_DIR/includes"
+		cp -R "$WPD_EXTRACT/tests/phpunit/data" "$WP_TESTS_DIR/data"
+		cp "$WPD_EXTRACT/wp-tests-config-sample.php" "$WP_TESTS_DIR/wp-tests-config-sample.php"
+		rm -rf "$WPD_EXTRACT" "$WPD_TARBALL"
 	fi
 
 	if [ ! -f wp-tests-config.php ]; then
-		download https://develop.svn.wordpress.org/${WP_TESTS_TAG}/wp-tests-config-sample.php "$WP_TESTS_DIR"/wp-tests-config.php
+		cp "$WP_TESTS_DIR/wp-tests-config-sample.php" "$WP_TESTS_DIR/wp-tests-config.php"
 		# remove all forward slashes in the end
 		WP_CORE_DIR=$(echo $WP_CORE_DIR | sed "s:/\+$::")
 		sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR/':" "$WP_TESTS_DIR"/wp-tests-config.php

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -19,7 +19,9 @@ WP_CORE_DIR=${WP_CORE_DIR-$TMPDIR/wordpress/}
 
 download() {
     if [ `which curl` ]; then
-        curl -s "$1" > "$2";
+        # -f: fail on HTTP errors, -s: silent, -S: still show errors, -L: follow redirects
+        # (GitHub archive URLs 302 to codeload.github.com, so -L is required).
+        curl -fsSL "$1" -o "$2";
     elif [ `which wget` ]; then
         wget -nv -O "$2" "$1"
     fi


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Makes the PHP test job resilient to `develop.svn.wordpress.org` flakiness (which has been causing unrelated CI failures across Newspack repos, most recently on Automattic/newspack-manager#541).

**1. Fetch the WP PHPUnit test suite from GitHub instead of SVN (`bin/install-wp-tests.sh`)**

`develop.svn.wordpress.org` is the upstream WordPress SVN server and is notoriously flaky – connection timeouts on `svn co` are a frequent source of spurious CI failures. The GitHub mirror at `WordPress/wordpress-develop` hosts the same content and is orders of magnitude more reliable.

The script now downloads a single tarball from `https://github.com/WordPress/wordpress-develop/archive/<ref>.tar.gz` and extracts `tests/phpunit/includes`, `tests/phpunit/data`, and `wp-tests-config-sample.php` from it. `subversion` is no longer required.

**2. Cache the WP test suite and core between runs (`.github/workflows/php.yml`)**

The test-php job is inlined (instead of calling the reusable workflow from `newspack-scripts`, which hard-codes `rm -rf /tmp/wordpress-tests-lib /tmp/wordpress` before running the install script, making caching impossible). An `actions/cache@v4` step caches `/tmp/wordpress-tests-lib` and `/tmp/wordpress`, keyed on WP version + hash of `bin/install-wp-tests.sh`. On cache hit, the install script's existing `[ ! -d $WP_TESTS_DIR ]` / `[ -d $WP_CORE_DIR ]` checks short-circuit the download entirely.

Cache key: `wp-tests-${{ env.WP_VERSION }}-${{ hashFiles('bin/install-wp-tests.sh') }}` – invalidates automatically when either the WP version or the install script changes.

### How to test the changes in this Pull Request:

1. Check that the `PHP` CI job passes on this draft PR (cache miss path – first run after the script changed).
2. Push a trivial no-op change to this branch and re-check that the `PHP` job passes and the `Cache WordPress test suite and core` step reports `Cache restored successfully` (cache hit path).
3. Verify no `svn:` or `develop.svn.wordpress.org` traffic appears in the `Setup WordPress test environment` step logs on a cache miss – only a `curl` to `github.com/WordPress/wordpress-develop`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally? (Verified the tarball URL + extraction end-to-end locally; CI will confirm the full flow.)

If this works here, the same two-line pattern can be copied to other `newspack-*` repos that share the same `install-wp-tests.sh` bootstrap.