### PR TITLE
chore(deps): drop joshtronic/php-loremipsum, inline starter content lipsum

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,6 @@
 	},
 	"require": {
 		"composer/installers": "~2.0",
-		"joshtronic/php-loremipsum": "^2.1",
 		"google/auth": "^1.15",
 		"woocommerce/action-scheduler": "^3.9"
 	},

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cd506e00bbd2bbf41c61d65382d6f343",
+    "content-hash": "6b6268ba2c15e3c66299046a44fd2a9c",
     "packages": [
         {
             "name": "composer/installers",
@@ -602,56 +602,6 @@
                 }
             ],
             "time": "2026-03-10T16:41:02+00:00"
-        },
-        {
-            "name": "joshtronic/php-loremipsum",
-            "version": "2.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/joshtronic/php-loremipsum.git",
-                "reference": "6d7f8cff6a092a53d66b5237edbe97d398b14f88"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/joshtronic/php-loremipsum/zipball/6d7f8cff6a092a53d66b5237edbe97d398b14f88",
-                "reference": "6d7f8cff6a092a53d66b5237edbe97d398b14f88",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.8.36 || ^9.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "joshtronic\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Josh Sherman",
-                    "email": "hello@joshtronic.com",
-                    "homepage": "https://joshtronic.com"
-                }
-            ],
-            "description": "Lorem ipsum generator in PHP without dependencies",
-            "homepage": "https://github.com/joshtronic/php-loremipsum",
-            "keywords": [
-                "generator",
-                "ipsum",
-                "lorem"
-            ],
-            "support": {
-                "issues": "https://github.com/joshtronic/php-loremipsum/issues",
-                "source": "https://github.com/joshtronic/php-loremipsum/tree/2.1.0"
-            },
-            "time": "2022-01-23T23:27:44+00:00"
         },
         {
             "name": "psr/cache",
@@ -4575,13 +4525,13 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": {},
-    "platform-dev": {},
+    "platform": [],
+    "platform-dev": [],
     "platform-overrides": {
         "php": "8.3"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/includes/starter_content/class-starter-content-generated.php
+++ b/includes/starter_content/class-starter-content-generated.php
@@ -260,6 +260,135 @@ class Starter_Content_Generated extends Starter_Content_Provider {
 	}
 
 	/**
+	 * Lorem ipsum word list used by {@see self::get_lipsum()}.
+	 *
+	 * @var string[]
+	 */
+	private const LIPSUM_WORDS = [
+		'lorem',
+		'ipsum',
+		'dolor',
+		'sit',
+		'amet',
+		'consectetur',
+		'adipiscing',
+		'elit',
+		'sed',
+		'do',
+		'eiusmod',
+		'tempor',
+		'incididunt',
+		'ut',
+		'labore',
+		'et',
+		'dolore',
+		'magna',
+		'aliqua',
+		'enim',
+		'ad',
+		'minim',
+		'veniam',
+		'quis',
+		'nostrud',
+		'exercitation',
+		'ullamco',
+		'laboris',
+		'nisi',
+		'aliquip',
+		'ex',
+		'ea',
+		'commodo',
+		'consequat',
+		'duis',
+		'aute',
+		'irure',
+		'in',
+		'reprehenderit',
+		'voluptate',
+		'velit',
+		'esse',
+		'cillum',
+		'eu',
+		'fugiat',
+		'nulla',
+		'pariatur',
+		'excepteur',
+		'sint',
+		'occaecat',
+		'cupidatat',
+		'non',
+		'proident',
+		'sunt',
+		'culpa',
+		'qui',
+		'officia',
+		'deserunt',
+		'mollit',
+		'anim',
+		'id',
+		'est',
+		'laborum',
+		'at',
+		'vero',
+		'eos',
+		'accusamus',
+		'accusantium',
+		'doloremque',
+		'laudantium',
+		'totam',
+		'rem',
+		'aperiam',
+		'eaque',
+		'ipsa',
+		'quae',
+		'ab',
+		'illo',
+		'inventore',
+		'veritatis',
+		'quasi',
+		'architecto',
+		'beatae',
+		'vitae',
+		'dicta',
+		'explicabo',
+		'nemo',
+		'ipsam',
+		'voluptas',
+		'aspernatur',
+		'odit',
+		'aut',
+		'sequi',
+		'nesciunt',
+		'neque',
+		'porro',
+		'quisquam',
+		'dolorem',
+		'adipisci',
+		'numquam',
+		'eius',
+		'modi',
+		'tempora',
+		'incidunt',
+		'magnam',
+		'quaerat',
+		'etiam',
+		'minima',
+		'nostrum',
+		'exercitationem',
+		'corporis',
+		'suscipit',
+		'laboriosam',
+		'aliquid',
+		'commodi',
+		'consequatur',
+		'quo',
+		'vel',
+		'illum',
+		'eum',
+		'iure',
+	];
+
+	/**
 	 * Generate dummy text.
 	 *
 	 * @param string $type The type of Lorem Ipsum to retrieve: paras|words.
@@ -270,18 +399,46 @@ class Starter_Content_Generated extends Starter_Content_Provider {
 		if ( Starter_Content::is_e2e() ) {
 			return file_get_contents( NEWSPACK_ABSPATH . 'includes/raw_assets/markup/body.txt' );
 		}
-		$lipsum = new \joshtronic\LoremIpsum();
-		switch ( $type ) {
-			case 'paras':
-				$text = $lipsum->paragraphs( $amount + 1 );
-				$text = implode( PHP_EOL, array_slice( explode( PHP_EOL, $text ), 1 ) );
-				break;
-			default:
-				$text = $lipsum->words( $amount + 12 );
-				$text = implode( ' ', array_slice( explode( ' ', $text ), 12 ) );
-				break;
+		if ( 'paras' === $type ) {
+			return implode( PHP_EOL, self::lipsum_paragraphs( $amount ) );
 		}
-		return $text;
+		return implode( ' ', self::lipsum_words( $amount ) );
+	}
+
+	/**
+	 * Pick $count random words from the lorem ipsum pool.
+	 *
+	 * @param int $count Number of words to return.
+	 * @return string[]
+	 */
+	private static function lipsum_words( $count ) {
+		$max    = count( self::LIPSUM_WORDS ) - 1;
+		$output = [];
+		for ( $i = 0; $i < $count; $i++ ) {
+			$output[] = self::LIPSUM_WORDS[ wp_rand( 0, $max ) ];
+		}
+		return $output;
+	}
+
+	/**
+	 * Build $count lorem ipsum paragraphs.
+	 *
+	 * @param int $count Number of paragraphs to return.
+	 * @return string[]
+	 */
+	private static function lipsum_paragraphs( $count ) {
+		$paragraphs = [];
+		for ( $i = 0; $i < $count; $i++ ) {
+			$sentences = [];
+			$num       = wp_rand( 4, 7 );
+			for ( $j = 0; $j < $num; $j++ ) {
+				$words       = self::lipsum_words( wp_rand( 6, 14 ) );
+				$words[0]    = ucfirst( $words[0] );
+				$sentences[] = implode( ' ', $words ) . '.';
+			}
+			$paragraphs[] = implode( ' ', $sentences );
+		}
+		return $paragraphs;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The `joshtronic/php-loremipsum` package is used in the starter content generator (`Starter_Content_Generated::get_lipsum()`) to produce dummy paragraphs and words for the demo site bootstrapped by the setup wizard. It's no longer available, so this PR removes the dependency and inlines a tiny equivalent generator (an embedded word list plus two small helpers, `lipsum_words()` and `lipsum_paragraphs()`).

The public signature of `get_lipsum( $type, $amount )` is unchanged, so the three existing callers (post titles, excerpts, body paragraphs) keep working exactly as before. Output remains lowercase space-separated words for `'words'` and sentence-cased paragraphs joined by `PHP_EOL` for `'paras'`.

Closes NPPM-2827

### How to test the changes in this Pull Request:

1. Pull this branch and run `composer install` in `newspack-plugin`. Confirm `vendor/joshtronic/` no longer exists and `composer.lock` no longer mentions `joshtronic/php-loremipsum`.
2. On a fresh site, run the Newspack setup wizard (or `wp newspack starter-content generate` if available) and let it generate starter posts.
3. Verify the generated posts have:
   - Titles that look like lorem-ipsum word strings (7–14 words, sentence-cased, no periods).
   - Excerpts of ~20–30 lowercase words ending in a period.
   - Bodies composed of several paragraphs of varied sentence length, separated by paragraph breaks.
4. Smoke test directly via WP-CLI:
   ```bash
   wp eval 'echo Newspack\Starter_Content_Generated::get_lipsum("words", 10), "\n---\n", Newspack\Starter_Content_Generated::get_lipsum("paras", 2);'
   ```
   Confirm `words` returns a single space-separated string with no punctuation and no leading uppercase, and `paras` returns paragraphs separated by `\n`, each containing multiple sentences.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?