### PR TITLE
feat(my-account): build v2 prototype account settings (Phase 9)

### DIFF
--- a/docs/my-account-v2-prototype-devlog.md
+++ b/docs/my-account-v2-prototype-devlog.md
@@ -437,6 +437,41 @@ The guide deliberately *doesn't* duplicate brief §2.1.1's full reflex order. Th
 
 ---
 
+## Phase 9 — Account settings
+
+> Out-of-roadmap addition after Phase 8. Targets Figma frames `2636:46773` (Account settings), `2636:46785` (Delete account modal), `4865:92398` (Check inbox success), and `4863:20067` (variant section).
+
+**Date:** 2026-04-30
+**By:** thomas@a8c.com
+**Branch:** `prototype/my-account-demo-phase-9`
+**PR:** _pending — own draft PR for Copilot review per Thomas's request_
+
+**What I built**
+
+The Account settings surface end-to-end. Hooked `wc_get_template` at priority 2 (so we land after v1's priority-1 swap) and pointed `myaccount/form-edit-account.php` at a new v2-demo template. Reused v1's DOM verbatim — `<form class="woocommerce-EditAccountForm">`, `<p class="form-row form-row-first">`, the section ids `account-profile` / `account-password` / `delete-account`, and the v1 input + button classes — so the existing v1 SCSS does the heavy lifting (per brief §2.1.1). Form submits are stateless: client-side `submit` event handlers fire snackbars (`Profile updated.` / `Password updated.`) and return. Forgot-password link fires a `Password reset email sent.` snackbar.
+
+The Delete account button opens a two-step modal partial (`templates/my-account-v2-demo/partials/delete-account-modal.php`). Step 1 is the "Are you sure?" prose plus an action list of three rows — Donations / Subscriptions / Newsletters — each with a brief description and a Manage button that links to the corresponding endpoint with the demo flag preserved (the existing `preserve_demo_flag_on_endpoint_url` filter handles that). Confirm flips `data-step` from `init` to `success`, which renders the "check inbox" state from frame `4865:92398` — small black circular icon (`emailSend`), bold title, and a paragraph reading `We have just sent instructions on how to delete your account to <strong>{email}</strong>.` Modal close (X / Cancel / ESC / backdrop) resets via the `closeModal` event newspack-ui's `modals.js` dispatches when `data-state` flips back to `closed`.
+
+**What I learned**
+
+Two patterns from the prior phases ported cleanly: (a) the Phase 5 two-step modal pattern (`data-step="init"` and `data-step="success"` divs with `hidden` toggling, reset-on-close listening for the `closeModal` event), and (b) the Phase 6 wc_get_template swap. The only judgement call was whether to use `wc_get_template` filter (template-level swap) or take over `woocommerce_account_edit-account_endpoint` action (action-level removal). Filter approach won because v1 already establishes that pattern for the same template; action removal would have orphaned the existing wc_print_notices output WC core wraps around the form.
+
+The fake-data plumbing surprised me. WC core calls `wc_get_template( 'myaccount/form-edit-account.php' )` without passing the `data` arg the demo's other templates expect, so the new template self-fetches via `\Newspack\My_Account_V2_Demo::get_fake_data()` when `$args['data']` is absent. Both code paths converge on the same shape.
+
+**Decisions and why**
+
+- **Reused v1's DOM, not Figma's.** Brief §2.1.1 reflex order. The Figma input pattern (rounded button-shaped fields with internal padding) is what `.newspack-ui input.input-text` already paints when you wrap the input in a v1 `.form-row` paragraph — no new SCSS needed for the input chrome.
+- **Stateless forms.** Brief §7. No nonces, no real `wc_save_account_details` action; just snackbars. Productionisation re-attaches the WC handlers and removes the JS submit listener.
+- **Single Delete account button, not the v1 query-string-and-nonce bounce.** v1's Delete account button generates a one-shot nonce URL and bounces through a confirmation page; v2-demo opens an in-page modal. Closer to Figma and easier for design review.
+- **Three "soft alternatives" rows are a small scoped block.** The action-list layout (label + description on the left, Manage button on the right, hairline between rows) has no newspack-ui primitive — `__stack--horizontal --justify-between` would have lost the description+title vertical grouping. Added ~25 lines of scoped SCSS under `.newspack-my-account-v2-demo-account-settings__alternatives*`. Logged here because brief §2.1 wants the SCSS-add to be declared before the commit.
+- **`wc_get_template` priority 2.** v1 hooks at priority 1; running at 2 means we see v1's swap and can override it for the demo flag. v1 stays untouched on non-demo /my-account/?…/edit-account/.
+
+**Open questions**
+
+- **Real Stripe / WC wiring on productionisation.** All form submits, the password "Forgot password" link, and the modal's Confirm button will need real handlers when this folds into v1. Same shape as the modal handlers across Phases 4–6.
+- **Email-change flow.** The Figma shows the email field as disabled with a "contact us" helper. v1 has a separate code path for `is_email_change_enabled` that lets readers actually change their email. Phase 9 keeps it disabled — productionisation should decide whether to surface the change flow.
+- **Reset-vs-update password parity.** v1 has a "Create a password" / "Reset password" branch when the reader is password-less or arriving via reset link. Phase 9 collapses both into the basic Current/New form. If the v2 design actually wants the magic-link parity, that's a follow-up.
+
 ---
 
 ## Decision log (cross-phase)

--- a/docs/my-account-v2-prototype-devlog.md
+++ b/docs/my-account-v2-prototype-devlog.md
@@ -444,7 +444,7 @@ The guide deliberately *doesn't* duplicate brief §2.1.1's full reflex order. Th
 **Date:** 2026-04-30
 **By:** thomas@a8c.com
 **Branch:** `prototype/my-account-demo-phase-9`
-**PR:** _pending — own draft PR for Copilot review per Thomas's request_
+**PR:** [#4688](https://github.com/Automattic/newspack-plugin/pull/4688) — phase branch targets `prototype/my-account-demo` (umbrella tracker [#4679](https://github.com/Automattic/newspack-plugin/pull/4679))
 
 **What I built**
 

--- a/includes/plugins/woocommerce/my-account/class-my-account-v2-demo.php
+++ b/includes/plugins/woocommerce/my-account/class-my-account-v2-demo.php
@@ -134,6 +134,11 @@ final class My_Account_V2_Demo {
 		// Preserve `?my-account-v2-demo` on every internal nav link (sidebar, post-login
 		// redirect, etc.) so a single click can't drop you back into v1.
 		\add_filter( 'woocommerce_get_endpoint_url', [ __CLASS__, 'preserve_demo_flag_on_endpoint_url' ], 10, 4 );
+		// Swap WC core's edit-account form for the v2-demo Account settings
+		// template when the demo flag is active. v1 hooks the same filter at
+		// priority 1; we run at 2 so we fire after v1's swap and get the
+		// last word on the demo flag's specific surface.
+		\add_filter( 'wc_get_template', [ __CLASS__, 'wc_get_template' ], 2, 2 );
 		// Register custom endpoints + auto-flush rewrite rules once per
 		// version bump. Called directly because this class is itself loaded
 		// inside an `init` callback (see class-woocommerce-my-account.php),
@@ -384,6 +389,25 @@ final class My_Account_V2_Demo {
 			return $url;
 		}
 		return \add_query_arg( self::DEMO_FLAG, '1', $url );
+	}
+
+	/**
+	 * Filter `wc_get_template` to swap WC core's edit-account form for the
+	 * v2-demo Account settings template when the demo flag is active.
+	 * Mirrors the v1 wc_get_template swap pattern (see class-my-account-ui-v1.php).
+	 *
+	 * @param string $template      Resolved template path.
+	 * @param string $template_name Template slug (e.g. `myaccount/form-edit-account.php`).
+	 * @return string
+	 */
+	public static function wc_get_template( $template, $template_name ) {
+		if ( ! self::is_demo_active() ) {
+			return $template;
+		}
+		if ( 'myaccount/form-edit-account.php' === $template_name ) {
+			return __DIR__ . '/templates/my-account-v2-demo/account-settings.php';
+		}
+		return $template;
 	}
 
 	/**

--- a/includes/plugins/woocommerce/my-account/class-my-account-v2-demo.php
+++ b/includes/plugins/woocommerce/my-account/class-my-account-v2-demo.php
@@ -137,8 +137,10 @@ final class My_Account_V2_Demo {
 		// Swap WC core's edit-account form for the v2-demo Account settings
 		// template when the demo flag is active. v1 hooks the same filter at
 		// priority 1; we run at 2 so we fire after v1's swap and get the
-		// last word on the demo flag's specific surface.
-		\add_filter( 'wc_get_template', [ __CLASS__, 'wc_get_template' ], 2, 2 );
+		// last word on the demo flag's specific surface. accepted_args=5
+		// mirrors v0 / v1 so any future need for `$args`, `$template_path`,
+		// or `$default_path` is already wired.
+		\add_filter( 'wc_get_template', [ __CLASS__, 'wc_get_template' ], 2, 5 );
 		// Register custom endpoints + auto-flush rewrite rules once per
 		// version bump. Called directly because this class is itself loaded
 		// inside an `init` callback (see class-woocommerce-my-account.php),
@@ -398,9 +400,13 @@ final class My_Account_V2_Demo {
 	 *
 	 * @param string $template      Resolved template path.
 	 * @param string $template_name Template slug (e.g. `myaccount/form-edit-account.php`).
+	 * @param array  $args          Template args (unused — kept to match the filter shape v0/v1 use).
+	 * @param string $template_path Template directory (unused — same).
+	 * @param string $default_path  Default template directory (unused — same).
 	 * @return string
 	 */
-	public static function wc_get_template( $template, $template_name ) {
+	public static function wc_get_template( $template, $template_name, $args = [], $template_path = '', $default_path = '' ) {
+		unset( $args, $template_path, $default_path );
 		if ( ! self::is_demo_active() ) {
 			return $template;
 		}

--- a/includes/plugins/woocommerce/my-account/templates/my-account-v2-demo/account-settings.php
+++ b/includes/plugins/woocommerce/my-account/templates/my-account-v2-demo/account-settings.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * My Account v2 prototype — Account settings page.
+ *
+ * Profile / Password / Delete account, rendered when the demo flag is active
+ * and the visitor lands on /my-account/edit-account/. Reuses the v1 DOM and
+ * class names verbatim (per brief §2.1.1) so the existing v1 SCSS styling
+ * applies for free; adds a Delete account modal hooked client-side.
+ *
+ * @package Newspack
+ * @var array $args Template args; expected keys: `data` => fake-data array.
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+// WC core loads this via `wc_get_template( 'myaccount/form-edit-account.php' )`
+// — the call site doesn't pass the demo's `data` arg, so fall back to the
+// class' fake-data builder. Both code paths converge on the same shape.
+$data   = isset( $args['data'] ) && is_array( $args['data'] )
+	? $args['data']
+	: \Newspack\My_Account_V2_Demo::get_fake_data();
+$reader = isset( $data['reader'] ) ? $data['reader'] : [];
+$user   = wp_get_current_user();
+$email  = isset( $reader['email'] ) ? (string) $reader['email'] : (string) $user->user_email;
+
+// Pull real values from the current user so reviewers can see their own data
+// rendered in the template — matches how the homepage greeting picks up the
+// admin's first name. Fake names fall back to the slug so the template never
+// renders an empty input.
+$first_name   = ! empty( $user->first_name ) ? $user->first_name : '';
+$last_name    = ! empty( $user->last_name ) ? $user->last_name : '';
+$display_name = ! empty( $user->display_name ) ? $user->display_name : $user->user_login;
+?>
+<div class="newspack-my-account-v2-demo-account-settings" data-newspack-my-account-v2-demo="account-settings">
+	<section id="account-profile">
+		<h4 class="newspack-ui__font--m newspack-ui__spacing-top--0"><?php esc_html_e( 'Profile', 'newspack-plugin' ); ?></h4>
+		<form class="woocommerce-EditAccountForm edit-profile" data-action="update-profile">
+			<p class="woocommerce-form-row woocommerce-form-row--first form-row form-row-first">
+				<label for="account_first_name"><?php esc_html_e( 'First name', 'newspack-plugin' ); ?></label>
+				<input
+					type="text"
+					class="woocommerce-Input woocommerce-Input--text input-text"
+					name="account_first_name"
+					id="account_first_name"
+					autocomplete="given-name"
+					value="<?php echo esc_attr( $first_name ); ?>"
+				/>
+			</p>
+			<p class="woocommerce-form-row woocommerce-form-row--last form-row form-row-last">
+				<label for="account_last_name"><?php esc_html_e( 'Last name', 'newspack-plugin' ); ?></label>
+				<input
+					type="text"
+					class="woocommerce-Input woocommerce-Input--text input-text"
+					name="account_last_name"
+					id="account_last_name"
+					autocomplete="family-name"
+					value="<?php echo esc_attr( $last_name ); ?>"
+				/>
+			</p>
+			<div class="clear"></div>
+
+			<p class="woocommerce-form-row woocommerce-form-row--wide form-row form-row-wide mt0">
+				<label for="account_display_name"><?php esc_html_e( 'Display name', 'newspack-plugin' ); ?></label>
+				<input
+					type="text"
+					class="woocommerce-Input woocommerce-Input--text input-text"
+					name="account_display_name"
+					id="account_display_name"
+					autocomplete="name"
+					value="<?php echo esc_attr( $display_name ); ?>"
+				/>
+				<span class="legend"><?php esc_html_e( 'This is how your name is displayed publicly.', 'newspack-plugin' ); ?></span>
+			</p>
+
+			<p class="woocommerce-form-row woocommerce-form-row--wide form-row form-row-wide mt0">
+				<label for="account_email_display"><?php esc_html_e( 'Email address', 'newspack-plugin' ); ?></label>
+				<input
+					type="email"
+					class="woocommerce-Input woocommerce-Input--email input-text"
+					name="account_email_display"
+					id="account_email_display"
+					autocomplete="email"
+					disabled
+					value="<?php echo esc_attr( $email ); ?>"
+				/>
+				<span class="legend">
+					<?php
+					echo wp_kses_post(
+						sprintf(
+							// translators: %s is the contact-us URL.
+							__( 'To update your email address, please <a href="%s">contact us</a>.', 'newspack-plugin' ),
+							'#'
+						)
+					);
+					?>
+				</span>
+			</p>
+
+			<p class="woocommerce-buttons-card">
+				<button
+					type="submit"
+					class="woocommerce-Button button primary newspack-ui__button--wide-on-mobile"
+				>
+					<span><?php esc_html_e( 'Update profile', 'newspack-plugin' ); ?></span>
+				</button>
+			</p>
+		</form>
+	</section>
+
+	<section id="account-password">
+		<h4 class="newspack-ui__font--m"><?php esc_html_e( 'Password', 'newspack-plugin' ); ?></h4>
+		<form class="woocommerce-ResetPassword lost_reset_password" data-action="update-password">
+			<p class="woocommerce-form-row woocommerce-form-row--wide form-row form-row-wide">
+				<label for="current_password"><?php esc_html_e( 'Current password', 'newspack-plugin' ); ?></label>
+				<input
+					type="password"
+					class="woocommerce-Input woocommerce-Input--text input-text"
+					name="current_password"
+					id="current_password"
+				/>
+			</p>
+			<p class="woocommerce-form-row woocommerce-form-row--wide form-row form-row-wide">
+				<label for="password_1"><?php esc_html_e( 'New password', 'newspack-plugin' ); ?></label>
+				<input
+					type="password"
+					class="woocommerce-Input woocommerce-Input--text input-text"
+					name="password_1"
+					id="password_1"
+					autocomplete="new-password"
+				/>
+				<span class="legend"><?php esc_html_e( 'Your new password must be more than 12 characters.', 'newspack-plugin' ); ?></span>
+			</p>
+
+			<p class="woocommerce-buttons-card">
+				<button
+					type="submit"
+					class="woocommerce-Button button primary newspack-ui__button--wide-on-mobile"
+				>
+					<span><?php esc_html_e( 'Update password', 'newspack-plugin' ); ?></span>
+				</button>
+				<a class="woocommerce-Button button ghost newspack-ui__button--wide-on-mobile" href="#" data-action="forgot-password">
+					<?php esc_html_e( 'Forgot password', 'newspack-plugin' ); ?>
+				</a>
+			</p>
+		</form>
+	</section>
+
+	<section id="delete-account">
+		<h4 class="newspack-ui__font--m is-destructive"><?php esc_html_e( 'Delete account', 'newspack-plugin' ); ?></h4>
+		<p>
+			<?php esc_html_e( 'Please note, account deletion is final, and there will be no way to restore your account.', 'newspack-plugin' ); ?>
+		</p>
+		<p class="woocommerce-buttons-card">
+			<button
+				type="button"
+				class="newspack-ui__button newspack-ui__button--destructive newspack-ui__button--wide-on-mobile"
+				data-action="delete-account"
+			>
+				<span><?php esc_html_e( 'Delete account', 'newspack-plugin' ); ?></span>
+			</button>
+		</p>
+	</section>
+</div>
+
+<?php
+load_template(
+	__DIR__ . '/partials/delete-account-modal.php',
+	false,
+	[
+		'email' => $email,
+		'data'  => $data,
+	]
+);

--- a/includes/plugins/woocommerce/my-account/templates/my-account-v2-demo/account-settings.php
+++ b/includes/plugins/woocommerce/my-account/templates/my-account-v2-demo/account-settings.php
@@ -23,10 +23,11 @@ $reader = isset( $data['reader'] ) ? $data['reader'] : [];
 $user   = wp_get_current_user();
 $email  = isset( $reader['email'] ) ? (string) $reader['email'] : (string) $user->user_email;
 
-// Pull real values from the current user so reviewers can see their own data
-// rendered in the template — matches how the homepage greeting picks up the
-// admin's first name. Fake names fall back to the slug so the template never
-// renders an empty input.
+// Pull real values from the current user so reviewers see their own data
+// rendered in the template — matches how the homepage greeting picks up
+// the admin's first name. First / last name fall back to empty (mirrors v1
+// behaviour and what WC core does); display name falls back to user_login
+// so the field always renders something visible.
 $first_name   = ! empty( $user->first_name ) ? $user->first_name : '';
 $last_name    = ! empty( $user->last_name ) ? $user->last_name : '';
 $display_name = ! empty( $user->display_name ) ? $user->display_name : $user->user_login;

--- a/includes/plugins/woocommerce/my-account/templates/my-account-v2-demo/partials/delete-account-modal.php
+++ b/includes/plugins/woocommerce/my-account/templates/my-account-v2-demo/partials/delete-account-modal.php
@@ -74,7 +74,7 @@ $alternatives = [
 			<ul class="newspack-my-account-v2-demo-account-settings__alternatives">
 				<?php foreach ( $alternatives as $alternative ) : ?>
 					<li class="newspack-my-account-v2-demo-account-settings__alternatives-item">
-						<div class="newspack-my-account-v2-demo-account-settings__alternatives-details">
+						<div class="newspack-my-account-v2-demo-account-settings__alternatives-details newspack-ui__stack newspack-ui__stack--vertical">
 							<strong><?php echo esc_html( $alternative['title'] ); ?></strong>
 							<span><?php echo esc_html( $alternative['description'] ); ?></span>
 						</div>

--- a/includes/plugins/woocommerce/my-account/templates/my-account-v2-demo/partials/delete-account-modal.php
+++ b/includes/plugins/woocommerce/my-account/templates/my-account-v2-demo/partials/delete-account-modal.php
@@ -44,12 +44,13 @@ $alternatives = [
 ];
 ?>
 <div
-	class="newspack-ui__modal-container"
+	class="newspack-ui newspack-ui__modal-container"
 	id="newspack-my-account__delete-account"
 	data-state="closed"
 	data-newspack-my-account-v2-demo="delete-account-modal"
 >
-	<div class="newspack-ui__modal newspack-ui__modal--small">
+	<div class="newspack-ui__modal-container__overlay"></div>
+	<div class="newspack-ui__modal">
 		<div class="newspack-ui__modal__header">
 			<h2><?php esc_html_e( 'Delete account', 'newspack-plugin' ); ?></h2>
 			<button
@@ -114,10 +115,12 @@ $alternatives = [
 				</p>
 				<p>
 					<?php
-					printf(
-						/* translators: %s is the reader's email address. */
-						esc_html__( 'We have just sent instructions on how to delete your account to %s.', 'newspack-plugin' ),
-						'<strong>' . esc_html( $email ) . '</strong>' // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					echo wp_kses_post(
+						sprintf(
+							/* translators: %s is the reader's email address. */
+							__( 'We have just sent instructions on how to delete your account to %s.', 'newspack-plugin' ),
+							'<strong>' . esc_html( $email ) . '</strong>'
+						)
 					);
 					?>
 				</p>

--- a/includes/plugins/woocommerce/my-account/templates/my-account-v2-demo/partials/delete-account-modal.php
+++ b/includes/plugins/woocommerce/my-account/templates/my-account-v2-demo/partials/delete-account-modal.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * My Account v2 prototype — Delete account modal.
+ *
+ * Two-step flow:
+ *   - init: "Are you sure?" prose + action list pointing the reader at the
+ *     three "soft" alternatives (Manage donations / Manage subscriptions /
+ *     Manage newsletters), plus Delete account / Cancel buttons.
+ *   - success: "Your account deletion has been requested." + we just sent
+ *     instructions to {email}.
+ *
+ * @package Newspack
+ * @var array $args Template args; expected keys: `email`, `data`.
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+use Newspack\Newspack_UI_Icons;
+
+$email = isset( $args['email'] ) ? (string) $args['email'] : '';
+
+// Build the three "alternatives" rows. Each row links to the corresponding
+// v2-demo endpoint with the demo flag preserved by the existing endpoint-URL
+// filter.
+$alternatives = [
+	[
+		'title'       => __( 'Donations', 'newspack-plugin' ),
+		'description' => __( 'Review and cancel any recurring donation.', 'newspack-plugin' ),
+		'cta_label'   => __( 'Manage donations', 'newspack-plugin' ),
+		'url'         => wc_get_account_endpoint_url( 'donations' ),
+	],
+	[
+		'title'       => __( 'Subscriptions', 'newspack-plugin' ),
+		'description' => __( 'Review and cancel any active subscription.', 'newspack-plugin' ),
+		'cta_label'   => __( 'Manage subscriptions', 'newspack-plugin' ),
+		'url'         => wc_get_account_endpoint_url( 'subscriptions' ),
+	],
+	[
+		'title'       => __( 'Newsletters', 'newspack-plugin' ),
+		'description' => __( 'Update your newsletter preferences.', 'newspack-plugin' ),
+		'cta_label'   => __( 'Manage newsletters', 'newspack-plugin' ),
+		'url'         => wc_get_account_endpoint_url( 'newsletters' ),
+	],
+];
+?>
+<div
+	class="newspack-ui__modal-container"
+	id="newspack-my-account__delete-account"
+	data-state="closed"
+	data-newspack-my-account-v2-demo="delete-account-modal"
+>
+	<div class="newspack-ui__modal newspack-ui__modal--small">
+		<div class="newspack-ui__modal__header">
+			<h2><?php esc_html_e( 'Delete account', 'newspack-plugin' ); ?></h2>
+			<button
+				type="button"
+				class="newspack-ui__button newspack-ui__button--ghost newspack-ui__button--icon newspack-ui__modal__close"
+				aria-label="<?php esc_attr_e( 'Close modal', 'newspack-plugin' ); ?>"
+			>
+				<?php Newspack_UI_Icons::print_svg( 'close' ); ?>
+			</button>
+		</div>
+
+		<div class="newspack-ui__modal__content" data-step="init">
+			<h3 class="newspack-ui__font--l newspack-ui__font--bold newspack-ui__spacing-top--0"><?php esc_html_e( 'Are you sure?', 'newspack-plugin' ); ?></h3>
+			<p>
+				<?php esc_html_e( 'Deleting your account is permanent and cannot be undone. All your data will be removed from our systems. Your newsletter subscriptions and all recurring payments will be cancelled.', 'newspack-plugin' ); ?>
+			</p>
+			<p>
+				<?php esc_html_e( 'Instead of deleting your account, you may want to:', 'newspack-plugin' ); ?>
+			</p>
+
+			<ul class="newspack-my-account-v2-demo-account-settings__alternatives">
+				<?php foreach ( $alternatives as $alternative ) : ?>
+					<li class="newspack-my-account-v2-demo-account-settings__alternatives-item">
+						<div class="newspack-my-account-v2-demo-account-settings__alternatives-details">
+							<strong><?php echo esc_html( $alternative['title'] ); ?></strong>
+							<span><?php echo esc_html( $alternative['description'] ); ?></span>
+						</div>
+						<a
+							href="<?php echo esc_url( $alternative['url'] ); ?>"
+							class="newspack-ui__button newspack-ui__button--secondary"
+						>
+							<?php echo esc_html( $alternative['cta_label'] ); ?>
+						</a>
+					</li>
+				<?php endforeach; ?>
+			</ul>
+
+			<div class="newspack-ui__stack newspack-ui__stack--vertical newspack-ui__stack--gap-3">
+				<button
+					type="button"
+					class="newspack-ui__button newspack-ui__button--destructive"
+					data-action="confirm-delete-account"
+				>
+					<span><?php esc_html_e( 'Delete account', 'newspack-plugin' ); ?></span>
+				</button>
+				<button
+					type="button"
+					class="newspack-ui__button newspack-ui__button--ghost newspack-ui__modal__close"
+				>
+					<?php esc_html_e( 'Cancel', 'newspack-plugin' ); ?>
+				</button>
+			</div>
+		</div>
+
+		<div class="newspack-ui__modal__content" data-step="success" hidden>
+			<div class="newspack-ui__box newspack-ui__box--text-center">
+				<div class="newspack-my-account-v2-demo-account-settings__success-icon" aria-hidden="true">
+					<?php Newspack_UI_Icons::print_svg( 'emailSend' ); ?>
+				</div>
+				<p class="newspack-ui__font--bold">
+					<?php esc_html_e( 'Your account deletion has been requested.', 'newspack-plugin' ); ?>
+				</p>
+				<p>
+					<?php
+					printf(
+						/* translators: %s is the reader's email address. */
+						esc_html__( 'We have just sent instructions on how to delete your account to %s.', 'newspack-plugin' ),
+						'<strong>' . esc_html( $email ) . '</strong>' // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					);
+					?>
+				</p>
+			</div>
+		</div>
+	</div>
+</div>

--- a/src/my-account-v2-demo/account-settings.js
+++ b/src/my-account-v2-demo/account-settings.js
@@ -1,0 +1,112 @@
+/**
+ * Account settings screen — client-side only.
+ *
+ * Form submits don't post anywhere; they fire a snackbar and return. The
+ * Delete account button opens the two-step modal; the inner Delete account
+ * button flips the modal from `init` to `success` (the "check inbox" state).
+ * Modal close + reset logic reuses the closeModal event newspack-ui's
+ * modals.js dispatches when data-state flips to closed (same shape as the
+ * Phase 5 modals).
+ */
+
+import { __ } from '@wordpress/i18n';
+
+import { snackbar } from './util/snackbar';
+
+const ROOT_SELECTOR = '[data-newspack-my-account-v2-demo="account-settings"]';
+const MODAL_SELECTOR = '#newspack-my-account__delete-account';
+
+/**
+ * Open the modal by flipping its `data-state` attribute. newspack-ui's
+ * modals.js observes this attribute and handles the rest (focus trap,
+ * close button, ESC, backdrop click).
+ *
+ * @param {HTMLElement} modal Modal container element.
+ */
+function openModal( modal ) {
+	modal.setAttribute( 'data-state', 'open' );
+}
+
+/**
+ * Switch the modal to its success ("check inbox") step.
+ *
+ * @param {HTMLElement} modal Modal container element.
+ */
+function showSuccessStep( modal ) {
+	modal.querySelectorAll( '[data-step]' ).forEach( step => {
+		step.hidden = step.dataset.step !== 'success';
+	} );
+}
+
+/**
+ * Reset the modal back to the init step. Wired to the closeModal event
+ * dispatched by newspack-ui modals.js so the next open shows the right
+ * step.
+ *
+ * @param {HTMLElement} modal Modal container element.
+ */
+function resetModal( modal ) {
+	modal.querySelectorAll( '[data-step]' ).forEach( step => {
+		step.hidden = step.dataset.step !== 'init';
+	} );
+}
+
+/**
+ * Wire one account-settings root. Idempotent.
+ *
+ * @param {HTMLElement} root Container element.
+ */
+function wireRoot( root ) {
+	if ( root.dataset.newspackMyAccountV2DemoAccountSettingsWired === 'true' ) {
+		return;
+	}
+	root.dataset.newspackMyAccountV2DemoAccountSettingsWired = 'true';
+
+	const modal = document.querySelector( MODAL_SELECTOR );
+
+	root.addEventListener( 'submit', event => {
+		const form = event.target.closest( 'form[data-action]' );
+		if ( ! form ) {
+			return;
+		}
+		event.preventDefault();
+		const action = form.dataset.action;
+		if ( action === 'update-profile' ) {
+			snackbar( __( 'Profile updated.', 'newspack-plugin' ) );
+		} else if ( action === 'update-password' ) {
+			snackbar( __( 'Password updated.', 'newspack-plugin' ) );
+		}
+	} );
+
+	root.addEventListener( 'click', event => {
+		const trigger = event.target.closest( '[data-action]' );
+		if ( ! trigger ) {
+			return;
+		}
+		const action = trigger.dataset.action;
+		if ( action === 'forgot-password' ) {
+			event.preventDefault();
+			snackbar( __( 'Password reset email sent.', 'newspack-plugin' ) );
+			return;
+		}
+		if ( action === 'delete-account' && modal ) {
+			event.preventDefault();
+			openModal( modal );
+		}
+	} );
+
+	if ( modal ) {
+		modal.addEventListener( 'click', event => {
+			const confirmButton = event.target.closest( '[data-action="confirm-delete-account"]' );
+			if ( confirmButton ) {
+				event.preventDefault();
+				showSuccessStep( modal );
+			}
+		} );
+		modal.addEventListener( 'closeModal', () => resetModal( modal ) );
+	}
+}
+
+document.addEventListener( 'DOMContentLoaded', () => {
+	document.querySelectorAll( ROOT_SELECTOR ).forEach( wireRoot );
+} );

--- a/src/my-account-v2-demo/index.js
+++ b/src/my-account-v2-demo/index.js
@@ -8,6 +8,7 @@
 
 import '../shared/js/public-path';
 import './style.scss';
+import './account-settings';
 import './newsletters';
 import './donations';
 import './subscriptions';

--- a/src/my-account-v2-demo/style.scss
+++ b/src/my-account-v2-demo/style.scss
@@ -33,7 +33,13 @@
 	// label and description on the left, Manage button on the right,
 	// separated by hairlines. No newspack-ui primitive matches this
 	// layout so it lives here as a small scoped block.
+	// Two-column subgrid so all three Manage * buttons share the same
+	// auto-sized column track — grid sizes the column to fit the widest
+	// button across rows, so every button matches the longest one without
+	// hardcoded widths or JS measuring.
 	.newspack-my-account-v2-demo-account-settings__alternatives {
+		display: grid;
+		grid-template-columns: minmax(0, 1fr) auto;
 		list-style: none;
 		margin: 0 0 var(--newspack-ui-spacer-3);
 		padding: 0;
@@ -42,21 +48,30 @@
 	.newspack-my-account-v2-demo-account-settings__alternatives-item {
 		align-items: center;
 		border-bottom: 1px solid var(--newspack-ui-color-border, #ddd);
-		display: flex;
+		display: grid;
 		gap: var(--newspack-ui-spacer-5);
+		grid-column: 1 / -1;
+		grid-template-columns: subgrid;
 		padding-bottom: var(--newspack-ui-spacer-5);
 		padding-top: var(--newspack-ui-spacer-5);
 
 		&:first-child {
 			padding-top: 0;
 		}
+
+		// Stretch each button to fill the auto-sized column so widths align
+		// across rows.
+		.newspack-ui__button {
+			justify-content: center;
+			width: 100%;
+		}
 	}
 
+	// Layout comes from `newspack-ui__stack newspack-ui__stack--vertical` on
+	// the markup; the only thing this override carries is a 4px gap (half of
+	// spacer-1, no utility for it) and the description's muted typography.
 	.newspack-my-account-v2-demo-account-settings__alternatives-details {
-		display: flex;
-		flex: 1 1 auto;
-		flex-direction: column;
-		gap: var(--newspack-ui-spacer-1);
+		gap: calc(var(--newspack-ui-spacer-1) / 2);
 		min-width: 0;
 
 		span {

--- a/src/my-account-v2-demo/style.scss
+++ b/src/my-account-v2-demo/style.scss
@@ -60,9 +60,13 @@
 		}
 
 		// Stretch each button to fill the auto-sized column so widths align
-		// across rows.
+		// across rows. `.newspack-ui__button` ships with
+		// `margin-bottom: spacer-2` (12px) which extends the grid row and
+		// creates phantom whitespace above each next row — zero it out so
+		// the row's padding fully controls vertical rhythm.
 		.newspack-ui__button {
 			justify-content: center;
+			margin: 0;
 			width: 100%;
 		}
 	}

--- a/src/my-account-v2-demo/style.scss
+++ b/src/my-account-v2-demo/style.scss
@@ -28,4 +28,59 @@
 		font-size: var(--newspack-ui-font-size-m);
 		line-height: var(--newspack-ui-line-height-m);
 	}
+
+	// Phase 9 — Delete account modal action list. Three rows of
+	// label and description on the left, Manage button on the right,
+	// separated by hairlines. No newspack-ui primitive matches this
+	// layout so it lives here as a small scoped block.
+	.newspack-my-account-v2-demo-account-settings__alternatives {
+		list-style: none;
+		margin: 0 0 var(--newspack-ui-spacer-3);
+		padding: 0;
+	}
+
+	.newspack-my-account-v2-demo-account-settings__alternatives-item {
+		align-items: center;
+		border-bottom: 1px solid var(--newspack-ui-color-border, #ddd);
+		display: flex;
+		gap: var(--newspack-ui-spacer-5);
+		padding-bottom: var(--newspack-ui-spacer-5);
+		padding-top: var(--newspack-ui-spacer-5);
+
+		&:first-child {
+			padding-top: 0;
+		}
+	}
+
+	.newspack-my-account-v2-demo-account-settings__alternatives-details {
+		display: flex;
+		flex: 1 1 auto;
+		flex-direction: column;
+		gap: var(--newspack-ui-spacer-1);
+		min-width: 0;
+
+		span {
+			color: var(--newspack-ui-color-neutral-60, #6c6c6c);
+			font-size: var(--newspack-ui-font-size-xs);
+			line-height: var(--newspack-ui-line-height-xs);
+		}
+	}
+
+	// Email-send icon at the top of the success step. Black filled
+	// circle, white icon — matches Figma frame 4865:92398.
+	.newspack-my-account-v2-demo-account-settings__success-icon {
+		align-items: center;
+		background: var(--newspack-ui-color-neutral-90, #1e1e1e);
+		border-radius: 999px;
+		color: var(--newspack-ui-color-bg-base, #fff);
+		display: inline-flex;
+		height: 40px;
+		justify-content: center;
+		margin: 0 auto var(--newspack-ui-spacer-3);
+		width: 40px;
+
+		svg {
+			fill: currentcolor;
+		}
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Phase 9 of the My Account v2 prototype — adds the **Account settings** surface (Profile / Password / Delete account) and a two-step Delete account modal, gated to admins by the existing \`?my-account-v2-demo\` flag.

**Figma:** [\`2636:46773\`](https://www.figma.com/design/mkvHE3qozmmGrytPt9RGrV/My-Account?node-id=2636-46773) (page) · [\`2636:46785\`](https://www.figma.com/design/mkvHE3qozmmGrytPt9RGrV/My-Account?node-id=2636-46785) (delete modal — init) · [\`4865:92398\`](https://www.figma.com/design/mkvHE3qozmmGrytPt9RGrV/My-Account?node-id=4865-92398) (delete modal — check inbox) · [\`4863:20067\`](https://www.figma.com/design/mkvHE3qozmmGrytPt9RGrV/My-Account?node-id=4863-20067) (variant section).

#### What ships

- **Account settings page** rendered when an admin visits \`/my-account/edit-account/?my-account-v2-demo=1\`. Three sections per Figma: Profile (First name / Last name / Display name / Email address — disabled with a \"contact us\" helper), Password (Current / New + helper text), and Delete account (red title, prose, destructive button).
- **Delete account modal**, two-step:
  - **Init** — \"Are you sure?\" prose plus an action list of three soft alternatives (Manage donations / Manage subscriptions / Manage newsletters), each linking to the corresponding v2-demo endpoint with the demo flag preserved.
  - **Success** — the \"check inbox\" state from Figma frame \`4865:92398\` (small black circular email-send icon, bold title, helper paragraph quoting the reader's email).
- **Stateless submits.** All form submits and the \"Forgot password\" link fire snackbars (\`Profile updated.\` / \`Password updated.\` / \`Password reset email sent.\`) and return — same prototype contract as Phases 2–7.
- **v1 DOM reused verbatim** (per brief §2.1.1). The page copies v1's \`account-settings.php\` markup — \`<form class=\"woocommerce-EditAccountForm\">\`, \`<p class=\"form-row form-row-first\">\`, the \`account-profile\` / \`account-password\` / \`delete-account\` section ids — so the existing v1 SCSS does the heavy lifting. ~25 lines of new scoped SCSS only for the modal action-list rows and the success-step icon.

#### How it's wired

- Hooks \`wc_get_template\` at priority 2 (v1 hooks at 1) so \`myaccount/form-edit-account.php\` resolves to the v2-demo template only when \`is_demo_active()\` is true. Non-demo /my-account/?…/edit-account/ stays unchanged.
- WC core's call to \`wc_get_template\` doesn't pass the demo's fake-data \`data\` arg, so the template self-fetches via \`\\Newspack\\My_Account_V2_Demo::get_fake_data()\` when the arg is absent.
- Modal markup mirrors the Phase 5 two-step pattern: \`data-step=\"init\"\` and \`data-step=\"success\"\` divs in one container, JS toggles \`hidden\`. Reset on close listens for the \`closeModal\` event newspack-ui's \`modals.js\` dispatches when \`data-state\` flips back to \`closed\`.
- Manage X buttons in the modal use \`wc_get_account_endpoint_url(\$slug)\` so the existing \`preserve_demo_flag_on_endpoint_url\` filter re-appends \`?my-account-v2-demo=1\` automatically.

### How to test the changes in this Pull Request:

1. **Pull the branch** (\`prototype/my-account-demo-phase-9\`) into a Newspack site with WooCommerce installed and run \`n npm run build\`.
2. **Happy path.** As an admin, visit \`/my-account/edit-account/?my-account-v2-demo=1\`. Confirm:
    - Three sections render (Profile / Password / Delete account) using v1 styling.
    - First name / Last name / Display name fields pre-fill from the current admin user.
    - Email field is disabled and shows a \"contact us\" helper.
    - Sidebar still highlights the correct active item and the homepage drawer flag survives clicks (e.g. clicking Newsletters keeps you in the demo).
3. **Form submits.** Type into any input, click **Update profile** — page does not reload, snackbar fires \`Profile updated.\` Repeat for **Update password** (\`Password updated.\`) and **Forgot password** (\`Password reset email sent.\`).
4. **Delete account modal — init.** Click **Delete account** in the bottom section. Modal opens with the \"Are you sure?\" prose, three action rows (Donations / Subscriptions / Newsletters), and Delete account / Cancel buttons. Confirm:
    - Each Manage X button links to the corresponding endpoint with \`?my-account-v2-demo=1\` preserved.
    - Pressing ESC, clicking the X, clicking the backdrop, and clicking **Cancel** all close the modal.
5. **Delete account modal — success.** Reopen the modal, click **Delete account** inside. Modal switches to the \"check inbox\" state with the email-send icon, the bold title, and your admin email rendered in the helper paragraph. Close — next open returns to the init step (reset confirmed).
6. **Gating regression.**
    - Log out (or as a non-admin), visit \`/my-account/edit-account/\` — v1 form renders unchanged.
    - As an admin, visit \`/my-account/edit-account/\` (no flag) — v1 form renders unchanged.
    - Visit \`/my-account/?my-account-v2-demo=1\` (no \`/edit-account/\`) — Dashboard, no v2 swap.
7. **Lint + build.** \`npm run lint\` (JS+SCSS), \`npm run lint:php\`, and \`n build newspack-plugin\` should all pass clean.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? _(prototype-only, no automated tests)_
* [x] Have you successfully ran tests with your changes locally?