### PR TITLE
fix(access-control): allow `0` member limit values to be shown

### DIFF
--- a/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-settings.php
+++ b/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-settings.php
@@ -227,8 +227,10 @@ class Group_Subscription_Settings {
 		if ( ! $product ) {
 			return $settings;
 		}
-		$settings['enabled'] = $product->get_meta( self::GROUP_SUBSCRIPTION_META_PREFIX . 'enabled', true ) ? \wc_string_to_bool( $product->get_meta( self::GROUP_SUBSCRIPTION_META_PREFIX . 'enabled', true ) ) : self::DEFAULT_SETTINGS['enabled'];
-		$settings['limit']   = (int) $product->get_meta( self::GROUP_SUBSCRIPTION_META_PREFIX . 'limit', true ) ?: self::DEFAULT_SETTINGS['limit']; // phpcs:ignore Universal.Operators.DisallowShortTernary.Found
+		$enabled_meta        = $product->get_meta( self::GROUP_SUBSCRIPTION_META_PREFIX . 'enabled', true );
+		$limit_meta          = $product->get_meta( self::GROUP_SUBSCRIPTION_META_PREFIX . 'limit', true );
+		$settings['enabled'] = '' !== $enabled_meta ? \wc_string_to_bool( $enabled_meta ) : $settings['enabled']; // Empty string means the meta is unset; any other value, including 'no' or false, is a real override.
+		$settings['limit']   = '' !== $limit_meta ? (int) $limit_meta : $settings['limit']; // Empty string means the meta is unset; any other value, including '0', is a real override.
 
 		/**
 		 * Filter the group subscription settings for a product.
@@ -257,8 +259,8 @@ class Group_Subscription_Settings {
 		$enabled_meta        = $subscription->get_meta( self::GROUP_SUBSCRIPTION_META_PREFIX . 'enabled', true );
 		$limit_meta          = $subscription->get_meta( self::GROUP_SUBSCRIPTION_META_PREFIX . 'limit', true );
 		$name_meta           = $subscription->get_meta( self::GROUP_SUBSCRIPTION_META_PREFIX . 'name', true );
-		$settings['enabled'] = $enabled_meta ? \wc_string_to_bool( $enabled_meta ) : $settings['enabled'];
-		$settings['limit']   = (int) $limit_meta ?: $settings['limit']; // phpcs:ignore Universal.Operators.DisallowShortTernary.Found
+		$settings['enabled'] = '' !== $enabled_meta ? \wc_string_to_bool( $enabled_meta ) : $settings['enabled']; // Empty string means the meta is unset; any other value, including 'no' or false, is a real override.
+		$settings['limit']   = '' !== $limit_meta ? (int) $limit_meta : $settings['limit']; // Empty string means the meta is unset; any other value, including '0', is a real override.
 		if ( $name_meta ) {
 			$settings['name'] = $name_meta;
 		} elseif ( $owner_name ) {

--- a/tests/mocks/wc-mocks.php
+++ b/tests/mocks/wc-mocks.php
@@ -401,6 +401,9 @@ function wcs_get_users_subscriptions( $user_id ) {
 	return $user_subscriptions;
 }
 function wcs_get_canonical_product_id( $item ) {
+	if ( is_object( $item ) && method_exists( $item, 'get_product_id' ) ) {
+		return $item->get_product_id();
+	}
 	return null;
 }
 function wc_string_to_bool( $string ) {

--- a/tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-settings.php
+++ b/tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-settings.php
@@ -14,6 +14,16 @@ use Newspack\Group_Subscription_Settings;
 class Test_Group_Subscription_Settings extends WP_UnitTestCase {
 
 	/**
+	 * Set up test fixtures.
+	 */
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
+		// Include WC mocks.
+		require_once dirname( __DIR__, 4 ) . '/mocks/wc-mocks.php';
+	}
+
+	/**
 	 * Tear down: reset subscriptions and products databases.
 	 */
 	public function tear_down() {

--- a/tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-settings.php
+++ b/tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-settings.php
@@ -44,52 +44,70 @@ class Test_Group_Subscription_Settings extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Build a subscription linked to a product with a non-zero group subscription limit.
+	 * Build a subscription linked to a product, optionally setting group subscription
+	 * meta on either side and arbitrary subscription data.
 	 *
-	 * @param int        $product_limit         The product's group subscription limit.
-	 * @param mixed|null $subscription_override If not null, set as the subscription's limit meta override.
+	 * Meta keys are passed without the GROUP_SUBSCRIPTION_META_PREFIX; the helper
+	 * applies the prefix.
+	 *
+	 * @param array $product_meta      Map of meta key => value to set on the product.
+	 * @param array $subscription_meta Map of meta key => value to set on the subscription.
+	 * @param array $subscription_args Extra arguments merged into the subscription data
+	 *                                 (e.g. billing_first_name, billing_last_name).
 	 *
 	 * @return WC_Subscription
 	 */
-	private function make_subscription_with_product_limit( $product_limit, $subscription_override = null ) {
-		$product_id = 123;
+	private function make_subscription_with_product( $product_meta = [], $subscription_meta = [], $subscription_args = [] ) {
+		$product_id            = 123;
+		$prefixed_product_meta = [];
+		foreach ( $product_meta as $key => $value ) {
+			$prefixed_product_meta[ Group_Subscription_Settings::GROUP_SUBSCRIPTION_META_PREFIX . $key ] = $value;
+		}
 		wc_create_mock_product(
 			[
 				'id'   => $product_id,
-				'meta' => [
-					Group_Subscription_Settings::GROUP_SUBSCRIPTION_META_PREFIX . 'enabled' => 'yes',
-					Group_Subscription_Settings::GROUP_SUBSCRIPTION_META_PREFIX . 'limit'   => (string) $product_limit,
-				],
+				'meta' => $prefixed_product_meta,
 			]
 		);
 
 		$subscription = wcs_create_subscription(
-			[
-				'customer_id'    => 1,
-				'status'         => 'active',
-				'billing_period' => 'month',
-				'items'          => [
-					new WC_Order_Item_Product( [ 'product_id' => $product_id ] ),
+			array_merge(
+				[
+					'customer_id'    => 1,
+					'status'         => 'active',
+					'billing_period' => 'month',
+					'items'          => [
+						new WC_Order_Item_Product( [ 'product_id' => $product_id ] ),
+					],
 				],
-			]
+				$subscription_args
+			)
 		);
 
-		if ( null !== $subscription_override ) {
-			$subscription->update_meta_data( Group_Subscription_Settings::GROUP_SUBSCRIPTION_META_PREFIX . 'limit', $subscription_override );
+		foreach ( $subscription_meta as $key => $value ) {
+			$subscription->update_meta_data( Group_Subscription_Settings::GROUP_SUBSCRIPTION_META_PREFIX . $key, $value );
 		}
 
 		return $subscription;
 	}
 
+	/*
+	 * --- 'limit' setting ---
+	 */
+
 	/**
 	 * When a subscription has no limit override, the inherited product limit applies.
 	 */
 	public function test_inherits_product_limit_when_subscription_override_unset() {
-		$subscription = $this->make_subscription_with_product_limit( 10 );
+		$subscription = $this->make_subscription_with_product(
+			[
+				'enabled' => 'yes',
+				'limit'   => '10',
+			]
+		);
 
 		$settings = Group_Subscription_Settings::get_subscription_settings( $subscription );
 
-		$this->assertTrue( $settings['enabled'], 'Enabled should be inherited from the product.' );
 		$this->assertSame( 10, $settings['limit'], 'Limit should be inherited from the product when no subscription override is set.' );
 	}
 
@@ -97,8 +115,13 @@ class Test_Group_Subscription_Settings extends WP_UnitTestCase {
 	 * A subscription limit override of 0 takes precedence over a non-zero product limit.
 	 */
 	public function test_zero_subscription_limit_overrides_product_limit() {
-		// '0' as string, matching how WooCommerce stores meta.
-		$subscription = $this->make_subscription_with_product_limit( 10, '0' );
+		$subscription = $this->make_subscription_with_product(
+			[
+				'enabled' => 'yes',
+				'limit'   => '10',
+			],
+			[ 'limit' => '0' ] // String, as stored by WooCommerce meta.
+		);
 
 		$settings = Group_Subscription_Settings::get_subscription_settings( $subscription );
 
@@ -109,10 +132,110 @@ class Test_Group_Subscription_Settings extends WP_UnitTestCase {
 	 * A non-zero subscription limit override takes precedence over the product limit.
 	 */
 	public function test_nonzero_subscription_limit_overrides_product_limit() {
-		$subscription = $this->make_subscription_with_product_limit( 10, '5' );
+		$subscription = $this->make_subscription_with_product(
+			[
+				'enabled' => 'yes',
+				'limit'   => '10',
+			],
+			[ 'limit' => '5' ]
+		);
 
 		$settings = Group_Subscription_Settings::get_subscription_settings( $subscription );
 
 		$this->assertSame( 5, $settings['limit'], 'A subscription limit of 5 should override the product limit of 10.' );
+	}
+
+	/*
+	 * --- 'enabled' setting ---
+	 */
+
+	/**
+	 * When a subscription has no enabled override, the inherited product value applies.
+	 */
+	public function test_inherits_product_enabled_when_subscription_override_unset() {
+		$subscription = $this->make_subscription_with_product( [ 'enabled' => 'yes' ] );
+
+		$settings = Group_Subscription_Settings::get_subscription_settings( $subscription );
+
+		$this->assertTrue( $settings['enabled'], 'Enabled should be inherited from the product when no subscription override is set.' );
+	}
+
+	/**
+	 * A subscription enabled override of 'no' takes precedence over a product 'yes'.
+	 */
+	public function test_no_subscription_enabled_overrides_product_yes() {
+		$subscription = $this->make_subscription_with_product(
+			[ 'enabled' => 'yes' ],
+			[ 'enabled' => 'no' ]
+		);
+
+		$settings = Group_Subscription_Settings::get_subscription_settings( $subscription );
+
+		$this->assertFalse( $settings['enabled'], 'A subscription enabled value of "no" should override the product value of "yes".' );
+	}
+
+	/**
+	 * A subscription enabled override of 'yes' takes effect when the product has no value set.
+	 */
+	public function test_yes_subscription_enabled_overrides_product_unset() {
+		$subscription = $this->make_subscription_with_product(
+			[],
+			[ 'enabled' => 'yes' ]
+		);
+
+		$settings = Group_Subscription_Settings::get_subscription_settings( $subscription );
+
+		$this->assertTrue( $settings['enabled'], 'A subscription enabled value of "yes" should take effect when the product has no value set.' );
+	}
+
+	/*
+	 * --- 'name' setting ---
+	 */
+
+	/**
+	 * An explicit subscription name meta value is used as the group name.
+	 */
+	public function test_explicit_subscription_name_meta_wins() {
+		$subscription = $this->make_subscription_with_product(
+			[ 'enabled' => 'yes' ],
+			[ 'name' => 'My Custom Group' ],
+			[
+				'billing_first_name' => 'Jane',
+				'billing_last_name'  => 'Doe',
+			]
+		);
+
+		$settings = Group_Subscription_Settings::get_subscription_settings( $subscription );
+
+		$this->assertSame( 'My Custom Group', $settings['name'], 'Explicit subscription name meta should be used as the group name even when an owner name is available.' );
+	}
+
+	/**
+	 * Without an explicit name, the group name falls back to the billing owner's name.
+	 */
+	public function test_name_falls_back_to_owner_billing_name() {
+		$subscription = $this->make_subscription_with_product(
+			[ 'enabled' => 'yes' ],
+			[],
+			[
+				'billing_first_name' => 'Jane',
+				'billing_last_name'  => 'Doe',
+			]
+		);
+
+		$settings = Group_Subscription_Settings::get_subscription_settings( $subscription );
+
+		$this->assertStringContainsString( 'Jane Doe', $settings['name'], 'When no name meta is set, the group name should derive from the billing owner.' );
+	}
+
+	/**
+	 * Without an explicit name or billing owner, the group name falls back to the "Unnamed group" label.
+	 */
+	public function test_name_falls_back_to_unnamed_group() {
+		$subscription = $this->make_subscription_with_product( [ 'enabled' => 'yes' ] );
+
+		$settings = Group_Subscription_Settings::get_subscription_settings( $subscription );
+
+		$this->assertSame( 'Unnamed group', $settings['name'], 'When neither name meta nor a billing owner is set, the group name should default to "Unnamed group".' );
 	}
 }

--- a/tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-settings.php
+++ b/tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-settings.php
@@ -24,7 +24,7 @@ class Test_Group_Subscription_Settings extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Set up: simulate being on the account page.
+	 * Set up: reset subscriptions and products databases.
 	 */
 	public function set_up() {
 		parent::set_up();
@@ -44,35 +44,75 @@ class Test_Group_Subscription_Settings extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A subscription limit override of 0 takes precedence over a non-zero product limit.
+	 * Build a subscription linked to a product with a non-zero group subscription limit.
+	 *
+	 * @param int        $product_limit         The product's group subscription limit.
+	 * @param mixed|null $subscription_override If not null, set as the subscription's limit meta override.
+	 *
+	 * @return WC_Subscription
 	 */
-	public function test_subscription_limit_zero_overrides_product_limit() {
-		$product_limit = 10;
-
-		// Simulate a product that has a non-zero group subscription limit.
-		$product_settings_filter = function ( $settings ) use ( $product_limit ) {
-			$settings['enabled'] = true;
-			$settings['limit']   = $product_limit;
-			return $settings;
-		};
-		add_filter( 'newspack_group_subscription_product_settings', $product_settings_filter );
+	private function make_subscription_with_product_limit( $product_limit, $subscription_override = null ) {
+		$product_id = 123;
+		wc_create_mock_product(
+			[
+				'id'   => $product_id,
+				'meta' => [
+					Group_Subscription_Settings::GROUP_SUBSCRIPTION_META_PREFIX . 'enabled' => 'yes',
+					Group_Subscription_Settings::GROUP_SUBSCRIPTION_META_PREFIX . 'limit'   => (string) $product_limit,
+				],
+			]
+		);
 
 		$subscription = wcs_create_subscription(
 			[
 				'customer_id'    => 1,
 				'status'         => 'active',
 				'billing_period' => 'month',
+				'items'          => [
+					new WC_Order_Item_Product( [ 'product_id' => $product_id ] ),
+				],
 			]
 		);
 
-		$subscription->update_meta_data( Group_Subscription_Settings::GROUP_SUBSCRIPTION_META_PREFIX . 'enabled', 'yes' );
-		// Set the limit override to 0 (string, as stored by WooCommerce meta).
-		$subscription->update_meta_data( Group_Subscription_Settings::GROUP_SUBSCRIPTION_META_PREFIX . 'limit', '0' );
+		if ( null !== $subscription_override ) {
+			$subscription->update_meta_data( Group_Subscription_Settings::GROUP_SUBSCRIPTION_META_PREFIX . 'limit', $subscription_override );
+		}
+
+		return $subscription;
+	}
+
+	/**
+	 * When a subscription has no limit override, the inherited product limit applies.
+	 */
+	public function test_inherits_product_limit_when_subscription_override_unset() {
+		$subscription = $this->make_subscription_with_product_limit( 10 );
 
 		$settings = Group_Subscription_Settings::get_subscription_settings( $subscription );
 
-		remove_filter( 'newspack_group_subscription_product_settings', $product_settings_filter );
+		$this->assertTrue( $settings['enabled'], 'Enabled should be inherited from the product.' );
+		$this->assertSame( 10, $settings['limit'], 'Limit should be inherited from the product when no subscription override is set.' );
+	}
 
-		$this->assertSame( 0, $settings['limit'], 'A subscription limit of 0 should override the product limit of ' . $product_limit );
+	/**
+	 * A subscription limit override of 0 takes precedence over a non-zero product limit.
+	 */
+	public function test_zero_subscription_limit_overrides_product_limit() {
+		// '0' as string, matching how WooCommerce stores meta.
+		$subscription = $this->make_subscription_with_product_limit( 10, '0' );
+
+		$settings = Group_Subscription_Settings::get_subscription_settings( $subscription );
+
+		$this->assertSame( 0, $settings['limit'], 'A subscription limit of 0 should override the product limit of 10.' );
+	}
+
+	/**
+	 * A non-zero subscription limit override takes precedence over the product limit.
+	 */
+	public function test_nonzero_subscription_limit_overrides_product_limit() {
+		$subscription = $this->make_subscription_with_product_limit( 10, '5' );
+
+		$settings = Group_Subscription_Settings::get_subscription_settings( $subscription );
+
+		$this->assertSame( 5, $settings['limit'], 'A subscription limit of 5 should override the product limit of 10.' );
 	}
 }

--- a/tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-settings.php
+++ b/tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-settings.php
@@ -3,7 +3,7 @@
  * Tests for Group_Subscription_Settings.
  *
  * @package Newspack\Tests
- * @group group-subscription-settings
+ * @group WooCommerce_Subscriptions_Integration
  */
 
 use Newspack\Group_Subscription_Settings;
@@ -24,6 +24,16 @@ class Test_Group_Subscription_Settings extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Set up: simulate being on the account page.
+	 */
+	public function set_up() {
+		parent::set_up();
+		global $subscriptions_database, $products_database;
+		$subscriptions_database = [];
+		$products_database      = [];
+	}
+
+	/**
 	 * Tear down: reset subscriptions and products databases.
 	 */
 	public function tear_down() {
@@ -40,27 +50,28 @@ class Test_Group_Subscription_Settings extends WP_UnitTestCase {
 		$product_limit = 10;
 
 		// Simulate a product that has a non-zero group subscription limit.
-		$filter = function ( $settings ) use ( $product_limit ) {
+		$product_settings_filter = function ( $settings ) use ( $product_limit ) {
 			$settings['enabled'] = true;
 			$settings['limit']   = $product_limit;
 			return $settings;
 		};
-		add_filter( 'newspack_group_subscription_product_settings', $filter );
+		add_filter( 'newspack_group_subscription_product_settings', $product_settings_filter );
 
-		$sub = wcs_create_subscription(
+		$subscription = wcs_create_subscription(
 			[
 				'customer_id'    => 1,
 				'status'         => 'active',
 				'billing_period' => 'month',
 			]
 		);
-		$sub->update_meta_data( Group_Subscription_Settings::GROUP_SUBSCRIPTION_META_PREFIX . 'enabled', 'yes' );
+
+		$subscription->update_meta_data( Group_Subscription_Settings::GROUP_SUBSCRIPTION_META_PREFIX . 'enabled', 'yes' );
 		// Set the limit override to 0 (string, as stored by WooCommerce meta).
-		$sub->update_meta_data( Group_Subscription_Settings::GROUP_SUBSCRIPTION_META_PREFIX . 'limit', '0' );
+		$subscription->update_meta_data( Group_Subscription_Settings::GROUP_SUBSCRIPTION_META_PREFIX . 'limit', '0' );
 
-		$settings = Group_Subscription_Settings::get_subscription_settings( $sub );
+		$settings = Group_Subscription_Settings::get_subscription_settings( $subscription );
 
-		remove_filter( 'newspack_group_subscription_product_settings', $filter );
+		remove_filter( 'newspack_group_subscription_product_settings', $product_settings_filter );
 
 		$this->assertSame( 0, $settings['limit'], 'A subscription limit of 0 should override the product limit of ' . $product_limit );
 	}

--- a/tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-settings.php
+++ b/tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-settings.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Tests for Group_Subscription_Settings.
+ *
+ * @package Newspack\Tests
+ * @group group-subscription-settings
+ */
+
+use Newspack\Group_Subscription_Settings;
+
+/**
+ * Test Group_Subscription_Settings.
+ */
+class Test_Group_Subscription_Settings extends WP_UnitTestCase {
+
+	/**
+	 * Tear down: reset subscriptions and products databases.
+	 */
+	public function tear_down() {
+		global $subscriptions_database, $products_database;
+		$subscriptions_database = [];
+		$products_database      = [];
+		parent::tear_down();
+	}
+
+	/**
+	 * A subscription limit override of 0 takes precedence over a non-zero product limit.
+	 */
+	public function test_subscription_limit_zero_overrides_product_limit() {
+		$product_limit = 10;
+
+		// Simulate a product that has a non-zero group subscription limit.
+		$filter = function ( $settings ) use ( $product_limit ) {
+			$settings['enabled'] = true;
+			$settings['limit']   = $product_limit;
+			return $settings;
+		};
+		add_filter( 'newspack_group_subscription_product_settings', $filter );
+
+		$sub = wcs_create_subscription(
+			[
+				'customer_id'    => 1,
+				'status'         => 'active',
+				'billing_period' => 'month',
+			]
+		);
+		$sub->update_meta_data( Group_Subscription_Settings::GROUP_SUBSCRIPTION_META_PREFIX . 'enabled', 'yes' );
+		// Set the limit override to 0 (string, as stored by WooCommerce meta).
+		$sub->update_meta_data( Group_Subscription_Settings::GROUP_SUBSCRIPTION_META_PREFIX . 'limit', '0' );
+
+		$settings = Group_Subscription_Settings::get_subscription_settings( $sub );
+
+		remove_filter( 'newspack_group_subscription_product_settings', $filter );
+
+		$this->assertSame( 0, $settings['limit'], 'A subscription limit of 0 should override the product limit of ' . $product_limit );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a bug in the Group Subscription class where a subscription's override value of `0` for the member limit setting is interpreted by the UI as being not set, and will instead show the inherited product's limit setting.

### How to test the changes in this Pull Request:

1. Enable Group features for a product and set the limit to a non-zero value.
2. Create or edit a subscription and set the limit setting for the subscription to `0`. Save.
3. On `trunk`, observe that the `0` value isn't shown—instead, the inherited product value is shown.
4. On this branch, confirm that the `0` value is shown. Also confirm that other Group subscriptions that don't have any override value for the limit option still show the inherited product value.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->