### PR TITLE
fix(access-control): hide My Account group features if Memberships is active

### DIFF
--- a/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription.php
+++ b/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription.php
@@ -26,6 +26,10 @@ class Group_Subscription {
 	 * @return bool Whether the subscription is a group subscription.
 	 */
 	public static function is_group_subscription( $subscription ) {
+		// Don't show Group Subscription features in My Account if Woo Memberships is active. TODO: Remove this once Access Control is fully released.
+		if ( Memberships::is_active() && function_exists( 'is_account_page' ) && is_account_page() ) {
+			return false;
+		}
 		$settings = Group_Subscription_Settings::get_subscription_settings( $subscription );
 		return $settings['enabled'];
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

While Access Control is still in a prerelease state, reader-facing Group Subscription features shouldn't be shown in My Account if a site is still running a Memberships + Teams for Memberships setup. This condition should be removed once Access Control features are production-ready.

### How to test the changes in this Pull Request:

1. Enable Access Control features with `define( 'NEWSPACK_CONTENT_GATES', true );`
2. Enable or keep active the WooCommerce Memberships and Memberships for Teams plugins—this keeps reader-facing content gating features running with those systems
3. In WP admin, enable Group Subscription features for a Teams-enabled subscription
4. On `trunk`, log in as the reader who owns that subscription. Observe that you see UIs for both Group Subscription management and Team management.
5. Check out this branch and refresh. Confirm that Group Subscription features are no longer available in My Account.
6. Deactivate WooCommerce Memberships. Refresh and confirm that Group Subscription features are available again.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->