### PR TITLE
fix(my-account): v2 demo polish pass

### DIFF
--- a/includes/plugins/woocommerce/my-account/templates/my-account-v2-demo/donations.php
+++ b/includes/plugins/woocommerce/my-account/templates/my-account-v2-demo/donations.php
@@ -325,8 +325,8 @@ $status_label = static function ( $status ) {
 					<?php echo esc_html( isset( $billing_history_button['description'] ) ? $billing_history_button['description'] : '' ); ?>
 				</span>
 			</div>
-			<svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true" focusable="false">
-				<path d="M19 3H5C3.9 3 3 3.9 3 5v16l3-2 3 2 3-2 3 2 3-2 3 2V5c0-1.1-.9-2-2-2zm-1 14.5L17 17l-3 2-3-2-3 2-3-2-1 .5V5h14v12.5zM6 7h12v2H6V7zm0 4h12v2H6v-2zm0 4h7v2H6v-2z" fill="currentColor"/>
+			<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false">
+				<path fill-rule="evenodd" clip-rule="evenodd" fill="currentColor" d="M16.83 6.342l.602.3.625-.25.443-.176v12.569l-.443-.178-.625-.25-.603.301-1.444.723-2.41-.804-.475-.158-.474.158-2.41.803-1.445-.722-.603-.3-.625.25-.443.177V6.215l.443.178.625.25.603-.301 1.444-.722 2.41.803.475.158.474-.158 2.41-.803 1.445.722zM20 4l-1.5.6-1 .4-2-1-3 1-3-1-2 1-1-.4L5 4v17l1.5-.6 1-.4 2 1 3-1 3 1 2-1 1 .4 1.5.6V4zm-3.5 6.25v-1.5h-8v1.5h8zm0 3v-1.5h-8v1.5h8zm-8 3v-1.5h8v1.5h-8z"/>
 			</svg>
 		</a>
 	<?php endif; ?>

--- a/includes/plugins/woocommerce/my-account/templates/my-account-v2-demo/donations.php
+++ b/includes/plugins/woocommerce/my-account/templates/my-account-v2-demo/donations.php
@@ -146,7 +146,7 @@ $status_label = static function ( $status ) {
 	class="newspack-my-account-v2-demo-donations newspack-ui__stack newspack-ui__stack--vertical newspack-ui__stack--justify-between"
 	data-newspack-my-account-v2-demo="donations"
 >
-	<div class="newspack-ui__stack newspack-ui__stack--vertical newspack-ui__stack--gap-9">
+	<div class="newspack-ui__stack newspack-ui__stack--vertical newspack-ui__stack--gap-11">
 		<?php if ( empty( $active_recurring ) && empty( $previous ) ) : ?>
 			<div class="newspack-ui__notice">
 				<?php esc_html_e( 'You have no donations yet.', 'newspack-plugin' ); ?>

--- a/includes/plugins/woocommerce/my-account/templates/my-account-v2-demo/donations.php
+++ b/includes/plugins/woocommerce/my-account/templates/my-account-v2-demo/donations.php
@@ -155,7 +155,7 @@ $status_label = static function ( $status ) {
 
 		<?php if ( ! empty( $active_recurring ) ) : ?>
 			<section class="newspack-ui__stack newspack-ui__stack--vertical newspack-ui__stack--gap-5" data-section-id="recurring">
-			<h2 class="newspack-ui__font--l newspack-ui__font--bold newspack-ui__spacing-top--0 newspack-ui__spacing-bottom--0">
+			<h2 class="newspack-ui__font--m newspack-ui__font--bold newspack-ui__spacing-top--0 newspack-ui__spacing-bottom--0">
 				<?php
 				echo esc_html(
 					_n(
@@ -206,7 +206,7 @@ $status_label = static function ( $status ) {
 
 	<?php if ( ! empty( $previous ) ) : ?>
 		<section class="newspack-ui__stack newspack-ui__stack--vertical newspack-ui__stack--gap-3" data-section-id="previous">
-			<h2 class="newspack-ui__font--l newspack-ui__font--bold newspack-ui__spacing-top--0 newspack-ui__spacing-bottom--0">
+			<h2 class="newspack-ui__font--m newspack-ui__font--bold newspack-ui__spacing-top--0 newspack-ui__spacing-bottom--0">
 				<?php esc_html_e( 'Previous donations', 'newspack-plugin' ); ?>
 			</h2>
 			<table class="newspack-my-account-v2-demo-donations__previous-table">
@@ -256,7 +256,7 @@ $status_label = static function ( $status ) {
 
 	<?php if ( $billing_history_inline ) : ?>
 		<section class="newspack-ui__stack newspack-ui__stack--vertical newspack-ui__stack--gap-3" data-section-id="billing-history">
-			<h2 class="newspack-ui__font--l newspack-ui__font--bold newspack-ui__spacing-top--0 newspack-ui__spacing-bottom--0">
+			<h2 class="newspack-ui__font--m newspack-ui__font--bold newspack-ui__spacing-top--0 newspack-ui__spacing-bottom--0">
 				<?php esc_html_e( 'Billing history', 'newspack-plugin' ); ?>
 			</h2>
 			<?php

--- a/includes/plugins/woocommerce/my-account/templates/my-account-v2-demo/donations.php
+++ b/includes/plugins/woocommerce/my-account/templates/my-account-v2-demo/donations.php
@@ -312,8 +312,8 @@ $status_label = static function ( $status ) {
 			</table>
 		</section>
 	<?php elseif ( ! empty( $billing_history_button['enabled'] ) ) : ?>
-		<a
-			href="#"
+		<button
+			type="button"
 			class="newspack-ui__button newspack-ui__button--secondary newspack-ui__button--wide newspack-ui__stack newspack-ui__stack--horizontal newspack-ui__stack--gap-5 newspack-ui__stack--align-center newspack-ui__stack--justify-between"
 			data-action="open-billing-history"
 		>
@@ -328,6 +328,6 @@ $status_label = static function ( $status ) {
 			<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false">
 				<path fill-rule="evenodd" clip-rule="evenodd" fill="currentColor" d="M16.83 6.342l.602.3.625-.25.443-.176v12.569l-.443-.178-.625-.25-.603.301-1.444.723-2.41-.804-.475-.158-.474.158-2.41.803-1.445-.722-.603-.3-.625.25-.443.177V6.215l.443.178.625.25.603-.301 1.444-.722 2.41.803.475.158.474-.158 2.41-.803 1.445.722zM20 4l-1.5.6-1 .4-2-1-3 1-3-1-2 1-1-.4L5 4v17l1.5-.6 1-.4 2 1 3-1 3 1 2-1 1 .4 1.5.6V4zm-3.5 6.25v-1.5h-8v1.5h8zm0 3v-1.5h-8v1.5h8zm-8 3v-1.5h8v1.5h-8z"/>
 			</svg>
-		</a>
+		</button>
 	<?php endif; ?>
 </div>

--- a/includes/plugins/woocommerce/my-account/templates/my-account-v2-demo/donations.php
+++ b/includes/plugins/woocommerce/my-account/templates/my-account-v2-demo/donations.php
@@ -143,17 +143,18 @@ $status_label = static function ( $status ) {
 };
 ?>
 <div
-	class="newspack-my-account-v2-demo-donations newspack-ui__stack newspack-ui__stack--vertical newspack-ui__stack--gap-9"
+	class="newspack-my-account-v2-demo-donations newspack-ui__stack newspack-ui__stack--vertical newspack-ui__stack--justify-between"
 	data-newspack-my-account-v2-demo="donations"
 >
-	<?php if ( empty( $active_recurring ) && empty( $previous ) ) : ?>
-		<div class="newspack-ui__notice">
-			<?php esc_html_e( 'You have no donations yet.', 'newspack-plugin' ); ?>
-		</div>
-	<?php endif; ?>
+	<div class="newspack-ui__stack newspack-ui__stack--vertical newspack-ui__stack--gap-9">
+		<?php if ( empty( $active_recurring ) && empty( $previous ) ) : ?>
+			<div class="newspack-ui__notice">
+				<?php esc_html_e( 'You have no donations yet.', 'newspack-plugin' ); ?>
+			</div>
+		<?php endif; ?>
 
-	<?php if ( ! empty( $active_recurring ) ) : ?>
-		<section class="newspack-ui__stack newspack-ui__stack--vertical newspack-ui__stack--gap-5" data-section-id="recurring">
+		<?php if ( ! empty( $active_recurring ) ) : ?>
+			<section class="newspack-ui__stack newspack-ui__stack--vertical newspack-ui__stack--gap-5" data-section-id="recurring">
 			<h2 class="newspack-ui__font--l newspack-ui__font--bold newspack-ui__spacing-top--0 newspack-ui__spacing-bottom--0">
 				<?php
 				echo esc_html(
@@ -250,7 +251,8 @@ $status_label = static function ( $status ) {
 				</tbody>
 			</table>
 		</section>
-	<?php endif; ?>
+		<?php endif; ?>
+	</div>
 
 	<?php if ( $billing_history_inline ) : ?>
 		<section class="newspack-ui__stack newspack-ui__stack--vertical newspack-ui__stack--gap-3" data-section-id="billing-history">

--- a/includes/plugins/woocommerce/my-account/templates/my-account-v2-demo/donations.php
+++ b/includes/plugins/woocommerce/my-account/templates/my-account-v2-demo/donations.php
@@ -314,7 +314,7 @@ $status_label = static function ( $status ) {
 	<?php elseif ( ! empty( $billing_history_button['enabled'] ) ) : ?>
 		<a
 			href="#"
-			class="newspack-ui__box newspack-ui__stack newspack-ui__stack--horizontal newspack-ui__stack--gap-5 newspack-ui__stack--align-center newspack-ui__stack--justify-between"
+			class="newspack-ui__box newspack-ui__spacing-bottom--0 newspack-ui__stack newspack-ui__stack--horizontal newspack-ui__stack--gap-5 newspack-ui__stack--align-center newspack-ui__stack--justify-between"
 			data-action="open-billing-history"
 		>
 			<div class="newspack-ui__stack newspack-ui__stack--vertical newspack-ui__stack--gap-1">

--- a/includes/plugins/woocommerce/my-account/templates/my-account-v2-demo/donations.php
+++ b/includes/plugins/woocommerce/my-account/templates/my-account-v2-demo/donations.php
@@ -180,7 +180,7 @@ $status_label = static function ( $status ) {
 					?>
 					<div class="newspack-ui__box newspack-ui__box--border newspack-ui__stack newspack-ui__stack--horizontal newspack-ui__stack--gap-5 newspack-ui__stack--align-center newspack-ui__stack--justify-between">
 						<div class="newspack-ui__stack newspack-ui__stack--vertical newspack-ui__stack--gap-1">
-							<span class="newspack-ui__font--m newspack-ui__font--bold"><?php echo esc_html( $amount_per ); ?></span>
+							<span class="newspack-ui__font--s newspack-ui__font--bold"><?php echo esc_html( $amount_per ); ?></span>
 							<?php if ( $next_payment ) : ?>
 								<span class="newspack-ui__font--xs newspack-ui__color--neutral-60">
 									<?php
@@ -318,7 +318,7 @@ $status_label = static function ( $status ) {
 			data-action="open-billing-history"
 		>
 			<div class="newspack-ui__stack newspack-ui__stack--vertical newspack-ui__stack--gap-1">
-				<span class="newspack-ui__font--m newspack-ui__font--bold">
+				<span class="newspack-ui__font--s newspack-ui__font--bold">
 					<?php echo esc_html( isset( $billing_history_button['title'] ) ? $billing_history_button['title'] : __( 'Billing history', 'newspack-plugin' ) ); ?>
 				</span>
 				<span class="newspack-ui__font--xs newspack-ui__color--neutral-60">

--- a/includes/plugins/woocommerce/my-account/templates/my-account-v2-demo/donations.php
+++ b/includes/plugins/woocommerce/my-account/templates/my-account-v2-demo/donations.php
@@ -314,17 +314,17 @@ $status_label = static function ( $status ) {
 	<?php elseif ( ! empty( $billing_history_button['enabled'] ) ) : ?>
 		<a
 			href="#"
-			class="newspack-ui__box newspack-ui__spacing-bottom--0 newspack-ui__stack newspack-ui__stack--horizontal newspack-ui__stack--gap-5 newspack-ui__stack--align-center newspack-ui__stack--justify-between"
+			class="newspack-ui__button newspack-ui__button--secondary newspack-ui__button--wide newspack-ui__stack newspack-ui__stack--horizontal newspack-ui__stack--gap-5 newspack-ui__stack--align-center newspack-ui__stack--justify-between"
 			data-action="open-billing-history"
 		>
-			<div class="newspack-ui__stack newspack-ui__stack--vertical newspack-ui__stack--gap-1">
+			<span class="newspack-ui__stack newspack-ui__stack--vertical newspack-ui__stack--gap-1">
 				<span class="newspack-ui__font--s newspack-ui__font--bold">
 					<?php echo esc_html( isset( $billing_history_button['title'] ) ? $billing_history_button['title'] : __( 'Billing history', 'newspack-plugin' ) ); ?>
 				</span>
-				<span class="newspack-ui__font--xs newspack-ui__color--neutral-60">
+				<span class="newspack-ui__font--xs newspack-ui__font--normal newspack-ui__color--neutral-60">
 					<?php echo esc_html( isset( $billing_history_button['description'] ) ? $billing_history_button['description'] : '' ); ?>
 				</span>
-			</div>
+			</span>
 			<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false">
 				<path fill-rule="evenodd" clip-rule="evenodd" fill="currentColor" d="M16.83 6.342l.602.3.625-.25.443-.176v12.569l-.443-.178-.625-.25-.603.301-1.444.723-2.41-.804-.475-.158-.474.158-2.41.803-1.445-.722-.603-.3-.625.25-.443.177V6.215l.443.178.625.25.603-.301 1.444-.722 2.41.803.475.158.474-.158 2.41-.803 1.445.722zM20 4l-1.5.6-1 .4-2-1-3 1-3-1-2 1-1-.4L5 4v17l1.5-.6 1-.4 2 1 3-1 3 1 2-1 1 .4 1.5.6V4zm-3.5 6.25v-1.5h-8v1.5h8zm0 3v-1.5h-8v1.5h8zm-8 3v-1.5h8v1.5h-8z"/>
 			</svg>

--- a/includes/plugins/woocommerce/my-account/templates/my-account-v2-demo/newsletters.php
+++ b/includes/plugins/woocommerce/my-account/templates/my-account-v2-demo/newsletters.php
@@ -27,7 +27,7 @@ $reader_email         = isset( $reader['email'] ) ? (string) $reader['email'] : 
 >
 	<?php foreach ( $sections as $section ) : ?>
 		<section class="newspack-ui__stack newspack-ui__stack--vertical newspack-ui__stack--gap-5" data-section-id="<?php echo esc_attr( $section['id'] ); ?>">
-			<header class="newspack-ui__stack newspack-ui__stack--vertical newspack-ui__stack--gap-1">
+			<header class="newspack-ui__stack newspack-ui__stack--vertical newspack-ui__stack--gap-0">
 				<h2 class="newspack-ui__font--m newspack-ui__font--bold newspack-ui__spacing-top--0 newspack-ui__spacing-bottom--0">
 					<?php echo esc_html( $section['label'] ); ?>
 				</h2>
@@ -68,7 +68,7 @@ $reader_email         = isset( $reader['email'] ) ? (string) $reader['email'] : 
 			class="newspack-my-account-v2-demo-newsletters__unsubscribe-all newspack-ui__stack newspack-ui__stack--horizontal newspack-ui__stack--gap-5 newspack-ui__stack--align-center newspack-ui__stack--justify-between"
 			data-section-id="unsubscribe-all"
 		>
-			<div class="newspack-ui__stack newspack-ui__stack--vertical newspack-ui__stack--gap-1">
+			<div class="newspack-ui__stack newspack-ui__stack--vertical newspack-ui__stack--gap-0">
 				<h2 class="newspack-ui__font--m newspack-ui__font--bold newspack-ui__spacing-top--0 newspack-ui__spacing-bottom--0">
 					<?php echo esc_html( $unsubscribe_from_all['title'] ); ?>
 				</h2>

--- a/src/my-account-v2-demo/account-settings.js
+++ b/src/my-account-v2-demo/account-settings.js
@@ -28,7 +28,9 @@ function openModal( modal ) {
 }
 
 /**
- * Switch the modal to its success ("check inbox") step.
+ * Switch the modal to its success ("check inbox") step. The success step
+ * narrows the inner modal to --small; init keeps the default width because
+ * its alternatives list needs the room.
  *
  * @param {HTMLElement} modal Modal container element.
  */
@@ -36,6 +38,7 @@ function showSuccessStep( modal ) {
 	modal.querySelectorAll( '[data-step]' ).forEach( step => {
 		step.hidden = step.dataset.step !== 'success';
 	} );
+	modal.querySelector( '.newspack-ui__modal' )?.classList.add( 'newspack-ui__modal--small' );
 }
 
 /**
@@ -49,6 +52,7 @@ function resetModal( modal ) {
 	modal.querySelectorAll( '[data-step]' ).forEach( step => {
 		step.hidden = step.dataset.step !== 'init';
 	} );
+	modal.querySelector( '.newspack-ui__modal' )?.classList.remove( 'newspack-ui__modal--small' );
 }
 
 /**

--- a/src/my-account-v2-demo/style.scss
+++ b/src/my-account-v2-demo/style.scss
@@ -87,12 +87,14 @@
 		min-width: 0;
 	}
 
-	// v1 ships a `:not(.__stack--gap-11) section + section { margin-top:
-	// spacer-11 }` rule that fires on our consecutive <section> elements
-	// because the body and .woocommerce-MyAccount-content match the :not
-	// — so it stacks an extra spacer-11 on top of __stack--gap-11. Zero
-	// it inside donations so the parent gap controls spacing.
-	.newspack-my-account-v2-demo-donations section + section {
+	// v1 ships a `.newspack-my-account .woocommerce-MyAccount-content
+	// :not(.__stack--gap-11) section + section { margin-top: spacer-11 }`
+	// rule that fires on our consecutive <section> elements because the
+	// outer wrapper isn't __stack--gap-11 (only the inner one is) — so
+	// it stacks an extra spacer-11 on top of __stack--gap-11. The v1
+	// selector has 3 classes; this override compounds the section's own
+	// __stack class to land at 4 classes and win the specificity battle.
+	.newspack-my-account-v2-demo-donations section.newspack-ui__stack + section.newspack-ui__stack {
 		margin-top: 0;
 	}
 

--- a/src/my-account-v2-demo/style.scss
+++ b/src/my-account-v2-demo/style.scss
@@ -39,13 +39,21 @@
 	}
 
 	// Donations list anchors the billing-history block to the bottom of
-	// the available height (Figma 2636:46467). Parent
-	// .woocommerce-MyAccount-content auto-sizes to its content, so we
-	// give the wrapper a viewport-based min-height for justify-between
-	// to have room to distribute. Conservative offset accounts for the
-	// admin bar; longer pages still scroll naturally.
+	// the visible viewport (Figma 2636:46467). Sidebar is position:fixed
+	// 100vh, so our content has no parent to inherit height from — we
+	// pin a viewport-based min-height for justify-between to distribute.
+	// Subtract the WP admin bar offset and the .woocommerce wrapper's
+	// spacer-11 vertical padding (top + bottom = 128px) so the page
+	// doesn't overflow. Desktop only; below 768px the sidebar is an
+	// overlay and there's nothing to match.
 	.newspack-my-account-v2-demo-donations {
-		min-height: calc(100vh - var(--newspack-ui-spacer-9));
+		@media ( min-width: 768px ) {
+			min-height: calc(
+				100vh
+				- var(--wp-admin--admin-bar--height, 0px)
+				- var(--newspack-ui-spacer-11) * 2
+			);
+		}
 	}
 
 	// Section title font-size pin. The newspack-ui font-m utility

--- a/src/my-account-v2-demo/style.scss
+++ b/src/my-account-v2-demo/style.scss
@@ -85,26 +85,6 @@
 		margin-top: 0;
 	}
 
-	// Billing history Button Card sits compact in Figma (4007:732289):
-	// padding 12px / 24px (spacer-2 / spacer-5), against the default
-	// __box's 24px all-sides. Override scoped to this single instance
-	// via the `data-action` selector so the rest of the __box family
-	// stays untouched. The card behaves like a secondary button — it's
-	// an <a> with a single click action — so it gets a matching hover
-	// transition (mirrors __button--secondary's neutral-5 → neutral-10
-	// step rather than the harder secondary jump to neutral-30, since
-	// the card's resting bg is already the lighter neutral-5).
-	.newspack-my-account-v2-demo-donations [data-action="open-billing-history"] {
-		padding: var(--newspack-ui-spacer-2) var(--newspack-ui-spacer-5);
-		text-decoration: none;
-		transition: background-color 125ms ease-in-out;
-
-		&:hover,
-		&:focus-visible {
-			background: var(--newspack-ui-color-neutral-10);
-		}
-	}
-
 	// Previous donations table polish (Figma 2636:46479). Header gets a
 	// stronger bottom border (--color-border, #ddd); rows get a lighter
 	// divider (neutral-5, #f0f0f0); rows are clickable so cursor flips

--- a/src/my-account-v2-demo/style.scss
+++ b/src/my-account-v2-demo/style.scss
@@ -29,6 +29,15 @@
 		line-height: var(--newspack-ui-line-height-m);
 	}
 
+	// Sign up / Unsubscribe row buttons share the same width so the right
+	// edge stays steady as rows toggle between subscribed states (and so
+	// the loading-state spinner doesn't reveal a wider label after the
+	// flip). Targets only per-row buttons, not the bottom "Unsubscribe
+	// from all" CTA which sits in a different context.
+	.newspack-my-account-v2-demo-newsletters [data-list-id] > .newspack-ui__button {
+		min-width: 8rem;
+	}
+
 	// Phase 9 — Delete account modal action list. Three rows of
 	// label and description on the left, Manage button on the right,
 	// separated by hairlines. No newspack-ui primitive matches this

--- a/src/my-account-v2-demo/style.scss
+++ b/src/my-account-v2-demo/style.scss
@@ -76,6 +76,15 @@
 		margin-bottom: 0;
 	}
 
+	// v1 ships a `:not(.__stack--gap-11) section + section { margin-top:
+	// spacer-11 }` rule that fires on our consecutive <section> elements
+	// because the body and .woocommerce-MyAccount-content match the :not
+	// — so it stacks an extra spacer-11 on top of __stack--gap-11. Zero
+	// it inside donations so the parent gap controls spacing.
+	.newspack-my-account-v2-demo-donations section + section {
+		margin-top: 0;
+	}
+
 	// Billing history Button Card sits compact in Figma (4007:732289):
 	// padding 12px / 24px (spacer-2 / spacer-5), against the default
 	// __box's 24px all-sides. Override scoped to this single instance

--- a/src/my-account-v2-demo/style.scss
+++ b/src/my-account-v2-demo/style.scss
@@ -64,6 +64,15 @@
 		line-height: var(--newspack-ui-line-height-m);
 	}
 
+	// Billing history Button Card sits compact in Figma (4007:732289):
+	// padding 12px / 24px (spacer-2 / spacer-5), against the default
+	// __box's 24px all-sides. Override scoped to this single instance
+	// via the `data-action` selector so the rest of the __box family
+	// stays untouched.
+	.newspack-my-account-v2-demo-donations [data-action="open-billing-history"] {
+		padding: var(--newspack-ui-spacer-2) var(--newspack-ui-spacer-5);
+	}
+
 	// Previous donations table polish (Figma 2636:46479). Header gets a
 	// stronger bottom border (--color-border, #ddd); rows get a lighter
 	// divider (neutral-5, #f0f0f0); rows are clickable so cursor flips

--- a/src/my-account-v2-demo/style.scss
+++ b/src/my-account-v2-demo/style.scss
@@ -94,6 +94,16 @@
 		}
 	}
 
+	// Sidebar nav footer (secondary links + Sign out) renders as a stack
+	// with spacer-1 between items. v1's `_navigation.scss` controls the
+	// outer footer block but doesn't gap the children, so the v2-demo
+	// secondary links sit too tight against the Sign out row.
+	.newspack-my-account__navigation-footer ul {
+		display: flex;
+		flex-direction: column;
+		gap: var(--newspack-ui-spacer-1);
+	}
+
 	// Email-send icon at the top of the success step. Black filled
 	// circle, white icon — matches Figma frame 4865:92398.
 	.newspack-my-account-v2-demo-account-settings__success-icon {

--- a/src/my-account-v2-demo/style.scss
+++ b/src/my-account-v2-demo/style.scss
@@ -80,9 +80,20 @@
 	// padding 12px / 24px (spacer-2 / spacer-5), against the default
 	// __box's 24px all-sides. Override scoped to this single instance
 	// via the `data-action` selector so the rest of the __box family
-	// stays untouched.
+	// stays untouched. The card behaves like a secondary button — it's
+	// an <a> with a single click action — so it gets a matching hover
+	// transition (mirrors __button--secondary's neutral-5 → neutral-10
+	// step rather than the harder secondary jump to neutral-30, since
+	// the card's resting bg is already the lighter neutral-5).
 	.newspack-my-account-v2-demo-donations [data-action="open-billing-history"] {
 		padding: var(--newspack-ui-spacer-2) var(--newspack-ui-spacer-5);
+		text-decoration: none;
+		transition: background-color 125ms ease-in-out;
+
+		&:hover,
+		&:focus-visible {
+			background: var(--newspack-ui-color-neutral-10);
+		}
 	}
 
 	// Previous donations table polish (Figma 2636:46479). Header gets a

--- a/src/my-account-v2-demo/style.scss
+++ b/src/my-account-v2-demo/style.scss
@@ -48,6 +48,36 @@
 		min-height: calc(100vh - var(--newspack-ui-spacer-9));
 	}
 
+	// Section title font-size pin. The newspack-ui font-m utility
+	// compiles to a two-class selector and gets out-specificed by some
+	// theme rules on entry-content headings. Same fix as newsletters.
+	.newspack-my-account-v2-demo-donations h2 {
+		font-size: var(--newspack-ui-font-size-m);
+		line-height: var(--newspack-ui-line-height-m);
+	}
+
+	// Previous donations table polish (Figma 2636:46479). Header gets a
+	// stronger bottom border (--color-border, #ddd); rows get a lighter
+	// divider (neutral-5, #f0f0f0); rows are clickable so cursor flips
+	// to pointer; cell padding bumps row height closer to Figma's 48px.
+	.newspack-my-account-v2-demo-donations__previous-table {
+		thead th {
+			border-bottom: 1px solid var(--newspack-ui-color-border);
+			padding: var(--newspack-ui-spacer-2) 0;
+		}
+
+		tbody {
+			td {
+				border-bottom: 1px solid var(--newspack-ui-color-neutral-5);
+				padding: var(--newspack-ui-spacer-3) 0;
+			}
+
+			tr {
+				cursor: pointer;
+			}
+		}
+	}
+
 	// Phase 9 — Delete account modal action list. Three rows of
 	// label and description on the left, Manage button on the right,
 	// separated by hairlines. No newspack-ui primitive matches this

--- a/src/my-account-v2-demo/style.scss
+++ b/src/my-account-v2-demo/style.scss
@@ -59,9 +59,21 @@
 	// Section title font-size pin. The newspack-ui font-m utility
 	// compiles to a two-class selector and gets out-specificed by some
 	// theme rules on entry-content headings. Same fix as newsletters.
+	// Also zero margins so the parent stack's gap is the only spacing
+	// between sections (themes often ship h2 margin-top/bottom that
+	// stacks on top of __stack--gap-11).
 	.newspack-my-account-v2-demo-donations h2 {
 		font-size: var(--newspack-ui-font-size-m);
 		line-height: var(--newspack-ui-line-height-m);
+		margin: 0;
+	}
+
+	// __box ships with margin-bottom: spacer-5; inside a __stack the
+	// margin gets added on top of the gap, inflating the visible space
+	// between sections. Zero it inside donations so the stack gap is
+	// the single source of inter-section spacing.
+	.newspack-my-account-v2-demo-donations .newspack-ui__box {
+		margin-bottom: 0;
 	}
 
 	// Billing history Button Card sits compact in Figma (4007:732289):

--- a/src/my-account-v2-demo/style.scss
+++ b/src/my-account-v2-demo/style.scss
@@ -38,6 +38,16 @@
 		min-width: 8rem;
 	}
 
+	// Donations list anchors the billing-history block to the bottom of
+	// the available height (Figma 2636:46467). Parent
+	// .woocommerce-MyAccount-content auto-sizes to its content, so we
+	// give the wrapper a viewport-based min-height for justify-between
+	// to have room to distribute. Conservative offset accounts for the
+	// admin bar; longer pages still scroll naturally.
+	.newspack-my-account-v2-demo-donations {
+		min-height: calc(100vh - var(--newspack-ui-spacer-9));
+	}
+
 	// Phase 9 — Delete account modal action list. Three rows of
 	// label and description on the left, Manage button on the right,
 	// separated by hairlines. No newspack-ui primitive matches this

--- a/src/my-account-v2-demo/style.scss
+++ b/src/my-account-v2-demo/style.scss
@@ -76,6 +76,17 @@
 		margin-bottom: 0;
 	}
 
+	// Billing history Button Card label block fills the remaining width
+	// so the title/description stretch across the button instead of
+	// sitting at content width while justify-between leaves a wide gap
+	// before the icon. Mirrors Figma's `flex-[1_0_0]` on the label.
+	// newspack-ui has no flex-grow utility, so this stays as a scoped
+	// rule for the single instance.
+	.newspack-my-account-v2-demo-donations [data-action="open-billing-history"] > .newspack-ui__stack--vertical {
+		flex: 1;
+		min-width: 0;
+	}
+
 	// v1 ships a `:not(.__stack--gap-11) section + section { margin-top:
 	// spacer-11 }` rule that fires on our consecutive <section> elements
 	// because the body and .woocommerce-MyAccount-content match the :not


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

A polish pass on the My Account v2 demo prototype, addressing several visual nits surfaced while reviewing the merged Phases 2-9 against Figma. Stacks on top of `prototype/my-account-demo` (umbrella PR #4679).

**Donations list (Figma `2636:46467`)**
- Billing history block now anchors to the bottom of the visible viewport via `__stack--justify-between` on the outer wrapper plus a viewport-based `min-height` (offset for admin bar + the `.woocommerce` wrapper's vertical padding so the page never overflows).
- Recurring + Previous section titles dropped from `__font--l` to `__font--m` to match the design token; recurring card amount likewise from `--m` to `--s`.
- Previous donations table picks up a stronger header underline (`--color-border`), lighter row dividers (`neutral-5`), `cursor: pointer` on rows, and roomier padding.
- Inter-section gap pinned to `__stack--gap-11`. Required overriding a v1 `:not(.__stack--gap-11) section + section` rule that fired on our consecutive `<section>` elements (the outer wrapper isn't `--gap-11`, only the inner one is) and zeroing the `__box`'s default `margin-bottom` plus theme `<h2>` margins so the parent gap is the single source of inter-section spacing.
- Billing history "Button Card" rebuilt as a `<button>` styled with `__button--secondary --wide` rather than a `__box` wrapped in custom CSS — picks up bg, padding, hover, focus-visible outline, and transition for free. Inner label block stretches to fill width via `flex: 1` since newspack-ui has no flex-grow utility.
- Receipt icon SVG swapped for the new design.

**Account settings - Delete account modal (Figma `4865:92398`)**
- The "Your account deletion has been requested" success step now narrows to `__modal--small`. Init keeps the wider default because of the alternatives list. Toggle is JS-driven on step transition and resets on close.

**Sidebar nav footer**
- Secondary links + Sign out row now stack with a `spacer-1` (8px) gap; previously sat too tight against each other.

**Newsletters list**
- Sign up / Unsubscribe row buttons share a common `min-width` so the right edge stays steady when toggling subscribed state and the loading-state spinner doesn't reveal a wider label after the flip. The bottom "Unsubscribe from all" CTA is unaffected (different context).
- Section header (h2 + description) gap tightened to `__stack--gap-0`.

### How to test the changes in this Pull Request:

Log in as administrator. Each surface lives behind the demo flag.

1. Visit `/my-account/donations/?my-account-v2-demo=1`. Verify: Recurring + Previous section titles read at medium size; the gap between them is exactly `spacer-11` (no extra phantom whitespace); billing history sits at the bottom of the viewport (not floating right under Previous donations); page height does not overflow the viewport. Hover the billing history card - it should darken to `neutral-30` and show a focus-visible outline on tab. Click it (no-op, just visual). Confirm the receipt icon matches the new SVG, and the URL bar does not pick up a `#` fragment when clicking.
2. Visit `/my-account/donations/?my-account-v2-demo=billing-history`. Verify the inline billing history table replaces the Button Card and still sits at the bottom.
3. Visit `/my-account/donations/?my-account-v2-demo=no-donations` and `=empty`. Verify the empty notice + billing history layout still spaces correctly.
4. Visit `/my-account/newsletters/?my-account-v2-demo=1`. Verify Sign up and Unsubscribe row buttons render at the same width (tight against each label, but identical right edge across rows). Toggle a row - the loading spinner sits inside the same-width pill before the label flips. The "Unsubscribe from all" row at the bottom stays its natural width. Confirm the section header (e.g., "Featured") sits flush against its description.
5. Visit `/my-account/edit-account/?my-account-v2-demo=1`. Click Delete account. Verify the modal opens at default width with the alternatives list. Click Delete account inside the modal. Verify it transitions to the "Your account deletion has been requested" success step at `--small` width. Close the modal and reopen - should reset to init at default width.
6. Visit any `/my-account/<endpoint>/?my-account-v2-demo=1` URL with the v1 sidebar showing FAQ / Contact us / Privacy Policy / Terms of Service / Sign out. Verify there is a `spacer-1` (8px) gap between each item.
7. Sanity-check non-demo flows: visit `/my-account/donations/` (no flag) - should 404 / fall through to v1 unchanged. Visit `/my-account/edit-account/` - v1 form renders unchanged.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?