### PR TITLE
fix(campaigns): remove wrapper div around add campaign modal input

### DIFF
--- a/src/wizards/audience/views/campaigns/campaigns/index.js
+++ b/src/wizards/audience/views/campaigns/campaigns/index.js
@@ -6,7 +6,7 @@
  * WordPress dependencies.
  */
 import { __experimentalVStack as VStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
-import { useContext, useEffect, useRef, useState, Fragment } from '@wordpress/element';
+import { useContext, useEffect, useState, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { ENTER } from '@wordpress/keycodes';
 import { moreVertical } from '@wordpress/icons';
@@ -111,8 +111,6 @@ const Campaigns = props => {
 		renameCampaignGroup,
 	} = props;
 
-	const modalTextRef = useRef( null );
-
 	const [ popoverVisible, setPopoverVisible ] = useState();
 	const [ modalVisible, setModalVisible ] = useState();
 	const [ modalType, setModalType ] = useState();
@@ -124,7 +122,7 @@ const Campaigns = props => {
 
 	useEffect( () => {
 		if ( modalVisible ) {
-			modalTextRef.current.querySelector( 'input' ).focus();
+			document.getElementById( 'newspack-add-campaigns-modal-input' )?.focus();
 		}
 	}, [ modalVisible ] );
 
@@ -267,21 +265,20 @@ const Campaigns = props => {
 								setModalVisible( false );
 							} }
 						>
-							<div ref={ modalTextRef }>
-								<TextControl
-									placeholder={ __( 'Campaign Name', 'newspack-plugin' ) }
-									onChange={ setCampaignName }
-									label={ __( 'Campaign Name', 'newspack-plugin' ) }
-									hideLabelFromVision={ true }
-									value={ campaignName }
-									onKeyDown={ event => {
-										if ( ENTER === event.keyCode && '' !== campaignName ) {
-											event.preventDefault();
-											submitModal( campaignName );
-										}
-									} }
-								/>
-							</div>
+							<TextControl
+								id="newspack-add-campaigns-modal-input"
+								placeholder={ __( 'Campaign Name', 'newspack-plugin' ) }
+								onChange={ setCampaignName }
+								label={ __( 'Campaign Name', 'newspack-plugin' ) }
+								hideLabelFromVision={ true }
+								value={ campaignName }
+								onKeyDown={ event => {
+									if ( ENTER === event.keyCode && '' !== campaignName ) {
+										event.preventDefault();
+										submitModal( campaignName );
+									}
+								} }
+							/>
 							<Card buttonsCard noBorder className="justify-end">
 								<Button
 									variant="secondary"


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes a spacing issue in WordPress 7.0 by removing a containing element in the Add New Campaign popup and adding focus to the input via an ID instead. 

In 7.0 some component styles changed, removing the bottom margin we're counting on here; I went this way to work around the `:last-child` styles removing our component's bottom margin styles. 

Closes NEWS-1950

### How to test the changes in this Pull Request:

1. On a site running the latest WordPress 7.0 RC, navigate to Audience > Campaigns, and click Add New Campaign.
2. Note the funky spacing in the modal that opens:

<img width="538" height="237" alt="image" src="https://github.com/user-attachments/assets/4214bf85-4c46-464c-8a61-a4b6df75c054" />

3. Apply this PR and run `npm run build`.
4. Refresh the page and reopen the modal; the spacing should now be more reasonable, and the input should still get focus on open:

<img width="544" height="250" alt="CleanShot 2026-05-06 at 09 50 09" src="https://github.com/user-attachments/assets/48b856a7-3611-4c6d-ac38-af1a4b2f9a11" />

5. Bonus: test on a site still running WP 6.9.4 and confirm all still looks well.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->