### PR TITLE
feat(content-gate): expose institutional IP allowlist endpoint

### DIFF
--- a/includes/content-gate/class-ip-access-rule.php
+++ b/includes/content-gate/class-ip-access-rule.php
@@ -575,8 +575,10 @@ class IP_Access_Rule {
 	/**
 	 * Parse a comma-separated list of IPs and CIDR blocks.
 	 *
-	 * Trims whitespace, drops empty tokens, and discards anything that isn't a
-	 * valid IPv4 address or CIDR block (`<ipv4>/<0-32>`).
+	 * Trims whitespace (around tokens and around the `/` separator), drops
+	 * empty tokens, and discards anything that isn't a valid IPv4 address or
+	 * CIDR block (`<ipv4>/<0-32>`). Returned CIDR entries are emitted in their
+	 * trimmed form.
 	 *
 	 * @param string $raw Comma-separated list (e.g. `"192.168.1.0/24,10.0.0.5"`).
 	 *
@@ -591,14 +593,15 @@ class IP_Access_Rule {
 		foreach ( $tokens as $token ) {
 			if ( strpos( $token, '/' ) !== false ) {
 				list( $subnet, $bits ) = explode( '/', $token, 2 );
+				$subnet = trim( $subnet );
+				$bits   = trim( $bits );
 				if ( ! ctype_digit( $bits ) ) {
 					continue;
 				}
-				$bits = (int) $bits;
-				if ( $bits > 32 || ! filter_var( $subnet, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 ) ) {
+				if ( (int) $bits > 32 || ! filter_var( $subnet, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 ) ) {
 					continue;
 				}
-				$valid[] = $token;
+				$valid[] = $subnet . '/' . $bits;
 			} elseif ( filter_var( $token, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 ) ) {
 				$valid[] = $token;
 			}

--- a/includes/content-gate/class-ip-access-rule.php
+++ b/includes/content-gate/class-ip-access-rule.php
@@ -35,6 +35,11 @@ class IP_Access_Rule {
 	const REST_ROUTE = '/institutional-access/check';
 
 	/**
+	 * The REST API route for the institutional IP allowlist.
+	 */
+	const REST_ROUTE_IP_ALLOWLIST = '/institutional-access/ip-allowlist';
+
+	/**
 	 * Initialize hooks.
 	 */
 	public static function init() {
@@ -88,7 +93,7 @@ class IP_Access_Rule {
 				[
 					'methods'             => 'POST',
 					'callback'            => [ __CLASS__, 'check_external_ip_rest' ],
-					'permission_callback' => [ __CLASS__, 'check_external_ip_permission' ],
+					'permission_callback' => [ __CLASS__, 'api_permissions_check' ],
 					'args'                => [
 						'ip' => [
 							'type'              => 'string',
@@ -97,6 +102,19 @@ class IP_Access_Rule {
 						],
 					],
 				],
+			]
+		);
+
+		\register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			self::REST_ROUTE_IP_ALLOWLIST,
+			[
+				[
+					'methods'             => 'GET',
+					'callback'            => [ __CLASS__, 'get_ip_allowlist_rest' ],
+					'permission_callback' => [ __CLASS__, 'api_permissions_check' ],
+				],
+				'schema' => [ __CLASS__, 'get_ip_allowlist_schema' ],
 			]
 		);
 	}
@@ -189,12 +207,83 @@ class IP_Access_Rule {
 	}
 
 	/**
-	 * Permission check for the external IP query endpoint.
+	 * Permission check for admin-gated REST routes in this class.
 	 *
 	 * @return bool
 	 */
-	public static function check_external_ip_permission() {
+	public static function api_permissions_check() {
 		return current_user_can( 'manage_options' );
+	}
+
+	/**
+	 * REST API callback for the institutional IP allowlist.
+	 *
+	 * Returns one entry per institution that has at least one valid IPv4 or
+	 * CIDR range. Malformed entries are dropped silently. Email-domain and
+	 * reader-data rules are not exposed.
+	 *
+	 * @return \WP_REST_Response
+	 */
+	public static function get_ip_allowlist_rest() {
+		if ( function_exists( 'batcache_cancel' ) ) {
+			batcache_cancel();
+		}
+		nocache_headers();
+
+		$cached = \Newspack\Institution::get_cached_institutions();
+		ksort( $cached );
+		$institutions = [];
+		foreach ( $cached as $post_id => $rules ) {
+			$ip_ranges = self::parse_ip_ranges( $rules['ip_range'] );
+			if ( empty( $ip_ranges ) ) {
+				continue;
+			}
+			$institutions[] = [
+				'id'        => (int) $post_id,
+				'name'      => get_the_title( $post_id ),
+				'ip_ranges' => $ip_ranges,
+			];
+		}
+
+		/**
+		 * Filter the institutional IP allowlist response.
+		 *
+		 * @param array[] $institutions List of entries: `[ 'id' => int, 'name' => string, 'ip_ranges' => string[] ]`.
+		 */
+		$institutions = apply_filters( 'newspack_content_gate_ip_allowlist', $institutions );
+
+		return new \WP_REST_Response( $institutions );
+	}
+
+	/**
+	 * Schema for a single IP allowlist entry.
+	 *
+	 * @return array
+	 */
+	public static function get_ip_allowlist_schema() {
+		return [
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'institutional-ip-allowlist-entry',
+			'type'       => 'object',
+			'properties' => [
+				'id'        => [
+					'description' => __( 'Institution post ID.', 'newspack-plugin' ),
+					'type'        => 'integer',
+					'readonly'    => true,
+				],
+				'name'      => [
+					'description' => __( 'Institution name.', 'newspack-plugin' ),
+					'type'        => 'string',
+					'readonly'    => true,
+				],
+				'ip_ranges' => [
+					'description' => __( 'Validated IPv4 addresses or CIDR blocks granting access.', 'newspack-plugin' ),
+					'type'        => 'array',
+					'items'       => [ 'type' => 'string' ],
+					'readonly'    => true,
+				],
+			],
+		];
 	}
 
 	/**
@@ -484,6 +573,40 @@ class IP_Access_Rule {
 	}
 
 	/**
+	 * Parse a comma-separated list of IPs and CIDR blocks.
+	 *
+	 * Trims whitespace, drops empty tokens, and discards anything that isn't a
+	 * valid IPv4 address or CIDR block (`<ipv4>/<0-32>`).
+	 *
+	 * @param string $raw Comma-separated list (e.g. `"192.168.1.0/24,10.0.0.5"`).
+	 *
+	 * @return string[] Validated entries.
+	 */
+	private static function parse_ip_ranges( $raw ) {
+		if ( empty( $raw ) ) {
+			return [];
+		}
+		$tokens = array_filter( array_map( 'trim', explode( ',', $raw ) ) );
+		$valid  = [];
+		foreach ( $tokens as $token ) {
+			if ( strpos( $token, '/' ) !== false ) {
+				list( $subnet, $bits ) = explode( '/', $token, 2 );
+				if ( ! ctype_digit( $bits ) ) {
+					continue;
+				}
+				$bits = (int) $bits;
+				if ( $bits > 32 || ! filter_var( $subnet, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 ) ) {
+					continue;
+				}
+				$valid[] = $token;
+			} elseif ( filter_var( $token, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 ) ) {
+				$valid[] = $token;
+			}
+		}
+		return array_values( $valid );
+	}
+
+	/**
 	 * Check if an IP address matches any of the given ranges.
 	 *
 	 * @param string $ip     The IP address to check.
@@ -492,32 +615,21 @@ class IP_Access_Rule {
 	 * @return bool Whether the IP matches any range.
 	 */
 	public static function ip_matches_ranges( $ip, $ranges ) {
-		if ( empty( $ranges ) || ! filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 ) ) {
+		if ( ! filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 ) ) {
 			return false;
 		}
-		$ranges  = array_map( 'trim', explode( ',', $ranges ) );
-		$ranges  = array_filter( $ranges );
 		$ip_long = ip2long( $ip );
 
-		foreach ( $ranges as $range ) {
+		foreach ( self::parse_ip_ranges( $ranges ) as $range ) {
 			if ( strpos( $range, '/' ) !== false ) {
 				list( $subnet, $bits ) = explode( '/', $range, 2 );
-				if ( ! ctype_digit( $bits ) ) {
-					continue;
-				}
-				$bits = (int) $bits;
-				if ( $bits > 32 || ! filter_var( $subnet, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 ) ) {
-					continue;
-				}
 				$subnet_long = ip2long( $subnet );
-				$mask        = -1 << ( 32 - $bits );
+				$mask        = -1 << ( 32 - (int) $bits );
 				if ( ( $ip_long & $mask ) === ( $subnet_long & $mask ) ) {
 					return true;
 				}
-			} elseif ( filter_var( $range, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 ) ) {
-				if ( $ip_long === ip2long( $range ) ) {
-					return true;
-				}
+			} elseif ( $ip_long === ip2long( $range ) ) {
+				return true;
 			}
 		}
 		return false;

--- a/includes/content-gate/class-ip-access-rule.php
+++ b/includes/content-gate/class-ip-access-rule.php
@@ -225,11 +225,6 @@ class IP_Access_Rule {
 	 * @return \WP_REST_Response
 	 */
 	public static function get_ip_allowlist_rest() {
-		if ( function_exists( 'batcache_cancel' ) ) {
-			batcache_cancel();
-		}
-		nocache_headers();
-
 		$cached = \Newspack\Institution::get_cached_institutions();
 		ksort( $cached );
 		$institutions = [];

--- a/includes/content-gate/class-ip-access-rule.php
+++ b/includes/content-gate/class-ip-access-rule.php
@@ -502,8 +502,11 @@ class IP_Access_Rule {
 		foreach ( $ranges as $range ) {
 			if ( strpos( $range, '/' ) !== false ) {
 				list( $subnet, $bits ) = explode( '/', $range, 2 );
+				if ( ! ctype_digit( $bits ) ) {
+					continue;
+				}
 				$bits = (int) $bits;
-				if ( $bits < 0 || $bits > 32 || ! filter_var( $subnet, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 ) ) {
+				if ( $bits > 32 || ! filter_var( $subnet, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 ) ) {
 					continue;
 				}
 				$subnet_long = ip2long( $subnet );

--- a/tests/unit-tests/content-gate/class-ip-access-rule.php
+++ b/tests/unit-tests/content-gate/class-ip-access-rule.php
@@ -62,6 +62,21 @@ class Newspack_Test_IP_Access_Rule extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that malformed CIDR prefixes do not match.
+	 *
+	 * Previously `(int) $bits` silently coerced non-numeric strings to 0,
+	 * letting "10.0.0.0/foo" and "10.0.0.0/" match every IP.
+	 */
+	public function test_malformed_cidr_prefix_does_not_match() {
+		$this->assertFalse( IP_Access_Rule::ip_matches_ranges( '10.0.0.5', '10.0.0.0/foo' ) );
+		$this->assertFalse( IP_Access_Rule::ip_matches_ranges( '10.0.0.5', '10.0.0.0/' ) );
+		$this->assertFalse( IP_Access_Rule::ip_matches_ranges( '10.0.0.5', '10.0.0.0/24junk' ) );
+		$this->assertFalse( IP_Access_Rule::ip_matches_ranges( '10.0.0.5', '10.0.0.0/-1' ) );
+		// Valid CIDR continues to match.
+		$this->assertTrue( IP_Access_Rule::ip_matches_ranges( '10.0.0.5', '10.0.0.0/24' ) );
+	}
+
+	/**
 	 * Test that the REST route is registered.
 	 */
 	public function test_rest_route_registered() {

--- a/tests/unit-tests/content-gate/class-ip-access-rule.php
+++ b/tests/unit-tests/content-gate/class-ip-access-rule.php
@@ -365,4 +365,292 @@ class Newspack_Test_IP_Access_Rule extends WP_UnitTestCase {
 
 		remove_all_filters( 'newspack_content_gate_check_ip' );
 	}
+
+	/**
+	 * Test the IP allowlist GET route is registered.
+	 */
+	public function test_ip_allowlist_route_registered() {
+		do_action( 'rest_api_init' );
+
+		$routes         = rest_get_server()->get_routes( NEWSPACK_API_NAMESPACE );
+		$expected_route = '/' . NEWSPACK_API_NAMESPACE . IP_Access_Rule::REST_ROUTE_IP_ALLOWLIST;
+		$this->assertArrayHasKey( $expected_route, $routes, 'The IP allowlist REST route should be registered.' );
+
+		$endpoint = $routes[ $expected_route ][0];
+		$this->assertArrayHasKey( 'GET', $endpoint['methods'], 'The route should accept GET requests.' );
+		$this->assertSame( [ IP_Access_Rule::class, 'api_permissions_check' ], $endpoint['permission_callback'], 'The route should be gated by the admin permission callback.' );
+	}
+
+	/**
+	 * Test the IP allowlist endpoint requires manage_options.
+	 */
+	public function test_ip_allowlist_requires_authentication() {
+		$route = '/' . NEWSPACK_API_NAMESPACE . IP_Access_Rule::REST_ROUTE_IP_ALLOWLIST;
+
+		$request  = new WP_REST_Request( 'GET', $route );
+		$response = rest_do_request( $request );
+		$this->assertSame( 401, $response->get_status() );
+
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'subscriber' ] ) );
+		$request  = new WP_REST_Request( 'GET', $route );
+		$response = rest_do_request( $request );
+		$this->assertSame( 403, $response->get_status() );
+	}
+
+	/**
+	 * Test the IP allowlist endpoint response shape.
+	 */
+	public function test_ip_allowlist_response_shape() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		$inst_id = \Newspack\Institution::create(
+			'Allowlist Test Library',
+			'',
+			[ 'ip_range' => '192.168.1.0/24,10.0.0.5' ]
+		);
+		$this->assertIsInt( $inst_id );
+		delete_transient( \Newspack\Institution::TRANSIENT_KEY );
+
+		$route    = '/' . NEWSPACK_API_NAMESPACE . IP_Access_Rule::REST_ROUTE_IP_ALLOWLIST;
+		$request  = new WP_REST_Request( 'GET', $route );
+		$response = rest_do_request( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertIsArray( $data );
+
+		$entry = null;
+		foreach ( $data as $item ) {
+			if ( $item['id'] === $inst_id ) {
+				$entry = $item;
+				break;
+			}
+		}
+		$this->assertNotNull( $entry, 'Created institution should appear in response.' );
+		$this->assertSame( 'Allowlist Test Library', $entry['name'] );
+		$this->assertSame( [ '192.168.1.0/24', '10.0.0.5' ], $entry['ip_ranges'] );
+	}
+
+	/**
+	 * Test institutions without configured IP ranges are excluded.
+	 */
+	public function test_ip_allowlist_excludes_institutions_without_ip_ranges() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		$with_ip = \Newspack\Institution::create( 'Has IPs', '', [ 'ip_range' => '10.0.0.1' ] );
+		$no_ip   = \Newspack\Institution::create( 'No IPs', '', [ 'email_domain' => 'example.edu' ] );
+		$this->assertIsInt( $with_ip );
+		$this->assertIsInt( $no_ip );
+		delete_transient( \Newspack\Institution::TRANSIENT_KEY );
+
+		$route    = '/' . NEWSPACK_API_NAMESPACE . IP_Access_Rule::REST_ROUTE_IP_ALLOWLIST;
+		$request  = new WP_REST_Request( 'GET', $route );
+		$response = rest_do_request( $request );
+		$ids      = wp_list_pluck( $response->get_data(), 'id' );
+
+		$this->assertContains( $with_ip, $ids );
+		$this->assertNotContains( $no_ip, $ids );
+	}
+
+	/**
+	 * Test institutions are returned sorted by id ascending.
+	 */
+	public function test_ip_allowlist_sorted_by_id_ascending() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		$first  = \Newspack\Institution::create( 'First', '', [ 'ip_range' => '10.0.0.1' ] );
+		$second = \Newspack\Institution::create( 'Second', '', [ 'ip_range' => '10.0.0.2' ] );
+		$third  = \Newspack\Institution::create( 'Third', '', [ 'ip_range' => '10.0.0.3' ] );
+		delete_transient( \Newspack\Institution::TRANSIENT_KEY );
+
+		$route    = '/' . NEWSPACK_API_NAMESPACE . IP_Access_Rule::REST_ROUTE_IP_ALLOWLIST;
+		$request  = new WP_REST_Request( 'GET', $route );
+		$response = rest_do_request( $request );
+		$ids      = wp_list_pluck( $response->get_data(), 'id' );
+
+		$this->assertContains( $first, $ids );
+		$this->assertContains( $second, $ids );
+		$this->assertContains( $third, $ids );
+
+		$sorted = $ids;
+		sort( $sorted, SORT_NUMERIC );
+		$this->assertSame( $sorted, $ids, 'Full institutions list should be in id-ascending order.' );
+	}
+
+	/**
+	 * Test comma-separated ip_range meta is split, trimmed, and emptied entries dropped.
+	 */
+	public function test_ip_allowlist_parses_comma_separated_ranges() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		$inst_id = \Newspack\Institution::create(
+			'Whitespace Test',
+			'',
+			[ 'ip_range' => '  10.0.0.1 ,, 192.168.1.0/24 , ' ]
+		);
+		delete_transient( \Newspack\Institution::TRANSIENT_KEY );
+
+		$route    = '/' . NEWSPACK_API_NAMESPACE . IP_Access_Rule::REST_ROUTE_IP_ALLOWLIST;
+		$request  = new WP_REST_Request( 'GET', $route );
+		$response = rest_do_request( $request );
+		$data     = $response->get_data();
+
+		$entry = null;
+		foreach ( $data as $item ) {
+			if ( $item['id'] === $inst_id ) {
+				$entry = $item;
+				break;
+			}
+		}
+		$this->assertNotNull( $entry );
+		$this->assertSame( [ '10.0.0.1', '192.168.1.0/24' ], $entry['ip_ranges'] );
+	}
+
+	/**
+	 * Test the endpoint returns an empty institutions array when none exist.
+	 */
+	public function test_ip_allowlist_returns_empty_when_no_institutions() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+		delete_transient( \Newspack\Institution::TRANSIENT_KEY );
+
+		$route    = '/' . NEWSPACK_API_NAMESPACE . IP_Access_Rule::REST_ROUTE_IP_ALLOWLIST;
+		$request  = new WP_REST_Request( 'GET', $route );
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( [], $response->get_data() );
+	}
+
+	/**
+	 * Test institutions with only separators or whitespace in ip_range are excluded.
+	 */
+	public function test_ip_allowlist_excludes_institution_with_only_separators() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		$inst_id = \Newspack\Institution::create( 'Separators Only', '', [ 'ip_range' => ',, ,' ] );
+		$this->assertIsInt( $inst_id );
+		delete_transient( \Newspack\Institution::TRANSIENT_KEY );
+
+		$route    = '/' . NEWSPACK_API_NAMESPACE . IP_Access_Rule::REST_ROUTE_IP_ALLOWLIST;
+		$request  = new WP_REST_Request( 'GET', $route );
+		$response = rest_do_request( $request );
+		$ids      = wp_list_pluck( $response->get_data(), 'id' );
+
+		$this->assertNotContains( $inst_id, $ids );
+	}
+
+	/**
+	 * Test syntactically invalid IPv4/CIDR entries are dropped from the response.
+	 */
+	public function test_ip_allowlist_drops_invalid_ip_entries() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		$inst_id = \Newspack\Institution::create(
+			'Mixed Validity',
+			'',
+			[ 'ip_range' => 'not-an-ip,10.0.0.1,999.999.999.999,192.168.1.0/24,10.0.0.5/40' ]
+		);
+		$this->assertIsInt( $inst_id );
+		delete_transient( \Newspack\Institution::TRANSIENT_KEY );
+
+		$route    = '/' . NEWSPACK_API_NAMESPACE . IP_Access_Rule::REST_ROUTE_IP_ALLOWLIST;
+		$request  = new WP_REST_Request( 'GET', $route );
+		$response = rest_do_request( $request );
+
+		$entry = null;
+		foreach ( $response->get_data() as $item ) {
+			if ( $item['id'] === $inst_id ) {
+				$entry = $item;
+				break;
+			}
+		}
+		$this->assertNotNull( $entry );
+		$this->assertSame( [ '10.0.0.1', '192.168.1.0/24' ], $entry['ip_ranges'] );
+	}
+
+	/**
+	 * Test malformed CIDR prefixes are rejected.
+	 *
+	 * Previously `(int) $bits` silently coerced non-numeric strings to 0,
+	 * letting `"10.0.0.0/foo"` and `"10.0.0.0/"` match all IPs.
+	 */
+	public function test_ip_allowlist_drops_malformed_cidr_prefixes() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		$inst_id = \Newspack\Institution::create(
+			'Malformed CIDR',
+			'',
+			[ 'ip_range' => '10.0.0.0/foo,10.0.0.0/,10.0.0.0/24junk,10.0.0.0/-1,10.0.0.0/24' ]
+		);
+		$this->assertIsInt( $inst_id );
+		delete_transient( \Newspack\Institution::TRANSIENT_KEY );
+
+		$route    = '/' . NEWSPACK_API_NAMESPACE . IP_Access_Rule::REST_ROUTE_IP_ALLOWLIST;
+		$request  = new WP_REST_Request( 'GET', $route );
+		$response = rest_do_request( $request );
+
+		$entry = null;
+		foreach ( $response->get_data() as $item ) {
+			if ( $item['id'] === $inst_id ) {
+				$entry = $item;
+				break;
+			}
+		}
+		$this->assertNotNull( $entry );
+		$this->assertSame( [ '10.0.0.0/24' ], $entry['ip_ranges'] );
+
+		// Matcher must agree: malformed prefixes should not match anything.
+		$this->assertFalse( IP_Access_Rule::ip_matches_ranges( '10.0.0.5', '10.0.0.0/foo' ) );
+		$this->assertFalse( IP_Access_Rule::ip_matches_ranges( '10.0.0.5', '10.0.0.0/' ) );
+		$this->assertFalse( IP_Access_Rule::ip_matches_ranges( '10.0.0.5', '10.0.0.0/-1' ) );
+	}
+
+	/**
+	 * Test the `newspack_content_gate_ip_allowlist` filter is applied and
+	 * receives the built institution list as input.
+	 */
+	public function test_ip_allowlist_filter_is_applied() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		$inst_id = \Newspack\Institution::create( 'Filter Source', '', [ 'ip_range' => '10.1.2.3' ] );
+		$this->assertIsInt( $inst_id );
+		delete_transient( \Newspack\Institution::TRANSIENT_KEY );
+
+		$captured    = null;
+		$replacement = [
+			[
+				'id'        => 999999,
+				'name'      => 'Filtered',
+				'ip_ranges' => [ '8.8.8.8' ],
+			],
+		];
+		add_filter(
+			'newspack_content_gate_ip_allowlist',
+			function ( $list ) use ( &$captured, $replacement ) {
+				$captured = $list;
+				return $replacement;
+			}
+		);
+
+		$route    = '/' . NEWSPACK_API_NAMESPACE . IP_Access_Rule::REST_ROUTE_IP_ALLOWLIST;
+		$request  = new WP_REST_Request( 'GET', $route );
+		$response = rest_do_request( $request );
+
+		$this->assertIsArray( $captured, 'Filter should receive the pre-filter list.' );
+
+		$found = null;
+		foreach ( $captured as $entry ) {
+			if ( ( $entry['id'] ?? null ) === $inst_id ) {
+				$found = $entry;
+				break;
+			}
+		}
+		$this->assertNotNull( $found, 'Filter input should include freshly built institution entries.' );
+		$this->assertSame( 'Filter Source', $found['name'] );
+		$this->assertSame( [ '10.1.2.3' ], $found['ip_ranges'] );
+
+		$this->assertSame( $replacement, $response->get_data(), 'Response should reflect the filter return value.' );
+
+		remove_all_filters( 'newspack_content_gate_ip_allowlist' );
+	}
 }

--- a/tests/unit-tests/content-gate/class-ip-access-rule.php
+++ b/tests/unit-tests/content-gate/class-ip-access-rule.php
@@ -77,6 +77,18 @@ class Newspack_Test_IP_Access_Rule extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that whitespace around the CIDR separator is tolerated.
+	 *
+	 * Common admin typos like "192.168.1.0 / 24" should not silently
+	 * disable the rule.
+	 */
+	public function test_cidr_tolerates_whitespace_around_slash() {
+		$this->assertTrue( IP_Access_Rule::ip_matches_ranges( '192.168.1.50', '192.168.1.0/ 24' ) );
+		$this->assertTrue( IP_Access_Rule::ip_matches_ranges( '192.168.1.50', '192.168.1.0 /24' ) );
+		$this->assertTrue( IP_Access_Rule::ip_matches_ranges( '192.168.1.50', '192.168.1.0 / 24' ) );
+	}
+
+	/**
 	 * Test that the REST route is registered.
 	 */
 	public function test_rest_route_registered() {
@@ -566,6 +578,35 @@ class Newspack_Test_IP_Access_Rule extends WP_UnitTestCase {
 		}
 		$this->assertNotNull( $entry );
 		$this->assertSame( [ '10.0.0.1', '192.168.1.0/24' ], $entry['ip_ranges'] );
+	}
+
+	/**
+	 * Test the endpoint normalizes whitespace around the CIDR separator.
+	 */
+	public function test_ip_allowlist_normalizes_whitespace_around_cidr_slash() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		$inst_id = \Newspack\Institution::create(
+			'Whitespace CIDR',
+			'',
+			[ 'ip_range' => '192.168.1.0 / 24, 10.0.0.0/ 8' ]
+		);
+		$this->assertIsInt( $inst_id );
+		delete_transient( \Newspack\Institution::TRANSIENT_KEY );
+
+		$route    = '/' . NEWSPACK_API_NAMESPACE . IP_Access_Rule::REST_ROUTE_IP_ALLOWLIST;
+		$request  = new WP_REST_Request( 'GET', $route );
+		$response = rest_do_request( $request );
+
+		$entry = null;
+		foreach ( $response->get_data() as $item ) {
+			if ( $item['id'] === $inst_id ) {
+				$entry = $item;
+				break;
+			}
+		}
+		$this->assertNotNull( $entry );
+		$this->assertSame( [ '192.168.1.0/24', '10.0.0.0/8' ], $entry['ip_ranges'] );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds a `GET /newspack/v1/institutional-access/ip-allowlist` REST endpoint, gated by `manage_options`, that returns the institutional IP allowlist configured for the site. Designed for external systems to mirror the list locally and decide gating without hitting the origin per request.

The endpoint exposes only IP rules. Email domain and reader data rules are not surfaced. Entries that fail IPv4 or CIDR validation are dropped before being returned. A `newspack_content_gate_ip_allowlist` filter is provided so other plugins can augment the list.

This PR also includes a security fix for a bug in `IP_Access_Rule::ip_matches_ranges()` (introduced in #4574): the `(int) $bits` cast silently coerced any value that wasn't numeric to `0`, causing typo'd entries like `10.0.0.5/foo` or `10.0.0.5/` to match every IP. Validation is now tightened with `ctype_digit()` before the cast. Caused by admin input only, not externally exploitable, but operationally risky.

Closes NPPM-2770.

### How to test the changes in this Pull Request:

1. Configure an institution with a valid IP range (e.g. `192.168.1.0/24,10.0.0.5`) under Audience > Access Control > Institutions.
2. As an administrator, `curl -u admin:app_password https://your-site.com/wp-json/newspack/v1/institutional-access/ip-allowlist`. Confirm the response is a JSON array of `{ id, name, ip_ranges }` entries, sorted by `id` ascending.
3. Hit the endpoint as an unauthenticated user. Confirm a 401 response.
4. Hit the endpoint as a user without admin permissions (e.g. subscriber). Confirm a 403 response.
5. Configure a second institution with no IP range. Confirm it does NOT appear in the response.
6. Configure an institution with a mix of valid and malformed entries (e.g. `10.0.0.1,not-an-ip,10.0.0.5/foo,192.168.1.0/24,10.0.0.5/40`). Confirm only the valid ones (`10.0.0.1`, `192.168.1.0/24`) appear.
7. Confirm the existing `/check` endpoint (POST and GET) still works unchanged.
8. Verify the security fix: configure an institution with `10.0.0.0/foo` as its IP range. An unrelated visitor IP like `203.0.113.5` must NOT pass the institutional IP gate. Previously it would have, due to the loose validation.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?