### PR TITLE
fix: remove colour label changes to avoid bleeding into other blocks

### DIFF
--- a/src/blocks/author-profile-social/block.json
+++ b/src/blocks/author-profile-social/block.json
@@ -19,6 +19,24 @@
 		"iconSize": {
 			"type": "number",
 			"default": 24
+		},
+		"iconColor": {
+			"type": "string"
+		},
+		"customIconColor": {
+			"type": "string"
+		},
+		"iconColorValue": {
+			"type": "string"
+		},
+		"iconBackgroundColor": {
+			"type": "string"
+		},
+		"customIconBackgroundColor": {
+			"type": "string"
+		},
+		"iconBackgroundColorValue": {
+			"type": "string"
 		}
 	},
 	"styles": [
@@ -26,13 +44,6 @@
 		{ "name": "brand", "label": "Brand" }
 	],
 	"supports": {
-		"color": {
-			"enableContrastChecker": false,
-			"background": true,
-			"text": true,
-			"link": false,
-			"__experimentalSkipSerialization": [ "text", "background" ]
-		},
 		"html": false,
 		"layout": {
 			"allowSwitching": false,

--- a/src/blocks/author-profile-social/class-author-profile-social-block.php
+++ b/src/blocks/author-profile-social/class-author-profile-social-block.php
@@ -221,8 +221,6 @@ final class Author_Profile_Social_Block {
 
 	/**
 	 * Get wrapper attributes (class, style, etc.) for the block.
-	 * Sets block context so core includes default class, custom className, and other supports.
-	 * Color serialization is skipped via block.json so colors are applied only as CSS vars.
 	 *
 	 * @param WP_Block $block      Block instance.
 	 * @param array    $attributes Block attributes.
@@ -230,49 +228,30 @@ final class Author_Profile_Social_Block {
 	 * @return string HTML attributes for the wrapper element.
 	 */
 	private static function get_block_wrapper_attributes( WP_Block $block, array $attributes, int $icon_size ): string {
-		$previous = \WP_Block_Supports::$block_to_render ?? null;
-		\WP_Block_Supports::$block_to_render = $block->parsed_block;
-
-		$wrapper_attributes = get_block_wrapper_attributes(
+		return get_block_wrapper_attributes(
 			[
 				'class' => 'author-profile-social__list',
 				'style' => self::get_wrapper_style( $attributes, $icon_size ),
 			]
 		);
-
-		\WP_Block_Supports::$block_to_render = $previous;
-
-		return $wrapper_attributes;
 	}
 
 	/**
-	 * Convert a preset token (var:preset|type|slug) to a CSS variable reference.
-	 *
-	 * @param string $value Raw value, e.g. "var:preset|color|primary" or "#fff".
-	 * @return string CSS value, e.g. "var(--wp--preset--color--primary)" or "#fff".
-	 */
-	private static function preset_to_css( string $value ): string {
-		if ( preg_match( '/^var:preset\|([^|]+)\|(.+)$/', $value, $matches ) ) {
-			return sprintf( 'var(--wp--preset--%s--%s)', $matches[1], $matches[2] );
-		}
-		return $value;
-	}
-
-	/**
-	 * Resolve a color value from attributes (preset slug or custom style token).
+	 * Resolve a color value from the block's icon color attributes.
+	 * Prefers the preset slug (so theme switches reflect new palette values)
+	 * and falls back to the saved hex/CSS value when no preset is set.
 	 *
 	 * @param array  $attributes Block attributes.
-	 * @param string $preset_key Top-level preset attribute key (e.g. "textColor").
-	 * @param string $style_key  Key under style.color (e.g. "text").
+	 * @param string $preset_key Preset slug attribute key (e.g. "iconColor").
+	 * @param string $value_key  Resolved CSS value attribute key (e.g. "iconColorValue").
 	 * @return string|null CSS color value or null.
 	 */
-	private static function resolve_color( array $attributes, string $preset_key, string $style_key ): ?string {
+	private static function resolve_color( array $attributes, string $preset_key, string $value_key ): ?string {
 		if ( ! empty( $attributes[ $preset_key ] ) && is_string( $attributes[ $preset_key ] ) ) {
 			return sprintf( 'var(--wp--preset--color--%s)', $attributes[ $preset_key ] );
 		}
-		$custom = $attributes['style']['color'][ $style_key ] ?? null;
-		if ( ! empty( $custom ) && is_string( $custom ) ) {
-			return self::preset_to_css( $custom );
+		if ( ! empty( $attributes[ $value_key ] ) && is_string( $attributes[ $value_key ] ) ) {
+			return $attributes[ $value_key ];
 		}
 		return null;
 	}
@@ -281,7 +260,6 @@ final class Author_Profile_Social_Block {
 	 * Build wrapper inline style with CSS variables for icon sizing and color.
 	 * Margin is handled natively by get_block_wrapper_attributes().
 	 * Gap is handled by WP layout support (outputs scoped <style> tag per block).
-	 * Color classes/inline styles are skipped via __experimentalSkipSerialization in block.json.
 	 *
 	 * @param array $attributes Block attributes.
 	 * @param int   $icon_size  Icon size in pixels.
@@ -292,8 +270,8 @@ final class Author_Profile_Social_Block {
 		$is_brand = ! empty( $attributes['className'] ) && str_contains( $attributes['className'], 'is-style-brand' );
 
 		if ( ! $is_brand ) {
-			$icon_color      = self::resolve_color( $attributes, 'textColor', 'text' );
-			$icon_background = self::resolve_color( $attributes, 'backgroundColor', 'background' );
+			$icon_color      = self::resolve_color( $attributes, 'iconColor', 'iconColorValue' );
+			$icon_background = self::resolve_color( $attributes, 'iconBackgroundColor', 'iconBackgroundColorValue' );
 
 			if ( null !== $icon_color ) {
 				$parts[] = sprintf( '--icon-color: %s;', $icon_color );

--- a/src/blocks/author-profile-social/class-author-profile-social-block.php
+++ b/src/blocks/author-profile-social/class-author-profile-social-block.php
@@ -249,8 +249,11 @@ final class Author_Profile_Social_Block {
 
 	/**
 	 * Resolve a color value from the block's icon color attributes.
-	 * Prefers the preset slug (so theme switches reflect new palette values)
-	 * and falls back to the saved hex/CSS value when no preset is set.
+	 * When both a preset slug and a resolved value are present, emits the
+	 * CSS variable with the value as a native fallback — so theme switches
+	 * that redefine the slug pick up the new palette value, and theme
+	 * switches that drop the slug fall back to the saved hex instead of
+	 * rendering uncoloured.
 	 *
 	 * @param array  $attributes Block attributes.
 	 * @param string $preset_key Preset slug attribute key (e.g. "iconColor").
@@ -258,11 +261,17 @@ final class Author_Profile_Social_Block {
 	 * @return string|null CSS color value or null.
 	 */
 	private static function resolve_color( array $attributes, string $preset_key, string $value_key ): ?string {
-		if ( ! empty( $attributes[ $preset_key ] ) && is_string( $attributes[ $preset_key ] ) ) {
-			return sprintf( 'var(--wp--preset--color--%s)', $attributes[ $preset_key ] );
+		$slug  = ! empty( $attributes[ $preset_key ] ) && is_string( $attributes[ $preset_key ] ) ? $attributes[ $preset_key ] : null;
+		$value = ! empty( $attributes[ $value_key ] ) && is_string( $attributes[ $value_key ] ) ? $attributes[ $value_key ] : null;
+
+		if ( $slug && $value ) {
+			return sprintf( 'var(--wp--preset--color--%s, %s)', $slug, $value );
 		}
-		if ( ! empty( $attributes[ $value_key ] ) && is_string( $attributes[ $value_key ] ) ) {
-			return $attributes[ $value_key ];
+		if ( $slug ) {
+			return sprintf( 'var(--wp--preset--color--%s)', $slug );
+		}
+		if ( $value ) {
+			return $value;
 		}
 		return null;
 	}

--- a/src/blocks/author-profile-social/class-author-profile-social-block.php
+++ b/src/blocks/author-profile-social/class-author-profile-social-block.php
@@ -228,12 +228,23 @@ final class Author_Profile_Social_Block {
 	 * @return string HTML attributes for the wrapper element.
 	 */
 	private static function get_block_wrapper_attributes( WP_Block $block, array $attributes, int $icon_size ): string {
-		return get_block_wrapper_attributes(
+		// Inner blocks have already rendered by this point in the InnerBlocks
+		// path, leaving $block_to_render pointing at the last child — so the
+		// wrapper would otherwise be built from the wrong block's attributes
+		// and lose this block's className, spacing, default class, etc.
+		$previous                            = \WP_Block_Supports::$block_to_render ?? null;
+		\WP_Block_Supports::$block_to_render = $block->parsed_block;
+
+		$wrapper_attributes = get_block_wrapper_attributes(
 			[
 				'class' => 'author-profile-social__list',
 				'style' => self::get_wrapper_style( $attributes, $icon_size ),
 			]
 		);
+
+		\WP_Block_Supports::$block_to_render = $previous;
+
+		return $wrapper_attributes;
 	}
 
 	/**

--- a/src/blocks/author-profile-social/class-author-profile-social-block.php
+++ b/src/blocks/author-profile-social/class-author-profile-social-block.php
@@ -228,10 +228,13 @@ final class Author_Profile_Social_Block {
 	 * @return string HTML attributes for the wrapper element.
 	 */
 	private static function get_block_wrapper_attributes( WP_Block $block, array $attributes, int $icon_size ): string {
-		// Inner blocks have already rendered by this point in the InnerBlocks
-		// path, leaving $block_to_render pointing at the last child — so the
-		// wrapper would otherwise be built from the wrong block's attributes
-		// and lose this block's className, spacing, default class, etc.
+		// Defensive: each inner WP_Block::render() snapshots/restores
+		// $block_to_render around its own callback, so by this point it
+		// should already point at the parent's parsed_block. Re-set
+		// explicitly to guard against a third-party filter or future Core
+		// change breaking that chain — otherwise the wrapper would be built
+		// from the wrong block's supports and lose this block's className,
+		// spacing, default class, etc.
 		$previous                            = \WP_Block_Supports::$block_to_render ?? null;
 		\WP_Block_Supports::$block_to_render = $block->parsed_block;
 

--- a/src/blocks/author-profile-social/edit.jsx
+++ b/src/blocks/author-profile-social/edit.jsx
@@ -52,9 +52,10 @@ const resolveColor = ( presetSlug, customValue ) => {
  * @param {Object}   props.attributes    Block attributes.
  * @param {Function} props.setAttributes Function to update attributes.
  * @param {string}   props.clientId      Block client ID.
+ * @param {boolean}  props.isSelected    Whether the block is currently selected.
  * @return {JSX.Element} The edit component.
  */
-export default function Edit( { attributes, setAttributes, clientId } ) {
+export default function Edit( { attributes, setAttributes, clientId, isSelected } ) {
 	const AuthorContext = getSharedAuthorContext();
 	const author = useContext( AuthorContext );
 	const { iconSize, style: styleAttr, textColor, backgroundColor, className } = attributes;
@@ -67,7 +68,12 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 	const iconBackground = ! isBrand ? resolveColor( backgroundColor, styleAttr?.color?.background ) : undefined;
 
 	// Hide color panel when "Brand" is active; rename labels when "Default".
+	// Only run while this block is selected — otherwise the global sidebar
+	// query leaks the relabel/hide into every other block's color panel.
 	useEffect( () => {
+		if ( ! isSelected ) {
+			return;
+		}
 		const sidebar = document.querySelector( '.interface-complementary-area' );
 		if ( ! sidebar ) {
 			return;
@@ -105,7 +111,7 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 		observer.observe( sidebar, { childList: true, subtree: true } );
 
 		return () => observer.disconnect();
-	}, [ isBrand ] );
+	}, [ isBrand, isSelected ] );
 
 	const blockProps = useBlockProps( {
 		className: 'author-profile-social__list',

--- a/src/blocks/author-profile-social/edit.jsx
+++ b/src/blocks/author-profile-social/edit.jsx
@@ -2,7 +2,17 @@
  * WordPress dependencies
  */
 import { useContext, useEffect, useMemo, useRef, useState } from '@wordpress/element';
-import { BlockControls, useBlockProps, useInnerBlocksProps, InspectorControls } from '@wordpress/block-editor';
+import {
+	BlockControls,
+	useBlockProps,
+	useInnerBlocksProps,
+	InspectorControls,
+	withColors,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalColorGradientSettingsDropdown as ColorGradientSettingsDropdown,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalUseMultipleOriginColorsAndGradients as useMultipleOriginColorsAndGradients,
+} from '@wordpress/block-editor';
 import { PanelBody, SelectControl, Button, ToolbarButton, ToolbarGroup, Tooltip } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
@@ -28,97 +38,63 @@ const fetchAllServiceKeys = () => {
 	return allServiceKeysCache;
 };
 
-const presetToVar = value => {
-	if ( typeof value !== 'string' ) {
-		return value;
-	}
-	return value.replace( /^var:preset\|([^|]+)\|(.+)$/, 'var(--wp--preset--$1--$2)' );
-};
-
-const resolveColor = ( presetSlug, customValue ) => {
-	if ( presetSlug ) {
-		return `var(--wp--preset--color--${ presetSlug })`;
-	}
-	if ( typeof customValue === 'string' ) {
-		return presetToVar( customValue ) || customValue;
-	}
-	return undefined;
-};
-
 /**
  * Edit component for the Author Social Links inner block.
  *
- * @param {Object}   props               Block props.
- * @param {Object}   props.attributes    Block attributes.
- * @param {Function} props.setAttributes Function to update attributes.
- * @param {string}   props.clientId      Block client ID.
- * @param {boolean}  props.isSelected    Whether the block is currently selected.
+ * @param {Object}   props                        Block props.
+ * @param {Object}   props.attributes             Block attributes.
+ * @param {Function} props.setAttributes          Function to update attributes.
+ * @param {string}   props.clientId               Block client ID.
+ * @param {Object}   props.iconColor              Resolved icon color (from withColors).
+ * @param {Function} props.setIconColor           Setter for icon color (from withColors).
+ * @param {Object}   props.iconBackgroundColor    Resolved icon background color (from withColors).
+ * @param {Function} props.setIconBackgroundColor Setter for icon background color (from withColors).
  * @return {JSX.Element} The edit component.
  */
-export default function Edit( { attributes, setAttributes, clientId, isSelected } ) {
+function Edit( { attributes, setAttributes, clientId, iconColor, setIconColor, iconBackgroundColor, setIconBackgroundColor } ) {
 	const AuthorContext = getSharedAuthorContext();
 	const author = useContext( AuthorContext );
-	const { iconSize, style: styleAttr, textColor, backgroundColor, className } = attributes;
+	const { iconSize, iconColorValue, iconBackgroundColorValue, className } = attributes;
 	const hasPopulated = useRef( false );
 	const [ allServiceKeys, setAllServiceKeys ] = useState( null ); // null = loading
 
 	const isBrand = ( className || '' ).split( ' ' ).includes( 'is-style-brand' );
 	const iconSizeValue = typeof iconSize === 'number' ? iconSize : parseInt( iconSize ?? 24, 10 ) || 24;
-	const iconColor = ! isBrand ? resolveColor( textColor, styleAttr?.color?.text ) : undefined;
-	const iconBackground = ! isBrand ? resolveColor( backgroundColor, styleAttr?.color?.background ) : undefined;
 
-	// Hide color panel when "Brand" is active; rename labels when "Default".
-	// Only run while this block is selected — otherwise the global sidebar
-	// query leaks the relabel/hide into every other block's color panel.
-	useEffect( () => {
-		if ( ! isSelected ) {
-			return;
-		}
-		const sidebar = document.querySelector( '.interface-complementary-area' );
-		if ( ! sidebar ) {
-			return;
-		}
+	const resolvedIconColor = ! isBrand ? iconColor?.color || iconColorValue : undefined;
+	const resolvedIconBackground = ! isBrand ? iconBackgroundColor?.color || iconBackgroundColorValue : undefined;
 
-		const COLOR_LABEL_MAP = {
-			Text: __( 'Icon color', 'newspack-plugin' ),
-			Background: __( 'Icon background', 'newspack-plugin' ),
-		};
-
-		const updateColorPanel = container => {
-			container.querySelectorAll( '.color-block-support-panel' ).forEach( el => {
-				el.style.display = isBrand ? 'none' : '';
-			} );
-
-			if ( isBrand ) {
-				return;
-			}
-
-			container.querySelectorAll( '.block-editor-panel-color-gradient-settings__color-name' ).forEach( el => {
-				if ( COLOR_LABEL_MAP[ el.textContent ] ) {
-					el.textContent = COLOR_LABEL_MAP[ el.textContent ];
-				}
-			} );
-			container.querySelectorAll( '.components-menu-item__item' ).forEach( el => {
-				if ( COLOR_LABEL_MAP[ el.textContent ] ) {
-					el.textContent = COLOR_LABEL_MAP[ el.textContent ];
-				}
-			} );
-		};
-
-		updateColorPanel( sidebar );
-
-		const observer = new MutationObserver( () => updateColorPanel( sidebar ) );
-		observer.observe( sidebar, { childList: true, subtree: true } );
-
-		return () => observer.disconnect();
-	}, [ isBrand, isSelected ] );
+	// Color panel is hidden entirely when the "Brand" style is active —
+	// brand uses each service's own colors, so neither icon nor background
+	// apply. The settings render as ToolsPanelItems directly inside the
+	// Styles tab's Color slot, so they integrate with WP's native panel
+	// (no nested panel-in-a-panel).
+	const colorGradientSettings = useMultipleOriginColorsAndGradients();
+	const colorSettings = [
+		{
+			colorValue: iconColor?.color || iconColorValue,
+			onColorChange: value => {
+				setIconColor( value );
+				setAttributes( { iconColorValue: value } );
+			},
+			label: __( 'Icon color', 'newspack-plugin' ),
+		},
+		{
+			colorValue: iconBackgroundColor?.color || iconBackgroundColorValue,
+			onColorChange: value => {
+				setIconBackgroundColor( value );
+				setAttributes( { iconBackgroundColorValue: value } );
+			},
+			label: __( 'Icon background', 'newspack-plugin' ),
+		},
+	];
 
 	const blockProps = useBlockProps( {
 		className: 'author-profile-social__list',
 		style: {
 			'--icon-size': `${ roundIconSize( iconSizeValue ) }px`,
-			...( iconColor && { '--icon-color': iconColor } ),
-			...( iconBackground && { '--icon-background': iconBackground } ),
+			...( resolvedIconColor && { '--icon-color': resolvedIconColor } ),
+			...( resolvedIconBackground && { '--icon-background': resolvedIconBackground } ),
 		},
 	} );
 
@@ -207,7 +183,17 @@ export default function Edit( { attributes, setAttributes, clientId, isSelected 
 					) }
 				</PanelBody>
 			</InspectorControls>
+			{ ! isBrand && (
+				<InspectorControls group="color">
+					<ColorGradientSettingsDropdown settings={ colorSettings } panelId={ clientId } { ...colorGradientSettings } />
+				</InspectorControls>
+			) }
 			<ul { ...innerBlocksProps } />
 		</>
 	);
 }
+
+export default withColors( {
+	iconColor: 'icon-color',
+	iconBackgroundColor: 'icon-background-color',
+} )( Edit );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The Author Profile block's Social Links block includes some code that relabels the Color and Background colour pickers to Icon Color and Icon Background. This is having an unintended side effect and bleeding into other block settings.

This PR changes the approach to match how this is handled in Core's Social Links block, to (hopefully!) make it a little less fragile (the alternative seemed to be checking if the Author Profile social links block was active again and again, and adding/removing the label, but that seemed subpar). 

Another option would be just to show the default 'Text' prefix. It's not as nice UX-wise, but much simpler under the hood. It doesn't match Core's Social Links block, but it matches the labelling in Core's new Icon block coming in WP 7.0.

Closes NPPD-1458

### How to test the changes in this Pull Request:

1. Using the Block Theme, edit one of the Single Post templates in the Site Editor (after resetting it if it has saved changes). These templates will already have the Author Profile block in place.
2. In the site editor, click on any of the other blocks -- like the Post Title block -- and note the colour settings:

<img width="283" height="346" alt="CleanShot 2026-05-05 at 14 37 06" src="https://github.com/user-attachments/assets/b529e334-2773-4d39-a835-71e077bae131" />

3. Apply this PR and run `npm run build`.
4. Refresh the editor, and ensure standard blocks are no longer inheriting the 'Icon' prefix on the colour picker.
5. Edit the Author Profile block and select the Social Icons block.
6. Confirm the Colors panel shows up on the Style tab, under the Styles panel 
7. Ensure each colour has the prefix 'Icon'
8. Try togglng the block between Default and Brand styles, and confirm that the colour pickers go away when "Brand" is picked, and appear again when "Default" is picked.
9. Try changing the icon colours and saving - confirm colours can be changed and saved, and switching back to the Brand style switches back to the branded colours.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->