### PR TITLE
fix(reader-revenue): handle PayPal Payments 4.x container service IDs

### DIFF
--- a/includes/configuration_managers/class-woocommerce-configuration-manager.php
+++ b/includes/configuration_managers/class-woocommerce-configuration-manager.php
@@ -251,20 +251,40 @@ class WooCommerce_Configuration_Manager extends Configuration_Manager {
 		$test_mode    = $gateway && 'yes' === $gateway->get_option( 'test_mode', false ) ? true : false;
 
 		// PayPal gateway doesn't provide helper functions, so we need to use its internal API.
+		// Service IDs vary across plugin versions: `onboarding.environment` (≤2.9.6) was
+		// renamed to `settings.environment` in 3.0.0, and `onboarding.state` was removed in
+		// 4.0.0. Probe with has() before get() and wrap the whole block to keep future
+		// container changes from taking the wizard down.
 		if ( 'ppcp-gateway' === $gateway_slug && method_exists( 'WooCommerce\PayPalCommerce\PPCP', 'container' ) ) {
 			$paypal = \WooCommerce\PayPalCommerce\PPCP::container();
 			if ( $paypal ) {
 				try {
-					$env = $paypal->get( 'onboarding.environment' ); // woocommerce-paypal-payments@2.9.6.
+					$env = null;
+					if ( $paypal->has( 'settings.environment' ) ) {
+						$env = $paypal->get( 'settings.environment' );
+					} elseif ( $paypal->has( 'onboarding.environment' ) ) {
+						$env = $paypal->get( 'onboarding.environment' );
+					}
+					if ( $env && $env->current_environment_is( $env::SANDBOX ) ) {
+						$test_mode = true;
+					}
+					if ( $paypal->has( 'onboarding.state' ) ) {
+						$state = $paypal->get( 'onboarding.state' );
+						if ( $state && $state::STATE_ONBOARDED <= $state->current_state() ) {
+							$is_connected = true;
+						}
+					}
 				} catch ( \Throwable $th ) {
-					$env = $paypal->get( 'settings.environment' ); // woocommerce-paypal-payments@3.0.0.
-				}
-				if ( $env && $env->current_environment_is( $env::SANDBOX ) ) {
-					$test_mode = true;
-				}
-				$state = $paypal->get( 'onboarding.state' );
-				if ( $state && $state::STATE_ONBOARDED <= $state->current_state() ) {
-					$is_connected = true;
+					// Container shape changed unexpectedly; degrade to gateway-derived values
+					// so the wizard keeps rendering, and surface the cause for debugging.
+					error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+						sprintf(
+							'[Newspack] PayPal container access failed in gateway_data(): %s in %s on line %d',
+							$th->getMessage(),
+							$th->getFile(),
+							$th->getLine()
+						)
+					);
 				}
 			}
 		}

--- a/includes/configuration_managers/class-woocommerce-configuration-manager.php
+++ b/includes/configuration_managers/class-woocommerce-configuration-manager.php
@@ -277,13 +277,13 @@ class WooCommerce_Configuration_Manager extends Configuration_Manager {
 				} catch ( \Throwable $th ) {
 					// Container shape changed unexpectedly; degrade to gateway-derived values
 					// so the wizard keeps rendering, and surface the cause for debugging.
-					error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+					Logger::log(
 						sprintf(
-							'[Newspack] PayPal container access failed in gateway_data(): %s in %s on line %d',
+							'PayPal container access failed in gateway_data(): %s on line %d',
 							$th->getMessage(),
-							$th->getFile(),
 							$th->getLine()
-						)
+						),
+						'error'
 					);
 				}
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Addresses a fatal in `WooCommerce_Configuration_Manager::gateway_data()` when `woocommerce-paypal-payments` 4.x is active.

v4.0.0 removed the `onboarding.state` and `onboarding.environment` service IDs from the Inpsyde Modularity container (only `settings.environment` remains); the prior call sites threw an uncaught `NotFoundExceptionInterface` (anonymous class, `ReadOnlyContainer.php:61`).

### How to test the changes in this Pull Request:

1. While on the release branch, make sure you have the PayPal Payments gateway >= v4.x plugin installed
2. Try to enable the gateway and confirm it doesn't work
3. Navigate to Audience -> Configuration -> Checkout & Payment
4. Switch your Reader Revenue Platform to "Other"
5. Enable the PayPal Payments gateway
6. Back to the Checkout & Payment settings, confirm you are unable to switch to "Newspack" as reader revenue platform
7. Switch to this branch and switch the platform to Newspack
8. Confirm it's now switched to Newspack
9. Configure the PayPal Payments gateway in sandbox mode
10. Confirm you are able to use the gateway for a donation via the modal checkout

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->