### PR TITLE
fix(integrations): conditionally enable ESP on first registration

### DIFF
--- a/includes/reader-activation/class-integrations.php
+++ b/includes/reader-activation/class-integrations.php
@@ -215,9 +215,14 @@ class Integrations {
 		// Hook for other plugins/code to register their integrations.
 		do_action( 'newspack_reader_activation_register_integrations' );
 
-		// Auto-enable ESP on first registration only.
-		if ( false === get_option( self::OPTION_NAME ) ) {
-			self::enable( 'esp' );
+		// Auto-enable ESP on first registration only, while preserving the legacy sync setting on upgraded sites.
+		$enabled_integrations = get_option( self::OPTION_NAME, null );
+		if ( null === $enabled_integrations ) {
+			$legacy_sync_esp = get_option( 'newspack_reader_activation_sync_esp', null );
+
+			if ( null === $legacy_sync_esp || rest_sanitize_boolean( $legacy_sync_esp ) ) {
+				self::enable( 'esp' );
+			}
 		}
 
 		// Let each integration register its data event handlers.

--- a/includes/reader-activation/class-integrations.php
+++ b/includes/reader-activation/class-integrations.php
@@ -215,8 +215,10 @@ class Integrations {
 		// Hook for other plugins/code to register their integrations.
 		do_action( 'newspack_reader_activation_register_integrations' );
 
-		// hardcode ESP integration as enabled for now.
-		self::enable( 'esp' );
+		// Auto-enable ESP on first registration only.
+		if ( false === get_option( self::OPTION_NAME ) ) {
+			self::enable( 'esp' );
+		}
 
 		// Let each integration register its data event handlers.
 		foreach ( self::$integrations as $integration ) {


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
- [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The ESP integration was being force-enabled on every request via `self::enable( 'esp' )` inside `Integrations::register_integrations()`. That made the ESP toggle in the Reader Activation settings effectively read-only: any time a publisher disabled it, the next page load would re-enable it.

This change only auto-enables ESP when the integrations option has never been written (i.e. `get_option( self::OPTION_NAME ) === false`). After the initial bootstrap, the stored value is respected and publishers can toggle ESP off and have it stick.

### How to test the changes in this Pull Request:

1. On a fresh site (or one where the `newspack_reader_activation_integrations` option does not yet exist), confirm that ESP is auto-enabled on first load — the Reader Activation settings should show ESP toggled on.
2. Toggle the ESP integration off and save. Reload the page or trigger another request that runs `register_integrations()`.
3. Confirm ESP remains disabled and is not silently re-enabled.
4. Re-enable ESP, save, and confirm the setting persists across reloads.

### Other information:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?