### PR TITLE
fix(advertising): toggle spacing under category autocomplete

### DIFF
--- a/src/wizards/advertising/style.scss
+++ b/src/wizards/advertising/style.scss
@@ -11,6 +11,10 @@
 		margin: 24px 0 0;
 	}
 
+	.newspack-category-autocomplete + .components-toggle-control {
+		margin-top: 16px;
+	}
+
 	&__ad-unit-fluid {
 		align-items: center;
 		display: flex;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The `All tag archive pages` and `All category archive pages` toggles in *Advertising > Display Ads > Settings* sit flush against the inputs above them on WordPress 7.0. The 7.0 Gutenberg components dropped the default bottom margin from `FormTokenField` (which `CategoryAutocomplete` wraps), so the toggle ends up touching the autocomplete with no gap.

This adds a 16px top margin to any `ToggleControl` that immediately follows a `CategoryAutocomplete` inside the Display Ads wizard, restoring the previous spacing. Scope is intentionally narrow – only the wizard root, only the adjacent-sibling pair.

Closes NEWS-1681.

### How to test the changes in this Pull Request:

1. On a site running WordPress 7.0, go to *Advertising > Display Ads > Settings* (the **Settings** tab inside the Advertising wizard).
2. Scroll to the **Tags** section. Confirm the `All tag archive pages` toggle has a visible gap (~16px) between it and the *Tags to suppress ads on* input above.
3. Scroll to the **Categories** section. Confirm the `All category archive pages` toggle has the same gap above it.
4. Confirm the *Author Archive Pages* section (which uses a section header above the toggle, not an input) is unchanged.
5. Toggle each control on/off to make sure the click target still hits cleanly and the autocomplete becomes disabled as expected.
6. Open the **Providers** and **Placements** tabs and verify nothing else moved.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?