### PR TITLE
fix(access-control): bump content rule suggestion limit to 100

### DIFF
--- a/src/wizards/audience/views/content-gates/edit/content-rule-control-tokenfield.tsx
+++ b/src/wizards/audience/views/content-gates/edit/content-rule-control-tokenfield.tsx
@@ -49,7 +49,7 @@ export default function ContentRuleControlTokenField( { slug, value, exclusion, 
 			apiFetch< { db_id?: number; id: number; name: string; type_label?: string }[] >( {
 				path: addQueryArgs( endpoint, {
 					search,
-					per_page: 10,
+					per_page: 100,
 					_fields: 'db_id,id,name,type_label',
 				} ),
 			} )

--- a/src/wizards/audience/views/content-gates/edit/content-rule-control-tokenfield.tsx
+++ b/src/wizards/audience/views/content-gates/edit/content-rule-control-tokenfield.tsx
@@ -84,6 +84,7 @@ export default function ContentRuleControlTokenField( { slug, value, exclusion, 
 		apiFetch< { db_id?: number; id: number; name: string; type_label?: string }[] >( {
 			path: addQueryArgs( endpoint, {
 				include: value.join( ',' ),
+				per_page: 100,
 				_fields: 'db_id,id,name,type_label',
 			} ),
 		} )


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a bug that causes the UI for managing taxonomy-based content rules to show a maximum of 10 saved tokens. 

Closes NPPD-1459.

### How to test the changes in this Pull Request:

1. With `define( 'NEWSPACK_CONTENT_GATES', true );` defined in wp-config.php, create or edit a content gate.
2. Select "Choose specific content", enable the Categories rule, and attempt to add more than 10 category terms without saving in between.
3. On `trunk`, observe that as you add more than 10, the UI starts to drop display of some terms you added previously.
4. Save the gate.
5. In the Content Gates list view, observe that on `trunk` the Content Rules summary also only shows a max of 10 terms.
6. Check out this branch, repeat steps 2-5, and confirm that you're able to add up to 100 terms and see them represented visually in both UIs.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->