### PR TITLE
feat(block-theme): add size options to the Overlay Menu

### DIFF
--- a/src/blocks/overlay-menu/panel/block.json
+++ b/src/blocks/overlay-menu/panel/block.json
@@ -15,6 +15,7 @@
 	"attributes": {
 		"slideDirection": {
 			"type": "string",
+			"enum": [ "left", "right" ],
 			"default": "left"
 		},
 		"isFullScreen": {
@@ -23,6 +24,7 @@
 		},
 		"panelWidth": {
 			"type": "string",
+			"enum": [ "x-small", "small", "medium", "large", "x-large" ],
 			"default": "small"
 		},
 		"overlayColor": {

--- a/src/blocks/overlay-menu/panel/block.json
+++ b/src/blocks/overlay-menu/panel/block.json
@@ -39,7 +39,8 @@
 		}
 	},
 	"supports": {
-		"html": false
+		"html": false,
+		"lock": false
 	},
 	"editorStyle": "file:../../../../dist/blocks.css",
 	"style": "file:../../../../dist/blocks.css"

--- a/src/blocks/overlay-menu/panel/block.json
+++ b/src/blocks/overlay-menu/panel/block.json
@@ -17,6 +17,14 @@
 			"type": "string",
 			"default": "left"
 		},
+		"isFullScreen": {
+			"type": "boolean",
+			"default": false
+		},
+		"panelWidth": {
+			"type": "string",
+			"default": "small"
+		},
 		"overlayColor": {
 			"type": "string",
 			"default": ""

--- a/src/blocks/overlay-menu/panel/class-overlay-menu-panel-block.php
+++ b/src/blocks/overlay-menu/panel/class-overlay-menu-panel-block.php
@@ -55,12 +55,24 @@ final class Overlay_Menu_Panel_Block {
 		$overlay_color    = $attributes['overlayColor'] ?? '';
 		$panel_bg_color   = $attributes['panelBackgroundColor'] ?? '';
 		$panel_text_color = $attributes['panelTextColor'] ?? '';
+		$is_full_screen   = ! empty( $attributes['isFullScreen'] );
+		$panel_width      = $attributes['panelWidth'] ?? 'small';
 
 		$valid_directions = [ 'left', 'right' ];
 		if ( ! in_array( $direction, $valid_directions, true ) ) {
 			$direction = 'left';
 		}
-		$position_class = 'overlay-menu__panel--' . $direction;
+
+		$valid_widths = [ 'x-small', 'small', 'medium', 'large', 'x-large' ];
+		if ( ! in_array( $panel_width, $valid_widths, true ) ) {
+			$panel_width = 'small';
+		}
+
+		if ( $is_full_screen ) {
+			$panel_class = 'overlay-menu__panel is-layout-constrained overlay-menu__panel--full-screen';
+		} else {
+			$panel_class = 'overlay-menu__panel is-layout-constrained overlay-menu__panel--' . $direction . ' overlay-menu__panel--width--' . $panel_width;
+		}
 
 		$panel_styles = [];
 		if ( $panel_bg_color ) {
@@ -71,8 +83,8 @@ final class Overlay_Menu_Panel_Block {
 		}
 		$extra_attributes = [
 			'id'                 => 'newspack-overlay-panel-' . $instance_id,
-			'class'              => 'overlay-menu__panel is-layout-constrained ' . $position_class,
-			'data-direction'     => $direction,
+			'class'              => $panel_class,
+			'data-direction'     => $is_full_screen ? 'full-screen' : $direction,
 			'data-overlay-color' => $overlay_color,
 			'aria-hidden'        => 'true',
 			'inert'              => 'true',

--- a/src/blocks/overlay-menu/panel/class-overlay-menu-panel-block.php
+++ b/src/blocks/overlay-menu/panel/class-overlay-menu-panel-block.php
@@ -84,7 +84,6 @@ final class Overlay_Menu_Panel_Block {
 		$extra_attributes = [
 			'id'                 => 'newspack-overlay-panel-' . $instance_id,
 			'class'              => $panel_class,
-			'data-direction'     => $is_full_screen ? 'full-screen' : $direction,
 			'data-overlay-color' => $overlay_color,
 			'aria-hidden'        => 'true',
 			'inert'              => 'true',

--- a/src/blocks/overlay-menu/panel/edit.js
+++ b/src/blocks/overlay-menu/panel/edit.js
@@ -34,6 +34,14 @@ const DIRECTION_CONFIG = {
 
 const INNER_BLOCKS_TEMPLATE = [ [ 'core/navigation', { layout: { type: 'flex', orientation: 'vertical' } } ] ];
 
+const PANEL_WIDTH_OPTIONS = [
+	{ value: 'x-small', label: __( 'XS', 'newspack-plugin' ), ariaLabel: __( 'Extra small', 'newspack-plugin' ) },
+	{ value: 'small', label: __( 'S', 'newspack-plugin' ), ariaLabel: __( 'Small', 'newspack-plugin' ) },
+	{ value: 'medium', label: __( 'M', 'newspack-plugin' ), ariaLabel: __( 'Medium', 'newspack-plugin' ) },
+	{ value: 'large', label: __( 'L', 'newspack-plugin' ), ariaLabel: __( 'Large', 'newspack-plugin' ) },
+	{ value: 'x-large', label: __( 'XL', 'newspack-plugin' ), ariaLabel: __( 'Extra large', 'newspack-plugin' ) },
+];
+
 /**
  * Edit component for the Overlay Menu Panel block.
  *
@@ -128,11 +136,9 @@ export default function OverlayMenuPanelEdit( { attributes, clientId, setAttribu
 								onChange={ val => setAttributes( { panelWidth: val } ) }
 								isBlock
 							>
-								<ToggleGroupControlOption value="x-small" label={ __( 'XS', 'newspack-plugin' ) } />
-								<ToggleGroupControlOption value="small" label={ __( 'S', 'newspack-plugin' ) } />
-								<ToggleGroupControlOption value="medium" label={ __( 'M', 'newspack-plugin' ) } />
-								<ToggleGroupControlOption value="large" label={ __( 'L', 'newspack-plugin' ) } />
-								<ToggleGroupControlOption value="x-large" label={ __( 'XL', 'newspack-plugin' ) } />
+								{ PANEL_WIDTH_OPTIONS.map( ( { value, label, ariaLabel } ) => (
+									<ToggleGroupControlOption key={ value } value={ value } label={ label } aria-label={ ariaLabel } />
+								) ) }
 							</ToggleGroupControl>
 						</>
 					) }

--- a/src/blocks/overlay-menu/panel/edit.js
+++ b/src/blocks/overlay-menu/panel/edit.js
@@ -14,6 +14,7 @@ import {
 } from '@wordpress/block-editor';
 import {
 	PanelBody,
+	ToggleControl,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
@@ -44,7 +45,7 @@ const INNER_BLOCKS_TEMPLATE = [ [ 'core/navigation', { layout: { type: 'flex', o
  * @return {JSX.Element} The block editor UI.
  */
 export default function OverlayMenuPanelEdit( { attributes, clientId, setAttributes } ) {
-	const { slideDirection, overlayColor, panelBackgroundColor, panelTextColor } = attributes;
+	const { slideDirection, overlayColor, panelBackgroundColor, panelTextColor, isFullScreen, panelWidth } = attributes;
 
 	const [ isPreviewOpen, setIsPreviewOpen ] = useState( false );
 
@@ -75,9 +76,11 @@ export default function OverlayMenuPanelEdit( { attributes, clientId, setAttribu
 	// Fetch the theme's color palette for the color panel.
 	const [ colorSettings ] = useSettings( 'color.palette' );
 
-	const panelClassName = isPreviewOpen
-		? `overlay-menu__panel is-layout-constrained ${ positionClass } overlay-menu__panel--open`
-		: 'overlay-menu__editor-panel-hidden';
+	const openPanelClasses = isFullScreen
+		? 'overlay-menu__panel is-layout-constrained overlay-menu__panel--full-screen overlay-menu__panel--open'
+		: `overlay-menu__panel is-layout-constrained ${ positionClass } overlay-menu__panel--width--${ panelWidth } overlay-menu__panel--open`;
+
+	const panelClassName = isPreviewOpen ? openPanelClasses : 'overlay-menu__editor-panel-hidden';
 	const panelStyle = isPreviewOpen
 		? {
 				// Force fixed positioning in the editor — Gutenberg can override
@@ -97,16 +100,42 @@ export default function OverlayMenuPanelEdit( { attributes, clientId, setAttribu
 
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings', 'newspack-plugin' ) } initialOpen={ true }>
-					<ToggleGroupControl
-						label={ __( 'Slide direction', 'newspack-plugin' ) }
-						help={ __( 'Choose which side of the screen the panel slides in from.', 'newspack-plugin' ) }
-						value={ slideDirection }
-						onChange={ val => setAttributes( { slideDirection: val } ) }
-						isBlock
-					>
-						<ToggleGroupControlOption value="left" label={ __( 'Left', 'newspack-plugin' ) } />
-						<ToggleGroupControlOption value="right" label={ __( 'Right', 'newspack-plugin' ) } />
-					</ToggleGroupControl>
+					<ToggleControl
+						label={ __( 'Full screen', 'newspack-plugin' ) }
+						help={ __( 'When enabled, the panel expands to fill the entire viewport.', 'newspack-plugin' ) }
+						checked={ isFullScreen }
+						onChange={ val => setAttributes( { isFullScreen: val } ) }
+					/>
+					{ ! isFullScreen && (
+						<>
+							<ToggleGroupControl
+								label={ __( 'Slide direction', 'newspack-plugin' ) }
+								help={ __( 'Choose which side of the screen the panel slides in from.', 'newspack-plugin' ) }
+								value={ slideDirection }
+								onChange={ val => setAttributes( { slideDirection: val } ) }
+								isBlock
+							>
+								<ToggleGroupControlOption value="left" label={ __( 'Left', 'newspack-plugin' ) } />
+								<ToggleGroupControlOption value="right" label={ __( 'Right', 'newspack-plugin' ) } />
+							</ToggleGroupControl>
+							<ToggleGroupControl
+								label={ __( 'Width', 'newspack-plugin' ) }
+								help={ __(
+									'Set how wide the panel appears when opened. Use smaller sizes for simple navigation and larger sizes for rich content layouts.',
+									'newspack-plugin'
+								) }
+								value={ panelWidth }
+								onChange={ val => setAttributes( { panelWidth: val } ) }
+								isBlock
+							>
+								<ToggleGroupControlOption value="x-small" label={ __( 'XS', 'newspack-plugin' ) } />
+								<ToggleGroupControlOption value="small" label={ __( 'S', 'newspack-plugin' ) } />
+								<ToggleGroupControlOption value="medium" label={ __( 'M', 'newspack-plugin' ) } />
+								<ToggleGroupControlOption value="large" label={ __( 'L', 'newspack-plugin' ) } />
+								<ToggleGroupControlOption value="x-large" label={ __( 'XL', 'newspack-plugin' ) } />
+							</ToggleGroupControl>
+						</>
+					) }
 				</PanelBody>
 			</InspectorControls>
 

--- a/src/blocks/overlay-menu/style.scss
+++ b/src/blocks/overlay-menu/style.scss
@@ -101,29 +101,76 @@
 			top: 32px;
 		}
 	}
-}
 
-// Side panels slide in from left or right.
-.overlay-menu__panel--left {
-	left: -100%;
-	max-width: min( 400px, 90vw );
-	right: auto;
-}
+	// Side panels slide in from left or right.
+	&--left {
+		left: -100%;
+		right: auto;
+	}
 
-.overlay-menu__panel--right {
-	left: auto;
-	max-width: min( 400px, 90vw );
-	right: -100%;
-}
+	&--right {
+		left: auto;
+		right: -100%;
+	}
 
+	// Full-screen panel fades in without a directional slide.
+	&--full-screen {
+		left: 0;
+		max-width: 100%;
+		right: 0;
+	}
 
-// ─── Open state (shared by frontend JS and block editor preview) ──────────────
+	// ─── Open state (shared by frontend JS and block editor preview) ──────────
 
-.overlay-menu__panel--open {
-	opacity: 1;
+	&--open {
+		opacity: 1;
 
-	&.overlay-menu__panel--left   { left: 0; }
-	&.overlay-menu__panel--right  { right: 0; }
+		&.overlay-menu__panel--left  { left: 0; }
+		&.overlay-menu__panel--right { right: 0; }
+	}
+
+	// ─── Panel width ──────────────────────────────────────────────────────────
+	// Pixel fallbacks cover sites where the theme's custom properties aren't defined.
+
+	&--width--x-small {
+		max-width: calc( var( --wp--preset--spacing--30, 1rem ) + var( --wp--custom--width--x-small, 300px ) + var( --wp--preset--spacing--30, 1rem ) );
+
+		@media ( min-width: 782px ) {
+			max-width: calc( var( --wp--preset--spacing--40, 1.5rem ) + var( --wp--custom--width--x-small, 300px ) + var( --wp--preset--spacing--40, 1.5rem ) );
+		}
+	}
+
+	&--width--small {
+		max-width: calc( var( --wp--preset--spacing--30, 1rem ) + var( --wp--custom--width--small, 410px ) + var( --wp--preset--spacing--30, 1rem ) );
+
+		@media ( min-width: 782px ) {
+			max-width: calc( var( --wp--preset--spacing--40, 1.5rem ) + var( --wp--custom--width--small, 410px ) + var( --wp--preset--spacing--40, 1.5rem ) );
+		}
+	}
+
+	&--width--medium {
+		max-width: calc( var( --wp--preset--spacing--30, 1rem ) + var( --wp--style--global--content-size, 632px ) + var( --wp--preset--spacing--30, 1rem ) );
+
+		@media ( min-width: 782px ) {
+			max-width: calc( var( --wp--preset--spacing--40, 1.5rem ) + var( --wp--style--global--content-size, 632px ) + var( --wp--preset--spacing--40, 1.5rem ) );
+		}
+	}
+
+	&--width--large {
+		max-width: calc( var( --wp--preset--spacing--30, 1rem ) + var( --wp--custom--width--large, 964px ) + var( --wp--preset--spacing--30, 1rem ) );
+
+		@media ( min-width: 782px ) {
+			max-width: calc( var( --wp--preset--spacing--40, 1.5rem ) + var( --wp--custom--width--large, 964px ) + var( --wp--preset--spacing--40, 1.5rem ) );
+		}
+	}
+
+	&--width--x-large {
+		max-width: calc( var( --wp--preset--spacing--30, 1rem ) + var( --wp--custom--width--x-large, 1296px ) + var( --wp--preset--spacing--30, 1rem ) );
+
+		@media ( min-width: 782px ) {
+			max-width: calc( var( --wp--preset--spacing--40, 1.5rem ) + var( --wp--custom--width--x-large, 1296px ) + var( --wp--preset--spacing--40, 1.5rem ) );
+		}
+	}
 }
 
 // ─── Scrim ────────────────────────────────────────────────────────────────────

--- a/src/blocks/overlay-menu/style.scss
+++ b/src/blocks/overlay-menu/style.scss
@@ -1,3 +1,5 @@
+@use "../../newspack-ui/scss/variables/breakpoints";
+
 .wp-block-newspack-overlay-menu {
 	.overlay-menu__trigger {
 		align-items: center;
@@ -43,7 +45,7 @@
 	justify-content: flex-end;
 	margin-right: calc( -1 * var( --wp--preset--spacing--30 ) );
 
-	@media ( min-width: 782px ) {
+	@media ( min-width: breakpoints.$tablet_width ) {
 		margin-right: calc( -1 * var( --wp--preset--spacing--40 ) );
 	}
 }
@@ -91,14 +93,14 @@
 	width: 100%;
 	z-index: 50;
 
-	@media ( min-width: 782px ) {
+	@media ( min-width: breakpoints.$tablet_width ) {
 		padding: var( --wp--preset--spacing--40, 1.5rem );
 	}
 
 	.admin-bar & {
 		top: 46px;
 
-		@media ( min-width: 782px ) {
+		@media ( min-width: breakpoints.$tablet_width ) {
 			top: 32px;
 		}
 	}
@@ -144,46 +146,21 @@
 
 	// ─── Panel width ──────────────────────────────────────────────────────────
 	// Sets the panel to a specific width; the 90vw cap on --left/--right takes over on narrow screens.
+	// Each size adds horizontal padding to the content-size variable so the inner content area matches.
 
-	&--width--x-small {
-		width: calc( var( --wp--preset--spacing--30, 1rem ) + var( --wp--custom--width--x-small, 300px ) + var( --wp--preset--spacing--30, 1rem ) );
+	@mixin panel-width( $var, $fallback ) {
+		width: calc( var( --wp--preset--spacing--30, 1rem ) + var( #{$var}, #{$fallback} ) + var( --wp--preset--spacing--30, 1rem ) );
 
-		@media ( min-width: 782px ) {
-			width: calc( var( --wp--preset--spacing--40, 1.5rem ) + var( --wp--custom--width--x-small, 300px ) + var( --wp--preset--spacing--40, 1.5rem ) );
+		@media ( min-width: breakpoints.$tablet_width ) {
+			width: calc( var( --wp--preset--spacing--40, 1.5rem ) + var( #{$var}, #{$fallback} ) + var( --wp--preset--spacing--40, 1.5rem ) );
 		}
 	}
 
-	&--width--small {
-		width: calc( var( --wp--preset--spacing--30, 1rem ) + var( --wp--custom--width--small, 410px ) + var( --wp--preset--spacing--30, 1rem ) );
-
-		@media ( min-width: 782px ) {
-			width: calc( var( --wp--preset--spacing--40, 1.5rem ) + var( --wp--custom--width--small, 410px ) + var( --wp--preset--spacing--40, 1.5rem ) );
-		}
-	}
-
-	&--width--medium {
-		width: calc( var( --wp--preset--spacing--30, 1rem ) + var( --wp--style--global--content-size, 632px ) + var( --wp--preset--spacing--30, 1rem ) );
-
-		@media ( min-width: 782px ) {
-			width: calc( var( --wp--preset--spacing--40, 1.5rem ) + var( --wp--style--global--content-size, 632px ) + var( --wp--preset--spacing--40, 1.5rem ) );
-		}
-	}
-
-	&--width--large {
-		width: calc( var( --wp--preset--spacing--30, 1rem ) + var( --wp--custom--width--large, 964px ) + var( --wp--preset--spacing--30, 1rem ) );
-
-		@media ( min-width: 782px ) {
-			width: calc( var( --wp--preset--spacing--40, 1.5rem ) + var( --wp--custom--width--large, 964px ) + var( --wp--preset--spacing--40, 1.5rem ) );
-		}
-	}
-
-	&--width--x-large {
-		width: calc( var( --wp--preset--spacing--30, 1rem ) + var( --wp--custom--width--x-large, 1296px ) + var( --wp--preset--spacing--30, 1rem ) );
-
-		@media ( min-width: 782px ) {
-			width: calc( var( --wp--preset--spacing--40, 1.5rem ) + var( --wp--custom--width--x-large, 1296px ) + var( --wp--preset--spacing--40, 1.5rem ) );
-		}
-	}
+	&--width--x-small { @include panel-width( --wp--custom--width--x-small, 300px ); }
+	&--width--small   { @include panel-width( --wp--custom--width--small, 410px ); }
+	&--width--medium  { @include panel-width( --wp--style--global--content-size, 632px ); }
+	&--width--large   { @include panel-width( --wp--custom--width--large, 964px ); }
+	&--width--x-large { @include panel-width( --wp--custom--width--x-large, 1296px ); }
 }
 
 // ─── Scrim ────────────────────────────────────────────────────────────────────

--- a/src/blocks/overlay-menu/style.scss
+++ b/src/blocks/overlay-menu/style.scss
@@ -158,6 +158,7 @@
 
 	&--width--x-small { @include panel-width( --wp--custom--width--x-small, 300px ); }
 	&--width--small   { @include panel-width( --wp--custom--width--small, 410px ); }
+	// Medium intentionally maps to the theme's content size (from theme.json), not the --wp--custom--width-- family used by the other sizes.
 	&--width--medium  { @include panel-width( --wp--style--global--content-size, 632px ); }
 	&--width--large   { @include panel-width( --wp--custom--width--large, 964px ); }
 	&--width--x-large { @include panel-width( --wp--custom--width--x-large, 1296px ); }

--- a/src/blocks/overlay-menu/style.scss
+++ b/src/blocks/overlay-menu/style.scss
@@ -87,6 +87,7 @@
 		top 250ms ease-in-out,
 		bottom 250ms ease-in-out,
 		transform 250ms ease-in-out;
+	max-width: 90vw;
 	width: 100%;
 	z-index: 50;
 
@@ -130,45 +131,47 @@
 	}
 
 	// ─── Panel width ──────────────────────────────────────────────────────────
-	// Pixel fallbacks cover sites where the theme's custom properties aren't defined.
+	// Sets the panel to a specific width; the 90vw cap on --left/--right takes
+	// over on narrow screens. Pixel fallbacks cover sites without the theme's
+	// custom properties.
 
 	&--width--x-small {
-		max-width: calc( var( --wp--preset--spacing--30, 1rem ) + var( --wp--custom--width--x-small, 300px ) + var( --wp--preset--spacing--30, 1rem ) );
+		width: calc( var( --wp--preset--spacing--30, 1rem ) + var( --wp--custom--width--x-small, 300px ) + var( --wp--preset--spacing--30, 1rem ) );
 
 		@media ( min-width: 782px ) {
-			max-width: calc( var( --wp--preset--spacing--40, 1.5rem ) + var( --wp--custom--width--x-small, 300px ) + var( --wp--preset--spacing--40, 1.5rem ) );
+			width: calc( var( --wp--preset--spacing--40, 1.5rem ) + var( --wp--custom--width--x-small, 300px ) + var( --wp--preset--spacing--40, 1.5rem ) );
 		}
 	}
 
 	&--width--small {
-		max-width: calc( var( --wp--preset--spacing--30, 1rem ) + var( --wp--custom--width--small, 410px ) + var( --wp--preset--spacing--30, 1rem ) );
+		width: calc( var( --wp--preset--spacing--30, 1rem ) + var( --wp--custom--width--small, 410px ) + var( --wp--preset--spacing--30, 1rem ) );
 
 		@media ( min-width: 782px ) {
-			max-width: calc( var( --wp--preset--spacing--40, 1.5rem ) + var( --wp--custom--width--small, 410px ) + var( --wp--preset--spacing--40, 1.5rem ) );
+			width: calc( var( --wp--preset--spacing--40, 1.5rem ) + var( --wp--custom--width--small, 410px ) + var( --wp--preset--spacing--40, 1.5rem ) );
 		}
 	}
 
 	&--width--medium {
-		max-width: calc( var( --wp--preset--spacing--30, 1rem ) + var( --wp--style--global--content-size, 632px ) + var( --wp--preset--spacing--30, 1rem ) );
+		width: calc( var( --wp--preset--spacing--30, 1rem ) + var( --wp--style--global--content-size, 632px ) + var( --wp--preset--spacing--30, 1rem ) );
 
 		@media ( min-width: 782px ) {
-			max-width: calc( var( --wp--preset--spacing--40, 1.5rem ) + var( --wp--style--global--content-size, 632px ) + var( --wp--preset--spacing--40, 1.5rem ) );
+			width: calc( var( --wp--preset--spacing--40, 1.5rem ) + var( --wp--style--global--content-size, 632px ) + var( --wp--preset--spacing--40, 1.5rem ) );
 		}
 	}
 
 	&--width--large {
-		max-width: calc( var( --wp--preset--spacing--30, 1rem ) + var( --wp--custom--width--large, 964px ) + var( --wp--preset--spacing--30, 1rem ) );
+		width: calc( var( --wp--preset--spacing--30, 1rem ) + var( --wp--custom--width--large, 964px ) + var( --wp--preset--spacing--30, 1rem ) );
 
 		@media ( min-width: 782px ) {
-			max-width: calc( var( --wp--preset--spacing--40, 1.5rem ) + var( --wp--custom--width--large, 964px ) + var( --wp--preset--spacing--40, 1.5rem ) );
+			width: calc( var( --wp--preset--spacing--40, 1.5rem ) + var( --wp--custom--width--large, 964px ) + var( --wp--preset--spacing--40, 1.5rem ) );
 		}
 	}
 
 	&--width--x-large {
-		max-width: calc( var( --wp--preset--spacing--30, 1rem ) + var( --wp--custom--width--x-large, 1296px ) + var( --wp--preset--spacing--30, 1rem ) );
+		width: calc( var( --wp--preset--spacing--30, 1rem ) + var( --wp--custom--width--x-large, 1296px ) + var( --wp--preset--spacing--30, 1rem ) );
 
 		@media ( min-width: 782px ) {
-			max-width: calc( var( --wp--preset--spacing--40, 1.5rem ) + var( --wp--custom--width--x-large, 1296px ) + var( --wp--preset--spacing--40, 1.5rem ) );
+			width: calc( var( --wp--preset--spacing--40, 1.5rem ) + var( --wp--custom--width--x-large, 1296px ) + var( --wp--preset--spacing--40, 1.5rem ) );
 		}
 	}
 }

--- a/src/blocks/overlay-menu/style.scss
+++ b/src/blocks/overlay-menu/style.scss
@@ -119,6 +119,8 @@
 		left: 0;
 		max-width: 100%;
 		right: 0;
+		transition: opacity 125ms ease-in-out, visibility 0s 125ms;
+		visibility: hidden;
 	}
 
 	// ─── Open state (shared by frontend JS and block editor preview) ──────────
@@ -128,6 +130,11 @@
 
 		&.overlay-menu__panel--left  { left: 0; }
 		&.overlay-menu__panel--right { right: 0; }
+
+		&.overlay-menu__panel--full-screen {
+			transition: opacity 125ms ease-in-out, visibility 0s;
+			visibility: visible;
+		}
 	}
 
 	// ─── Panel width ──────────────────────────────────────────────────────────

--- a/src/blocks/overlay-menu/style.scss
+++ b/src/blocks/overlay-menu/style.scss
@@ -128,8 +128,13 @@
 	&--open {
 		opacity: 1;
 
-		&.overlay-menu__panel--left  { left: 0; }
-		&.overlay-menu__panel--right { right: 0; }
+		&.overlay-menu__panel--left  {
+			left: 0;
+		}
+
+		&.overlay-menu__panel--right {
+			right: 0;
+		}
 
 		&.overlay-menu__panel--full-screen {
 			transition: opacity 125ms ease-in-out, visibility 0s;
@@ -138,9 +143,7 @@
 	}
 
 	// ─── Panel width ──────────────────────────────────────────────────────────
-	// Sets the panel to a specific width; the 90vw cap on --left/--right takes
-	// over on narrow screens. Pixel fallbacks cover sites without the theme's
-	// custom properties.
+	// Sets the panel to a specific width; the 90vw cap on --left/--right takes over on narrow screens.
 
 	&--width--x-small {
 		width: calc( var( --wp--preset--spacing--30, 1rem ) + var( --wp--custom--width--x-small, 300px ) + var( --wp--preset--spacing--30, 1rem ) );

--- a/src/blocks/overlay-menu/trigger/block.json
+++ b/src/blocks/overlay-menu/trigger/block.json
@@ -13,6 +13,7 @@
 	},
 	"supports": {
 		"html": false,
+		"lock": false,
 		"color": {
 			"background": true,
 			"text": true

--- a/tests/unit-tests/class-test-overlay-menu-panel-block.php
+++ b/tests/unit-tests/class-test-overlay-menu-panel-block.php
@@ -1,0 +1,192 @@
+<?php
+/**
+ * Tests for Overlay Menu Panel block.
+ *
+ * @package Newspack\Tests
+ * @covers \Newspack\Blocks\Overlay_Menu\Overlay_Menu_Panel_Block
+ */
+
+use Newspack\Blocks\Overlay_Menu\Overlay_Menu_Panel_Block;
+
+/**
+ * Test class for the Overlay Menu Panel Block.
+ *
+ * @group overlay-menu-panel-block
+ */
+class Newspack_Test_Overlay_Menu_Panel_Block extends WP_UnitTestCase {
+
+	const BLOCK_NAME = 'newspack/overlay-menu-panel';
+
+	/**
+	 * Setup.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		require_once NEWSPACK_ABSPATH . 'src/blocks/overlay-menu/panel/class-overlay-menu-panel-block.php';
+
+		if ( ! \WP_Block_Type_Registry::get_instance()->is_registered( self::BLOCK_NAME ) ) {
+			Overlay_Menu_Panel_Block::register_block();
+		}
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tear_down(): void {
+		if ( \WP_Block_Type_Registry::get_instance()->is_registered( self::BLOCK_NAME ) ) {
+			unregister_block_type( self::BLOCK_NAME );
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Render the panel block with given attributes and parent context.
+	 *
+	 * @param array $attributes Block attributes.
+	 * @return string Rendered HTML.
+	 */
+	private function render( array $attributes ): string {
+		$parsed_block = [
+			'blockName'    => self::BLOCK_NAME,
+			'attrs'        => $attributes,
+			'innerBlocks'  => [],
+			'innerHTML'    => '',
+			'innerContent' => [],
+		];
+		$block        = new WP_Block( $parsed_block, [ 'newspack-overlay-menu/instanceId' => 'test' ] );
+
+		return $block->render();
+	}
+
+	/**
+	 * Extract the class attribute value from rendered output.
+	 *
+	 * @param string $output Rendered HTML.
+	 * @return string Class attribute value, or empty string if not found.
+	 */
+	private function get_class_string( string $output ): string {
+		return preg_match( '/class="([^"]*)"/', $output, $matches ) ? $matches[1] : '';
+	}
+
+	/**
+	 * Default attributes produce a left-direction, small-width panel.
+	 */
+	public function test_default_attributes() {
+		$class = $this->get_class_string( $this->render( [] ) );
+
+		$this->assertStringContainsString( 'overlay-menu__panel', $class );
+		$this->assertStringContainsString( 'is-layout-constrained', $class );
+		$this->assertStringContainsString( 'overlay-menu__panel--left', $class );
+		$this->assertStringContainsString( 'overlay-menu__panel--width--small', $class );
+		$this->assertStringNotContainsString( 'overlay-menu__panel--full-screen', $class );
+	}
+
+	/**
+	 * Valid direction and width combos produce the matching modifier classes.
+	 */
+	public function test_valid_direction_and_width() {
+		$class = $this->get_class_string(
+			$this->render(
+				[
+					'slideDirection' => 'right',
+					'panelWidth'     => 'large',
+				]
+			)
+		);
+
+		$this->assertStringContainsString( 'overlay-menu__panel--right', $class );
+		$this->assertStringContainsString( 'overlay-menu__panel--width--large', $class );
+		$this->assertStringNotContainsString( 'overlay-menu__panel--left', $class );
+		$this->assertStringNotContainsString( 'overlay-menu__panel--width--small', $class );
+	}
+
+	/**
+	 * Full-screen short-circuits direction and width modifiers.
+	 */
+	public function test_full_screen_short_circuits_direction_and_width() {
+		$class = $this->get_class_string(
+			$this->render(
+				[
+					'isFullScreen'   => true,
+					'slideDirection' => 'right',
+					'panelWidth'     => 'large',
+				]
+			)
+		);
+
+		$this->assertStringContainsString( 'overlay-menu__panel--full-screen', $class );
+		$this->assertStringNotContainsString( 'overlay-menu__panel--right', $class );
+		$this->assertStringNotContainsString( 'overlay-menu__panel--left', $class );
+		$this->assertStringNotContainsString( 'overlay-menu__panel--width--', $class );
+	}
+
+	/**
+	 * Invalid direction falls back to 'left'.
+	 */
+	public function test_invalid_direction_falls_back_to_left() {
+		$class = $this->get_class_string( $this->render( [ 'slideDirection' => 'diagonal' ] ) );
+
+		$this->assertStringContainsString( 'overlay-menu__panel--left', $class );
+		$this->assertStringNotContainsString( 'diagonal', $class );
+	}
+
+	/**
+	 * Invalid width falls back to 'small'.
+	 */
+	public function test_invalid_width_falls_back_to_small() {
+		$class = $this->get_class_string( $this->render( [ 'panelWidth' => 'gigantic' ] ) );
+
+		$this->assertStringContainsString( 'overlay-menu__panel--width--small', $class );
+		$this->assertStringNotContainsString( 'gigantic', $class );
+	}
+
+	/**
+	 * Allowlist prevents arbitrary strings from being concatenated into the class attribute.
+	 */
+	public function test_allowlist_blocks_class_injection() {
+		$class = $this->get_class_string(
+			$this->render(
+				[
+					'slideDirection' => '" onclick="alert(1)" data-x="',
+					'panelWidth'     => 'evil"><script>alert(1)</script>',
+				]
+			)
+		);
+
+		$this->assertStringContainsString( 'overlay-menu__panel--left', $class );
+		$this->assertStringContainsString( 'overlay-menu__panel--width--small', $class );
+		$this->assertStringNotContainsString( 'onclick', $class );
+		$this->assertStringNotContainsString( 'script', $class );
+		$this->assertStringNotContainsString( 'evil', $class );
+	}
+
+	/**
+	 * Non-string attribute values fall back to defaults via the strict allowlist.
+	 */
+	public function test_non_string_values_fall_back_to_defaults() {
+		$class = $this->get_class_string(
+			$this->render(
+				[
+					'slideDirection' => [ 'left' ],
+					'panelWidth'     => 42,
+				]
+			)
+		);
+
+		$this->assertStringContainsString( 'overlay-menu__panel--left', $class );
+		$this->assertStringContainsString( 'overlay-menu__panel--width--small', $class );
+	}
+
+	/**
+	 * Boundary width values (x-small, x-large) produce their matching classes.
+	 */
+	public function test_boundary_width_values() {
+		$x_small = $this->get_class_string( $this->render( [ 'panelWidth' => 'x-small' ] ) );
+		$this->assertStringContainsString( 'overlay-menu__panel--width--x-small', $x_small );
+
+		$x_large = $this->get_class_string( $this->render( [ 'panelWidth' => 'x-large' ] ) );
+		$this->assertStringContainsString( 'overlay-menu__panel--width--x-large', $x_large );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a couple options to the Overlay Menu block:
1. It adds a toggle to open the Menu Overlay panel as a full screen size. When this is enabled, the direction (and new size option) is hidden.
2. It adds an option to change the menu panel's width

It also adds `"supports": { "lock": false }` to both the Overlay Button (trigger) and Menu Panel block.json files, so users can't toggle the lock UI on those children. The parent Overlay Menu block already uses `templateLock="all"` on its `InnerBlocks`, so combined with this change the trigger and panel can't be removed or moved.

Closes NPPD-1362

### How to test the changes in this Pull Request:

1. Edit a post/page/template part, and add the Overlay Menu Block.
2. Open the panel, and select it. In the right sidebar, confirm you now have an option to switch the menu to 'full width', and to change its widths -- by default, the full-width option should be off, the panel should come from the left, and should use the 'S' size:

<img width="279" height="677" alt="CleanShot 2026-04-10 at 08 30 48" src="https://github.com/user-attachments/assets/7f8d6fa3-7ca2-4336-8013-6fd7d70eddc9" />

4. Try enabling 'Full screen'; confirm that the other two options go away. This is because the menu will fade in (a left-or-right entry would be a little jarring at that size), and doesn't need a size set. 

<img width="277" height="464" alt="CleanShot 2026-04-10 at 08 31 42" src="https://github.com/user-attachments/assets/8f46e45f-19e8-46d4-8cbb-9209213d302c" />

5. Publish and test on front-end; ensure it works well.  
6. Edit again, toggle off "Full screen", and test out the size options. Try them in the editor and on the front end; combine them with the different direction options, and test on different screen sizes. Confirm everything looks good. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->