### PR TITLE
fix: prevent content-gate editor.scss styles from getting chunked into the common.css file

### DIFF
--- a/includes/content-gate/class-block-visibility.php
+++ b/includes/content-gate/class-block-visibility.php
@@ -186,6 +186,13 @@ class Block_Visibility {
 			true
 		);
 
+		wp_enqueue_style(
+			'newspack-content-gate-block-visibility',
+			Newspack::plugin_url() . '/dist/content-gate-block-visibility.css',
+			[],
+			$asset['version']
+		);
+
 		wp_localize_script(
 			'newspack-content-gate-block-visibility',
 			'newspackBlockVisibility',

--- a/src/content-gate/editor/block-visibility.scss
+++ b/src/content-gate/editor/block-visibility.scss
@@ -1,0 +1,24 @@
+@use "~@wordpress/base-styles/variables" as wp-vars;
+
+.newspack-access-control-block-visibility-panel {
+	.components-base-control,
+	.components-form-token-field {
+		width: 100%;
+	}
+	// Gutenberg's `.block-editor-block-inspector p:not(.components-base-control__help)` rule
+	// strips the emotion margin-top on FormTokenField's help text. Nested here to bump
+	// specificity above Gutenberg's and restore the gap.
+	.components-form-token-field .components-form-token-field__help {
+		margin-top: wp-vars.$grid-unit-10;
+	}
+	.components-toggle-control {
+		margin-top: wp-vars.$grid-unit-10;
+		width: 100%;
+		.components-base-control__field {
+			margin-bottom: wp-vars.$grid-unit-05;
+		}
+		.components-base-control__help {
+			margin-top: 0;
+		}
+	}
+}

--- a/src/content-gate/editor/block-visibility.tsx
+++ b/src/content-gate/editor/block-visibility.tsx
@@ -22,7 +22,7 @@ import { __, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import './editor.scss';
+import './block-visibility.scss';
 
 /**
  * Target block types that receive access control attributes.

--- a/src/content-gate/editor/editor.js
+++ b/src/content-gate/editor/editor.js
@@ -60,7 +60,11 @@ function GateEdit() {
 					<p>{ __( "Newspack Campaign prompts won't be displayed when rendering gated content.", 'newspack-plugin' ) }</p>
 				</PluginPostStatusInfo>
 			) }
-			<PluginDocumentSettingPanel name="content-gate-styles-panel" title={ __( 'Styles', 'newspack-plugin' ) }>
+			<PluginDocumentSettingPanel
+				name="content-gate-styles-panel"
+				className="newspack-content-gate-panel"
+				title={ __( 'Styles', 'newspack-plugin' ) }
+			>
 				<div className="newspack-content-gate-style-selector">
 					{ styles.map( style => (
 						<Button
@@ -105,7 +109,11 @@ function GateEdit() {
 					</Fragment>
 				) }
 			</PluginDocumentSettingPanel>
-			<PluginDocumentSettingPanel name="content-gate-settings-panel" title={ __( 'Settings', 'newspack-plugin' ) }>
+			<PluginDocumentSettingPanel
+				name="content-gate-settings-panel"
+				className="newspack-content-gate-panel"
+				title={ __( 'Settings', 'newspack-plugin' ) }
+			>
 				<TextControl
 					type="number"
 					min="0"

--- a/src/content-gate/editor/editor.scss
+++ b/src/content-gate/editor/editor.scss
@@ -5,9 +5,8 @@
 	display: none;
 }
 
-.components-base-control {
+.newspack-content-gate-panel .components-base-control {
 	margin-bottom: 16px;
-	.components-datetime__time-wrapper &,
 	&:last-child {
 		margin-bottom: 0;
 	}

--- a/src/content-gate/editor/editor.scss
+++ b/src/content-gate/editor/editor.scss
@@ -8,6 +8,7 @@
 
 .components-base-control {
 	margin-bottom: 16px;
+	.components-datetime__time-wrapper &,
 	&:last-child {
 		margin-bottom: 0;
 	}

--- a/src/content-gate/editor/editor.scss
+++ b/src/content-gate/editor/editor.scss
@@ -1,4 +1,5 @@
 @use "~@wordpress/base-styles/colors" as wp-colors;
+@use "~@wordpress/base-styles/variables" as wp-vars;
 @use "../vars" as gate;
 
 .edit-post-post-visibility {
@@ -6,7 +7,7 @@
 }
 
 .newspack-content-gate-panel .components-base-control {
-	margin-bottom: 16px;
+	margin-bottom: wp-vars.$grid-unit-20;
 	&:last-child {
 		margin-bottom: 0;
 	}

--- a/src/content-gate/editor/editor.scss
+++ b/src/content-gate/editor/editor.scss
@@ -1,5 +1,4 @@
 @use "~@wordpress/base-styles/colors" as wp-colors;
-@use "~@wordpress/base-styles/variables" as wp-vars;
 @use "../vars" as gate;
 
 .edit-post-post-visibility {
@@ -59,28 +58,3 @@
 	display: none;
 }
 
-/**
- * Access control block visibility panel.
- */
-.newspack-access-control-block-visibility-panel {
-	.components-base-control,
-	.components-form-token-field {
-		width: 100%;
-	}
-	// Gutenberg's `.block-editor-block-inspector p:not(.components-base-control__help)` rule
-	// strips the emotion margin-top on FormTokenField's help text. Nested here to bump
-	// specificity above Gutenberg's and restore the gap.
-	.components-form-token-field .components-form-token-field__help {
-		margin-top: wp-vars.$grid-unit-10;
-	}
-	.components-toggle-control {
-		margin-top: wp-vars.$grid-unit-10;
-		width: 100%;
-		.components-base-control__field {
-			margin-bottom: wp-vars.$grid-unit-05;
-		}
-		.components-base-control__help {
-			margin-top: 0;
-		}
-	}
-}

--- a/src/content-gate/editor/metering-settings.js
+++ b/src/content-gate/editor/metering-settings.js
@@ -16,7 +16,11 @@ function MeteringSettings() {
 	} );
 	const { editPost } = useDispatch( 'core/editor' );
 	return (
-		<PluginDocumentSettingPanel name="content-gate-metering-panel" title={ __( 'Metering', 'newspack-plugin' ) }>
+		<PluginDocumentSettingPanel
+			name="content-gate-metering-panel"
+			className="newspack-content-gate-panel"
+			title={ __( 'Metering', 'newspack-plugin' ) }
+		>
 			<CheckboxControl
 				label={ __( 'Enable metering', 'newspack-plugin' ) }
 				checked={ meta.metering }

--- a/src/content-gate/editor/post-settings.js
+++ b/src/content-gate/editor/post-settings.js
@@ -59,7 +59,11 @@ function PostSettings() {
 	);
 
 	return (
-		<PluginDocumentSettingPanel name="content-gate-post-exemptions-panel" title={ __( 'Access control settings', 'newspack-plugin' ) }>
+		<PluginDocumentSettingPanel
+			name="content-gate-post-exemptions-panel"
+			className="newspack-content-gate-panel"
+			title={ __( 'Access control settings', 'newspack-plugin' ) }
+		>
 			{ matchingGates.length > 0 ? (
 				<p>
 					{ __( 'Gates that apply to this post: ', 'newspack-plugin' ) }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This one was weird! 

In https://github.com/Automattic/newspack-plugin/pull/4646, a new file `block-visibility.tsx` started importing `content-gate/editor.scss`. Newspack Plugin's Webpack has `minChunks: 2`; since this was the second file editor.css was imported into, it started getting included in the common.css, which caused the `.components-base-control` styles in that CSS file to bleed into more post types.

The `.components-base-control` style wasn't very specific, but this only started being an issue when the styles were imported into more editors.

This PR does two things:
1. It moves the styles block-visiblity.tsx needed into its own CSS file, so editor.scss isn't being imported twice, and isn't getting added to the common.scss.
2. It makes the `.components-base-control` styles more specific (adding content gate-specific CSS classes) since this issue was still happening when you edited a Content Gate. 

Closes NPPM-2812

### How to test the changes in this Pull Request:

1. On trunk, edit a post and click the publish date in the sidebar; note the appearance of the date picker. 
2. Apply this PR and run `npm run build`; refresh the post editor and confirm the date picker looks okay. 
3. Using Woo Memberships, set up a Content Gate and confirm the same date picker looks okay.
4. Set up access control (add `define( 'NEWSPACK_CONTENT_GATES', true );` to your wp-config.php, and set up a content gate).
5. Edit a post, and add a group block. Confirm the options in the 'Access Control' panel look okay.
6. Smoke test some of the other steps from https://github.com/Automattic/newspack-plugin/pull/4646 and confirm things look okay.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->