### PR TITLE
feat(demo): add integrations dashboard composition section

### DIFF
--- a/src/wizards/componentsDemo/index.js
+++ b/src/wizards/componentsDemo/index.js
@@ -12,7 +12,7 @@ import '../../shared/js/public-path';
 import { CardBody, CardDivider, CardMedia, ExternalLink, ToggleControl, __experimentalVStack as VStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { Component, Fragment, render, createInterpolateElement, createRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Icon, category, plus, postList, settings } from '@wordpress/icons';
+import { Icon, category, cloud, envelope, plus, postList, settings } from '@wordpress/icons';
 
 /**
  * Internal dependencies.
@@ -74,6 +74,9 @@ class ComponentsDemo extends Component {
 			settingsGroupCardActive: false,
 			cardFeatureEnabled: false,
 			cardFeatureCustomEnabled: false,
+			integrationEspEnabled: false,
+			integrationFundraiseUpEnabled: true,
+			integrationSalesforceEnabled: true,
 		};
 		this.dragWrapperRef = createRef();
 	}
@@ -994,6 +997,123 @@ class ComponentsDemo extends Component {
 									{ title: __( 'Preview', 'newspack-plugin' ), onClick: () => {} },
 									{ title: __( 'Disable', 'newspack-plugin' ), onClick: () => {} },
 								] }
+							/>
+						</Grid>
+					</Card>
+					<Card>
+						<h2>{ __( 'Integrations Dashboard', 'newspack-plugin' ) }</h2>
+						<p>
+							{ __(
+								'Demonstrates how CardFeature cards compose into an integrations admin screen. Click Connect/Disable to cycle card states interactively.',
+								'newspack-plugin'
+							) }
+						</p>
+						<Grid columns={ 2 } gutter={ 16 }>
+							<CardFeature
+								title={ __( 'Newsletter ESP', 'newspack-plugin' ) }
+								description={ __( 'Sync reader data and activity to the connected email service provider.', 'newspack-plugin' ) }
+								icon={ {
+									node: <Icon icon={ envelope } />,
+									fill: '#757575',
+									backgroundColor: '#f0f0f0',
+								} }
+								enabled={ this.state.integrationEspEnabled }
+								enableLabel={ __( 'Connect', 'newspack-plugin' ) }
+								onEnable={ () => this.setState( { integrationEspEnabled: true } ) }
+								onConfigure={ () => {} }
+								moreControls={
+									this.state.integrationEspEnabled
+										? [
+												{
+													title: __( 'Logs', 'newspack-plugin' ),
+													onClick: () => {},
+												},
+												{
+													title: __( 'Disable', 'newspack-plugin' ),
+													onClick: () =>
+														this.setState( {
+															integrationEspEnabled: false,
+														} ),
+												},
+										  ]
+										: undefined
+								}
+							/>
+							<CardFeature
+								title={ __( 'Fundraise Up', 'newspack-plugin' ) }
+								description={ __( 'Sync donation and supporter data from Fundraise Up campaigns.', 'newspack-plugin' ) }
+								icon={ {
+									node: <Icon icon={ postList } />,
+									fill: '#003da5',
+									backgroundColor: '#dfe7f4',
+									radius: 'full',
+								} }
+								enabled={ this.state.integrationFundraiseUpEnabled }
+								enableLabel={ __( 'Connect', 'newspack-plugin' ) }
+								onEnable={ () => this.setState( { integrationFundraiseUpEnabled: true } ) }
+								onConfigure={ () => {} }
+								moreControls={
+									this.state.integrationFundraiseUpEnabled
+										? [
+												{
+													title: __( 'Logs', 'newspack-plugin' ),
+													onClick: () => {},
+												},
+												{
+													title: __( 'Disable', 'newspack-plugin' ),
+													onClick: () =>
+														this.setState( {
+															integrationFundraiseUpEnabled: false,
+														} ),
+												},
+										  ]
+										: undefined
+								}
+							/>
+							<CardFeature
+								title={ __( 'WisePops', 'newspack-plugin' ) }
+								description={ __( 'Import popup interaction data for reader segmentation.', 'newspack-plugin' ) }
+								icon={ {
+									node: <Icon icon={ category } />,
+									fill: '#757575',
+									backgroundColor: '#f0f0f0',
+								} }
+								requirements={ __( 'Requires WisePops plugin', 'newspack-plugin' ) }
+								onEnable={ () => {} }
+								onConfigure={ () => {} }
+							/>
+							<CardFeature
+								title={ __( 'Salesforce', 'newspack-plugin' ) }
+								description={ __( 'Bi-directional sync of reader and contact data with Salesforce CRM.', 'newspack-plugin' ) }
+								icon={ {
+									node: <Icon icon={ cloud } />,
+									fill: '#003da5',
+									backgroundColor: '#dfe7f4',
+									radius: 'full',
+								} }
+								enabled={ this.state.integrationSalesforceEnabled }
+								enableLabel={ __( 'Connect', 'newspack-plugin' ) }
+								badgeText={ __( 'Sandbox mode', 'newspack-plugin' ) }
+								badgeLevel="info"
+								onEnable={ () => this.setState( { integrationSalesforceEnabled: true } ) }
+								onConfigure={ () => {} }
+								moreControls={
+									this.state.integrationSalesforceEnabled
+										? [
+												{
+													title: __( 'Logs', 'newspack-plugin' ),
+													onClick: () => {},
+												},
+												{
+													title: __( 'Disable', 'newspack-plugin' ),
+													onClick: () =>
+														this.setState( {
+															integrationSalesforceEnabled: false,
+														} ),
+												},
+										  ]
+										: undefined
+								}
 							/>
 						</Grid>
 					</Card>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds a new "Integrations Dashboard" demo section to the Components Demo page (`src/wizards/componentsDemo/index.js`). This showcases how `CardFeature` cards compose into a 2×2 grid layout for the upcoming Integrations i3 redesign (DSGNEWS-135).

The demo includes four integration cards demonstrating all CardFeature states:
- **Newsletter ESP** — Disconnected (no badge, "Connect" button)
- **Fundraise Up** — Enabled (green "Enabled" badge, "Configure" button, kebab menu)
- **WisePops** — Requirements unmet (red error badge, disabled button, muted card)
- **Salesforce** — Enabled with custom badge (blue "Sandbox mode", kebab menu)

Interactive state cycling is wired up: clicking Connect/Disable toggles cards between enabled and disconnected states.

Closes DSGNEWS-153.

### How to test the changes in this Pull Request:

1. Build the plugin: `n build newspack-plugin`
2. Navigate to **wp-admin → Newspack → Components Demo**
3. Scroll down to the **"Integrations Dashboard"** section (after the existing CardFeature demos)
4. Verify four cards render in a 2×2 grid with correct states, icons, and badges
5. Click "Connect" on Newsletter ESP — verify it transitions to enabled state with badge and kebab menu
6. Click kebab → "Disable" on Fundraise Up — verify it transitions to disconnected state
7. Verify WisePops card is muted with disabled "Enable" button
8. Click kebab → "Disable" on Salesforce, then "Connect" — verify it re-enables with "Sandbox mode" badge

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?