### PR TITLE
fix(recaptcha): skip script registration on TEC Community Events pages

### DIFF
--- a/includes/class-recaptcha.php
+++ b/includes/class-recaptcha.php
@@ -115,6 +115,15 @@ final class Recaptcha {
 	 * Register the reCAPTCHA script.
 	 */
 	public static function register_scripts() {
+		// The Events Calendar Community Events loads its own reCAPTCHA api.js on its
+		// submission/edit pages. Two api.js loads with different site keys break
+		// reCAPTCHA, and Newspack's client does not protect TEC forms, so bail
+		// early rather than breaking TEC's own reCAPTCHA. Scoped here (not in
+		// can_use_captcha) so server-side verify_captcha() and Woo helpers still
+		// run for any embedded Newspack-protected forms on TEC pages.
+		if ( \function_exists( 'tribe_is_community_edit_event_page' ) && \tribe_is_community_edit_event_page() ) {
+			return;
+		}
 		if ( self::can_use_captcha() ) {
 			\wp_enqueue_style(
 				self::SCRIPT_HANDLE,
@@ -349,13 +358,6 @@ final class Recaptcha {
 	 * @return boolean True if we can use reCaptcha to secure checkout requests.
 	 */
 	public static function can_use_captcha( $version = null ) {
-		// The Events Calendar Community Events loads its own reCAPTCHA api.js on its
-		// submission/edit pages. Two api.js loads with different site keys break
-		// reCAPTCHA, and Newspack's client does not protect TEC forms, so treat
-		// captcha as unavailable here rather than breaking TEC's own reCAPTCHA.
-		if ( \function_exists( 'tribe_is_community_edit_event_page' ) && \tribe_is_community_edit_event_page() ) {
-			return false;
-		}
 		$settings = self::get_settings();
 		if ( empty( $settings['use_captcha'] ) ) {
 			return false;

--- a/includes/class-recaptcha.php
+++ b/includes/class-recaptcha.php
@@ -115,6 +115,13 @@ final class Recaptcha {
 	 * Register the reCAPTCHA script.
 	 */
 	public static function register_scripts() {
+		// The Events Calendar Community Events loads its own reCAPTCHA api.js on its
+		// submission page. Two api.js loads with different site keys break reCAPTCHA,
+		// and Newspack's client does not protect TEC forms, so bail early rather 
+		// than breaking TEC's own reCAPTCHA.
+		if ( function_exists( 'tribe_is_community_edit_event_page' ) && tribe_is_community_edit_event_page() ) {
+			return;
+		}
 		if ( self::can_use_captcha() ) {
 			\wp_enqueue_style(
 				self::SCRIPT_HANDLE,

--- a/includes/class-recaptcha.php
+++ b/includes/class-recaptcha.php
@@ -115,13 +115,6 @@ final class Recaptcha {
 	 * Register the reCAPTCHA script.
 	 */
 	public static function register_scripts() {
-		// The Events Calendar Community Events loads its own reCAPTCHA api.js on its
-		// submission page. Two api.js loads with different site keys break reCAPTCHA,
-		// and Newspack's client does not protect TEC forms, so bail early rather
-		// than breaking TEC's own reCAPTCHA.
-		if ( \function_exists( 'tribe_is_community_edit_event_page' ) && \tribe_is_community_edit_event_page() ) {
-			return;
-		}
 		if ( self::can_use_captcha() ) {
 			\wp_enqueue_style(
 				self::SCRIPT_HANDLE,
@@ -356,6 +349,13 @@ final class Recaptcha {
 	 * @return boolean True if we can use reCaptcha to secure checkout requests.
 	 */
 	public static function can_use_captcha( $version = null ) {
+		// The Events Calendar Community Events loads its own reCAPTCHA api.js on its
+		// submission page. Two api.js loads with different site keys break reCAPTCHA,
+		// and Newspack's client does not protect TEC forms, so treat captcha as
+		// unavailable here rather than breaking TEC's own reCAPTCHA.
+		if ( \function_exists( 'tribe_is_community_edit_event_page' ) && \tribe_is_community_edit_event_page() ) {
+			return false;
+		}
 		$settings = self::get_settings();
 		if ( empty( $settings['use_captcha'] ) ) {
 			return false;

--- a/includes/class-recaptcha.php
+++ b/includes/class-recaptcha.php
@@ -350,9 +350,9 @@ final class Recaptcha {
 	 */
 	public static function can_use_captcha( $version = null ) {
 		// The Events Calendar Community Events loads its own reCAPTCHA api.js on its
-		// submission page. Two api.js loads with different site keys break reCAPTCHA,
-		// and Newspack's client does not protect TEC forms, so treat captcha as
-		// unavailable here rather than breaking TEC's own reCAPTCHA.
+		// submission/edit pages. Two api.js loads with different site keys break
+		// reCAPTCHA, and Newspack's client does not protect TEC forms, so treat
+		// captcha as unavailable here rather than breaking TEC's own reCAPTCHA.
 		if ( \function_exists( 'tribe_is_community_edit_event_page' ) && \tribe_is_community_edit_event_page() ) {
 			return false;
 		}

--- a/includes/class-recaptcha.php
+++ b/includes/class-recaptcha.php
@@ -117,9 +117,9 @@ final class Recaptcha {
 	public static function register_scripts() {
 		// The Events Calendar Community Events loads its own reCAPTCHA api.js on its
 		// submission page. Two api.js loads with different site keys break reCAPTCHA,
-		// and Newspack's client does not protect TEC forms, so bail early rather 
+		// and Newspack's client does not protect TEC forms, so bail early rather
 		// than breaking TEC's own reCAPTCHA.
-		if ( function_exists( 'tribe_is_community_edit_event_page' ) && tribe_is_community_edit_event_page() ) {
+		if ( \function_exists( 'tribe_is_community_edit_event_page' ) && \tribe_is_community_edit_event_page() ) {
 			return;
 		}
 		if ( self::can_use_captcha() ) {

--- a/tests/mocks/tec-community-events-mocks.php
+++ b/tests/mocks/tec-community-events-mocks.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * The Events Calendar Community Events mocks.
+ *
+ * @package Newspack\Tests
+ */
+
+if ( ! function_exists( 'tribe_is_community_edit_event_page' ) ) {
+	/**
+	 * Stub for The Events Calendar Community Events plugin helper.
+	 *
+	 * Reads a global so tests can toggle the TEC community submission page state.
+	 *
+	 * @return bool
+	 */
+	function tribe_is_community_edit_event_page() {
+		global $newspack_test_is_tec_community_page;
+		return $newspack_test_is_tec_community_page ?? false;
+	}
+}

--- a/tests/unit-tests/recaptcha.php
+++ b/tests/unit-tests/recaptcha.php
@@ -95,4 +95,18 @@ class Test_Recaptcha extends WP_UnitTestCase {
 			'reCAPTCHA api.js should not be enqueued when reCAPTCHA is disabled.'
 		);
 	}
+
+	/**
+	 * can_use_captcha() should treat reCAPTCHA as unavailable on TEC Community Events pages,
+	 * so all callers (register_scripts, verify_captcha, Woo helpers) skip it consistently.
+	 */
+	public function test_can_use_captcha_returns_false_on_tec_community_page() {
+		$this->enable_recaptcha();
+		$GLOBALS['newspack_test_is_tec_community_page'] = true;
+
+		$this->assertFalse(
+			Recaptcha::can_use_captcha(),
+			'can_use_captcha() should return false on TEC Community Events submission pages.'
+		);
+	}
 }

--- a/tests/unit-tests/recaptcha.php
+++ b/tests/unit-tests/recaptcha.php
@@ -97,8 +97,8 @@ class Test_Recaptcha extends WP_UnitTestCase {
 	}
 
 	/**
-	 * can_use_captcha() should treat reCAPTCHA as unavailable on TEC Community Events pages,
-	 * so all callers (register_scripts, verify_captcha, Woo helpers) skip it consistently.
+	 * Verify can_use_captcha() returns false on TEC Community Events pages so all
+	 * callers (register_scripts, verify_captcha, Woo helpers) skip it consistently.
 	 */
 	public function test_can_use_captcha_returns_false_on_tec_community_page() {
 		$this->enable_recaptcha();

--- a/tests/unit-tests/recaptcha.php
+++ b/tests/unit-tests/recaptcha.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Tests for the Recaptcha class.
+ *
+ * @package Newspack
+ */
+
+use Newspack\Recaptcha;
+
+if ( ! function_exists( 'tribe_is_community_edit_event_page' ) ) {
+	/**
+	 * Test stub for The Events Calendar Community Events plugin helper.
+	 *
+	 * Reads a global so tests can toggle the TEC community submission page state.
+	 */
+	function tribe_is_community_edit_event_page() {
+		global $newspack_test_is_tec_community_page;
+		return $newspack_test_is_tec_community_page ?? false;
+	}
+}
+
+/**
+ * Class Test_Recaptcha
+ */
+class Test_Recaptcha extends WP_UnitTestCase {
+	/**
+	 * Reset options, enqueued scripts, and the TEC page global before each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+		delete_option( 'newspack_recaptcha_use_captcha' );
+		delete_option( 'newspack_recaptcha_version' );
+		delete_option( 'newspack_recaptcha_credentials' );
+		wp_dequeue_script( 'newspack-recaptcha' );
+		wp_dequeue_script( 'newspack-recaptcha-api' );
+		wp_deregister_script( 'newspack-recaptcha' );
+		wp_deregister_script( 'newspack-recaptcha-api' );
+		$GLOBALS['newspack_test_is_tec_community_page'] = false;
+	}
+
+	/**
+	 * Configure valid reCAPTCHA v3 credentials so can_use_captcha() returns true.
+	 */
+	private function enable_recaptcha() {
+		update_option( 'newspack_recaptcha_use_captcha', true );
+		update_option( 'newspack_recaptcha_version', 'v3' );
+		update_option(
+			'newspack_recaptcha_credentials',
+			[
+				'v3'           => [
+					'site_key'    => 'test_key',
+					'site_secret' => 'test_secret',
+				],
+				'v2_invisible' => [
+					'site_key'    => '',
+					'site_secret' => '',
+				],
+			]
+		);
+	}
+
+	/**
+	 * Normal front-end pages should enqueue Google's reCAPTCHA api.js.
+	 */
+	public function test_enqueues_api_script_on_normal_page() {
+		$this->enable_recaptcha();
+		$GLOBALS['newspack_test_is_tec_community_page'] = false;
+
+		Recaptcha::register_scripts();
+
+		$this->assertTrue(
+			wp_script_is( 'newspack-recaptcha-api', 'registered' ),
+			'reCAPTCHA api.js should be registered on a normal page when reCAPTCHA is enabled.'
+		);
+	}
+
+	/**
+	 * The TEC Community Events submission page should bail out and not enqueue api.js.
+	 */
+	public function test_skips_api_script_on_tec_community_page() {
+		$this->enable_recaptcha();
+		$GLOBALS['newspack_test_is_tec_community_page'] = true;
+
+		Recaptcha::register_scripts();
+
+		$this->assertFalse(
+			wp_script_is( 'newspack-recaptcha-api', 'registered' ),
+			'reCAPTCHA api.js should NOT be registered on TEC Community Events submission pages.'
+		);
+	}
+
+	/**
+	 * When reCAPTCHA is disabled, api.js should never be enqueued regardless of page.
+	 */
+	public function test_does_not_enqueue_when_recaptcha_disabled() {
+		delete_option( 'newspack_recaptcha_use_captcha' );
+		$GLOBALS['newspack_test_is_tec_community_page'] = false;
+
+		Recaptcha::register_scripts();
+
+		$this->assertFalse(
+			wp_script_is( 'newspack-recaptcha-api', 'registered' ),
+			'reCAPTCHA api.js should not be registered when reCAPTCHA is disabled.'
+		);
+	}
+}

--- a/tests/unit-tests/recaptcha.php
+++ b/tests/unit-tests/recaptcha.php
@@ -2,7 +2,7 @@
 /**
  * Tests for the Recaptcha class.
  *
- * @package Newspack
+ * @package Newspack\Tests
  */
 
 use Newspack\Recaptcha;
@@ -25,6 +25,8 @@ class Test_Recaptcha extends WP_UnitTestCase {
 		wp_dequeue_script( 'newspack-recaptcha-api' );
 		wp_deregister_script( 'newspack-recaptcha' );
 		wp_deregister_script( 'newspack-recaptcha-api' );
+		wp_dequeue_style( 'newspack-recaptcha' );
+		wp_deregister_style( 'newspack-recaptcha' );
 		$GLOBALS['newspack_test_is_tec_community_page'] = false;
 	}
 
@@ -59,8 +61,8 @@ class Test_Recaptcha extends WP_UnitTestCase {
 		Recaptcha::register_scripts();
 
 		$this->assertTrue(
-			wp_script_is( 'newspack-recaptcha-api', 'registered' ),
-			'reCAPTCHA api.js should be registered on a normal page when reCAPTCHA is enabled.'
+			wp_script_is( 'newspack-recaptcha-api', 'enqueued' ),
+			'reCAPTCHA api.js should be enqueued on a normal page when reCAPTCHA is enabled.'
 		);
 	}
 
@@ -74,8 +76,8 @@ class Test_Recaptcha extends WP_UnitTestCase {
 		Recaptcha::register_scripts();
 
 		$this->assertFalse(
-			wp_script_is( 'newspack-recaptcha-api', 'registered' ),
-			'reCAPTCHA api.js should NOT be registered on TEC Community Events submission pages.'
+			wp_script_is( 'newspack-recaptcha-api', 'enqueued' ),
+			'reCAPTCHA api.js should NOT be enqueued on TEC Community Events submission pages.'
 		);
 	}
 
@@ -89,8 +91,8 @@ class Test_Recaptcha extends WP_UnitTestCase {
 		Recaptcha::register_scripts();
 
 		$this->assertFalse(
-			wp_script_is( 'newspack-recaptcha-api', 'registered' ),
-			'reCAPTCHA api.js should not be registered when reCAPTCHA is disabled.'
+			wp_script_is( 'newspack-recaptcha-api', 'enqueued' ),
+			'reCAPTCHA api.js should not be enqueued when reCAPTCHA is disabled.'
 		);
 	}
 }

--- a/tests/unit-tests/recaptcha.php
+++ b/tests/unit-tests/recaptcha.php
@@ -7,17 +7,7 @@
 
 use Newspack\Recaptcha;
 
-if ( ! function_exists( 'tribe_is_community_edit_event_page' ) ) {
-	/**
-	 * Test stub for The Events Calendar Community Events plugin helper.
-	 *
-	 * Reads a global so tests can toggle the TEC community submission page state.
-	 */
-	function tribe_is_community_edit_event_page() {
-		global $newspack_test_is_tec_community_page;
-		return $newspack_test_is_tec_community_page ?? false;
-	}
-}
+require_once NEWSPACK_ABSPATH . 'tests/mocks/tec-community-events-mocks.php';
 
 /**
  * Class Test_Recaptcha

--- a/tests/unit-tests/recaptcha.php
+++ b/tests/unit-tests/recaptcha.php
@@ -95,18 +95,4 @@ class Test_Recaptcha extends WP_UnitTestCase {
 			'reCAPTCHA api.js should not be enqueued when reCAPTCHA is disabled.'
 		);
 	}
-
-	/**
-	 * Verify can_use_captcha() returns false on TEC Community Events pages so all
-	 * callers (register_scripts, verify_captcha, Woo helpers) skip it consistently.
-	 */
-	public function test_can_use_captcha_returns_false_on_tec_community_page() {
-		$this->enable_recaptcha();
-		$GLOBALS['newspack_test_is_tec_community_page'] = true;
-
-		$this->assertFalse(
-			Recaptcha::can_use_captcha(),
-			'can_use_captcha() should return false on TEC Community Events submission pages.'
-		);
-	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Newspack's reCAPTCHA loads Google's `api.js` on every front-end page. When The Events Calendar Community Events is active and the publisher has configured TEC's own reCAPTCHA key, the TEC Community Events submission page also loads `api.js` with a different site key. Two `api.js` loading on the same page with different keys break reCAPTCHA resulting in errors when trying to submit a community event.

Newspack's reCAPTCHA client only protects `form[data-newspack-recaptcha]`, `form#add_payment_method`, and `form.checkout`, so it was never protecting TEC forms to begin with. This change adds an early return in `Recaptcha::register_scripts()` when we're on a TEC Community Events submission page, preventing the conflict while leaving TEC's own reCAPTCHA spam protection intact.

Closes NPPM-2743.

### How to test the changes in this Pull Request:

**Setup:**
1. Activate The Events Calendar and The Events Calendar Community Events.
2. In Newspack wizard → Connections → reCAPTCHA, enable reCAPTCHA (v2 or v3)
3. In WP Admin → Events → Settings → Addons, save a different reCAPTCHA site key (v2 or v3)
4. Log out or open an incognito window as reCAPTCHA only renders for logged-out users on TEC forms.

**Reproduce the problem (on `trunk`, before this PR):**
1. Visit `/events/community/add/`.
2. Open DevTools → Network, filter by `api.js`. Confirm two separate `https://www.google.com/recaptcha/api.js` requests load.
3. Fill in the community event form and submit. Confirm the form fails with an error.

<img width="1396" height="287" alt="download-1" src="https://github.com/user-attachments/assets/776cbfdc-3194-4198-bcb8-37b555315530" />
&nbsp;

**Verify the fix (with this PR):**
1. Reload `/events/community/add/`. Confirm only TEC's `api.js` loads, Newspack's is no longer present.
2. Fill in and submit the community event form. Confirm it submits successfully.
3. Load the homepage (or any non-TEC page). Confirm Newspack's `api.js?render=<site_key>` still loads (no regression).
5. Switch Newspack reCAPTCHA to the other version (v2 if you used v3, or vice versa) and repeat steps 1 and 3 to confirm the guard works regardless of version.
6. From `repos/newspack-plugin/`, run `n test-php --filter Test_Recaptcha` and confirm all 3 new tests pass.

<img width="1370" height="257" alt="Screenshot 2026-04-15 at 1 53 28 PM" src="https://github.com/user-attachments/assets/025ae2c7-f98e-4620-bc2f-93aacedafe37" />
&nbsp;

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
