### PR TITLE
fix(woocommerce): persist custom meta on new product first save

### DIFF
--- a/includes/plugins/woocommerce/class-woocommerce-products.php
+++ b/includes/plugins/woocommerce/class-woocommerce-products.php
@@ -284,9 +284,15 @@ class WooCommerce_Products {
 			return;
 		}
 
+		// When saving a new product whose type is changing, WC core's
+		// WC_Meta_Box_Product_Data::save runs at the same priority as this handler
+		// and may not have updated the product-type term yet. Use the POSTed
+		// product-type as the source of truth, matching WC core's own pattern.
+		$product_type = isset( $_POST['product-type'] ) ? sanitize_title( wp_unslash( $_POST['product-type'] ) ) : $product->get_type(); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+
 		$custom_options = array_merge( self::get_custom_options(), self::get_custom_product_pricing_options() );
 		foreach ( $custom_options as $option_key => $option_config ) {
-			if ( isset( $option_config['product_types'] ) && ! in_array( $product->get_type(), $option_config['product_types'], true ) ) {
+			if ( isset( $option_config['product_types'] ) && ! in_array( $product_type, $option_config['product_types'], true ) ) {
 				continue;
 			}
 			$meta_key   = $option_config['id'];

--- a/includes/plugins/woocommerce/class-woocommerce-products.php
+++ b/includes/plugins/woocommerce/class-woocommerce-products.php
@@ -284,11 +284,15 @@ class WooCommerce_Products {
 			return;
 		}
 
-		// When saving a new product whose type is changing, WC core's
-		// WC_Meta_Box_Product_Data::save runs at the same priority as this handler
-		// and may not have updated the product-type term yet. Use the POSTed
-		// product-type as the source of truth, matching WC core's own pattern.
-		$product_type = isset( $_POST['product-type'] ) ? sanitize_title( wp_unslash( $_POST['product-type'] ) ) : $product->get_type(); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		// Both this handler and WC core's WC_Meta_Box_Product_Data::save are
+		// hooked on `woocommerce_process_product_meta` at priority 10, so the
+		// order depends on registration timing. Newspack typically registers
+		// first, which means when saving a brand-new product whose type is
+		// changing via the dropdown, $product->get_type() still returns the
+		// auto-draft default ("simple") at this point. Read the POSTed
+		// product-type as the source of truth, matching WC core's own pattern
+		// in WC_Meta_Box_Product_Data::save().
+		$product_type = ! empty( $_POST['product-type'] ) ? sanitize_title( wp_unslash( $_POST['product-type'] ) ) : $product->get_type(); // phpcs:ignore WordPress.Security.NonceVerification.Missing
 
 		$custom_options = array_merge( self::get_custom_options(), self::get_custom_product_pricing_options() );
 		foreach ( $custom_options as $option_key => $option_config ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Fixes a bug where Newspack's custom product options (e.g., **Group subscription** enabled flag and member limit) were silently dropped on the **first save** of a brand-new product whose type was being changed via the product-type dropdown (e.g., new product → "Simple subscription"). Subsequent edits to existing products were unaffected.

**Root cause:** Both `WooCommerce_Products::save_custom_product_options` and WC core's `WC_Meta_Box_Product_Data::save` are hooked on `woocommerce_process_product_meta` at priority 10, so the order depends on registration timing. Newspack registers first, which means at the moment our handler runs, `$product->get_type()` still returns the auto-draft default (`simple`) — WC hasn't yet updated the product-type term. Our type-filter at `class-woocommerce-products.php:289` then skips options whose `product_types` list doesn't include `simple` (Group subscription requires `subscription` or `subscription_variation`).

**Fix:** Read the product type from `$_POST['product-type']` as the source of truth, falling back to `$product->get_type()` when not present (REST, programmatic saves). Mirrors WC core's own pattern in `WC_Meta_Box_Product_Data::save()`.

Closes NPPD-1485.

### How to test the changes in this Pull Request:

1. Set `define( 'NEWSPACK_CONTENT_GATES', true );` in `wp-config.php` so the Group subscription option is registered.
2. Ensure WooCommerce + WooCommerce Subscriptions are active.
3. **Simple subscription, first save (the bug):**
   1. Go to *Products → Add New*.
   2. Set product title, choose product type "Simple subscription", set a subscription price.
   3. Tick **Group subscription** and set **Group subscription member limit** to e.g. `5`.
   4. Click **Save Draft**.
   5. ✅ Reload the product — Group subscription should still be enabled and the limit preserved. Pre-fix: both values were lost.
4. **Existing-product edit (no regression):**
   1. Open the product saved in step 3.
   2. Change the limit to a different value, click **Update**.
   3. ✅ The new value persists.
5. **Variable subscription parent + variations (untouched code path):**
   1. *Products → Add New*, set type to **Variable subscription**, save draft.
   2. Add an attribute (used for variations), generate variations.
   3. Expand a variation, set subscription price and tick **Group subscription**, set a limit.
   4. *Save changes*.
   5. ✅ Variation persists Group subscription meta on its first save (this code path was already correct — verified in review).
6. **Programmatic / REST save (out of scope):** REST API (`POST /wp-json/wc/v3/products`) and the new WC product block editor bypass `woocommerce_process_product_meta` entirely and are not covered by this PR. To be tracked in a follow-up.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? — *Deferred: extending the existing `WC_Product` mock at `tests/mocks/wc-mocks.php` (no `update_meta_data`/`save`/`get_status`/`get_date_*`) is out of scope for this hotfix. Verified empirically against a live env. Follow-up ticket recommended.*
* [x] Have you successfully ran tests with your changes locally? — `n test-php`: 924 tests, 2859 assertions, all passing.