### PR TITLE
fix(access-control): allow access rules with `supports_anonymous` to evaluate anonymous readers

### DIFF
--- a/includes/content-gate/class-access-rules.php
+++ b/includes/content-gate/class-access-rules.php
@@ -35,13 +35,20 @@ class Access_Rules {
 	 * @param array $config {
 	 *     The rule configuration.
 	 *
-	 *     @type string   $id          The rule ID.
-	 *     @type string   $name        The rule name.
-	 *     @type string   $description The rule description.
-	 *     @type mixed    $default     The rule default value.
-	 *     @type array    $options     The rule options.
-	 *     @type callable $callback    The rule callback.
-	 *     @type bool     $is_boolean  Whether the rule is a boolean rule.
+	 *     @type string   $id                 The rule ID.
+	 *     @type string   $name               The rule name.
+	 *     @type string   $description        The rule description.
+	 *     @type mixed    $default            The rule default value.
+	 *     @type array    $options            The rule options.
+	 *     @type callable $callback           The rule callback.
+	 *     @type bool     $is_boolean         Whether the rule is a boolean rule.
+	 *     @type bool     $supports_anonymous Whether the rule's callback can evaluate access for
+	 *                                        a logged-out visitor (`user_id = 0`). Defaults to
+	 *                                        false — `evaluate_rule` short-circuits to false for
+	 *                                        anonymous users on rules that don't opt in. Rules
+	 *                                        that opt in are responsible for cache-safety
+	 *                                        (e.g. only running per-IP logic when the page is
+	 *                                        already uncached).
 	 * }
 	 *
 	 * @return void|\WP_Error

--- a/includes/content-gate/class-access-rules.php
+++ b/includes/content-gate/class-access-rules.php
@@ -184,6 +184,60 @@ class Access_Rules {
 	}
 
 	/**
+	 * Determine whether the gate's custom_access rules grant access to an
+	 * anonymous (logged-out) visitor.
+	 *
+	 * Only rules that (a) declare `supports_anonymous` and (b) have a populated
+	 * `value` are considered. An unpopulated rule is treated as "not configured"
+	 * rather than "matches everyone" — Access_Rules's underlying evaluators
+	 * return true for empty values as the rule's own no-constraint semantics,
+	 * which is correct for the rule in isolation but must not silently bypass
+	 * registration here.
+	 *
+	 * Groups containing any non-eligible rule are dropped (the AND-within-group
+	 * semantics would force the group to fail for an anonymous visitor anyway,
+	 * since non-anonymous rules return false for `user_id = 0`).
+	 *
+	 * @param array $access_rules Custom access rules in grouped or flat format.
+	 *
+	 * @return bool True if a populated, anonymous-capable rule grants access.
+	 */
+	public static function evaluate_anonymous_rules( $access_rules ) {
+		if ( empty( $access_rules ) ) {
+			return false;
+		}
+		$eligible_groups = [];
+		foreach ( self::normalize_rules( $access_rules ) as $group ) {
+			if ( empty( $group ) || ! is_array( $group ) ) {
+				continue;
+			}
+			$group_eligible = true;
+			foreach ( $group as $rule ) {
+				// `empty()` is acceptable for `value` while the only `supports_anonymous` rule
+				// (`institution`) stores an array of post IDs — empty array means "no institutions
+				// selected." If a future anonymous-capable rule uses a falsy-but-valid scalar (e.g.
+				// `0`, `'0'`, `false`), tighten this check accordingly.
+				if ( ! isset( $rule['slug'] ) || empty( $rule['value'] ) ) {
+					$group_eligible = false;
+					break;
+				}
+				$rule_def = self::get_rule( $rule['slug'] );
+				if ( empty( $rule_def['supports_anonymous'] ) ) {
+					$group_eligible = false;
+					break;
+				}
+			}
+			if ( $group_eligible ) {
+				$eligible_groups[] = $group;
+			}
+		}
+		if ( empty( $eligible_groups ) ) {
+			return false;
+		}
+		return self::evaluate_rules( $eligible_groups, 0 );
+	}
+
+	/**
 	 * Evaluate access rules with OR logic between groups and AND logic within groups.
 	 *
 	 * Rules structure: [ [ rule1, rule2 ], [ rule3, rule4 ] ]

--- a/includes/content-gate/class-content-restriction-control.php
+++ b/includes/content-gate/class-content-restriction-control.php
@@ -239,11 +239,11 @@ class Content_Restriction_Control {
 		}
 
 		$user_id = $user_id ?? get_current_user_id();
-		// Cache the user ID for the current request. Used only for self::$post_gate_layout_id_map,
-		// so the page-render's user's layout is the one templates retrieve via get_gate_layout_id.
-		// Other instances of $user_id below are intentional so that this method can be called
-		// repeatedly with different user IDs in the same execution context.
-		// See: Newspack_Premium_Newsletters::check_access, called for each user in the queue.
+		// Each call evaluates restriction for its own $user_id; only self::$user_id — used by
+		// get_gate_layout_id() to surface the page-render viewer's layout to templates — is
+		// cached across calls. This lets the same request evaluate multiple users (e.g.
+		// Newspack_Premium_Newsletters::check_access iterating over a queue) without the
+		// first caller's user ID hijacking subsequent evaluations.
 		if ( ! self::$user_id ) {
 			self::$user_id = $user_id;
 		}

--- a/includes/content-gate/class-content-restriction-control.php
+++ b/includes/content-gate/class-content-restriction-control.php
@@ -28,13 +28,6 @@ class Content_Restriction_Control {
 	private static $post_gate_layout_id_map = [];
 
 	/**
-	 * Cached user ID to check restrictions for.
-	 *
-	 * @var int
-	 */
-	private static $user_id = 0;
-
-	/**
 	 * Post meta key for exempting a post from access control restrictions.
 	 *
 	 * @var string
@@ -239,14 +232,6 @@ class Content_Restriction_Control {
 		}
 
 		$user_id = $user_id ?? get_current_user_id();
-		// Each call evaluates restriction for its own $user_id; only self::$user_id — used by
-		// get_gate_post_id() and get_gate_layout_id() to surface the page-render viewer's gate
-		// to templates — is cached across calls. This lets the same request evaluate multiple
-		// users (e.g. Newspack_Premium_Newsletters::check_access iterating over a queue)
-		// without the first caller's user ID hijacking subsequent evaluations.
-		if ( ! self::$user_id ) {
-			self::$user_id = $user_id;
-		}
 
 		// Don't restrict this post for users who can edit it.
 		if ( ! empty( $post_id ) && user_can( $user_id, 'edit_post', $post_id ) ) {
@@ -312,7 +297,12 @@ class Content_Restriction_Control {
 	}
 
 	/**
-	 * Get the current gate post ID.
+	 * Get the current gate post ID for the current user.
+	 *
+	 * Looks up the cache entry written by the most recent is_post_restricted()
+	 * call for the current user. Calls made for a *different* user (e.g.
+	 * queue workers, REST callbacks iterating over readers) write to their
+	 * own cache slot and do not surface here.
 	 *
 	 * @param int $post_id Post ID. If not given, uses the current post ID.
 	 *
@@ -328,14 +318,20 @@ class Content_Restriction_Control {
 		if ( ! $post_id ) {
 			return false;
 		}
-		if ( ! empty( self::$post_gate_id_map[ $post_id . '_' . self::$user_id ] ) ) {
-			return self::$post_gate_id_map[ $post_id . '_' . self::$user_id ];
+		$user_id = get_current_user_id();
+		if ( ! empty( self::$post_gate_id_map[ $post_id . '_' . $user_id ] ) ) {
+			return self::$post_gate_id_map[ $post_id . '_' . $user_id ];
 		}
 		return false;
 	}
 
 	/**
-	 * Get the current gate layout ID.
+	 * Get the current gate layout ID for the current user.
+	 *
+	 * Looks up the cache entry written by the most recent is_post_restricted()
+	 * call for the current user. Calls made for a *different* user (e.g.
+	 * queue workers, REST callbacks iterating over readers) write to their
+	 * own cache slot and do not surface here.
 	 *
 	 * @param int $post_id Post ID. If not given, uses the current post ID.
 	 *
@@ -351,8 +347,9 @@ class Content_Restriction_Control {
 		if ( ! $post_id ) {
 			return false;
 		}
-		if ( ! empty( self::$post_gate_layout_id_map[ $post_id . '_' . self::$user_id ] ) ) {
-			return self::$post_gate_layout_id_map[ $post_id . '_' . self::$user_id ];
+		$user_id = get_current_user_id();
+		if ( ! empty( self::$post_gate_layout_id_map[ $post_id . '_' . $user_id ] ) ) {
+			return self::$post_gate_layout_id_map[ $post_id . '_' . $user_id ];
 		}
 		return false;
 	}

--- a/includes/content-gate/class-content-restriction-control.php
+++ b/includes/content-gate/class-content-restriction-control.php
@@ -280,7 +280,7 @@ class Content_Restriction_Control {
 					// not grant access — Access_Rules treats an empty value as "no constraint" and
 					// returns true, which would silently bypass registration here.
 					$anonymous_bypass_passed = ! empty( $gate['custom_access']['active'] )
-						&& self::custom_access_passes_for_anonymous( $gate['custom_access']['access_rules'] ?? [] );
+						&& Access_Rules::evaluate_anonymous_rules( $gate['custom_access']['access_rules'] ?? [] );
 					$is_restricted  = ! $anonymous_bypass_passed;
 					$gate_layout_id = $gate['registration']['gate_layout_id'] ?? $gate['id'];
 				} elseif ( ! empty( $gate['registration']['require_verification'] ) ) {
@@ -355,60 +355,6 @@ class Content_Restriction_Control {
 			return self::$post_gate_layout_id_map[ $post_id . '_' . self::$user_id ];
 		}
 		return false;
-	}
-
-	/**
-	 * Determine whether the gate's custom_access rules grant access to an
-	 * anonymous (logged-out) visitor.
-	 *
-	 * Only rules that (a) declare `supports_anonymous` and (b) have a populated
-	 * `value` are considered. An unpopulated rule is treated as "not configured"
-	 * rather than "matches everyone" — Access_Rules's underlying evaluators
-	 * return true for empty values as the rule's own no-constraint semantics,
-	 * which is correct for the rule in isolation but must not silently bypass
-	 * registration here.
-	 *
-	 * Groups containing any non-eligible rule are dropped (the AND-within-group
-	 * semantics would force the group to fail for an anonymous visitor anyway,
-	 * since non-anonymous rules return false for `user_id = 0`).
-	 *
-	 * @param array $access_rules Custom access rules in grouped or flat format.
-	 *
-	 * @return bool True if a populated, anonymous-capable rule grants access.
-	 */
-	private static function custom_access_passes_for_anonymous( $access_rules ) {
-		if ( empty( $access_rules ) ) {
-			return false;
-		}
-		$eligible_groups = [];
-		foreach ( Access_Rules::normalize_rules( $access_rules ) as $group ) {
-			if ( empty( $group ) || ! is_array( $group ) ) {
-				continue;
-			}
-			$group_eligible = true;
-			foreach ( $group as $rule ) {
-				// `empty()` is acceptable for `value` while the only `supports_anonymous` rule
-				// (`institution`) stores an array of post IDs — empty array means "no institutions
-				// selected." If a future anonymous-capable rule uses a falsy-but-valid scalar (e.g.
-				// `0`, `'0'`, `false`), tighten this check accordingly.
-				if ( ! isset( $rule['slug'] ) || empty( $rule['value'] ) ) {
-					$group_eligible = false;
-					break;
-				}
-				$rule_def = Access_Rules::get_rule( $rule['slug'] );
-				if ( empty( $rule_def['supports_anonymous'] ) ) {
-					$group_eligible = false;
-					break;
-				}
-			}
-			if ( $group_eligible ) {
-				$eligible_groups[] = $group;
-			}
-		}
-		if ( empty( $eligible_groups ) ) {
-			return false;
-		}
-		return Access_Rules::evaluate_rules( $eligible_groups, 0 );
 	}
 
 	/**

--- a/includes/content-gate/class-content-restriction-control.php
+++ b/includes/content-gate/class-content-restriction-control.php
@@ -240,10 +240,10 @@ class Content_Restriction_Control {
 
 		$user_id = $user_id ?? get_current_user_id();
 		// Each call evaluates restriction for its own $user_id; only self::$user_id — used by
-		// get_gate_layout_id() to surface the page-render viewer's layout to templates — is
-		// cached across calls. This lets the same request evaluate multiple users (e.g.
-		// Newspack_Premium_Newsletters::check_access iterating over a queue) without the
-		// first caller's user ID hijacking subsequent evaluations.
+		// get_gate_post_id() and get_gate_layout_id() to surface the page-render viewer's gate
+		// to templates — is cached across calls. This lets the same request evaluate multiple
+		// users (e.g. Newspack_Premium_Newsletters::check_access iterating over a queue)
+		// without the first caller's user ID hijacking subsequent evaluations.
 		if ( ! self::$user_id ) {
 			self::$user_id = $user_id;
 		}

--- a/includes/content-gate/class-content-restriction-control.php
+++ b/includes/content-gate/class-content-restriction-control.php
@@ -247,7 +247,7 @@ class Content_Restriction_Control {
 		}
 
 		// Don't restrict this post for users who can edit it.
-		if ( ! empty( $post_id ) && user_can( $user_id, 'edit_post', $post_id ) ) {
+		if ( ! empty( $post_id ) && user_can( self::$user_id, 'edit_post', $post_id ) ) {
 			return false;
 		}
 
@@ -268,12 +268,15 @@ class Content_Restriction_Control {
 			// If registration mode is active.
 			if ( ! empty( $gate['registration']['active'] ) ) {
 				// Check if user is logged in.
-				if ( $user_id === 0 ) {
-					$is_restricted  = true;
+				if ( self::$user_id === 0 ) {
+					// Anonymous visitors can still pass via the gate's custom_access rules if they
+					// match a rule with `supports_anonymous` (currently only `institution`).
+					$is_restricted  = empty( $gate['custom_access']['active'] ) || empty( $gate['custom_access']['access_rules'] )
+						|| ! Access_Rules::evaluate_rules( $gate['custom_access']['access_rules'], 0 );
 					$gate_layout_id = $gate['registration']['gate_layout_id'] ?? $gate['id'];
 				} elseif ( ! empty( $gate['registration']['require_verification'] ) ) {
 					// Check if email verification is required.
-					$user = get_user_by( 'id', $user_id );
+					$user = get_user_by( 'id', self::$user_id );
 					if ( ! $user || ! \get_user_meta( $user->ID, Reader_Activation::EMAIL_VERIFIED, true ) ) {
 						$is_restricted  = true;
 						$gate_layout_id = $gate['registration']['gate_layout_id'] ?? $gate['id'];
@@ -284,7 +287,7 @@ class Content_Restriction_Control {
 			// If custom_access mode is active.
 			if ( ! $is_restricted && ! empty( $gate['custom_access']['active'] ) ) {
 				$access_rules = $gate['custom_access']['access_rules'] ?? [];
-				if ( ! empty( $access_rules ) && ! Access_Rules::evaluate_rules( $access_rules, $user_id ) ) {
+				if ( ! empty( $access_rules ) && ! Access_Rules::evaluate_rules( $access_rules, self::$user_id ) ) {
 					$is_restricted  = true;
 					$gate_layout_id = $gate['custom_access']['gate_layout_id'] ?? $gate['id'];
 				}

--- a/includes/content-gate/class-content-restriction-control.php
+++ b/includes/content-gate/class-content-restriction-control.php
@@ -266,15 +266,22 @@ class Content_Restriction_Control {
 		foreach ( $post_gates as $gate ) {
 			$gate_layout_id = null;
 			$is_restricted  = false;
+			// Tracks the anonymous-bypass result so the same custom_access rules don't get
+			// evaluated twice in the second pass below. Stays null for non-anonymous calls.
+			$anonymous_bypass_passed = null;
 
 			// If registration mode is active.
 			if ( ! empty( $gate['registration']['active'] ) ) {
 				// Check if user is logged in.
 				if ( $user_id === 0 ) {
 					// Anonymous visitors can still pass via the gate's custom_access rules if they
-					// match a rule with `supports_anonymous` (currently only `institution`).
-					$is_restricted  = empty( $gate['custom_access']['active'] ) || empty( $gate['custom_access']['access_rules'] )
-						|| ! Access_Rules::evaluate_rules( $gate['custom_access']['access_rules'], 0 );
+					// match a populated rule with `supports_anonymous` (currently only `institution`).
+					// An unpopulated rule (e.g., institution rule with no institutions selected) must
+					// not grant access — Access_Rules treats an empty value as "no constraint" and
+					// returns true, which would silently bypass registration here.
+					$anonymous_bypass_passed = ! empty( $gate['custom_access']['active'] )
+						&& self::custom_access_passes_for_anonymous( $gate['custom_access']['access_rules'] ?? [] );
+					$is_restricted  = ! $anonymous_bypass_passed;
 					$gate_layout_id = $gate['registration']['gate_layout_id'] ?? $gate['id'];
 				} elseif ( ! empty( $gate['registration']['require_verification'] ) ) {
 					// Check if email verification is required.
@@ -286,8 +293,8 @@ class Content_Restriction_Control {
 				}
 			}
 
-			// If custom_access mode is active.
-			if ( ! $is_restricted && ! empty( $gate['custom_access']['active'] ) ) {
+			// If custom_access mode is active and we didn't already evaluate it above for an anonymous bypass.
+			if ( ! $is_restricted && null === $anonymous_bypass_passed && ! empty( $gate['custom_access']['active'] ) ) {
 				$access_rules = $gate['custom_access']['access_rules'] ?? [];
 				if ( ! empty( $access_rules ) && ! Access_Rules::evaluate_rules( $access_rules, $user_id ) ) {
 					$is_restricted  = true;
@@ -348,6 +355,56 @@ class Content_Restriction_Control {
 			return self::$post_gate_layout_id_map[ $post_id . '_' . self::$user_id ];
 		}
 		return false;
+	}
+
+	/**
+	 * Determine whether the gate's custom_access rules grant access to an
+	 * anonymous (logged-out) visitor.
+	 *
+	 * Only rules that (a) declare `supports_anonymous` and (b) have a populated
+	 * `value` are considered. An unpopulated rule is treated as "not configured"
+	 * rather than "matches everyone" — Access_Rules's underlying evaluators
+	 * return true for empty values as the rule's own no-constraint semantics,
+	 * which is correct for the rule in isolation but must not silently bypass
+	 * registration here.
+	 *
+	 * Groups containing any non-eligible rule are dropped (the AND-within-group
+	 * semantics would force the group to fail for an anonymous visitor anyway,
+	 * since non-anonymous rules return false for `user_id = 0`).
+	 *
+	 * @param array $access_rules Custom access rules in grouped or flat format.
+	 *
+	 * @return bool True if a populated, anonymous-capable rule grants access.
+	 */
+	private static function custom_access_passes_for_anonymous( $access_rules ) {
+		if ( empty( $access_rules ) ) {
+			return false;
+		}
+		$eligible_groups = [];
+		foreach ( Access_Rules::normalize_rules( $access_rules ) as $group ) {
+			if ( empty( $group ) || ! is_array( $group ) ) {
+				continue;
+			}
+			$group_eligible = true;
+			foreach ( $group as $rule ) {
+				if ( ! isset( $rule['slug'] ) || empty( $rule['value'] ) ) {
+					$group_eligible = false;
+					break;
+				}
+				$rule_def = Access_Rules::get_rule( $rule['slug'] );
+				if ( empty( $rule_def['supports_anonymous'] ) ) {
+					$group_eligible = false;
+					break;
+				}
+			}
+			if ( $group_eligible ) {
+				$eligible_groups[] = $group;
+			}
+		}
+		if ( empty( $eligible_groups ) ) {
+			return false;
+		}
+		return Access_Rules::evaluate_rules( $eligible_groups, 0 );
 	}
 
 	/**

--- a/includes/content-gate/class-content-restriction-control.php
+++ b/includes/content-gate/class-content-restriction-control.php
@@ -387,6 +387,10 @@ class Content_Restriction_Control {
 			}
 			$group_eligible = true;
 			foreach ( $group as $rule ) {
+				// `empty()` is acceptable for `value` while the only `supports_anonymous` rule
+				// (`institution`) stores an array of post IDs — empty array means "no institutions
+				// selected." If a future anonymous-capable rule uses a falsy-but-valid scalar (e.g.
+				// `0`, `'0'`, `false`), tighten this check accordingly.
 				if ( ! isset( $rule['slug'] ) || empty( $rule['value'] ) ) {
 					$group_eligible = false;
 					break;

--- a/includes/content-gate/class-content-restriction-control.php
+++ b/includes/content-gate/class-content-restriction-control.php
@@ -242,12 +242,17 @@ class Content_Restriction_Control {
 		}
 
 		$user_id = $user_id ?? get_current_user_id();
+		// Cache the user ID for the current request. Used only for self::$post_gate_layout_id_map,
+		// so the page-render's user's layout is the one templates retrieve via get_gate_layout_id.
+		// Other instances of $user_id below are intentional so that this method can be called
+		// repeatedly with different user IDs in the same execution context.
+		// See: Newspack_Premium_Newsletters::check_access, called for each user in the queue.
 		if ( ! self::$user_id ) {
 			self::$user_id = $user_id;
 		}
 
 		// Don't restrict this post for users who can edit it.
-		if ( ! empty( $post_id ) && user_can( self::$user_id, 'edit_post', $post_id ) ) {
+		if ( ! empty( $post_id ) && user_can( $user_id, 'edit_post', $post_id ) ) {
 			return false;
 		}
 
@@ -257,7 +262,7 @@ class Content_Restriction_Control {
 		}
 
 		// Return if the post gate has already been determined.
-		if ( ! empty( self::$post_gate_id_map[ $post_id . '_' . self::$user_id ] ) ) {
+		if ( ! empty( self::$post_gate_id_map[ $post_id . '_' . $user_id ] ) ) {
 			return true;
 		}
 
@@ -268,7 +273,7 @@ class Content_Restriction_Control {
 			// If registration mode is active.
 			if ( ! empty( $gate['registration']['active'] ) ) {
 				// Check if user is logged in.
-				if ( self::$user_id === 0 ) {
+				if ( $user_id === 0 ) {
 					// Anonymous visitors can still pass via the gate's custom_access rules if they
 					// match a rule with `supports_anonymous` (currently only `institution`).
 					$is_restricted  = empty( $gate['custom_access']['active'] ) || empty( $gate['custom_access']['access_rules'] )
@@ -276,7 +281,7 @@ class Content_Restriction_Control {
 					$gate_layout_id = $gate['registration']['gate_layout_id'] ?? $gate['id'];
 				} elseif ( ! empty( $gate['registration']['require_verification'] ) ) {
 					// Check if email verification is required.
-					$user = get_user_by( 'id', self::$user_id );
+					$user = get_user_by( 'id', $user_id );
 					if ( ! $user || ! \get_user_meta( $user->ID, Reader_Activation::EMAIL_VERIFIED, true ) ) {
 						$is_restricted  = true;
 						$gate_layout_id = $gate['registration']['gate_layout_id'] ?? $gate['id'];
@@ -287,15 +292,15 @@ class Content_Restriction_Control {
 			// If custom_access mode is active.
 			if ( ! $is_restricted && ! empty( $gate['custom_access']['active'] ) ) {
 				$access_rules = $gate['custom_access']['access_rules'] ?? [];
-				if ( ! empty( $access_rules ) && ! Access_Rules::evaluate_rules( $access_rules, self::$user_id ) ) {
+				if ( ! empty( $access_rules ) && ! Access_Rules::evaluate_rules( $access_rules, $user_id ) ) {
 					$is_restricted  = true;
 					$gate_layout_id = $gate['custom_access']['gate_layout_id'] ?? $gate['id'];
 				}
 			}
 
 			if ( $is_restricted && $gate_layout_id ) {
-				self::$post_gate_id_map[ $post_id . '_' . self::$user_id ] = $gate['id'];
-				self::$post_gate_layout_id_map[ $post_id . '_' . self::$user_id ] = $gate_layout_id;
+				self::$post_gate_id_map[ $post_id . '_' . $user_id ] = $gate['id'];
+				self::$post_gate_layout_id_map[ $post_id . '_' . $user_id ] = $gate_layout_id;
 				return true;
 			}
 		}

--- a/includes/content-gate/class-institution.php
+++ b/includes/content-gate/class-institution.php
@@ -253,7 +253,7 @@ class Institution {
 		}
 
 		if ( ! empty( $rules['ip_range'] ) ) {
-			$is_uncached = $uncached || ! empty( $user_id ) || isset( $_COOKIE[ IP_Access_Rule::COOKIE_NAME ] ); // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+			$is_uncached = $uncached || ! empty( $user_id ) || IP_Access_Rule::is_cookie_set();
 			if ( $is_uncached && IP_Access_Rule::ip_matches_ranges( IP_Access_Rule::get_visitor_ip(), $rules['ip_range'] ) ) {
 				return true;
 			}

--- a/includes/content-gate/class-institution.php
+++ b/includes/content-gate/class-institution.php
@@ -253,6 +253,12 @@ class Institution {
 		}
 
 		if ( ! empty( $rules['ip_range'] ) ) {
+			// IP evaluation is page-cache-safe only when the response would be uncached anyway:
+			// the caller flagged it as such, the visitor is logged in, or the visitor carries
+			// the IP-access bypass cookie. A first-time anonymous on-campus visitor landing
+			// directly on a gated post matches none of these and will see the gate — they must
+			// first complete the IP check at /institutional-access (or ?institutional-access=1)
+			// to set the cookie before subsequent gated requests can evaluate their IP.
 			$is_uncached = $uncached || ! empty( $user_id ) || IP_Access_Rule::is_cookie_set();
 			if ( $is_uncached && IP_Access_Rule::ip_matches_ranges( IP_Access_Rule::get_visitor_ip(), $rules['ip_range'] ) ) {
 				return true;

--- a/includes/content-gate/class-ip-access-rule.php
+++ b/includes/content-gate/class-ip-access-rule.php
@@ -575,11 +575,12 @@ class IP_Access_Rule {
 	/**
 	 * Whether the IP-access bypass cookie was sent on the current request.
 	 *
-	 * The cookie is set by the institutional-access flow once a visitor's IP
-	 * matches an institution's IP range, and is the signal that downstream
-	 * IP-rule checks may safely run server-side without breaking the page
-	 * cache. Centralizes the `phpcs:ignore` for the restricted `$_COOKIE`
-	 * read so callers don't each carry their own annotation.
+	 * The cookie is set after a successful institutional-access verification
+	 * (any of an institution's rules matching — IP range, email domain, or
+	 * reader data) and signals that downstream IP-rule checks may safely
+	 * run server-side without breaking the page cache. Centralizes the
+	 * `phpcs:ignore` for the restricted `$_COOKIE` read so callers don't
+	 * each carry their own annotation.
 	 *
 	 * @return bool True if the cookie is present on this request.
 	 */

--- a/includes/content-gate/class-ip-access-rule.php
+++ b/includes/content-gate/class-ip-access-rule.php
@@ -573,9 +573,15 @@ class IP_Access_Rule {
 	}
 
 	/**
-	 * Check if the IP access cookie is set.
+	 * Whether the IP-access bypass cookie was sent on the current request.
 	 *
-	 * @return bool Whether the cookie is set.
+	 * The cookie is set by the institutional-access flow once a visitor's IP
+	 * matches an institution's IP range, and is the signal that downstream
+	 * IP-rule checks may safely run server-side without breaking the page
+	 * cache. Centralizes the `phpcs:ignore` for the restricted `$_COOKIE`
+	 * read so callers don't each carry their own annotation.
+	 *
+	 * @return bool True if the cookie is present on this request.
 	 */
 	public static function is_cookie_set() {
 		return isset( $_COOKIE[ self::COOKIE_NAME ] ); // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE

--- a/includes/content-gate/class-ip-access-rule.php
+++ b/includes/content-gate/class-ip-access-rule.php
@@ -571,5 +571,14 @@ class IP_Access_Rule {
 		}
 		return '';
 	}
+
+	/**
+	 * Check if the IP access cookie is set.
+	 *
+	 * @return bool Whether the cookie is set.
+	 */
+	public static function is_cookie_set() {
+		return isset( $_COOKIE[ self::COOKIE_NAME ] ); // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+	}
 }
 IP_Access_Rule::init();

--- a/tests/unit-tests/content-gate/content-gates.php
+++ b/tests/unit-tests/content-gate/content-gates.php
@@ -1947,11 +1947,10 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Regression: is_post_restricted must evaluate each call's $user_id
-	 * independently. Previously, a static-cached `self::$user_id` made every
-	 * call after the first reuse the first user's restriction state — broke
-	 * Newspack_Premium_Newsletters::process_queue, which loops over multiple
-	 * user IDs.
+	 * Each is_post_restricted() call must evaluate restrictions for its own
+	 * $user_id, both for the bool return and for the cache slot it writes.
+	 * Regression coverage for Newspack_Premium_Newsletters::process_queue,
+	 * which loops over multiple user IDs in a single request.
 	 */
 	public function test_is_post_restricted_evaluates_each_user_independently() {
 		$inst_id = Institution::create( 'University', '', [ 'email_domain' => 'university.edu' ] );

--- a/tests/unit-tests/content-gate/content-gates.php
+++ b/tests/unit-tests/content-gate/content-gates.php
@@ -1721,6 +1721,42 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Blocker: an institution rule saved with no institutions selected
+	 * (`value => []`) must not silently grant anonymous access. Without a
+	 * value, the rule is "not configured" — Institution::evaluate(0, [])
+	 * returns true as the rule's own no-constraint semantics, but for the
+	 * registration bypass we require a populated rule that actually matches.
+	 */
+	public function test_anonymous_with_unpopulated_institution_rule_is_restricted() {
+		$this->configure_published_gate(
+			[ 'active' => true ],
+			[
+				'active'       => true,
+				'access_rules' => [
+					[
+						[
+							'slug'  => 'institution',
+							'value' => [],
+						],
+					],
+				],
+			]
+		);
+
+		wp_set_current_user( 0 );
+		// Even with a matching IP and the cookie set, an unpopulated rule must not bypass.
+		$this->set_visitor_ip( '10.1.2.3' );
+		$this->reset_restriction_cache();
+
+		$this->assertTrue(
+			apply_filters( 'newspack_is_post_restricted', false, $this->post_ids[0] ),
+			'An institution rule with no institutions selected must not grant anonymous access.'
+		);
+
+		$this->reset_visitor_state();
+	}
+
+	/**
 	 * On a custom_access-only gate (no registration), an anonymous visitor
 	 * with a non-matching IP must be restricted, and the gate layout shown
 	 * must be the custom_access layout.

--- a/tests/unit-tests/content-gate/content-gates.php
+++ b/tests/unit-tests/content-gate/content-gates.php
@@ -879,8 +879,7 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 	/**
 	 * Reset the static per-post restriction cache on Content_Restriction_Control.
 	 * This cache is populated by is_post_restricted() and must be cleared between
-	 * tests to prevent cross-test contamination. Also resets the cached user ID,
-	 * which is seeded on the first call and used by get_gate_layout_id().
+	 * tests to prevent cross-test contamination.
 	 */
 	private function reset_restriction_cache() {
 		foreach ( [ 'post_gate_id_map', 'post_gate_layout_id_map' ] as $prop ) {
@@ -888,22 +887,6 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 			$reflection->setAccessible( true );
 			$reflection->setValue( null, [] );
 		}
-		$user_id_reflection = new \ReflectionProperty( Content_Restriction_Control::class, 'user_id' );
-		$user_id_reflection->setAccessible( true );
-		$user_id_reflection->setValue( null, 0 );
-	}
-
-	/**
-	 * Read the cached user ID on Content_Restriction_Control via reflection.
-	 * Used to assert the seeding logic directly rather than through downstream
-	 * layout behavior.
-	 *
-	 * @return int Cached user ID (0 when not yet seeded or last seeded as anonymous).
-	 */
-	private function get_cached_user_id() {
-		$reflection = new \ReflectionProperty( Content_Restriction_Control::class, 'user_id' );
-		$reflection->setAccessible( true );
-		return (int) $reflection->getValue();
 	}
 
 	/**
@@ -2023,24 +2006,23 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Pin the seeding contract for self::$user_id directly: the static is
-	 * seeded by the *first* caller and is not overwritten by subsequent
-	 * callers in the same request. This is what get_gate_post_id() and
-	 * get_gate_layout_id() rely on to surface the page-render viewer's
-	 * gate to templates regardless of any later evaluations (e.g. queue
-	 * workers, REST callbacks) that pass a different user ID.
-	 *
-	 * Catches seeding regressions directly via reflection rather than
-	 * through downstream layout behavior.
+	 * Pin the gate-layout cache contract: get_gate_layout_id() must read for
+	 * the *current* user (via get_current_user_id()), not for whichever user
+	 * happened to populate the cache via an earlier is_post_restricted()
+	 * call. This protects the page-render viewer from seeing a queue
+	 * worker's or REST callback's cached layout.
 	 */
-	public function test_is_post_restricted_seeds_user_id_from_first_caller_only() {
-		$first_user = $this->factory->user->create( [ 'role' => 'subscriber' ] );
-		update_user_meta( $first_user, Reader_Activation::EMAIL_VERIFIED, true );
-		$second_user = $this->factory->user->create( [ 'role' => 'subscriber' ] );
-		update_user_meta( $second_user, Reader_Activation::EMAIL_VERIFIED, true );
+	public function test_get_gate_layout_id_does_not_return_other_users_cached_layout() {
+		$queue_user = $this->factory->user->create( [ 'role' => 'subscriber' ] );
+		// $queue_user is intentionally unverified — gate's require_verification will restrict it.
+		$page_user = $this->factory->user->create( [ 'role' => 'subscriber' ] );
+		update_user_meta( $page_user, Reader_Activation::EMAIL_VERIFIED, true );
 
 		$this->configure_published_gate(
-			[ 'active' => true ],
+			[
+				'active'               => true,
+				'require_verification' => true,
+			],
 			[
 				'active'       => false,
 				'access_rules' => [],
@@ -2048,34 +2030,28 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 		);
 
 		$this->reset_restriction_cache();
-		$this->assertSame( 0, $this->get_cached_user_id(), 'Sanity: cache is reset before first call.' );
 
-		// First call seeds self::$user_id from the caller's $user_id.
-		Content_Restriction_Control::is_post_restricted( false, $this->post_ids[0], $first_user );
-		$this->assertSame(
-			$first_user,
-			$this->get_cached_user_id(),
-			'self::$user_id must be seeded from the first caller.'
+		// Queue-worker pattern: is_post_restricted called with an explicit, non-current user.
+		// This must populate the cache under $queue_user only.
+		$this->assertTrue(
+			Content_Restriction_Control::is_post_restricted( false, $this->post_ids[0], $queue_user ),
+			'Unverified queue user must be restricted by the require_verification gate.'
 		);
 
-		// Subsequent call with a different user must not overwrite the seed.
-		Content_Restriction_Control::is_post_restricted( false, $this->post_ids[0], $second_user );
-		$this->assertSame(
-			$first_user,
-			$this->get_cached_user_id(),
-			'self::$user_id must NOT be overwritten by a subsequent caller — first caller wins.'
+		// Switch to the page-render viewer.
+		wp_set_current_user( $page_user );
+
+		$this->assertFalse(
+			Content_Restriction_Control::get_gate_layout_id( $this->post_ids[0] ),
+			'get_gate_layout_id must not surface a cache entry written for a different user.'
+		);
+		$this->assertFalse(
+			Content_Restriction_Control::get_gate_post_id( $this->post_ids[0] ),
+			'get_gate_post_id must not surface a cache entry written for a different user.'
 		);
 
-		// Anonymous call after seeding must also leave the seed alone.
-		Content_Restriction_Control::is_post_restricted( false, $this->post_ids[0], 0 );
-		$this->assertSame(
-			$first_user,
-			$this->get_cached_user_id(),
-			'Anonymous call after seeding must not zero out self::$user_id.'
-		);
-
-		wp_delete_user( $first_user );
-		wp_delete_user( $second_user );
+		wp_delete_user( $queue_user );
+		wp_delete_user( $page_user );
 		$this->reset_visitor_state();
 	}
 }

--- a/tests/unit-tests/content-gate/content-gates.php
+++ b/tests/unit-tests/content-gate/content-gates.php
@@ -193,7 +193,6 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 		unset( $_COOKIE[ IP_Access_Rule::COOKIE_NAME ] );
 		// phpcs:enable
 		delete_transient( Institution::TRANSIENT_KEY );
-		wp_set_current_user( 0 );
 		parent::tear_down();
 	}
 
@@ -1995,14 +1994,14 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 			[
 				'role'       => 'subscriber',
 				'user_email' => 'a@university.edu',
-			] 
+			]
 		);
 		update_user_meta( $matching_user, Reader_Activation::EMAIL_VERIFIED, true );
 		$other_user = $this->factory->user->create(
 			[
 				'role'       => 'subscriber',
 				'user_email' => 'b@other.com',
-			] 
+			]
 		);
 		update_user_meta( $other_user, Reader_Activation::EMAIL_VERIFIED, true );
 

--- a/tests/unit-tests/content-gate/content-gates.php
+++ b/tests/unit-tests/content-gate/content-gates.php
@@ -1646,11 +1646,6 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 			'Anonymous visitor with non-matching IP must be restricted.'
 		);
 		$this->assertSame(
-			0,
-			$this->get_cached_user_id(),
-			'self::$user_id must be seeded to 0 on the first anonymous evaluation, so the layout accessors return the anonymous lookup.'
-		);
-		$this->assertSame(
 			$layouts['registration_layout_id'],
 			Content_Restriction_Control::get_gate_layout_id( $this->post_ids[0] ),
 			'Anonymous visitor must see the registration layout, not the custom_access one.'
@@ -2025,6 +2020,63 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 
 		wp_delete_user( $matching_user );
 		wp_delete_user( $other_user );
+		$this->reset_visitor_state();
+	}
+
+	/**
+	 * Pin the seeding contract for self::$user_id directly: the static is
+	 * seeded by the *first* caller and is not overwritten by subsequent
+	 * callers in the same request. This is what get_gate_post_id() and
+	 * get_gate_layout_id() rely on to surface the page-render viewer's
+	 * gate to templates regardless of any later evaluations (e.g. queue
+	 * workers, REST callbacks) that pass a different user ID.
+	 *
+	 * Catches seeding regressions directly via reflection rather than
+	 * through downstream layout behavior.
+	 */
+	public function test_is_post_restricted_seeds_user_id_from_first_caller_only() {
+		$first_user = $this->factory->user->create( [ 'role' => 'subscriber' ] );
+		update_user_meta( $first_user, Reader_Activation::EMAIL_VERIFIED, true );
+		$second_user = $this->factory->user->create( [ 'role' => 'subscriber' ] );
+		update_user_meta( $second_user, Reader_Activation::EMAIL_VERIFIED, true );
+
+		$this->configure_published_gate(
+			[ 'active' => true ],
+			[
+				'active'       => false,
+				'access_rules' => [],
+			]
+		);
+
+		$this->reset_restriction_cache();
+		$this->assertSame( 0, $this->get_cached_user_id(), 'Sanity: cache is reset before first call.' );
+
+		// First call seeds self::$user_id from the caller's $user_id.
+		Content_Restriction_Control::is_post_restricted( false, $this->post_ids[0], $first_user );
+		$this->assertSame(
+			$first_user,
+			$this->get_cached_user_id(),
+			'self::$user_id must be seeded from the first caller.'
+		);
+
+		// Subsequent call with a different user must not overwrite the seed.
+		Content_Restriction_Control::is_post_restricted( false, $this->post_ids[0], $second_user );
+		$this->assertSame(
+			$first_user,
+			$this->get_cached_user_id(),
+			'self::$user_id must NOT be overwritten by a subsequent caller — first caller wins.'
+		);
+
+		// Anonymous call after seeding must also leave the seed alone.
+		Content_Restriction_Control::is_post_restricted( false, $this->post_ids[0], 0 );
+		$this->assertSame(
+			$first_user,
+			$this->get_cached_user_id(),
+			'Anonymous call after seeding must not zero out self::$user_id.'
+		);
+
+		wp_delete_user( $first_user );
+		wp_delete_user( $second_user );
 		$this->reset_visitor_state();
 	}
 }

--- a/tests/unit-tests/content-gate/content-gates.php
+++ b/tests/unit-tests/content-gate/content-gates.php
@@ -12,6 +12,8 @@ use Newspack\Access_Rules;
 use Newspack\Content_Rules;
 use Newspack\Content_Gate;
 use Newspack\Content_Restriction_Control;
+use Newspack\Content_Gate\IP_Access_Rule;
+use Newspack\Institution;
 
 /**
  * Tests for the Content Gates class.
@@ -33,6 +35,15 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 	protected $gate_ids = [];
 
 	/**
+	 * Original $_SERVER['REMOTE_ADDR'] saved in set_up and restored in tear_down
+	 * so the institutional-access scenarios can mutate it without leaking into
+	 * other test classes.
+	 *
+	 * @var string|null
+	 */
+	private $original_remote_addr;
+
+	/**
 	 * Define the Content Gates feature flag for this test class only and force
 	 * the REST server to re-init so audience-content-gates routes register with
 	 * the flag on. Defining in bootstrap would flip the flag for every test in
@@ -52,6 +63,8 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 	 */
 	public function set_up() {
 		parent::set_up();
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__REMOTE_ADDR__
+		$this->original_remote_addr = isset( $_SERVER['REMOTE_ADDR'] ) ? $_SERVER['REMOTE_ADDR'] : null;
 		$this->gate_ids[] = Content_Gate::create_gate( [ 'title' => 'Draft Gate' ] );
 		Content_Gate::update_gate_settings(
 			$this->gate_ids[0],
@@ -171,6 +184,17 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 			wp_delete_post( $post_id, true );
 		}
 		$this->reset_restriction_cache();
+		// phpcs:disable WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__REMOTE_ADDR__, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+		if ( null === $this->original_remote_addr ) {
+			unset( $_SERVER['REMOTE_ADDR'] );
+		} else {
+			$_SERVER['REMOTE_ADDR'] = $this->original_remote_addr;
+		}
+		unset( $_COOKIE[ IP_Access_Rule::COOKIE_NAME ] );
+		// phpcs:enable
+		delete_transient( Institution::TRANSIENT_KEY );
+		wp_set_current_user( 0 );
+		parent::tear_down();
 	}
 
 	/**
@@ -838,7 +862,8 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 	/**
 	 * Reset the static per-post restriction cache on Content_Restriction_Control.
 	 * This cache is populated by is_post_restricted() and must be cleared between
-	 * tests to prevent cross-test contamination.
+	 * tests to prevent cross-test contamination. Also resets the cached user ID,
+	 * which is seeded on the first call and used by get_gate_layout_id().
 	 */
 	private function reset_restriction_cache() {
 		foreach ( [ 'post_gate_id_map', 'post_gate_layout_id_map' ] as $prop ) {
@@ -846,6 +871,9 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 			$reflection->setAccessible( true );
 			$reflection->setValue( null, [] );
 		}
+		$user_id_reflection = new \ReflectionProperty( Content_Restriction_Control::class, 'user_id' );
+		$user_id_reflection->setAccessible( true );
+		$user_id_reflection->setValue( null, 0 );
 	}
 
 	/**
@@ -1362,5 +1390,480 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertLessThanOrEqual( 100, count( $response->get_data() ), 'Include result set is capped at 100' );
+	}
+
+	// =========================================================================
+	// Institutional access bypassing registration (NPPD-1494)
+	//
+	// When a gate has both registration mode and custom_access mode active,
+	// anonymous visitors must be able to pass via custom_access rules that
+	// support anonymous evaluation (currently `institution`). The institution
+	// rule re-checks the visitor's live IP, so a stale IP-access cookie alone
+	// must not be enough to grant access.
+	// =========================================================================
+
+	/**
+	 * Configure the gate at $this->gate_ids[2] (the published gate from set_up)
+	 * with the given registration and custom_access blocks. Returns the
+	 * gate's registration and custom_access layout IDs for layout assertions.
+	 *
+	 * @param array $registration  Registration block.
+	 * @param array $custom_access Custom access block.
+	 *
+	 * @return array{registration_layout_id:int, custom_access_layout_id:int}
+	 */
+	private function configure_published_gate( $registration, $custom_access ) {
+		$gate_id = $this->gate_ids[2];
+		$gate    = Content_Gate::get_gate( $gate_id );
+
+		Content_Gate::update_gate_settings(
+			$gate_id,
+			[
+				'title'         => 'Published Gate',
+				'status'        => 'publish',
+				'priority'      => 2,
+				'content_rules' => [
+					[
+						'slug'  => 'post_types',
+						'value' => [ 'post' ],
+					],
+				],
+				'registration'  => array_merge(
+					[
+						'gate_layout_id'       => $gate['registration']['gate_layout_id'],
+						'metering'             => [
+							'enabled' => false,
+							'count'   => 0,
+							'period'  => 'month',
+						],
+						'require_verification' => false,
+						'gate_id'              => 0,
+					],
+					$registration
+				),
+				'custom_access' => array_merge(
+					[
+						'gate_layout_id' => $gate['custom_access']['gate_layout_id'],
+						'metering'       => [
+							'enabled' => false,
+							'count'   => 0,
+							'period'  => 'month',
+						],
+						'gate_id'        => 0,
+						'access_rules'   => [],
+					],
+					$custom_access
+				),
+			]
+		);
+
+		return [
+			'registration_layout_id'  => (int) $gate['registration']['gate_layout_id'],
+			'custom_access_layout_id' => (int) $gate['custom_access']['gate_layout_id'],
+		];
+	}
+
+	/**
+	 * Set the visitor's IP and the cache-bypass cookie for anonymous IP rule
+	 * evaluation. Pair with reset_visitor_state() in tear-down or between
+	 * scenarios.
+	 *
+	 * @param string $ip          Visitor IP.
+	 * @param bool   $with_cookie Whether to also set the IP_Access_Rule cookie.
+	 */
+	private function set_visitor_ip( $ip, $with_cookie = true ) {
+		// phpcs:disable WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__REMOTE_ADDR__, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+		$_SERVER['REMOTE_ADDR'] = $ip;
+		if ( $with_cookie ) {
+			$_COOKIE[ IP_Access_Rule::COOKIE_NAME ] = '1';
+		} else {
+			unset( $_COOKIE[ IP_Access_Rule::COOKIE_NAME ] );
+		}
+		// phpcs:enable
+	}
+
+	/**
+	 * Clear visitor IP, cookie, current user, institution cache, and the
+	 * per-request restriction cache. Call at the end of each scenario to
+	 * avoid leaking state into other tests in the suite.
+	 */
+	private function reset_visitor_state() {
+		// phpcs:disable WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__REMOTE_ADDR__, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+		unset( $_SERVER['REMOTE_ADDR'] );
+		unset( $_COOKIE[ IP_Access_Rule::COOKIE_NAME ] );
+		// phpcs:enable
+		wp_set_current_user( 0 );
+		delete_transient( Institution::TRANSIENT_KEY );
+		$this->reset_restriction_cache();
+	}
+
+	/**
+	 * Anonymous visitor whose IP matches an institution allowed by the gate's
+	 * custom_access rules must be granted access even when registration mode
+	 * is also active.
+	 */
+	public function test_anonymous_with_matching_ip_bypasses_registration() {
+		$inst_id = Institution::create( 'University', '', [ 'ip_range' => '10.0.0.0/8' ] );
+		$this->post_ids[] = $inst_id;
+		delete_transient( Institution::TRANSIENT_KEY );
+
+		$this->configure_published_gate(
+			[ 'active' => true ],
+			[
+				'active'       => true,
+				'access_rules' => [
+					[
+						[
+							'slug'  => 'institution',
+							'value' => [ $inst_id ],
+						],
+					],
+				],
+			]
+		);
+
+		wp_set_current_user( 0 );
+		$this->set_visitor_ip( '10.1.2.3' );
+		$this->reset_restriction_cache();
+
+		$this->assertFalse(
+			apply_filters( 'newspack_is_post_restricted', false, $this->post_ids[0] ),
+			'Anonymous visitor with matching institutional IP must not be restricted.'
+		);
+
+		$this->reset_visitor_state();
+	}
+
+	/**
+	 * Anonymous visitor without a matching IP must be restricted, and the
+	 * gate layout shown must be the registration layout (not the
+	 * custom_access one), since registration is the relevant prompt for an
+	 * anonymous visitor.
+	 */
+	public function test_anonymous_without_matching_ip_is_restricted_with_registration_layout() {
+		$inst_id = Institution::create( 'University', '', [ 'ip_range' => '10.0.0.0/8' ] );
+		$this->post_ids[] = $inst_id;
+		delete_transient( Institution::TRANSIENT_KEY );
+
+		$layouts = $this->configure_published_gate(
+			[ 'active' => true ],
+			[
+				'active'       => true,
+				'access_rules' => [
+					[
+						[
+							'slug'  => 'institution',
+							'value' => [ $inst_id ],
+						],
+					],
+				],
+			]
+		);
+
+		wp_set_current_user( 0 );
+		$this->set_visitor_ip( '192.168.1.1' );
+		$this->reset_restriction_cache();
+
+		$this->assertTrue(
+			apply_filters( 'newspack_is_post_restricted', false, $this->post_ids[0] ),
+			'Anonymous visitor with non-matching IP must be restricted.'
+		);
+		$this->assertSame(
+			$layouts['registration_layout_id'],
+			Content_Restriction_Control::get_gate_layout_id( $this->post_ids[0] ),
+			'Anonymous visitor must see the registration layout, not the custom_access one.'
+		);
+
+		$this->reset_visitor_state();
+	}
+
+	/**
+	 * A stale IP-access cookie (e.g., set on campus, visitor now at home)
+	 * must not grant access on its own — the institution rule re-checks the
+	 * live IP, so a non-matching current IP results in restriction.
+	 */
+	public function test_anonymous_with_stale_cookie_but_changed_ip_is_restricted() {
+		$inst_id = Institution::create( 'University', '', [ 'ip_range' => '10.0.0.0/8' ] );
+		$this->post_ids[] = $inst_id;
+		delete_transient( Institution::TRANSIENT_KEY );
+
+		$this->configure_published_gate(
+			[ 'active' => true ],
+			[
+				'active'       => true,
+				'access_rules' => [
+					[
+						[
+							'slug'  => 'institution',
+							'value' => [ $inst_id ],
+						],
+					],
+				],
+			]
+		);
+
+		wp_set_current_user( 0 );
+		// Cookie present (stale from a previous on-campus session) but IP no longer matches.
+		$this->set_visitor_ip( '192.168.1.1', true );
+		$this->reset_restriction_cache();
+
+		$this->assertTrue(
+			apply_filters( 'newspack_is_post_restricted', false, $this->post_ids[0] ),
+			'Stale IP cookie alone must not grant access — the live IP must match.'
+		);
+
+		$this->reset_visitor_state();
+	}
+
+	/**
+	 * Anonymous visitor on a registration-only gate (no custom_access) must
+	 * be restricted regardless of cookie or IP.
+	 */
+	public function test_anonymous_on_registration_only_gate_is_restricted() {
+		$this->configure_published_gate(
+			[ 'active' => true ],
+			[
+				'active'       => false,
+				'access_rules' => [],
+			]
+		);
+
+		wp_set_current_user( 0 );
+		$this->set_visitor_ip( '10.1.2.3' );
+		$this->reset_restriction_cache();
+
+		$this->assertTrue(
+			apply_filters( 'newspack_is_post_restricted', false, $this->post_ids[0] ),
+			'Anonymous visitor must be restricted by a registration-only gate.'
+		);
+
+		$this->reset_visitor_state();
+	}
+
+	/**
+	 * When custom_access is active but its access_rules array is empty,
+	 * anonymous visitors must still be restricted — empty rules cannot
+	 * grant access (even though Access_Rules::evaluate_rules returns true
+	 * for empty inputs).
+	 */
+	public function test_anonymous_with_empty_access_rules_is_restricted() {
+		$this->configure_published_gate(
+			[ 'active' => true ],
+			[
+				'active'       => true,
+				'access_rules' => [],
+			]
+		);
+
+		wp_set_current_user( 0 );
+		$this->reset_restriction_cache();
+
+		$this->assertTrue(
+			apply_filters( 'newspack_is_post_restricted', false, $this->post_ids[0] ),
+			'Anonymous visitor must be restricted when custom_access has no rules to evaluate.'
+		);
+
+		$this->reset_visitor_state();
+	}
+
+	/**
+	 * When custom_access only contains rules that don't support anonymous
+	 * evaluation (subscription, email_domain, reader_data), anonymous
+	 * visitors must remain restricted.
+	 */
+	public function test_anonymous_cannot_bypass_via_non_anonymous_rules() {
+		$this->configure_published_gate(
+			[ 'active' => true ],
+			[
+				'active'       => true,
+				'access_rules' => [
+					[
+						[
+							'slug'  => 'email_domain',
+							'value' => 'example.com',
+						],
+					],
+				],
+			]
+		);
+
+		wp_set_current_user( 0 );
+		$this->reset_restriction_cache();
+
+		$this->assertTrue(
+			apply_filters( 'newspack_is_post_restricted', false, $this->post_ids[0] ),
+			'Anonymous visitor must not bypass registration via rules that require login.'
+		);
+
+		$this->reset_visitor_state();
+	}
+
+	/**
+	 * On a custom_access-only gate (no registration), an anonymous visitor
+	 * with a non-matching IP must be restricted, and the gate layout shown
+	 * must be the custom_access layout.
+	 */
+	public function test_anonymous_on_custom_access_only_gate_is_restricted_with_custom_layout() {
+		$inst_id = Institution::create( 'University', '', [ 'ip_range' => '10.0.0.0/8' ] );
+		$this->post_ids[] = $inst_id;
+		delete_transient( Institution::TRANSIENT_KEY );
+
+		$layouts = $this->configure_published_gate(
+			[ 'active' => false ],
+			[
+				'active'       => true,
+				'access_rules' => [
+					[
+						[
+							'slug'  => 'institution',
+							'value' => [ $inst_id ],
+						],
+					],
+				],
+			]
+		);
+
+		wp_set_current_user( 0 );
+		$this->set_visitor_ip( '192.168.1.1' );
+		$this->reset_restriction_cache();
+
+		$this->assertTrue(
+			apply_filters( 'newspack_is_post_restricted', false, $this->post_ids[0] ),
+			'Anonymous visitor must be restricted by a custom_access-only gate when IP does not match.'
+		);
+		$this->assertSame(
+			$layouts['custom_access_layout_id'],
+			Content_Restriction_Control::get_gate_layout_id( $this->post_ids[0] ),
+			'Custom-access-only gate must surface the custom_access layout.'
+		);
+
+		$this->reset_visitor_state();
+	}
+
+	/**
+	 * On a custom_access-only gate, an anonymous visitor with a matching IP
+	 * must pass.
+	 */
+	public function test_anonymous_on_custom_access_only_gate_passes_with_matching_ip() {
+		$inst_id = Institution::create( 'University', '', [ 'ip_range' => '10.0.0.0/8' ] );
+		$this->post_ids[] = $inst_id;
+		delete_transient( Institution::TRANSIENT_KEY );
+
+		$this->configure_published_gate(
+			[ 'active' => false ],
+			[
+				'active'       => true,
+				'access_rules' => [
+					[
+						[
+							'slug'  => 'institution',
+							'value' => [ $inst_id ],
+						],
+					],
+				],
+			]
+		);
+
+		wp_set_current_user( 0 );
+		$this->set_visitor_ip( '10.1.2.3' );
+		$this->reset_restriction_cache();
+
+		$this->assertFalse(
+			apply_filters( 'newspack_is_post_restricted', false, $this->post_ids[0] ),
+			'Anonymous visitor with matching IP must not be restricted by a custom_access-only gate.'
+		);
+
+		$this->reset_visitor_state();
+	}
+
+	/**
+	 * A logged-in unverified user with `require_verification` must remain
+	 * restricted — the IP cookie must not bypass email verification.
+	 */
+	public function test_unverified_user_with_require_verification_is_restricted_despite_cookie() {
+		$user_id = $this->factory->user->create( [ 'role' => 'subscriber' ] );
+		// Intentionally not setting EMAIL_VERIFIED meta.
+
+		$this->configure_published_gate(
+			[
+				'active'               => true,
+				'require_verification' => true,
+			],
+			[
+				'active'       => false,
+				'access_rules' => [],
+			]
+		);
+
+		wp_set_current_user( $user_id );
+		$this->set_visitor_ip( '10.1.2.3' );
+		$this->reset_restriction_cache();
+
+		$this->assertTrue(
+			apply_filters( 'newspack_is_post_restricted', false, $this->post_ids[0] ),
+			'Unverified user must remain restricted even with the IP-access cookie set.'
+		);
+
+		wp_delete_user( $user_id );
+		$this->reset_visitor_state();
+	}
+
+	/**
+	 * Regression: is_post_restricted must evaluate each call's $user_id
+	 * independently. Previously, a static-cached `self::$user_id` made every
+	 * call after the first reuse the first user's restriction state — broke
+	 * Newspack_Premium_Newsletters::process_queue, which loops over multiple
+	 * user IDs.
+	 */
+	public function test_is_post_restricted_evaluates_each_user_independently() {
+		$inst_id = Institution::create( 'University', '', [ 'email_domain' => 'university.edu' ] );
+		$this->post_ids[] = $inst_id;
+		delete_transient( Institution::TRANSIENT_KEY );
+
+		$this->configure_published_gate(
+			[ 'active' => true ],
+			[
+				'active'       => true,
+				'access_rules' => [
+					[
+						[
+							'slug'  => 'institution',
+							'value' => [ $inst_id ],
+						],
+					],
+				],
+			]
+		);
+
+		$matching_user = $this->factory->user->create(
+			[
+				'role'       => 'subscriber',
+				'user_email' => 'a@university.edu',
+			] 
+		);
+		update_user_meta( $matching_user, Reader_Activation::EMAIL_VERIFIED, true );
+		$other_user = $this->factory->user->create(
+			[
+				'role'       => 'subscriber',
+				'user_email' => 'b@other.com',
+			] 
+		);
+		update_user_meta( $other_user, Reader_Activation::EMAIL_VERIFIED, true );
+
+		$this->reset_restriction_cache();
+
+		// Call order must not affect outcome: the matching user passes regardless of who was checked first.
+		$this->assertTrue(
+			Content_Restriction_Control::is_post_restricted( false, $this->post_ids[0], $other_user ),
+			'Non-matching user must be restricted.'
+		);
+		$this->assertFalse(
+			Content_Restriction_Control::is_post_restricted( false, $this->post_ids[0], $matching_user ),
+			'Matching user must not be restricted, even when called after a different user.'
+		);
+
+		wp_delete_user( $matching_user );
+		wp_delete_user( $other_user );
+		$this->reset_visitor_state();
 	}
 }

--- a/tests/unit-tests/content-gate/content-gates.php
+++ b/tests/unit-tests/content-gate/content-gates.php
@@ -895,6 +895,19 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Read the cached user ID on Content_Restriction_Control via reflection.
+	 * Used to assert the seeding logic directly rather than through downstream
+	 * layout behavior.
+	 *
+	 * @return int Cached user ID (0 when not yet seeded or last seeded as anonymous).
+	 */
+	private function get_cached_user_id() {
+		$reflection = new \ReflectionProperty( Content_Restriction_Control::class, 'user_id' );
+		$reflection->setAccessible( true );
+		return (int) $reflection->getValue();
+	}
+
+	/**
 	 * Test comment filters on fully gated posts.
 	 */
 	public function test_comments_closed_on_gated_post() {
@@ -1557,6 +1570,48 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Anonymous visitor on a matching IP but without the IP-access bypass
+	 * cookie must still be restricted. The cookie is the page-cache-safety
+	 * signal that lets Institution::user_matches_institution evaluate the
+	 * IP server-side. First-time on-campus visitors have to complete the
+	 * institutional-access check (which sets the cookie) before subsequent
+	 * gated requests can grant access via IP — landing directly on a gated
+	 * post does not.
+	 */
+	public function test_anonymous_with_matching_ip_without_cookie_is_restricted() {
+		$inst_id = Institution::create( 'University', '', [ 'ip_range' => '10.0.0.0/8' ] );
+		$this->post_ids[] = $inst_id;
+		delete_transient( Institution::TRANSIENT_KEY );
+
+		$this->configure_published_gate(
+			[ 'active' => true ],
+			[
+				'active'       => true,
+				'access_rules' => [
+					[
+						[
+							'slug'  => 'institution',
+							'value' => [ $inst_id ],
+						],
+					],
+				],
+			]
+		);
+
+		wp_set_current_user( 0 );
+		// Matching IP, but no cookie — institution rule won't run server-side.
+		$this->set_visitor_ip( '10.1.2.3', false );
+		$this->reset_restriction_cache();
+
+		$this->assertTrue(
+			apply_filters( 'newspack_is_post_restricted', false, $this->post_ids[0] ),
+			'Anonymous visitor on matching IP without the IP-access cookie must be restricted.'
+		);
+
+		$this->reset_visitor_state();
+	}
+
+	/**
 	 * Anonymous visitor without a matching IP must be restricted, and the
 	 * gate layout shown must be the registration layout (not the
 	 * custom_access one), since registration is the relevant prompt for an
@@ -1589,6 +1644,11 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 		$this->assertTrue(
 			apply_filters( 'newspack_is_post_restricted', false, $this->post_ids[0] ),
 			'Anonymous visitor with non-matching IP must be restricted.'
+		);
+		$this->assertSame(
+			0,
+			$this->get_cached_user_id(),
+			'self::$user_id must be seeded to 0 on the first anonymous evaluation, so the layout accessors return the anonymous lookup.'
 		);
 		$this->assertSame(
 			$layouts['registration_layout_id'],
@@ -1751,6 +1811,49 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 		$this->assertTrue(
 			apply_filters( 'newspack_is_post_restricted', false, $this->post_ids[0] ),
 			'An institution rule with no institutions selected must not grant anonymous access.'
+		);
+
+		$this->reset_visitor_state();
+	}
+
+	/**
+	 * Anonymous visitor with a matching IP must remain restricted when the
+	 * institution rule is AND-grouped with a non-anonymous-capable rule
+	 * (e.g. email_domain). AND-within-group means the group can only pass
+	 * if every rule passes; email_domain returns false for `user_id = 0`,
+	 * so the group fails even with a matching institutional IP.
+	 */
+	public function test_anonymous_with_matching_ip_and_grouped_with_email_domain_is_restricted() {
+		$inst_id = Institution::create( 'University', '', [ 'ip_range' => '10.0.0.0/8' ] );
+		$this->post_ids[] = $inst_id;
+		delete_transient( Institution::TRANSIENT_KEY );
+
+		$this->configure_published_gate(
+			[ 'active' => true ],
+			[
+				'active'       => true,
+				'access_rules' => [
+					[
+						[
+							'slug'  => 'institution',
+							'value' => [ $inst_id ],
+						],
+						[
+							'slug'  => 'email_domain',
+							'value' => 'example.com',
+						],
+					],
+				],
+			]
+		);
+
+		wp_set_current_user( 0 );
+		$this->set_visitor_ip( '10.1.2.3' );
+		$this->reset_restriction_cache();
+
+		$this->assertTrue(
+			apply_filters( 'newspack_is_post_restricted', false, $this->post_ids[0] ),
+			'Anonymous visitor must be restricted when institution is AND-grouped with email_domain (which requires login).'
 		);
 
 		$this->reset_visitor_state();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an important bug in the current implementation of IP-based access via Institutions: when a content gate has both Registered and Paid Access (with institutional/IP access) enabled, the Registered Access rule will gate content for non-logged-in users even if they've already passed the IP access check at the special URL. This happens before we even evaluate the Paid Access rules, so we never even get a chance to grant access to someone who should be whitelisted via Institution.

#4574 already implemented a `supports_anonymous` flag in the access rule schema, so the proposed fix here uses this to address the above scenario. If an anonymous user encounters a gate with Registered Access rule requirements, we evaluate any active Paid Access rules. Since only rules with `supports_anonymous => true` will potentially pass for an anonymous readers, this allows institutions' IP-based access rules to pass if the anonymous user has already successfully completed the IP access check, but not any other access rules.

Closes NPPD-1494.

### How to test the changes in this Pull Request:

1. Publish a content gate with both Registered + Paid Access enabled, with Paid Access rules requiring either an active subscription or institutional access to an institution that whitelists an IP range that includes your public IP.
2. As an anonymous reader, visit the Institution's access check URL with a privileged IP to set the `wp_nocache_ip` cookie.
3. On `trunk`, visit some restricted posts and observe that the posts are gated with the Registered Access layout despite you matching the institution's IP whitelist.
4. Check out this branch and refresh. Now confirm that after passing the IP check, restricted posts are shown even while not logged in.
5. As an admin, remove the institution from the content gate's access rules.
6. In the same reader session that was granted access via IP whitelist, visit more restricted posts and confirm that they're restricted again with the Registered Access gate layout.
7. Still in the same session, register a new account and visit more restricted posts, and confirm that they're restricted with the Paid Access gate layout.
8. Confirm all unit tests pass and there are no regressions in other gating logic unrelated to IP access rules.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->