### PR TITLE
fix(my-account): remove v1 script dependency

### DIFF
--- a/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php
+++ b/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php
@@ -131,7 +131,7 @@ class My_Account_UI_V1 {
 			\wp_enqueue_script(
 				'newspack-my-account-v1',
 				\Newspack\Newspack::plugin_url() . '/dist/my-account-v1.js',
-				[ 'newspack-my-account' ],
+				[],
 				NEWSPACK_PLUGIN_VERSION,
 				true
 			);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

When Reader Activation is disabled, the My Account v1 surface still renders (template hijack, body classes, button markup, CSS) — but the v1 JS never loads, so the "Add payment method" button and the address Edit / Delete buttons silently fall through to native `<a>` navigation instead of opening their modals. Because the v1 `add_payment_method_endpoint` filter rewrites the button's href to the `payment-methods` endpoint, the click looks like it "links to the same page the reader is already on" — matching the symptom reported on Halifax Examiner.

Root cause: `My_Account_UI_V1::enqueue_assets()` declares a dependency on the `newspack-my-account` script handle:

```php
\wp_enqueue_script(
    'newspack-my-account-v1',
    \Newspack\Newspack::plugin_url() . '/dist/my-account-v1.js',
    [ 'newspack-my-account' ],   // <-- the problem
    NEWSPACK_PLUGIN_VERSION,
    true
);
```

That handle is only registered by `WooCommerce_My_Account::enqueue_scripts()`, which is hooked inside the `if ( Reader_Activation::is_enabled() )` block in `WooCommerce_My_Account::init()`. With Reader Activation off, the dependency is never registered, and WordPress silently skips enqueueing the v1 script. The v1 stylesheet has no dependency, so it loads regardless — producing the asymmetric "styles render, JS missing" state.

The dependency is not actually needed. The v1 webpack entry (`src/my-account/v1/index.js`) is self-contained:

- No v1 source file references the `newspack_my_account` global (the base script's localized var). v1 uses its own `newspackMyAccountV1`.
- No v1 module imports from `../activity`, `../payment-methods`, or `../newsletters` (the base entry's modules).
- The shared helpers v1 uses (`domReady`, `registerElementActivity`, `registerCheckoutActivity`, `onOverlaysClose`, `queuePageReload`) live in `src/utils.js` and `src/reader-activation/utils.js` and are bundled into both entries independently.

Git history shows the dependency was scaffolded in the original v1 commit (e4aa5a2e8) and never had a runtime justification — it just got carried forward.

Fix: drop the dependency from the v1 script enqueue.

Closes https://linear.app/a8c/issue/NPPM-2771/halifax-examiner-add-a-payment-method-not-working-with-am-deactivated.

### How to test the changes in this Pull Request:

**Before applying this PR — confirm the bug:**

1. Disable Reader Activation (`wp option delete newspack_reader_activation_enabled`).
2. Log in as a customer/subscriber and visit `/my-account/payment-methods/`.
3. Confirm the "Add payment method" button has the `newspack-my-account__add-payment-method` class (v1 template is rendering).
4. View source / DevTools Network tab and confirm `dist/my-account-v1.css` is loaded but `dist/my-account-v1.js` is **not**.
5. Click "Add payment method" — confirm no modal opens; the URL bar shows the same `/my-account/payment-methods/` URL.

**Apply the PR:**

7. Reload `/my-account/payment-methods/`. Confirm `dist/my-account-v1.js` now loads.
8. Click "Add payment method" — confirm the modal opens.
9. Submit the Add payment method form to verify the underlying flow still works.

**Regression check — Reader Activation enabled:**

10. Re-enable Reader Activation in the Audience wizard.
11. Reload `/my-account/payment-methods/`. Confirm both `dist/my-account.js` and `dist/my-account-v1.js` load.
12. Confirm all modals (Add / Delete payment method, Edit / Delete address) still open and submit correctly.
13. Visit `/my-account/edit-account/`, `/my-account/subscriptions/`, and a single subscription view — confirm modal-checkout buttons (`.resubscribe`, `.subscription_renewal_early`, `.change_payment_method`, `.pay`, `p.order-again a`) and the cancel-subscription / delete-account modals still open and behave as before.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?