### PR TITLE
fix(subscriptions): allow migrated subs to resubscribe

### DIFF
--- a/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
+++ b/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
@@ -22,6 +22,7 @@ class WooCommerce_Subscriptions {
 		add_filter( 'woocommerce_subscriptions_product_trial_length', [ __CLASS__, 'limit_free_trials_to_one_per_user' ], 10, 2 );
 		add_filter( 'wcs_get_users_subscriptions', [ __CLASS__, 'filter_subscriptions_for_account_page' ], 10, 1 );
 		add_filter( 'woocommerce_subscriptions_can_item_be_switched', [ __CLASS__, 'allow_migrated_subscription_switch' ], 10, 3 );
+		add_filter( 'wcs_can_user_resubscribe_to', [ __CLASS__, 'allow_migrated_subscription_to_resubscribe' ], 10, 3 );
 	}
 
 	/**
@@ -343,6 +344,48 @@ class WooCommerce_Subscriptions {
 			}
 		}
 		return $product_id;
+	}
+
+	/**
+	 * Allow migrated subscription to resubscribe.
+	 *
+	 * The original function only allows resubscriptions if there are payments
+	 * associated with the subscription to avoid circumventing the sign-up fees.
+	 * This filter allows resubscriptions for migrated subscriptions, which don't
+	 * have any payments associated with them.
+	 *
+	 * @param bool             $can_resubscribe Whether the user can resubscribe to the subscription.
+	 * @param \WC_Subscription $subscription    The subscription.
+	 * @param int              $user_id         The user ID.
+	 *
+	 * @return bool Whether the user can resubscribe to the subscription.
+	 */
+	public static function allow_migrated_subscription_to_resubscribe( $can_resubscribe, $subscription, $user_id ) {
+		if ( $can_resubscribe ) {
+			return $can_resubscribe;
+		}
+
+		/**
+		 * Replicate the original checks.
+		 */
+		if (
+			empty( $subscription ) ||
+			! user_can( $user_id, 'subscribe_again', $subscription->get_id() ) ||
+			! $subscription->has_status( array( 'pending-cancel', 'cancelled', 'expired', 'trash' ) ) ||
+			$subscription->get_total() <= 0 ||
+			$subscription->contains_unavailable_product()
+		) {
+			return false;
+		}
+
+		$migrated_meta = [ '_piano_subscription_id', '_stripe_subscription_id' ];
+		foreach ( $migrated_meta as $meta ) {
+			if ( $subscription->get_meta( $meta ) ) {
+				$can_resubscribe = true;
+				break;
+			}
+		}
+		return $can_resubscribe;
 	}
 }
 WooCommerce_Subscriptions::init();

--- a/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
+++ b/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
@@ -371,7 +371,7 @@ class WooCommerce_Subscriptions {
 		if (
 			empty( $subscription ) ||
 			! user_can( $user_id, 'subscribe_again', $subscription->get_id() ) || // phpcs:ignore WordPress.WP.Capabilities.Unknown
-			! $subscription->has_status( array( 'pending-cancel', 'cancelled', 'expired', 'trash' ) ) ||
+			! $subscription->has_status( [ 'pending-cancel', 'cancelled', 'expired', 'trash' ] ) ||
 			$subscription->get_total() <= 0 ||
 			$subscription->contains_unavailable_product()
 		) {

--- a/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
+++ b/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
@@ -370,7 +370,7 @@ class WooCommerce_Subscriptions {
 		 */
 		if (
 			empty( $subscription ) ||
-			! user_can( $user_id, 'subscribe_again', $subscription->get_id() ) ||
+			! user_can( $user_id, 'subscribe_again', $subscription->get_id() ) || // phpcs:ignore WordPress.WP.Capabilities.Unknown
 			! $subscription->has_status( array( 'pending-cancel', 'cancelled', 'expired', 'trash' ) ) ||
 			$subscription->get_total() <= 0 ||
 			$subscription->contains_unavailable_product()

--- a/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
+++ b/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
@@ -22,7 +22,7 @@ class WooCommerce_Subscriptions {
 		add_filter( 'woocommerce_subscriptions_product_trial_length', [ __CLASS__, 'limit_free_trials_to_one_per_user' ], 10, 2 );
 		add_filter( 'wcs_get_users_subscriptions', [ __CLASS__, 'filter_subscriptions_for_account_page' ], 10, 1 );
 		add_filter( 'woocommerce_subscriptions_can_item_be_switched', [ __CLASS__, 'allow_migrated_subscription_switch' ], 10, 3 );
-		add_filter( 'wcs_can_user_resubscribe_to', [ __CLASS__, 'allow_migrated_subscription_to_resubscribe' ], 10, 3 );
+		add_filter( 'wcs_can_user_resubscribe_to_subscription', [ __CLASS__, 'allow_migrated_subscription_to_resubscribe' ], 10, 3 );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Migrated subscriptions do not have previous payments on record, which prevents resubscription. That restriction is applied on the Woo Subscriptions side to prevent circumventing sign-up fees.

We need to filter into `wcs_can_user_resubscribe_to` in order to allow resubscription of migrated subs.

### How to test the changes in this Pull Request:

1. In a fresh session, purchase a subscription with a new reader account
2. In the admin, edit the subscription and change its status to expired
3. Back as the reader, visit the subscription page in "My Account" and confirm there's no regression, and you can resubscribe without issues
4. Now, as an admin, create a subscription manually, assigning it to the reader and to a subscription product
5. Change the manually created subscription status to "expired."
6. As the reader, confirm you are not able to resubscribe (there are no previous payments)
7. Now, via shell, add a stripe subscription ID meta to simulate a migration:

```php
$sub = wcs_get_subscription( {sub_id} );
$sub->add_meta_data( '_stripe_subscription_id', 1234 );
$sub->save();
```

8. Refresh the subscription page in My Account and confirm you are now able to resubscribe

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->