### PR TITLE
fix(donations): add reset method for flagged products cache

### DIFF
--- a/includes/class-donations.php
+++ b/includes/class-donations.php
@@ -304,11 +304,21 @@ class Donations {
 	}
 
 	/**
+	 * Cached list of product IDs flagged as donations.
+	 *
+	 * @var int[]|null
+	 */
+	private static $flagged_donation_product_ids = null;
+
+	/**
 	 * Get IDs of all products flagged as donations via the _newspack_is_donation meta.
 	 *
 	 * @return int[] Array of product IDs.
 	 */
 	public static function get_flagged_donation_product_ids() {
+		if ( null !== self::$flagged_donation_product_ids ) {
+			return self::$flagged_donation_product_ids;
+		}
 		if ( ! function_exists( 'wc_bool_to_string' ) ) {
 			return [];
 		}
@@ -326,7 +336,18 @@ class Donations {
 				],
 			]
 		);
-		return array_map( 'intval', $flagged_products );
+		self::$flagged_donation_product_ids = array_map( 'intval', $flagged_products );
+		return self::$flagged_donation_product_ids;
+	}
+
+	/**
+	 * Reset the cached list of flagged donation product IDs.
+	 *
+	 * Tests must call this when seeding flagged products mid-process, since
+	 * the static cache survives WP_UnitTestCase's database rollback.
+	 */
+	public static function reset_flagged_donation_product_ids_cache() {
+		self::$flagged_donation_product_ids = null;
 	}
 
 	/**

--- a/includes/class-donations.php
+++ b/includes/class-donations.php
@@ -343,8 +343,9 @@ class Donations {
 	/**
 	 * Reset the cached list of flagged donation product IDs.
 	 *
-	 * Tests must call this when seeding flagged products mid-process, since
-	 * the static cache survives WP_UnitTestCase's database rollback.
+	 * Call this after updating donation-flag product meta in the same request
+	 * or other long-lived process so subsequent lookups reload the current set
+	 * of flagged donation products.
 	 */
 	public static function reset_flagged_donation_product_ids_cache() {
 		self::$flagged_donation_product_ids = null;

--- a/includes/class-donations.php
+++ b/includes/class-donations.php
@@ -309,10 +309,6 @@ class Donations {
 	 * @return int[] Array of product IDs.
 	 */
 	public static function get_flagged_donation_product_ids() {
-		static $memo = null;
-		if ( null !== $memo ) {
-			return $memo;
-		}
 		if ( ! function_exists( 'wc_bool_to_string' ) ) {
 			return [];
 		}
@@ -330,8 +326,7 @@ class Donations {
 				],
 			]
 		);
-		$memo = array_map( 'intval', $flagged_products );
-		return $memo;
+		return array_map( 'intval', $flagged_products );
 	}
 
 	/**

--- a/tests/unit-tests/donations.php
+++ b/tests/unit-tests/donations.php
@@ -149,6 +149,7 @@ class Newspack_Test_Donations extends WP_UnitTestCase {
 		update_post_meta( $product_1, WooCommerce_Products::DONATION_FLAG_META_KEY, wc_bool_to_string( true ) );
 		update_post_meta( $product_3, WooCommerce_Products::DONATION_FLAG_META_KEY, wc_bool_to_string( true ) );
 
+		Donations::reset_flagged_donation_product_ids_cache();
 		$flagged_ids = Donations::get_flagged_donation_product_ids();
 		self::assertContains( $product_1, $flagged_ids, 'Flagged product 1 should be in the list.' );
 		self::assertNotContains( $product_2, $flagged_ids, 'Unflagged product 2 should not be in the list.' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds `Donations::reset_flagged_donation_product_ids_cache()` so the in-memory cache backing `get_flagged_donation_product_ids()` (introduced in #4635) can be cleared mid-process. The cache is also moved from a function-level `static` to a class-level static property so it has a single, well-known location.

**Why this is needed.** Since #4635 merged, `Newspack_Test_Donations::test_get_flagged_donation_product_ids` has failed deterministically on trunk. Cause: `WP_UnitTestCase` rolls back the database between tests but does not reset PHP statics. After #4687 (`feat(data-events): woo transactional events`) landed, the data-events tests run before the donations tests and trigger code paths that call `get_flagged_donation_product_ids()` while no products are flagged — populating the cache with `[]`. When the donations test then flags products and calls the function, the stale empty cache is returned and the assertion fails.

### How to test the changes in this Pull Request:

Make sure tests are now passing

1. Create a product and flag it as a donation product (#4635)
2. Open wp shell and confirm the created product is included here:

```php
Newspack\Donations::get_flagged_donation_product_ids();
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable? (The existing test added by #4635 already covers this — the fix makes it pass under realistic suite conditions.)
* [x] Have you successfully ran tests with your changes locally?