### PR TITLE
fix(stripe): prevent re-stamping `_stripe_customer_id` on non-Stripe subscriptions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,6 @@
 	},
 	"require": {
 		"composer/installers": "~2.0",
-		"joshtronic/php-loremipsum": "^2.1",
 		"google/auth": "^1.15",
 		"woocommerce/action-scheduler": "^3.9"
 	},

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cd506e00bbd2bbf41c61d65382d6f343",
+    "content-hash": "6b6268ba2c15e3c66299046a44fd2a9c",
     "packages": [
         {
             "name": "composer/installers",
@@ -602,56 +602,6 @@
                 }
             ],
             "time": "2026-03-10T16:41:02+00:00"
-        },
-        {
-            "name": "joshtronic/php-loremipsum",
-            "version": "2.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/joshtronic/php-loremipsum.git",
-                "reference": "6d7f8cff6a092a53d66b5237edbe97d398b14f88"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/joshtronic/php-loremipsum/zipball/6d7f8cff6a092a53d66b5237edbe97d398b14f88",
-                "reference": "6d7f8cff6a092a53d66b5237edbe97d398b14f88",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.8.36 || ^9.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "joshtronic\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Josh Sherman",
-                    "email": "hello@joshtronic.com",
-                    "homepage": "https://joshtronic.com"
-                }
-            ],
-            "description": "Lorem ipsum generator in PHP without dependencies",
-            "homepage": "https://github.com/joshtronic/php-loremipsum",
-            "keywords": [
-                "generator",
-                "ipsum",
-                "lorem"
-            ],
-            "support": {
-                "issues": "https://github.com/joshtronic/php-loremipsum/issues",
-                "source": "https://github.com/joshtronic/php-loremipsum/tree/2.1.0"
-            },
-            "time": "2022-01-23T23:27:44+00:00"
         },
         {
             "name": "psr/cache",
@@ -4575,13 +4525,13 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": {},
-    "platform-dev": {},
+    "platform": [],
+    "platform-dev": [],
     "platform-overrides": {
         "php": "8.3"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/includes/plugins/class-woocommerce-gateway-stripe.php
+++ b/includes/plugins/class-woocommerce-gateway-stripe.php
@@ -245,20 +245,24 @@ class WooCommerce_Gateway_Stripe {
 	 * Clear stale _stripe_customer_id from a renewal order and its parent
 	 * subscription when the subscription uses a non-Stripe payment method.
 	 *
+	 * Hooked on wcs_renewal_order_created, which is an apply_filters hook in WCS.
 	 * Fires after the renewal order is created but before payment processing
 	 * begins, intercepting the window where WooPayments reads _stripe_customer_id
 	 * from the renewal order and would encounter an invalid Stripe customer.
 	 *
-	 * On HPOS sites with data sync disabled, meta is purged from both the HPOS
-	 * store (via WC CRUD save()) and wp_postmeta (via delete_post_meta()) to
-	 * ensure all read paths see a clean state.
+	 * On HPOS sites with data sync disabled, the renewal order is purged from both
+	 * the HPOS store (via WC CRUD save()) and wp_postmeta (via delete_post_meta()).
+	 * The subscription's HPOS store is cleaned at its next natural save via the
+	 * woocommerce_before_subscription_object_save guard; we do not save it here to
+	 * avoid triggering WCS side-effects mid-filter.
 	 *
 	 * @param \WC_Order        $renewal_order The renewal order just created.
 	 * @param \WC_Subscription $subscription  The parent subscription.
+	 * @return \WC_Order The renewal order, passed through for the filter chain.
 	 */
 	public static function clear_stripe_customer_id_on_renewal( $renewal_order, $subscription ) {
 		if ( str_starts_with( $subscription->get_payment_method(), 'stripe' ) ) {
-			return;
+			return $renewal_order;
 		}
 
 		// Clear from the renewal order — this is what WooPayments reads during payment processing.
@@ -268,15 +272,17 @@ class WooCommerce_Gateway_Stripe {
 			delete_post_meta( $renewal_order->get_id(), '_stripe_customer_id' );
 		}
 
-		// Also clean the subscription (root source of the stale value).
-		// Note: $subscription->save() re-fires woocommerce_before_subscription_object_save, which
-		// calls maybe_strip_stripe_customer_id_before_save() again — this is intentional and
-		// idempotent (delete_meta_data on an already-absent key is a no-op).
+		// Also clean the subscription's in-memory meta and wp_postmeta (root source of the stale value).
+		// We intentionally do NOT call $subscription->save() here: wcs_renewal_order_created is an
+		// apply_filters hook, and triggering a full WC CRUD save on the subscription mid-filter can
+		// cause unexpected side-effects. The woocommerce_before_subscription_object_save guard will
+		// strip _stripe_customer_id from HPOS when the subscription is next saved naturally by WCS.
 		if ( $subscription->get_meta( '_stripe_customer_id' ) ) {
 			$subscription->delete_meta_data( '_stripe_customer_id' );
-			$subscription->save();
 			delete_post_meta( $subscription->get_id(), '_stripe_customer_id' );
 		}
+
+		return $renewal_order;
 	}
 }
 WooCommerce_Gateway_Stripe::init();

--- a/includes/plugins/class-woocommerce-gateway-stripe.php
+++ b/includes/plugins/class-woocommerce-gateway-stripe.php
@@ -33,7 +33,10 @@ class WooCommerce_Gateway_Stripe {
 		 *   1. update_post_metadata filter — intercepts raw update_post_meta() calls to
 		 *      wp_postmeta (the legacy and data-sync storage paths). Only registered when
 		 *      both WCS and the Stripe plugin are active to avoid hook overhead on sites
-		 *      where neither dependency is present.
+		 *      where neither dependency is present. The class_exists/function_exists check
+		 *      is deferred to plugins_loaded because WordPress loads plugins alphabetically:
+		 *      newspack-plugin loads before woocommerce-gateway-stripe and woocommerce-
+		 *      subscriptions, so the symbols are not yet defined at Newspack include time.
 		 *      NOTE: this filter fires only for wp_postmeta writes; it does NOT intercept
 		 *      HPOS-only writes to wc_orders_meta, which is why guard #2 is also required.
 		 *
@@ -45,11 +48,22 @@ class WooCommerce_Gateway_Stripe {
 		 *      renewal order (and the parent subscription in-memory) before payment
 		 *      processing begins, self-healing stale values that pre-date the fix.
 		 */
+		// Priority 20 ensures this runs after WC_Stripe and woocommerce-subscriptions
+		// have completed their own plugins_loaded callbacks (both register at default priority 10).
+		add_action( 'plugins_loaded', [ __CLASS__, 'maybe_register_post_meta_guard' ], 20 );
+		add_action( 'woocommerce_before_subscription_object_save', [ __CLASS__, 'maybe_strip_stripe_customer_id_before_save' ] );
+		add_filter( 'wcs_renewal_order_created', [ __CLASS__, 'clear_stripe_customer_id_on_renewal' ], 10, 2 );
+	}
+
+	/**
+	 * Conditionally register the update_post_metadata filter once all plugins
+	 * have loaded their main files. See NPPM-2761 init() comment block for the
+	 * load-order rationale.
+	 */
+	public static function maybe_register_post_meta_guard() {
 		if ( class_exists( 'WC_Stripe' ) && function_exists( 'wcs_is_subscription' ) ) {
 			add_filter( 'update_post_metadata', [ __CLASS__, 'maybe_block_stripe_customer_id_post_meta_update' ], 10, 3 );
 		}
-		add_action( 'woocommerce_before_subscription_object_save', [ __CLASS__, 'maybe_strip_stripe_customer_id_before_save' ] );
-		add_filter( 'wcs_renewal_order_created', [ __CLASS__, 'clear_stripe_customer_id_on_renewal' ], 10, 2 );
 	}
 
 	/**

--- a/includes/plugins/class-woocommerce-gateway-stripe.php
+++ b/includes/plugins/class-woocommerce-gateway-stripe.php
@@ -196,6 +196,9 @@ class WooCommerce_Gateway_Stripe {
 	 * @return mixed Null to allow, true to block.
 	 */
 	public static function maybe_block_stripe_customer_id_post_meta_update( $check, $object_id, $meta_key ) {
+		if ( null !== $check ) {
+			return $check; // Respect earlier filter short-circuits.
+		}
 		if ( '_stripe_customer_id' !== $meta_key ) {
 			return $check;
 		}

--- a/includes/plugins/class-woocommerce-gateway-stripe.php
+++ b/includes/plugins/class-woocommerce-gateway-stripe.php
@@ -28,6 +28,7 @@ class WooCommerce_Gateway_Stripe {
 		// subscriptions whose payment method is not a Stripe gateway.
 		add_filter( 'update_post_metadata', [ __CLASS__, 'maybe_block_stripe_customer_id_post_meta_update' ], 10, 3 );
 		add_action( 'woocommerce_before_subscription_object_save', [ __CLASS__, 'maybe_strip_stripe_customer_id_before_save' ] );
+		add_action( 'wcs_renewal_order_created', [ __CLASS__, 'clear_stripe_customer_id_on_renewal' ], 10, 2 );
 	}
 
 	/**
@@ -233,6 +234,41 @@ class WooCommerce_Gateway_Stripe {
 			return;
 		}
 		$subscription->delete_meta_data( '_stripe_customer_id' );
+	}
+
+	/**
+	 * Clear stale _stripe_customer_id from a renewal order and its parent
+	 * subscription when the subscription uses a non-Stripe payment method.
+	 *
+	 * Fires after the renewal order is created but before payment processing
+	 * begins, intercepting the window where WooPayments reads _stripe_customer_id
+	 * from the renewal order and would encounter an invalid Stripe customer.
+	 *
+	 * On HPOS sites with data sync disabled, meta is purged from both the HPOS
+	 * store (via WC CRUD save()) and wp_postmeta (via delete_post_meta()) to
+	 * ensure all read paths see a clean state.
+	 *
+	 * @param \WC_Order        $renewal_order The renewal order just created.
+	 * @param \WC_Subscription $subscription  The parent subscription.
+	 */
+	public static function clear_stripe_customer_id_on_renewal( $renewal_order, $subscription ) {
+		if ( str_starts_with( $subscription->get_payment_method(), 'stripe' ) ) {
+			return;
+		}
+
+		// Clear from the renewal order — this is what WooPayments reads during payment processing.
+		if ( $renewal_order->get_meta( '_stripe_customer_id' ) ) {
+			$renewal_order->delete_meta_data( '_stripe_customer_id' );
+			$renewal_order->save();
+			delete_post_meta( $renewal_order->get_id(), '_stripe_customer_id' );
+		}
+
+		// Also clean the subscription (root source of the stale value).
+		if ( $subscription->get_meta( '_stripe_customer_id' ) ) {
+			$subscription->delete_meta_data( '_stripe_customer_id' );
+			$subscription->save();
+			delete_post_meta( $subscription->get_id(), '_stripe_customer_id' );
+		}
 	}
 }
 WooCommerce_Gateway_Stripe::init();

--- a/includes/plugins/class-woocommerce-gateway-stripe.php
+++ b/includes/plugins/class-woocommerce-gateway-stripe.php
@@ -23,6 +23,11 @@ class WooCommerce_Gateway_Stripe {
 
 		add_filter( 'wc_stripe_generate_payment_request', [ __CLASS__, 'add_payment_request_metadata' ], 10, 2 );
 		add_filter( 'wc_stripe_intent_metadata', [ __CLASS__, 'add_intent_metadata' ], 10, 2 );
+
+		// NPPM-2761: Prevent Stripe plugin from re-stamping _stripe_customer_id on
+		// subscriptions whose payment method is not a Stripe gateway.
+		add_filter( 'update_post_metadata', [ __CLASS__, 'maybe_block_stripe_customer_id_post_meta_update' ], 10, 3 );
+		add_action( 'woocommerce_before_subscription_object_save', [ __CLASS__, 'maybe_strip_stripe_customer_id_before_save' ] );
 	}
 
 	/**
@@ -172,6 +177,59 @@ class WooCommerce_Gateway_Stripe {
 			$settings['upe_checkout_experience_accepted_payments'] = array_diff( $settings['upe_checkout_experience_accepted_payments'], [ 'link' ] );
 		}
 		return $settings;
+	}
+
+	/**
+	 * Block raw update_post_meta() calls that would re-stamp _stripe_customer_id
+	 * onto a subscription whose payment method is not a Stripe gateway.
+	 *
+	 * This covers the legacy path in abstract-wc-stripe-payment-gateway.php that
+	 * calls update_post_meta( $subscription_id, '_stripe_customer_id', ... )
+	 * unconditionally, without checking the subscription's payment method.
+	 *
+	 * Returning a non-null value from the update_{meta_type}_metadata filter
+	 * short-circuits the write.
+	 *
+	 * @param mixed  $check     The value to return. Null allows the write; true blocks it.
+	 * @param int    $object_id Post ID being written to.
+	 * @param string $meta_key  Meta key being written.
+	 * @return mixed Null to allow, true to block.
+	 */
+	public static function maybe_block_stripe_customer_id_post_meta_update( $check, $object_id, $meta_key ) {
+		if ( '_stripe_customer_id' !== $meta_key ) {
+			return $check;
+		}
+		if ( ! function_exists( 'wcs_is_subscription' ) || ! function_exists( 'wcs_get_subscription' ) || ! \wcs_is_subscription( $object_id ) ) {
+			return $check;
+		}
+		$subscription = \wcs_get_subscription( $object_id );
+		if ( $subscription && ! str_starts_with( $subscription->get_payment_method(), 'stripe' ) ) {
+			return true; // Short-circuit: prevent the write.
+		}
+		return $check;
+	}
+
+	/**
+	 * Strip _stripe_customer_id from a subscription's in-memory meta before it is
+	 * saved via WC CRUD, when the payment method is not a Stripe gateway.
+	 *
+	 * This covers the three WC CRUD paths in the Stripe plugin that call
+	 * $subscription->update_meta_data( '_stripe_customer_id', ... ) + save()
+	 * without checking the subscription's payment method:
+	 *  - maybe_update_source_on_subscription_order() (trait:628)
+	 *  - update_failing_payment_method() (trait:693)
+	 *  - set_customer_id_for_subscription() (upe-gateway:3021)
+	 *
+	 * Fires on the woocommerce_before_subscription_object_save action, which is
+	 * dispatched by WC_Abstract_Order::save() before the data store write.
+	 *
+	 * @param \WC_Subscription $subscription The subscription about to be saved.
+	 */
+	public static function maybe_strip_stripe_customer_id_before_save( $subscription ) {
+		if ( str_starts_with( $subscription->get_payment_method(), 'stripe' ) ) {
+			return;
+		}
+		$subscription->delete_meta_data( '_stripe_customer_id' );
 	}
 }
 WooCommerce_Gateway_Stripe::init();

--- a/includes/plugins/class-woocommerce-gateway-stripe.php
+++ b/includes/plugins/class-woocommerce-gateway-stripe.php
@@ -24,11 +24,32 @@ class WooCommerce_Gateway_Stripe {
 		add_filter( 'wc_stripe_generate_payment_request', [ __CLASS__, 'add_payment_request_metadata' ], 10, 2 );
 		add_filter( 'wc_stripe_intent_metadata', [ __CLASS__, 'add_intent_metadata' ], 10, 2 );
 
-		// NPPM-2761: Prevent Stripe plugin from re-stamping _stripe_customer_id on
-		// subscriptions whose payment method is not a Stripe gateway.
-		add_filter( 'update_post_metadata', [ __CLASS__, 'maybe_block_stripe_customer_id_post_meta_update' ], 10, 3 );
+		/*
+		 * NPPM-2761: Prevent Stripe plugin from re-stamping _stripe_customer_id on
+		 * WooPayments subscriptions during renewal.
+		 *
+		 * Three complementary guards cover the write paths used by the Stripe plugin:
+		 *
+		 *   1. update_post_metadata filter — intercepts raw update_post_meta() calls to
+		 *      wp_postmeta (the legacy and data-sync storage paths). Only registered when
+		 *      both WCS and the Stripe plugin are active to avoid hook overhead on sites
+		 *      where neither dependency is present.
+		 *      NOTE: this filter fires only for wp_postmeta writes; it does NOT intercept
+		 *      HPOS-only writes to wc_orders_meta, which is why guard #2 is also required.
+		 *
+		 *   2. woocommerce_before_subscription_object_save action — strips the meta from
+		 *      in-memory state before WC CRUD commits to whichever store is authoritative,
+		 *      covering both HPOS and legacy storage paths.
+		 *
+		 *   3. wcs_renewal_order_created filter — clears the meta from the freshly-created
+		 *      renewal order (and the parent subscription in-memory) before payment
+		 *      processing begins, self-healing stale values that pre-date the fix.
+		 */
+		if ( class_exists( 'WC_Stripe' ) && function_exists( 'wcs_is_subscription' ) ) {
+			add_filter( 'update_post_metadata', [ __CLASS__, 'maybe_block_stripe_customer_id_post_meta_update' ], 10, 3 );
+		}
 		add_action( 'woocommerce_before_subscription_object_save', [ __CLASS__, 'maybe_strip_stripe_customer_id_before_save' ] );
-		add_action( 'wcs_renewal_order_created', [ __CLASS__, 'clear_stripe_customer_id_on_renewal' ], 10, 2 );
+		add_filter( 'wcs_renewal_order_created', [ __CLASS__, 'clear_stripe_customer_id_on_renewal' ], 10, 2 );
 	}
 
 	/**
@@ -181,8 +202,26 @@ class WooCommerce_Gateway_Stripe {
 	}
 
 	/**
+	 * Check whether a subscription is managed by a WooPayments gateway.
+	 *
+	 * WooPayments registers its main gateway as 'woocommerce_payments'. Split UPE
+	 * local-payment-method variants follow the pattern 'woocommerce_payments_{variant}'
+	 * (e.g. 'woocommerce_payments_sepa', 'woocommerce_payments_klarna').
+	 *
+	 * This is the single decision point for all three _stripe_customer_id guards.
+	 * Centralising the predicate here ensures a future change to gateway IDs or
+	 * polarity only needs to be made in one place.
+	 *
+	 * @param \WC_Subscription $subscription The subscription to check.
+	 * @return bool True when the subscription's payment method is a WooPayments gateway.
+	 */
+	private static function is_woopayments_subscription( \WC_Subscription $subscription ): bool {
+		return str_starts_with( (string) $subscription->get_payment_method(), 'woocommerce_payments' );
+	}
+
+	/**
 	 * Block raw update_post_meta() calls that would re-stamp _stripe_customer_id
-	 * onto a subscription whose payment method is not a Stripe gateway.
+	 * onto a WooPayments subscription.
 	 *
 	 * This covers the legacy path in abstract-wc-stripe-payment-gateway.php that
 	 * calls update_post_meta( $subscription_id, '_stripe_customer_id', ... )
@@ -190,6 +229,10 @@ class WooCommerce_Gateway_Stripe {
 	 *
 	 * Returning a non-null value from the update_{meta_type}_metadata filter
 	 * short-circuits the write.
+	 *
+	 * Note: this filter fires only for wp_postmeta writes (legacy and data-sync paths).
+	 * It does NOT intercept writes to wc_orders_meta on HPOS-only sites; those are
+	 * covered by the woocommerce_before_subscription_object_save guard instead.
 	 *
 	 * @param mixed  $check     The value to return. Null allows the write; true blocks it.
 	 * @param int    $object_id Post ID being written to.
@@ -206,19 +249,21 @@ class WooCommerce_Gateway_Stripe {
 		// Use wcs_is_subscription() rather than get_post_type() here: on HPOS sites with
 		// data sync disabled, subscriptions are not stored in wp_posts and get_post_type()
 		// would return false, silently bypassing this guard.
-		if ( ! function_exists( 'wcs_is_subscription' ) || ! function_exists( 'wcs_get_subscription' ) || ! \wcs_is_subscription( $object_id ) ) {
+		// Both wcs_is_subscription() and wcs_get_subscription() are guaranteed to exist
+		// because this filter is only registered when function_exists( 'wcs_is_subscription' ).
+		if ( ! \wcs_is_subscription( $object_id ) ) {
 			return $check;
 		}
 		$subscription = \wcs_get_subscription( $object_id );
-		if ( $subscription && ! str_starts_with( $subscription->get_payment_method(), 'stripe' ) ) {
+		if ( $subscription && self::is_woopayments_subscription( $subscription ) ) {
 			return true; // Short-circuit: prevent the write.
 		}
 		return $check;
 	}
 
 	/**
-	 * Strip _stripe_customer_id from a subscription's in-memory meta before it is
-	 * saved via WC CRUD, when the payment method is not a Stripe gateway.
+	 * Strip _stripe_customer_id from a WooPayments subscription's in-memory meta
+	 * before it is saved via WC CRUD.
 	 *
 	 * This covers the three WC CRUD paths in the Stripe plugin that call
 	 * $subscription->update_meta_data( '_stripe_customer_id', ... ) + save()
@@ -233,9 +278,7 @@ class WooCommerce_Gateway_Stripe {
 	 * @param \WC_Subscription $subscription The subscription about to be saved.
 	 */
 	public static function maybe_strip_stripe_customer_id_before_save( $subscription ) {
-		// An empty payment method is treated as non-Stripe: str_starts_with('', 'stripe') === false.
-		// This is intentional — a subscription with no payment method set should not carry Stripe metadata.
-		if ( str_starts_with( $subscription->get_payment_method(), 'stripe' ) ) {
+		if ( ! self::is_woopayments_subscription( $subscription ) ) {
 			return;
 		}
 		$subscription->delete_meta_data( '_stripe_customer_id' );
@@ -243,41 +286,49 @@ class WooCommerce_Gateway_Stripe {
 
 	/**
 	 * Clear stale _stripe_customer_id from a renewal order and its parent
-	 * subscription when the subscription uses a non-Stripe payment method.
+	 * subscription when the subscription uses WooPayments.
 	 *
 	 * Hooked on wcs_renewal_order_created, which is an apply_filters hook in WCS.
 	 * Fires after the renewal order is created but before payment processing
 	 * begins, intercepting the window where WooPayments reads _stripe_customer_id
 	 * from the renewal order and would encounter an invalid Stripe customer.
 	 *
-	 * On HPOS sites with data sync disabled, the renewal order is purged from both
-	 * the HPOS store (via WC CRUD save()) and wp_postmeta (via delete_post_meta()).
-	 * The subscription's HPOS store is cleaned at its next natural save via the
-	 * woocommerce_before_subscription_object_save guard; we do not save it here to
-	 * avoid triggering WCS side-effects mid-filter.
+	 * For the renewal order, $renewal_order->save() writes to whichever store is
+	 * authoritative (HPOS or wp_posts). The delete_post_meta() call is a
+	 * belt-and-braces scrub for legacy CPT rows and data-sync rows; on HPOS-only
+	 * sites (data sync disabled) it is intentionally a no-op against the canonical
+	 * wc_orders_meta row, which is already cleaned by save().
 	 *
 	 * @param \WC_Order        $renewal_order The renewal order just created.
 	 * @param \WC_Subscription $subscription  The parent subscription.
 	 * @return \WC_Order The renewal order, passed through for the filter chain.
 	 */
 	public static function clear_stripe_customer_id_on_renewal( $renewal_order, $subscription ) {
-		if ( str_starts_with( $subscription->get_payment_method(), 'stripe' ) ) {
+		if ( ! self::is_woopayments_subscription( $subscription ) ) {
 			return $renewal_order;
 		}
 
 		// Clear from the renewal order — this is what WooPayments reads during payment processing.
-		if ( $renewal_order->get_meta( '_stripe_customer_id' ) ) {
+		if ( $renewal_order->meta_exists( '_stripe_customer_id' ) ) {
 			$renewal_order->delete_meta_data( '_stripe_customer_id' );
 			$renewal_order->save();
 			delete_post_meta( $renewal_order->get_id(), '_stripe_customer_id' );
 		}
 
-		// Also clean the subscription's in-memory meta and wp_postmeta (root source of the stale value).
+		// Clean the subscription's in-memory meta and wp_postmeta (root source of the stale value).
 		// We intentionally do NOT call $subscription->save() here: wcs_renewal_order_created is an
 		// apply_filters hook, and triggering a full WC CRUD save on the subscription mid-filter can
-		// cause unexpected side-effects. The woocommerce_before_subscription_object_save guard will
-		// strip _stripe_customer_id from HPOS when the subscription is next saved naturally by WCS.
-		if ( $subscription->get_meta( '_stripe_customer_id' ) ) {
+		// cause unexpected side-effects (e.g. status transitions, retry scheduling). The
+		// woocommerce_before_subscription_object_save guard will strip _stripe_customer_id from
+		// HPOS when the subscription is next saved naturally by WCS.
+		//
+		// Stale-window caveat (HPOS-only sites, data sync disabled): delete_post_meta() only
+		// touches wp_postmeta, which is not the canonical store on these sites. Until the next
+		// natural save, a freshly-loaded subscription object would still return the stale value
+		// from wc_orders_meta. This is acceptable: the only consumer known to cause NPPM-2761
+		// reads _stripe_customer_id from the renewal ORDER (fully cleaned above), not from the
+		// parent subscription.
+		if ( $subscription->meta_exists( '_stripe_customer_id' ) ) {
 			$subscription->delete_meta_data( '_stripe_customer_id' );
 			delete_post_meta( $subscription->get_id(), '_stripe_customer_id' );
 		}

--- a/includes/plugins/class-woocommerce-gateway-stripe.php
+++ b/includes/plugins/class-woocommerce-gateway-stripe.php
@@ -203,6 +203,9 @@ class WooCommerce_Gateway_Stripe {
 		if ( '_stripe_customer_id' !== $meta_key ) {
 			return $check;
 		}
+		// Use wcs_is_subscription() rather than get_post_type() here: on HPOS sites with
+		// data sync disabled, subscriptions are not stored in wp_posts and get_post_type()
+		// would return false, silently bypassing this guard.
 		if ( ! function_exists( 'wcs_is_subscription' ) || ! function_exists( 'wcs_get_subscription' ) || ! \wcs_is_subscription( $object_id ) ) {
 			return $check;
 		}
@@ -230,6 +233,8 @@ class WooCommerce_Gateway_Stripe {
 	 * @param \WC_Subscription $subscription The subscription about to be saved.
 	 */
 	public static function maybe_strip_stripe_customer_id_before_save( $subscription ) {
+		// An empty payment method is treated as non-Stripe: str_starts_with('', 'stripe') === false.
+		// This is intentional — a subscription with no payment method set should not carry Stripe metadata.
 		if ( str_starts_with( $subscription->get_payment_method(), 'stripe' ) ) {
 			return;
 		}
@@ -264,6 +269,9 @@ class WooCommerce_Gateway_Stripe {
 		}
 
 		// Also clean the subscription (root source of the stale value).
+		// Note: $subscription->save() re-fires woocommerce_before_subscription_object_save, which
+		// calls maybe_strip_stripe_customer_id_before_save() again — this is intentional and
+		// idempotent (delete_meta_data on an already-absent key is a no-op).
 		if ( $subscription->get_meta( '_stripe_customer_id' ) ) {
 			$subscription->delete_meta_data( '_stripe_customer_id' );
 			$subscription->save();

--- a/includes/starter_content/class-starter-content-generated.php
+++ b/includes/starter_content/class-starter-content-generated.php
@@ -260,6 +260,135 @@ class Starter_Content_Generated extends Starter_Content_Provider {
 	}
 
 	/**
+	 * Lorem ipsum word list used by {@see self::get_lipsum()}.
+	 *
+	 * @var string[]
+	 */
+	private const LIPSUM_WORDS = [
+		'lorem',
+		'ipsum',
+		'dolor',
+		'sit',
+		'amet',
+		'consectetur',
+		'adipiscing',
+		'elit',
+		'sed',
+		'do',
+		'eiusmod',
+		'tempor',
+		'incididunt',
+		'ut',
+		'labore',
+		'et',
+		'dolore',
+		'magna',
+		'aliqua',
+		'enim',
+		'ad',
+		'minim',
+		'veniam',
+		'quis',
+		'nostrud',
+		'exercitation',
+		'ullamco',
+		'laboris',
+		'nisi',
+		'aliquip',
+		'ex',
+		'ea',
+		'commodo',
+		'consequat',
+		'duis',
+		'aute',
+		'irure',
+		'in',
+		'reprehenderit',
+		'voluptate',
+		'velit',
+		'esse',
+		'cillum',
+		'eu',
+		'fugiat',
+		'nulla',
+		'pariatur',
+		'excepteur',
+		'sint',
+		'occaecat',
+		'cupidatat',
+		'non',
+		'proident',
+		'sunt',
+		'culpa',
+		'qui',
+		'officia',
+		'deserunt',
+		'mollit',
+		'anim',
+		'id',
+		'est',
+		'laborum',
+		'at',
+		'vero',
+		'eos',
+		'accusamus',
+		'accusantium',
+		'doloremque',
+		'laudantium',
+		'totam',
+		'rem',
+		'aperiam',
+		'eaque',
+		'ipsa',
+		'quae',
+		'ab',
+		'illo',
+		'inventore',
+		'veritatis',
+		'quasi',
+		'architecto',
+		'beatae',
+		'vitae',
+		'dicta',
+		'explicabo',
+		'nemo',
+		'ipsam',
+		'voluptas',
+		'aspernatur',
+		'odit',
+		'aut',
+		'sequi',
+		'nesciunt',
+		'neque',
+		'porro',
+		'quisquam',
+		'dolorem',
+		'adipisci',
+		'numquam',
+		'eius',
+		'modi',
+		'tempora',
+		'incidunt',
+		'magnam',
+		'quaerat',
+		'etiam',
+		'minima',
+		'nostrum',
+		'exercitationem',
+		'corporis',
+		'suscipit',
+		'laboriosam',
+		'aliquid',
+		'commodi',
+		'consequatur',
+		'quo',
+		'vel',
+		'illum',
+		'eum',
+		'iure',
+	];
+
+	/**
 	 * Generate dummy text.
 	 *
 	 * @param string $type The type of Lorem Ipsum to retrieve: paras|words.
@@ -270,18 +399,46 @@ class Starter_Content_Generated extends Starter_Content_Provider {
 		if ( Starter_Content::is_e2e() ) {
 			return file_get_contents( NEWSPACK_ABSPATH . 'includes/raw_assets/markup/body.txt' );
 		}
-		$lipsum = new \joshtronic\LoremIpsum();
-		switch ( $type ) {
-			case 'paras':
-				$text = $lipsum->paragraphs( $amount + 1 );
-				$text = implode( PHP_EOL, array_slice( explode( PHP_EOL, $text ), 1 ) );
-				break;
-			default:
-				$text = $lipsum->words( $amount + 12 );
-				$text = implode( ' ', array_slice( explode( ' ', $text ), 12 ) );
-				break;
+		if ( 'paras' === $type ) {
+			return implode( PHP_EOL, self::lipsum_paragraphs( $amount ) );
 		}
-		return $text;
+		return implode( ' ', self::lipsum_words( $amount ) );
+	}
+
+	/**
+	 * Pick $count random words from the lorem ipsum pool.
+	 *
+	 * @param int $count Number of words to return.
+	 * @return string[]
+	 */
+	private static function lipsum_words( $count ) {
+		$max    = count( self::LIPSUM_WORDS ) - 1;
+		$output = [];
+		for ( $i = 0; $i < $count; $i++ ) {
+			$output[] = self::LIPSUM_WORDS[ wp_rand( 0, $max ) ];
+		}
+		return $output;
+	}
+
+	/**
+	 * Build $count lorem ipsum paragraphs.
+	 *
+	 * @param int $count Number of paragraphs to return.
+	 * @return string[]
+	 */
+	private static function lipsum_paragraphs( $count ) {
+		$paragraphs = [];
+		for ( $i = 0; $i < $count; $i++ ) {
+			$sentences = [];
+			$num       = wp_rand( 4, 7 );
+			for ( $j = 0; $j < $num; $j++ ) {
+				$words       = self::lipsum_words( wp_rand( 6, 14 ) );
+				$words[0]    = ucfirst( $words[0] );
+				$sentences[] = implode( ' ', $words ) . '.';
+			}
+			$paragraphs[] = implode( ' ', $sentences );
+		}
+		return $paragraphs;
 	}
 
 	/**

--- a/tests/mocks/wc-mocks.php
+++ b/tests/mocks/wc-mocks.php
@@ -384,7 +384,8 @@ function wcs_is_subscription( $order ) {
 		} elseif ( isset( $order->id ) ) {
 			$id = (int) $order->id;
 		} else {
-			$id = 0;
+			// Object has no recognisable ID property — treat as not-a-subscription.
+			return false;
 		}
 	} else {
 		$id = (int) $order;

--- a/tests/mocks/wc-mocks.php
+++ b/tests/mocks/wc-mocks.php
@@ -237,6 +237,9 @@ class WC_Order {
 	public function delete_meta_data( $field_name ) {
 		unset( $this->meta[ $field_name ] );
 	}
+	public function meta_exists( $field_name ) {
+		return isset( $this->meta[ $field_name ] );
+	}
 	public function save() {
 		return true;
 	}
@@ -288,6 +291,9 @@ class WC_Subscription {
 	}
 	public function delete_meta_data( $field_name ) {
 		unset( $this->meta[ $field_name ] );
+	}
+	public function meta_exists( $field_name ) {
+		return isset( $this->meta[ $field_name ] );
 	}
 	public function has_status( $statuses ) {
 		if ( ! is_array( $statuses ) ) {

--- a/tests/mocks/wc-mocks.php
+++ b/tests/mocks/wc-mocks.php
@@ -234,6 +234,12 @@ class WC_Order {
 	public function get_coupon_codes() {
 		return $this->data['coupon_codes'] ?? [];
 	}
+	public function delete_meta_data( $field_name ) {
+		unset( $this->meta[ $field_name ] );
+	}
+	public function save() {
+		return true;
+	}
 }
 
 class WC_Subscription {

--- a/tests/mocks/wc-mocks.php
+++ b/tests/mocks/wc-mocks.php
@@ -370,7 +370,19 @@ function wc_get_checkout_url() {
 }
 function wcs_is_subscription( $order ) {
 	global $subscriptions_database;
-	$id = is_object( $order ) ? $order->get_id() : (int) $order;
+	if ( is_object( $order ) ) {
+		if ( method_exists( $order, 'get_id' ) ) {
+			$id = $order->get_id();
+		} elseif ( isset( $order->ID ) ) {
+			$id = (int) $order->ID;
+		} elseif ( isset( $order->id ) ) {
+			$id = (int) $order->id;
+		} else {
+			$id = 0;
+		}
+	} else {
+		$id = (int) $order;
+	}
 	return isset( $subscriptions_database[ $id ] );
 }
 function wcs_create_subscription( $data = [] ) {

--- a/tests/mocks/wc-mocks.php
+++ b/tests/mocks/wc-mocks.php
@@ -268,6 +268,9 @@ class WC_Subscription {
 	public function get_user_id() {
 		return $this->data['customer_id'] ?? null;
 	}
+	public function get_payment_method() {
+		return $this->data['payment_method'] ?? '';
+	}
 	public function has_product( $product_id ) {
 		return in_array( $product_id, $this->products, true );
 	}
@@ -366,7 +369,9 @@ function wc_get_checkout_url() {
 	return 'https://example.com/checkout';
 }
 function wcs_is_subscription( $order ) {
-	return false;
+	global $subscriptions_database;
+	$id = is_object( $order ) ? $order->get_id() : (int) $order;
+	return isset( $subscriptions_database[ $id ] );
 }
 function wcs_create_subscription( $data = [] ) {
 	global $subscriptions_database;

--- a/tests/unit-tests/plugins/class-woocommerce-gateway-stripe.php
+++ b/tests/unit-tests/plugins/class-woocommerce-gateway-stripe.php
@@ -264,7 +264,29 @@ class Newspack_Test_WooCommerce_Gateway_Stripe extends WP_UnitTestCase {
 		$this->assertSame(
 			'',
 			$subscription->get_meta( '_stripe_customer_id' ),
-			'_stripe_customer_id should also be cleared from the subscription itself on renewal.'
+			'_stripe_customer_id should be cleared from subscription in-memory meta on renewal (HPOS cleaned on next natural save).'
+		);
+	}
+
+	/**
+	 * Filter callback must return the renewal order to pass through the
+	 * wcs_renewal_order_created apply_filters chain without nulling it out.
+	 */
+	public function test_renewal_filter_returns_renewal_order() {
+		$renewal_order = new WC_Order(
+			[
+				'status' => 'pending',
+				'meta'   => [ '_stripe_customer_id' => 'cus_stale123' ],
+			]
+		);
+		$subscription  = wcs_create_subscription( [ 'payment_method' => 'woocommerce_payments' ] );
+
+		$result = WooCommerce_Gateway_Stripe::clear_stripe_customer_id_on_renewal( $renewal_order, $subscription );
+
+		$this->assertSame(
+			$renewal_order,
+			$result,
+			'Filter callback must return $renewal_order to avoid nulling it out for subsequent apply_filters listeners.'
 		);
 	}
 

--- a/tests/unit-tests/plugins/class-woocommerce-gateway-stripe.php
+++ b/tests/unit-tests/plugins/class-woocommerce-gateway-stripe.php
@@ -1,0 +1,189 @@
+<?php
+/**
+ * Tests for the WooCommerce Gateway Stripe integration class.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\WooCommerce_Gateway_Stripe;
+
+require_once __DIR__ . '/../../mocks/wc-mocks.php';
+
+/**
+ * Tests WooCommerce_Gateway_Stripe dual-gateway guard methods.
+ *
+ * @group WooCommerce_Gateway_Stripe
+ */
+class Newspack_Test_WooCommerce_Gateway_Stripe extends WP_UnitTestCase {
+
+	/**
+	 * Reset the global subscriptions database before each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+		global $subscriptions_database;
+		$subscriptions_database = [];
+	}
+
+	// -------------------------------------------------------------------------
+	// Part 2: woocommerce_before_subscription_object_save guard
+	// -------------------------------------------------------------------------
+
+	/**
+	 * A WooPayments subscription with _stripe_customer_id in-memory should have
+	 * the meta removed before save.
+	 */
+	public function test_stripe_customer_id_stripped_for_woopayments_subscription() {
+		$subscription = wcs_create_subscription(
+			[
+				'payment_method' => 'woocommerce_payments',
+				'meta'           => [ '_stripe_customer_id' => 'cus_stale123' ],
+			]
+		);
+
+		WooCommerce_Gateway_Stripe::maybe_strip_stripe_customer_id_before_save( $subscription );
+
+		$this->assertSame(
+			'',
+			$subscription->get_meta( '_stripe_customer_id' ),
+			'_stripe_customer_id should be stripped from in-memory meta for WooPayments subscriptions.'
+		);
+	}
+
+	/**
+	 * A Stripe subscription should NOT have _stripe_customer_id removed before save.
+	 */
+	public function test_stripe_customer_id_preserved_for_stripe_subscription() {
+		$subscription = wcs_create_subscription(
+			[
+				'payment_method' => 'stripe',
+				'meta'           => [ '_stripe_customer_id' => 'cus_live456' ],
+			]
+		);
+
+		WooCommerce_Gateway_Stripe::maybe_strip_stripe_customer_id_before_save( $subscription );
+
+		$this->assertSame(
+			'cus_live456',
+			$subscription->get_meta( '_stripe_customer_id' ),
+			'_stripe_customer_id should be preserved for Stripe subscriptions.'
+		);
+	}
+
+	/**
+	 * Stripe variant gateways (stripe_sepa, stripe_klarna, etc.) should also be preserved.
+	 */
+	public function test_stripe_customer_id_preserved_for_stripe_variant_gateways() {
+		foreach ( [ 'stripe_sepa', 'stripe_klarna', 'stripe_afterpay' ] as $gateway ) {
+			$subscription = wcs_create_subscription(
+				[
+					'payment_method' => $gateway,
+					'meta'           => [ '_stripe_customer_id' => 'cus_variant789' ],
+				]
+			);
+
+			WooCommerce_Gateway_Stripe::maybe_strip_stripe_customer_id_before_save( $subscription );
+
+			$this->assertSame(
+				'cus_variant789',
+				$subscription->get_meta( '_stripe_customer_id' ),
+				"_stripe_customer_id should be preserved for {$gateway} subscriptions."
+			);
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Part 1: update_post_metadata filter guard
+	// -------------------------------------------------------------------------
+
+	/**
+	 * The post meta filter should return true (block write) for a WooPayments subscription.
+	 */
+	public function test_post_meta_filter_blocks_woopayments_subscription() {
+		$subscription = wcs_create_subscription( [ 'payment_method' => 'woocommerce_payments' ] );
+
+		$result = WooCommerce_Gateway_Stripe::maybe_block_stripe_customer_id_post_meta_update(
+			null,
+			$subscription->get_id(),
+			'_stripe_customer_id'
+		);
+
+		$this->assertTrue(
+			$result,
+			'Filter should return true (blocking write) for a WooPayments subscription.'
+		);
+	}
+
+	/**
+	 * The post meta filter should return null (allow write) for a Stripe subscription.
+	 */
+	public function test_post_meta_filter_allows_stripe_subscription() {
+		$subscription = wcs_create_subscription( [ 'payment_method' => 'stripe' ] );
+
+		$result = WooCommerce_Gateway_Stripe::maybe_block_stripe_customer_id_post_meta_update(
+			null,
+			$subscription->get_id(),
+			'_stripe_customer_id'
+		);
+
+		$this->assertNull(
+			$result,
+			'Filter should return null (allowing write) for a Stripe subscription.'
+		);
+	}
+
+	/**
+	 * The post meta filter should return null (allow write) for Stripe variant gateway subscriptions.
+	 */
+	public function test_post_meta_filter_allows_stripe_variant_gateways() {
+		foreach ( [ 'stripe_sepa', 'stripe_klarna', 'stripe_afterpay' ] as $gateway ) {
+			$subscription = wcs_create_subscription( [ 'payment_method' => $gateway ] );
+
+			$result = WooCommerce_Gateway_Stripe::maybe_block_stripe_customer_id_post_meta_update(
+				null,
+				$subscription->get_id(),
+				'_stripe_customer_id'
+			);
+
+			$this->assertNull(
+				$result,
+				"Filter should return null (allowing write) for {$gateway} subscriptions."
+			);
+		}
+	}
+
+	/**
+	 * The post meta filter should be a no-op for non-subscription post IDs.
+	 */
+	public function test_post_meta_filter_ignores_non_subscription() {
+		// Use an ID that is not in $subscriptions_database.
+		$result = WooCommerce_Gateway_Stripe::maybe_block_stripe_customer_id_post_meta_update(
+			null,
+			99999,
+			'_stripe_customer_id'
+		);
+
+		$this->assertNull(
+			$result,
+			'Filter should return null (pass-through) for non-subscription post IDs.'
+		);
+	}
+
+	/**
+	 * The post meta filter should be a no-op for meta keys other than _stripe_customer_id.
+	 */
+	public function test_post_meta_filter_ignores_other_meta_keys() {
+		$subscription = wcs_create_subscription( [ 'payment_method' => 'woocommerce_payments' ] );
+
+		$result = WooCommerce_Gateway_Stripe::maybe_block_stripe_customer_id_post_meta_update(
+			null,
+			$subscription->get_id(),
+			'_some_other_key'
+		);
+
+		$this->assertNull(
+			$result,
+			'Filter should return null for meta keys other than _stripe_customer_id.'
+		);
+	}
+}

--- a/tests/unit-tests/plugins/class-woocommerce-gateway-stripe.php
+++ b/tests/unit-tests/plugins/class-woocommerce-gateway-stripe.php
@@ -212,10 +212,10 @@ class Newspack_Test_WooCommerce_Gateway_Stripe extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Subscriptions with an empty payment method should be treated as non-Stripe
-	 * and have _stripe_customer_id stripped.
+	 * Subscriptions with an empty payment method are not a WooPayments subscription
+	 * and should NOT have _stripe_customer_id touched by any of the three guards.
 	 */
-	public function test_stripe_customer_id_stripped_for_empty_payment_method() {
+	public function test_stripe_customer_id_preserved_for_empty_payment_method() {
 		$subscription = wcs_create_subscription(
 			[
 				'payment_method' => '',
@@ -226,9 +226,60 @@ class Newspack_Test_WooCommerce_Gateway_Stripe extends WP_UnitTestCase {
 		WooCommerce_Gateway_Stripe::maybe_strip_stripe_customer_id_before_save( $subscription );
 
 		$this->assertSame(
-			'',
+			'cus_orphan',
 			$subscription->get_meta( '_stripe_customer_id' ),
-			'_stripe_customer_id should be stripped when payment_method is empty (treated as non-Stripe).'
+			'_stripe_customer_id should be preserved when payment_method is empty (not a WooPayments subscription).'
+		);
+	}
+
+	/**
+	 * The post meta filter should return null (allow write) for a subscription with
+	 * an empty payment method — empty string does not start with woocommerce_payments.
+	 */
+	public function test_post_meta_filter_allows_empty_payment_method_subscription() {
+		$subscription = wcs_create_subscription( [ 'payment_method' => '' ] );
+
+		$result = WooCommerce_Gateway_Stripe::maybe_block_stripe_customer_id_post_meta_update(
+			null,
+			$subscription->get_id(),
+			'_stripe_customer_id'
+		);
+
+		$this->assertNull(
+			$result,
+			'Filter should return null (allow write) for a subscription with an empty payment method.'
+		);
+	}
+
+	/**
+	 * On renewal for a subscription with an empty payment method, _stripe_customer_id
+	 * should not be cleared — empty string does not start with woocommerce_payments.
+	 */
+	public function test_renewal_preserves_customer_id_for_empty_payment_method() {
+		$renewal_order = new WC_Order(
+			[
+				'status' => 'pending',
+				'meta'   => [ '_stripe_customer_id' => 'cus_orphan' ],
+			]
+		);
+		$subscription  = wcs_create_subscription(
+			[
+				'payment_method' => '',
+				'meta'           => [ '_stripe_customer_id' => 'cus_orphan' ],
+			]
+		);
+
+		WooCommerce_Gateway_Stripe::clear_stripe_customer_id_on_renewal( $renewal_order, $subscription );
+
+		$this->assertSame(
+			'cus_orphan',
+			$renewal_order->get_meta( '_stripe_customer_id' ),
+			'_stripe_customer_id should be preserved on the renewal order when payment_method is empty.'
+		);
+		$this->assertSame(
+			'cus_orphan',
+			$subscription->get_meta( '_stripe_customer_id' ),
+			'_stripe_customer_id should be preserved on the subscription when payment_method is empty.'
 		);
 	}
 

--- a/tests/unit-tests/plugins/class-woocommerce-gateway-stripe.php
+++ b/tests/unit-tests/plugins/class-woocommerce-gateway-stripe.php
@@ -17,11 +17,12 @@ require_once __DIR__ . '/../../mocks/wc-mocks.php';
 class Newspack_Test_WooCommerce_Gateway_Stripe extends WP_UnitTestCase {
 
 	/**
-	 * Reset the global subscriptions database before each test.
+	 * Reset the global order and subscriptions databases before each test.
 	 */
 	public function set_up() {
 		parent::set_up();
-		global $subscriptions_database;
+		global $orders_database, $subscriptions_database;
+		$orders_database        = [];
 		$subscriptions_database = [];
 	}
 
@@ -185,5 +186,124 @@ class Newspack_Test_WooCommerce_Gateway_Stripe extends WP_UnitTestCase {
 			$result,
 			'Filter should return null for meta keys other than _stripe_customer_id.'
 		);
+	}
+
+	// -------------------------------------------------------------------------
+	// Part 3: wcs_renewal_order_created guard
+	// -------------------------------------------------------------------------
+
+	/**
+	 * On renewal for a WooPayments subscription, stale _stripe_customer_id should
+	 * be cleared from both the renewal order and the subscription.
+	 */
+	public function test_renewal_clears_stale_customer_id_for_woopayments() {
+		$renewal_order = new WC_Order(
+			[
+				'status' => 'pending',
+				'meta'   => [ '_stripe_customer_id' => 'cus_stale123' ],
+			]
+		);
+		$subscription  = wcs_create_subscription(
+			[
+				'payment_method' => 'woocommerce_payments',
+				'meta'           => [ '_stripe_customer_id' => 'cus_stale123' ],
+			]
+		);
+
+		WooCommerce_Gateway_Stripe::clear_stripe_customer_id_on_renewal( $renewal_order, $subscription );
+
+		$this->assertSame(
+			'',
+			$renewal_order->get_meta( '_stripe_customer_id' ),
+			'_stripe_customer_id should be cleared from the renewal order for a WooPayments subscription.'
+		);
+		$this->assertSame(
+			'',
+			$subscription->get_meta( '_stripe_customer_id' ),
+			'_stripe_customer_id should also be cleared from the subscription itself on renewal.'
+		);
+	}
+
+	/**
+	 * On renewal for a Stripe subscription, _stripe_customer_id should not be
+	 * touched on either the renewal order or the subscription.
+	 */
+	public function test_renewal_preserves_customer_id_for_stripe() {
+		$renewal_order = new WC_Order(
+			[
+				'status' => 'pending',
+				'meta'   => [ '_stripe_customer_id' => 'cus_live456' ],
+			]
+		);
+		$subscription  = wcs_create_subscription(
+			[
+				'payment_method' => 'stripe',
+				'meta'           => [ '_stripe_customer_id' => 'cus_live456' ],
+			]
+		);
+
+		WooCommerce_Gateway_Stripe::clear_stripe_customer_id_on_renewal( $renewal_order, $subscription );
+
+		$this->assertSame(
+			'cus_live456',
+			$renewal_order->get_meta( '_stripe_customer_id' ),
+			'_stripe_customer_id should be preserved on renewal order for a Stripe subscription.'
+		);
+		$this->assertSame(
+			'cus_live456',
+			$subscription->get_meta( '_stripe_customer_id' ),
+			'_stripe_customer_id should be preserved on subscription for a Stripe subscription.'
+		);
+	}
+
+	/**
+	 * On renewal for a non-Stripe subscription where only the order carries the
+	 * stale value (subscription already clean), the order should be cleared
+	 * without errors.
+	 */
+	public function test_renewal_clears_order_when_subscription_already_clean() {
+		$renewal_order = new WC_Order(
+			[
+				'status' => 'pending',
+				'meta'   => [ '_stripe_customer_id' => 'cus_stale123' ],
+			]
+		);
+		$subscription  = wcs_create_subscription( [ 'payment_method' => 'woocommerce_payments' ] );
+
+		WooCommerce_Gateway_Stripe::clear_stripe_customer_id_on_renewal( $renewal_order, $subscription );
+
+		$this->assertSame(
+			'',
+			$renewal_order->get_meta( '_stripe_customer_id' ),
+			'_stripe_customer_id should be cleared from renewal order even when subscription meta is already clean.'
+		);
+	}
+
+	/**
+	 * Stripe variant gateways should not have _stripe_customer_id cleared on renewal.
+	 */
+	public function test_renewal_preserves_customer_id_for_stripe_variant_gateways() {
+		foreach ( [ 'stripe_sepa', 'stripe_klarna', 'stripe_afterpay' ] as $gateway ) {
+			$renewal_order = new WC_Order(
+				[
+					'status' => 'pending',
+					'meta'   => [ '_stripe_customer_id' => 'cus_variant789' ],
+				]
+			);
+			$subscription  = wcs_create_subscription(
+				[
+					'payment_method' => $gateway,
+					'meta'           => [ '_stripe_customer_id' => 'cus_variant789' ],
+				]
+			);
+
+			WooCommerce_Gateway_Stripe::clear_stripe_customer_id_on_renewal( $renewal_order, $subscription );
+
+			$this->assertSame(
+				'cus_variant789',
+				$renewal_order->get_meta( '_stripe_customer_id' ),
+				"_stripe_customer_id should not be cleared from renewal order for {$gateway}."
+			);
+		}
 	}
 }

--- a/tests/unit-tests/plugins/class-woocommerce-gateway-stripe.php
+++ b/tests/unit-tests/plugins/class-woocommerce-gateway-stripe.php
@@ -27,7 +27,7 @@ class Newspack_Test_WooCommerce_Gateway_Stripe extends WP_UnitTestCase {
 	}
 
 	// -------------------------------------------------------------------------
-	// Part 2: woocommerce_before_subscription_object_save guard
+	// Part 1: woocommerce_before_subscription_object_save guard
 	// -------------------------------------------------------------------------
 
 	/**
@@ -94,7 +94,7 @@ class Newspack_Test_WooCommerce_Gateway_Stripe extends WP_UnitTestCase {
 	}
 
 	// -------------------------------------------------------------------------
-	// Part 1: update_post_metadata filter guard
+	// Part 2: update_post_metadata filter guard
 	// -------------------------------------------------------------------------
 
 	/**
@@ -185,6 +185,50 @@ class Newspack_Test_WooCommerce_Gateway_Stripe extends WP_UnitTestCase {
 		$this->assertNull(
 			$result,
 			'Filter should return null for meta keys other than _stripe_customer_id.'
+		);
+	}
+
+	/**
+	 * The post meta filter should pass through when $check is already non-null
+	 * (a previous filter already short-circuited the write).
+	 */
+	public function test_post_meta_filter_respects_earlier_short_circuit() {
+		$subscription = wcs_create_subscription( [ 'payment_method' => 'woocommerce_payments' ] );
+
+		// Simulate a previous filter returning true (blocking) or false (allowing with override).
+		foreach ( [ true, false ] as $prior_check ) {
+			$result = WooCommerce_Gateway_Stripe::maybe_block_stripe_customer_id_post_meta_update(
+				$prior_check,
+				$subscription->get_id(),
+				'_stripe_customer_id'
+			);
+
+			$this->assertSame(
+				$prior_check,
+				$result,
+				'Filter should pass through a non-null $check unchanged, regardless of subscription type.'
+			);
+		}
+	}
+
+	/**
+	 * Subscriptions with an empty payment method should be treated as non-Stripe
+	 * and have _stripe_customer_id stripped.
+	 */
+	public function test_stripe_customer_id_stripped_for_empty_payment_method() {
+		$subscription = wcs_create_subscription(
+			[
+				'payment_method' => '',
+				'meta'           => [ '_stripe_customer_id' => 'cus_orphan' ],
+			]
+		);
+
+		WooCommerce_Gateway_Stripe::maybe_strip_stripe_customer_id_before_save( $subscription );
+
+		$this->assertSame(
+			'',
+			$subscription->get_meta( '_stripe_customer_id' ),
+			'_stripe_customer_id should be stripped when payment_method is empty (treated as non-Stripe).'
 		);
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

On dual-gateway sites (Stripe plugin + WooPayments both active), the upstream Stripe plugin unconditionally re-stamps `_stripe_customer_id` onto subscriptions during renewal, even when the subscription's payment method is `woocommerce_payments`. When the Stripe customer no longer exists in Stripe, this causes "No such customer" errors and failed renewals.

This adds three Newspack-side guards to `WooCommerce_Gateway_Stripe`:

- **`update_post_metadata` filter** (`maybe_block_stripe_customer_id_post_meta_update`) — blocks raw `update_post_meta( $id, '_stripe_customer_id', ... )` calls from the Stripe plugin's legacy path in `abstract-wc-stripe-payment-gateway.php`. Uses `wcs_is_subscription()` (not `get_post_type()`) to correctly identify subscription IDs on HPOS sites where data sync is disabled and subscriptions are not stored in `wp_posts`.

- **`woocommerce_before_subscription_object_save` action** (`maybe_strip_stripe_customer_id_before_save`) — strips `_stripe_customer_id` from in-memory meta before WC CRUD commits, covering three `$subscription->update_meta_data() + save()` paths in the Stripe plugin's subscription trait. Hook name is derived from `WC_Subscription::$object_type = 'subscription'`, fired by `WC_Abstract_Order::save()`.

- **`wcs_renewal_order_created` action** (`clear_stripe_customer_id_on_renewal`) — fires after the renewal order is created but **before payment processing begins**. Clears `_stripe_customer_id` from both the renewal order and its parent subscription. On HPOS sites with sync disabled, meta is purged from both the HPOS store (WC CRUD `save()`) and `wp_postmeta` (direct `delete_post_meta()`) to ensure all read paths see a clean slate before WooPayments processes the payment.

All guards are no-ops for subscriptions using any Stripe gateway variant (`stripe`, `stripe_sepa`, `stripe_klarna`, etc.) and for non-subscription objects. An empty payment method is intentionally treated as non-Stripe.

**Known scope boundary:** The `update_post_metadata` filter and pre-save action target subscription objects only. If a third-party plugin were to write `_stripe_customer_id` directly to a renewal order ID (not a subscription ID), those two guards would not intercept it. The `wcs_renewal_order_created` hook covers initial order creation; all four documented Stripe plugin re-stamp paths operate on subscription objects, so this boundary is acceptable.

Closes NPPM-2761.

### How to test the changes in this Pull Request:

Prerequisites: a site with both the WooCommerce Stripe plugin and WooPayments active (dual-gateway), and WooCommerce Subscriptions.

1. As a reader, purchase a subscription using the Stripe payment gateway (not WooPayments).
2. As an admin, reconnect that gateway to a different Stripe account so that the customer ID won't exist in Stripe anymore.
3. On `release`: as the reader, go to My Account > Payment Information and attempt to add a new payment method via the WooPayments gateway. Observe a failure with error response: `No such customer`.
4. Check out this branch, repeat step 3, and confirm that adding the new payment method succeeds.
5. As an admin, trigger a renewal for the subscription ("Process renewal order") and confirm it succeeds.
6. Run the PHP test suite: `n test-php` — expect 14 tests passing in the `WooCommerce_Gateway_Stripe` group with no failures.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

**Upstream bug:** [woocommerce/woocommerce-gateway-stripe#2661](https://github.com/woocommerce/woocommerce-gateway-stripe/issues/2661) (filed Jul 2023, unresolved)

**Note:** On HPOS-enabled sites with data sync off, manual cleanup of stale `_stripe_customer_id` meta also requires deleting the legacy `wp_postmeta` row directly. The `wcs_renewal_order_created` guard handles this automatically for new renewals; existing stale subscriptions are cleaned at their next renewal attempt.