### PR TITLE
feat(co-authors): support CAP core entity store alongside legacy store

### DIFF
--- a/src/bylines/hooks/use-author-tokens.js
+++ b/src/bylines/hooks/use-author-tokens.js
@@ -1,0 +1,59 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import { useCoAuthors } from '../../shared/hooks/use-coauthors';
+
+const BASE_QUERY = {
+	_fields: 'id,name',
+	context: 'view',
+};
+
+/**
+ * WP user coauthors (or post_author fallback) as `{ id, name }` byline tokens.
+ * Guests are excluded since the `[Author id=N]` shortcode requires a WP user ID.
+ *
+ * @param {number} postId The post ID.
+ * @return {Object[]} Array of `{ id, name }` tokens.
+ */
+export function useAuthorTokens( postId ) {
+	const { authors: coAuthors, isCapAvailable, isLoading } = useCoAuthors( postId );
+
+	const postAuthor = useSelect( select => {
+		const editorStore = select( 'core/editor' );
+		const authorId = editorStore?.getEditedPostAttribute?.( 'author' );
+		if ( ! authorId ) {
+			return null;
+		}
+		return select( coreStore ).getUser( authorId, BASE_QUERY );
+	}, [] );
+
+	// Prevent `insertDefaultByline()` from seeding a truncated byline during new-CAP async resolve.
+	if ( isLoading ) {
+		return [];
+	}
+
+	// When coauthors exist, return only WP users — never fall back to post_author,
+	// which would credit the wrong person on guest-only posts.
+	if ( isCapAvailable && coAuthors && coAuthors.length > 0 ) {
+		const wpUsers = coAuthors
+			.filter( author => author.isGuest === false )
+			.filter( ( author, index, arr ) => arr.findIndex( other => other.id === author.id ) === index );
+		return wpUsers.map( author => ( {
+			id: Number( author.id ),
+			name: author.display_name,
+		} ) );
+	}
+
+	// No coauthors (or CAP inactive) — fall back to the post author.
+	if ( postAuthor ) {
+		return [ postAuthor ];
+	}
+
+	return [];
+}

--- a/src/bylines/hooks/use-author-tokens.js
+++ b/src/bylines/hooks/use-author-tokens.js
@@ -15,14 +15,15 @@ const BASE_QUERY = {
 };
 
 /**
- * WP user coauthors (or post_author fallback) as `{ id, name }` byline tokens.
- * Guests are excluded since the `[Author id=N]` shortcode requires a WP user ID.
+ * WP user coauthors as `{ id, name }` byline tokens. Falls back to the `post_author` only when
+ * no coauthors are present and CAP is inactive (or has no term IDs assigned). Guests are excluded
+ * since the `[Author id=N]` shortcode requires a WP user ID.
  *
  * @param {number} postId The post ID.
  * @return {Object[]} Array of `{ id, name }` tokens.
  */
 export function useAuthorTokens( postId ) {
-	const { authors: coAuthors, isCapAvailable, isLoading } = useCoAuthors( postId );
+	const { authors: coAuthors, isCapAvailable, isLoading, hasCoauthorTermIds } = useCoAuthors( postId );
 
 	const postAuthor = useSelect( select => {
 		const editorStore = select( 'core/editor' );
@@ -35,6 +36,14 @@ export function useAuthorTokens( postId ) {
 
 	// Prevent `insertDefaultByline()` from seeding a truncated byline during new-CAP async resolve.
 	if ( isLoading ) {
+		return [];
+	}
+
+	// New CAP has term IDs assigned but resolution returned no authors — likely a permission-denied
+	// REST response (the `authors-by-term-ids` endpoint requires `edit_others_posts`) or a transient
+	// error. Returning `[]` instead of falling back to `post_author` avoids silently crediting the
+	// wrong person on a post where coauthors are explicitly set.
+	if ( hasCoauthorTermIds && ( ! coAuthors || coAuthors.length === 0 ) ) {
 		return [];
 	}
 

--- a/src/bylines/hooks/use-author-tokens.test.js
+++ b/src/bylines/hooks/use-author-tokens.test.js
@@ -26,8 +26,8 @@ jest.mock( '../../shared/hooks/use-coauthors', () => ( {
 	useCoAuthors: jest.fn(),
 } ) );
 
-const mockUseCoAuthors = ( { authors = [], isCapAvailable = false, isLoading = false } = {} ) => {
-	useCoAuthors.mockReturnValue( { authors, isCapAvailable, isLoading } );
+const mockUseCoAuthors = ( { authors = [], isCapAvailable = false, isLoading = false, hasCoauthorTermIds = false } = {} ) => {
+	useCoAuthors.mockReturnValue( { authors, isCapAvailable, isLoading, hasCoauthorTermIds } );
 };
 
 /**
@@ -123,7 +123,19 @@ describe( 'useAuthorTokens', () => {
 	it( 'should return empty while coauthor data is still loading (new-CAP async window)', () => {
 		// During the term-ID resolution window, fall back to post_author would write a
 		// truncated byline. Return empty so `insertDefaultByline` is a no-op.
-		mockUseCoAuthors( { authors: [], isCapAvailable: true, isLoading: true } );
+		mockUseCoAuthors( { authors: [], isCapAvailable: true, isLoading: true, hasCoauthorTermIds: true } );
+		mockPostAuthorSelect( { authorId: 5, user: { id: 5, name: 'Post Author' } } );
+
+		const { result } = renderHook( () => useAuthorTokens( 123 ) );
+
+		expect( result.current ).toEqual( [] );
+	} );
+
+	it( 'should return empty when CAP has term IDs assigned but resolution returned no authors', () => {
+		// Mirrors the 403 / transient-error path: the `authors-by-term-ids` REST endpoint
+		// requires `edit_others_posts`, so an author editing their own post sees an empty
+		// resolved list. Falling back to `post_author` would credit the wrong person.
+		mockUseCoAuthors( { authors: [], isCapAvailable: true, isLoading: false, hasCoauthorTermIds: true } );
 		mockPostAuthorSelect( { authorId: 5, user: { id: 5, name: 'Post Author' } } );
 
 		const { result } = renderHook( () => useAuthorTokens( 123 ) );

--- a/src/bylines/hooks/use-author-tokens.test.js
+++ b/src/bylines/hooks/use-author-tokens.test.js
@@ -1,0 +1,168 @@
+/**
+ * External dependencies
+ */
+import { renderHook } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { useAuthorTokens } from './use-author-tokens';
+import { useCoAuthors } from '../../shared/hooks/use-coauthors';
+
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/core-data', () => ( {
+	store: 'core',
+} ) );
+
+jest.mock( '../../shared/hooks/use-coauthors', () => ( {
+	useCoAuthors: jest.fn(),
+} ) );
+
+const mockUseCoAuthors = ( { authors = [], isCapAvailable = false, isLoading = false } = {} ) => {
+	useCoAuthors.mockReturnValue( { authors, isCapAvailable, isLoading } );
+};
+
+/**
+ * Mock `useSelect` for the hook's own post_author lookup.
+ *
+ * @param {Object}  options
+ * @param {number}  options.authorId The author ID returned by `getEditedPostAttribute('author')`.
+ * @param {?Object} options.user     User record returned by `getUser`, or null.
+ */
+const mockPostAuthorSelect = ( { authorId = 1, user = { id: 1, name: 'WP User' } } = {} ) => {
+	useSelect.mockImplementation( callback => {
+		return callback( storeName => {
+			if ( storeName === 'core/editor' ) {
+				return { getEditedPostAttribute: attr => ( attr === 'author' ? authorId : undefined ) };
+			}
+			if ( storeName === 'core' ) {
+				return { getUser: id => ( id === authorId ? user : null ) };
+			}
+			return null;
+		} );
+	} );
+};
+
+describe( 'useAuthorTokens', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'should fall back to the post author when CAP is unavailable', () => {
+		mockUseCoAuthors( { authors: [], isCapAvailable: false } );
+		mockPostAuthorSelect( { authorId: 7, user: { id: 7, name: 'Post Author' } } );
+
+		const { result } = renderHook( () => useAuthorTokens( 123 ) );
+
+		expect( result.current ).toEqual( [ { id: 7, name: 'Post Author' } ] );
+	} );
+
+	it( 'should return an empty array when there is no coauthor and no post author', () => {
+		mockUseCoAuthors( { authors: [], isCapAvailable: false } );
+		mockPostAuthorSelect( { authorId: 0, user: null } );
+
+		const { result } = renderHook( () => useAuthorTokens( 123 ) );
+
+		expect( result.current ).toEqual( [] );
+	} );
+
+	it( 'should return WP user coauthors as tokens', () => {
+		mockUseCoAuthors( {
+			authors: [
+				{ id: 1, display_name: 'Jane Doe', user_nicename: 'jane', isGuest: false },
+				{ id: 2, display_name: 'John Smith', user_nicename: 'john', isGuest: false },
+			],
+			isCapAvailable: true,
+		} );
+		mockPostAuthorSelect();
+
+		const { result } = renderHook( () => useAuthorTokens( 123 ) );
+
+		expect( result.current ).toEqual( [
+			{ id: 1, name: 'Jane Doe' },
+			{ id: 2, name: 'John Smith' },
+		] );
+	} );
+
+	it( 'should exclude guest authors from the token list', () => {
+		mockUseCoAuthors( {
+			authors: [
+				{ id: 1, display_name: 'Jane Doe', user_nicename: 'jane', isGuest: false },
+				{ id: 1591, display_name: 'Guest Writer', user_nicename: 'guest', isGuest: true },
+			],
+			isCapAvailable: true,
+		} );
+		mockPostAuthorSelect();
+
+		const { result } = renderHook( () => useAuthorTokens( 123 ) );
+
+		expect( result.current ).toEqual( [ { id: 1, name: 'Jane Doe' } ] );
+	} );
+
+	it( 'should return an empty list when the post is guest-only (no post_author fallback)', () => {
+		// A guest-authored post must not seed the custom byline with the unrelated post_author.
+		mockUseCoAuthors( {
+			authors: [ { id: 1591, display_name: 'Guest', user_nicename: 'guest', isGuest: true } ],
+			isCapAvailable: true,
+		} );
+		mockPostAuthorSelect( { authorId: 5, user: { id: 5, name: 'Post Author' } } );
+
+		const { result } = renderHook( () => useAuthorTokens( 123 ) );
+
+		expect( result.current ).toEqual( [] );
+	} );
+
+	it( 'should return empty while coauthor data is still loading (new-CAP async window)', () => {
+		// During the term-ID resolution window, fall back to post_author would write a
+		// truncated byline. Return empty so `insertDefaultByline` is a no-op.
+		mockUseCoAuthors( { authors: [], isCapAvailable: true, isLoading: true } );
+		mockPostAuthorSelect( { authorId: 5, user: { id: 5, name: 'Post Author' } } );
+
+		const { result } = renderHook( () => useAuthorTokens( 123 ) );
+
+		expect( result.current ).toEqual( [] );
+	} );
+
+	it( 'should coerce string ids from CAP to integer', () => {
+		// New CAP returns `id` as a string ("25"). Tokens must be integers for the shortcode.
+		mockUseCoAuthors( {
+			authors: [ { id: '25', display_name: 'Boba Fett', user_nicename: 'boba-fett', isGuest: false } ],
+			isCapAvailable: true,
+		} );
+		mockPostAuthorSelect();
+
+		const { result } = renderHook( () => useAuthorTokens( 123 ) );
+
+		expect( result.current[ 0 ].id ).toBe( 25 );
+		expect( typeof result.current[ 0 ].id ).toBe( 'number' );
+	} );
+
+	it( 'should dedupe duplicate WP user coauthors by id', () => {
+		// Defensive: if the upstream store accidentally has duplicates (seen in a
+		// legacy-CAP resolver race), the token list should still contain each id once.
+		mockUseCoAuthors( {
+			authors: [
+				{ id: 1, display_name: 'wordpress', user_nicename: 'wordpress', isGuest: false },
+				{ id: 25, display_name: 'Boba Fett', user_nicename: 'boba-fett', isGuest: false },
+				{ id: 1, display_name: 'wordpress', user_nicename: 'wordpress', isGuest: false },
+			],
+			isCapAvailable: true,
+		} );
+		mockPostAuthorSelect();
+
+		const { result } = renderHook( () => useAuthorTokens( 123 ) );
+
+		expect( result.current ).toEqual( [
+			{ id: 1, name: 'wordpress' },
+			{ id: 25, name: 'Boba Fett' },
+		] );
+	} );
+} );

--- a/src/bylines/index.js
+++ b/src/bylines/index.js
@@ -10,17 +10,12 @@ import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
 import { __ } from '@wordpress/i18n';
 import { registerPlugin } from '@wordpress/plugins';
 import { plus } from '@wordpress/icons';
-import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
  */
+import { useAuthorTokens } from './hooks/use-author-tokens';
 import './style.scss';
-
-const BASE_QUERY = {
-	_fields: 'id,name',
-	context: 'view', // Allows non-admins to perform requests.
-};
 
 /** Close icon copied from @wordpress/icons/src/library/close.js to be used as markup */
 const close = `
@@ -90,33 +85,6 @@ const transformByline = element => {
 };
 
 /**
- * Get the author tokens for a post.
- *
- * @param {number} postId The post ID.
- *
- * @return {Object[]} The author tokens.
- */
-function useAuthorTokens( postId ) {
-	const { postAuthor, coAuthors } = useSelect( select => {
-		return {
-			postAuthor: select( coreStore ).getUser( select( 'core/editor' ).getEditedPostAttribute( 'author' ), BASE_QUERY ),
-			coAuthors: postId && select( 'cap/authors' ) ? select( 'cap/authors' ).getAuthors( postId ) : [],
-		};
-	} );
-
-	if ( coAuthors.length ) {
-		return coAuthors
-			.filter( author => author.userType === 'wpuser' )
-			.map( author => ( {
-				id: parseInt( author.id ),
-				name: author.display,
-			} ) );
-	}
-
-	return [ postAuthor ];
-}
-
-/**
  * An author "token" button, to add an author to the byline.
  *
  * @param {Object}   props          Component props.
@@ -179,15 +147,19 @@ const BylinesSettingsPanel = () => {
 
 	const tokens = useAuthorTokens( postId );
 
-	const { getEditedPostAttribute } = useSelect( select => select( 'core/editor' ) );
+	const { customByline, isActiveMeta } = useSelect( select => {
+		const meta = select( 'core/editor' ).getEditedPostAttribute( 'meta' );
+		return {
+			customByline: meta?.[ newspackBylines.metaKeyByline ] || '',
+			isActiveMeta: !! meta?.[ newspackBylines.metaKeyActive ],
+		};
+	}, [] );
 
 	/** Toggle if custom byline is enabled */
-	const [ isEnabled, setIsEnabled ] = useState( !! getEditedPostAttribute( 'meta' )[ newspackBylines.metaKeyActive ] );
+	const [ isEnabled, setIsEnabled ] = useState( isActiveMeta );
 
 	/** Toggle if custom byline modal is open */
 	const [ isModalOpen, setModalOpen ] = useState( false );
-
-	const customByline = getEditedPostAttribute( 'meta' )[ newspackBylines.metaKeyByline ];
 
 	const [ editedByline, setEditedByline ] = useState( customByline );
 

--- a/src/shared/hooks/use-coauthors.js
+++ b/src/shared/hooks/use-coauthors.js
@@ -6,11 +6,10 @@ import { useState, useEffect, useMemo } from '@wordpress/element';
 import { store as coreStore } from '@wordpress/core-data';
 import apiFetch from '@wordpress/api-fetch';
 
-/**
- * CoAuthors Plus store name.
- */
+// CAP_STORE is the legacy Redux store, removed in CAP 3.8+. Its absence triggers the new-CAP path.
 const CAP_STORE = 'cap/authors';
 const COAUTHORS_ENDPOINT = '/coauthors/v1/coauthors';
+const COAUTHORS_BY_TERM_IDS_ENDPOINT = '/coauthors/v1/authors-by-term-ids';
 
 // Module-level cache for guest author avatar URLs, keyed by user_nicename.
 // Prevents duplicate REST requests when components re-mount or when
@@ -22,6 +21,66 @@ const guestAvatarCache = {};
 // mount simultaneously (e.g. Query Loop) and all check the cache before
 // any fetch has completed.
 const inflightRequests = {};
+
+// Term-ID to author object cache (new CAP). A cached `false` means the server omitted the ID.
+const coauthorDetailsCache = {};
+
+// In-flight term-ID fetches keyed by sorted CSV, so concurrent mounts share one REST call.
+const inflightTermResolves = {};
+
+// Stable empty-state reference so setState is a no-op when already empty.
+const EMPTY_AUTHORS = Object.freeze( [] );
+
+/**
+ * Fetch coauthor details for an array of taxonomy term IDs (new CAP).
+ * Deduplicates concurrent requests and caches results by term ID.
+ *
+ * @param {number[]} termIds Array of coauthor taxonomy term IDs.
+ * @return {Promise} Resolves once results are in `coauthorDetailsCache`.
+ */
+function fetchCoauthorsByTermIds( termIds ) {
+	if ( ! termIds || termIds.length === 0 ) {
+		return Promise.resolve();
+	}
+	const uncachedIds = termIds.filter( id => ! ( id in coauthorDetailsCache ) );
+	if ( uncachedIds.length === 0 ) {
+		return Promise.resolve();
+	}
+	const key = [ ...uncachedIds ].sort( ( a, b ) => a - b ).join( ',' );
+	if ( inflightTermResolves[ key ] ) {
+		return inflightTermResolves[ key ];
+	}
+	inflightTermResolves[ key ] = apiFetch( {
+		path: `${ COAUTHORS_BY_TERM_IDS_ENDPOINT }?ids=${ uncachedIds.join( ',' ) }`,
+	} )
+		.then( results => {
+			if ( Array.isArray( results ) ) {
+				results.forEach( author => {
+					if ( author?.termId ) {
+						coauthorDetailsCache[ author.termId ] = author;
+					}
+				} );
+			}
+			// Mark IDs that the server omitted as permanently unresolved (e.g. deleted author).
+			// Only done on a successful response — transient errors leave cache untouched to allow retries.
+			uncachedIds.forEach( id => {
+				if ( ! ( id in coauthorDetailsCache ) ) {
+					coauthorDetailsCache[ id ] = false;
+				}
+			} );
+		} )
+		.catch( error => {
+			// Do not poison the cache on transient errors (network, 5xx). Concurrent calls are
+			// already deduped via `inflightTermResolves`, and leaving the cache untouched lets
+			// the next render retry once the issue clears.
+			// eslint-disable-next-line no-console
+			console.warn( '[Newspack] Failed to resolve coauthor term IDs:', error );
+		} )
+		.finally( () => {
+			delete inflightTermResolves[ key ];
+		} );
+	return inflightTermResolves[ key ];
+}
 
 /**
  * Fetch a single coauthor's avatar URLs, deduplicating concurrent requests.
@@ -60,6 +119,14 @@ export function resetGuestAvatarCacheForTests() {
 }
 
 /**
+ * Reset the module-level coauthor details cache. Exposed for testing only.
+ */
+export function resetCoauthorDetailsCacheForTests() {
+	Object.keys( coauthorDetailsCache ).forEach( key => delete coauthorDetailsCache[ key ] );
+	Object.keys( inflightTermResolves ).forEach( key => delete inflightTermResolves[ key ] );
+}
+
+/**
  * Extract user_nicename from an author archive URL.
  *
  * @param {string} link Author archive URL (e.g. /author/jane/).
@@ -83,58 +150,121 @@ function extractNicenameFromLink( link ) {
 /**
  * Hook to get CoAuthors Plus authors from the CAP store or REST API.
  *
- * For the currently-edited post, it uses CAP's JS store for real-time updates.
- * For Query Loop posts, it uses REST API data since CAP's store only works for the
- * currently-edited post.
+ * For the currently-edited post, uses one of two sources depending on which
+ * CAP version is active:
+ *   - Legacy CAP (<3.8): reads from the `cap/authors` Redux store for real-time updates.
+ *   - New CAP (3.8+): reads taxonomy term IDs from `getEditedPostAttribute('coauthors')`
+ *     and resolves them to rich author data via the `authors-by-term-ids` REST endpoint.
+ * For Query Loop posts, it uses REST data from `newspack_author_info` (unaffected by CAP version).
  *
  * @param {number}  postId   Post ID to get authors for.
  * @param {string}  postType Post type (default: 'post').
  * @param {boolean} skip     Skip fetching (default: false).
- * @return {Object} Authors array and availability state.
+ * @return {Object} `{ authors, isCapAvailable, isLoading }`. `isLoading` is true only while
+ *                  the new-CAP term-ID resolution is in flight. Legacy CAP is synchronous.
  */
 export function useCoAuthors( postId, postType = 'post', skip = false ) {
 	// Return raw store references from useSelect to avoid creating new objects
 	// on every render (which triggers useSelect memoization warnings).
 	// The .map() transformations happen in useMemo below.
-	const { capAuthors, restAuthors, isCapAvailable } = useSelect(
+	const { legacyCapAuthors, coauthorTermIds, restAuthors, isCapAvailable } = useSelect(
 		select => {
 			if ( skip ) {
-				return { capAuthors: null, restAuthors: null, isCapAvailable: false };
+				return { legacyCapAuthors: null, coauthorTermIds: null, restAuthors: null, isCapAvailable: false };
 			}
 
 			const capStore = select( CAP_STORE );
-			const isCapStoreAvailable = Boolean( capStore && typeof capStore.getAuthors === 'function' );
+			const isLegacyCapStoreAvailable = Boolean( capStore && typeof capStore.getAuthors === 'function' );
 
 			const editorStore = select( 'core/editor' );
 			const currentPostId = editorStore?.getCurrentPostId?.();
 			const isQueryLoopContext = postId && currentPostId && postId !== currentPostId;
 
-			// For the currently-edited post, use CAP's store for real-time updates.
-			if ( isCapStoreAvailable && ! isQueryLoopContext ) {
-				const rawCapAuthors = postId ? capStore.getAuthors( postId ) : null;
-				return { capAuthors: rawCapAuthors, restAuthors: null, isCapAvailable: true };
-			}
-
-			// For Query Loop context, try to get coauthors from REST API.
-			// If REST author data exists, treat CAP as available (matching original behavior)
-			// since the server-side plugin provided the data even if the JS store isn't loaded.
+			// Query Loop: read from newspack_author_info on the post entity.
+			// Unaffected by CAP version.
 			if ( isQueryLoopContext && postId ) {
 				const { getEntityRecord } = select( coreStore );
 				const post = getEntityRecord( 'postType', postType, postId );
 				const restData = post?.newspack_author_info || null;
-				return { capAuthors: null, restAuthors: restData, isCapAvailable: restData ? true : isCapStoreAvailable };
+				return {
+					legacyCapAuthors: null,
+					coauthorTermIds: null,
+					restAuthors: restData,
+					isCapAvailable: restData ? true : isLegacyCapStoreAvailable,
+				};
 			}
 
-			return { capAuthors: null, restAuthors: null, isCapAvailable: isCapStoreAvailable };
+			// Legacy CAP: read from cap/authors store for real-time updates.
+			if ( isLegacyCapStoreAvailable ) {
+				const rawCapAuthors = postId ? capStore.getAuthors( postId ) : null;
+				return { legacyCapAuthors: rawCapAuthors, coauthorTermIds: null, restAuthors: null, isCapAvailable: true };
+			}
+
+			// New CAP: read taxonomy term IDs from the post entity.
+			// Returns null when the post hasn't loaded yet; an empty array when it has loaded
+			// but there are no coauthors; an array of term IDs when coauthors are set.
+			const termIds = editorStore?.getEditedPostAttribute?.( 'coauthors' );
+			if ( Array.isArray( termIds ) ) {
+				return { legacyCapAuthors: null, coauthorTermIds: termIds, restAuthors: null, isCapAvailable: true };
+			}
+
+			// No CAP detected (plugin inactive).
+			return { legacyCapAuthors: null, coauthorTermIds: null, restAuthors: null, isCapAvailable: false };
 		},
 		[ postId, postType, skip ]
 	);
 
+	// Resolve coauthor term IDs to author data via REST (new CAP path only).
+	// Uses a module-level cache + in-flight dedup so concurrent mounts share a single fetch.
+	const [ resolvedTermAuthors, setResolvedTermAuthors ] = useState( EMPTY_AUTHORS );
+	const [ isLoading, setIsLoading ] = useState( false );
+	const termIdsKey = coauthorTermIds ? coauthorTermIds.join( ',' ) : null;
+
+	useEffect( () => {
+		if ( skip || termIdsKey === null ) {
+			// Use the module-level frozen empty array so the identity is stable
+			// and setState is a no-op when already empty.
+			setResolvedTermAuthors( EMPTY_AUTHORS );
+			setIsLoading( false );
+			return;
+		}
+		const ids = termIdsKey === '' ? [] : termIdsKey.split( ',' ).map( Number ).filter( Number.isInteger );
+		if ( ids.length === 0 ) {
+			setResolvedTermAuthors( EMPTY_AUTHORS );
+			setIsLoading( false );
+			return;
+		}
+
+		// If everything is already cached, resolve synchronously without flipping loading state.
+		const allCached = ids.every( id => id in coauthorDetailsCache );
+		if ( allCached ) {
+			const resolved = ids.map( id => coauthorDetailsCache[ id ] ).filter( author => author && typeof author === 'object' );
+			setResolvedTermAuthors( resolved.length === 0 ? EMPTY_AUTHORS : resolved );
+			setIsLoading( false );
+			return;
+		}
+
+		let cancelled = false;
+		setIsLoading( true );
+		fetchCoauthorsByTermIds( ids ).then( () => {
+			if ( cancelled ) {
+				return;
+			}
+			const resolved = ids.map( id => coauthorDetailsCache[ id ] ).filter( author => author && typeof author === 'object' );
+			setResolvedTermAuthors( resolved.length === 0 ? EMPTY_AUTHORS : resolved );
+			setIsLoading( false );
+		} );
+
+		return () => {
+			cancelled = true;
+		};
+	}, [ termIdsKey, skip ] );
+
 	// Map raw store data to our normalized author format.
 	const authors = useMemo( () => {
-		// CAP store authors: { id, label, display, value, userType }
-		if ( capAuthors && capAuthors.length > 0 ) {
-			return capAuthors.map( author => ( {
+		// Legacy CAP store authors: { id, label, display, value, userType }
+		if ( legacyCapAuthors && legacyCapAuthors.length > 0 ) {
+			return legacyCapAuthors.map( author => ( {
 				id: author.id,
 				display_name: author.display || author.value || author.label,
 				user_nicename: author.value,
@@ -142,7 +272,18 @@ export function useCoAuthors( postId, postType = 'post', skip = false ) {
 			} ) );
 		}
 
-		// REST API authors from newspack_author_info.
+		// New CAP authors resolved from term IDs: { id, termId, displayName, userNicename, userType, ... }
+		if ( resolvedTermAuthors && resolvedTermAuthors.length > 0 ) {
+			return resolvedTermAuthors.map( author => ( {
+				id: author.id,
+				termId: author.termId,
+				display_name: author.displayName,
+				user_nicename: author.userNicename,
+				isGuest: author.userType === 'guest-author',
+			} ) );
+		}
+
+		// REST API authors from newspack_author_info (Query Loop).
 		if ( restAuthors && Array.isArray( restAuthors ) && restAuthors.length > 0 ) {
 			return restAuthors.map( author => ( {
 				id: author.id,
@@ -155,7 +296,7 @@ export function useCoAuthors( postId, postType = 'post', skip = false ) {
 		}
 
 		return [];
-	}, [ capAuthors, restAuthors ] );
+	}, [ legacyCapAuthors, resolvedTermAuthors, restAuthors ] );
 
 	// Fetch avatar URLs from the CAP REST API for authors that need it.
 	// The CAP store strips avatar data via formatAuthorData(), so we need
@@ -216,5 +357,5 @@ export function useCoAuthors( postId, postType = 'post', skip = false ) {
 		return { ...author, avatar_urls: urls };
 	} );
 
-	return { authors: authorsWithAvatars, isCapAvailable };
+	return { authors: authorsWithAvatars, isCapAvailable, isLoading };
 }

--- a/src/shared/hooks/use-coauthors.js
+++ b/src/shared/hooks/use-coauthors.js
@@ -71,8 +71,8 @@ function fetchCoauthorsByTermIds( termIds ) {
 		} )
 		.catch( error => {
 			// Do not poison the cache on transient errors (network, 5xx). Concurrent calls are
-			// already deduped via `inflightTermResolves`, and leaving the cache untouched lets
-			// the next render retry once the issue clears.
+			// already deduped via `inflightTermResolves`, and leaving the cache untouched allows
+			// a later call to `fetchCoauthorsByTermIds` to retry after this in-flight request clears.
 			// eslint-disable-next-line no-console
 			console.warn( '[Newspack] Failed to resolve coauthor term IDs:', error );
 		} )

--- a/src/shared/hooks/use-coauthors.js
+++ b/src/shared/hooks/use-coauthors.js
@@ -6,7 +6,8 @@ import { useState, useEffect, useMemo } from '@wordpress/element';
 import { store as coreStore } from '@wordpress/core-data';
 import apiFetch from '@wordpress/api-fetch';
 
-// CAP_STORE is the legacy Redux store, removed in CAP 3.8+. Its absence triggers the new-CAP path.
+// Detection key for the optional Redux store published by CAP <4.0. When present and exposing
+// `getAuthors`, prefer the synchronous path; otherwise fall back to term-ID resolution via REST.
 const CAP_STORE = 'cap/authors';
 const COAUTHORS_ENDPOINT = '/coauthors/v1/coauthors';
 const COAUTHORS_BY_TERM_IDS_ENDPOINT = '/coauthors/v1/authors-by-term-ids';
@@ -69,12 +70,12 @@ function fetchCoauthorsByTermIds( termIds ) {
 				}
 			} );
 		} )
-		.catch( error => {
-			// Do not poison the cache on transient errors (network, 5xx). Concurrent calls are
-			// already deduped via `inflightTermResolves`, and leaving the cache untouched allows
-			// a later call to `fetchCoauthorsByTermIds` to retry after this in-flight request clears.
-			// eslint-disable-next-line no-console
-			console.warn( '[Newspack] Failed to resolve coauthor term IDs:', error );
+		.catch( () => {
+			// Do not poison the cache on transient errors (network, 5xx) or permission errors (403).
+			// Concurrent calls are already deduped via `inflightTermResolves`, and leaving the cache
+			// untouched allows a later call to `fetchCoauthorsByTermIds` to retry after this
+			// in-flight request clears. Failure is signalled to consumers via `hasCoauthorTermIds`
+			// remaining true while `authors` stays empty.
 		} )
 		.finally( () => {
 			delete inflightTermResolves[ key ];
@@ -150,27 +151,32 @@ function extractNicenameFromLink( link ) {
 /**
  * Hook to get CoAuthors Plus authors from the CAP store or REST API.
  *
- * For the currently-edited post, uses one of two sources depending on which
- * CAP version is active:
- *   - Legacy CAP (<3.8): reads from the `cap/authors` Redux store for real-time updates.
- *   - New CAP (3.8+): reads taxonomy term IDs from `getEditedPostAttribute('coauthors')`
- *     and resolves them to rich author data via the `authors-by-term-ids` REST endpoint.
+ * For the currently-edited post, uses one of two sources depending on which CAP version is active:
+ *   - Legacy CAP (Redux store published by CAP <4.0): reads from `cap/authors` for real-time updates.
+ *   - New CAP (no Redux store, CAP 4.0+): reads taxonomy term IDs from
+ *     `getEditedPostAttribute('coauthors')` and resolves them to rich author data via the
+ *     `authors-by-term-ids` REST endpoint.
  * For Query Loop posts, it uses REST data from `newspack_author_info` (unaffected by CAP version).
  *
  * @param {number}  postId   Post ID to get authors for.
  * @param {string}  postType Post type (default: 'post').
  * @param {boolean} skip     Skip fetching (default: false).
- * @return {Object} `{ authors, isCapAvailable, isLoading }`. `isLoading` is true only while
- *                  the new-CAP term-ID resolution is in flight. Legacy CAP is synchronous.
+ * @return {Object} `{ authors, isCapAvailable, isLoading, hasCoauthorTermIds }`.
+ *                  `isLoading` is true during the new-CAP term-ID resolution window (including the
+ *                  pre-flight render before the effect fires); legacy CAP is synchronous.
+ *                  `hasCoauthorTermIds` is true when the new-CAP path is in use AND term IDs are
+ *                  assigned — consumers should treat `authors.length === 0` while this flag is true
+ *                  as "resolution unavailable" (e.g. permission-denied REST) rather than "no coauthors",
+ *                  to avoid silently falling back to default state.
  */
 export function useCoAuthors( postId, postType = 'post', skip = false ) {
 	// Return raw store references from useSelect to avoid creating new objects
 	// on every render (which triggers useSelect memoization warnings).
 	// The .map() transformations happen in useMemo below.
-	const { legacyCapAuthors, coauthorTermIds, restAuthors, isCapAvailable } = useSelect(
+	const { legacyCapAuthors, coauthorTermIdsKey, restAuthors, isCapAvailable } = useSelect(
 		select => {
 			if ( skip ) {
-				return { legacyCapAuthors: null, coauthorTermIds: null, restAuthors: null, isCapAvailable: false };
+				return { legacyCapAuthors: null, coauthorTermIdsKey: null, restAuthors: null, isCapAvailable: false };
 			}
 
 			const capStore = select( CAP_STORE );
@@ -188,7 +194,7 @@ export function useCoAuthors( postId, postType = 'post', skip = false ) {
 				const restData = post?.newspack_author_info || null;
 				return {
 					legacyCapAuthors: null,
-					coauthorTermIds: null,
+					coauthorTermIdsKey: null,
 					restAuthors: restData,
 					isCapAvailable: restData ? true : isLegacyCapStoreAvailable,
 				};
@@ -197,19 +203,26 @@ export function useCoAuthors( postId, postType = 'post', skip = false ) {
 			// Legacy CAP: read from cap/authors store for real-time updates.
 			if ( isLegacyCapStoreAvailable ) {
 				const rawCapAuthors = postId ? capStore.getAuthors( postId ) : null;
-				return { legacyCapAuthors: rawCapAuthors, coauthorTermIds: null, restAuthors: null, isCapAvailable: true };
+				return { legacyCapAuthors: rawCapAuthors, coauthorTermIdsKey: null, restAuthors: null, isCapAvailable: true };
 			}
 
-			// New CAP: read taxonomy term IDs from the post entity.
-			// Returns null when the post hasn't loaded yet; an empty array when it has loaded
-			// but there are no coauthors; an array of term IDs when coauthors are set.
+			// New CAP: read taxonomy term IDs from the post entity. Serialize to a stable string
+			// inside the selector so a fresh array reference from `getEditedPostAttribute` doesn't
+			// trigger spurious re-renders. `null` = attribute not loaded; `''` = loaded but empty;
+			// CSV (e.g. `'471,488'`) = term IDs assigned.
 			const termIds = editorStore?.getEditedPostAttribute?.( 'coauthors' );
 			if ( Array.isArray( termIds ) ) {
-				return { legacyCapAuthors: null, coauthorTermIds: termIds, restAuthors: null, isCapAvailable: true };
+				const validIds = termIds.map( Number ).filter( Number.isInteger );
+				return {
+					legacyCapAuthors: null,
+					coauthorTermIdsKey: validIds.length === 0 ? '' : validIds.join( ',' ),
+					restAuthors: null,
+					isCapAvailable: true,
+				};
 			}
 
 			// No CAP detected (plugin inactive).
-			return { legacyCapAuthors: null, coauthorTermIds: null, restAuthors: null, isCapAvailable: false };
+			return { legacyCapAuthors: null, coauthorTermIdsKey: null, restAuthors: null, isCapAvailable: false };
 		},
 		[ postId, postType, skip ]
 	);
@@ -217,21 +230,30 @@ export function useCoAuthors( postId, postType = 'post', skip = false ) {
 	// Resolve coauthor term IDs to author data via REST (new CAP path only).
 	// Uses a module-level cache + in-flight dedup so concurrent mounts share a single fetch.
 	const [ resolvedTermAuthors, setResolvedTermAuthors ] = useState( EMPTY_AUTHORS );
-	const [ isLoading, setIsLoading ] = useState( false );
-	const termIdsKey = coauthorTermIds ? coauthorTermIds.join( ',' ) : null;
+	const [ asyncIsLoading, setAsyncIsLoading ] = useState( false );
+	// Tracks the last `coauthorTermIdsKey` the effect has processed. Used to derive a synchronous
+	// pre-flight loading state during the render between key change and effect firing — without
+	// it, consumers briefly see "term IDs assigned but isLoading false" and may pick wrong defaults.
+	const [ processedKey, setProcessedKey ] = useState( null );
+
+	const hasCoauthorTermIds = coauthorTermIdsKey !== null && coauthorTermIdsKey !== '';
+	const isPreFlight = hasCoauthorTermIds && processedKey !== coauthorTermIdsKey;
+	const isLoading = isPreFlight || asyncIsLoading;
 
 	useEffect( () => {
-		if ( skip || termIdsKey === null ) {
+		if ( skip || coauthorTermIdsKey === null ) {
 			// Use the module-level frozen empty array so the identity is stable
 			// and setState is a no-op when already empty.
 			setResolvedTermAuthors( EMPTY_AUTHORS );
-			setIsLoading( false );
+			setAsyncIsLoading( false );
+			setProcessedKey( coauthorTermIdsKey );
 			return;
 		}
-		const ids = termIdsKey === '' ? [] : termIdsKey.split( ',' ).map( Number ).filter( Number.isInteger );
+		const ids = coauthorTermIdsKey === '' ? [] : coauthorTermIdsKey.split( ',' ).map( Number ).filter( Number.isInteger );
 		if ( ids.length === 0 ) {
 			setResolvedTermAuthors( EMPTY_AUTHORS );
-			setIsLoading( false );
+			setAsyncIsLoading( false );
+			setProcessedKey( coauthorTermIdsKey );
 			return;
 		}
 
@@ -240,25 +262,27 @@ export function useCoAuthors( postId, postType = 'post', skip = false ) {
 		if ( allCached ) {
 			const resolved = ids.map( id => coauthorDetailsCache[ id ] ).filter( author => author && typeof author === 'object' );
 			setResolvedTermAuthors( resolved.length === 0 ? EMPTY_AUTHORS : resolved );
-			setIsLoading( false );
+			setAsyncIsLoading( false );
+			setProcessedKey( coauthorTermIdsKey );
 			return;
 		}
 
 		let cancelled = false;
-		setIsLoading( true );
+		setAsyncIsLoading( true );
 		fetchCoauthorsByTermIds( ids ).then( () => {
 			if ( cancelled ) {
 				return;
 			}
 			const resolved = ids.map( id => coauthorDetailsCache[ id ] ).filter( author => author && typeof author === 'object' );
 			setResolvedTermAuthors( resolved.length === 0 ? EMPTY_AUTHORS : resolved );
-			setIsLoading( false );
+			setAsyncIsLoading( false );
+			setProcessedKey( coauthorTermIdsKey );
 		} );
 
 		return () => {
 			cancelled = true;
 		};
-	}, [ termIdsKey, skip ] );
+	}, [ coauthorTermIdsKey, skip ] );
 
 	// Map raw store data to our normalized author format.
 	const authors = useMemo( () => {
@@ -272,10 +296,13 @@ export function useCoAuthors( postId, postType = 'post', skip = false ) {
 			} ) );
 		}
 
-		// New CAP authors resolved from term IDs: { id, termId, displayName, userNicename, userType, ... }
+		// New CAP authors resolved from term IDs.
+		// REST shape: { id (string), termId, displayName, userNicename, userType, ... }
+		// Coerce `id` to Number at the source so consumers and the in-file dedupe (`other.id === author.id`)
+		// see a consistent shape across legacy CAP (numeric id) and new CAP (string id).
 		if ( resolvedTermAuthors && resolvedTermAuthors.length > 0 ) {
 			return resolvedTermAuthors.map( author => ( {
-				id: author.id,
+				id: Number( author.id ),
 				termId: author.termId,
 				display_name: author.displayName,
 				user_nicename: author.userNicename,
@@ -357,5 +384,5 @@ export function useCoAuthors( postId, postType = 'post', skip = false ) {
 		return { ...author, avatar_urls: urls };
 	} );
 
-	return { authors: authorsWithAvatars, isCapAvailable, isLoading };
+	return { authors: authorsWithAvatars, isCapAvailable, isLoading, hasCoauthorTermIds };
 }

--- a/src/shared/hooks/use-coauthors.test.js
+++ b/src/shared/hooks/use-coauthors.test.js
@@ -12,7 +12,7 @@ import apiFetch from '@wordpress/api-fetch';
 /**
  * Internal dependencies
  */
-import { useCoAuthors, resetGuestAvatarCacheForTests } from './use-coauthors';
+import { useCoAuthors, resetGuestAvatarCacheForTests, resetCoauthorDetailsCacheForTests } from './use-coauthors';
 
 jest.mock( '@wordpress/data', () => ( {
 	useSelect: jest.fn(),
@@ -27,13 +27,16 @@ jest.mock( '@wordpress/api-fetch', () => jest.fn() );
 /**
  * Helper to create a mock select function for multiple stores.
  *
- * @param {Object} options               Mock options.
- * @param {Object} options.capStore      CAP store mock (null if unavailable).
- * @param {number} options.currentPostId Currently-edited post ID.
- * @param {Object} options.entityRecords Map of postId -> post entity record.
+ * @param {Object}   options                 Mock options.
+ * @param {Object}   options.capStore        Legacy CAP store mock (null if unavailable — i.e., new CAP).
+ * @param {number}   options.currentPostId   Currently-edited post ID.
+ * @param {Object}   options.entityRecords   Map of postId -> post entity record (used for Query Loop).
+ * @param {number[]} options.coauthorTermIds `coauthors` post attribute (new CAP).
+ *                                           `undefined` means attribute not set (legacy CAP / plugin missing);
+ *                                           `[]` means the attribute is present but empty.
  * @return {Function} Mock select function.
  */
-const createMockSelect = ( { capStore = null, currentPostId = 123, entityRecords = {} } = {} ) => {
+const createMockSelect = ( { capStore = null, currentPostId = 123, entityRecords = {}, coauthorTermIds } = {} ) => {
 	return storeName => {
 		if ( storeName === 'cap/authors' ) {
 			return capStore;
@@ -41,6 +44,7 @@ const createMockSelect = ( { capStore = null, currentPostId = 123, entityRecords
 		if ( storeName === 'core/editor' ) {
 			return {
 				getCurrentPostId: () => currentPostId,
+				getEditedPostAttribute: attr => ( attr === 'coauthors' ? coauthorTermIds : undefined ),
 			};
 		}
 		if ( storeName === 'core' ) {
@@ -56,6 +60,7 @@ describe( 'useCoAuthors', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
 		resetGuestAvatarCacheForTests();
+		resetCoauthorDetailsCacheForTests();
 		// Default: apiFetch resolves with empty object (no avatar_urls).
 		apiFetch.mockResolvedValue( {} );
 	} );
@@ -178,6 +183,230 @@ describe( 'useCoAuthors', () => {
 
 			expect( result.current.authors[ 0 ].display_name ).toBe( 'from-value' );
 			expect( result.current.authors[ 1 ].display_name ).toBe( 'Only Label' );
+		} );
+	} );
+
+	describe( 'currently-edited post (new CAP, term ID resolution)', () => {
+		const NEW_CAP_RESPONSE = [
+			{ id: '1', termId: 471, displayName: 'Jane Doe', userNicename: 'jane-doe', userType: 'wpuser', login: 'jane', email: 'jane@x.com' },
+			{ id: '2', termId: 488, displayName: 'John Smith', userNicename: 'john-smith', userType: 'wpuser', login: 'john', email: 'john@x.com' },
+			{ id: '1591', termId: 483, displayName: 'External', userNicename: 'external', userType: 'guest-author', login: 'external', email: '' },
+		];
+
+		it( 'should resolve term IDs via REST when legacy CAP store is absent', async () => {
+			apiFetch.mockResolvedValueOnce( NEW_CAP_RESPONSE );
+
+			useSelect.mockImplementation( callback =>
+				callback(
+					createMockSelect( {
+						capStore: null, // legacy CAP not registered
+						currentPostId: 123,
+						coauthorTermIds: [ 471, 488, 483 ],
+					} )
+				)
+			);
+
+			const { result } = renderHook( () => useCoAuthors( 123 ) );
+
+			await waitFor( () => {
+				expect( result.current.authors ).toHaveLength( 3 );
+			} );
+
+			expect( apiFetch ).toHaveBeenCalledWith( {
+				path: '/coauthors/v1/authors-by-term-ids?ids=471,488,483',
+			} );
+			expect( result.current.authors[ 0 ] ).toMatchObject( {
+				id: '1',
+				termId: 471,
+				display_name: 'Jane Doe',
+				user_nicename: 'jane-doe',
+				isGuest: false,
+			} );
+			expect( result.current.authors[ 2 ].isGuest ).toBe( true );
+			expect( result.current.isCapAvailable ).toBe( true );
+		} );
+
+		it( 'should return empty authors when coauthors attribute is an empty array', async () => {
+			useSelect.mockImplementation( callback =>
+				callback(
+					createMockSelect( {
+						capStore: null,
+						currentPostId: 123,
+						coauthorTermIds: [],
+					} )
+				)
+			);
+
+			const { result } = renderHook( () => useCoAuthors( 123 ) );
+
+			await act( () => Promise.resolve() );
+
+			expect( result.current.authors ).toEqual( [] );
+			expect( result.current.isCapAvailable ).toBe( true );
+			expect( apiFetch ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should mark isCapAvailable false when neither legacy store nor coauthors attribute are present', () => {
+			useSelect.mockImplementation( callback =>
+				callback(
+					createMockSelect( {
+						capStore: null,
+						currentPostId: 123,
+						// coauthorTermIds undefined
+					} )
+				)
+			);
+
+			const { result } = renderHook( () => useCoAuthors( 123 ) );
+
+			expect( result.current.isCapAvailable ).toBe( false );
+			expect( result.current.authors ).toEqual( [] );
+		} );
+
+		it( 'should prefer legacy CAP store when both legacy store and coauthors attribute are present', async () => {
+			// This simulates an in-flight upgrade scenario where old JS is still loaded.
+			// Legacy path should win to keep behavior consistent.
+			useSelect.mockImplementation( callback =>
+				callback(
+					createMockSelect( {
+						capStore: {
+							getAuthors: () => [ { id: 99, display: 'Legacy', value: 'legacy', userType: 'wpuser' } ],
+						},
+						currentPostId: 123,
+						coauthorTermIds: [ 471 ],
+					} )
+				)
+			);
+
+			const { result } = renderHook( () => useCoAuthors( 123 ) );
+
+			await act( () => Promise.resolve() );
+
+			expect( apiFetch ).not.toHaveBeenCalled();
+			expect( result.current.authors ).toEqual( [ { id: 99, display_name: 'Legacy', user_nicename: 'legacy', isGuest: false } ] );
+		} );
+
+		it( 'should cache results so subsequent mounts skip the REST call', async () => {
+			apiFetch.mockResolvedValue( NEW_CAP_RESPONSE );
+
+			useSelect.mockImplementation( callback =>
+				callback(
+					createMockSelect( {
+						capStore: null,
+						currentPostId: 123,
+						coauthorTermIds: [ 471, 488, 483 ],
+					} )
+				)
+			);
+
+			const { result: result1 } = renderHook( () => useCoAuthors( 123 ) );
+
+			await waitFor( () => {
+				expect( result1.current.authors ).toHaveLength( 3 );
+			} );
+
+			const callsAfterFirstMount = apiFetch.mock.calls.length;
+
+			// A later mount re-uses the cache and makes no additional calls.
+			const { result: result2 } = renderHook( () => useCoAuthors( 123 ) );
+
+			await waitFor( () => {
+				expect( result2.current.authors ).toHaveLength( 3 );
+			} );
+
+			expect( apiFetch ).toHaveBeenCalledTimes( callsAfterFirstMount );
+		} );
+
+		it( 'should silently drop term IDs that do not resolve', async () => {
+			// REST returns only 2 of 3 requested IDs (the third was deleted).
+			apiFetch.mockResolvedValueOnce( [ NEW_CAP_RESPONSE[ 0 ], NEW_CAP_RESPONSE[ 1 ] ] );
+
+			useSelect.mockImplementation( callback =>
+				callback(
+					createMockSelect( {
+						capStore: null,
+						currentPostId: 123,
+						coauthorTermIds: [ 471, 488, 99999 ],
+					} )
+				)
+			);
+
+			const { result } = renderHook( () => useCoAuthors( 123 ) );
+
+			await waitFor( () => {
+				expect( result.current.authors ).toHaveLength( 2 );
+			} );
+
+			expect( result.current.authors.map( a => a.termId ) ).toEqual( [ 471, 488 ] );
+		} );
+
+		it( 'should handle REST errors without blocking the component', async () => {
+			apiFetch.mockRejectedValueOnce( new Error( 'Server error' ) );
+			// Silence the expected console.warn from the fetcher's catch handler.
+			const warnSpy = jest.spyOn( console, 'warn' ).mockImplementation( () => {} );
+
+			useSelect.mockImplementation( callback =>
+				callback(
+					createMockSelect( {
+						capStore: null,
+						currentPostId: 123,
+						coauthorTermIds: [ 471 ],
+					} )
+				)
+			);
+
+			const { result } = renderHook( () => useCoAuthors( 123 ) );
+
+			// Allow the failed promise to settle.
+			await act( () => Promise.resolve().then( () => Promise.resolve() ) );
+
+			expect( result.current.authors ).toEqual( [] );
+			expect( result.current.isCapAvailable ).toBe( true );
+			expect( warnSpy ).toHaveBeenCalled();
+			warnSpy.mockRestore();
+		} );
+
+		it( 'should allow retry after a transient REST error (no negative caching on catch)', async () => {
+			const RETRY_RESPONSE = [
+				{ id: '1', termId: 471, displayName: 'Jane', userNicename: 'jane', userType: 'wpuser', login: 'jane', email: '' },
+			];
+			const warnSpy = jest.spyOn( console, 'warn' ).mockImplementation( () => {} );
+
+			useSelect.mockImplementation( callback =>
+				callback(
+					createMockSelect( {
+						capStore: null,
+						currentPostId: 123,
+						coauthorTermIds: [ 471 ],
+					} )
+				)
+			);
+
+			// First attempt fails with a transient error; cache should NOT be poisoned.
+			apiFetch.mockRejectedValueOnce( new Error( 'Transient 500' ) );
+
+			const { result: result1, unmount: unmount1 } = renderHook( () => useCoAuthors( 123 ) );
+
+			await act( () => Promise.resolve().then( () => Promise.resolve() ) );
+
+			expect( result1.current.authors ).toEqual( [] );
+			expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+
+			unmount1();
+
+			// Second attempt succeeds — we should actually re-fetch (not a cached failure).
+			apiFetch.mockResolvedValueOnce( RETRY_RESPONSE );
+
+			const { result: result2 } = renderHook( () => useCoAuthors( 123 ) );
+
+			await waitFor( () => {
+				expect( result2.current.authors ).toHaveLength( 1 );
+			} );
+
+			expect( apiFetch ).toHaveBeenCalledTimes( 2 );
+			expect( result2.current.authors[ 0 ].display_name ).toBe( 'Jane' );
+
+			warnSpy.mockRestore();
 		} );
 	} );
 

--- a/src/shared/hooks/use-coauthors.test.js
+++ b/src/shared/hooks/use-coauthors.test.js
@@ -216,7 +216,7 @@ describe( 'useCoAuthors', () => {
 				path: '/coauthors/v1/authors-by-term-ids?ids=471,488,483',
 			} );
 			expect( result.current.authors[ 0 ] ).toMatchObject( {
-				id: '1',
+				id: 1,
 				termId: 471,
 				display_name: 'Jane Doe',
 				user_nicename: 'jane-doe',
@@ -224,6 +224,7 @@ describe( 'useCoAuthors', () => {
 			} );
 			expect( result.current.authors[ 2 ].isGuest ).toBe( true );
 			expect( result.current.isCapAvailable ).toBe( true );
+			expect( result.current.hasCoauthorTermIds ).toBe( true );
 		} );
 
 		it( 'should return empty authors when coauthors attribute is an empty array', async () => {
@@ -342,8 +343,6 @@ describe( 'useCoAuthors', () => {
 
 		it( 'should handle REST errors without blocking the component', async () => {
 			apiFetch.mockRejectedValueOnce( new Error( 'Server error' ) );
-			// Silence the expected console.warn from the fetcher's catch handler.
-			const warnSpy = jest.spyOn( console, 'warn' ).mockImplementation( () => {} );
 
 			useSelect.mockImplementation( callback =>
 				callback(
@@ -362,15 +361,15 @@ describe( 'useCoAuthors', () => {
 
 			expect( result.current.authors ).toEqual( [] );
 			expect( result.current.isCapAvailable ).toBe( true );
-			expect( warnSpy ).toHaveBeenCalled();
-			warnSpy.mockRestore();
+			// Term IDs are assigned but resolution returned empty — surface this so consumers
+			// don't silently fall back to `post_author` and credit the wrong person.
+			expect( result.current.hasCoauthorTermIds ).toBe( true );
 		} );
 
 		it( 'should allow retry after a transient REST error (no negative caching on catch)', async () => {
 			const RETRY_RESPONSE = [
 				{ id: '1', termId: 471, displayName: 'Jane', userNicename: 'jane', userType: 'wpuser', login: 'jane', email: '' },
 			];
-			const warnSpy = jest.spyOn( console, 'warn' ).mockImplementation( () => {} );
 
 			useSelect.mockImplementation( callback =>
 				callback(
@@ -405,8 +404,6 @@ describe( 'useCoAuthors', () => {
 
 			expect( apiFetch ).toHaveBeenCalledTimes( 2 );
 			expect( result2.current.authors[ 0 ].display_name ).toBe( 'Jane' );
-
-			warnSpy.mockRestore();
 		} );
 	} );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds dual-version support for Co-Authors Plus so the plugin works with both the current released CAP (which uses a `cap/authors` Redux store) and the upcoming CAP 3.8+ (https://github.com/Automattic/co-authors-plus/pull/1217, which replaces the store with the core entity store and resolves coauthors via taxonomy term IDs + a REST endpoint).

When the legacy `cap/authors` store is present, the existing synchronous path is used. When it is absent, the hook reads `getEditedPostAttribute('coauthors')` for term IDs and resolves them via `/coauthors/v1/authors-by-term-ids`. The Query Loop path (reading `newspack_author_info` from the post entity) is unchanged.

Also extracts `useAuthorTokens` from `src/bylines/index.js` into its own module so it can be unit tested independently, and fixes a pre-existing `useSelect` reactivity issue in the bylines sidebar where the selector returned a function rather than values.

Closes [NEWS-1732](https://linear.app/a8c/issue/NEWS-1732), .

### How to test the changes in this Pull Request:

This PR should be tested against both the current stable CAP and the new CAP ([co-authors-plus#1217](https://github.com/Automattic/co-authors-plus/pull/1217), branch `issue-1204`). To use the new CAP: check out that branch, run `npm install && npm run build`, and activate the plugin.

**Verify the problem on trunk (before this PR):**

1. With new CAP active, stay on the `trunk` branch of newspack-plugin.
2. Open a post with 2+ coauthors in the editor.
3. The byline block (block theme) renders only the post author, ignoring the other coauthors.
4. The avatar block (block theme) renders only one avatar instead of all coauthors.
5. The custom bylines sidebar only shows the post author in the byline, ignoring the other coauthors. The token picker is empty because only the post_author fallback is available.
6. The console shows a `useSelect hook returns different values... Non-equal value keys: coAuthors` warning.

**Switch to this PR branch and verify the fix:**

**Custom bylines sidebar (any theme):**

7. Open a post with 2+ WP user coauthors assigned via CAP.
8. Open the "Byline" sidebar panel and enable "Enable custom byline."
9. Verify the default byline is auto-populated with all WP user coauthors (guest authors should NOT appear as tokens).
10. Click "Edit byline" and verify the token picker shows the correct WP users.
11. Remove a token, verify it reappears in the available picker. Re-add it.
12. Save and reload. Verify the custom byline persists.

**Guest-only post:**

13. Create a post with only a guest author as the coauthor (no WP users).
14. Enable custom byline. The preview should be empty (not auto-seeded with the post author). This is intentional: guest authors cannot be tokenized with `[Author id=N]`.

**Post-author fallback (no CAP coauthors):**

15. Create a fresh post with default post_author only (do not add coauthors via CAP sidebar).
16. Custom byline toggle should auto-insert "By [post author name]."

**Byline block + Avatar block (block theme):**

17. Activate `newspack-block-theme`.
18. Create a new post, add 2-3 coauthors via CAP's "Authors" sidebar (include at least one guest author if `NEWSPACK_ENABLE_CAP_GUEST_AUTHORS` is defined).
19. Insert `newspack/byline` and `newspack/avatar` blocks.
20. Verify the byline renders all coauthors (e.g. "By Alice, Bob and Guest Author") and the avatar block renders one avatar per coauthor.
21. Verify guest author avatars use the uploaded featured image, not gravatar.
22. Save, reload, and verify data persists. You may briefly see only the post author before the full list renders, depending on network/rendering speed.
23. View the post on the frontend and confirm the server-rendered output matches.

**Author profile block (block theme):**

24. On a single post with multiple coauthors, verify the `newspack-blocks/author-profile` block (contextual mode) displays the correct authors with nested avatar and social blocks.

**Backwards compatibility (legacy CAP):**

25. Switch CAP to the current stable version (e.g., `git checkout 3.7.0 && npm install && npm run build`).
26. Repeat steps 7-24. All should work identically via the legacy `cap/authors` store path.
27. Verify in DevTools: `wp.data.select('cap/authors')?.getAuthors` should be a function on legacy CAP, undefined on new CAP.

**Console:**

28. Check for the absence of the previously-seen `useSelect hook returns different values... Non-equal value keys: coAuthors` warning.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?