### PR TITLE
fix(content-gate): pass redirectToLayout explicitly on Save

### DIFF
--- a/src/wizards/audience/views/content-gates/edit/index.tsx
+++ b/src/wizards/audience/views/content-gates/edit/index.tsx
@@ -336,7 +336,7 @@ const Edit = ( { match, updateGatesData, slug = AUDIENCE_CONTENT_GATES_WIZARD_SL
 			{
 				type: 'primary',
 				label: __( 'Save', 'newspack-plugin' ),
-				action: isNew ? handleCreate : handleSave,
+				action: isNew ? () => handleCreate() : handleSave,
 				disabled:
 					isFetching ||
 					! title ||


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

p1778008459631959-slack-C0ANXE4NDT3

When saving a new gate from Audience → Access Control, the user is being redirected to the gate layout editor with a malformed query string:

```
/wp-admin/admin.php?action=newspack_edit_gate_layout[...]gate_mode=%5Bobject%20Object%5D
```

The root cause is the `handleCreate` being passed directly as the action for the Save button. When the button fires, the click handler is invoked with the synthetic event as the first argument. The if ( redirectToLayout !== '' ) guard passes, and getEditGateLayoutUrl( data.id, event ) is called. addQueryArgs stringifies the event to [object Object].

TypeScript didn't catch this because the = '' default makes handleCreate's signature assignable to () => void.

The fix is to wrap the action so the event is discarded.

### How to test the changes in this Pull Request:

1. Go to Audience → Access Control → Add new gate.
2. Configure rules so the gate can be saved (title + at least one content rule + an active mode), then click Save.
3. Confirm you land on the #/content-gates list view
4. Open an existing gate and click Configure registration / Configure custom access — should still navigate to the layout editor with the correct gate_mode.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->