### PR TITLE
feat(google-site-kit): enable custom GA frontend params by default

### DIFF
--- a/includes/plugins/google-site-kit/class-googlesitekit.php
+++ b/includes/plugins/google-site-kit/class-googlesitekit.php
@@ -278,18 +278,16 @@ class GoogleSiteKit {
 		$gtag_opt['transport_type'] = 'beacon';
 
 		/**
-		 * Enables custom Google Analytics parameters on the frontend.
-		 * Adds enhanced tracking parameters to GA events.
+		 * Disables custom Google Analytics parameters on the frontend.
+		 * Custom tracking parameters are enabled by default.
 		 *
-		 * @constant NEWSPACK_GA_ENABLE_CUSTOM_FE_PARAMS
+		 * @constant NEWSPACK_GA_DISABLE_CUSTOM_FE_PARAMS
 		 * @type     bool
-		 * @default  Custom frontend GA parameters disabled
-		 * @status   draft
+		 * @default  Custom frontend GA parameters enabled
 		 *
-		 * @example define( 'NEWSPACK_GA_ENABLE_CUSTOM_FE_PARAMS', true );
+		 * @example define( 'NEWSPACK_GA_DISABLE_CUSTOM_FE_PARAMS', true );
 		 */
-		$enable_fe_custom_params = defined( 'NEWSPACK_GA_ENABLE_CUSTOM_FE_PARAMS' ) && NEWSPACK_GA_ENABLE_CUSTOM_FE_PARAMS;
-		if ( ! $enable_fe_custom_params ) {
+		if ( defined( 'NEWSPACK_GA_DISABLE_CUSTOM_FE_PARAMS' ) && NEWSPACK_GA_DISABLE_CUSTOM_FE_PARAMS ) {
 			return $gtag_opt;
 		}
 		$custom_params = self::get_custom_event_parameters();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Custom Google Analytics frontend parameters (added via the `add_ga_custom_parameters` method) are now **enabled by default** instead of requiring an opt-in constant.

The `NEWSPACK_GA_ENABLE_CUSTOM_FE_PARAMS` constant has been replaced with `NEWSPACK_GA_DISABLE_CUSTOM_FE_PARAMS`, inverting the logic. Sites that need to disable custom GA parameters can define the new constant as `true`.

### How to test the changes in this Pull Request:

1. Ensure Google Site Kit is connected with GA4 on your test site.
2. Visit the frontend of the site and inspect the page source or use browser dev tools to check the gtag configuration.
3. Verify that custom event parameters (from `get_custom_event_parameters`) are now included in the gtag options **without** needing to define any constant.
4. Add `define( 'NEWSPACK_GA_DISABLE_CUSTOM_FE_PARAMS', true );` to `wp-config.php`.
5. Reload the frontend and verify that custom event parameters are **no longer** included in the gtag options.
6. Remove the constant (or set it to `false`) and confirm custom parameters are included again.
7. Verify that the old `NEWSPACK_GA_ENABLE_CUSTOM_FE_PARAMS` constant has no effect when defined — custom params should be enabled regardless.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?