### PR TITLE
feat(integrations): redesign dashboard with CardFeature grid

### DIFF
--- a/includes/reader-activation/class-integrations.php
+++ b/includes/reader-activation/class-integrations.php
@@ -215,8 +215,10 @@ class Integrations {
 		// Hook for other plugins/code to register their integrations.
 		do_action( 'newspack_reader_activation_register_integrations' );
 
-		// hardcode ESP integration as enabled for now.
-		self::enable( 'esp' );
+		// Auto-enable ESP on first registration only.
+		if ( false === get_option( self::OPTION_NAME ) ) {
+			self::enable( 'esp' );
+		}
 
 		// Let each integration register its data event handlers.
 		foreach ( self::$integrations as $integration ) {
@@ -386,15 +388,14 @@ class Integrations {
 			if ( is_wp_error( $can_sync ) ) {
 				$can_sync->remove( 'ras_esp_sync_not_enabled' );
 			}
-			$can_sync_value = is_wp_error( $can_sync ) && $can_sync->has_errors()
-				? $can_sync->get_error_message()
-				: true;
-			$result[ $id ] = [
+			$can_sync_value = ! ( is_wp_error( $can_sync ) && $can_sync->has_errors() );
+			$result[ $id ]  = [
 				'id'          => $id,
 				'name'        => $integration->get_name(),
 				'description' => $integration->get_description(),
 				'enabled'     => self::is_enabled( $id ),
 				'can_sync'    => $can_sync_value,
+				'setup_url'   => $integration->get_setup_url(),
 				'settings'    => $integration->get_settings_config(),
 			];
 		}

--- a/includes/reader-activation/class-integrations.php
+++ b/includes/reader-activation/class-integrations.php
@@ -382,19 +382,12 @@ class Integrations {
 			if ( empty( $fields ) ) {
 				continue;
 			}
-			$can_sync = $integration->can_sync( true );
-			// Filter out the "not enabled" error — that's a user-controlled state,
-			// not a requirement. The frontend uses can_sync for unmet prerequisites only.
-			if ( is_wp_error( $can_sync ) ) {
-				$can_sync->remove( 'ras_esp_sync_not_enabled' );
-			}
-			$can_sync_value = ! ( is_wp_error( $can_sync ) && $can_sync->has_errors() );
-			$result[ $id ]  = [
+			$result[ $id ] = [
 				'id'          => $id,
 				'name'        => $integration->get_name(),
 				'description' => $integration->get_description(),
 				'enabled'     => self::is_enabled( $id ),
-				'can_sync'    => $can_sync_value,
+				'is_set_up'   => $integration->is_set_up(),
 				'setup_url'   => $integration->get_setup_url(),
 				'settings'    => $integration->get_settings_config(),
 			];

--- a/includes/reader-activation/class-integrations.php
+++ b/includes/reader-activation/class-integrations.php
@@ -381,12 +381,20 @@ class Integrations {
 				continue;
 			}
 			$can_sync = $integration->can_sync( true );
+			// Filter out the "not enabled" error — that's a user-controlled state,
+			// not a requirement. The frontend uses can_sync for unmet prerequisites only.
+			if ( is_wp_error( $can_sync ) ) {
+				$can_sync->remove( 'ras_esp_sync_not_enabled' );
+			}
+			$can_sync_value = is_wp_error( $can_sync ) && $can_sync->has_errors()
+				? $can_sync->get_error_message()
+				: true;
 			$result[ $id ] = [
 				'id'          => $id,
 				'name'        => $integration->get_name(),
 				'description' => $integration->get_description(),
 				'enabled'     => self::is_enabled( $id ),
-				'can_sync'    => is_wp_error( $can_sync ) ? $can_sync->get_error_message() : true,
+				'can_sync'    => $can_sync_value,
 				'settings'    => $integration->get_settings_config(),
 			];
 		}

--- a/includes/reader-activation/class-integrations.php
+++ b/includes/reader-activation/class-integrations.php
@@ -380,11 +380,13 @@ class Integrations {
 			if ( empty( $fields ) ) {
 				continue;
 			}
+			$can_sync = $integration->can_sync( true );
 			$result[ $id ] = [
 				'id'          => $id,
 				'name'        => $integration->get_name(),
 				'description' => $integration->get_description(),
 				'enabled'     => self::is_enabled( $id ),
+				'can_sync'    => is_wp_error( $can_sync ) ? $can_sync->get_error_message() : true,
 				'settings'    => $integration->get_settings_config(),
 			];
 		}

--- a/includes/reader-activation/integrations/class-esp.php
+++ b/includes/reader-activation/integrations/class-esp.php
@@ -35,6 +35,16 @@ class ESP extends Integration {
 	}
 
 	/**
+	 * Whether the ESP service provider is configured.
+	 *
+	 * @return bool True if an ESP provider is selected and configured.
+	 */
+	public function is_set_up() {
+		$newsletters_configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-newsletters' );
+		return (bool) $newsletters_configuration_manager->is_esp_set_up();
+	}
+
+	/**
 	 * Get the URL where the user can set up the ESP.
 	 *
 	 * @return string The Newspack Newsletters settings page URL.
@@ -289,14 +299,6 @@ class ESP extends Integration {
 			$errors->add(
 				'newspack_newsletters_contacts_not_found',
 				__( 'Newspack Newsletters is not available.', 'newspack-plugin' )
-			);
-		}
-
-		$newsletters_configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-newsletters' );
-		if ( $newsletters_configuration_manager->is_esp_set_up() === false ) {
-			$errors->add(
-				'ras_esp_sync_not_set_up',
-				__( 'ESP sync is not set up.', 'newspack-plugin' )
 			);
 		}
 

--- a/includes/reader-activation/integrations/class-esp.php
+++ b/includes/reader-activation/integrations/class-esp.php
@@ -13,6 +13,7 @@ use Newspack\Reader_Activation\Integrations;
 use Newspack\Reader_Activation;
 use Newspack_Newsletters_Contacts;
 use Newspack_Newsletters_Subscription;
+use Newspack\Configuration_Managers;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -28,9 +29,18 @@ class ESP extends Integration {
 	public function __construct() {
 		parent::__construct(
 			'esp',
-			__( 'ESP', 'newspack-plugin' ),
-			__( 'Sync reader data and activity to the connected email service provider.', 'newspack-plugin' )
+			__( 'Newsletter ESP', 'newspack-plugin' ),
+			__( 'Syncs reader data with your Newspack Newsletters email service provider.', 'newspack-plugin' )
 		);
+	}
+
+	/**
+	 * Get the URL where the user can set up the ESP.
+	 *
+	 * @return string The Newspack Newsletters settings page URL.
+	 */
+	public function get_setup_url() {
+		return admin_url( 'edit.php?post_type=newspack_nl_cpt&page=newspack-newsletters' );
 	}
 
 	/**
@@ -279,6 +289,14 @@ class ESP extends Integration {
 			$errors->add(
 				'newspack_newsletters_contacts_not_found',
 				__( 'Newspack Newsletters is not available.', 'newspack-plugin' )
+			);
+		}
+
+		$newsletters_configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-newsletters' );
+		if ( $newsletters_configuration_manager->is_esp_set_up() === false ) {
+			$errors->add(
+				'ras_esp_sync_not_set_up',
+				__( 'ESP sync is not set up.', 'newspack-plugin' )
 			);
 		}
 

--- a/includes/reader-activation/integrations/class-esp.php
+++ b/includes/reader-activation/integrations/class-esp.php
@@ -41,6 +41,9 @@ class ESP extends Integration {
 	 */
 	public function is_set_up() {
 		$newsletters_configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-newsletters' );
+		if ( is_wp_error( $newsletters_configuration_manager ) ) {
+			return false;
+		}
 		return (bool) $newsletters_configuration_manager->is_esp_set_up();
 	}
 

--- a/includes/reader-activation/integrations/class-integration.php
+++ b/includes/reader-activation/integrations/class-integration.php
@@ -127,6 +127,18 @@ abstract class Integration {
 	}
 
 	/**
+	 * Get the URL where the user can set up this integration.
+	 *
+	 * Child classes should override this to return the admin page where
+	 * the integration's prerequisites can be configured.
+	 *
+	 * @return string The setup URL, or empty string if not applicable.
+	 */
+	public function get_setup_url() {
+		return '';
+	}
+
+	/**
 	 * Register settings fields for this integration.
 	 *
 	 * Child classes should override this method to return static field

--- a/includes/reader-activation/integrations/class-integration.php
+++ b/includes/reader-activation/integrations/class-integration.php
@@ -127,6 +127,19 @@ abstract class Integration {
 	}
 
 	/**
+	 * Whether this integration's external prerequisites are configured.
+	 *
+	 * Child classes should override this to check whether the third-party
+	 * service or plugin the integration depends on is set up (e.g., API
+	 * key entered, provider selected). Returns true by default.
+	 *
+	 * @return bool True if set up, false otherwise.
+	 */
+	public function is_set_up() {
+		return true;
+	}
+
+	/**
 	 * Get the URL where the user can set up this integration.
 	 *
 	 * Child classes should override this to return the admin page where

--- a/packages/components/src/card-feature/index.tsx
+++ b/packages/components/src/card-feature/index.tsx
@@ -102,8 +102,6 @@ const CardFeature = ( {
 		badge = { text: requirements, level: 'error' };
 	} else if ( enabled ) {
 		badge = { text: badgeText ?? __( 'Enabled', 'newspack-plugin' ), level: badgeLevel };
-	} else if ( badgeText ) {
-		badge = { text: badgeText, level: badgeLevel };
 	}
 
 	const isConfigureState = enabled && ! requirements;

--- a/packages/components/src/card-feature/index.tsx
+++ b/packages/components/src/card-feature/index.tsx
@@ -102,6 +102,8 @@ const CardFeature = ( {
 		badge = { text: requirements, level: 'error' };
 	} else if ( enabled ) {
 		badge = { text: badgeText ?? __( 'Enabled', 'newspack-plugin' ), level: badgeLevel };
+	} else if ( badgeText ) {
+		badge = { text: badgeText, level: badgeLevel };
 	}
 
 	const isConfigureState = enabled && ! requirements;

--- a/src/admin/style.scss
+++ b/src/admin/style.scss
@@ -195,6 +195,23 @@ h1 {
 	}
 }
 
+.newspack-wizard__sections.newspack-audience-integrations {
+	> h1 {
+		margin-bottom: 0;
+	}
+
+	.newspack-wizard__sections__description {
+		color: wp-colors.$gray-700;
+		margin-top: 8px;
+
+		// Match the width of a single card in the 2-column CardFeature grid
+		// (grid has 16px gutter; falls back to 1 column below 744px viewport).
+		@media screen and ( min-width: 744px ) {
+			max-width: calc((100% - 16px) / 2);
+		}
+	}
+}
+
 .newspack-wizard__section {
 	margin-block-end: 4rem;
 

--- a/src/wizards/audience/views/integrations/configure-view.js
+++ b/src/wizards/audience/views/integrations/configure-view.js
@@ -1,0 +1,63 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { Button, Grid } from '../../../../../packages/components/src';
+import WizardsTab from '../../../wizards-tab';
+import WizardSection from '../../../wizards-section';
+import { SettingsField } from './settings-field';
+
+export const ConfigureView = ( { integrations, pendingChanges, saving, onFieldChange, onSave, match } ) => {
+	const integrationId = match?.params?.integrationId;
+	const integration = integrations[ integrationId ];
+
+	if ( ! integration ) {
+		return (
+			<WizardsTab title={ __( 'Integration not found', 'newspack-plugin' ) }>
+				<WizardSection>
+					<p>{ __( 'The requested integration could not be found.', 'newspack-plugin' ) }</p>
+				</WizardSection>
+			</WizardsTab>
+		);
+	}
+
+	const getFieldValue = field => {
+		if ( pendingChanges[ integrationId ] && field.key in pendingChanges[ integrationId ] ) {
+			return pendingChanges[ integrationId ][ field.key ];
+		}
+		return field.value;
+	};
+
+	const hasPending = pendingChanges[ integrationId ] && Object.keys( pendingChanges[ integrationId ] ).length > 0;
+
+	return (
+		<WizardsTab title={ integration.name }>
+			<WizardSection>
+				<Grid columns={ 1 } rowGap={ 16 }>
+					{ integration.settings.map( field => (
+						<SettingsField
+							key={ field.key }
+							field={ field }
+							value={ getFieldValue( field ) }
+							onChange={ val => onFieldChange( integrationId, field.key, val ) }
+						/>
+					) ) }
+				</Grid>
+				<div style={ { marginTop: 16 } }>
+					<Button
+						variant="primary"
+						onClick={ () => onSave( integrationId ) }
+						disabled={ ! hasPending || saving[ integrationId ] }
+						isBusy={ saving[ integrationId ] }
+					>
+						{ __( 'Save Settings', 'newspack-plugin' ) }
+					</Button>
+				</div>
+			</WizardSection>
+		</WizardsTab>
+	);
+};

--- a/src/wizards/audience/views/integrations/configure-view.js
+++ b/src/wizards/audience/views/integrations/configure-view.js
@@ -2,6 +2,8 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { useDispatch } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -10,10 +12,22 @@ import { Button, Grid } from '../../../../../packages/components/src';
 import WizardsTab from '../../../wizards-tab';
 import WizardSection from '../../../wizards-section';
 import { SettingsField } from './settings-field';
+import { WIZARD_STORE_NAMESPACE } from '../../../../../packages/components/src/wizard/store';
 
 export const ConfigureView = ( { integrations, pendingChanges, saving, onFieldChange, onSave, match } ) => {
+	const { setHeaderData } = useDispatch( WIZARD_STORE_NAMESPACE );
+
 	const integrationId = match?.params?.integrationId;
 	const integration = integrations[ integrationId ];
+
+	// Set header navigation and actions.
+	useEffect( () => {
+		if ( integration ) {
+			setHeaderData( {
+				title: integration.name,
+			} );
+		}
+	}, [ integration, setHeaderData ] );
 
 	if ( ! integration ) {
 		return (

--- a/src/wizards/audience/views/integrations/configure-view.js
+++ b/src/wizards/audience/views/integrations/configure-view.js
@@ -14,7 +14,7 @@ import WizardSection from '../../../wizards-section';
 import { SettingsField } from './settings-field';
 import { WIZARD_STORE_NAMESPACE } from '../../../../../packages/components/src/wizard/store';
 
-export const ConfigureView = ( { integrations, pendingChanges, saving, onFieldChange, onSave, match } ) => {
+export const ConfigureView = ( { integrations, loading, pendingChanges, saving, onFieldChange, onSave, match } ) => {
 	const { setHeaderData } = useDispatch( WIZARD_STORE_NAMESPACE );
 
 	const integrationId = match?.params?.integrationId;
@@ -24,12 +24,12 @@ export const ConfigureView = ( { integrations, pendingChanges, saving, onFieldCh
 	useEffect( () => {
 		if ( integration ) {
 			setHeaderData( {
-				title: integration.name,
+				sectionTitle: integration.name,
 			} );
 		}
 	}, [ integration, setHeaderData ] );
 
-	if ( ! integration ) {
+	if ( ! loading && ! integration ) {
 		return (
 			<WizardsTab title={ __( 'Integration not found', 'newspack-plugin' ) }>
 				<WizardSection>
@@ -49,7 +49,7 @@ export const ConfigureView = ( { integrations, pendingChanges, saving, onFieldCh
 	const hasPending = pendingChanges[ integrationId ] && Object.keys( pendingChanges[ integrationId ] ).length > 0;
 
 	return (
-		<WizardsTab title={ integration.name }>
+		<WizardsTab isFetching={ loading }>
 			<WizardSection>
 				<Grid columns={ 1 } rowGap={ 16 }>
 					{ integration.settings.map( field => (

--- a/src/wizards/audience/views/integrations/index.js
+++ b/src/wizards/audience/views/integrations/index.js
@@ -112,9 +112,10 @@ const AudienceIntegrations = ( props, ref ) => {
 				{
 					path: '/settings/:integrationId',
 					render: ConfigureView,
+					props: sharedProps,
 					backNav: '#/settings',
 					title: __( 'Configure Integration', 'newspack-plugin' ),
-					props: sharedProps,
+					description: __( 'Syncs reader data with your Newspack Newsletters email service provider.', 'newspack-plugin' ),
 				},
 			] }
 			ref={ ref }

--- a/src/wizards/audience/views/integrations/index.js
+++ b/src/wizards/audience/views/integrations/index.js
@@ -114,6 +114,7 @@ const AudienceIntegrations = ( props, ref ) => {
 					render: ConfigureView,
 					props: sharedProps,
 					backNav: '#/settings',
+					isHidden: true,
 					title: __( 'Configure Integration', 'newspack-plugin' ),
 					description: __( 'Syncs reader data with your Newspack Newsletters email service provider.', 'newspack-plugin' ),
 				},

--- a/src/wizards/audience/views/integrations/index.js
+++ b/src/wizards/audience/views/integrations/index.js
@@ -10,6 +10,7 @@ import { forwardRef, useState, useEffect, useCallback } from '@wordpress/element
  */
 import { Wizard, withWizard } from '../../../../../packages/components/src';
 import { SettingsSection } from './settings-section';
+import { ConfigureView } from './configure-view';
 
 const API_PATH = '/newspack/v1/wizard/newspack-audience-integrations/settings';
 
@@ -86,6 +87,17 @@ const AudienceIntegrations = ( props, ref ) => {
 			} );
 	}, [] );
 
+	const sharedProps = {
+		integrations,
+		pendingChanges,
+		saving,
+		toggling,
+		loading,
+		onFieldChange: handleFieldChange,
+		onSave: handleSave,
+		onToggleEnabled: handleToggleEnabled,
+	};
+
 	return (
 		<Wizard
 			headerText={ __( 'Audience Management / Integrations', 'newspack-plugin' ) }
@@ -93,17 +105,16 @@ const AudienceIntegrations = ( props, ref ) => {
 				{
 					label: __( 'Settings', 'newspack-plugin' ),
 					path: '/settings',
+					exact: true,
 					render: SettingsSection,
-					props: {
-						integrations,
-						pendingChanges,
-						saving,
-						toggling,
-						loading,
-						onFieldChange: handleFieldChange,
-						onSave: handleSave,
-						onToggleEnabled: handleToggleEnabled,
-					},
+					props: sharedProps,
+				},
+				{
+					path: '/settings/:integrationId',
+					render: ConfigureView,
+					backNav: '#/settings',
+					title: __( 'Configure Integration', 'newspack-plugin' ),
+					props: sharedProps,
 				},
 			] }
 			ref={ ref }

--- a/src/wizards/audience/views/integrations/settings-section.js
+++ b/src/wizards/audience/views/integrations/settings-section.js
@@ -1,25 +1,41 @@
 /**
- * Internal dependencies
+ * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { ActionCard, Button, Card, Grid } from '../../../../../packages/components/src';
+import { Icon, envelope } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import { Card, CardFeature, Grid } from '../../../../../packages/components/src';
 import WizardsTab from '../../../wizards-tab';
 import WizardSection from '../../../wizards-section';
 
-import { SettingsField } from './settings-field';
+/**
+ * Icon configuration per integration ID.
+ * Only ESP exists today. When new integrations are added (DSGNEWS-157),
+ * this moves to the PHP API response.
+ */
+const INTEGRATION_ICONS = {
+	esp: {
+		node: <Icon icon={ envelope } />,
+		fill: '#003da5',
+		backgroundColor: '#dfe7f4',
+		radius: 'full',
+	},
+};
 
-export const SettingsSection = ( { integrations, pendingChanges, saving, toggling, loading, onFieldChange, onSave, onToggleEnabled } ) => {
-	const getFieldValue = ( integrationId, field ) => {
-		if ( pendingChanges[ integrationId ] && field.key in pendingChanges[ integrationId ] ) {
-			return pendingChanges[ integrationId ][ field.key ];
-		}
-		return field.value;
-	};
+const DEFAULT_ICON = {
+	node: <Icon icon={ envelope } />,
+	fill: '#757575',
+	backgroundColor: '#f0f0f0',
+};
 
+export const SettingsSection = ( { integrations, loading, onToggleEnabled, onConfigure, history } ) => {
 	const integrationIds = Object.keys( integrations );
 
 	return (
-		<WizardsTab title={ __( 'Integrations Settings', 'newspack-plugin' ) }>
+		<WizardsTab title={ __( 'Integrations', 'newspack-plugin' ) }>
 			<WizardSection>
 				{ loading && <p>{ __( 'Loading…', 'newspack-plugin' ) }</p> }
 				{ ! loading && integrationIds.length === 0 && (
@@ -27,50 +43,42 @@ export const SettingsSection = ( { integrations, pendingChanges, saving, togglin
 						<p>{ __( 'No integrations with configurable settings are registered.', 'newspack-plugin' ) }</p>
 					</Card>
 				) }
-				{ ! loading &&
-					integrationIds.map( id => {
-						const integration = integrations[ id ];
-						const hasPending = pendingChanges[ id ] && Object.keys( pendingChanges[ id ] ).length > 0;
-						const isEnabled = integration.enabled;
-						return (
-							<ActionCard
-								key={ id }
-								title={ integration.name }
-								description={ integration.description }
-								toggleChecked={ isEnabled }
-								toggleOnChange={ () => onToggleEnabled( id, ! isEnabled ) }
-								disabled={ toggling[ id ] }
-								hasGreyHeader={ isEnabled }
-								actionContent={
-									isEnabled ? (
-										<Button
-											variant="primary"
-											onClick={ () => onSave( id ) }
-											disabled={ ! hasPending || saving[ id ] }
-											isBusy={ saving[ id ] }
-										>
-											{ __( 'Save Settings', 'newspack-plugin' ) }
-										</Button>
-									) : null
-								}
-							>
-								{ isEnabled && (
-									<>
-										<Grid columns={ 1 } rowGap={ 16 }>
-											{ integration.settings.map( field => (
-												<SettingsField
-													key={ field.key }
-													field={ field }
-													value={ getFieldValue( id, field ) }
-													onChange={ val => onFieldChange( id, field.key, val ) }
-												/>
-											) ) }
-										</Grid>
-									</>
-								) }
-							</ActionCard>
-						);
-					} ) }
+				{ ! loading && integrationIds.length > 0 && (
+					<Grid columns={ 2 } gutter={ 16 }>
+						{ integrationIds.map( id => {
+							const integration = integrations[ id ];
+							const isEnabled = integration.enabled;
+							const canSyncError = integration.can_sync !== true ? integration.can_sync : undefined;
+							return (
+								<CardFeature
+									key={ id }
+									title={ integration.name }
+									description={ integration.description }
+									icon={ INTEGRATION_ICONS[ id ] || DEFAULT_ICON }
+									enabled={ isEnabled }
+									requirements={ canSyncError }
+									enableLabel={ __( 'Connect', 'newspack-plugin' ) }
+									onEnable={ () => onToggleEnabled( id, true ) }
+									onConfigure={ () => ( onConfigure ? onConfigure( id ) : history?.push( `/settings/${ id }` ) ) }
+									moreControls={
+										isEnabled && ! canSyncError
+											? [
+													{
+														title: __( 'Logs', 'newspack-plugin' ),
+														onClick: () => {},
+													},
+													{
+														title: __( 'Disable', 'newspack-plugin' ),
+														onClick: () => onToggleEnabled( id, false ),
+													},
+											  ]
+											: undefined
+									}
+								/>
+							);
+						} ) }
+					</Grid>
+				) }
 			</WizardSection>
 		</WizardsTab>
 	);

--- a/src/wizards/audience/views/integrations/settings-section.js
+++ b/src/wizards/audience/views/integrations/settings-section.js
@@ -36,6 +36,7 @@ export const SettingsSection = ( { integrations, loading, onToggleEnabled, onCon
 
 	return (
 		<WizardsTab
+			className="newspack-audience-integrations"
 			title={ __( 'Integrations', 'newspack-plugin' ) }
 			description={ __(
 				'Manage how Newspack syncs reader data with your tools. Connect an integration to start syncing reader activity across your stack.',

--- a/src/wizards/audience/views/integrations/settings-section.js
+++ b/src/wizards/audience/views/integrations/settings-section.js
@@ -64,10 +64,6 @@ export const SettingsSection = ( { integrations, loading, onToggleEnabled, onCon
 										isEnabled && ! canSyncError
 											? [
 													{
-														title: __( 'Logs', 'newspack-plugin' ),
-														onClick: () => {},
-													},
-													{
 														title: __( 'Disable', 'newspack-plugin' ),
 														onClick: () => onToggleEnabled( id, false ),
 													},

--- a/src/wizards/audience/views/integrations/settings-section.js
+++ b/src/wizards/audience/views/integrations/settings-section.js
@@ -46,9 +46,9 @@ export const SettingsSection = ( { integrations, loading, onToggleEnabled, onCon
 				{ ! loading && integrationIds.length > 0 && (
 					<Grid columns={ 2 } gutter={ 16 }>
 						{ integrationIds.map( id => {
-							const { enabled, can_sync: canSync, setup_url, name, description } = integrations[ id ];
-							const isEnabled = enabled && canSync;
-							const needsSetup = ! canSync && !! setup_url;
+							const { enabled, is_set_up: isSetUp, setup_url, name, description } = integrations[ id ];
+							const isEnabled = enabled;
+							const needsSetup = ! isSetUp && !! setup_url;
 							const goToSetup = () => {
 								window.location.href = setup_url;
 							};
@@ -58,8 +58,8 @@ export const SettingsSection = ( { integrations, loading, onToggleEnabled, onCon
 									title={ name }
 									description={ description }
 									icon={ INTEGRATION_ICONS[ id ] || DEFAULT_ICON }
-									enabled={ isEnabled }
-									enableLabel={ __( 'Connect', 'newspack-plugin' ) }
+									enabled={ isEnabled && isSetUp }
+									enableLabel={ isSetUp ? __( 'Enable', 'newspack-plugin' ) : __( 'Connect', 'newspack-plugin' ) }
 									configureLabel={ needsSetup ? __( 'Configure', 'newspack-plugin' ) : undefined }
 									onEnable={ needsSetup ? goToSetup : () => onToggleEnabled( id, true ) }
 									onConfigure={
@@ -68,7 +68,7 @@ export const SettingsSection = ( { integrations, loading, onToggleEnabled, onCon
 									badgeText={ undefined }
 									badgeLevel={ undefined }
 									moreControls={
-										isEnabled && canSync
+										isEnabled
 											? [
 													{
 														title: __( 'Disable', 'newspack-plugin' ),

--- a/src/wizards/audience/views/integrations/settings-section.js
+++ b/src/wizards/audience/views/integrations/settings-section.js
@@ -35,7 +35,13 @@ export const SettingsSection = ( { integrations, loading, onToggleEnabled, onCon
 	const integrationIds = Object.keys( integrations );
 
 	return (
-		<WizardsTab title={ __( 'Integrations', 'newspack-plugin' ) }>
+		<WizardsTab
+			title={ __( 'Integrations', 'newspack-plugin' ) }
+			description={ __(
+				'Manage how Newspack syncs reader data with your tools. Connect an integration to start syncing reader activity across your stack.',
+				'newspack-plugin'
+			) }
+		>
 			<WizardSection>
 				{ loading && <p>{ __( 'Loading…', 'newspack-plugin' ) }</p> }
 				{ ! loading && integrationIds.length === 0 && (

--- a/src/wizards/audience/views/integrations/settings-section.js
+++ b/src/wizards/audience/views/integrations/settings-section.js
@@ -46,22 +46,29 @@ export const SettingsSection = ( { integrations, loading, onToggleEnabled, onCon
 				{ ! loading && integrationIds.length > 0 && (
 					<Grid columns={ 2 } gutter={ 16 }>
 						{ integrationIds.map( id => {
-							const integration = integrations[ id ];
-							const isEnabled = integration.enabled;
-							const canSyncError = integration.can_sync !== true ? integration.can_sync : undefined;
+							const { enabled, can_sync: canSync, setup_url, name, description } = integrations[ id ];
+							const isEnabled = enabled && canSync;
+							const needsSetup = ! canSync && !! setup_url;
+							const goToSetup = () => {
+								window.location.href = setup_url;
+							};
 							return (
 								<CardFeature
 									key={ id }
-									title={ integration.name }
-									description={ integration.description }
+									title={ name }
+									description={ description }
 									icon={ INTEGRATION_ICONS[ id ] || DEFAULT_ICON }
 									enabled={ isEnabled }
-									requirements={ canSyncError }
 									enableLabel={ __( 'Connect', 'newspack-plugin' ) }
-									onEnable={ () => onToggleEnabled( id, true ) }
-									onConfigure={ () => ( onConfigure ? onConfigure( id ) : history?.push( `/settings/${ id }` ) ) }
+									configureLabel={ needsSetup ? __( 'Configure', 'newspack-plugin' ) : undefined }
+									onEnable={ needsSetup ? goToSetup : () => onToggleEnabled( id, true ) }
+									onConfigure={
+										needsSetup ? goToSetup : () => ( onConfigure ? onConfigure( id ) : history?.push( `/settings/${ id }` ) )
+									}
+									badgeText={ undefined }
+									badgeLevel={ undefined }
 									moreControls={
-										isEnabled && ! canSyncError
+										isEnabled && canSync
 											? [
 													{
 														title: __( 'Disable', 'newspack-plugin' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Replaces the `ActionCard`-based integrations settings view with a `CardFeature` card grid layout as part of the Integrations i3 redesign (DSGNEWS-135).

[57274ba28a38fb9a41de4dadeeb540f0.webm](https://github.com/user-attachments/assets/d1bbb13b-d208-4ae4-a13f-037dd69f9536)

**PHP changes:**
- Fixed ESP disable not persisting: `self::enable('esp')` was running unconditionally on every page load in `register_integrations()`, overwriting user-initiated disables. Now only auto-enables on first registration (when the option doesn't exist yet)
- Added `is_set_up()` method to the `Integration` base class (returns `true` by default). ESP overrides it to check whether the ESP service provider is configured via the Newsletters configuration manager
- Added `get_setup_url()` method to the `Integration` base class (returns empty string by default). ESP overrides it to return the Newspack Newsletters settings page URL
- Added `is_set_up` and `setup_url` fields to the REST API response

**Frontend changes:**
- Rewrote `settings-section.js` to render integrations as `CardFeature` cards in a 2-column `Grid` with proper state mapping (enabled, requirements, badges, kebab menu)
- When the integration is not set up (`is_set_up` is false) and has a `setup_url`, the primary button navigates to the setup page (e.g., Newsletters settings) instead of toggling the integration. This applies regardless of whether the integration is enabled or disabled
- When the integration is set up but not enabled, the button toggles the integration on
- Created `configure-view.js` — a scaffold for per-integration settings, reusing existing `SettingsField` components with a back button
- Updated `index.js` to add hash routing with two Wizard sections: dashboard grid (`#/settings`) and configure view (`#/settings/:integrationId`)
- Added integration icon config map (ESP gets a blue envelope icon; fallback for future integrations)
- Updated `CardFeature` component to support showing a badge via explicit `badgeText` prop even when the feature is not enabled

Closes DSGNEWS-154.

### How to test the changes in this Pull Request:

1. Enable the feature gate: add `define( 'NEWSPACK_INTEGRATIONS_SETTINGS_ENABLED', true );` to `wp-config.php`
2. Build the plugin: `n build newspack-plugin`
3. Navigate to **wp-admin → Audience → Integrations**
4. Verify the ESP integration renders as a `CardFeature` card in a 2-column grid with a blue envelope icon

**ESP not set up (Newspack Newsletters not configured with a provider):**
5. Verify the card shows a "Connect" button
6. Click "Connect" — verify it navigates to the Newspack Newsletters settings page

**ESP set up but not enabled:**
7. Verify the card shows an "Enable" button
8. Click "Enable" — verify the integration toggles on

**ESP enabled:**
9. Verify the card shows as enabled with a "Configure" button and kebab menu with "Disable"
10. Click kebab → "Disable" — verify the card toggles to disconnected
11. **Refresh the page** — verify the disabled state persists (previously it did not)
12. Re-enable, then click "Configure" — verify navigation to `#/settings/esp` showing settings fields and a back chevron in the header
13. Click the back chevron — verify return to the dashboard grid

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?