### PR TITLE
feat(admin): admin UX modernisation — settings rebuild + shared scaffolding (NEWS-2152, NEWS-2168, NEWS-2263)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ Thumbs.db
 /vendor/
 
 # Built files
+/build
 /dist
 /packages/components/colors
 /packages/components/dist

--- a/src/wizards/newsletters/views/settings/index.js
+++ b/src/wizards/newsletters/views/settings/index.js
@@ -34,12 +34,11 @@ const NN_EVENTS = {
 };
 const NN_FALLBACK_TIMEOUT_MS = 500;
 
-let bridgeMounted = false;
-if ( typeof document !== 'undefined' ) {
-	document.addEventListener( NN_EVENTS.BRIDGE_MOUNTED, () => {
-		bridgeMounted = true;
-	} );
-}
+// Read the bridge-readiness flag synchronously rather than relying on a
+// one-shot `BRIDGE_MOUNTED` event. The bridge sets the flag before
+// dispatching, so listeners that register late still observe a ready
+// bridge — avoiding a spurious fallback redirect.
+const isBridgeReady = () => typeof window !== 'undefined' && window.newspackNewslettersBridgeReady === true;
 
 /**
  * Internal dependencies
@@ -332,12 +331,12 @@ export const SubscriptionLists = ( { lockedLists, onUpdate, provider } ) => {
 	}, [] );
 
 	const startFallbackTimer = fallbackUrl => {
-		if ( bridgeMounted || ! fallbackUrl ) {
+		if ( isBridgeReady() || ! fallbackUrl ) {
 			return;
 		}
 		clearTimeout( fallbackTimerRef.current );
 		fallbackTimerRef.current = setTimeout( () => {
-			if ( ! bridgeMounted ) {
+			if ( ! isBridgeReady() ) {
 				window.location.href = fallbackUrl;
 			}
 		}, NN_FALLBACK_TIMEOUT_MS );

--- a/src/wizards/newsletters/views/settings/index.js
+++ b/src/wizards/newsletters/views/settings/index.js
@@ -16,7 +16,6 @@ import apiFetch from '@wordpress/api-fetch';
 import { sprintf, __ } from '@wordpress/i18n';
 import {
 	CheckboxControl,
-	TextareaControl,
 	ExternalLink,
 	Notice,
 	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
@@ -275,6 +274,7 @@ export const Settings = ( {
 export const SubscriptionLists = ( { lockedLists, onUpdate, provider } ) => {
 	const [ error, setError ] = useState( false );
 	const [ inFlight, setInFlight ] = useState( false );
+	const [ togglingId, setTogglingId ] = useState( null );
 	const [ lists, setLists ] = useState( [] );
 	const fallbackTimerRef = useRef( null );
 
@@ -294,22 +294,27 @@ export const SubscriptionLists = ( { lockedLists, onUpdate, provider } ) => {
 			.catch( setError )
 			.finally( () => setInFlight( false ) );
 	};
-	const saveLists = () => {
+	const handleToggleActive = async ( list, next ) => {
+		if ( ! list?.db_id ) {
+			return;
+		}
+		const snapshot = lists;
+		updateConfig( lists.map( row => ( row.db_id === list.db_id ? { ...row, active: next } : row ) ) );
+		setTogglingId( list.db_id );
 		setError( false );
-		setInFlight( true );
-		apiFetch( {
-			path: '/newspack-newsletters/v1/lists',
-			method: 'post',
-			data: { lists },
-		} )
-			.then( updateConfig )
-			.catch( setError )
-			.finally( () => setInFlight( false ) );
-	};
-	const handleChange = ( index, name ) => value => {
-		const newLists = [ ...lists ];
-		newLists[ index ][ name ] = value;
-		updateConfig( newLists );
+		try {
+			const response = await apiFetch( {
+				path: `/newspack-newsletters/v1/lists/${ list.db_id }`,
+				method: 'PATCH',
+				data: { active: next },
+			} );
+			updateConfig( lists.map( row => ( row.db_id === list.db_id ? { ...row, ...response } : row ) ) );
+		} catch ( err ) {
+			updateConfig( snapshot );
+			setError( err );
+		} finally {
+			setTogglingId( null );
+		}
 	};
 
 	useEffect( () => {
@@ -346,8 +351,8 @@ export const SubscriptionLists = ( { lockedLists, onUpdate, provider } ) => {
 		document.dispatchEvent( new CustomEvent( NN_EVENTS.OPEN_MODAL, { detail: { mode: 'add' } } ) );
 		startFallbackTimer( newspack_newsletters_wizard.new_subscription_lists_url );
 	};
-	const dispatchOpenEdit = list => {
-		document.dispatchEvent( new CustomEvent( NN_EVENTS.OPEN_MODAL, { detail: { mode: 'edit', list } } ) );
+	const dispatchOpenEdit = ( list, kind ) => {
+		document.dispatchEvent( new CustomEvent( NN_EVENTS.OPEN_MODAL, { detail: { mode: 'edit', kind, list } } ) );
 		startFallbackTimer( list?.edit_link );
 	};
 	const dispatchConfirmDelete = list => {
@@ -382,16 +387,11 @@ export const SubscriptionLists = ( { lockedLists, onUpdate, provider } ) => {
 			notificationLevel={ error ? 'error' : 'warning' }
 			hasGreyHeader
 			actionContent={
-				<>
-					{ newspack_newsletters_wizard.new_subscription_lists_url && (
-						<Button variant="secondary" disabled={ inFlight || lockedLists } onClick={ dispatchOpenAdd }>
-							{ __( 'Add New', 'newspack-plugin' ) }
-						</Button>
-					) }
-					<Button isPrimary onClick={ saveLists } disabled={ inFlight || lockedLists }>
-						{ __( 'Save Subscription Lists', 'newspack-plugin' ) }
+				newspack_newsletters_wizard.new_subscription_lists_url && (
+					<Button variant="secondary" disabled={ inFlight || lockedLists } onClick={ dispatchOpenAdd }>
+						{ __( 'Add New', 'newspack-plugin' ) }
 					</Button>
-				</>
+				)
 			}
 			disabled={ inFlight || lockedLists }
 		>
@@ -399,6 +399,7 @@ export const SubscriptionLists = ( { lockedLists, onUpdate, provider } ) => {
 				! error &&
 				lists.map( ( list, index ) => {
 					const isLocal = 'local' === list?.type;
+					const rowDisabled = inFlight || togglingId === list?.db_id;
 					return (
 						<ActionCard
 							key={ index }
@@ -406,9 +407,17 @@ export const SubscriptionLists = ( { lockedLists, onUpdate, provider } ) => {
 							simple
 							hasWhiteHeader
 							title={ list.name }
-							description={ list?.type_label ? list.type_label : null }
-							disabled={ inFlight }
-							toggleOnChange={ handleChange( index, 'active' ) }
+							description={ () => (
+								<>
+									{ list.description }
+									{ list.description && list?.type_label && <br /> }
+									{ list?.type_label && (
+										<small className="newspack-newsletters-sub-list-item__type-label">{ list.type_label }</small>
+									) }
+								</>
+							) }
+							disabled={ rowDisabled }
+							toggleOnChange={ next => handleToggleActive( list, next ) }
 							toggleChecked={ list.active }
 							className={
 								list?.id && ( list.id.startsWith( 'group' ) || list.id.startsWith( 'tag' ) )
@@ -416,37 +425,22 @@ export const SubscriptionLists = ( { lockedLists, onUpdate, provider } ) => {
 									: ''
 							}
 							actionText={
-								isLocal ? (
-									<HStack spacing={ 2 } justify="flex-end" expanded={ false }>
-										<Button variant="link" onClick={ () => dispatchOpenEdit( list ) } disabled={ inFlight }>
-											{ __( 'Edit', 'newspack-plugin' ) }
-										</Button>
-										<Button variant="link" isDestructive onClick={ () => dispatchConfirmDelete( list ) } disabled={ inFlight }>
+								<HStack spacing={ 2 } justify="flex-end" expanded={ false }>
+									<Button
+										variant="link"
+										onClick={ () => dispatchOpenEdit( list, isLocal ? 'local' : 'esp' ) }
+										disabled={ rowDisabled }
+									>
+										{ __( 'Edit', 'newspack-plugin' ) }
+									</Button>
+									{ isLocal && (
+										<Button variant="link" isDestructive onClick={ () => dispatchConfirmDelete( list ) } disabled={ rowDisabled }>
 											{ __( 'Delete', 'newspack-plugin' ) }
 										</Button>
-									</HStack>
-								) : list?.edit_link ? (
-									<ExternalLink href={ list.edit_link }>{ __( 'Edit', 'newspack-plugin' ) }</ExternalLink>
-								) : null
+									) }
+								</HStack>
 							}
-						>
-							{ list.active && ! isLocal && (
-								<>
-									<TextControl
-										label={ __( 'List title', 'newspack-plugin' ) }
-										value={ list.title }
-										disabled={ inFlight || isLocal }
-										onChange={ handleChange( index, 'title' ) }
-									/>
-									<TextareaControl
-										label={ __( 'List description', 'newspack-plugin' ) }
-										value={ list.description }
-										disabled={ inFlight || isLocal }
-										onChange={ handleChange( index, 'description' ) }
-									/>
-								</>
-							) }
-						</ActionCard>
+						/>
 					);
 				} ) }
 		</ActionCard>

--- a/src/wizards/newsletters/views/settings/index.js
+++ b/src/wizards/newsletters/views/settings/index.js
@@ -11,10 +11,35 @@ import once from 'lodash/once';
 /**
  * WordPress dependencies
  */
-import { useEffect, useState, Fragment } from '@wordpress/element';
+import { useEffect, useRef, useState, Fragment } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 import { sprintf, __ } from '@wordpress/i18n';
-import { CheckboxControl, TextareaControl, ExternalLink, Notice } from '@wordpress/components';
+import {
+	CheckboxControl,
+	TextareaControl,
+	ExternalLink,
+	Notice,
+	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+} from '@wordpress/components';
+
+// Wizard-bridge events. Mirror of `newspack-newsletters/src/wizard-bridge/events.js`
+// — kept locally so this file is self-contained without a cross-repo import.
+const NN_EVENT_NAMESPACE = 'newspack-newsletters';
+const NN_EVENTS = {
+	BRIDGE_MOUNTED: `${ NN_EVENT_NAMESPACE }:bridge-mounted`,
+	OPEN_MODAL: `${ NN_EVENT_NAMESPACE }:open-local-list-modal`,
+	OPEN_CONFIRM_DELETE: `${ NN_EVENT_NAMESPACE }:open-local-list-confirm-delete`,
+	LOCAL_LIST_SAVED: `${ NN_EVENT_NAMESPACE }:local-list-saved`,
+	LOCAL_LIST_DELETED: `${ NN_EVENT_NAMESPACE }:local-list-deleted`,
+};
+const NN_FALLBACK_TIMEOUT_MS = 500;
+
+let bridgeMounted = false;
+if ( typeof document !== 'undefined' ) {
+	document.addEventListener( NN_EVENTS.BRIDGE_MOUNTED, () => {
+		bridgeMounted = true;
+	} );
+}
 
 /**
  * Internal dependencies
@@ -252,6 +277,8 @@ export const SubscriptionLists = ( { lockedLists, onUpdate, provider } ) => {
 	const [ error, setError ] = useState( false );
 	const [ inFlight, setInFlight ] = useState( false );
 	const [ lists, setLists ] = useState( [] );
+	const fallbackTimerRef = useRef( null );
+
 	const updateConfig = data => {
 		setLists( data );
 		if ( typeof onUpdate === 'function' ) {
@@ -285,20 +312,53 @@ export const SubscriptionLists = ( { lockedLists, onUpdate, provider } ) => {
 		newLists[ index ][ name ] = value;
 		updateConfig( newLists );
 	};
-	// Handle provider updates.
+
 	useEffect( () => {
 		setError( false );
 		if ( provider && ! lockedLists ) {
-			// Empty lists before fetching to prevent previous list from appearing while fetching.
 			setLists( [] );
 			fetchLists();
 		}
 	}, [ provider, lockedLists ] );
 
+	useEffect( () => {
+		const reload = () => fetchLists();
+		document.addEventListener( NN_EVENTS.LOCAL_LIST_SAVED, reload );
+		document.addEventListener( NN_EVENTS.LOCAL_LIST_DELETED, reload );
+		return () => {
+			document.removeEventListener( NN_EVENTS.LOCAL_LIST_SAVED, reload );
+			document.removeEventListener( NN_EVENTS.LOCAL_LIST_DELETED, reload );
+		};
+	}, [] );
+
+	const startFallbackTimer = fallbackUrl => {
+		if ( bridgeMounted || ! fallbackUrl ) {
+			return;
+		}
+		clearTimeout( fallbackTimerRef.current );
+		fallbackTimerRef.current = setTimeout( () => {
+			if ( ! bridgeMounted ) {
+				window.location.href = fallbackUrl;
+			}
+		}, NN_FALLBACK_TIMEOUT_MS );
+	};
+
+	const dispatchOpenAdd = () => {
+		document.dispatchEvent( new CustomEvent( NN_EVENTS.OPEN_MODAL, { detail: { mode: 'add' } } ) );
+		startFallbackTimer( newspack_newsletters_wizard.new_subscription_lists_url );
+	};
+	const dispatchOpenEdit = list => {
+		document.dispatchEvent( new CustomEvent( NN_EVENTS.OPEN_MODAL, { detail: { mode: 'edit', list } } ) );
+		startFallbackTimer( list?.edit_link );
+	};
+	const dispatchConfirmDelete = list => {
+		document.dispatchEvent( new CustomEvent( NN_EVENTS.OPEN_CONFIRM_DELETE, { detail: { list } } ) );
+		startFallbackTimer( list?.edit_link );
+	};
+
 	if ( ! inFlight && ! lists?.length && ! error ) {
 		return null;
 	}
-
 	if ( inFlight && ! lists?.length && ! error ) {
 		return (
 			<div className="flex justify-around mt4">
@@ -325,11 +385,7 @@ export const SubscriptionLists = ( { lockedLists, onUpdate, provider } ) => {
 			actionContent={
 				<>
 					{ newspack_newsletters_wizard.new_subscription_lists_url && (
-						<Button
-							variant="secondary"
-							disabled={ inFlight || lockedLists }
-							href={ newspack_newsletters_wizard.new_subscription_lists_url }
-						>
+						<Button variant="secondary" disabled={ inFlight || lockedLists } onClick={ dispatchOpenAdd }>
 							{ __( 'Add New', 'newspack-plugin' ) }
 						</Button>
 					) }
@@ -342,42 +398,58 @@ export const SubscriptionLists = ( { lockedLists, onUpdate, provider } ) => {
 		>
 			{ ! lockedLists &&
 				! error &&
-				lists.map( ( list, index ) => (
-					<ActionCard
-						key={ index }
-						isSmall
-						simple
-						hasWhiteHeader
-						title={ list.name }
-						description={ list?.type_label ? list.type_label : null }
-						disabled={ inFlight }
-						toggleOnChange={ handleChange( index, 'active' ) }
-						toggleChecked={ list.active }
-						className={
-							list?.id && ( list.id.startsWith( 'group' ) || list.id.startsWith( 'tag' ) ) ? 'newspack-newsletters-sub-list-item' : ''
-						}
-						actionText={
-							list?.edit_link ? <ExternalLink href={ list.edit_link }>{ __( 'Edit', 'newspack-plugin' ) }</ExternalLink> : null
-						}
-					>
-						{ list.active && 'local' !== list?.type && (
-							<>
-								<TextControl
-									label={ __( 'List title', 'newspack-plugin' ) }
-									value={ list.title }
-									disabled={ inFlight || 'local' === list?.type }
-									onChange={ handleChange( index, 'title' ) }
-								/>
-								<TextareaControl
-									label={ __( 'List description', 'newspack-plugin' ) }
-									value={ list.description }
-									disabled={ inFlight || 'local' === list?.type }
-									onChange={ handleChange( index, 'description' ) }
-								/>
-							</>
-						) }
-					</ActionCard>
-				) ) }
+				lists.map( ( list, index ) => {
+					const isLocal = 'local' === list?.type;
+					return (
+						<ActionCard
+							key={ index }
+							isSmall
+							simple
+							hasWhiteHeader
+							title={ list.name }
+							description={ list?.type_label ? list.type_label : null }
+							disabled={ inFlight }
+							toggleOnChange={ handleChange( index, 'active' ) }
+							toggleChecked={ list.active }
+							className={
+								list?.id && ( list.id.startsWith( 'group' ) || list.id.startsWith( 'tag' ) )
+									? 'newspack-newsletters-sub-list-item'
+									: ''
+							}
+							actionText={
+								isLocal ? (
+									<HStack spacing={ 2 } justify="flex-end" expanded={ false }>
+										<Button variant="link" onClick={ () => dispatchOpenEdit( list ) } disabled={ inFlight }>
+											{ __( 'Edit', 'newspack-plugin' ) }
+										</Button>
+										<Button variant="link" isDestructive onClick={ () => dispatchConfirmDelete( list ) } disabled={ inFlight }>
+											{ __( 'Delete', 'newspack-plugin' ) }
+										</Button>
+									</HStack>
+								) : list?.edit_link ? (
+									<ExternalLink href={ list.edit_link }>{ __( 'Edit', 'newspack-plugin' ) }</ExternalLink>
+								) : null
+							}
+						>
+							{ list.active && ! isLocal && (
+								<>
+									<TextControl
+										label={ __( 'List title', 'newspack-plugin' ) }
+										value={ list.title }
+										disabled={ inFlight || isLocal }
+										onChange={ handleChange( index, 'title' ) }
+									/>
+									<TextareaControl
+										label={ __( 'List description', 'newspack-plugin' ) }
+										value={ list.description }
+										disabled={ inFlight || isLocal }
+										onChange={ handleChange( index, 'description' ) }
+									/>
+								</>
+							) }
+						</ActionCard>
+					);
+				} ) }
 		</ActionCard>
 	);
 };

--- a/src/wizards/newsletters/views/settings/index.test.js
+++ b/src/wizards/newsletters/views/settings/index.test.js
@@ -1,0 +1,79 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+
+import { SubscriptionLists } from './index';
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+
+const NN_EVENTS = {
+	BRIDGE_MOUNTED: 'newspack-newsletters:bridge-mounted',
+	OPEN_MODAL: 'newspack-newsletters:open-local-list-modal',
+	OPEN_CONFIRM_DELETE: 'newspack-newsletters:open-local-list-confirm-delete',
+	LOCAL_LIST_SAVED: 'newspack-newsletters:local-list-saved',
+	LOCAL_LIST_DELETED: 'newspack-newsletters:local-list-deleted',
+};
+
+beforeAll( () => {
+	global.newspack_newsletters_wizard = {
+		new_subscription_lists_url: 'https://example.test/wp-admin/post-new.php?post_type=newspack_nl_list',
+	};
+} );
+
+beforeEach( () => {
+	apiFetch.mockReset();
+	apiFetch.mockResolvedValue( [
+		{ id: 'tag-1', name: 'Local A', type: 'local', active: false, db_id: 1, edit_link: 'https://example.test/edit-local-a' },
+		{ id: 'group-1', name: 'Remote group', type: 'group', active: true },
+	] );
+	// Pretend the bridge bundle is loaded so the fallback timer doesn't navigate the test window.
+	document.dispatchEvent( new CustomEvent( NN_EVENTS.BRIDGE_MOUNTED ) );
+} );
+
+describe( 'SubscriptionLists — wizard-bridge wiring', () => {
+	it( 'dispatches OPEN_MODAL with mode=add when Add New is clicked', async () => {
+		const listener = jest.fn();
+		document.addEventListener( NN_EVENTS.OPEN_MODAL, listener );
+		render( <SubscriptionLists lockedLists={ false } provider="mailchimp" /> );
+		await waitFor( () => expect( screen.getByRole( 'button', { name: /^Add New$/ } ) ).toBeEnabled() );
+		fireEvent.click( screen.getByRole( 'button', { name: /^Add New$/ } ) );
+		expect( listener ).toHaveBeenCalled();
+		expect( listener.mock.calls[ 0 ][ 0 ].detail ).toEqual( { mode: 'add' } );
+		document.removeEventListener( NN_EVENTS.OPEN_MODAL, listener );
+	} );
+
+	it( 'dispatches OPEN_MODAL with mode=edit + list when Edit is clicked on a local row', async () => {
+		const listener = jest.fn();
+		document.addEventListener( NN_EVENTS.OPEN_MODAL, listener );
+		render( <SubscriptionLists lockedLists={ false } provider="mailchimp" /> );
+		await waitFor( () => expect( screen.getByText( 'Local A' ) ).toBeInTheDocument() );
+		fireEvent.click( screen.getAllByRole( 'button', { name: /^Edit$/ } )[ 0 ] );
+		expect( listener.mock.calls[ 0 ][ 0 ].detail ).toEqual(
+			expect.objectContaining( { mode: 'edit', list: expect.objectContaining( { db_id: 1 } ) } )
+		);
+		document.removeEventListener( NN_EVENTS.OPEN_MODAL, listener );
+	} );
+
+	it( 'dispatches OPEN_CONFIRM_DELETE when Delete is clicked on a local row', async () => {
+		const listener = jest.fn();
+		document.addEventListener( NN_EVENTS.OPEN_CONFIRM_DELETE, listener );
+		render( <SubscriptionLists lockedLists={ false } provider="mailchimp" /> );
+		await waitFor( () => expect( screen.getByText( 'Local A' ) ).toBeInTheDocument() );
+		fireEvent.click( screen.getByRole( 'button', { name: /^Delete$/ } ) );
+		expect( listener.mock.calls[ 0 ][ 0 ].detail ).toEqual( expect.objectContaining( { list: expect.objectContaining( { db_id: 1 } ) } ) );
+		document.removeEventListener( NN_EVENTS.OPEN_CONFIRM_DELETE, listener );
+	} );
+
+	it( 'reloads lists when LOCAL_LIST_SAVED fires', async () => {
+		render( <SubscriptionLists lockedLists={ false } provider="mailchimp" /> );
+		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 1 ) );
+		document.dispatchEvent( new CustomEvent( NN_EVENTS.LOCAL_LIST_SAVED, { detail: { listId: 1, mode: 'edit' } } ) );
+		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 2 ) );
+	} );
+
+	it( 'reloads lists when LOCAL_LIST_DELETED fires', async () => {
+		render( <SubscriptionLists lockedLists={ false } provider="mailchimp" /> );
+		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 1 ) );
+		document.dispatchEvent( new CustomEvent( NN_EVENTS.LOCAL_LIST_DELETED, { detail: { listId: 1 } } ) );
+		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 2 ) );
+	} );
+} );

--- a/src/wizards/newsletters/views/settings/index.test.js
+++ b/src/wizards/newsletters/views/settings/index.test.js
@@ -23,7 +23,7 @@ beforeEach( () => {
 	apiFetch.mockReset();
 	apiFetch.mockResolvedValue( [
 		{ id: 'tag-1', name: 'Local A', type: 'local', active: false, db_id: 1, edit_link: 'https://example.test/edit-local-a' },
-		{ id: 'group-1', name: 'Remote group', type: 'group', active: true },
+		{ id: 'group-1', name: 'Remote group', type: 'group', active: true, db_id: 2, edit_link: 'https://example.test/edit-remote' },
 	] );
 	// Mark the bridge ready so the fallback timer doesn't navigate the test window.
 	window.newspackNewslettersBridgeReady = true;
@@ -45,16 +45,57 @@ describe( 'SubscriptionLists — wizard-bridge wiring', () => {
 		document.removeEventListener( NN_EVENTS.OPEN_MODAL, listener );
 	} );
 
-	it( 'dispatches OPEN_MODAL with mode=edit + list when Edit is clicked on a local row', async () => {
+	it( 'dispatches OPEN_MODAL with mode=edit + kind=local when Edit is clicked on a local row', async () => {
 		const listener = jest.fn();
 		document.addEventListener( NN_EVENTS.OPEN_MODAL, listener );
 		render( <SubscriptionLists lockedLists={ false } provider="mailchimp" /> );
 		await waitFor( () => expect( screen.getByText( 'Local A' ) ).toBeInTheDocument() );
 		fireEvent.click( screen.getAllByRole( 'button', { name: /^Edit$/ } )[ 0 ] );
 		expect( listener.mock.calls[ 0 ][ 0 ].detail ).toEqual(
-			expect.objectContaining( { mode: 'edit', list: expect.objectContaining( { db_id: 1 } ) } )
+			expect.objectContaining( { mode: 'edit', kind: 'local', list: expect.objectContaining( { db_id: 1 } ) } )
 		);
 		document.removeEventListener( NN_EVENTS.OPEN_MODAL, listener );
+	} );
+
+	it( 'dispatches OPEN_MODAL with mode=edit + kind=esp when Edit is clicked on a remote row', async () => {
+		const listener = jest.fn();
+		document.addEventListener( NN_EVENTS.OPEN_MODAL, listener );
+		render( <SubscriptionLists lockedLists={ false } provider="mailchimp" /> );
+		await waitFor( () => expect( screen.getByText( 'Remote group' ) ).toBeInTheDocument() );
+		// Remote rows now have an Edit button too — second one in the list.
+		fireEvent.click( screen.getAllByRole( 'button', { name: /^Edit$/ } )[ 1 ] );
+		expect( listener.mock.calls[ 0 ][ 0 ].detail ).toEqual(
+			expect.objectContaining( { mode: 'edit', kind: 'esp', list: expect.objectContaining( { db_id: 2 } ) } )
+		);
+		document.removeEventListener( NN_EVENTS.OPEN_MODAL, listener );
+	} );
+
+	it( 'commits the active toggle immediately via PATCH /lists/{db_id}', async () => {
+		render( <SubscriptionLists lockedLists={ false } provider="mailchimp" /> );
+		await waitFor( () => expect( screen.getByText( 'Local A' ) ).toBeInTheDocument() );
+		// Configure the next response (a successful PATCH echoing the row).
+		apiFetch.mockResolvedValueOnce( { id: 'tag-1', db_id: 1, active: true } );
+		fireEvent.click( screen.getAllByRole( 'checkbox' )[ 0 ] );
+		await waitFor( () =>
+			expect( apiFetch ).toHaveBeenLastCalledWith( {
+				path: '/newspack-newsletters/v1/lists/1',
+				method: 'PATCH',
+				data: { active: true },
+			} )
+		);
+	} );
+
+	it( 'does not render the bulk Save Subscription Lists button', async () => {
+		render( <SubscriptionLists lockedLists={ false } provider="mailchimp" /> );
+		await waitFor( () => expect( screen.getByText( 'Local A' ) ).toBeInTheDocument() );
+		expect( screen.queryByRole( 'button', { name: /Save Subscription Lists/ } ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'does not render inline title/description fields on remote rows', async () => {
+		render( <SubscriptionLists lockedLists={ false } provider="mailchimp" /> );
+		await waitFor( () => expect( screen.getByText( 'Remote group' ) ).toBeInTheDocument() );
+		expect( screen.queryByLabelText( /List title/ ) ).not.toBeInTheDocument();
+		expect( screen.queryByLabelText( /List description/ ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'dispatches OPEN_CONFIRM_DELETE when Delete is clicked on a local row', async () => {

--- a/src/wizards/newsletters/views/settings/index.test.js
+++ b/src/wizards/newsletters/views/settings/index.test.js
@@ -25,8 +25,12 @@ beforeEach( () => {
 		{ id: 'tag-1', name: 'Local A', type: 'local', active: false, db_id: 1, edit_link: 'https://example.test/edit-local-a' },
 		{ id: 'group-1', name: 'Remote group', type: 'group', active: true },
 	] );
-	// Pretend the bridge bundle is loaded so the fallback timer doesn't navigate the test window.
-	document.dispatchEvent( new CustomEvent( NN_EVENTS.BRIDGE_MOUNTED ) );
+	// Mark the bridge ready so the fallback timer doesn't navigate the test window.
+	window.newspackNewslettersBridgeReady = true;
+} );
+
+afterEach( () => {
+	delete window.newspackNewslettersBridgeReady;
 } );
 
 describe( 'SubscriptionLists — wizard-bridge wiring', () => {
@@ -75,5 +79,19 @@ describe( 'SubscriptionLists — wizard-bridge wiring', () => {
 		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 1 ) );
 		document.dispatchEvent( new CustomEvent( NN_EVENTS.LOCAL_LIST_DELETED, { detail: { listId: 1 } } ) );
 		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 2 ) );
+	} );
+
+	it( 'does not redirect when the bridge mounted before the wizard listener registered', async () => {
+		// The flag is already set in beforeEach, simulating the bridge having
+		// completed boot before this component mounted. The fallback timer
+		// must NOT navigate.
+		jest.useFakeTimers();
+		const originalHref = window.location.href;
+		render( <SubscriptionLists lockedLists={ false } provider="mailchimp" /> );
+		await waitFor( () => expect( screen.getByRole( 'button', { name: /^Add New$/ } ) ).toBeEnabled() );
+		fireEvent.click( screen.getByRole( 'button', { name: /^Add New$/ } ) );
+		jest.advanceTimersByTime( 600 );
+		expect( window.location.href ).toBe( originalHref );
+		jest.useRealTimers();
 	} );
 } );


### PR DESCRIPTION
Companion to https://github.com/Automattic/newspack-newsletters/pull/2108 (NEWS-2152) and https://github.com/Automattic/newspack-newsletters/pull/2110 (NEWS-2168).

Started as the wizard-bridge wiring for `<SubscriptionLists>` (NEWS-2152 / NEWS-2168) and grew to absorb the broader Newsletters Settings page rebuild and the shared scaffolding it needed (NEWS-2263 / admin UX modernisation milestone). Branch renamed from `news-2152-bundled-mode-modal-parity` to `news-admin-ux-modernisation` to reflect the broader scope.

## NEWS-2152 / NEWS-2168 — Subscription-list bridge + ESP-edit parity

- `<SubscriptionLists>` per-row Edit / Delete buttons dispatch `wizard-bridge` events instead of opening legacy URLs; reloads on save / delete.
- Edit on remote rows goes through the bridge with `kind: 'esp'` (no audience picker, title + description only).
- Active toggle commits per-row via `PATCH /lists/{db_id}`; bulk Save button retired.
- 500 ms fallback timer routes to the legacy CPT editor when the bridge bundle is missing.

## NEWS-2263 — Newsletters Settings page rebuild

Single-section wizard (`fixedHeader`, dirty tracking, unsaved-changes guard) with sections, top-to-bottom:

- **Email service provider** — 2x2 brand-icon card grid (Active Campaign, Mailchimp, Constant Contact, Manual / Other). Selecting a card sets the provider and reveals its credentials below the grid. OAuth Authorize prompt inlines for Constant Contact.
- **Newsletter posts** — slug, comments, related-posts as `ToggleControl`s.
- **Subscription lists** — per-row `ToggleControl` with Local / ESP badge, list description as help text, divider between rows, Edit / Delete on the right (Delete only for local lists). Below the list, a paragraph + secondary "Add new local list" button explain provider-specific syncing (label resolved per-ESP via the wizard's settings response).
- **Ads tracking** — merged in from the previous separate tab; `ToggleControl`s for click + impressions. Tracking tab removed from the ads-list admin header since the section now lives in Settings.
- **Letterhead** — separate section at the bottom for the Letterhead API key + help link.

PHP: wizard `/settings` response now includes the active provider's labels (`get_labels('local_list_explanation')`), guarded with `class_exists` for standalone-newspack-plugin installs.

## Shared scaffolding (packages/components)

- **`integration-icons`** namespace with 6 brand SVGs (Active Campaign, Constant Contact, Fundraise Up, Mailchimp, Salesforce, Wisepops); fills customisable via `var(--integration-icon-color)` / `--integration-icon-color-accent` with brand-colour defaults.
- **`useUnsavedChangesDialog`** hook — wraps `useConfirmDialog` with the standard "discard changes" messaging, intercepts outbound link clicks so the custom dialog fires instead of the silent native one, plus a `beforeunload` safety net.
- **`CardSettingsGroup`** gains optional `className` and `iconSize` props.
- **`CoreCard`** accepts `iconSize`; SCSS reads it via the new `--newspack-card-icon-size` custom property with fallback to existing defaults (no consumer changes required).
- **`SectionHeader`** — container margin now zeroes alongside its inner element when `noMargin` is set (via `:has()` so callsites need no change).
- **`admin.css`** — chrome section header only gets `margin-top` when it's not the first child of `newspack-wizard__content`, fixing the doubled spacing on audience `/edit/new/all`.
- **Audience content-gates edit** adopts `useUnsavedChangesDialog` so the same standardised confirm flow covers both wizards.

## Test plan

- [ ] Run paired `newspack-newsletters` branches (NEWS-2152 already merged into the epic; NEWS-2168 on `news-2168-revisit-esp-subscription-list-edit-flow-standalone`).
- [ ] Smoke-test Add / Edit / Delete on a Mailchimp + Constant Contact dev site for both local and remote rows.
- [ ] Verify the bottom Save Subscription Lists button is gone and the active toggle on a remote row persists across reloads.
- [ ] Disable `newspack-newsletters` bundle JS to confirm the fallback timer redirects to the legacy URL on Edit.
- [ ] Newsletters Settings: pick each ESP card, verify its credential fields appear; toggle settings; click Save; confirm the unsaved-changes guard fires on navigation away with a dirty form.
- [ ] Audience access control `/edit/new/all`: confirm the chrome section header sits flush with the wizard content padding (no doubled top margin) and the discard-changes dialog still fires via the shared hook.

## Merge order

Merge the `newspack-newsletters` branches first; this PR follows.