### PR TITLE
refactor(access-control): scope gate layout cache to current user

### DIFF
--- a/includes/content-gate/class-content-restriction-control.php
+++ b/includes/content-gate/class-content-restriction-control.php
@@ -28,13 +28,6 @@ class Content_Restriction_Control {
 	private static $post_gate_layout_id_map = [];
 
 	/**
-	 * Cached user ID to check restrictions for.
-	 *
-	 * @var int
-	 */
-	private static $user_id = 0;
-
-	/**
 	 * Post meta key for exempting a post from access control restrictions.
 	 *
 	 * @var string
@@ -239,14 +232,6 @@ class Content_Restriction_Control {
 		}
 
 		$user_id = $user_id ?? get_current_user_id();
-		// Each call evaluates restriction for its own $user_id; only self::$user_id — used by
-		// get_gate_post_id() and get_gate_layout_id() to surface the page-render viewer's gate
-		// to templates — is cached across calls. This lets the same request evaluate multiple
-		// users (e.g. Newspack_Premium_Newsletters::check_access iterating over a queue)
-		// without the first caller's user ID hijacking subsequent evaluations.
-		if ( ! self::$user_id ) {
-			self::$user_id = $user_id;
-		}
 
 		// Don't restrict this post for users who can edit it.
 		if ( ! empty( $post_id ) && user_can( $user_id, 'edit_post', $post_id ) ) {
@@ -312,7 +297,12 @@ class Content_Restriction_Control {
 	}
 
 	/**
-	 * Get the current gate post ID.
+	 * Get the current gate post ID for the current user.
+	 *
+	 * Looks up the cache entry written by the most recent is_post_restricted()
+	 * call for the current user. Calls made for a *different* user (e.g.
+	 * queue workers, REST callbacks iterating over readers) write to their
+	 * own cache slot and do not surface here.
 	 *
 	 * @param int $post_id Post ID. If not given, uses the current post ID.
 	 *
@@ -328,14 +318,20 @@ class Content_Restriction_Control {
 		if ( ! $post_id ) {
 			return false;
 		}
-		if ( ! empty( self::$post_gate_id_map[ $post_id . '_' . self::$user_id ] ) ) {
-			return self::$post_gate_id_map[ $post_id . '_' . self::$user_id ];
+		$user_id = get_current_user_id();
+		if ( ! empty( self::$post_gate_id_map[ $post_id . '_' . $user_id ] ) ) {
+			return self::$post_gate_id_map[ $post_id . '_' . $user_id ];
 		}
 		return false;
 	}
 
 	/**
-	 * Get the current gate layout ID.
+	 * Get the current gate layout ID for the current user.
+	 *
+	 * Looks up the cache entry written by the most recent is_post_restricted()
+	 * call for the current user. Calls made for a *different* user (e.g.
+	 * queue workers, REST callbacks iterating over readers) write to their
+	 * own cache slot and do not surface here.
 	 *
 	 * @param int $post_id Post ID. If not given, uses the current post ID.
 	 *
@@ -351,8 +347,9 @@ class Content_Restriction_Control {
 		if ( ! $post_id ) {
 			return false;
 		}
-		if ( ! empty( self::$post_gate_layout_id_map[ $post_id . '_' . self::$user_id ] ) ) {
-			return self::$post_gate_layout_id_map[ $post_id . '_' . self::$user_id ];
+		$user_id = get_current_user_id();
+		if ( ! empty( self::$post_gate_layout_id_map[ $post_id . '_' . $user_id ] ) ) {
+			return self::$post_gate_layout_id_map[ $post_id . '_' . $user_id ];
 		}
 		return false;
 	}

--- a/tests/unit-tests/content-gate/content-gates.php
+++ b/tests/unit-tests/content-gate/content-gates.php
@@ -1947,11 +1947,10 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Regression: is_post_restricted must evaluate each call's $user_id
-	 * independently. Previously, a static-cached `self::$user_id` made every
-	 * call after the first reuse the first user's restriction state — broke
-	 * Newspack_Premium_Newsletters::process_queue, which loops over multiple
-	 * user IDs.
+	 * Each is_post_restricted() call must evaluate restrictions for its own
+	 * $user_id, both for the bool return and for the cache slot it writes.
+	 * Regression coverage for Newspack_Premium_Newsletters::process_queue,
+	 * which loops over multiple user IDs in a single request.
 	 */
 	public function test_is_post_restricted_evaluates_each_user_independently() {
 		$inst_id = Institution::create( 'University', '', [ 'email_domain' => 'university.edu' ] );

--- a/tests/unit-tests/content-gate/content-gates.php
+++ b/tests/unit-tests/content-gate/content-gates.php
@@ -879,8 +879,7 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 	/**
 	 * Reset the static per-post restriction cache on Content_Restriction_Control.
 	 * This cache is populated by is_post_restricted() and must be cleared between
-	 * tests to prevent cross-test contamination. Also resets the cached user ID,
-	 * which is seeded on the first call and used by get_gate_layout_id().
+	 * tests to prevent cross-test contamination.
 	 */
 	private function reset_restriction_cache() {
 		foreach ( [ 'post_gate_id_map', 'post_gate_layout_id_map' ] as $prop ) {
@@ -888,22 +887,6 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 			$reflection->setAccessible( true );
 			$reflection->setValue( null, [] );
 		}
-		$user_id_reflection = new \ReflectionProperty( Content_Restriction_Control::class, 'user_id' );
-		$user_id_reflection->setAccessible( true );
-		$user_id_reflection->setValue( null, 0 );
-	}
-
-	/**
-	 * Read the cached user ID on Content_Restriction_Control via reflection.
-	 * Used to assert the seeding logic directly rather than through downstream
-	 * layout behavior.
-	 *
-	 * @return int Cached user ID (0 when not yet seeded or last seeded as anonymous).
-	 */
-	private function get_cached_user_id() {
-		$reflection = new \ReflectionProperty( Content_Restriction_Control::class, 'user_id' );
-		$reflection->setAccessible( true );
-		return (int) $reflection->getValue();
 	}
 
 	/**
@@ -2023,24 +2006,23 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Pin the seeding contract for self::$user_id directly: the static is
-	 * seeded by the *first* caller and is not overwritten by subsequent
-	 * callers in the same request. This is what get_gate_post_id() and
-	 * get_gate_layout_id() rely on to surface the page-render viewer's
-	 * gate to templates regardless of any later evaluations (e.g. queue
-	 * workers, REST callbacks) that pass a different user ID.
-	 *
-	 * Catches seeding regressions directly via reflection rather than
-	 * through downstream layout behavior.
+	 * Pin the gate-layout cache contract: get_gate_layout_id() must read for
+	 * the *current* user (via get_current_user_id()), not for whichever user
+	 * happened to populate the cache via an earlier is_post_restricted()
+	 * call. This protects the page-render viewer from seeing a queue
+	 * worker's or REST callback's cached layout.
 	 */
-	public function test_is_post_restricted_seeds_user_id_from_first_caller_only() {
-		$first_user = $this->factory->user->create( [ 'role' => 'subscriber' ] );
-		update_user_meta( $first_user, Reader_Activation::EMAIL_VERIFIED, true );
-		$second_user = $this->factory->user->create( [ 'role' => 'subscriber' ] );
-		update_user_meta( $second_user, Reader_Activation::EMAIL_VERIFIED, true );
+	public function test_get_gate_layout_id_does_not_return_other_users_cached_layout() {
+		$queue_user = $this->factory->user->create( [ 'role' => 'subscriber' ] );
+		// $queue_user is intentionally unverified — gate's require_verification will restrict it.
+		$page_user = $this->factory->user->create( [ 'role' => 'subscriber' ] );
+		update_user_meta( $page_user, Reader_Activation::EMAIL_VERIFIED, true );
 
 		$this->configure_published_gate(
-			[ 'active' => true ],
+			[
+				'active'               => true,
+				'require_verification' => true,
+			],
 			[
 				'active'       => false,
 				'access_rules' => [],
@@ -2048,34 +2030,28 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 		);
 
 		$this->reset_restriction_cache();
-		$this->assertSame( 0, $this->get_cached_user_id(), 'Sanity: cache is reset before first call.' );
 
-		// First call seeds self::$user_id from the caller's $user_id.
-		Content_Restriction_Control::is_post_restricted( false, $this->post_ids[0], $first_user );
-		$this->assertSame(
-			$first_user,
-			$this->get_cached_user_id(),
-			'self::$user_id must be seeded from the first caller.'
+		// Queue-worker pattern: is_post_restricted called with an explicit, non-current user.
+		// This must populate the cache under $queue_user only.
+		$this->assertTrue(
+			Content_Restriction_Control::is_post_restricted( false, $this->post_ids[0], $queue_user ),
+			'Unverified queue user must be restricted by the require_verification gate.'
 		);
 
-		// Subsequent call with a different user must not overwrite the seed.
-		Content_Restriction_Control::is_post_restricted( false, $this->post_ids[0], $second_user );
-		$this->assertSame(
-			$first_user,
-			$this->get_cached_user_id(),
-			'self::$user_id must NOT be overwritten by a subsequent caller — first caller wins.'
+		// Switch to the page-render viewer.
+		wp_set_current_user( $page_user );
+
+		$this->assertFalse(
+			Content_Restriction_Control::get_gate_layout_id( $this->post_ids[0] ),
+			'get_gate_layout_id must not surface a cache entry written for a different user.'
+		);
+		$this->assertFalse(
+			Content_Restriction_Control::get_gate_post_id( $this->post_ids[0] ),
+			'get_gate_post_id must not surface a cache entry written for a different user.'
 		);
 
-		// Anonymous call after seeding must also leave the seed alone.
-		Content_Restriction_Control::is_post_restricted( false, $this->post_ids[0], 0 );
-		$this->assertSame(
-			$first_user,
-			$this->get_cached_user_id(),
-			'Anonymous call after seeding must not zero out self::$user_id.'
-		);
-
-		wp_delete_user( $first_user );
-		wp_delete_user( $second_user );
+		wp_delete_user( $queue_user );
+		wp_delete_user( $page_user );
 		$this->reset_visitor_state();
 	}
 }


### PR DESCRIPTION
## Summary

Removes the `Content_Restriction_Control::$user_id` "first-caller-wins" static and keys the gate-cache lookups (`get_gate_post_id`, `get_gate_layout_id`) on `get_current_user_id()` directly.

Follow-up to #4695 — see [the inline thread on the original PR](https://github.com/Automattic/newspack-plugin/pull/4695#discussion_r3180597018) for context. @adekbadek flagged that the static was "whoever called `is_post_restricted` first in this request, and `get_gate_layout_id` reads it back. That works for the page-render path (first call IS the viewer) but if any code path – a REST callback, an early integration call, a queue worker – calls `is_post_restricted` with a non-current-user id before the page render, the layout lookup silently returns the wrong layout."

## What changed

- Drops `private static $user_id = 0;` from `Content_Restriction_Control`.
- Drops the seed-on-first-call block in `is_post_restricted` (the static no longer exists).
- `get_gate_post_id()` and `get_gate_layout_id()` resolve `$user_id = get_current_user_id()` at lookup time. They only return a cache entry written for the actual current user.
- `is_post_restricted()` already wrote cache entries keyed by its call-local `$user_id` (unchanged from PR #4695). Calls made for other users (`Premium_Newsletters::process_queue`, REST callbacks, integration hooks) populate their own cache slots and are inert to the page-render lookup.

No public API change — the dropped static was `private`, and the three method signatures (`is_post_restricted`, `get_gate_post_id`, `get_gate_layout_id`) are unchanged.

## Test changes

- Replaces `test_is_post_restricted_seeds_user_id_from_first_caller_only` (which pinned the now-removed seeding contract) with `test_get_gate_layout_id_does_not_return_other_users_cached_layout`. The new test sets up the queue-worker scenario directly: calls `is_post_restricted(false, $post_id, $queue_user)`, switches `wp_set_current_user($page_user)`, and asserts `get_gate_layout_id` and `get_gate_post_id` return `false` (no cross-user leak). RED on the prior code (returned a stale layout ID); GREEN here.
- Removes the obsolete `get_cached_user_id()` reflection helper and the `self::$user_id` reset from `reset_restriction_cache()`.

## Base / merge order

Targets `fix/ip-access-plus-registered-access-rules` (PR #4695) so the diff shows only the refactor. Once #4695 merges, this PR can be rebased onto `trunk`.

## Test plan

- [ ] PHPUnit suite is green locally (`n test-php` from `repos/newspack-plugin`): 1054 tests, 1 unrelated pre-existing skip.
- [ ] Manual smoke: gated post renders the right gate for the current viewer when `Premium_Newsletters` queue worker has previously run for other users in the same request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)