### PR TITLE
fix(audience): decode HTML entities in campaign prompt titles

### DIFF
--- a/src/wizards/audience/components/segment-group/SegmentGroup.test.js
+++ b/src/wizards/audience/components/segment-group/SegmentGroup.test.js
@@ -326,6 +326,26 @@ describe( 'A segment with conflicting prompts', () => {
 		expect( notice2.textContent ).toEqual( `${ PROMPTS.overlaysUncategorized[ 0 ].title }: ${ noticeText }` );
 	} );
 
+	it( 'decodes HTML entities in conflicting prompt titles', async () => {
+		SEGMENT.prompts = [
+			{ ...PROMPTS.overlaysUncategorized[ 0 ], id: 13, title: 'Donate &amp; Subscribe' },
+			{ ...PROMPTS.overlaysUncategorized[ 1 ], id: 14, title: 'Tom &amp; Jerry' },
+		];
+
+		// Expected warning text.
+		const noticeText = 'If multiple overlays are rendered on the same pageview, only the most recent one will be displayed.';
+		const props = {
+			campaignData: CAMPAIGN.campaignData,
+			campaign: CAMPAIGN.campaignId,
+			segment: SEGMENT,
+		};
+		const { getByTestId } = render( <SegmentGroup { ...props } /> );
+
+		// Each notice lists the *other* prompt's title, decoded.
+		expect( getByTestId( 'conflict-warning-13' ).textContent ).toEqual( `Tom & Jerry: ${ noticeText }` );
+		expect( getByTestId( 'conflict-warning-14' ).textContent ).toEqual( `Donate & Subscribe: ${ noticeText }` );
+	} );
+
 	it( 'renders a conflict notice for multiple above-header prompts in the same segment', async () => {
 		SEGMENT.prompts = PROMPTS.aboveHeadersUncategorized;
 

--- a/src/wizards/audience/views/campaigns/index.js
+++ b/src/wizards/audience/views/campaigns/index.js
@@ -11,6 +11,7 @@ import '../../../../shared/js/public-path';
 import { Component } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * External dependencies.
@@ -217,7 +218,11 @@ class AudienceCampaigns extends Component {
 		return (
 			<WebPreview
 				url={ previewUrl }
-				title={ previewTitle ? /* translators: %s: prompt title */ sprintf( __( 'Prompt: %s', 'newspack-plugin' ), previewTitle ) : null }
+				title={
+					previewTitle
+						? /* translators: %s: prompt title */ sprintf( __( 'Prompt: %s', 'newspack-plugin' ), decodeEntities( previewTitle ) )
+						: null
+				}
 				onClose={ () => this.setState( { previewUrl: null, previewTitle: null } ) }
 				renderButton={ ( { showPreview } ) => {
 					const sharedProps = {

--- a/src/wizards/audience/views/campaigns/utils.js
+++ b/src/wizards/audience/views/campaigns/utils.js
@@ -7,6 +7,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { applyFilters, addFilter } from '@wordpress/hooks';
 import { useEffect, useState, Fragment } from '@wordpress/element';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * External dependencies.
@@ -394,7 +395,7 @@ export const warningForPopup = ( prompts, prompt ) => {
 						{ filteredConflictingPrompts.map( conflictingPrompt => (
 							<li key={ conflictingPrompt.id }>
 								<p data-testid={ `conflict-warning-${ prompt.id }` }>
-									<strong>{ sprintf( '%s: ', conflictingPrompt.title ) }</strong>
+									<strong>{ sprintf( '%s: ', decodeEntities( conflictingPrompt.title ) ) }</strong>
 									<span>{ buildWarning( prompt, promptCategories ) }</span>
 								</p>
 							</li>

--- a/src/wizards/audience/views/campaigns/utils.js
+++ b/src/wizards/audience/views/campaigns/utils.js
@@ -395,7 +395,13 @@ export const warningForPopup = ( prompts, prompt ) => {
 						{ filteredConflictingPrompts.map( conflictingPrompt => (
 							<li key={ conflictingPrompt.id }>
 								<p data-testid={ `conflict-warning-${ prompt.id }` }>
-									<strong>{ sprintf( '%s: ', decodeEntities( conflictingPrompt.title ) ) }</strong>
+									<strong>
+										{ sprintf(
+											// Translators: %s: title of the conflicting prompt.
+											__( '%s:', 'newspack-plugin' ),
+											decodeEntities( conflictingPrompt.title )
+										) }{ ' ' }
+									</strong>
 									<span>{ buildWarning( prompt, promptCategories ) }</span>
 								</p>
 							</li>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Prompt titles come back from the REST API HTML-encoded (a prompt named `Foo & Bar` arrives as `Foo &amp; Bar`). The **Campaigns** wizard rendered the raw title string in two places, so the entity showed through literally:

1. The **"Conflict detected"** notice shown when two prompts target the same placement + segment – it listed the conflicting prompt's title verbatim.
2. The **prompt preview modal** title (`Prompt: …`).

Both now run the title through `decodeEntities` from `@wordpress/html-entities`, matching how prompt titles are already displayed elsewhere (e.g. `prompt-action-card`).

#### Before / After (conflict notice)

| | Rendered text |
|---|---|
| **Before** | `Spring Membership Drive &amp; Renewal: If multiple overlays are rendered…` |
| **After** | `Spring Membership Drive & Renewal: If multiple overlays are rendered…` |

### How to test the changes in this Pull Request:

1. Have Newspack Campaigns set up with at least two **published** overlay (or above-header / custom-placement) prompts assigned to the **same segment**, where one prompt's title contains an `&` that WordPress stored as `&amp;` (e.g. set it directly: `wp db query "UPDATE wp_posts SET post_title='Donate &amp; Subscribe' WHERE ID=<prompt_id>"`).
2. Open **Audience → Campaigns**. Find the segment group with the conflicting prompts.
3. The "Conflict detected" notice should list the other prompt's title with a literal `&`, not `&amp;`.
4. Also click **Preview** on a prompt whose title contains an entity – the modal heading should read `Prompt: Donate & Subscribe`, not `Prompt: Donate &amp; Subscribe`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable? (`SegmentGroup.test.js` – "decodes HTML entities in conflicting prompt titles"; red/green verified)
* [x] Have you successfully ran tests with your changes locally? (`SegmentGroup.test.js` suite passes; `wp-scripts lint-js` clean on changed files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
