### PR TITLE
fix: correct submit button text on change-payment-method page

### DIFF
--- a/includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php
+++ b/includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php
@@ -56,6 +56,7 @@ class WooCommerce_My_Account {
 		\add_filter( 'wc_stripe_update_subs_payment_method_card_statuses', [ __CLASS__, 'update_payment_methods_for_all_subs' ] );
 		\add_filter( 'wc_subscriptions_allow_subscription_token_deletion', [ __CLASS__, 'allow_braintree_token_deletion' ], 10, 2 );
 		\add_filter( 'woocommerce_payment_methods_list_item', [ __CLASS__, 'remove_braintree_edit_actions' ], 20, 2 );
+		\add_filter( 'woocommerce_order_button_text', [ __CLASS__, 'change_payment_method_button_text' ], 25 );
 
 		// Reader Activation mods.
 		if ( Reader_Activation::is_enabled() ) {
@@ -1053,6 +1054,19 @@ class WooCommerce_My_Account {
 			}
 		}
 		return $item;
+	}
+
+	/**
+	 * Override the order button text on the change-payment-method checkout page.
+	 *
+	 * @param string $text The button text.
+	 * @return string
+	 */
+	public static function change_payment_method_button_text( $text ) {
+		if ( self::is_payment_method_change_page() ) {
+			return __( 'Update payment method', 'newspack-plugin' );
+		}
+		return $text;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The "Change Payment" modal on the My Account subscription page shows "Place order" as its submit button text. This fixes it to read "Update payment method", matching the label used elsewhere in the My Account payment flow.

Closes NPPM-2655.

### How to test the changes in this Pull Request:

1. Set up a site with WooCommerce Subscriptions and a payment gateway that supports the change-payment-method flow (e.g., Braintree or Stripe).
2. Create or locate an active subscription for a test user.
3. Log in as that user and navigate to My Account → Subscriptions.
4. Click the three-dot menu on a subscription and select "Update payment method".
5. Verify the submit button in the modal reads **"Update payment method"** (not "Place order").
6. Navigate to a normal checkout page (e.g., add a product to cart and proceed to checkout).
7. Verify the checkout button still displays its expected text ("Place order", "Donate now", or "Change subscription" depending on cart contents).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?