### PR TITLE
docs(my-account): add v2 prototype guide (Phase 8)

### DIFF
--- a/docs/my-account-v2-prototype-devlog.md
+++ b/docs/my-account-v2-prototype-devlog.md
@@ -401,8 +401,8 @@ The reserved-globals trap didn't bite this phase — by phase 7 the muscle memor
 
 **Date:** 2026-04-28
 **By:** thomas@a8c.com
-**PR:** _pending — phase branch `prototype/my-account-demo-phase-8`, draft PR targets `prototype/my-account-demo` (umbrella tracker is #4679)_
-**Commits:** _pending — code is staged on `prototype/my-account-demo-phase-8`_
+**PR:** [#4684](https://github.com/Automattic/newspack-plugin/pull/4684) — phase branch `prototype/my-account-demo-phase-8`, draft PR targets `prototype/my-account-demo` (umbrella tracker is [#4679](https://github.com/Automattic/newspack-plugin/pull/4679))
+**Commit:** `d240a3fa4` — `docs(my-account): add v2 prototype guide (Phase 8)`
 
 **What I built**
 
@@ -414,7 +414,7 @@ No code touched. The brief was the spec; the devlog (this file) is the history; 
 
 The synthesis itself was load-bearing — the brief and devlog are exhaustive but not navigable. Walking the cross-phase decision log from top to bottom, every plumbing choice the prototype makes shows up in at least three places (the row in the log, the relevant phase entry, and the comment above the relevant `class-my-account-ui-v2-demo.php` method). The guide's job is to give a returning agent or new dev one click-through per concept instead of three. The exercise also exposed which decisions were *pattern-shaped* versus *one-off*: the modal id convention, the takeover priority pairing (8 / 9 / 1100), the auto-flush guard, the reserved-globals list, and the scenario switch all generalise; the per-template variant branching is too template-specific to compress further. That lets the guide stay short — the patterns are extracted; specifics stay in the templates and the brief.
 
-The other thing the docs pass surfaced: the productionisation playbook is shorter than I expected because every "thing to clean up" already had its rationale captured in the cross-phase decision log row that introduced it. The playbook ends up being mostly *links into the log* with a one-line "remove this when …" framing. Future-self benefit: when somebody productionises the prototype, they won't have to re-derive the *why* of any sledgehammer — they'll find the row that says "tightened to handler-name-keyed removal during productisation" and have the seam ready.
+The other thing the docs pass surfaced: the productionisation playbook is shorter than I expected because every "thing to clean up" already had its rationale captured in the cross-phase decision log row that introduced it. The playbook ends up being mostly *links into the log* with a one-line "remove this when …" framing. Future-self benefit: when somebody productionises the prototype, they won't have to re-derive the *why* of any sledgehammer — they'll find the row that says "tightened to handler-name-keyed removal during productionisation" and have the seam ready.
 
 The guide deliberately *doesn't* duplicate brief §2.1.1's full reflex order. The brief's table is canonical for "what v1 markup to copy" and lives in the brief because it predates Phase 4. The guide's table is a one-screen subset focused on "I'm rebuilding a v2 surface right now and need a finger-pointing reference." Cross-linking once is enough.
 

--- a/docs/my-account-v2-prototype-devlog.md
+++ b/docs/my-account-v2-prototype-devlog.md
@@ -395,6 +395,48 @@ The reserved-globals trap didn't bite this phase — by phase 7 the muscle memor
 
 ---
 
+## Phase 8 — Documentation pass
+
+> See [brief §10 → Phase 8](my-account-v2-prototype-brief.md#phase-8--documentation-pass-05-day).
+
+**Date:** 2026-04-28
+**By:** thomas@a8c.com
+**PR:** _pending — phase branch `prototype/my-account-demo-phase-8`, draft PR targets `prototype/my-account-demo` (umbrella tracker is #4679)_
+**Commits:** _pending — code is staged on `prototype/my-account-demo-phase-8`_
+
+**What I built**
+
+A single deliverable: [`docs/my-account-v2-prototype-guide.md`](my-account-v2-prototype-guide.md), the three-section map called out in brief §10. (1) **Reader's guide** — the entry URL, the canonical scenario index assembled from the `SCENARIOS` constant (with each scenario linked to its Figma frame node-id), and per-flow walkthroughs of newsletters / donations / subscriptions / payment methods that say what is clickable, what surfaces a snackbar, and where the multi-variant template branches live. (2) **Architectural map for agents** — file layout, the `get_fake_data()` slice index, a hooks-and-priorities table covering the two takeover handlers (priority 8) plus the redirect-non-demo guard (priority 9) plus the menu and endpoint-URL filters, the modal-router pattern (slug map → `tryOpenModal` → `newspack-my-account__<slug>-<id>` ids → `data-state="open"`), the v1-class-names-first reflex distilled into a one-screen table, the reserved-globals trap (the running list: `$id`, `$status`, `$title`, `$type`, `$frequency`, `$action`), the auto-flush plumbing including the dev-only opcache caveat, and the scenario merge flow (`get_scenario` allow-list → `apply_scenario` switch dispatcher → pluck-from-pool / flag-flip / empty-helper). (3) **Productionisation playbook** — the to-do list for when the prototype rolls into v1: real data sources to swap into each fake slice, real Stripe wiring on the renew/restart/modify/change forms, scrubbing the `remove_all_actions` sledgehammers down to handler-name-keyed removals, dropping the demo gate + body-class scope + auto-flush plumbing + menu-item conditional, and the deferred design-system work (CANCELLED badge saturation, detail-page gap tightening) that's better delivered as separate sign-off PRs.
+
+No code touched. The brief was the spec; the devlog (this file) is the history; the guide is the map.
+
+**What I learned**
+
+The synthesis itself was load-bearing — the brief and devlog are exhaustive but not navigable. Walking the cross-phase decision log from top to bottom, every plumbing choice the prototype makes shows up in at least three places (the row in the log, the relevant phase entry, and the comment above the relevant `class-my-account-ui-v2-demo.php` method). The guide's job is to give a returning agent or new dev one click-through per concept instead of three. The exercise also exposed which decisions were *pattern-shaped* versus *one-off*: the modal id convention, the takeover priority pairing (8 / 9 / 1100), the auto-flush guard, the reserved-globals list, and the scenario switch all generalise; the per-template variant branching is too template-specific to compress further. That lets the guide stay short — the patterns are extracted; specifics stay in the templates and the brief.
+
+The other thing the docs pass surfaced: the productionisation playbook is shorter than I expected because every "thing to clean up" already had its rationale captured in the cross-phase decision log row that introduced it. The playbook ends up being mostly *links into the log* with a one-line "remove this when …" framing. Future-self benefit: when somebody productionises the prototype, they won't have to re-derive the *why* of any sledgehammer — they'll find the row that says "tightened to handler-name-keyed removal during productisation" and have the seam ready.
+
+The guide deliberately *doesn't* duplicate brief §2.1.1's full reflex order. The brief's table is canonical for "what v1 markup to copy" and lives in the brief because it predates Phase 4. The guide's table is a one-screen subset focused on "I'm rebuilding a v2 surface right now and need a finger-pointing reference." Cross-linking once is enough.
+
+**Decisions and why**
+
+- **Three sections, not five or seven.** The brief's §10 entry already specifies the three deliverables; resisted breaking them into smaller chapters because the result would be more index than content. Each section is a few hundred words; the guide as a whole reads in ~10 minutes. That's the right granularity for the audience (somebody returning after time away or picking it up cold).
+- **File-paths first, code-snippets second, prose last** for the agent map. Lifted verbatim from the brief instructions. The reader's guide leads with copy-pasteable URLs; the architectural map leads with file paths and a hook-priority table; only the modal-router section drops into a code snippet, and only because the slug-map indirection is the seam future agents will ask about. Prose is reserved for "why this priority" / "why this name" callouts that grep won't surface.
+- **Productionisation playbook references the cross-phase decision log rows, not the phase entries.** The decision-log rows are the *terse* statement of each call; the phase entries are the long-form. A productionising engineer wants the terse version with a click-through if they want context — pointing at log rows gives them that. Pointing at phase entries would have buried the call inside a scrollwall.
+- **No "checklist of items to verify" section.** The brief §12 already owns definition-of-done; the guide doesn't repeat it. The single end-of-document checklist is the *productionisation* removal list (what gets deleted), not a verification checklist.
+- **Guide lives in `docs/` next to the brief and devlog.** Brief instructed this explicitly; reaffirms the "intent / history / map" trio as a single discoverable bundle. Filename `my-account-v2-prototype-guide.md` matches the existing prefix convention so directory listings sort the three together.
+- **No new code, no new patterns, no `ENDPOINTS_VERSION` bump.** Phase 8 is doc-only by design — the prototype is feature-complete after Phase 7.
+- **Reading-time labelling on the front matter.** Skipped. The companion docs don't carry estimates and adding one to the guide would be the only one in the bundle. Section headers serve the same wayfinding purpose.
+
+**Open questions**
+
+- **Will the guide drift?** The Phase 7 devlog called out the productionisation playbook as "the place future-you reads first when ripping the prototype out." If the prototype stays in `prototype/my-account-demo` for months without productionisation, the playbook will accrue stale references (e.g. file paths if anything moves). Mitigations considered: a CI doc-lint that greps the guide for `[…](../includes/…)` paths and fails when one breaks. Out of scope for Phase 8; flagging here so it's findable when somebody productionises.
+- **Does the guide replace or supplement `class-my-account-ui-v2-demo.php`'s docblock?** The class-file docblock currently captures phase-by-phase scope; the guide is the architectural read. Both have value but there's some overlap on the takeover and auto-flush descriptions. Resolving (collapse one into the other vs. keep both) is a call for productionisation rather than a doc-pass concern.
+- **Should the scenario index in §1 be auto-generated from `SCENARIOS`?** Tempted — the constant is the source of truth and a generator would prevent drift. Rejected for now because the index has per-row Figma node-ids and "what it does" copy that doesn't live in the constant; a generator would have to merge two sources anyway. Worth revisiting if scenarios start to churn.
+- **Multi-sub scenario carry-over from Phase 7.** Still open. The guide flags the scenario shape supports it trivially; whether to ship is a stakeholder-review call rather than an engineering one.
+
+---
+
 ---
 
 ## Decision log (cross-phase)

--- a/docs/my-account-v2-prototype-guide.md
+++ b/docs/my-account-v2-prototype-guide.md
@@ -135,7 +135,7 @@ function tryOpenModal( action, id, root ) {
 }
 ```
 
-Modal id convention: `newspack-my-account__<flow-slug>-<resource-id>` (e.g. `#newspack-my-account__cancel-donation-don-001`). One modal instance per resource, rendered after the detail-page wrap closes so internal clicks don't bubble through. Two-step modals (cancel-*, renew, change) put `data-step="init"` and `data-step="success"` divs in the same container and toggle `hidden` between them; the `closeModal` event newspack-ui's [`modals.js`](../src/newspack-ui/js/modals.js) dispatches resets state. Per-modal config rides on `data-*` attributes on the container (`data-unit-labels`, `data-vat-rate`, `data-currency-symbol`, …) — cheaper than a separate `wp_localize_script` pass.
+Modal id convention: `newspack-my-account__<flow-slug>-<resource-id>` (e.g. `#newspack-my-account__cancel-donation-don-001`). One modal instance per resource, rendered after the detail-page wrap closes so internal clicks don't bubble through. Two-step confirm/renew-style modals (`cancel-donation`, `cancel-subscription`, `renew-subscription`) keep `data-step="init"` and `data-step="success"` divs in the same container and toggle `hidden` between them; the **Change subscription** modal instead uses `data-step="select"` and `data-step="transaction"`. The `closeModal` event newspack-ui's [`modals.js`](../src/newspack-ui/js/modals.js) dispatches resets each modal back to its own initial step. Per-modal config rides on `data-*` attributes on the container (`data-unit-labels`, `data-vat-rate`, `data-currency-symbol`, …) — cheaper than a separate `wp_localize_script` pass.
 
 Actions with no modal fall through to `fallbackSnackbar(action)` — today only `update-payment-method` (subs) and the payment-methods action set.
 

--- a/docs/my-account-v2-prototype-guide.md
+++ b/docs/my-account-v2-prototype-guide.md
@@ -1,0 +1,250 @@
+# My Account v2 Prototype — Guide
+
+**Status:** Phase 8 documentation pass
+**Last updated:** 2026-04-28
+**Companion docs:** [`my-account-v2-prototype-brief.md`](my-account-v2-prototype-brief.md) (intent + spec) · [`my-account-v2-prototype-devlog.md`](my-account-v2-prototype-devlog.md) (history + cross-phase decision log)
+**Figma:** [My Account — i5 (Final)](https://www.figma.com/design/mkvHE3qozmmGrytPt9RGrV/My-Account?node-id=2636-44336)
+
+The brief is the spec. The devlog is the history. **This guide is the map** — read it when you're walking back into the prototype after time away, or picking it up cold for the first time.
+
+---
+
+## 1. Reader's guide — kicking the tyres
+
+### Entry URL
+
+```
+/my-account/?v2-demo=1
+```
+
+Logged in as an administrator (`manage_options`). Any other user — non-admin, anonymous, even an admin without the query parameter — sees v1 unchanged. The flag is preserved on every internal nav click, so once you're in the demo you stay in it.
+
+The same flag works on every account-page URL:
+
+- `/my-account/?v2-demo=1` — Dashboard (v1 — the demo doesn't customise this)
+- `/my-account/newsletters/?v2-demo=1`
+- `/my-account/donations/?v2-demo=1`
+- `/my-account/donations/<id>/?v2-demo=1` (e.g. `don-001`, `don-cancelled`, `don-onetime-1`)
+- `/my-account/subscriptions/?v2-demo=1`
+- `/my-account/subscriptions/<id>/?v2-demo=1` (e.g. `sub-001`)
+- `/my-account/payment-methods/?v2-demo=1`
+
+### Scenario index
+
+`?v2-demo=<scenario>` switches the fake-data fixture. Anything outside the allow-list (typos, `?v2-demo=1`, no value at all) falls through to the happy path.
+
+| Scenario | What it does | Figma frame |
+|---|---|---|
+| `1` *(or any unrecognised value)* | Happy path — one active sub, one cancelled donation, two saved cards | Init frames |
+| `cancelled-sub` | Active slot becomes a cancelled sub (CANCELLED badge, Renew button) | `2636:46177` |
+| `expiring` | Active slot becomes an expiring sub (inline error notice + "renew now") | `2636:46232` |
+| `renewed` | Active slot becomes a renewed sub | `2636:46204` |
+| `no-fees` | Active slot becomes an active sub with `fees_covered=true` (Amount breakdown collapses) | `4351:66807` |
+| `billing-history` | Donations list embeds a billing-history table at the bottom (replaces the Button Card) | `3619:292407` |
+| `no-categories` | Newsletters flatten to a single ungrouped 11-row list | `4645:19732` |
+| `expired-payment` | Non-default saved card's expiry rewritten to a past date — surfaces an inline `Expired` badge | n/a |
+| `empty` | Empties donations + subscriptions + payment methods at once | n/a |
+| `no-donations` | Empty donations slice; everything else stays populated | n/a |
+| `no-subscriptions` | Empty subscriptions slice | n/a |
+| `no-payment-methods` | Empty payment-methods slice | n/a |
+
+The full Figma node-id index for non-scenario screens is in [brief Appendix A](my-account-v2-prototype-brief.md#appendix-a--figma-screen-index-priority-screens-only).
+
+### Per-flow walkthroughs
+
+**Newsletters** ([`templates/v2-demo/newsletters.php`](../includes/plugins/woocommerce/my-account/templates/v2-demo/newsletters.php) · [`src/my-account/v2-demo/newsletters.js`](../src/my-account/v2-demo/newsletters.js)). Sectioned list (Featured / Technology / Subscriber-only) of newsletter rows. Each row's *Sign up* / *Unsubscribe* button toggles the row's subscribed state in the DOM and fires a snackbar — no fetch, state resets on reload. The bottom *Unsubscribe from all* button cascades the toggle and disables itself once nothing is subscribed. `?v2-demo=no-categories` flattens the sections.
+
+**Donations** ([`donations.php`](../includes/plugins/woocommerce/my-account/templates/v2-demo/donations.php) · [`donation-details.php`](../includes/plugins/woocommerce/my-account/templates/v2-demo/donation-details.php) · [`donations.js`](../src/my-account/v2-demo/donations.js)). List has *Active recurring* + *Previous donations* sections. Click a donation card → detail page. Detail page branches on `kind` (`recurring` / `one_time`) + `status` (`active` / `cancelled`) + `fees_covered` — one template, four visual variants. Header buttons / dropdown items open client-side modals: **Modify donation** (recomputes totals as the amount changes — Phase 5 math is approximate; submit fires a snackbar), **Cancel donation** (two-step: confirm → success), **Restart donation** (single-screen, submit fires a snackbar — no success state in Figma).
+
+**Subscriptions** ([`subscriptions.php`](../includes/plugins/woocommerce/my-account/templates/v2-demo/subscriptions.php) · [`subscription-details.php`](../includes/plugins/woocommerce/my-account/templates/v2-demo/subscription-details.php) · [`subscriptions.js`](../src/my-account/v2-demo/subscriptions.js)). List has one Active card and two Previous cards. Detail template branches on `status` (`active` / `cancelled` / `expiring` / `renewed`) + `fees_covered`. Header offers **Change subscription** (segmented control: frequency tabs + tier cards → transaction step with billing readout + payment form; *Pay now* fires a snackbar and closes), **Cancel subscription** (two-step: confirm → success), and **Renew subscription** on cancelled / expiring (init → success). The expiring variant adds an inline notice with a `renew now` link. **Update payment method** is a snackbar stub — productionisation hooks it to the v1 checkout flow.
+
+**Payment methods** ([`payment-methods.php`](../includes/plugins/woocommerce/my-account/templates/v2-demo/payment-methods.php) · [`payment-methods.js`](../src/my-account/v2-demo/payment-methods.js)). WC core's `<table class="account-payment-methods-table">` DOM rebuilt on the fake `payment_methods` slice. *Make default* / *Delete* / *Add payment method* are all stub snackbars. Inline Default badge sits next to the brand on the default row; under `?v2-demo=expired-payment` an inline `Expired` badge sits next to the non-default row.
+
+---
+
+## 2. Architectural map for agents
+
+> "I just walked into this codebase — where do I start?" Read [§2.1.1 of the brief](my-account-v2-prototype-brief.md#211--the-other-non-negotiable-rule-reuse-v1s-class-names) before this section: every reflex below assumes "v1 class names first, newspack-ui composition second, custom SCSS only after a devlog entry."
+
+### File layout
+
+```
+includes/plugins/woocommerce/my-account/
+├── class-my-account-ui-v2-demo.php          # ~1,547 lines — the whole demo lives here
+└── templates/v2-demo/
+    ├── newsletters.php                       # list + bulk unsubscribe
+    ├── donations.php                         # list (recurring + one-time + Button Card | inline billing history)
+    ├── donation-details.php                  # 4-variant branching: kind × status × fees_covered
+    ├── subscriptions.php                     # list (active + previous)
+    ├── subscription-details.php              # 5-variant branching: status × fees_covered
+    ├── payment-methods.php                   # WC core table DOM, fake-data fed
+    └── partials/
+        ├── newsletters-row.php
+        ├── cancel-donation-modal.php
+        ├── modify-donation-modal.php
+        ├── restart-donation-modal.php
+        ├── cancel-subscription-modal.php
+        ├── change-subscription-modal.php     # two-step: select → transaction
+        └── renew-subscription-modal.php      # two-step: init → success
+
+src/my-account/v2-demo/
+├── index.js                                  # webpack entry — public-path + style + per-screen modules
+├── style.scss                                # intentionally near-empty wrapper (.newspack-my-account--v2-demo)
+├── newsletters.js / donations.js / subscriptions.js / payment-methods.js
+└── util/snackbar.js                          # shared transient-toast helper (extracted Phase 5 rule-of-three)
+```
+
+Webpack entry: `'my-account-v2-demo'` in [`webpack.config.js`](../webpack.config.js).
+
+### Fake-data shape (single source of truth)
+
+`My_Account_UI_V2_Demo::get_fake_data()` returns an associative array; `wp_localize_script` ships it to `window.newspackMyAccountV2Demo` and templates receive it via `load_template(..., [ 'data' => self::get_fake_data() ])`.
+
+Top-level slices:
+
+- `reader` — `display_name`, `email` (auto-pulled from `wp_get_current_user()`).
+- `newsletters` — `sections[].lists[]` (per-row `id`, `name`, `description`, `frequency`, `subscriber_only`, `subscribed`); `unsubscribe_from_all`.
+- `donations` — `recurring[]`, `one_time[]`, `currency_symbol`, `currency_code`, `billing_history_inline` (bool), `billing_history_button` (`enabled` + copy). Each donation row carries its own `billing_history` array (per-donation table on the detail page).
+- `subscriptions` — `active[]`, `previous[]`, `tiers` (`frequencies[]` + a static `billing` fixture for transaction modals), `currency_*`. Subscription rows are sourced from `get_subscription_fixtures()` — an **id → row pool** that scenarios pluck from (`sub-001`, `sub-cancelled`, `sub-expired`, `sub-expiring`, `sub-renewed`, `sub-active-no-fees`).
+- `payment_methods.cc[]` — `method.brand`, `method.last4`, `expires` (`MM/YY`), `is_default`, `actions` (key → `[ name, url ]` map). Mirrors `wc_get_customer_saved_methods_list()`.
+
+### Takeover / redirect / menu plumbing (priorities matter)
+
+| Hook | Priority | Callback | Why |
+|---|---|---|---|
+| `template_redirect` | 8 | `takeover_subscriptions_endpoint` | `remove_all_actions('woocommerce_account_subscriptions_endpoint')` on demo requests — drops WCS's `WCS_Query::endpoint_content` (10) + `WooCommerce_My_Account::append_membership_table` (11) in one move, then re-adds our renderer |
+| `template_redirect` | 8 | `takeover_payment_methods_endpoint` | Same shape — drops WC core's `woocommerce_account_payment_methods` callback + v1's `wc_get_template` swap to `payment-information.php` |
+| `template_redirect` | 9 | `redirect_non_demo_v2_endpoints` | Bounces non-demo guessers off `/newsletters/`, `/donations/`, and `/subscriptions/` (the last only when WCS isn't installed). Runs *after* takeovers so a non-demo user can't take over anything they then redirect away from |
+| `woocommerce_account_menu_items` | 1100 | `menu_items` | Inserts Newsletters / Donations / Subscriptions / Payment methods after `edit-account`. v1 runs at 1001, so this layers on top |
+| `woocommerce_get_endpoint_url` | 10 | `preserve_demo_flag_on_endpoint_url` | Re-appends the *original* flag value (e.g. `?v2-demo=cancelled-sub`) to every internal endpoint URL — sidebar, post-login redirect, the WC redirect-to-account-details bounce |
+
+Endpoint registration (`add_rewrite_endpoint` for `newsletters`, `donations`, `subscriptions`, all `EP_PAGES`) is called **directly from `init()`**, not through `add_action('init', …)`. The class is itself loaded inside an `init` callback, so a deferred action would register too late. `add_rewrite_endpoint` is idempotent — re-registering `subscriptions` on a WCS-installed site is a no-op.
+
+### Modal-router pattern
+
+Triggers in templates carry `data-action="<slug>"` + a `data-subscription-id` / `data-donation-id`. The detail-page click handler routes through a slug map:
+
+```js
+function tryOpenModal( action, id, root ) {
+    const slug = { 'change-subscription': 'change-subscription', /* … */ }[ action ];
+    if ( ! slug || ! id ) return false;
+    const modal = document.getElementById( `newspack-my-account__${ slug }-${ id }` );
+    if ( ! modal ) return false;
+    modal.setAttribute( 'data-state', 'open' );
+    return true;
+}
+```
+
+Modal id convention: `newspack-my-account__<flow-slug>-<resource-id>` (e.g. `#newspack-my-account__cancel-donation-don-001`). One modal instance per resource, rendered after the detail-page wrap closes so internal clicks don't bubble through. Two-step modals (cancel-*, renew, change) put `data-step="init"` and `data-step="success"` divs in the same container and toggle `hidden` between them; the `closeModal` event newspack-ui's [`modals.js`](../src/newspack-ui/js/modals.js) dispatches resets state. Per-modal config rides on `data-*` attributes on the container (`data-unit-labels`, `data-vat-rate`, `data-currency-symbol`, …) — cheaper than a separate `wp_localize_script` pass.
+
+Actions with no modal fall through to `fallbackSnackbar(action)` — today only `update-payment-method` (subs) and the payment-methods action set.
+
+### v1-class-names-first reflex (one-screen index)
+
+This is brief [§2.1.1](my-account-v2-prototype-brief.md#211--the-other-non-negotiable-rule-reuse-v1s-class-names), restated for finger-pointing. When rebuilding a v2 surface, **copy v1's DOM verbatim before reaching for utility classes** — the v2-demo body class chain inherits every v1 SCSS rule for free.
+
+| Surface | Reuse from |
+|---|---|
+| Subscription detail header (back chevron, title, badge, action buttons, More dropdown) | `templates/v1/subscription-header.php` — `.newspack-my-account__subscription--header / --title / --back-link / --actions / --actions-container / --actions-dropdown` |
+| Subscription kv pairs (Status / dates / Payment) | WCS — `<table class="shop_table subscription_details">` |
+| Subscription totals / Amount breakdown | WCS — `<table class="shop_table order_details">` with `tr.order-total` |
+| Billing history / related orders | WCS — `<table class="shop_table shop_table_responsive my_account_orders woocommerce-orders-table woocommerce-orders-table--orders">` |
+| Status dot in a table | `.newspack-my-account__subscription--order-status-label.<status>` |
+| Tier picker (segmented control + tier cards + Current badge) | `class-subscriptions-tiers.php::render_form` / `render_product_card` — `.newspack-ui__segmented-control` + `.newspack-ui__input-card.current` + `<strong>` + `.newspack-ui__helper-text` |
+| Modal frame | `Newspack_UI::generate_modal()` — `.newspack-ui__modal-container` + `__modal__header` + `__modal__content`. **Don't use `__modal__footer` for action buttons** — its `neutral-5` background reads wrong |
+| Checkout fields (billing readout + payment radios + card form) | `newspack-blocks` `modal-checkout/templates/form-checkout.php` — `wc_payment_methods payment_methods methods`, `payment_box payment_method_stripe`, `form-row form-row-first/last/wide`, `woocommerce-customer-details` |
+
+### Reserved-globals trap
+
+PHPCS rejects these as template-local variable names because WP uses them as globals: **`$id`, `$status`, `$title`, `$type`, `$frequency`, `$action`**. Always entity-prefix: `$donation_id`, `$subscription_status`, `$header_title`, `$payment_method_id`, `$action_data`. Six iterations across Phases 2–6 make the reflex solid; future templates should skip the round-trip.
+
+### Auto-flush plumbing
+
+`ENDPOINTS_VERSION` (currently `5`) bumps every phase that touches endpoint plumbing. The first admin to visit `/my-account/` after a deploy compares it against the `newspack_my_account_v2_demo_endpoints_version` option and runs `flush_rewrite_rules()` exactly once per environment. **Caveat:** the guard isn't atomic against PHP opcache — on dev/staging, the first request after a bump may serve stale code that doesn't register the new endpoints before the flush. Workaround:
+
+```bash
+n wp eval 'opcache_reset();'
+n wp option delete newspack_my_account_v2_demo_endpoints_version
+n wp rewrite flush
+```
+
+Production deploys clear opcache, so this only bites in dev.
+
+### Scenario merge flow
+
+1. `get_scenario()` reads `$_GET['v2-demo']`, sanitises, returns the value iff it's in `SCENARIOS` — anything else (typos, malicious values, `1`) returns `''`.
+2. `get_fake_data()` builds the base fixture, then short-circuits if the scenario is empty or hands off to `apply_scenario($base, $scenario)`.
+3. `apply_scenario()` is a single switch dispatcher. Each case is a small mutation:
+   - **Pluck-from-pool** (subscription state swaps) — `$pool = self::get_subscription_fixtures(); $data['subscriptions']['active'] = [ $pool['sub-expiring'] ];`
+   - **Flag flip** (`billing-history`, `no-categories`, `expired-payment`) — toggles a value or rewrites a field.
+   - **Empty helper** (`empty`, `no-*`) — calls `empty_donations()` / `empty_subscriptions()` / `empty_payment_methods()`, which preserve currency + tier scaffolding so iterating templates don't hit undefined-index notices.
+
+Adding a scenario is a one-liner: append to `SCENARIOS`, add a `case` to `apply_scenario`, optionally add a fixture id to `get_subscription_fixtures()`.
+
+---
+
+## 3. Productionisation playbook
+
+The to-do list for when the prototype rolls into v1 (folds the demo into the production `My_Account_UI_V1` surface and drops the gate). Each item links to the cross-phase decision row that explains *why* the prototype shape is what it is, so a productionising engineer can decide what to keep or change.
+
+### Replace fake-data slices with real sources
+
+`get_fake_data()` is the single seam — every template and JS module reads through it. Swap the slice-builders one at a time:
+
+- **`reader`** — already pulls from `wp_get_current_user()`; nothing to do.
+- **`newsletters`** — from the real Newspack Newsletters / ESP integration. Fixture shape (`sections[].lists[]`) is close to what the existing newsletter-subscription-list helpers emit, but verify per-row keys against the production data.
+- **`donations`** — from `WC_Order` + `WC_Subscription` queries. The brief's `recurring` / `one_time` split maps to subscription products vs. simple-product orders. Per-donation `billing_history` comes from the related-orders helper.
+- **`subscriptions`** — from `wcs_get_users_subscriptions()`. The `tiers` catalogue + billing fixture currently power the Change modal (devlog Phase 4 / Phase 5 entries) — productionised tiers come from the existing `Subscriptions_Tiers` helper.
+- **`payment_methods`** — from `wc_get_customer_saved_methods_list()`. Fixture mirrors that shape already.
+
+### Wire real Stripe on the modal forms
+
+All Phase 5 modal submissions are client-side stubs — they fire a snackbar and close. Productionisation:
+
+- **Change subscription** (transaction step) — real WC cart math + `WC_Subscriptions::switch` flow (see Phase 4 devlog row on `Subscriptions_Tiers::render_modal` — instructive but not directly reusable).
+- **Renew subscription** (transaction step) — real WCS resubscribe flow.
+- **Modify donation** — real cart math (currently approximate; see Phase 5 open question on totals precision).
+- **Restart donation** — real subscription-restart flow.
+- **Update payment method / Add payment method** — both currently stub snackbars. The brief (§3) lumps them with the v1 checkout flow; productionisation routes them to the existing newspack-blocks `modal-checkout` form-change-payment-method template.
+
+### Scrub the takeover sledgehammers
+
+`takeover_subscriptions_endpoint` and `takeover_payment_methods_endpoint` use `remove_all_actions()` — they drop *every* handler on the action, including any third-party hook. That's fine for a prototype demoed by admins, not for production. Replace with handler-name-keyed removals:
+
+```php
+remove_action( 'woocommerce_account_subscriptions_endpoint', [ \WCS_Query::class, 'endpoint_content' ], 10 );
+remove_action( 'woocommerce_account_subscriptions_endpoint', [ \Newspack\WooCommerce_My_Account::class, 'append_membership_table' ], 11 );
+```
+
+See cross-phase decision log rows for [Phase 4](my-account-v2-prototype-devlog.md#decision-log-cross-phase) (subscriptions takeover) and Phase 6 (payment-methods takeover).
+
+### Drop the `?v2-demo` gate
+
+- Remove `is_demo_active()` short-circuits across every callback in the class.
+- Remove the `query_vars` filter entry for `v2-demo`.
+- Remove `preserve_demo_flag_on_endpoint_url`.
+- Remove the `newspack-my-account--v2-demo` body-class scope in [`style.scss`](../src/my-account/v2-demo/style.scss). The wrapper is currently load-bearing — it scopes future SCSS additions — but if the prototype's styles fold cleanly into v1's `_my-account.scss`, the wrapper goes too.
+
+### Remove the auto-flush plumbing
+
+- Delete the `newspack_my_account_v2_demo_endpoints_version` option (`wp option delete …`).
+- Re-flush rewrite rules so any v2-only endpoints not retained in production are dropped from the rules table.
+- Remove the `ENDPOINTS_VERSION` constant + the guard in `register_endpoints()`.
+
+### Menu-item filter cleanup
+
+`menu_items()` is gated on `is_demo_active()`. Productionised v1 should either always show the new items or gate them on Reader Activation (the same gate v1 already uses) — drop the demo conditional and decide.
+
+### Deferred design-system work (separate PRs)
+
+- **CANCELLED badge saturation.** Phase 3 carryover. `__badge--error` is lighter than Figma; the right fix is a `__badge--error-strong` (or similarly named) addition to [`src/newspack-ui/scss/elements/misc/_badge.scss`](../src/newspack-ui/scss/elements/misc/_badge.scss). Touches the shared design system → separate PR with design sign-off.
+- **Detail-page section gap tightening.** Phase 3 carryover. Sections sit in `__stack--gap-6`; Figma reads tighter (closer to `--gap-4`). A side-by-side review pass against Figma is the natural place to make the call.
+
+### Final cleanup checklist
+
+- [ ] `get_fake_data()` and its sub-builders deleted (or kept behind a `WP_DEBUG`-style flag, with caveats).
+- [ ] `SCENARIOS` constant + `get_scenario()` + `apply_scenario()` + `get_subscription_fixtures()` + `empty_*()` helpers deleted.
+- [ ] All four scenario doc-links from this guide marked stale (or this guide retired entirely).
+- [ ] `dist/my-account-v2-demo.*` no longer enqueued; webpack entry removed from [`webpack.config.js`](../webpack.config.js).
+- [ ] Templates folded into v1's template-override shape (or kept as-is and re-pointed).
+- [ ] `composer dump-autoload` run after class-file removals.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Phase 8 of the My Account v2 prototype: documentation pass. Adds [`docs/my-account-v2-prototype-guide.md`](https://github.com/Automattic/newspack-plugin/blob/prototype/my-account-demo-phase-8/docs/my-account-v2-prototype-guide.md), the architectural map called out in [brief §10 → Phase 8](https://github.com/Automattic/newspack-plugin/blob/prototype/my-account-demo-phase-8/docs/my-account-v2-prototype-brief.md#phase-8--documentation-pass-05-day) and the §12 definition-of-done bullet.

Three sections, each ~few hundred words:

1. **Reader's guide** — entry URL, the 11-row scenario index built from the `SCENARIOS` constant (with each scenario linked to its Figma frame node-id), and per-flow walkthroughs covering newsletters / donations / subscriptions / payment methods (what's clickable, what surfaces a snackbar, what's a real form).
2. **Architectural map for agents** — file layout, the `get_fake_data()` slice index, a hooks-and-priorities table for the takeover handlers (priority 8) + redirect-non-demo guard (priority 9) + menu and endpoint-URL filters (1100 / 10), the modal-router pattern (slug map → `tryOpenModal` → `newspack-my-account__<slug>-<id>` ids → `data-state="open"`), the v1-class-names-first reflex (one-screen index of "v1 already has this"), the reserved-globals trap, the auto-flush plumbing including the dev-only opcache caveat, and the scenario merge flow (`get_scenario` allow-list → `apply_scenario` switch dispatcher → pluck-from-pool / flag-flip / empty-helper).
3. **Productionisation playbook** — to-do list for when the prototype rolls into v1: real WC/WCS data sources to swap into each fake slice, real Stripe wiring on the renew/restart/modify/change forms, scrubbing the `remove_all_actions` sledgehammers down to handler-name-keyed removals, dropping the `?v2-demo` gate + body-class scope + auto-flush plumbing + menu-item conditional, and the deferred design-system work (CANCELLED badge saturation, detail-page gap tightening) that's better delivered as separate sign-off PRs.

Each productionisation item links into the cross-phase decision log row that introduced its rationale, so a productionising engineer can trace "why is this a sledgehammer?" → "tightened to handler-name-keyed removal during productisation" without re-deriving the call.

Also adds the Phase 8 devlog entry. No code touched — Phase 8 is doc-only by design.

Companion docs: the brief is the spec, the devlog is the history, this guide is the map.

### How to test the changes in this Pull Request:

1. Pull the branch and open [`docs/my-account-v2-prototype-guide.md`](https://github.com/Automattic/newspack-plugin/blob/prototype/my-account-demo-phase-8/docs/my-account-v2-prototype-guide.md). Read it end-to-end (~10 minutes) and check it reads cold — i.e. without prior conversation context.
2. **Reader's guide section.** As an admin on a local site, visit `/my-account/?v2-demo=1` and walk each scenario URL listed in §1's table. Confirm each scenario produces the visual change the row promises (e.g. `?v2-demo=expiring` swaps the active card to an expiring sub with the inline notice; `?v2-demo=billing-history` replaces the donations Button Card with the embedded billing-history table; `?v2-demo=expired-payment` surfaces an `Expired` badge on the non-default card).
3. **Architectural map section.** Spot-check a few cross-references: open [`class-my-account-ui-v2-demo.php`](https://github.com/Automattic/newspack-plugin/blob/prototype/my-account-demo-phase-8/includes/plugins/woocommerce/my-account/class-my-account-ui-v2-demo.php) and confirm the priorities-table values (`template_redirect` priority 8 for both takeovers, priority 9 for the redirect, `woocommerce_account_menu_items` 1100). Open [`subscriptions.js`](https://github.com/Automattic/newspack-plugin/blob/prototype/my-account-demo-phase-8/src/my-account/v2-demo/subscriptions.js) and confirm the modal id convention (`newspack-my-account__<slug>-<id>`) and the slug-map shape match what the guide describes.
4. **Productionisation playbook section.** Click each cross-phase decision-log link in §3 and verify it lands on a row that explains the rationale for the corresponding cleanup item.
5. **No code regressions.** The diff is docs-only — verify with `git diff prototype/my-account-demo --stat` that only `docs/my-account-v2-prototype-guide.md` (added) and `docs/my-account-v2-prototype-devlog.md` (Phase 8 entry appended) are changed. Lint and build are no-ops.
6. **Devlog entry.** Open [`docs/my-account-v2-prototype-devlog.md`](https://github.com/Automattic/newspack-plugin/blob/prototype/my-account-demo-phase-8/docs/my-account-v2-prototype-devlog.md), scroll to "Phase 8 — Documentation pass", confirm What I built / What I learned / Decisions / Open questions are populated and that the cross-phase decision log table at the bottom is intact.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? — N/A (docs-only)
* [x] Have you successfully ran tests with your changes locally? — Lint and build are no-ops; no PHP/JS/SCSS changed.