### PR TITLE
feat(analytics): auto-provision GA4 custom dimensions

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -217,6 +217,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-gravityforms.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/google-site-kit/class-googlesitekit.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/google-site-kit/class-googlesitekit-logger.php';
+		include_once NEWSPACK_ABSPATH . 'includes/plugins/google-site-kit/class-ga4-custom-dimensions.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-mailchimp-for-woocommerce.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-onesignal.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-organic-profile-block.php';

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -217,7 +217,6 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-gravityforms.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/google-site-kit/class-googlesitekit.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/google-site-kit/class-googlesitekit-logger.php';
-		include_once NEWSPACK_ABSPATH . 'includes/plugins/google-site-kit/class-googlesitekitanalytics.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/google-site-kit/class-ga4-custom-dimensions.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-mailchimp-for-woocommerce.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-onesignal.php';

--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -217,6 +217,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-gravityforms.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/google-site-kit/class-googlesitekit.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/google-site-kit/class-googlesitekit-logger.php';
+		include_once NEWSPACK_ABSPATH . 'includes/plugins/google-site-kit/class-googlesitekitanalytics.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/google-site-kit/class-ga4-custom-dimensions.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-mailchimp-for-woocommerce.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-onesignal.php';

--- a/includes/cli/class-ga4-dimensions.php
+++ b/includes/cli/class-ga4-dimensions.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * WP-CLI commands for GA4 custom dimension provisioning.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\CLI;
+
+use Newspack\GA4_Custom_Dimensions;
+use WP_CLI;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Provisions Newspack's standard GA4 custom dimensions.
+ */
+class GA4_Dimensions {
+
+	/**
+	 * Provision Newspack's GA4 custom dimensions on the connected property.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--dry-run]
+	 * : Report connection status and available slots without creating anything.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp newspack ga4-dimensions provision
+	 *     wp newspack ga4-dimensions provision --dry-run
+	 *
+	 * @param array $args       Positional args.
+	 * @param array $assoc_args Flags.
+	 */
+	public function provision( $args, $assoc_args ) {
+		$dry_run = ! empty( $assoc_args['dry-run'] );
+
+		if ( $dry_run ) {
+			$status = GA4_Custom_Dimensions::status();
+			if ( is_wp_error( $status ) ) {
+				WP_CLI::error( $status->get_error_message() );
+			}
+			WP_CLI::log( 'GA4 dimension provisioning status:' );
+			WP_CLI::log( sprintf( '  Property ID:               %s', $status['property_id'] ) );
+			WP_CLI::log( sprintf( '  Site Kit connected:        %s', $status['site_kit_connected'] ? 'yes' : 'no' ) );
+			WP_CLI::log( sprintf( '  Event-scoped existing:     %d', $status['event_scoped_existing'] ) );
+			WP_CLI::log( sprintf( '  Newspack dimensions:       %d total, %d present, %d missing', $status['newspack_total'], count( $status['newspack_present'] ), count( $status['newspack_missing'] ) ) );
+			if ( $status['newspack_missing'] ) {
+				WP_CLI::log( '  Missing:                   ' . implode( ', ', $status['newspack_missing'] ) );
+			}
+			return;
+		}
+
+		$result = GA4_Custom_Dimensions::provision();
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+		}
+		WP_CLI::log( sprintf( 'Property ID:      %s', $result['property_id'] ) );
+		WP_CLI::log( sprintf( 'Created:          %d (%s)', count( $result['created'] ), implode( ', ', $result['created'] ) ) );
+		WP_CLI::log( sprintf( 'Already existed:  %d', count( $result['skipped_exists'] ) ) );
+		if ( ! empty( $result['errors'] ) ) {
+			WP_CLI::warning( 'Errors:' );
+			foreach ( $result['errors'] as $name => $message ) {
+				WP_CLI::log( "  $name: $message" );
+			}
+		}
+		WP_CLI::success( 'GA4 dimension provisioning complete.' );
+	}
+}

--- a/includes/cli/class-ga4-dimensions.php
+++ b/includes/cli/class-ga4-dimensions.php
@@ -20,6 +20,13 @@ class GA4_Dimensions {
 	/**
 	 * Provision Newspack's GA4 custom dimensions on the connected property.
 	 *
+	 * Authenticates via Newspack's Google OAuth (preferred – its tokens carry
+	 * the `analytics.edit` scope) and falls back to Google Site Kit. Without an
+	 * explicit `--user`, it authenticates as the Site Kit module owner, so the
+	 * command works unattended from cron; pass `--user=<admin>` to run as a
+	 * specific administrator instead. Exits non-zero if any dimension could not
+	 * be created.
+	 *
 	 * ## OPTIONS
 	 *
 	 * [--dry-run]
@@ -29,6 +36,7 @@ class GA4_Dimensions {
 	 *
 	 *     wp newspack ga4-dimensions provision
 	 *     wp newspack ga4-dimensions provision --dry-run
+	 *     wp --user=admin newspack ga4-dimensions provision
 	 *
 	 * @param array $args       Positional args.
 	 * @param array $assoc_args Flags.
@@ -57,6 +65,7 @@ class GA4_Dimensions {
 		if ( is_wp_error( $result ) ) {
 			WP_CLI::error( $result->get_error_message() );
 		}
+		GA4_Custom_Dimensions::maybe_schedule_recheck();
 		WP_CLI::log( sprintf( 'Property ID:      %s', $result['property_id'] ) );
 		WP_CLI::log( sprintf( 'Auth source:      %s', $result['auth_source'] ?? 'unknown' ) );
 		WP_CLI::log( sprintf( 'Created:          %d (%s)', count( $result['created'] ), implode( ', ', $result['created'] ) ) );
@@ -66,6 +75,7 @@ class GA4_Dimensions {
 			foreach ( $result['errors'] as $name => $message ) {
 				WP_CLI::log( "  $name: $message" );
 			}
+			WP_CLI::error( sprintf( '%d dimension(s) could not be created.', count( $result['errors'] ) ) );
 		}
 		WP_CLI::success( 'GA4 dimension provisioning complete.' );
 	}

--- a/includes/cli/class-ga4-dimensions.php
+++ b/includes/cli/class-ga4-dimensions.php
@@ -44,6 +44,7 @@ class GA4_Dimensions {
 			WP_CLI::log( 'GA4 dimension provisioning status:' );
 			WP_CLI::log( sprintf( '  Property ID:               %s', $status['property_id'] ) );
 			WP_CLI::log( sprintf( '  Site Kit connected:        %s', $status['site_kit_connected'] ? 'yes' : 'no' ) );
+			WP_CLI::log( sprintf( '  Auth source:               %s', $status['auth_source'] ?? 'unknown' ) );
 			WP_CLI::log( sprintf( '  Event-scoped existing:     %d', $status['event_scoped_existing'] ) );
 			WP_CLI::log( sprintf( '  Newspack dimensions:       %d total, %d present, %d missing', $status['newspack_total'], count( $status['newspack_present'] ), count( $status['newspack_missing'] ) ) );
 			if ( $status['newspack_missing'] ) {
@@ -57,6 +58,7 @@ class GA4_Dimensions {
 			WP_CLI::error( $result->get_error_message() );
 		}
 		WP_CLI::log( sprintf( 'Property ID:      %s', $result['property_id'] ) );
+		WP_CLI::log( sprintf( 'Auth source:      %s', $result['auth_source'] ?? 'unknown' ) );
 		WP_CLI::log( sprintf( 'Created:          %d (%s)', count( $result['created'] ), implode( ', ', $result['created'] ) ) );
 		WP_CLI::log( sprintf( 'Already existed:  %d', count( $result['skipped_exists'] ) ) );
 		if ( ! empty( $result['errors'] ) ) {

--- a/includes/cli/class-initializer.php
+++ b/includes/cli/class-initializer.php
@@ -29,6 +29,7 @@ class Initializer {
 		include_once NEWSPACK_ABSPATH . 'includes/cli/class-mailchimp.php';
 		include_once NEWSPACK_ABSPATH . 'includes/cli/class-optional-modules.php';
 		include_once NEWSPACK_ABSPATH . 'includes/cli/class-woocommerce-subscriptions.php';
+		include_once NEWSPACK_ABSPATH . 'includes/cli/class-ga4-dimensions.php';
 	}
 
 	/**
@@ -78,6 +79,7 @@ class Initializer {
 		WP_CLI::add_command( 'newspack migrate-co-authors-guest-authors', [ 'Newspack\CLI\Co_Authors_Plus', 'migrate_guest_authors' ] );
 		WP_CLI::add_command( 'newspack backfill-non-editing-contributors', [ 'Newspack\CLI\Co_Authors_Plus', 'backfill_non_editing_contributor' ] );
 		WP_CLI::add_command( 'newspack migrate-expired-subscriptions', [ 'Newspack\CLI\WooCommerce_Subscriptions', 'migrate_expired_subscriptions' ] );
+		WP_CLI::add_command( 'newspack ga4-dimensions', 'Newspack\CLI\GA4_Dimensions' );
 
 		Optional_Modules::register_commands();
 	}

--- a/includes/oauth/class-google-oauth-ga4-client.php
+++ b/includes/oauth/class-google-oauth-ga4-client.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * GA4 Admin API client backed by Newspack's Google OAuth credentials.
+ *
+ * Mirrors the subset of the GA4 Admin API surface used by
+ * GA4_Custom_Dimensions (list + create custom dimensions), but calls
+ * analyticsadmin.googleapis.com directly with a Bearer token obtained
+ * through Newspack's own OAuth proxy rather than delegating to Site Kit.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Newspack-OAuth-backed GA4 Admin API client.
+ */
+final class Google_OAuth_GA4_Client {
+	const BASE_URL = 'https://analyticsadmin.googleapis.com/v1beta';
+
+	/**
+	 * OAuth access token.
+	 *
+	 * @var string
+	 */
+	private $access_token;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $access_token OAuth access token.
+	 */
+	private function __construct( $access_token ) {
+		$this->access_token = $access_token;
+	}
+
+	/**
+	 * Build a client using Newspack's saved Google OAuth credentials.
+	 *
+	 * Returns null if the OAuth proxy is not configured, no credentials are
+	 * saved, or the token can't be resolved. Callers should treat null as a
+	 * signal to fall back to another auth route.
+	 *
+	 * @return self|null
+	 */
+	public static function build() {
+		if ( ! class_exists( __NAMESPACE__ . '\\Google_OAuth' ) ) {
+			return null;
+		}
+		if ( ! Google_OAuth::is_oauth_configured() ) {
+			return null;
+		}
+		$credentials = Google_OAuth::get_oauth2_credentials();
+		if ( ! $credentials ) {
+			return null;
+		}
+		$token = $credentials->getAccessToken();
+		if ( empty( $token ) ) {
+			return null;
+		}
+		return new self( $token );
+	}
+
+	/**
+	 * List all custom dimensions on a GA4 property.
+	 *
+	 * @param string $property_id GA4 property ID (numeric, no "properties/" prefix).
+	 * @return array<int,array{name:string,parameterName:string,displayName:string,scope:string}>
+	 * @throws \RuntimeException On HTTP or API error.
+	 */
+	public function list_custom_dimensions( $property_id ) {
+		$dimensions = [];
+		$page_token = null;
+		do {
+			$url = self::BASE_URL . '/properties/' . rawurlencode( $property_id ) . '/customDimensions';
+			if ( $page_token ) {
+				$url = add_query_arg( 'pageToken', $page_token, $url );
+			}
+			$body  = $this->request( 'GET', $url );
+			$items = isset( $body['customDimensions'] ) && is_array( $body['customDimensions'] ) ? $body['customDimensions'] : [];
+			foreach ( $items as $dimension ) {
+				$dimensions[] = [
+					'name'          => isset( $dimension['name'] ) ? $dimension['name'] : '',
+					'parameterName' => isset( $dimension['parameterName'] ) ? $dimension['parameterName'] : '',
+					'displayName'   => isset( $dimension['displayName'] ) ? $dimension['displayName'] : '',
+					'scope'         => isset( $dimension['scope'] ) ? $dimension['scope'] : '',
+				];
+			}
+			$page_token = isset( $body['nextPageToken'] ) ? $body['nextPageToken'] : null;
+		} while ( $page_token );
+		return $dimensions;
+	}
+
+	/**
+	 * Create an event-scoped custom dimension on a GA4 property.
+	 *
+	 * @param string $property_id    GA4 property ID.
+	 * @param string $parameter_name Event parameter name.
+	 * @param string $display_name   Display name shown in the GA4 UI.
+	 * @return array Decoded API response.
+	 * @throws \RuntimeException On HTTP or API error.
+	 */
+	public function create_custom_dimension( $property_id, $parameter_name, $display_name ) {
+		$url     = self::BASE_URL . '/properties/' . rawurlencode( $property_id ) . '/customDimensions';
+		$payload = [
+			'parameterName' => $parameter_name,
+			'displayName'   => $display_name,
+			'scope'         => 'EVENT',
+		];
+		return $this->request( 'POST', $url, $payload );
+	}
+
+	/**
+	 * Issue an authenticated request to the Analytics Admin API.
+	 *
+	 * @param string     $method HTTP method.
+	 * @param string     $url    Full URL.
+	 * @param array|null $body   Optional JSON body.
+	 * @return array Decoded response.
+	 * @throws \RuntimeException On HTTP or API error.
+	 */
+	private function request( $method, $url, $body = null ) {
+		$args = [
+			'method'  => $method,
+			'timeout' => 15, // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
+			'headers' => [
+				'Authorization' => 'Bearer ' . $this->access_token,
+				'Accept'        => 'application/json',
+			],
+		];
+		if ( null !== $body ) {
+			$args['headers']['Content-Type'] = 'application/json';
+			$args['body']                    = wp_json_encode( $body );
+		}
+		$response = wp_remote_request( $url, $args );
+		if ( is_wp_error( $response ) ) {
+			throw new \RuntimeException( esc_html( $response->get_error_message() ) );
+		}
+		$code    = wp_remote_retrieve_response_code( $response );
+		$decoded = json_decode( wp_remote_retrieve_body( $response ), true );
+		if ( $code < 200 || $code >= 300 ) {
+			$message = is_array( $decoded ) && isset( $decoded['error']['message'] )
+				? $decoded['error']['message']
+				: 'HTTP ' . $code;
+			throw new \RuntimeException( esc_html( "Analytics Admin API error ($code): $message" ) );
+		}
+		return is_array( $decoded ) ? $decoded : [];
+	}
+}

--- a/includes/oauth/class-google-oauth-ga4-client.php
+++ b/includes/oauth/class-google-oauth-ga4-client.php
@@ -21,6 +21,11 @@ final class Google_OAuth_GA4_Client {
 	const BASE_URL = 'https://analyticsadmin.googleapis.com/v1beta';
 
 	/**
+	 * OAuth scope required to create GA4 custom dimensions via the Admin API.
+	 */
+	const EDIT_SCOPE = 'https://www.googleapis.com/auth/analytics.edit';
+
+	/**
 	 * OAuth access token.
 	 *
 	 * @var string
@@ -61,6 +66,20 @@ final class Google_OAuth_GA4_Client {
 			return null;
 		}
 		return new self( $token );
+	}
+
+	/**
+	 * Whether Newspack's stored Google OAuth token currently carries the
+	 * `analytics.edit` scope. Tokens issued before that scope was added to
+	 * Google_OAuth::REQUIRED_SCOPES, or after a publisher revoked it, will not –
+	 * in which case the Admin API rejects writes with a 403 and callers should
+	 * fall back to another auth route rather than this client.
+	 *
+	 * @return bool
+	 */
+	public static function has_edit_scope() {
+		return class_exists( __NAMESPACE__ . '\\Google_OAuth' )
+			&& Google_OAuth::token_has_scope( self::EDIT_SCOPE );
 	}
 
 	/**

--- a/includes/oauth/class-google-oauth.php
+++ b/includes/oauth/class-google-oauth.php
@@ -368,6 +368,38 @@ class Google_OAuth {
 	}
 
 	/**
+	 * Whether the saved Newspack Google OAuth token currently carries a given scope.
+	 *
+	 * Queries Google's tokeninfo endpoint. Returns false on any failure – no saved
+	 * credentials, network error, or the scope simply being absent – so callers can
+	 * treat a false result as "do not rely on this scope".
+	 *
+	 * @param string $scope Full scope URL, e.g. 'https://www.googleapis.com/auth/analytics.edit'.
+	 * @return bool
+	 */
+	public static function token_has_scope( $scope ) {
+		$credentials = self::get_oauth2_credentials();
+		if ( false === $credentials ) {
+			return false;
+		}
+		$token_info_response = wp_safe_remote_get(
+			add_query_arg(
+				'access_token',
+				$credentials->getAccessToken(),
+				'https://www.googleapis.com/oauth2/v1/tokeninfo'
+			)
+		);
+		if ( 200 !== wp_remote_retrieve_response_code( $token_info_response ) ) {
+			return false;
+		}
+		$token_info = json_decode( wp_remote_retrieve_body( $token_info_response ) );
+		if ( ! isset( $token_info->scope ) ) {
+			return false;
+		}
+		return in_array( $scope, explode( ' ', $token_info->scope ), true );
+	}
+
+	/**
 	 * Authenticated user's basic information.
 	 *
 	 * @return array|WP_Error Basic information, or error.

--- a/includes/plugins/google-site-kit/class-ga4-custom-dimensions.php
+++ b/includes/plugins/google-site-kit/class-ga4-custom-dimensions.php
@@ -1,0 +1,302 @@
+<?php
+/**
+ * Provisions Newspack's standard GA4 custom dimensions on the publisher's
+ * connected GA4 property.
+ *
+ * Delegates API calls to Site Kit's authenticated client via
+ * GoogleSiteKitAnalytics, so the call is made against Site Kit's Google Cloud
+ * project (which already has analyticsadmin.googleapis.com enabled) and uses
+ * Site Kit's stored credentials.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+use Google\Site_Kit\Context;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * GA4 custom dimensions provisioning.
+ */
+final class GA4_Custom_Dimensions {
+
+	const PROVISIONED_OPTION = 'newspack_ga4_dimensions_provisioned';
+	const LOGGER_HEADER      = 'NEWSPACK-GA4-DIMENSIONS';
+	const PROVISION_ACTION   = 'newspack_ga4_provision_dimensions';
+
+	/**
+	 * Register hooks.
+	 */
+	public static function init() {
+		// Re-run provisioning when Site Kit's GA4 property ID is first set or changes.
+		add_action( 'add_option_googlesitekit_analytics-4_settings', [ __CLASS__, 'on_sitekit_settings_added' ], 10, 2 );
+		add_action( 'update_option_googlesitekit_analytics-4_settings', [ __CLASS__, 'on_sitekit_settings_updated' ], 10, 2 );
+		add_action( self::PROVISION_ACTION, [ __CLASS__, 'provision' ] );
+	}
+
+	/**
+	 * Fired when Site Kit's analytics-4 option is first added. Schedules
+	 * provisioning if the new settings include a property ID.
+	 *
+	 * @param string $option Option name.
+	 * @param mixed  $value  New option value.
+	 */
+	public static function on_sitekit_settings_added( $option, $value ) {
+		if ( ! empty( $value['propertyID'] ) ) {
+			self::schedule_provisioning( (string) $value['propertyID'] );
+		}
+	}
+
+	/**
+	 * Fired when Site Kit's analytics-4 option is updated. Schedules
+	 * provisioning if the property ID has just been set or has changed.
+	 *
+	 * @param mixed $old_value Previous option value.
+	 * @param mixed $new_value New option value.
+	 */
+	public static function on_sitekit_settings_updated( $old_value, $new_value ) {
+		$new_property_id = is_array( $new_value ) && ! empty( $new_value['propertyID'] ) ? (string) $new_value['propertyID'] : '';
+		$old_property_id = is_array( $old_value ) && ! empty( $old_value['propertyID'] ) ? (string) $old_value['propertyID'] : '';
+		if ( '' === $new_property_id ) {
+			return;
+		}
+		if ( $old_property_id === $new_property_id ) {
+			return;
+		}
+		self::schedule_provisioning( $new_property_id );
+	}
+
+	/**
+	 * Schedule an immediate single-shot WP-Cron event to run provisioning in
+	 * the background. Skips if the property has already been provisioned.
+	 *
+	 * @param string $property_id The GA4 property ID that will be provisioned.
+	 */
+	private static function schedule_provisioning( $property_id ) {
+		$provisioned = get_option( self::PROVISIONED_OPTION, [] );
+		if (
+			is_array( $provisioned )
+			&& isset( $provisioned['property_id'] )
+			&& (string) $provisioned['property_id'] === $property_id
+		) {
+			return;
+		}
+		if ( wp_next_scheduled( self::PROVISION_ACTION ) ) {
+			return;
+		}
+		wp_schedule_single_event( time() + 10, self::PROVISION_ACTION );
+		Logger::log( "Scheduled GA4 dimension provisioning for property $property_id.", self::LOGGER_HEADER );
+	}
+
+	/**
+	 * Priority-ordered list of custom dimensions Newspack provisions.
+	 * Each entry: parameter name => display name.
+	 */
+	public static function get_dimensions() {
+		return [
+			'gate_post_id'                => 'Gate Post ID',
+			'is_reader'                   => 'Is Reader',
+			'action_type'                 => 'Action Type',
+			'action'                      => 'Action',
+			'logged_in'                   => 'Logged In',
+			'is_subscriber'               => 'Is Subscriber',
+			'is_donor'                    => 'Is Donor',
+			'is_newsletter_subscriber'    => 'Is Newsletter Subscriber',
+			'newspack_popup_id'           => 'Newspack Popup ID',
+			'prompt_placement'            => 'Prompt Placement',
+			'prompt_frequency'            => 'Prompt Frequency',
+			'prompt_title'                => 'Prompt Title',
+			'gate_has_donation_block'     => 'Gate Has Donation Block',
+			'gate_has_registration_block' => 'Gate Has Registration Block',
+			'gate_has_checkout_button'    => 'Gate Has Checkout Button',
+			'gate_has_registration_link'  => 'Gate Has Registration Link',
+			'gate_has_signin_link'        => 'Gate Has Signin Link',
+			'product_id'                  => 'Product ID',
+			'product_type'                => 'Product Type',
+			'recurrence'                  => 'Recurrence',
+			'price'                       => 'Price',
+			'donation_frequency'          => 'Donation Frequency',
+			'donation_amount'             => 'Donation Amount',
+			'registration_method'         => 'Registration Method',
+			'lists'                       => 'Newsletter Lists',
+			'categories'                  => 'Categories',
+			'author'                      => 'Author',
+		];
+	}
+
+	/**
+	 * Read the connected GA4 property ID from Site Kit's stored settings.
+	 *
+	 * @return string|false
+	 */
+	private static function get_property_id() {
+		$settings = get_option( 'googlesitekit_analytics-4_settings', [] );
+		if ( empty( $settings['propertyID'] ) ) {
+			return false;
+		}
+		return (string) $settings['propertyID'];
+	}
+
+	/**
+	 * Instantiate Newspack's Site Kit Analytics module wrapper, ensuring an
+	 * authenticated user context so Site Kit's client can resolve OAuth
+	 * tokens from user meta.
+	 *
+	 * Site Kit stores tokens keyed on user ID (User_Options). In WP-Cron,
+	 * WP-CLI, or anywhere without a logged-in user, `get_current_user_id()`
+	 * returns 0 and Site Kit can't find credentials. We fall back to the
+	 * Analytics module owner stored in Site Kit's own settings.
+	 *
+	 * @return GoogleSiteKitAnalytics|\WP_Error
+	 */
+	private static function get_analytics_module() {
+		if ( ! defined( 'GOOGLESITEKIT_PLUGIN_MAIN_FILE' ) ) {
+			return new \WP_Error( 'newspack_ga4_dimensions', 'Google Site Kit is not active.' );
+		}
+		if ( ! class_exists( __NAMESPACE__ . '\\GoogleSiteKitAnalytics' ) ) {
+			return new \WP_Error( 'newspack_ga4_dimensions', 'GoogleSiteKitAnalytics class not available.' );
+		}
+		if ( ! get_current_user_id() ) {
+			$settings = get_option( 'googlesitekit_analytics-4_settings', [] );
+			$owner_id = isset( $settings['ownerID'] ) ? (int) $settings['ownerID'] : 0;
+			if ( $owner_id > 0 ) {
+				wp_set_current_user( $owner_id );
+			} else {
+				return new \WP_Error( 'newspack_ga4_dimensions', 'No Site Kit module owner found to authenticate as.' );
+			}
+		}
+		return new GoogleSiteKitAnalytics( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
+	}
+
+	/**
+	 * Report the current state without making any changes: whether Site Kit
+	 * and its GA4 property are connected, whether we can list the property's
+	 * existing dimensions, and how many slots remain out of the 50-dim cap.
+	 *
+	 * @return array|\WP_Error
+	 */
+	public static function status() {
+		$property_id = self::get_property_id();
+		if ( ! $property_id ) {
+			return new \WP_Error( 'newspack_ga4_dimensions', 'No GA4 property ID configured in Site Kit.' );
+		}
+		$module = self::get_analytics_module();
+		if ( is_wp_error( $module ) ) {
+			return $module;
+		}
+		try {
+			$existing = $module->list_custom_dimensions( $property_id );
+		} catch ( \Throwable $e ) {
+			return new \WP_Error( 'newspack_ga4_dimensions', 'Failed listing custom dimensions: ' . $e->getMessage() );
+		}
+
+		$event_scoped = [];
+		foreach ( $existing as $dimension ) {
+			if ( isset( $dimension['scope'] ) && 'EVENT' === $dimension['scope'] ) {
+				$event_scoped[] = $dimension['parameterName'];
+			}
+		}
+
+		$desired          = array_keys( self::get_dimensions() );
+		$existing_params  = array_column( $existing, 'parameterName' );
+		$missing          = array_values( array_diff( $desired, $existing_params ) );
+		$already_present  = array_values( array_intersect( $desired, $existing_params ) );
+
+		return [
+			'property_id'           => $property_id,
+			'site_kit_connected'    => true,
+			'event_scoped_existing' => count( $event_scoped ),
+			'newspack_total'        => count( $desired ),
+			'newspack_present'      => $already_present,
+			'newspack_missing'      => $missing,
+			'provisioned_option'    => get_option( self::PROVISIONED_OPTION, null ),
+		];
+	}
+
+	/**
+	 * Provision Newspack's standard GA4 custom dimensions.
+	 *
+	 * Idempotent: existing dimensions are detected and skipped. Creates
+	 * missing dimensions in priority order, stopping if the property's 50
+	 * event-scoped dimension limit would be exceeded.
+	 *
+	 * @return array|\WP_Error Summary of what was created and skipped, or error.
+	 */
+	public static function provision() {
+		$property_id = self::get_property_id();
+		if ( ! $property_id ) {
+			Logger::log( 'No GA4 property ID found; skipping custom dimension provisioning.', self::LOGGER_HEADER );
+			return new \WP_Error( 'newspack_ga4_dimensions', 'No GA4 property ID configured.' );
+		}
+
+		$module = self::get_analytics_module();
+		if ( is_wp_error( $module ) ) {
+			Logger::log( 'Skipping provisioning: ' . $module->get_error_message(), self::LOGGER_HEADER );
+			return $module;
+		}
+
+		try {
+			$existing = $module->list_custom_dimensions( $property_id );
+		} catch ( \Throwable $e ) {
+			Logger::log( 'Failed listing GA4 custom dimensions: ' . $e->getMessage(), self::LOGGER_HEADER );
+			return new \WP_Error( 'newspack_ga4_dimensions', 'Failed listing custom dimensions: ' . $e->getMessage() );
+		}
+
+		$existing_params = [];
+		foreach ( $existing as $dimension ) {
+			if ( isset( $dimension['parameterName'] ) ) {
+				$existing_params[ $dimension['parameterName'] ] = true;
+			}
+		}
+
+		$created        = [];
+		$skipped_exists = [];
+		$errors         = [];
+
+		foreach ( self::get_dimensions() as $parameter_name => $display_name ) {
+			if ( isset( $existing_params[ $parameter_name ] ) ) {
+				$skipped_exists[] = $parameter_name;
+				continue;
+			}
+			try {
+				$module->create_custom_dimension( $property_id, $parameter_name, $display_name );
+				$created[] = $parameter_name;
+				Logger::log( "Created GA4 dimension '$parameter_name' on property $property_id.", self::LOGGER_HEADER );
+			} catch ( \Throwable $e ) {
+				$errors[ $parameter_name ] = $e->getMessage();
+				Logger::log( "Failed to create GA4 dimension '$parameter_name': " . $e->getMessage(), self::LOGGER_HEADER );
+			}
+		}
+
+		$summary = [
+			'property_id'    => $property_id,
+			'timestamp'      => time(),
+			'created'        => $created,
+			'skipped_exists' => $skipped_exists,
+			'errors'         => $errors,
+		];
+
+		$previous = get_option( self::PROVISIONED_OPTION, [] );
+		if ( is_array( $previous ) && isset( $previous['created'] ) && is_array( $previous['created'] ) ) {
+			$summary['created'] = array_values( array_unique( array_merge( $previous['created'], $created ) ) );
+		}
+
+		update_option( self::PROVISIONED_OPTION, $summary );
+
+		Logger::log(
+			sprintf(
+				'GA4 dimension provisioning complete for property %s. Created: %d, existed: %d, errors: %d',
+				$property_id,
+				count( $created ),
+				count( $skipped_exists ),
+				count( $errors )
+			),
+			self::LOGGER_HEADER
+		);
+
+		return $summary;
+	}
+}
+GA4_Custom_Dimensions::init();

--- a/includes/plugins/google-site-kit/class-ga4-custom-dimensions.php
+++ b/includes/plugins/google-site-kit/class-ga4-custom-dimensions.php
@@ -3,10 +3,9 @@
  * Provisions Newspack's standard GA4 custom dimensions on the publisher's
  * connected GA4 property.
  *
- * Delegates API calls to Site Kit's authenticated client via
- * GoogleSiteKitAnalytics, so the call is made against Site Kit's Google Cloud
- * project (which already has analyticsadmin.googleapis.com enabled) and uses
- * Site Kit's stored credentials.
+ * Prefers Newspack's own Google OAuth credentials (which already include
+ * `analytics.edit` for all authenticated users) and falls back to Site Kit's
+ * authenticated client when Newspack OAuth is not configured or fails.
  *
  * @package Newspack
  */
@@ -142,28 +141,30 @@ final class GA4_Custom_Dimensions {
 	}
 
 	/**
-	 * Run a callable within an authenticated-user context so Site Kit's
-	 * client can resolve OAuth tokens from user meta, and restore the
-	 * previous user when done.
+	 * Run a callable with an authenticated GA4 Admin API client.
 	 *
-	 * Site Kit stores tokens keyed on user ID (User_Options). In WP-Cron,
-	 * WP-CLI, or anywhere without a logged-in user, `get_current_user_id()`
-	 * returns 0 and Site Kit can't find credentials. We fall back to the
-	 * Analytics module owner stored in Site Kit's own settings and restore
-	 * the previous user after the callback runs so we don't leak an
-	 * unexpected identity into subsequent operations in the same process.
+	 * Tries Newspack's own Google OAuth first. Its tokens already carry
+	 * `analytics.edit` and the call hits the proxy's GCP project, which has
+	 * the Admin API enabled. If Newspack OAuth is not configured or the
+	 * callback throws/returns a WP_Error, falls back to Site Kit's client
+	 * (which stores tokens keyed on user ID and requires `analytics.edit`
+	 * to have been granted — which many publishers have not done).
 	 *
-	 * @param callable $callback Called with a GoogleSiteKitAnalytics instance.
+	 * Switches the current user to a capable one if none is set (e.g. in
+	 * WP-Cron) so permission checks in `Google_OAuth::get_oauth2_credentials()`
+	 * and Site Kit's `User_Options` can resolve credentials. Restores the
+	 * previous user before returning so we don't leak an unexpected identity
+	 * into subsequent operations in the same process.
+	 *
+	 * The callback is invoked as `$callback( $client, $source )` where
+	 * `$source` is either 'newspack' or 'sitekit'. Both client types expose
+	 * `list_custom_dimensions()` and `create_custom_dimension()` with
+	 * matching signatures.
+	 *
+	 * @param callable $callback Called with `( $client, string $source )`.
 	 * @return mixed|\WP_Error The callback's return value, or WP_Error.
 	 */
-	private static function with_analytics_module( callable $callback ) {
-		if ( ! defined( 'GOOGLESITEKIT_PLUGIN_MAIN_FILE' ) ) {
-			return new \WP_Error( 'newspack_ga4_dimensions', 'Google Site Kit is not active.' );
-		}
-		if ( ! class_exists( __NAMESPACE__ . '\\GoogleSiteKitAnalytics' ) ) {
-			return new \WP_Error( 'newspack_ga4_dimensions', 'GoogleSiteKitAnalytics class not available.' );
-		}
-
+	private static function with_admin_client( callable $callback ) {
 		$previous_user_id = get_current_user_id();
 		$switched_user    = false;
 
@@ -171,15 +172,39 @@ final class GA4_Custom_Dimensions {
 			$settings = get_option( 'googlesitekit_analytics-4_settings', [] );
 			$owner_id = isset( $settings['ownerID'] ) ? (int) $settings['ownerID'] : 0;
 			if ( $owner_id <= 0 ) {
-				return new \WP_Error( 'newspack_ga4_dimensions', 'No Site Kit module owner found to authenticate as.' );
+				return new \WP_Error( 'newspack_ga4_dimensions', 'No user context available to authenticate GA4 Admin API calls.' );
 			}
 			wp_set_current_user( $owner_id );
 			$switched_user = true;
 		}
 
 		try {
+			// Prefer Newspack's own OAuth. Returns null if not configured or
+			// no credentials are saved.
+			$np_client = Google_OAuth_GA4_Client::build();
+			if ( $np_client ) {
+				try {
+					$result = $callback( $np_client, 'newspack' );
+					if ( ! is_wp_error( $result ) ) {
+						return $result;
+					}
+					Logger::log( 'Newspack OAuth path returned WP_Error (' . $result->get_error_message() . '); falling back to Site Kit.', self::LOGGER_HEADER );
+				} catch ( \Throwable $e ) {
+					Logger::log( 'Newspack OAuth path threw (' . $e->getMessage() . '); falling back to Site Kit.', self::LOGGER_HEADER );
+				}
+			} else {
+				Logger::log( 'Newspack OAuth not available; using Site Kit.', self::LOGGER_HEADER );
+			}
+
+			// Fall back to Site Kit.
+			if ( ! defined( 'GOOGLESITEKIT_PLUGIN_MAIN_FILE' ) ) {
+				return new \WP_Error( 'newspack_ga4_dimensions', 'Neither Newspack OAuth nor Google Site Kit is available.' );
+			}
+			if ( ! class_exists( __NAMESPACE__ . '\\GoogleSiteKitAnalytics' ) ) {
+				return new \WP_Error( 'newspack_ga4_dimensions', 'GoogleSiteKitAnalytics class not available.' );
+			}
 			$module = new GoogleSiteKitAnalytics( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
-			return $callback( $module );
+			return $callback( $module, 'sitekit' );
 		} finally {
 			if ( $switched_user ) {
 				wp_set_current_user( $previous_user_id );
@@ -188,9 +213,9 @@ final class GA4_Custom_Dimensions {
 	}
 
 	/**
-	 * Report the current state without making any changes: whether Site Kit
-	 * and its GA4 property are connected, whether we can list the property's
-	 * existing dimensions, and how many slots remain out of the 50-dim cap.
+	 * Report the current state without making any changes: which auth route
+	 * is in use, whether the GA4 property is connected, and how many of our
+	 * standard dimensions are already present.
 	 *
 	 * @return array|\WP_Error
 	 */
@@ -200,10 +225,12 @@ final class GA4_Custom_Dimensions {
 			return new \WP_Error( 'newspack_ga4_dimensions', 'No GA4 property ID configured in Site Kit.' );
 		}
 
-		$existing = self::with_analytics_module(
-			function ( GoogleSiteKitAnalytics $module ) use ( $property_id ) {
+		$used_source = null;
+		$existing    = self::with_admin_client(
+			function ( $client, $source ) use ( $property_id, &$used_source ) {
+				$used_source = $source;
 				try {
-					return $module->list_custom_dimensions( $property_id );
+					return $client->list_custom_dimensions( $property_id );
 				} catch ( \Throwable $e ) {
 					return new \WP_Error( 'newspack_ga4_dimensions', 'Failed listing custom dimensions: ' . $e->getMessage() );
 				}
@@ -227,6 +254,7 @@ final class GA4_Custom_Dimensions {
 
 		return [
 			'property_id'           => $property_id,
+			'auth_source'           => $used_source,
 			'site_kit_connected'    => true,
 			'event_scoped_existing' => count( $event_scoped ),
 			'newspack_total'        => count( $desired ),
@@ -252,10 +280,12 @@ final class GA4_Custom_Dimensions {
 			return new \WP_Error( 'newspack_ga4_dimensions', 'No GA4 property ID configured.' );
 		}
 
-		$result = self::with_analytics_module(
-			function ( GoogleSiteKitAnalytics $module ) use ( $property_id ) {
+		$used_source = null;
+		$result      = self::with_admin_client(
+			function ( $client, $source ) use ( $property_id, &$used_source ) {
+				$used_source = $source;
 				try {
-					$existing = $module->list_custom_dimensions( $property_id );
+					$existing = $client->list_custom_dimensions( $property_id );
 				} catch ( \Throwable $e ) {
 					Logger::log( 'Failed listing GA4 custom dimensions: ' . $e->getMessage(), self::LOGGER_HEADER );
 					return new \WP_Error( 'newspack_ga4_dimensions', 'Failed listing custom dimensions: ' . $e->getMessage() );
@@ -278,7 +308,7 @@ final class GA4_Custom_Dimensions {
 						continue;
 					}
 					try {
-						$module->create_custom_dimension( $property_id, $parameter_name, $display_name );
+						$client->create_custom_dimension( $property_id, $parameter_name, $display_name );
 						$created[] = $parameter_name;
 						Logger::log( "Created GA4 dimension '$parameter_name' on property $property_id.", self::LOGGER_HEADER );
 					} catch ( \Throwable $e ) {
@@ -300,6 +330,7 @@ final class GA4_Custom_Dimensions {
 
 		$summary = [
 			'property_id'    => $property_id,
+			'auth_source'    => $used_source,
 			'timestamp'      => time(),
 			'created'        => $created,
 			'skipped_exists' => $skipped_exists,

--- a/includes/plugins/google-site-kit/class-ga4-custom-dimensions.php
+++ b/includes/plugins/google-site-kit/class-ga4-custom-dimensions.php
@@ -3,9 +3,10 @@
  * Provisions Newspack's standard GA4 custom dimensions on the publisher's
  * connected GA4 property.
  *
- * Prefers Newspack's own Google OAuth credentials (which already include
- * `analytics.edit` for all authenticated users) and falls back to Site Kit's
- * authenticated client when Newspack OAuth is not configured or fails.
+ * Prefers Newspack's own Google OAuth credentials (whose tokens carry the
+ * `analytics.edit` scope) and falls back to Site Kit's authenticated client
+ * when Newspack OAuth is not configured, its token lacks that scope, or a call
+ * through it fails.
  *
  * @package Newspack
  */
@@ -24,6 +25,8 @@ final class GA4_Custom_Dimensions {
 	const PROVISIONED_OPTION = 'newspack_ga4_dimensions_provisioned';
 	const LOGGER_HEADER      = 'NEWSPACK-GA4-DIMENSIONS';
 	const PROVISION_ACTION   = 'newspack_ga4_provision_dimensions';
+	const RECHECK_ACTION     = 'newspack_ga4_recheck_dimensions';
+	const RECHECK_GROUP      = 'newspack';
 
 	/**
 	 * Register hooks.
@@ -33,6 +36,9 @@ final class GA4_Custom_Dimensions {
 		add_action( 'add_option_googlesitekit_analytics-4_settings', [ __CLASS__, 'on_sitekit_settings_added' ], 10, 2 );
 		add_action( 'update_option_googlesitekit_analytics-4_settings', [ __CLASS__, 'on_sitekit_settings_updated' ], 10, 2 );
 		add_action( self::PROVISION_ACTION, [ __CLASS__, 'provision' ] );
+		add_action( self::RECHECK_ACTION, [ __CLASS__, 'provision' ] );
+		// Catch sites that were already connected before this code shipped.
+		add_action( 'admin_init', [ __CLASS__, 'maybe_schedule_recheck' ] );
 	}
 
 	/**
@@ -48,6 +54,7 @@ final class GA4_Custom_Dimensions {
 			return;
 		}
 		self::schedule_provisioning( $property_id );
+		self::maybe_schedule_recheck();
 	}
 
 	/**
@@ -60,18 +67,28 @@ final class GA4_Custom_Dimensions {
 	public static function on_sitekit_settings_updated( $old_value, $new_value ) {
 		$new_property_id = is_array( $new_value ) && ! empty( $new_value['propertyID'] ) ? (string) $new_value['propertyID'] : '';
 		$old_property_id = is_array( $old_value ) && ! empty( $old_value['propertyID'] ) ? (string) $old_value['propertyID'] : '';
-		if ( '' === $new_property_id ) {
-			return;
-		}
 		if ( $old_property_id === $new_property_id ) {
 			return;
 		}
+		if ( '' === $new_property_id ) {
+			// Property disconnected – drop the recurring recheck.
+			self::maybe_schedule_recheck();
+			return;
+		}
 		self::schedule_provisioning( $new_property_id );
+		self::maybe_schedule_recheck();
 	}
 
 	/**
 	 * Schedule an immediate single-shot WP-Cron event to run provisioning in
 	 * the background. Skips if the property has already been provisioned.
+	 *
+	 * The event is keyed only on the action name, not the property. If the
+	 * connected property changes again before a pending event fires, no second
+	 * event is queued; the handler reads the current property at run time, so
+	 * the latest value wins (the intended outcome). Any dimensions partially
+	 * created against a superseded property are simply left in place – harmless,
+	 * they just won't show up in the summary for the new property.
 	 *
 	 * @param string $property_id The GA4 property ID that will be provisioned.
 	 */
@@ -89,6 +106,33 @@ final class GA4_Custom_Dimensions {
 		}
 		wp_schedule_single_event( time() + 10, self::PROVISION_ACTION );
 		Logger::log( "Scheduled GA4 dimension provisioning for property $property_id.", self::LOGGER_HEADER );
+	}
+
+	/**
+	 * Keep a recurring monthly recheck scheduled while a GA4 property is
+	 * connected, and drop it when none is. The recheck re-runs provisioning so
+	 * additions to Newspack's dimension list, or dimensions deleted in GA4,
+	 * self-heal without a manual CLI run. When everything is already in place it
+	 * is a no-op: one list call, zero writes.
+	 *
+	 * Idempotent and safe to call repeatedly (e.g. on every admin page load).
+	 */
+	public static function maybe_schedule_recheck() {
+		if ( ! function_exists( 'as_schedule_recurring_action' ) || ! function_exists( 'as_has_scheduled_action' ) ) {
+			return;
+		}
+		$is_scheduled = as_has_scheduled_action( self::RECHECK_ACTION, [], self::RECHECK_GROUP );
+		if ( ! self::get_property_id() ) {
+			if ( $is_scheduled && function_exists( 'as_unschedule_all_actions' ) ) {
+				as_unschedule_all_actions( self::RECHECK_ACTION, [], self::RECHECK_GROUP );
+			}
+			return;
+		}
+		if ( $is_scheduled ) {
+			return;
+		}
+		as_schedule_recurring_action( time() + MONTH_IN_SECONDS, MONTH_IN_SECONDS, self::RECHECK_ACTION, [], self::RECHECK_GROUP );
+		Logger::log( 'Scheduled monthly GA4 dimension recheck.', self::LOGGER_HEADER );
 	}
 
 	/**
@@ -161,6 +205,11 @@ final class GA4_Custom_Dimensions {
 	 * `list_custom_dimensions()` and `create_custom_dimension()` with
 	 * matching signatures.
 	 *
+	 * If every route fails, the returned WP_Error names each route that was
+	 * tried and why it failed, so a 403 on writes (the common "publisher never
+	 * granted analytics.edit to Site Kit" case) is self-explanatory rather than
+	 * buried in the log.
+	 *
 	 * @param callable $callback Called with `( $client, string $source )`.
 	 * @return mixed|\WP_Error The callback's return value, or WP_Error.
 	 */
@@ -178,38 +227,70 @@ final class GA4_Custom_Dimensions {
 			$switched_user = true;
 		}
 
+		// Route name => why it was skipped or failed, used to compose the error
+		// if nothing works.
+		$attempts = [];
+
 		try {
-			// Prefer Newspack's own OAuth. Returns null if not configured or
-			// no credentials are saved.
+			// Prefer Newspack's own OAuth. Returns null if not configured or no
+			// credentials are saved; skip it outright if its token predates the
+			// analytics.edit scope, since writes would just 403.
 			$np_client = Google_OAuth_GA4_Client::build();
-			if ( $np_client ) {
+			if ( ! $np_client ) {
+				$attempts['Newspack OAuth'] = 'not configured';
+				Logger::log( 'Newspack OAuth not available; trying Site Kit.', self::LOGGER_HEADER );
+			} elseif ( ! Google_OAuth_GA4_Client::has_edit_scope() ) {
+				$attempts['Newspack OAuth'] = 'stored token lacks the analytics.edit scope (reconnect Google in the Newspack settings to grant it)';
+				Logger::log( 'Newspack OAuth token lacks analytics.edit; trying Site Kit.', self::LOGGER_HEADER );
+			} else {
 				try {
 					$result = $callback( $np_client, 'newspack' );
 					if ( ! is_wp_error( $result ) ) {
 						return $result;
 					}
-					Logger::log( 'Newspack OAuth path returned WP_Error (' . $result->get_error_message() . '); falling back to Site Kit.', self::LOGGER_HEADER );
+					$attempts['Newspack OAuth'] = $result->get_error_message();
 				} catch ( \Throwable $e ) {
-					Logger::log( 'Newspack OAuth path threw (' . $e->getMessage() . '); falling back to Site Kit.', self::LOGGER_HEADER );
+					$attempts['Newspack OAuth'] = $e->getMessage();
 				}
-			} else {
-				Logger::log( 'Newspack OAuth not available; using Site Kit.', self::LOGGER_HEADER );
+				Logger::log( 'Newspack OAuth path failed (' . $attempts['Newspack OAuth'] . '); trying Site Kit.', self::LOGGER_HEADER );
 			}
 
 			// Fall back to Site Kit.
-			if ( ! defined( 'GOOGLESITEKIT_PLUGIN_MAIN_FILE' ) ) {
-				return new \WP_Error( 'newspack_ga4_dimensions', 'Neither Newspack OAuth nor Google Site Kit is available.' );
+			if ( ! defined( 'GOOGLESITEKIT_PLUGIN_MAIN_FILE' ) || ! class_exists( __NAMESPACE__ . '\\GoogleSiteKitAnalytics' ) ) {
+				$attempts['Site Kit'] = 'not available';
+				return new \WP_Error( 'newspack_ga4_dimensions', self::describe_auth_failure( $attempts ) );
 			}
-			if ( ! class_exists( __NAMESPACE__ . '\\GoogleSiteKitAnalytics' ) ) {
-				return new \WP_Error( 'newspack_ga4_dimensions', 'GoogleSiteKitAnalytics class not available.' );
+			try {
+				$module = new GoogleSiteKitAnalytics( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
+				$result = $callback( $module, 'sitekit' );
+				if ( ! is_wp_error( $result ) ) {
+					return $result;
+				}
+				$attempts['Site Kit'] = $result->get_error_message();
+			} catch ( \Throwable $e ) {
+				$attempts['Site Kit'] = $e->getMessage();
 			}
-			$module = new GoogleSiteKitAnalytics( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
-			return $callback( $module, 'sitekit' );
+			return new \WP_Error( 'newspack_ga4_dimensions', self::describe_auth_failure( $attempts ) );
 		} finally {
 			if ( $switched_user ) {
 				wp_set_current_user( $previous_user_id );
 			}
 		}
+	}
+
+	/**
+	 * Compose a human-readable failure message from a map of auth route =>
+	 * failure reason.
+	 *
+	 * @param array<string,string> $attempts Route name => reason.
+	 * @return string
+	 */
+	private static function describe_auth_failure( array $attempts ) {
+		$parts = [];
+		foreach ( $attempts as $route => $reason ) {
+			$parts[] = "$route – $reason";
+		}
+		return 'Could not reach the GA4 Admin API. Tried: ' . implode( '; ', $parts ) . '.';
 	}
 
 	/**
@@ -271,9 +352,21 @@ final class GA4_Custom_Dimensions {
 	 * parameter name and skipped. Per-dimension create failures are logged
 	 * and recorded in the summary but do not abort the run.
 	 *
+	 * Cron and Action Scheduler run handlers synchronously inside a request
+	 * whose time limit is often 30–60s, while creating ~27 dimensions each
+	 * behind a 15s HTTP timeout can run longer in a pathological case. We lift
+	 * the limit where the host allows it (CLI already runs unlimited). On hosts
+	 * that disable `set_time_limit`, a very slow run may still be cut short
+	 * before the summary is written; that's safe – the next scheduled run lists
+	 * what already exists and only creates the remainder.
+	 *
 	 * @return array|\WP_Error Summary of what was created and skipped, or error.
 	 */
 	public static function provision() {
+		if ( function_exists( 'set_time_limit' ) ) {
+			set_time_limit( 0 );
+		}
+
 		$property_id = self::get_property_id();
 		if ( ! $property_id ) {
 			Logger::log( 'No GA4 property ID found; skipping custom dimension provisioning.', self::LOGGER_HEADER );
@@ -349,7 +442,7 @@ final class GA4_Custom_Dimensions {
 			$summary['created'] = array_values( array_unique( array_merge( $previous['created'], $created ) ) );
 		}
 
-		update_option( self::PROVISIONED_OPTION, $summary );
+		update_option( self::PROVISIONED_OPTION, $summary, false );
 
 		Logger::log(
 			sprintf(

--- a/includes/plugins/google-site-kit/class-ga4-custom-dimensions.php
+++ b/includes/plugins/google-site-kit/class-ga4-custom-dimensions.php
@@ -44,9 +44,11 @@ final class GA4_Custom_Dimensions {
 	 * @param mixed  $value  New option value.
 	 */
 	public static function on_sitekit_settings_added( $option, $value ) {
-		if ( ! empty( $value['propertyID'] ) ) {
-			self::schedule_provisioning( (string) $value['propertyID'] );
+		$property_id = is_array( $value ) && ! empty( $value['propertyID'] ) ? (string) $value['propertyID'] : '';
+		if ( '' === $property_id ) {
+			return;
 		}
+		self::schedule_provisioning( $property_id );
 	}
 
 	/**
@@ -140,34 +142,49 @@ final class GA4_Custom_Dimensions {
 	}
 
 	/**
-	 * Instantiate Newspack's Site Kit Analytics module wrapper, ensuring an
-	 * authenticated user context so Site Kit's client can resolve OAuth
-	 * tokens from user meta.
+	 * Run a callable within an authenticated-user context so Site Kit's
+	 * client can resolve OAuth tokens from user meta, and restore the
+	 * previous user when done.
 	 *
 	 * Site Kit stores tokens keyed on user ID (User_Options). In WP-Cron,
 	 * WP-CLI, or anywhere without a logged-in user, `get_current_user_id()`
 	 * returns 0 and Site Kit can't find credentials. We fall back to the
-	 * Analytics module owner stored in Site Kit's own settings.
+	 * Analytics module owner stored in Site Kit's own settings and restore
+	 * the previous user after the callback runs so we don't leak an
+	 * unexpected identity into subsequent operations in the same process.
 	 *
-	 * @return GoogleSiteKitAnalytics|\WP_Error
+	 * @param callable $callback Called with a GoogleSiteKitAnalytics instance.
+	 * @return mixed|\WP_Error The callback's return value, or WP_Error.
 	 */
-	private static function get_analytics_module() {
+	private static function with_analytics_module( callable $callback ) {
 		if ( ! defined( 'GOOGLESITEKIT_PLUGIN_MAIN_FILE' ) ) {
 			return new \WP_Error( 'newspack_ga4_dimensions', 'Google Site Kit is not active.' );
 		}
 		if ( ! class_exists( __NAMESPACE__ . '\\GoogleSiteKitAnalytics' ) ) {
 			return new \WP_Error( 'newspack_ga4_dimensions', 'GoogleSiteKitAnalytics class not available.' );
 		}
-		if ( ! get_current_user_id() ) {
+
+		$previous_user_id = get_current_user_id();
+		$switched_user    = false;
+
+		if ( ! $previous_user_id ) {
 			$settings = get_option( 'googlesitekit_analytics-4_settings', [] );
 			$owner_id = isset( $settings['ownerID'] ) ? (int) $settings['ownerID'] : 0;
-			if ( $owner_id > 0 ) {
-				wp_set_current_user( $owner_id );
-			} else {
+			if ( $owner_id <= 0 ) {
 				return new \WP_Error( 'newspack_ga4_dimensions', 'No Site Kit module owner found to authenticate as.' );
 			}
+			wp_set_current_user( $owner_id );
+			$switched_user = true;
 		}
-		return new GoogleSiteKitAnalytics( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
+
+		try {
+			$module = new GoogleSiteKitAnalytics( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
+			return $callback( $module );
+		} finally {
+			if ( $switched_user ) {
+				wp_set_current_user( $previous_user_id );
+			}
+		}
 	}
 
 	/**
@@ -182,14 +199,18 @@ final class GA4_Custom_Dimensions {
 		if ( ! $property_id ) {
 			return new \WP_Error( 'newspack_ga4_dimensions', 'No GA4 property ID configured in Site Kit.' );
 		}
-		$module = self::get_analytics_module();
-		if ( is_wp_error( $module ) ) {
-			return $module;
-		}
-		try {
-			$existing = $module->list_custom_dimensions( $property_id );
-		} catch ( \Throwable $e ) {
-			return new \WP_Error( 'newspack_ga4_dimensions', 'Failed listing custom dimensions: ' . $e->getMessage() );
+
+		$existing = self::with_analytics_module(
+			function ( GoogleSiteKitAnalytics $module ) use ( $property_id ) {
+				try {
+					return $module->list_custom_dimensions( $property_id );
+				} catch ( \Throwable $e ) {
+					return new \WP_Error( 'newspack_ga4_dimensions', 'Failed listing custom dimensions: ' . $e->getMessage() );
+				}
+			}
+		);
+		if ( is_wp_error( $existing ) ) {
+			return $existing;
 		}
 
 		$event_scoped = [];
@@ -218,9 +239,9 @@ final class GA4_Custom_Dimensions {
 	/**
 	 * Provision Newspack's standard GA4 custom dimensions.
 	 *
-	 * Idempotent: existing dimensions are detected and skipped. Creates
-	 * missing dimensions in priority order, stopping if the property's 50
-	 * event-scoped dimension limit would be exceeded.
+	 * Idempotent: existing dimensions on the property are detected by
+	 * parameter name and skipped. Per-dimension create failures are logged
+	 * and recorded in the summary but do not abort the run.
 	 *
 	 * @return array|\WP_Error Summary of what was created and skipped, or error.
 	 */
@@ -231,44 +252,51 @@ final class GA4_Custom_Dimensions {
 			return new \WP_Error( 'newspack_ga4_dimensions', 'No GA4 property ID configured.' );
 		}
 
-		$module = self::get_analytics_module();
-		if ( is_wp_error( $module ) ) {
-			Logger::log( 'Skipping provisioning: ' . $module->get_error_message(), self::LOGGER_HEADER );
-			return $module;
-		}
+		$result = self::with_analytics_module(
+			function ( GoogleSiteKitAnalytics $module ) use ( $property_id ) {
+				try {
+					$existing = $module->list_custom_dimensions( $property_id );
+				} catch ( \Throwable $e ) {
+					Logger::log( 'Failed listing GA4 custom dimensions: ' . $e->getMessage(), self::LOGGER_HEADER );
+					return new \WP_Error( 'newspack_ga4_dimensions', 'Failed listing custom dimensions: ' . $e->getMessage() );
+				}
 
-		try {
-			$existing = $module->list_custom_dimensions( $property_id );
-		} catch ( \Throwable $e ) {
-			Logger::log( 'Failed listing GA4 custom dimensions: ' . $e->getMessage(), self::LOGGER_HEADER );
-			return new \WP_Error( 'newspack_ga4_dimensions', 'Failed listing custom dimensions: ' . $e->getMessage() );
-		}
+				$existing_params = [];
+				foreach ( $existing as $dimension ) {
+					if ( isset( $dimension['parameterName'] ) ) {
+						$existing_params[ $dimension['parameterName'] ] = true;
+					}
+				}
 
-		$existing_params = [];
-		foreach ( $existing as $dimension ) {
-			if ( isset( $dimension['parameterName'] ) ) {
-				$existing_params[ $dimension['parameterName'] ] = true;
+				$created        = [];
+				$skipped_exists = [];
+				$errors         = [];
+
+				foreach ( self::get_dimensions() as $parameter_name => $display_name ) {
+					if ( isset( $existing_params[ $parameter_name ] ) ) {
+						$skipped_exists[] = $parameter_name;
+						continue;
+					}
+					try {
+						$module->create_custom_dimension( $property_id, $parameter_name, $display_name );
+						$created[] = $parameter_name;
+						Logger::log( "Created GA4 dimension '$parameter_name' on property $property_id.", self::LOGGER_HEADER );
+					} catch ( \Throwable $e ) {
+						$errors[ $parameter_name ] = $e->getMessage();
+						Logger::log( "Failed to create GA4 dimension '$parameter_name': " . $e->getMessage(), self::LOGGER_HEADER );
+					}
+				}
+
+				return [ $created, $skipped_exists, $errors ];
 			}
+		);
+
+		if ( is_wp_error( $result ) ) {
+			Logger::log( 'Skipping provisioning: ' . $result->get_error_message(), self::LOGGER_HEADER );
+			return $result;
 		}
 
-		$created        = [];
-		$skipped_exists = [];
-		$errors         = [];
-
-		foreach ( self::get_dimensions() as $parameter_name => $display_name ) {
-			if ( isset( $existing_params[ $parameter_name ] ) ) {
-				$skipped_exists[] = $parameter_name;
-				continue;
-			}
-			try {
-				$module->create_custom_dimension( $property_id, $parameter_name, $display_name );
-				$created[] = $parameter_name;
-				Logger::log( "Created GA4 dimension '$parameter_name' on property $property_id.", self::LOGGER_HEADER );
-			} catch ( \Throwable $e ) {
-				$errors[ $parameter_name ] = $e->getMessage();
-				Logger::log( "Failed to create GA4 dimension '$parameter_name': " . $e->getMessage(), self::LOGGER_HEADER );
-			}
-		}
+		list( $created, $skipped_exists, $errors ) = $result;
 
 		$summary = [
 			'property_id'    => $property_id,
@@ -278,8 +306,15 @@ final class GA4_Custom_Dimensions {
 			'errors'         => $errors,
 		];
 
+		// Merge created lists across runs only when the previous run targeted
+		// the same property, so a property switch starts fresh.
 		$previous = get_option( self::PROVISIONED_OPTION, [] );
-		if ( is_array( $previous ) && isset( $previous['created'] ) && is_array( $previous['created'] ) ) {
+		if (
+			is_array( $previous )
+			&& isset( $previous['property_id'], $previous['created'] )
+			&& (string) $previous['property_id'] === $property_id
+			&& is_array( $previous['created'] )
+		) {
 			$summary['created'] = array_values( array_unique( array_merge( $previous['created'], $created ) ) );
 		}
 

--- a/includes/plugins/google-site-kit/class-googlesitekitanalytics.php
+++ b/includes/plugins/google-site-kit/class-googlesitekitanalytics.php
@@ -104,10 +104,10 @@ class GoogleSiteKitAnalytics extends Module {
 			$items    = isset( $response['customDimensions'] ) && is_array( $response['customDimensions'] ) ? $response['customDimensions'] : [];
 			foreach ( $items as $dimension ) {
 				$dimensions[] = [
-					'name'          => $dimension['name'],
-					'parameterName' => $dimension['parameterName'],
-					'displayName'   => $dimension['displayName'],
-					'scope'         => $dimension['scope'],
+					'name'          => isset( $dimension['name'] ) ? $dimension['name'] : '',
+					'parameterName' => isset( $dimension['parameterName'] ) ? $dimension['parameterName'] : '',
+					'displayName'   => isset( $dimension['displayName'] ) ? $dimension['displayName'] : '',
+					'scope'         => isset( $dimension['scope'] ) ? $dimension['scope'] : '',
 				];
 			}
 			$page_token = isset( $response['nextPageToken'] ) ? $response['nextPageToken'] : null;

--- a/includes/plugins/google-site-kit/class-googlesitekitanalytics.php
+++ b/includes/plugins/google-site-kit/class-googlesitekitanalytics.php
@@ -101,7 +101,8 @@ class GoogleSiteKitAnalytics extends Module {
 			$response = $analyticsadmin
 				->properties_customDimensions // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 				->listPropertiesCustomDimensions( 'properties/' . $property_id, $params );
-			foreach ( $response['customDimensions'] as $dimension ) {
+			$items    = isset( $response['customDimensions'] ) && is_array( $response['customDimensions'] ) ? $response['customDimensions'] : [];
+			foreach ( $items as $dimension ) {
 				$dimensions[] = [
 					'name'          => $dimension['name'],
 					'parameterName' => $dimension['parameterName'],

--- a/includes/plugins/google-site-kit/class-googlesitekitanalytics.php
+++ b/includes/plugins/google-site-kit/class-googlesitekitanalytics.php
@@ -13,6 +13,7 @@ use Google\Site_Kit\Modules\Analytics_4\Settings;
 use Google\Site_Kit\Core\Modules\Module;
 use Google\Site_Kit\Core\Authentication\Clients\Google_Site_Kit_Client;
 use Google\Site_Kit_Dependencies\Google\Service\GoogleAnalyticsAdmin as Google_Service_GoogleAnalyticsAdmin;
+use Google\Site_Kit_Dependencies\Google\Service\GoogleAnalyticsAdmin\GoogleAnalyticsAdminV1betaCustomDimension;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -80,5 +81,54 @@ class GoogleSiteKitAnalytics extends Module {
 			'webDataStreamID' => $webstreamdata_id,
 			'measurementID'   => $datastream['webStreamData']['measurementId'],
 		];
+	}
+
+	/**
+	 * List custom dimensions for a GA4 property.
+	 *
+	 * @param string $property_id GA4 property ID.
+	 * @return array List of custom dimension objects (each with parameterName, displayName, scope, name).
+	 */
+	public function list_custom_dimensions( $property_id ) {
+		$analyticsadmin = $this->get_service( 'analyticsadmin' );
+		$dimensions     = [];
+		$page_token     = null;
+		do {
+			$params = [];
+			if ( $page_token ) {
+				$params['pageToken'] = $page_token;
+			}
+			$response = $analyticsadmin
+				->properties_customDimensions // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+				->listPropertiesCustomDimensions( 'properties/' . $property_id, $params );
+			foreach ( $response['customDimensions'] as $dimension ) {
+				$dimensions[] = [
+					'name'          => $dimension['name'],
+					'parameterName' => $dimension['parameterName'],
+					'displayName'   => $dimension['displayName'],
+					'scope'         => $dimension['scope'],
+				];
+			}
+			$page_token = isset( $response['nextPageToken'] ) ? $response['nextPageToken'] : null;
+		} while ( $page_token );
+		return $dimensions;
+	}
+
+	/**
+	 * Create an event-scoped custom dimension on a GA4 property.
+	 *
+	 * @param string $property_id    GA4 property ID.
+	 * @param string $parameter_name Event parameter name.
+	 * @param string $display_name   Display name shown in GA4 UI.
+	 */
+	public function create_custom_dimension( $property_id, $parameter_name, $display_name ) {
+		$analyticsadmin = $this->get_service( 'analyticsadmin' );
+		$dimension      = new GoogleAnalyticsAdminV1betaCustomDimension();
+		$dimension->setParameterName( $parameter_name );
+		$dimension->setDisplayName( $display_name );
+		$dimension->setScope( 'EVENT' );
+		return $analyticsadmin
+			->properties_customDimensions // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			->create( 'properties/' . $property_id, $dimension );
 	}
 }

--- a/tests/unit-tests/ga4-custom-dimensions.php
+++ b/tests/unit-tests/ga4-custom-dimensions.php
@@ -1,0 +1,524 @@
+<?php
+/**
+ * Tests for GA4 custom dimension provisioning.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\GA4_Custom_Dimensions;
+use Newspack\Google_OAuth_GA4_Client;
+
+/**
+ * GA4 custom dimensions provisioning.
+ *
+ * Mocks the GA4 Admin API at the HTTP layer (via `pre_http_request`) so the
+ * provisioner's branching – auth-route selection, idempotency, the
+ * property-switch summary merge – is exercised without a real Google project.
+ *
+ * @group ga4-dimensions
+ */
+class Newspack_Test_GA4_Custom_Dimensions extends WP_UnitTestCase {
+
+	const SK_SETTINGS_OPTION = 'googlesitekit_analytics-4_settings';
+
+	/**
+	 * Recorded HTTP requests, each `[ 'url' => string, 'method' => string, 'body' => string|null ]`.
+	 *
+	 * @var array
+	 */
+	private $http_log = [];
+
+	/**
+	 * URL-substring => response array (as returned to `pre_http_request`) or `callable( $url, $args )`.
+	 *
+	 * @var array
+	 */
+	private $http_routes = [];
+
+	/**
+	 * Administrator user id used as the Site Kit module owner.
+	 *
+	 * @var int
+	 */
+	private $owner_id;
+
+	/**
+	 * Set up fixtures.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->owner_id    = $this->factory()->user->create( [ 'role' => 'administrator' ] );
+		$this->http_log    = [];
+		$this->http_routes = [];
+		add_filter( 'pre_http_request', [ $this, 'mock_http' ], 10, 3 );
+
+		delete_option( GA4_Custom_Dimensions::PROVISIONED_OPTION );
+		delete_option( self::SK_SETTINGS_OPTION );
+		wp_clear_scheduled_hook( GA4_Custom_Dimensions::PROVISION_ACTION );
+
+		// The OAuth proxy constants persist across tests; define them once. The
+		// API-key option is what governs whether OAuth counts as configured.
+		if ( ! defined( 'NEWSPACK_MANAGER_API_KEY_OPTION_NAME' ) ) {
+			define( 'NEWSPACK_MANAGER_API_KEY_OPTION_NAME', 'newspack_manager_api_key' );
+		}
+		if ( ! defined( 'NEWSPACK_GOOGLE_OAUTH_PROXY' ) ) {
+			define( 'NEWSPACK_GOOGLE_OAUTH_PROXY', 'https://oauth.example.test' );
+		}
+		delete_option( NEWSPACK_MANAGER_API_KEY_OPTION_NAME );
+		delete_option( '_newspack_google_oauth' );
+	}
+
+	/**
+	 * Tear down fixtures.
+	 */
+	public function tear_down() {
+		remove_filter( 'pre_http_request', [ $this, 'mock_http' ], 10 );
+		parent::tear_down();
+	}
+
+	/**
+	 * `pre_http_request` handler: records the request and returns the first
+	 * registered route whose substring matches the URL, or a 404 otherwise so a
+	 * missing mock is obvious.
+	 *
+	 * @param mixed  $pre  Short-circuit value.
+	 * @param array  $args Request args.
+	 * @param string $url  Request URL.
+	 * @return array|WP_Error
+	 */
+	public function mock_http( $pre, $args, $url ) {
+		$method           = isset( $args['method'] ) ? strtoupper( $args['method'] ) : 'GET';
+		$this->http_log[] = [
+			'url'    => $url,
+			'method' => $method,
+			'body'   => isset( $args['body'] ) ? $args['body'] : null,
+		];
+		foreach ( $this->http_routes as $needle => $response ) {
+			if ( false !== strpos( $url, $needle ) ) {
+				return is_callable( $response ) ? call_user_func( $response, $url, $args ) : $response;
+			}
+		}
+		return $this->json_response( 404, [ 'error' => [ 'message' => "Unmocked request to $url" ] ] );
+	}
+
+	/**
+	 * Build an HTTP response array for `pre_http_request`.
+	 *
+	 * @param int   $code HTTP status code.
+	 * @param array $body Response body, JSON-encoded.
+	 * @return array
+	 */
+	private function json_response( $code, array $body ) {
+		return [
+			'response' => [
+				'code'    => $code,
+				'message' => '',
+			],
+			'body'     => wp_json_encode( $body ),
+			'headers'  => [],
+			'cookies'  => [],
+		];
+	}
+
+	/**
+	 * Count recorded requests whose URL contains $needle, optionally filtered by method.
+	 *
+	 * @param string      $needle URL substring.
+	 * @param string|null $method HTTP method, or null for any.
+	 * @return int
+	 */
+	private function count_requests( $needle, $method = null ) {
+		$count = 0;
+		foreach ( $this->http_log as $request ) {
+			if ( false === strpos( $request['url'], $needle ) ) {
+				continue;
+			}
+			if ( null !== $method && strtoupper( $method ) !== $request['method'] ) {
+				continue;
+			}
+			++$count;
+		}
+		return $count;
+	}
+
+	/**
+	 * Make Newspack's Google OAuth count as configured, with a stored token
+	 * whose scope set may or may not include `analytics.edit`.
+	 *
+	 * @param bool $with_edit_scope Whether the token carries `analytics.edit`.
+	 */
+	private function configure_newspack_oauth( $with_edit_scope = true ) {
+		update_option( NEWSPACK_MANAGER_API_KEY_OPTION_NAME, 'test-key' );
+		update_option(
+			'_newspack_google_oauth',
+			[
+				'access_token'  => 'fake-access-token',
+				'expires_at'    => time() + HOUR_IN_SECONDS,
+				'refresh_token' => 'fake-refresh-token',
+			]
+		);
+		$scopes = 'https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/analytics';
+		if ( $with_edit_scope ) {
+			$scopes .= ' https://www.googleapis.com/auth/analytics.edit';
+		}
+		$this->http_routes['oauth2/v1/tokeninfo'] = $this->json_response(
+			200,
+			[
+				'scope' => $scopes,
+				'email' => 'owner@example.test',
+			]
+		);
+	}
+
+	/**
+	 * Record a connected GA4 property (and module owner) in Site Kit's settings.
+	 *
+	 * @param string $property_id GA4 property ID.
+	 */
+	private function connect_property( $property_id ) {
+		update_option(
+			self::SK_SETTINGS_OPTION,
+			[
+				'propertyID' => $property_id,
+				'ownerID'    => $this->owner_id,
+			]
+		);
+	}
+
+	/**
+	 * Mock the GA4 Admin API `customDimensions` endpoint for a property: GET
+	 * lists $existing_param_names (all EVENT-scoped); POST records and accepts
+	 * the create unless $create_status is a non-2xx code.
+	 *
+	 * @param string $property_id          GA4 property ID.
+	 * @param array  $existing_param_names  Parameter names already present.
+	 * @param int    $create_status         HTTP status to return from create POSTs.
+	 */
+	private function mock_admin_api( $property_id, array $existing_param_names, $create_status = 200 ) {
+		$existing = array_map(
+			function ( $name ) use ( $property_id ) {
+				return [
+					'name'          => "properties/$property_id/customDimensions/$name",
+					'parameterName' => $name,
+					'displayName'   => ucfirst( $name ),
+					'scope'         => 'EVENT',
+				];
+			},
+			$existing_param_names
+		);
+		$this->http_routes[ "properties/$property_id/customDimensions" ] = function ( $url, $args ) use ( $existing, $create_status ) {
+			$method = isset( $args['method'] ) ? strtoupper( $args['method'] ) : 'GET';
+			if ( 'POST' === $method ) {
+				if ( $create_status < 200 || $create_status >= 300 ) {
+					return $this->json_response( $create_status, [ 'error' => [ 'message' => 'Request had insufficient authentication scopes.' ] ] );
+				}
+				$payload = json_decode( $args['body'], true );
+				return $this->json_response(
+					200,
+					[
+						'name'          => 'properties/x/customDimensions/y',
+						'parameterName' => $payload['parameterName'],
+						'scope'         => 'EVENT',
+					]
+				);
+			}
+			return $this->json_response( 200, [ 'customDimensions' => $existing ] );
+		};
+	}
+
+	/**
+	 * The provisioned dimension list must fit within GA4's event-scoped cap.
+	 */
+	public function test_dimension_list_fits_event_scoped_cap() {
+		$dimensions = GA4_Custom_Dimensions::get_dimensions();
+		$this->assertLessThanOrEqual( 50, count( $dimensions ), 'Provisioned dimension count must not exceed GA4\'s 50 event-scoped cap.' );
+		foreach ( $dimensions as $parameter_name => $display_name ) {
+			$this->assertNotEmpty( $parameter_name, 'Each dimension must have a non-empty parameter name.' );
+			$this->assertNotEmpty( $display_name, 'Each dimension must have a non-empty display name.' );
+		}
+	}
+
+	/**
+	 * Connecting / changing the GA4 property schedules background provisioning,
+	 * and the scheduler de-duplicates redundant requests.
+	 */
+	public function test_schedule_provisioning_is_deduplicated() {
+		// A newly connected property schedules provisioning.
+		GA4_Custom_Dimensions::on_sitekit_settings_added( self::SK_SETTINGS_OPTION, [ 'propertyID' => 'P1' ] );
+		$scheduled = wp_next_scheduled( GA4_Custom_Dimensions::PROVISION_ACTION );
+		$this->assertNotFalse( $scheduled, 'Connecting a property schedules provisioning.' );
+
+		// A second add for the same property does not queue a second event.
+		GA4_Custom_Dimensions::on_sitekit_settings_added( self::SK_SETTINGS_OPTION, [ 'propertyID' => 'P1' ] );
+		$this->assertSame( $scheduled, wp_next_scheduled( GA4_Custom_Dimensions::PROVISION_ACTION ), 'A second add does not queue a duplicate event.' );
+
+		// A property already recorded as provisioned, with nothing pending, is not rescheduled.
+		wp_clear_scheduled_hook( GA4_Custom_Dimensions::PROVISION_ACTION );
+		update_option(
+			GA4_Custom_Dimensions::PROVISIONED_OPTION,
+			[
+				'property_id' => 'P1',
+				'created'     => [],
+			]
+		);
+		GA4_Custom_Dimensions::on_sitekit_settings_updated( [ 'propertyID' => 'P0' ], [ 'propertyID' => 'P1' ] );
+		$this->assertFalse( wp_next_scheduled( GA4_Custom_Dimensions::PROVISION_ACTION ), 'An already-provisioned property is not rescheduled.' );
+
+		// A genuine property change schedules provisioning.
+		GA4_Custom_Dimensions::on_sitekit_settings_updated( [ 'propertyID' => 'P1' ], [ 'propertyID' => 'P2' ] );
+		$this->assertNotFalse( wp_next_scheduled( GA4_Custom_Dimensions::PROVISION_ACTION ), 'Changing the property schedules provisioning.' );
+
+		// An update that does not change the property ID is a no-op.
+		wp_clear_scheduled_hook( GA4_Custom_Dimensions::PROVISION_ACTION );
+		GA4_Custom_Dimensions::on_sitekit_settings_updated( [ 'propertyID' => 'P2' ], [ 'propertyID' => 'P2' ] );
+		$this->assertFalse( wp_next_scheduled( GA4_Custom_Dimensions::PROVISION_ACTION ), 'An unchanged property does not schedule provisioning.' );
+
+		// A non-array option value is tolerated without scheduling or warnings.
+		GA4_Custom_Dimensions::on_sitekit_settings_added( self::SK_SETTINGS_OPTION, 'not-an-array' );
+		$this->assertFalse( wp_next_scheduled( GA4_Custom_Dimensions::PROVISION_ACTION ), 'A non-array settings value does not schedule provisioning.' );
+	}
+
+	/**
+	 * With Newspack OAuth configured and its token carrying `analytics.edit`,
+	 * that route is used in preference to Site Kit.
+	 */
+	public function test_uses_newspack_oauth_when_edit_scope_present() {
+		$this->connect_property( 'PROP-A' );
+		$this->configure_newspack_oauth( true );
+		$this->mock_admin_api( 'PROP-A', [] );
+
+		$status = GA4_Custom_Dimensions::status();
+		$this->assertIsArray( $status );
+		$this->assertSame( 'newspack', $status['auth_source'] );
+		$this->assertCount( count( GA4_Custom_Dimensions::get_dimensions() ), $status['newspack_missing'] );
+	}
+
+	/**
+	 * If the Newspack OAuth token predates the `analytics.edit` scope, that
+	 * route is skipped before any Admin API call, and the failure message says
+	 * why.
+	 */
+	public function test_skips_newspack_oauth_without_edit_scope() {
+		$this->connect_property( 'PROP-B' );
+		$this->configure_newspack_oauth( false );
+
+		$result = GA4_Custom_Dimensions::status();
+		$this->assertWPError( $result );
+		$this->assertStringContainsString( 'analytics.edit', $result->get_error_message() );
+		$this->assertSame( 0, $this->count_requests( 'analyticsadmin.googleapis.com' ), 'The Admin API is not called when the token lacks the edit scope.' );
+	}
+
+	/**
+	 * When the Newspack OAuth path errors, the call falls back to Site Kit; if
+	 * that is unavailable too the WP_Error names both routes and surfaces the
+	 * underlying API error (so a 403 is self-explanatory).
+	 */
+	public function test_falls_back_and_reports_when_newspack_path_fails() {
+		$this->connect_property( 'PROP-C' );
+		$this->configure_newspack_oauth( true );
+		$this->http_routes['properties/PROP-C/customDimensions'] = $this->json_response( 403, [ 'error' => [ 'message' => 'Request had insufficient authentication scopes.' ] ] );
+
+		$result = GA4_Custom_Dimensions::status();
+		$this->assertWPError( $result );
+		$this->assertStringContainsString( '403', $result->get_error_message() );
+		$this->assertStringContainsString( 'Site Kit', $result->get_error_message() );
+	}
+
+	/**
+	 * With neither Newspack OAuth nor Site Kit available, the call fails with a
+	 * WP_Error that names both routes.
+	 */
+	public function test_errors_when_no_auth_route_available() {
+		$this->connect_property( 'PROP-D' );
+
+		$result = GA4_Custom_Dimensions::status();
+		$this->assertWPError( $result );
+		$this->assertStringContainsString( 'Newspack OAuth', $result->get_error_message() );
+		$this->assertStringContainsString( 'Site Kit', $result->get_error_message() );
+	}
+
+	/**
+	 * A run against a property that already has every dimension creates nothing.
+	 */
+	public function test_provision_is_idempotent() {
+		$this->connect_property( 'PROP-IDEM' );
+		$this->configure_newspack_oauth( true );
+		$this->mock_admin_api( 'PROP-IDEM', array_keys( GA4_Custom_Dimensions::get_dimensions() ) );
+
+		$summary = GA4_Custom_Dimensions::provision();
+		$this->assertIsArray( $summary );
+		$this->assertSame( 'newspack', $summary['auth_source'] );
+		$this->assertSame( [], $summary['created'], 'Nothing is created when every dimension already exists.' );
+		$this->assertCount( count( GA4_Custom_Dimensions::get_dimensions() ), $summary['skipped_exists'] );
+		$this->assertSame( 0, $this->count_requests( 'properties/PROP-IDEM/customDimensions', 'POST' ), 'No create requests are made.' );
+		$this->assertGreaterThanOrEqual( 1, $this->count_requests( 'properties/PROP-IDEM/customDimensions', 'GET' ), 'Existing dimensions are listed first.' );
+	}
+
+	/**
+	 * A run against a different property than the previous run does not carry
+	 * the previous run's created list into the new summary.
+	 */
+	public function test_provision_does_not_merge_across_a_property_switch() {
+		$this->connect_property( 'PROP-NEW' );
+		$this->configure_newspack_oauth( true );
+		// 'gate_post_id' already exists on the new property, so this run skips it.
+		$this->mock_admin_api( 'PROP-NEW', [ 'gate_post_id' ] );
+		// The previous run targeted a different property and created 'gate_post_id' there.
+		update_option(
+			GA4_Custom_Dimensions::PROVISIONED_OPTION,
+			[
+				'property_id'    => 'PROP-OLD',
+				'auth_source'    => 'newspack',
+				'timestamp'      => time(),
+				'created'        => [ 'gate_post_id', 'is_reader' ],
+				'skipped_exists' => [],
+				'errors'         => [],
+			]
+		);
+
+		$summary = GA4_Custom_Dimensions::provision();
+		$expected_created = count( GA4_Custom_Dimensions::get_dimensions() ) - 1;
+		$this->assertSame( 'PROP-NEW', $summary['property_id'] );
+		$this->assertContains( 'gate_post_id', $summary['skipped_exists'], "'gate_post_id' already exists on the new property." );
+		$this->assertNotContains( 'gate_post_id', $summary['created'], "The previous property's created list is not carried over." );
+		$this->assertCount( $expected_created, $summary['created'] );
+		$this->assertSame( $summary, get_option( GA4_Custom_Dimensions::PROVISIONED_OPTION ), 'The summary is persisted.' );
+	}
+
+	/**
+	 * A run against the same property as the previous run carries that run's
+	 * created list forward, even for a dimension that this run skipped.
+	 */
+	public function test_provision_merges_created_list_for_same_property() {
+		$this->connect_property( 'PROP-SAME' );
+		$this->configure_newspack_oauth( true );
+		// 'author' already exists, so this run skips it – but the previous run created it.
+		$this->mock_admin_api( 'PROP-SAME', [ 'author' ] );
+		update_option(
+			GA4_Custom_Dimensions::PROVISIONED_OPTION,
+			[
+				'property_id'    => 'PROP-SAME',
+				'auth_source'    => 'newspack',
+				'timestamp'      => time(),
+				'created'        => [ 'author' ],
+				'skipped_exists' => [],
+				'errors'         => [],
+			]
+		);
+
+		$summary = GA4_Custom_Dimensions::provision();
+		$this->assertContains( 'author', $summary['skipped_exists'], "'author' already exists on the property." );
+		$this->assertContains( 'author', $summary['created'], "The previous run's created list is carried forward for the same property." );
+		$this->assertCount( count( GA4_Custom_Dimensions::get_dimensions() ), $summary['created'] );
+	}
+
+	/**
+	 * `Google_OAuth_GA4_Client::build()` returns null when Newspack OAuth is
+	 * not configured.
+	 */
+	public function test_ga4_client_build_returns_null_when_unconfigured() {
+		$this->assertNull( Google_OAuth_GA4_Client::build() );
+	}
+
+	/**
+	 * The client follows pagination when listing custom dimensions.
+	 */
+	public function test_ga4_client_lists_custom_dimensions_with_pagination() {
+		wp_set_current_user( $this->owner_id );
+		$this->configure_newspack_oauth( true );
+
+		$page = 0;
+		$this->http_routes['properties/PAGED/customDimensions'] = function ( $url, $args ) use ( &$page ) {
+			++$page;
+			if ( 1 === $page ) {
+				return $this->json_response(
+					200,
+					[
+						'customDimensions' => [
+							[
+								'name'          => 'properties/PAGED/customDimensions/a',
+								'parameterName' => 'a',
+								'displayName'   => 'A',
+								'scope'         => 'EVENT',
+							],
+						],
+						'nextPageToken'    => 'PAGE2',
+					]
+				);
+			}
+			return $this->json_response(
+				200,
+				[
+					'customDimensions' => [
+						[
+							'name'          => 'properties/PAGED/customDimensions/b',
+							'parameterName' => 'b',
+							'displayName'   => 'B',
+							'scope'         => 'EVENT',
+						],
+					],
+				]
+			);
+		};
+
+		$client = Google_OAuth_GA4_Client::build();
+		$this->assertInstanceOf( Google_OAuth_GA4_Client::class, $client );
+		$dimensions = $client->list_custom_dimensions( 'PAGED' );
+		$this->assertSame( [ 'a', 'b' ], wp_list_pluck( $dimensions, 'parameterName' ) );
+		$this->assertSame( 1, $this->count_requests( 'pageToken=PAGE2', 'GET' ), 'The second page is fetched with the page token.' );
+	}
+
+	/**
+	 * The client posts an EVENT-scoped dimension with the given parameter and
+	 * display names.
+	 */
+	public function test_ga4_client_creates_event_scoped_dimension() {
+		wp_set_current_user( $this->owner_id );
+		$this->configure_newspack_oauth( true );
+
+		$captured = null;
+		$this->http_routes['properties/PROP/customDimensions'] = function ( $url, $args ) use ( &$captured ) {
+			$captured = json_decode( $args['body'], true );
+			return $this->json_response(
+				200,
+				[
+					'name'          => 'properties/PROP/customDimensions/z',
+					'parameterName' => $captured['parameterName'],
+					'scope'         => 'EVENT',
+				]
+			);
+		};
+
+		$client = Google_OAuth_GA4_Client::build();
+		$client->create_custom_dimension( 'PROP', 'my_param', 'My Param' );
+		$this->assertSame(
+			[
+				'parameterName' => 'my_param',
+				'displayName'   => 'My Param',
+				'scope'         => 'EVENT',
+			],
+			$captured
+		);
+		$this->assertSame( 1, $this->count_requests( 'properties/PROP/customDimensions', 'POST' ) );
+	}
+
+	/**
+	 * The client throws on a non-2xx Admin API response, including the status
+	 * code and the API's error message.
+	 */
+	public function test_ga4_client_throws_on_api_error() {
+		wp_set_current_user( $this->owner_id );
+		$this->configure_newspack_oauth( true );
+		$this->http_routes['properties/PROP/customDimensions'] = $this->json_response( 403, [ 'error' => [ 'message' => 'Insufficient Permission' ] ] );
+
+		$client = Google_OAuth_GA4_Client::build();
+		try {
+			$client->list_custom_dimensions( 'PROP' );
+			$this->fail( 'Expected a RuntimeException for a 403 response.' );
+		} catch ( \RuntimeException $e ) {
+			$this->assertStringContainsString( '403', $e->getMessage() );
+			$this->assertStringContainsString( 'Insufficient Permission', $e->getMessage() );
+		}
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Automatically provisions Newspack's standard set of GA4 event-scoped custom dimensions (27 total, covering Gate Intelligence, reader identity, prompt attribution, checkout, and content context) on the publisher's connected GA4 property.

Triggered automatically when Site Kit's `googlesitekit_analytics-4_settings` option gains a `propertyID` or the property changes, via a single-shot `wp_schedule_single_event` keyed on the property ID. Also exposed as `wp newspack ga4-dimensions provision[--dry-run]`. Provisioning is idempotent (existing parameter names are skipped) and per-dimension failures are logged but don't abort the run. The `newspack_ga4_dimensions_provisioned` option stores a summary of the last run keyed on property ID.

### Auth source: Newspack OAuth primary, Site Kit fallback

Site Kit's Analytics module only requests `analytics.readonly` by default; `analytics.edit` is granted on-demand for SK-initiated write actions, so publishers who connected an _existing_ GA4 property via Site Kit hit a 403 on the Admin API. Newspack's own Google OAuth (`_newspack_google_oauth`) already has `analytics.edit` in `Google_OAuth::REQUIRED_SCOPES`, so `GA4_Custom_Dimensions::with_admin_client()` now prefers it (via a raw-HTTP client against `analyticsadmin.googleapis.com/v1beta`) and falls back to Site Kit when Newspack OAuth isn't configured or the call errors. Active path is surfaced as an `Auth source:` line in CLI output and in the summary option. Prerequisite: `analyticsadmin.googleapis.com` enabled on the Newspack OAuth proxy's GCP project (done, prod + staging). Edge case: sites with neither Newspack OAuth nor Site Kit edit-scope still 403 – they need to reconnect Site Kit to grant edit.

Closes NPPM-2738.

### How to test the changes in this Pull Request:

1. On a site with Site Kit active but not yet connected to GA4, run `wp newspack ga4-dimensions provision --dry-run`. It should error out with "No GA4 property ID configured in Site Kit."
2. Connect Site Kit to a GA4 property. Confirm a `newspack_ga4_provision_dimensions` scheduled action appears (`wp cron event list | grep ga4`); wait for or manually trigger it. Verify all 27 Newspack dimensions exist in GA4 (Admin → Property → Custom definitions → Custom dimensions).
3. Re-run `wp newspack ga4-dimensions provision` and `... --dry-run`. Both should be no-ops (0 missing, every dimension reports as already existing).
4. **Auth-source selection.** On a site with Newspack OAuth connected (`wp option get _newspack_google_oauth` returns a populated option) and Site Kit in readonly mode, run `wp newspack ga4-dimensions provision --dry-run`. Output should include `Auth source: newspack` and successfully list existing event-scoped dimensions. On a site with Site Kit in edit mode and no Newspack OAuth, the same command should print `Auth source: sitekit`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?