### PR TITLE
feat(access-control): add Specific posts content rule

### DIFF
--- a/includes/content-gate/class-content-restriction-control.php
+++ b/includes/content-gate/class-content-restriction-control.php
@@ -154,8 +154,32 @@ class Content_Restriction_Control {
 				continue;
 			}
 
+			// Inclusion override: if this post ID is listed in any specific_posts rule
+			// for this gate, the gate applies regardless of other rules.
+			$specific_match = false;
 			foreach ( $content_rules as $content_rule ) {
-				$is_exclusion = isset( $content_rule['exclusion'] ) && $content_rule['exclusion'];
+				if ( 'specific_posts' === $content_rule['slug']
+					&& ! empty( $content_rule['value'] )
+					&& in_array( (int) $post_id, array_map( 'intval', (array) $content_rule['value'] ), true )
+				) {
+					$specific_match = true;
+					break;
+				}
+			}
+			if ( $specific_match ) {
+				$post_gates[] = $gate;
+				continue;
+			}
+
+			// Standard AND evaluation across remaining rules.
+			$has_non_specific_rule = false;
+			foreach ( $content_rules as $content_rule ) {
+				if ( 'specific_posts' === $content_rule['slug'] ) {
+					// Skip — already evaluated above as an override-only rule.
+					continue;
+				}
+				$has_non_specific_rule = true;
+				$is_exclusion          = isset( $content_rule['exclusion'] ) && $content_rule['exclusion'];
 				if ( $content_rule['slug'] === 'post_types' ) {
 					$post_type = get_post_type( $post_id );
 					if ( $is_exclusion ? in_array( $post_type, $content_rule['value'], true ) : ! in_array( $post_type, $content_rule['value'], true ) ) {
@@ -180,6 +204,13 @@ class Content_Restriction_Control {
 					}
 				}
 			}
+
+			// If the gate ONLY had a specific_posts rule and we got here, it means the
+			// override didn't match — don't include this gate.
+			if ( ! $has_non_specific_rule ) {
+				continue;
+			}
+
 			$post_gates[] = $gate;
 		}
 		return $post_gates;

--- a/includes/content-gate/class-content-rules.php
+++ b/includes/content-gate/class-content-rules.php
@@ -39,7 +39,7 @@ class Content_Rules {
 			'name'         => __( 'Specific posts', 'newspack-plugin' ),
 			'default'      => [],
 			'description'  => __( 'Also restrict specific posts, even if not covered by other rules above.', 'newspack-plugin' ),
-			'endpoint'     => '/' . NEWSPACK_API_NAMESPACE . '/wizard/audience-content-gates/posts-search',
+			'endpoint'     => '/' . NEWSPACK_API_NAMESPACE . '/wizard/newspack-audience-access-control/posts-search',
 			'include_only' => true,
 		];
 

--- a/includes/content-gate/class-content-rules.php
+++ b/includes/content-gate/class-content-rules.php
@@ -35,6 +35,14 @@ class Content_Rules {
 			];
 		}
 
+		$content_rules['specific_posts'] = [
+			'name'         => __( 'Specific posts', 'newspack-plugin' ),
+			'default'      => [],
+			'description'  => __( 'Also restrict specific posts, even if not covered by other rules above.', 'newspack-plugin' ),
+			'endpoint'     => '/' . NEWSPACK_API_NAMESPACE . '/wizard/audience-content-gates/posts-search',
+			'include_only' => true,
+		];
+
 		return $content_rules;
 	}
 

--- a/includes/wizards/audience/class-audience-content-gates.php
+++ b/includes/wizards/audience/class-audience-content-gates.php
@@ -545,6 +545,9 @@ class Audience_Content_Gates extends Wizard {
 			if ( empty( $ids ) ) {
 				return rest_ensure_response( [] );
 			}
+			// Broader status filter when hydrating saved tokens so the editor
+			// keeps showing items whose status changed since the gate was saved.
+			$args['post_status']    = [ 'publish', 'draft', 'pending', 'private', 'future' ];
 			$args['post__in']       = $ids;
 			$args['posts_per_page'] = min( count( $ids ), 100 );
 			$args['orderby']        = 'post__in';

--- a/includes/wizards/audience/class-audience-content-gates.php
+++ b/includes/wizards/audience/class-audience-content-gates.php
@@ -329,6 +329,30 @@ class Audience_Content_Gates extends Wizard {
 				],
 			]
 		);
+
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'/wizard/audience-content-gates/posts-search',
+			[
+				'methods'             => 'GET',
+				'callback'            => [ $this, 'posts_search' ],
+				'permission_callback' => [ $this, 'api_permissions_check' ],
+				'args'                => [
+					'search'   => [
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_text_field',
+					],
+					'include'  => [
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_text_field',
+					],
+					'per_page' => [
+						'type'    => 'integer',
+						'default' => 10,
+					],
+				],
+			]
+		);
 	}
 
 	/**
@@ -487,5 +511,70 @@ class Audience_Content_Gates extends Wizard {
 			$updated_gates[] = $updated_gate;
 		}
 		return rest_ensure_response( $updated_gates );
+	}
+
+	/**
+	 * REST callback: search published posts across all post types supported by content gates.
+	 *
+	 * Returns items in the shape consumed by ContentRuleControlTokenField:
+	 * `[{ id, name, type_label }]`. Supports `search` (by title/content) and `include`
+	 * (comma-separated IDs to hydrate saved tokens regardless of search match).
+	 *
+	 * @param \WP_REST_Request $request The request object.
+	 * @return \WP_REST_Response
+	 */
+	public function posts_search( $request ) {
+		$post_types = array_column( Content_Restriction_Control::get_available_post_types(), 'value' );
+
+		$args = [
+			'post_type'      => $post_types,
+			'post_status'    => 'publish',
+			'posts_per_page' => max( 1, min( 50, (int) $request->get_param( 'per_page' ) ) ),
+			'orderby'        => 'title',
+			'order'          => 'ASC',
+			'no_found_rows'  => true,
+		];
+
+		$include = $request->get_param( 'include' );
+		if ( ! empty( $include ) ) {
+			$ids = array_filter( array_map( 'absint', explode( ',', $include ) ) );
+			if ( empty( $ids ) ) {
+				return rest_ensure_response( [] );
+			}
+			$args['post__in']       = $ids;
+			$args['posts_per_page'] = count( $ids );
+			$args['orderby']        = 'post__in';
+		}
+
+		$search = $request->get_param( 'search' );
+		if ( ! empty( $search ) ) {
+			// Numeric search: treat as a post ID lookup.
+			if ( is_numeric( $search ) ) {
+				$args['p'] = absint( $search );
+			} else {
+				$args['s'] = $search;
+			}
+		}
+
+		$query = new \WP_Query( $args );
+
+		$labels = [];
+		foreach ( $post_types as $pt ) {
+			$obj = get_post_type_object( $pt );
+			$labels[ $pt ] = $obj && isset( $obj->labels->singular_name ) ? $obj->labels->singular_name : $pt;
+		}
+
+		$data = array_map(
+			function( $post ) use ( $labels ) {
+				return [
+					'id'         => (int) $post->ID,
+					'name'       => $post->post_title !== '' ? $post->post_title : sprintf( '#%d', $post->ID ),
+					'type_label' => $labels[ $post->post_type ] ?? $post->post_type,
+				];
+			},
+			$query->posts
+		);
+
+		return rest_ensure_response( $data );
 	}
 }

--- a/includes/wizards/audience/class-audience-content-gates.php
+++ b/includes/wizards/audience/class-audience-content-gates.php
@@ -347,8 +347,12 @@ class Audience_Content_Gates extends Wizard {
 						'sanitize_callback' => 'sanitize_text_field',
 					],
 					'per_page' => [
-						'type'    => 'integer',
-						'default' => 10,
+						'type'              => 'integer',
+						'default'           => 10,
+						'minimum'           => 1,
+						'maximum'           => 50,
+						'sanitize_callback' => 'absint',
+						'validate_callback' => 'rest_validate_request_arg',
 					],
 				],
 			]
@@ -529,7 +533,7 @@ class Audience_Content_Gates extends Wizard {
 		$args = [
 			'post_type'      => $post_types,
 			'post_status'    => 'publish',
-			'posts_per_page' => max( 1, min( 50, (int) $request->get_param( 'per_page' ) ) ),
+			'posts_per_page' => (int) $request->get_param( 'per_page' ),
 			'orderby'        => 'title',
 			'order'          => 'ASC',
 			'no_found_rows'  => true,
@@ -542,7 +546,7 @@ class Audience_Content_Gates extends Wizard {
 				return rest_ensure_response( [] );
 			}
 			$args['post__in']       = $ids;
-			$args['posts_per_page'] = count( $ids );
+			$args['posts_per_page'] = min( count( $ids ), 100 );
 			$args['orderby']        = 'post__in';
 		}
 

--- a/includes/wizards/audience/class-audience-content-gates.php
+++ b/includes/wizards/audience/class-audience-content-gates.php
@@ -332,7 +332,7 @@ class Audience_Content_Gates extends Wizard {
 
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
-			'/wizard/audience-content-gates/posts-search',
+			'/wizard/' . $this->slug . '/posts-search',
 			[
 				'methods'             => 'GET',
 				'callback'            => [ $this, 'posts_search' ],

--- a/src/content-gate/editor/post-settings.js
+++ b/src/content-gate/editor/post-settings.js
@@ -11,16 +11,38 @@ import { ExternalLink, ToggleControl } from '@wordpress/components';
 const { gates = [], taxonomyMap = {}, canEditGates = false } = window.newspackContentGates || {};
 
 /**
- * Check if a gate's content rules match the current post state.
+ * Check if a gate's content rules match the current post state. Mirrors
+ * the PHP `Content_Restriction_Control::get_post_gates()` evaluator.
  *
  * @param {Array}  contentRules Gate content rules.
  * @param {string} postType     Current post type.
  * @param {Object} termsByTax   Map of taxonomy REST base to array of term IDs.
+ * @param {number} postId       Current post ID, for the specific_posts override.
  *
- * @return {boolean} Whether all rules match.
+ * @return {boolean} Whether the gate applies to this post.
  */
-function gateMatchesPost( contentRules, postType, termsByTax ) {
-	return contentRules.every( rule => {
+function gateMatchesPost( contentRules, postType, termsByTax, postId ) {
+	// Inclusion override: if this post ID is listed in any specific_posts
+	// rule, the gate applies regardless of other rules.
+	const specificMatch = contentRules.some(
+		rule =>
+			rule.slug === 'specific_posts' &&
+			Array.isArray( rule.value ) &&
+			rule.value.length > 0 &&
+			rule.value.map( v => parseInt( v ) ).includes( parseInt( postId ) )
+	);
+	if ( specificMatch ) {
+		return true;
+	}
+
+	// Standard AND evaluation across remaining rules. specific_posts is skipped
+	// here; if it was the only rule and didn't match, the gate doesn't apply.
+	let hasNonSpecificRule = false;
+	const allMatch = contentRules.every( rule => {
+		if ( rule.slug === 'specific_posts' ) {
+			return true;
+		}
+		hasNonSpecificRule = true;
 		const isExclusion = rule.exclusion;
 		if ( rule.slug === 'post_types' ) {
 			return isExclusion ? ! rule.value.includes( postType ) : rule.value.includes( postType );
@@ -36,17 +58,20 @@ function gateMatchesPost( contentRules, postType, termsByTax ) {
 		const hasOverlap = rule.value.some( id => postTerms.includes( parseInt( id ) ) );
 		return isExclusion ? ! hasOverlap : hasOverlap;
 	} );
+
+	return allMatch && hasNonSpecificRule;
 }
 
 function PostSettings() {
-	const { meta, postType, termsByTax } = useSelect( select => {
-		const { getEditedPostAttribute } = select( 'core/editor' );
+	const { meta, postId, postType, termsByTax } = useSelect( select => {
+		const { getEditedPostAttribute, getCurrentPostId } = select( 'core/editor' );
 		const terms = {};
 		Object.values( taxonomyMap ).forEach( restBase => {
 			terms[ restBase ] = getEditedPostAttribute( restBase ) || [];
 		} );
 		return {
 			meta: getEditedPostAttribute( 'meta' ),
+			postId: getCurrentPostId(),
 			postType: getEditedPostAttribute( 'type' ),
 			termsByTax: terms,
 		};
@@ -54,8 +79,8 @@ function PostSettings() {
 	const { editPost } = useDispatch( 'core/editor' );
 
 	const matchingGates = useMemo(
-		() => gates.filter( gate => gateMatchesPost( gate.content_rules, postType, termsByTax ) ),
-		[ postType, termsByTax ]
+		() => gates.filter( gate => gateMatchesPost( gate.content_rules, postType, termsByTax, postId ) ),
+		[ postId, postType, termsByTax ]
 	);
 
 	return (

--- a/src/wizards/audience/views/content-gates/edit/content-rule-control-tokenfield.tsx
+++ b/src/wizards/audience/views/content-gates/edit/content-rule-control-tokenfield.tsx
@@ -53,24 +53,24 @@ export default function ContentRuleControlTokenField( { slug, value, exclusion, 
 					_fields: 'db_id,id,name,type_label',
 				} ),
 			} )
-				.then( terms => {
-					if ( ! terms || terms.length === 0 ) {
+				.then( items => {
+					if ( ! items || items.length === 0 ) {
 						setSuggestions( [] );
 						return;
 					}
 					setSuggestions(
-						terms.map( term => ( {
-							value: term.db_id ? term.db_id.toString() : term.id.toString(),
+						items.map( item => ( {
+							value: item.db_id ? item.db_id.toString() : item.id.toString(),
 							label: decodeEntities(
-								`${ term.db_id || term.id }: ${ term.name || __( '(no name)', 'newspack-plugin' ) }${
-									term.type_label ? ` (${ term.type_label })` : ''
+								`${ item.db_id || item.id }: ${ item.name || __( '(no name)', 'newspack-plugin' ) }${
+									item.type_label ? ` (${ item.type_label })` : ''
 								}`
 							),
 						} ) )
 					);
 				} )
 				.catch( error => {
-					console.warn( 'Error fetching suggestions for taxonomy: ' + endpoint, error ); // eslint-disable-line no-console
+					console.warn( 'Error fetching suggestions for content rule: ' + endpoint, error ); // eslint-disable-line no-console
 				} );
 		},
 		[ endpoint ]
@@ -87,20 +87,20 @@ export default function ContentRuleControlTokenField( { slug, value, exclusion, 
 				_fields: 'db_id,id,name,type_label',
 			} ),
 		} )
-			.then( terms => {
+			.then( items => {
 				setSavedItems(
-					terms.map( term => ( {
-						value: term.db_id ? term.db_id.toString() : term.id.toString(),
+					items.map( item => ( {
+						value: item.db_id ? item.db_id.toString() : item.id.toString(),
 						label: decodeEntities(
-							`${ term.db_id || term.id }: ${ term.name || __( '(no name)', 'newspack-plugin' ) }${
-								term.type_label ? ` (${ term.type_label })` : ''
+							`${ item.db_id || item.id }: ${ item.name || __( '(no name)', 'newspack-plugin' ) }${
+								item.type_label ? ` (${ item.type_label })` : ''
 							}`
 						),
 					} ) )
 				);
 			} )
 			.catch( error => {
-				console.warn( 'Error fetching saved items for taxonomy: ' + endpoint, error ); // eslint-disable-line no-console
+				console.warn( 'Error fetching saved items for content rule: ' + endpoint, error ); // eslint-disable-line no-console
 			} );
 	}, [ value, endpoint ] );
 

--- a/tests/class-newspack-unit-tests-bootstrap.php
+++ b/tests/class-newspack-unit-tests-bootstrap.php
@@ -84,6 +84,10 @@ class Newspack_Unit_Tests_Bootstrap {
 	 * Load Newspack.
 	 */
 	public function load_newspack() {
+		// Enable the Content Gates feature so its wizard and REST endpoints register under test.
+		if ( ! defined( 'NEWSPACK_CONTENT_GATES' ) ) {
+			define( 'NEWSPACK_CONTENT_GATES', true );
+		}
 		require_once $this->plugin_dir . '/newspack.php';
 	}
 

--- a/tests/class-newspack-unit-tests-bootstrap.php
+++ b/tests/class-newspack-unit-tests-bootstrap.php
@@ -84,10 +84,6 @@ class Newspack_Unit_Tests_Bootstrap {
 	 * Load Newspack.
 	 */
 	public function load_newspack() {
-		// Enable the Content Gates feature so its wizard and REST endpoints register under test.
-		if ( ! defined( 'NEWSPACK_CONTENT_GATES' ) ) {
-			define( 'NEWSPACK_CONTENT_GATES', true );
-		}
 		require_once $this->plugin_dir . '/newspack.php';
 	}
 

--- a/tests/unit-tests/content-gate/content-gates.php
+++ b/tests/unit-tests/content-gate/content-gates.php
@@ -1287,4 +1287,37 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 		$ids = wp_list_pluck( $response->get_data(), 'id' );
 		$this->assertSame( [ $target ], $ids, 'Numeric search returns only the post with that ID' );
 	}
+
+	/**
+	 * Test that per_page=0 is rejected at the schema boundary with a 400 status.
+	 */
+	public function test_posts_search_endpoint_per_page_below_minimum() {
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
+
+		$request = new \WP_REST_Request( 'GET', '/' . NEWSPACK_API_NAMESPACE . '/wizard/newspack-audience-access-control/posts-search' );
+		$request->set_param( 'per_page', 0 );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 400, $response->get_status(), 'per_page=0 fails schema validation' );
+	}
+
+	/**
+	 * Test that include with many IDs is capped at 100 results.
+	 */
+	public function test_posts_search_endpoint_caps_include_results() {
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
+
+		$ids = [];
+		for ( $i = 0; $i < 105; $i++ ) {
+			$ids[] = $this->factory->post->create( [ 'post_status' => 'publish' ] );
+		}
+		$this->post_ids = array_merge( $this->post_ids, $ids );
+
+		$request = new \WP_REST_Request( 'GET', '/' . NEWSPACK_API_NAMESPACE . '/wizard/newspack-audience-access-control/posts-search' );
+		$request->set_param( 'include', implode( ',', $ids ) );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertLessThanOrEqual( 100, count( $response->get_data() ), 'Include result set is capped at 100' );
+	}
 }

--- a/tests/unit-tests/content-gate/content-gates.php
+++ b/tests/unit-tests/content-gate/content-gates.php
@@ -1011,14 +1011,14 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 	 * Test that the specific_posts content rule is registered.
 	 */
 	public function test_specific_posts_rule_is_registered() {
-		$rules = \Newspack\Content_Rules::get_content_rules();
+		$rules = Content_Rules::get_content_rules();
 		$this->assertArrayHasKey( 'specific_posts', $rules, 'specific_posts rule is registered' );
 
 		$rule = $rules['specific_posts'];
 		$this->assertSame( 'Specific posts', $rule['name'] );
 		$this->assertSame( [], $rule['default'] );
 		$this->assertTrue( $rule['include_only'], 'specific_posts is include-only (no exclusion mode)' );
-		$this->assertNotEmpty( $rule['endpoint'], 'specific_posts has a REST endpoint' );
+		$this->assertSame( '/' . NEWSPACK_API_NAMESPACE . '/wizard/audience-content-gates/posts-search', $rule['endpoint'], 'endpoint matches the route Task 2 must register' );
 		$this->assertStringContainsString( 'restrict specific posts', $rule['description'], 'description signals override behavior' );
 
 		// Must be the LAST rule in the list.

--- a/tests/unit-tests/content-gate/content-gates.php
+++ b/tests/unit-tests/content-gate/content-gates.php
@@ -33,6 +33,18 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 	protected $gate_ids = [];
 
 	/**
+	 * Ensure the Content Gates feature flag is defined before any test runs.
+	 * `Audience_Content_Gates::register_api_endpoints()` early-returns on
+	 * `! $this->is_feature_enabled()`, so REST-dispatch tests need the flag on.
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+		if ( ! defined( 'NEWSPACK_CONTENT_GATES' ) ) {
+			define( 'NEWSPACK_CONTENT_GATES', true );
+		}
+	}
+
+	/**
 	 * Test set up.
 	 */
 	public function set_up() {
@@ -1030,9 +1042,6 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 	 * Test the posts-search REST endpoint returns published posts of supported post types.
 	 */
 	public function test_posts_search_endpoint_returns_published_posts() {
-		if ( ! defined( 'NEWSPACK_CONTENT_GATES' ) ) {
-			define( 'NEWSPACK_CONTENT_GATES', true );
-		}
 		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
 
 		$published_post = $this->factory->post->create(
@@ -1081,9 +1090,6 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 	 * Test the posts-search endpoint can hydrate saved tokens via include.
 	 */
 	public function test_posts_search_endpoint_supports_include() {
-		if ( ! defined( 'NEWSPACK_CONTENT_GATES' ) ) {
-			define( 'NEWSPACK_CONTENT_GATES', true );
-		}
 		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
 
 		$post_a = $this->factory->post->create(
@@ -1119,9 +1125,6 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 	 * permission callback returns boolean false / null).
 	 */
 	public function test_posts_search_endpoint_requires_permissions() {
-		if ( ! defined( 'NEWSPACK_CONTENT_GATES' ) ) {
-			define( 'NEWSPACK_CONTENT_GATES', true );
-		}
 		wp_set_current_user( 0 );
 
 		$request  = new \WP_REST_Request( 'GET', '/' . NEWSPACK_API_NAMESPACE . '/wizard/newspack-audience-access-control/posts-search' );
@@ -1211,5 +1214,89 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 
 		$this->assertCount( 1, Content_Restriction_Control::get_post_gates( $gated_id ) );
 		$this->assertCount( 0, Content_Restriction_Control::get_post_gates( $ungated_id ) );
+	}
+
+	/**
+	 * Test specific_posts override wins against a category rule, too.
+	 */
+	public function test_specific_posts_overrides_taxonomy_rule() {
+		$cat_id = $this->factory->term->create(
+			[
+				'taxonomy' => 'category',
+				'name'     => 'Restricted Only',
+			]
+		);
+
+		// Post with NO category — would fail the taxonomy rule normally.
+		$post_id          = $this->factory->post->create( [ 'post_status' => 'publish' ] );
+		$this->post_ids[] = $post_id;
+
+		Content_Rules::update_gate_content_rules(
+			$this->gate_ids[2],
+			[
+				[
+					'slug'  => 'category',
+					'value' => [ $cat_id ],
+				],
+				[
+					'slug'  => 'specific_posts',
+					'value' => [ (string) $post_id ],
+				],
+			]
+		);
+
+		$gates = Content_Restriction_Control::get_post_gates( $post_id );
+		$this->assertCount( 1, $gates, 'Post is gated via specific_posts override despite not matching the category rule' );
+	}
+
+	/**
+	 * Test empty specific_posts value does NOT trigger the override and — when it's
+	 * the gate's only rule — does NOT accidentally include the gate.
+	 */
+	public function test_specific_posts_empty_value_does_not_match() {
+		$post_id          = $this->factory->post->create( [ 'post_status' => 'publish' ] );
+		$this->post_ids[] = $post_id;
+
+		Content_Rules::update_gate_content_rules(
+			$this->gate_ids[2],
+			[
+				[
+					'slug'  => 'specific_posts',
+					'value' => [],
+				],
+			]
+		);
+
+		$this->assertCount( 0, Content_Restriction_Control::get_post_gates( $post_id ), 'Empty specific_posts does not include any gate' );
+	}
+
+	/**
+	 * Test the posts-search endpoint treats a numeric search as a post ID lookup.
+	 */
+	public function test_posts_search_endpoint_numeric_search_is_id_lookup() {
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
+
+		$target           = $this->factory->post->create(
+			[
+				'post_status' => 'publish',
+				'post_title'  => 'Findable',
+			]
+		);
+		$other            = $this->factory->post->create(
+			[
+				'post_status' => 'publish',
+				'post_title'  => 'Decoy',
+			]
+		);
+		$this->post_ids[] = $target;
+		$this->post_ids[] = $other;
+
+		$request = new \WP_REST_Request( 'GET', '/' . NEWSPACK_API_NAMESPACE . '/wizard/newspack-audience-access-control/posts-search' );
+		$request->set_param( 'search', (string) $target );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$ids = wp_list_pluck( $response->get_data(), 'id' );
+		$this->assertSame( [ $target ], $ids, 'Numeric search returns only the post with that ID' );
 	}
 }

--- a/tests/unit-tests/content-gate/content-gates.php
+++ b/tests/unit-tests/content-gate/content-gates.php
@@ -1015,11 +1015,11 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 		$this->assertArrayHasKey( 'specific_posts', $rules, 'specific_posts rule is registered' );
 
 		$rule = $rules['specific_posts'];
-		$this->assertSame( 'Specific posts', $rule['name'] );
+		$this->assertSame( __( 'Specific posts', 'newspack-plugin' ), $rule['name'] );
 		$this->assertSame( [], $rule['default'] );
 		$this->assertTrue( $rule['include_only'], 'specific_posts is include-only (no exclusion mode)' );
 		$this->assertSame( '/' . NEWSPACK_API_NAMESPACE . '/wizard/newspack-audience-access-control/posts-search', $rule['endpoint'], 'endpoint matches the route Task 2 must register' );
-		$this->assertStringContainsString( 'restrict specific posts', $rule['description'], 'description signals override behavior' );
+		$this->assertStringContainsString( __( 'restrict specific posts', 'newspack-plugin' ), $rule['description'], 'description signals override behavior' );
 
 		// Must be the LAST rule in the list.
 		$keys = array_keys( $rules );

--- a/tests/unit-tests/content-gate/content-gates.php
+++ b/tests/unit-tests/content-gate/content-gates.php
@@ -1033,12 +1033,8 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 		$this->assertSame( __( 'Specific posts', 'newspack-plugin' ), $rule['name'] );
 		$this->assertSame( [], $rule['default'] );
 		$this->assertTrue( $rule['include_only'], 'specific_posts is include-only (no exclusion mode)' );
-		$this->assertSame( '/' . NEWSPACK_API_NAMESPACE . '/wizard/newspack-audience-access-control/posts-search', $rule['endpoint'], 'endpoint matches the route Task 2 must register' );
-		$this->assertStringContainsString( __( 'restrict specific posts', 'newspack-plugin' ), $rule['description'], 'description signals override behavior' );
-
-		// Must be the LAST rule in the list.
-		$keys = array_keys( $rules );
-		$this->assertSame( 'specific_posts', end( $keys ), 'specific_posts appears last' );
+		$this->assertSame( '/' . NEWSPACK_API_NAMESPACE . '/wizard/newspack-audience-access-control/posts-search', $rule['endpoint'], 'endpoint matches the registered REST route' );
+		$this->assertStringContainsString( 'restrict specific posts', $rule['description'], 'description signals override behavior' );
 	}
 
 	/**

--- a/tests/unit-tests/content-gate/content-gates.php
+++ b/tests/unit-tests/content-gate/content-gates.php
@@ -1025,4 +1025,108 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 		$keys = array_keys( $rules );
 		$this->assertSame( 'specific_posts', end( $keys ), 'specific_posts appears last' );
 	}
+
+	/**
+	 * Test the posts-search REST endpoint returns published posts of supported post types.
+	 */
+	public function test_posts_search_endpoint_returns_published_posts() {
+		if ( ! defined( 'NEWSPACK_CONTENT_GATES' ) ) {
+			define( 'NEWSPACK_CONTENT_GATES', true );
+		}
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
+
+		$published_post = $this->factory->post->create(
+			[
+				'post_status' => 'publish',
+				'post_title'  => 'Searchable Post',
+			] 
+		);
+		$draft_post     = $this->factory->post->create(
+			[
+				'post_status' => 'draft',
+				'post_title'  => 'Searchable Draft',
+			] 
+		);
+		$published_page = $this->factory->post->create(
+			[
+				'post_status' => 'publish',
+				'post_type'   => 'page',
+				'post_title'  => 'Searchable Page',
+			] 
+		);
+		$this->post_ids[] = $published_post;
+		$this->post_ids[] = $draft_post;
+		$this->post_ids[] = $published_page;
+
+		$request = new \WP_REST_Request( 'GET', '/' . NEWSPACK_API_NAMESPACE . '/wizard/audience-content-gates/posts-search' );
+		$request->set_param( 'search', 'Searchable' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$data = $response->get_data();
+		$ids  = wp_list_pluck( $data, 'id' );
+
+		$this->assertContains( $published_post, $ids, 'Includes published post' );
+		$this->assertContains( $published_page, $ids, 'Includes published page (other supported post type)' );
+		$this->assertNotContains( $draft_post, $ids, 'Excludes non-published post' );
+
+		foreach ( $data as $item ) {
+			$this->assertArrayHasKey( 'id', $item );
+			$this->assertArrayHasKey( 'name', $item );
+			$this->assertArrayHasKey( 'type_label', $item );
+		}
+	}
+
+	/**
+	 * Test the posts-search endpoint can hydrate saved tokens via include.
+	 */
+	public function test_posts_search_endpoint_supports_include() {
+		if ( ! defined( 'NEWSPACK_CONTENT_GATES' ) ) {
+			define( 'NEWSPACK_CONTENT_GATES', true );
+		}
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
+
+		$post_a = $this->factory->post->create(
+			[
+				'post_status' => 'publish',
+				'post_title'  => 'A',
+			] 
+		);
+		$post_b = $this->factory->post->create(
+			[
+				'post_status' => 'publish',
+				'post_title'  => 'B',
+			] 
+		);
+		$this->post_ids[] = $post_a;
+		$this->post_ids[] = $post_b;
+
+		$request = new \WP_REST_Request( 'GET', '/' . NEWSPACK_API_NAMESPACE . '/wizard/audience-content-gates/posts-search' );
+		$request->set_param( 'include', $post_a . ',' . $post_b );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$ids = wp_list_pluck( $response->get_data(), 'id' );
+		$this->assertEqualsCanonicalizing( [ $post_a, $post_b ], $ids );
+	}
+
+	/**
+	 * Test the posts-search endpoint requires admin permissions.
+	 *
+	 * The shared `api_permissions_check` helper used by all wizard routes returns a
+	 * WP_Error with status 403 when `current_user_can( $this->capability )` fails.
+	 * That error code is preserved by WP_REST_Server (it only re-maps to 401 when the
+	 * permission callback returns boolean false / null).
+	 */
+	public function test_posts_search_endpoint_requires_permissions() {
+		if ( ! defined( 'NEWSPACK_CONTENT_GATES' ) ) {
+			define( 'NEWSPACK_CONTENT_GATES', true );
+		}
+		wp_set_current_user( 0 );
+
+		$request  = new \WP_REST_Request( 'GET', '/' . NEWSPACK_API_NAMESPACE . '/wizard/audience-content-gates/posts-search' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 403, $response->get_status() );
+	}
 }

--- a/tests/unit-tests/content-gate/content-gates.php
+++ b/tests/unit-tests/content-gate/content-gates.php
@@ -1129,4 +1129,87 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 
 		$this->assertSame( 403, $response->get_status() );
 	}
+
+	/**
+	 * Test specific_posts overrides post_types: a page in specific_posts is restricted
+	 * even when the gate's post_types rule only allows posts.
+	 */
+	public function test_specific_posts_overrides_post_types_rule() {
+		$page_id = $this->factory->post->create(
+			[
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+			]
+		);
+		$this->post_ids[] = $page_id;
+
+		// Reuse the published gate (gate_ids[2]) — currently restricts post_types=['post'].
+		Content_Rules::update_gate_content_rules(
+			$this->gate_ids[2],
+			[
+				[
+					'slug'  => 'post_types',
+					'value' => [ 'post' ],
+				],
+				[
+					'slug'  => 'specific_posts',
+					'value' => [ (string) $page_id ],
+				],
+			]
+		);
+
+		$gates = Content_Restriction_Control::get_post_gates( $page_id );
+		$this->assertCount( 1, $gates, 'Page is gated because it is listed in specific_posts, despite post_types=post' );
+		$this->assertSame( $this->gate_ids[2], $gates[0]['id'] );
+	}
+
+	/**
+	 * Test specific_posts with no match: gate falls back to AND evaluation of other rules.
+	 */
+	public function test_specific_posts_no_match_falls_through_to_other_rules() {
+		$post_id          = $this->factory->post->create( [ 'post_status' => 'publish' ] );
+		$other_id         = $this->factory->post->create( [ 'post_status' => 'publish' ] );
+		$this->post_ids[] = $post_id;
+		$this->post_ids[] = $other_id;
+
+		Content_Rules::update_gate_content_rules(
+			$this->gate_ids[2],
+			[
+				[
+					'slug'  => 'post_types',
+					'value' => [ 'post' ],
+				],
+				[
+					'slug'  => 'specific_posts',
+					'value' => [ (string) $other_id ],
+				],
+			]
+		);
+
+		$gates = Content_Restriction_Control::get_post_gates( $post_id );
+		$this->assertCount( 1, $gates, 'Post is gated by post_types AND-chain (specific_posts did not match it)' );
+	}
+
+	/**
+	 * Test specific_posts alone (no post_types rule) restricts only the listed posts.
+	 */
+	public function test_specific_posts_alone_restricts_only_listed_posts() {
+		$gated_id         = $this->factory->post->create( [ 'post_status' => 'publish' ] );
+		$ungated_id       = $this->factory->post->create( [ 'post_status' => 'publish' ] );
+		$this->post_ids[] = $gated_id;
+		$this->post_ids[] = $ungated_id;
+
+		Content_Rules::update_gate_content_rules(
+			$this->gate_ids[2],
+			[
+				[
+					'slug'  => 'specific_posts',
+					'value' => [ (string) $gated_id ],
+				],
+			]
+		);
+
+		$this->assertCount( 1, Content_Restriction_Control::get_post_gates( $gated_id ) );
+		$this->assertCount( 0, Content_Restriction_Control::get_post_gates( $ungated_id ) );
+	}
 }

--- a/tests/unit-tests/content-gate/content-gates.php
+++ b/tests/unit-tests/content-gate/content-gates.php
@@ -33,18 +33,6 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 	protected $gate_ids = [];
 
 	/**
-	 * Ensure the Content Gates feature flag is defined before any test runs.
-	 * `Audience_Content_Gates::register_api_endpoints()` early-returns on
-	 * `! $this->is_feature_enabled()`, so REST-dispatch tests need the flag on.
-	 */
-	public static function setUpBeforeClass(): void {
-		parent::setUpBeforeClass();
-		if ( ! defined( 'NEWSPACK_CONTENT_GATES' ) ) {
-			define( 'NEWSPACK_CONTENT_GATES', true );
-		}
-	}
-
-	/**
 	 * Test set up.
 	 */
 	public function set_up() {

--- a/tests/unit-tests/content-gate/content-gates.php
+++ b/tests/unit-tests/content-gate/content-gates.php
@@ -1036,20 +1036,20 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 			[
 				'post_status' => 'publish',
 				'post_title'  => 'Searchable Post',
-			] 
+			]
 		);
 		$draft_post     = $this->factory->post->create(
 			[
 				'post_status' => 'draft',
 				'post_title'  => 'Searchable Draft',
-			] 
+			]
 		);
 		$published_page = $this->factory->post->create(
 			[
 				'post_status' => 'publish',
 				'post_type'   => 'page',
 				'post_title'  => 'Searchable Page',
-			] 
+			]
 		);
 		$this->post_ids[] = $published_post;
 		$this->post_ids[] = $draft_post;
@@ -1084,13 +1084,13 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 			[
 				'post_status' => 'publish',
 				'post_title'  => 'A',
-			] 
+			]
 		);
 		$post_b = $this->factory->post->create(
 			[
 				'post_status' => 'publish',
 				'post_title'  => 'B',
-			] 
+			]
 		);
 		$this->post_ids[] = $post_a;
 		$this->post_ids[] = $post_b;

--- a/tests/unit-tests/content-gate/content-gates.php
+++ b/tests/unit-tests/content-gate/content-gates.php
@@ -1006,4 +1006,23 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 		$this->assertCount( 1, $gates, 'Newsletter content rule must match a post whose ID is in the value array.' );
 		$this->assertEquals( $this->gate_ids[2], $gates[0]['id'] );
 	}
+
+	/**
+	 * Test that the specific_posts content rule is registered.
+	 */
+	public function test_specific_posts_rule_is_registered() {
+		$rules = \Newspack\Content_Rules::get_content_rules();
+		$this->assertArrayHasKey( 'specific_posts', $rules, 'specific_posts rule is registered' );
+
+		$rule = $rules['specific_posts'];
+		$this->assertSame( 'Specific posts', $rule['name'] );
+		$this->assertSame( [], $rule['default'] );
+		$this->assertTrue( $rule['include_only'], 'specific_posts is include-only (no exclusion mode)' );
+		$this->assertNotEmpty( $rule['endpoint'], 'specific_posts has a REST endpoint' );
+		$this->assertStringContainsString( 'restrict specific posts', $rule['description'], 'description signals override behavior' );
+
+		// Must be the LAST rule in the list.
+		$keys = array_keys( $rules );
+		$this->assertSame( 'specific_posts', end( $keys ), 'specific_posts appears last' );
+	}
 }

--- a/tests/unit-tests/content-gate/content-gates.php
+++ b/tests/unit-tests/content-gate/content-gates.php
@@ -33,6 +33,21 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 	protected $gate_ids = [];
 
 	/**
+	 * Define the Content Gates feature flag for this test class only and force
+	 * the REST server to re-init so audience-content-gates routes register with
+	 * the flag on. Defining in bootstrap would flip the flag for every test in
+	 * the suite — including any future test that asserts feature-off behavior.
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+		if ( ! defined( 'NEWSPACK_CONTENT_GATES' ) ) {
+			define( 'NEWSPACK_CONTENT_GATES', true );
+		}
+		$GLOBALS['wp_rest_server'] = null;
+		do_action( 'rest_api_init', rest_get_server() );
+	}
+
+	/**
 	 * Test set up.
 	 */
 	public function set_up() {

--- a/tests/unit-tests/content-gate/content-gates.php
+++ b/tests/unit-tests/content-gate/content-gates.php
@@ -1018,7 +1018,7 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 		$this->assertSame( 'Specific posts', $rule['name'] );
 		$this->assertSame( [], $rule['default'] );
 		$this->assertTrue( $rule['include_only'], 'specific_posts is include-only (no exclusion mode)' );
-		$this->assertSame( '/' . NEWSPACK_API_NAMESPACE . '/wizard/audience-content-gates/posts-search', $rule['endpoint'], 'endpoint matches the route Task 2 must register' );
+		$this->assertSame( '/' . NEWSPACK_API_NAMESPACE . '/wizard/newspack-audience-access-control/posts-search', $rule['endpoint'], 'endpoint matches the route Task 2 must register' );
 		$this->assertStringContainsString( 'restrict specific posts', $rule['description'], 'description signals override behavior' );
 
 		// Must be the LAST rule in the list.
@@ -1058,7 +1058,7 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 		$this->post_ids[] = $draft_post;
 		$this->post_ids[] = $published_page;
 
-		$request = new \WP_REST_Request( 'GET', '/' . NEWSPACK_API_NAMESPACE . '/wizard/audience-content-gates/posts-search' );
+		$request = new \WP_REST_Request( 'GET', '/' . NEWSPACK_API_NAMESPACE . '/wizard/newspack-audience-access-control/posts-search' );
 		$request->set_param( 'search', 'Searchable' );
 		$response = rest_get_server()->dispatch( $request );
 
@@ -1101,7 +1101,7 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 		$this->post_ids[] = $post_a;
 		$this->post_ids[] = $post_b;
 
-		$request = new \WP_REST_Request( 'GET', '/' . NEWSPACK_API_NAMESPACE . '/wizard/audience-content-gates/posts-search' );
+		$request = new \WP_REST_Request( 'GET', '/' . NEWSPACK_API_NAMESPACE . '/wizard/newspack-audience-access-control/posts-search' );
 		$request->set_param( 'include', $post_a . ',' . $post_b );
 		$response = rest_get_server()->dispatch( $request );
 
@@ -1124,7 +1124,7 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 		}
 		wp_set_current_user( 0 );
 
-		$request  = new \WP_REST_Request( 'GET', '/' . NEWSPACK_API_NAMESPACE . '/wizard/audience-content-gates/posts-search' );
+		$request  = new \WP_REST_Request( 'GET', '/' . NEWSPACK_API_NAMESPACE . '/wizard/newspack-audience-access-control/posts-search' );
 		$response = rest_get_server()->dispatch( $request );
 
 		$this->assertSame( 403, $response->get_status() );

--- a/tests/unit-tests/content-gate/content-gates.php
+++ b/tests/unit-tests/content-gate/content-gates.php
@@ -1289,6 +1289,38 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that include hydrates non-published tokens so the editor keeps
+	 * showing items whose status changed after the gate was saved.
+	 */
+	public function test_posts_search_endpoint_include_hydrates_non_published() {
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
+
+		$draft = $this->factory->post->create(
+			[
+				'post_status' => 'draft',
+				'post_title'  => 'Was Published, Now Draft',
+			]
+		);
+		$this->post_ids[] = $draft;
+
+		// `include` should return the draft.
+		$request = new \WP_REST_Request( 'GET', '/' . NEWSPACK_API_NAMESPACE . '/wizard/newspack-audience-access-control/posts-search' );
+		$request->set_param( 'include', (string) $draft );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertSame( 200, $response->get_status() );
+		$ids = wp_list_pluck( $response->get_data(), 'id' );
+		$this->assertContains( $draft, $ids, 'include hydrates non-published tokens' );
+
+		// `search` should NOT return the draft (search-mode stays publish-only).
+		$request2 = new \WP_REST_Request( 'GET', '/' . NEWSPACK_API_NAMESPACE . '/wizard/newspack-audience-access-control/posts-search' );
+		$request2->set_param( 'search', 'Was Published' );
+		$response2 = rest_get_server()->dispatch( $request2 );
+		$this->assertSame( 200, $response2->get_status() );
+		$ids2 = wp_list_pluck( $response2->get_data(), 'id' );
+		$this->assertNotContains( $draft, $ids2, 'search-mode does not surface non-published posts' );
+	}
+
+	/**
 	 * Test that per_page=0 is rejected at the schema boundary with a 400 status.
 	 */
 	public function test_posts_search_endpoint_per_page_below_minimum() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds a new **Specific posts** content rule to Access Control gates so publishers can restrict individual posts or pages by ID, without having to match them through a broader post-type or taxonomy rule.

The rule appears last in the gate editor (after Categories and Tags) and uses a `FormTokenField` that searches posts by title or numeric ID across all post types supported by content gates (defaults: posts, pages, plus anything registered via the `newspack_content_gate_supported_post_types` filter).

Semantically this rule behaves differently from the others: it's an **inclusion override**. If a post's ID is listed in a gate's `specific_posts` rule, the gate applies to that post regardless of whether the gate's other rules (post types, categories, tags) would normally match it. The rule's UI description spells this out: *"Also restrict specific posts, even if not covered by other rules above."* A publisher can still combine it with the other rules — e.g. a gate that restricts all posts in the Entertainment category AND additionally gates a specific page that isn't in Entertainment.

<img width="494" height="812" alt="Screenshot 2026-04-17 at 12 37 46 PM" src="https://github.com/user-attachments/assets/0c120fe8-e916-464a-9850-d61c74f546b0" />

Implementation highlights:

* New rule slug `specific_posts` registered in `Content_Rules::get_content_rules()`, `include_only` (no include/exclude toggle), with a custom REST endpoint.
* New admin REST endpoint `GET /newspack/v1/wizard/newspack-audience-access-control/posts-search` returns `{ id, name, type_label }` for published posts matching a title search or `include` lookup. Numeric searches are treated as post-ID lookups so publishers can paste IDs directly.
* `Content_Restriction_Control::get_post_gates()` now checks `specific_posts` before the existing AND evaluation — a match short-circuits to "gate applies", and the rule is skipped inside the AND loop so it never participates in AND logic. A guard prevents a gate whose only rule is `specific_posts` from being vacuously included when nothing matches.
* The existing `ContentRuleControlTokenField` already supported custom endpoints; this PR just genericizes its variable names and log messages (previously referred to "taxonomy" in places).
* PHPUnit bootstrap now defines `NEWSPACK_CONTENT_GATES` so Content Gates code paths (including the new REST endpoint) can be exercised under test.

Closes NPPD-1457.

### How to test the changes in this Pull Request:

1. On a test site with `define( 'NEWSPACK_CONTENT_GATES', true );` in `wp-config.php`, create or edit an Access Control gate (Newspack → Access control).
2. Scroll to the bottom of the rule list — verify **Specific posts** appears last (after Tags) with the description "Also restrict specific posts, even if not covered by other rules above."
3. Toggle Specific posts on. Verify there is no include/exclude toggle (the rule is include-only) and that a search token field is shown.
4. Type a post title — verify autocomplete shows suggestions as `"<id>: <title> (Post)"` for posts and `"<id>: <title> (Page)"` for pages. Select one.
5. Type a numeric post ID — verify the specific post with that ID is returned.
6. Save the gate. Reload the editor — verify the saved tokens re-display with their titles (not raw IDs).
7. Activate the gate (registration rule active, status Published).
8. With the gate configured to restrict **Post types = post** AND **Specific posts = [some page ID]**, in an incognito window:
   * Visit the page listed in Specific posts — the gate should appear (override in effect despite the page not matching the post_types rule).
   * Visit a regular post — the gate should appear (AND-chain still works).
   * Visit a different page not in Specific posts — no gate (override doesn't match, AND-chain fails the page on post_types).
9. With a gate whose ONLY content rule is Specific posts = [some-post-id]:
   * Visit the specific post — gate appears.
   * Visit any other post — no gate (guards against the AND loop vacuously succeeding on zero non-specific rules).
10. Run `composer run phpcs` and the PHPUnit suite (`phpunit --filter Test_Content_Gates`) — both should be clean. The full suite should also pass.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

Override semantics and rule ordering are covered by new PHPUnit tests in `tests/unit-tests/content-gate/content-gates.php`. Full `Test_Content_Gates` suite: 37/37 passing. Full newspack-plugin suite: 939/939.