### PR TITLE
feat(group-subs): polish invite-links UX in My Account

### DIFF
--- a/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-invite.php
+++ b/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-invite.php
@@ -121,6 +121,46 @@ class Group_Subscription_Invite {
 	}
 
 	/**
+	 * Get the expiration window as a human-readable label (e.g. "30 days", "1 hour").
+	 *
+	 * Unlike core's human_time_diff(), this keeps the natural unit instead of rolling
+	 * 30 days up to "1 month".
+	 *
+	 * @return string Localized label.
+	 */
+	public static function get_expiration_label() {
+		$seconds = (int) self::get_expiration_time();
+
+		if ( $seconds < HOUR_IN_SECONDS ) {
+			$minutes = max( 1, (int) round( $seconds / MINUTE_IN_SECONDS ) );
+			/* translators: %d: number of minutes. */
+			return sprintf( _n( '%d minute', '%d minutes', $minutes, 'newspack-plugin' ), $minutes );
+		}
+
+		if ( $seconds < DAY_IN_SECONDS ) {
+			$hours = max( 1, (int) round( $seconds / HOUR_IN_SECONDS ) );
+			/* translators: %d: number of hours. */
+			return sprintf( _n( '%d hour', '%d hours', $hours, 'newspack-plugin' ), $hours );
+		}
+
+		if ( $seconds < WEEK_IN_SECONDS ) {
+			$days = max( 1, (int) round( $seconds / DAY_IN_SECONDS ) );
+			/* translators: %d: number of days. */
+			return sprintf( _n( '%d day', '%d days', $days, 'newspack-plugin' ), $days );
+		}
+
+		if ( $seconds < MONTH_IN_SECONDS ) {
+			$weeks = max( 1, (int) round( $seconds / WEEK_IN_SECONDS ) );
+			/* translators: %d: number of weeks. */
+			return sprintf( _n( '%d week', '%d weeks', $weeks, 'newspack-plugin' ), $weeks );
+		}
+
+		$days = max( 1, (int) round( $seconds / DAY_IN_SECONDS ) );
+		/* translators: %d: number of days. */
+		return sprintf( _n( '%d day', '%d days', $days, 'newspack-plugin' ), $days );
+	}
+
+	/**
 	 * Check if a group subscription invitation has expired.
 	 * Expiration timestamps are stored as an array map keyed by invite key.
 	 *

--- a/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-invite.php
+++ b/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-invite.php
@@ -123,41 +123,36 @@ class Group_Subscription_Invite {
 	/**
 	 * Get the expiration window as a human-readable label (e.g. "30 days", "1 hour").
 	 *
-	 * Unlike core's human_time_diff(), this keeps the natural unit instead of rolling
-	 * 30 days up to "1 month".
-	 *
 	 * @return string Localized label.
 	 */
 	public static function get_expiration_label() {
 		$seconds = (int) self::get_expiration_time();
 
-		if ( $seconds < HOUR_IN_SECONDS ) {
-			$minutes = max( 1, (int) round( $seconds / MINUTE_IN_SECONDS ) );
-			/* translators: %d: number of minutes. */
-			return sprintf( _n( '%d minute', '%d minutes', $minutes, 'newspack-plugin' ), $minutes );
+		if ( $seconds <= 0 ) {
+			$seconds = 1;
 		}
 
-		if ( $seconds < DAY_IN_SECONDS ) {
-			$hours = max( 1, (int) round( $seconds / HOUR_IN_SECONDS ) );
-			/* translators: %d: number of hours. */
-			return sprintf( _n( '%d hour', '%d hours', $hours, 'newspack-plugin' ), $hours );
-		}
-
-		if ( $seconds < WEEK_IN_SECONDS ) {
-			$days = max( 1, (int) round( $seconds / DAY_IN_SECONDS ) );
-			/* translators: %d: number of days. */
-			return sprintf( _n( '%d day', '%d days', $days, 'newspack-plugin' ), $days );
-		}
-
-		if ( $seconds < MONTH_IN_SECONDS ) {
-			$weeks = max( 1, (int) round( $seconds / WEEK_IN_SECONDS ) );
+		if ( $seconds >= WEEK_IN_SECONDS && 0 === $seconds % WEEK_IN_SECONDS ) {
+			$weeks = (int) ( $seconds / WEEK_IN_SECONDS );
 			/* translators: %d: number of weeks. */
 			return sprintf( _n( '%d week', '%d weeks', $weeks, 'newspack-plugin' ), $weeks );
 		}
 
-		$days = max( 1, (int) round( $seconds / DAY_IN_SECONDS ) );
-		/* translators: %d: number of days. */
-		return sprintf( _n( '%d day', '%d days', $days, 'newspack-plugin' ), $days );
+		if ( $seconds >= DAY_IN_SECONDS && 0 === $seconds % DAY_IN_SECONDS ) {
+			$days = (int) ( $seconds / DAY_IN_SECONDS );
+			/* translators: %d: number of days. */
+			return sprintf( _n( '%d day', '%d days', $days, 'newspack-plugin' ), $days );
+		}
+
+		if ( $seconds >= HOUR_IN_SECONDS && 0 === $seconds % HOUR_IN_SECONDS ) {
+			$hours = (int) ( $seconds / HOUR_IN_SECONDS );
+			/* translators: %d: number of hours. */
+			return sprintf( _n( '%d hour', '%d hours', $hours, 'newspack-plugin' ), $hours );
+		}
+
+		$minutes = max( 1, (int) ceil( $seconds / MINUTE_IN_SECONDS ) );
+		/* translators: %d: number of minutes. */
+		return sprintf( _n( '%d minute', '%d minutes', $minutes, 'newspack-plugin' ), $minutes );
 	}
 
 	/**

--- a/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-invite.php
+++ b/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-invite.php
@@ -150,7 +150,7 @@ class Group_Subscription_Invite {
 			return sprintf( _n( '%d hour', '%d hours', $hours, 'newspack-plugin' ), $hours );
 		}
 
-		$minutes = max( 1, (int) ceil( $seconds / MINUTE_IN_SECONDS ) );
+		$minutes = max( 1, (int) floor( $seconds / MINUTE_IN_SECONDS ) );
 		/* translators: %d: number of minutes. */
 		return sprintf( _n( '%d minute', '%d minutes', $minutes, 'newspack-plugin' ), $minutes );
 	}

--- a/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-invite.php
+++ b/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-invite.php
@@ -134,25 +134,25 @@ class Group_Subscription_Invite {
 
 		if ( $seconds >= WEEK_IN_SECONDS && 0 === $seconds % WEEK_IN_SECONDS ) {
 			$weeks = (int) ( $seconds / WEEK_IN_SECONDS );
-			/* translators: %d: number of weeks. */
-			return sprintf( _n( '%d week', '%d weeks', $weeks, 'newspack-plugin' ), $weeks );
+			/* translators: %s: number of weeks. */
+			return sprintf( _n( '%s week', '%s weeks', $weeks, 'newspack-plugin' ), number_format_i18n( $weeks ) );
 		}
 
 		if ( $seconds >= DAY_IN_SECONDS && 0 === $seconds % DAY_IN_SECONDS ) {
 			$days = (int) ( $seconds / DAY_IN_SECONDS );
-			/* translators: %d: number of days. */
-			return sprintf( _n( '%d day', '%d days', $days, 'newspack-plugin' ), $days );
+			/* translators: %s: number of days. */
+			return sprintf( _n( '%s day', '%s days', $days, 'newspack-plugin' ), number_format_i18n( $days ) );
 		}
 
 		if ( $seconds >= HOUR_IN_SECONDS && 0 === $seconds % HOUR_IN_SECONDS ) {
 			$hours = (int) ( $seconds / HOUR_IN_SECONDS );
-			/* translators: %d: number of hours. */
-			return sprintf( _n( '%d hour', '%d hours', $hours, 'newspack-plugin' ), $hours );
+			/* translators: %s: number of hours. */
+			return sprintf( _n( '%s hour', '%s hours', $hours, 'newspack-plugin' ), number_format_i18n( $hours ) );
 		}
 
 		$minutes = max( 1, (int) floor( $seconds / MINUTE_IN_SECONDS ) );
-		/* translators: %d: number of minutes. */
-		return sprintf( _n( '%d minute', '%d minutes', $minutes, 'newspack-plugin' ), $minutes );
+		/* translators: %s: number of minutes. */
+		return sprintf( _n( '%s minute', '%s minutes', $minutes, 'newspack-plugin' ), number_format_i18n( $minutes ) );
 	}
 
 	/**

--- a/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php
+++ b/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php
@@ -111,8 +111,8 @@ class My_Account_UI_V1 {
 				'change_payment_method_title' => __( 'Change payment method', 'newspack-plugin' ),
 				'switch_subscription_title'   => __( 'Change Subscription', 'newspack-plugin' ),
 				'invite_link_copied'          => __( 'Invite link copied.', 'newspack-plugin' ),
-				'invite_link_regenerated'     => __( 'New invite link copied. Previous link is no longer valid.', 'newspack-plugin' ),
-				'invite_link_disabled'        => __( 'Invite link disabled.', 'newspack-plugin' ),
+				'invite_link_regenerated'     => __( 'New invite link copied. The old one no longer works.', 'newspack-plugin' ),
+				'invite_link_disabled'        => __( 'Invite link disabled. You can create a new link any time.', 'newspack-plugin' ),
 			],
 			'rest'         => [
 				'base_url'   => get_rest_url(),

--- a/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php
+++ b/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php
@@ -112,6 +112,8 @@ class My_Account_UI_V1 {
 				'switch_subscription_title'   => __( 'Change Subscription', 'newspack-plugin' ),
 				'invite_link_copied'          => __( 'Invite link copied.', 'newspack-plugin' ),
 				'invite_link_regenerated'     => __( 'New invite link copied. The old one no longer works.', 'newspack-plugin' ),
+				'invite_link_copy_failed'     => __( 'Couldn\'t copy the invite link to your clipboard. Copy it manually:', 'newspack-plugin' ),
+				'dismiss'                     => __( 'Dismiss', 'newspack-plugin' ),
 				'invite_link_disabled'        => __( 'Invite link disabled. You can create a new link any time.', 'newspack-plugin' ),
 			],
 			'rest'         => [

--- a/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php
+++ b/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php
@@ -113,7 +113,6 @@ class My_Account_UI_V1 {
 				'invite_link_copied'          => __( 'Invite link copied.', 'newspack-plugin' ),
 				'invite_link_regenerated'     => __( 'New invite link copied. The old one no longer works.', 'newspack-plugin' ),
 				'invite_link_copy_failed'     => __( 'Couldn\'t copy the invite link to your clipboard. Copy it manually:', 'newspack-plugin' ),
-				'dismiss'                     => __( 'Dismiss', 'newspack-plugin' ),
 				'invite_link_disabled'        => __( 'Invite link disabled. You can create a new link any time.', 'newspack-plugin' ),
 			],
 			'rest'         => [

--- a/includes/plugins/woocommerce/my-account/templates/v1/group-subscription-members.php
+++ b/includes/plugins/woocommerce/my-account/templates/v1/group-subscription-members.php
@@ -125,32 +125,39 @@ $active_tab  = ( isset( $_GET['activeTab'] ) && 'invites' === sanitize_key( wp_u
 
 <div class="newspack-my-account__group_subscription__content" data-subscription-id="<?php echo esc_attr( $subscription->get_id() ); ?>" data-invite-link="<?php echo esc_attr( $invite_link_url ); ?>">
 	<div class="newspack-ui__segmented-control newspack-my-account__group_subscription__segmented-control">
-		<div class="newspack-ui__segmented-control__tabs">
-			<button type="button" class="newspack-ui__button newspack-ui__button--small<?php echo 'members' === $active_tab ? ' selected' : ''; ?>">
-				<?php
-				echo wp_kses_post(
-					sprintf(
-						// translators: %d: The number of members.
-						__( 'Members <span class="newspack-ui__badge newspack-ui__badge--outline newspack-group-subscription--members-count">%d</span>', 'newspack-plugin' ),
-						count( $managers_and_members )
-					)
-				);
-				?>
+		<div class="newspack-ui__segmented-control__tabs" role="tablist">
+			<button
+				type="button"
+				role="tab"
+				id="newspack-my-account__group_subscription__tab-members"
+				aria-controls="newspack-my-account__group_subscription__panel-members"
+				aria-selected="<?php echo 'members' === $active_tab ? 'true' : 'false'; ?>"
+				tabindex="<?php echo 'members' === $active_tab ? '0' : '-1'; ?>"
+				class="newspack-ui__button newspack-ui__button--small<?php echo 'members' === $active_tab ? ' selected' : ''; ?>"
+			>
+				<?php esc_html_e( 'Members', 'newspack-plugin' ); ?>
+				<span class="newspack-ui__badge newspack-ui__badge--outline newspack-group-subscription--members-count"><?php echo esc_html( count( $managers_and_members ) ); ?></span>
 			</button>
-			<button type="button" class="newspack-ui__button newspack-ui__button--small<?php echo 'invites' === $active_tab ? ' selected' : ''; ?>">
-				<?php
-				echo wp_kses_post(
-					sprintf(
-						// translators: %d: The number of invitations.
-						__( 'Invitations <span class="newspack-ui__badge newspack-ui__badge--outline newspack-group-subscription--invitations-count">%d</span>', 'newspack-plugin' ),
-						count( $all_invites )
-					)
-				);
-				?>
+			<button
+				type="button"
+				role="tab"
+				id="newspack-my-account__group_subscription__tab-invites"
+				aria-controls="newspack-my-account__group_subscription__panel-invites"
+				aria-selected="<?php echo 'invites' === $active_tab ? 'true' : 'false'; ?>"
+				tabindex="<?php echo 'invites' === $active_tab ? '0' : '-1'; ?>"
+				class="newspack-ui__button newspack-ui__button--small<?php echo 'invites' === $active_tab ? ' selected' : ''; ?>"
+			>
+				<?php esc_html_e( 'Invitations', 'newspack-plugin' ); ?>
+				<span class="newspack-ui__badge newspack-ui__badge--outline newspack-group-subscription--invitations-count"><?php echo esc_html( count( $all_invites ) ); ?></span>
 			</button>
 		</div>
 		<div class="newspack-ui__segmented-control__content">
-			<div class="newspack-ui__segmented-control__panel<?php echo 'members' === $active_tab ? ' selected' : ''; ?>">
+			<div
+				id="newspack-my-account__group_subscription__panel-members"
+				role="tabpanel"
+				aria-labelledby="newspack-my-account__group_subscription__tab-members"
+				class="newspack-ui__segmented-control__panel<?php echo 'members' === $active_tab ? ' selected' : ''; ?>"
+			>
 	<table class="shop_table shop_table_responsive newspack-my-account__group_subscription__members">
 		<thead>
 			<tr>
@@ -337,7 +344,7 @@ $active_tab  = ( isset( $_GET['activeTab'] ) && 'invites' === sanitize_key( wp_u
 
 				<section class="newspack-ui__modal__content">
 						<p>
-							<?php esc_html_e( 'The current link will stop working. You\'ll get a new link to share, and anyone who hasn\'t joined yet will need it.', 'newspack-plugin' ); ?>
+							<?php esc_html_e( 'The current link will stop working. You\'ll get a new link to share, and anyone who hasn\'t joined yet will need the new link.', 'newspack-plugin' ); ?>
 						</p>
 
 						<button type="button" class="newspack-ui__button newspack-ui__button--primary newspack-ui__button--wide newspack-my-account__group_subscription__invite-link__regenerate" data-error-text="<?php echo esc_attr( __( 'Could not regenerate. Please try again.', 'newspack-plugin' ) ); ?>"><span><?php esc_html_e( 'Regenerate link', 'newspack-plugin' ); ?></span></button>
@@ -361,7 +368,7 @@ $active_tab  = ( isset( $_GET['activeTab'] ) && 'invites' === sanitize_key( wp_u
 
 				<section class="newspack-ui__modal__content">
 						<p>
-							<?php esc_html_e( 'The current link will stop working. Anyone who hasn\'t joined yet won\'t be able to. You can create a new link any time.', 'newspack-plugin' ); ?>
+							<?php esc_html_e( 'The current link will stop working. Anyone who hasn\'t joined yet will no longer be able to. You can create a new link at any time.', 'newspack-plugin' ); ?>
 						</p>
 
 						<button type="button" class="newspack-ui__button newspack-ui__button--primary newspack-ui__button--wide newspack-ui__button--destructive newspack-my-account__group_subscription__invite-link__disable" data-error-text="<?php echo esc_attr( __( 'Could not disable. Please try again.', 'newspack-plugin' ) ); ?>"><span><?php esc_html_e( 'Disable link', 'newspack-plugin' ); ?></span></button>

--- a/includes/plugins/woocommerce/my-account/templates/v1/group-subscription-members.php
+++ b/includes/plugins/woocommerce/my-account/templates/v1/group-subscription-members.php
@@ -25,6 +25,7 @@ $current_user_id      = get_current_user_id();
 $invite_link          = Group_Subscription_Invite::get_link_invite( $subscription, $current_user_id );
 $invite_link_url      = $invite_link ? Group_Subscription_Invite::get_link_invite_url( $subscription->get_id(), $current_user_id, $invite_link['key'] ) : '';
 $is_at_limit = $member_limit > 0 && ( count( $members ) + count( $pending_invites ) ) >= $member_limit;
+$active_tab  = ( isset( $_GET['activeTab'] ) && 'invites' === $_GET['activeTab'] ) ? 'invites' : 'members'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 ?>
 <header class="newspack-my-account__subscription--header">
 	<?php
@@ -122,32 +123,34 @@ $is_at_limit = $member_limit > 0 && ( count( $members ) + count( $pending_invite
 	</div>
 </header>
 
-<div class="newspack-my-account__group_subscription__content" data-active-tab="members" data-subscription-id="<?php echo esc_attr( $subscription->get_id() ); ?>" data-invite-link="<?php echo esc_attr( $invite_link_url ); ?>">
-	<p class="newspack-my-account__group_subscription__tabs">
-		<a href="#" data-tab="members" class="newspack-my-account__group_subscription__tabs--members">
-			<?php
-			echo wp_kses_post(
-				sprintf(
-					// translators: %d: The number of members.
-					__( 'Members (<span class="newspack-group-subscription--members-count">%d</span>)', 'newspack-plugin' ),
-					count( $managers_and_members )
-				)
-			);
-			?>
-		</a>
-		|
-		<a href="#" data-tab="invites" class="newspack-my-account__group_subscription__tabs--invites">
-			<?php
-			echo wp_kses_post(
-				sprintf(
-					// translators: %d: The number of members.
-					__( 'Invitations (<span class="newspack-group-subscription--invitations-count">%d</span>)', 'newspack-plugin' ),
-					count( $all_invites )
-				)
-			);
-			?>
-		</a>
-	</p>
+<div class="newspack-my-account__group_subscription__content" data-subscription-id="<?php echo esc_attr( $subscription->get_id() ); ?>" data-invite-link="<?php echo esc_attr( $invite_link_url ); ?>">
+	<div class="newspack-ui__segmented-control newspack-my-account__group_subscription__segmented-control">
+		<div class="newspack-ui__segmented-control__tabs">
+			<button type="button" class="newspack-ui__button newspack-ui__button--small<?php echo 'members' === $active_tab ? ' selected' : ''; ?>">
+				<?php
+				echo wp_kses_post(
+					sprintf(
+						// translators: %d: The number of members.
+						__( 'Members <span class="newspack-ui__badge newspack-ui__badge--outline newspack-group-subscription--members-count">%d</span>', 'newspack-plugin' ),
+						count( $managers_and_members )
+					)
+				);
+				?>
+			</button>
+			<button type="button" class="newspack-ui__button newspack-ui__button--small<?php echo 'invites' === $active_tab ? ' selected' : ''; ?>">
+				<?php
+				echo wp_kses_post(
+					sprintf(
+						// translators: %d: The number of invitations.
+						__( 'Invitations <span class="newspack-ui__badge newspack-ui__badge--outline newspack-group-subscription--invitations-count">%d</span>', 'newspack-plugin' ),
+						count( $all_invites )
+					)
+				);
+				?>
+			</button>
+		</div>
+		<div class="newspack-ui__segmented-control__content">
+			<div class="newspack-ui__segmented-control__panel">
 	<table class="shop_table shop_table_responsive newspack-my-account__group_subscription__members">
 		<thead>
 			<tr>
@@ -211,7 +214,8 @@ $is_at_limit = $member_limit > 0 && ( count( $members ) + count( $pending_invite
 		<?php endforeach; ?>
 		</tbody>
 	</table>
-
+			</div><!-- .newspack-ui__segmented-control__panel (members) -->
+			<div class="newspack-ui__segmented-control__panel">
 	<table class="shop_table shop_table_responsive newspack-my-account__group_subscription__invites">
 		<thead>
 			<tr>
@@ -268,6 +272,9 @@ $is_at_limit = $member_limit > 0 && ( count( $members ) + count( $pending_invite
 		<?php endforeach; ?>
 		</tbody>
 	</table>
+			</div><!-- .newspack-ui__segmented-control__panel (invites) -->
+		</div><!-- .newspack-ui__segmented-control__content -->
+	</div><!-- .newspack-ui__segmented-control -->
 
 	<!-- .newspack-ui__modal: invite by email -->
 	<div id="newspack-my-account__group_subscription--invite-member" class="newspack-ui__modal-container">
@@ -289,7 +296,15 @@ $is_at_limit = $member_limit > 0 && ( count( $members ) + count( $pending_invite
 						</p>
 					<?php else : ?>
 						<p>
-							<?php esc_html_e( 'Invite a member by email, or share a link to let multiple members join.', 'newspack-plugin' ); ?>
+							<?php
+							echo esc_html(
+								sprintf(
+									// translators: %s is a duration label like "30 days" or "1 hour".
+									__( 'They\'ll get an email with a link to join the group. The link expires in %s.', 'newspack-plugin' ),
+									Group_Subscription_Invite::get_expiration_label()
+								)
+							);
+							?>
 						</p>
 						<form name="newspack-group-subscription-invite-member" method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
 							<input type="hidden" name="action" value="newspack_group_subscription_invite">
@@ -322,10 +337,10 @@ $is_at_limit = $member_limit > 0 && ( count( $members ) + count( $pending_invite
 
 				<section class="newspack-ui__modal__content">
 						<p>
-							<?php esc_html_e( 'The existing link will no longer allow users to join the group. Create a new link?', 'newspack-plugin' ); ?>
+							<?php esc_html_e( 'The current link will stop working. You\'ll get a new link to share, and anyone who hasn\'t joined yet will need it.', 'newspack-plugin' ); ?>
 						</p>
 
-						<button type="button" class="newspack-ui__button newspack-ui__button--primary newspack-ui__button--wide newspack-ui__button--destructive newspack-my-account__group_subscription__invite-link__regenerate" data-error-text="<?php echo esc_attr( __( 'Could not regenerate. Please try again.', 'newspack-plugin' ) ); ?>"><span><?php esc_html_e( 'OK', 'newspack-plugin' ); ?></span></button>
+						<button type="button" class="newspack-ui__button newspack-ui__button--primary newspack-ui__button--wide newspack-my-account__group_subscription__invite-link__regenerate" data-error-text="<?php echo esc_attr( __( 'Could not regenerate. Please try again.', 'newspack-plugin' ) ); ?>"><span><?php esc_html_e( 'Regenerate link', 'newspack-plugin' ); ?></span></button>
 						<button type="button" class="newspack-ui__button newspack-ui__button--ghost newspack-ui__button--wide newspack-ui__modal__close"><?php esc_html_e( 'Cancel', 'newspack-plugin' ); ?></button>
 				</section>
 			</div><!-- .newspack-ui__modal__small -->
@@ -346,10 +361,10 @@ $is_at_limit = $member_limit > 0 && ( count( $members ) + count( $pending_invite
 
 				<section class="newspack-ui__modal__content">
 						<p>
-							<?php esc_html_e( 'The existing link will no longer allow users to join the group. Disable the link?', 'newspack-plugin' ); ?>
+							<?php esc_html_e( 'The current link will stop working. Anyone who hasn\'t joined yet won\'t be able to. You can create a new link any time.', 'newspack-plugin' ); ?>
 						</p>
 
-						<button type="button" class="newspack-ui__button newspack-ui__button--primary newspack-ui__button--wide newspack-ui__button--destructive newspack-my-account__group_subscription__invite-link__disable" data-error-text="<?php echo esc_attr( __( 'Could not disable. Please try again.', 'newspack-plugin' ) ); ?>"><span><?php esc_html_e( 'OK', 'newspack-plugin' ); ?></span></button>
+						<button type="button" class="newspack-ui__button newspack-ui__button--primary newspack-ui__button--wide newspack-ui__button--destructive newspack-my-account__group_subscription__invite-link__disable" data-error-text="<?php echo esc_attr( __( 'Could not disable. Please try again.', 'newspack-plugin' ) ); ?>"><span><?php esc_html_e( 'Disable link', 'newspack-plugin' ); ?></span></button>
 						<button type="button" class="newspack-ui__button newspack-ui__button--ghost newspack-ui__button--wide newspack-ui__modal__close"><?php esc_html_e( 'Cancel', 'newspack-plugin' ); ?></button>
 				</section>
 			</div><!-- .newspack-ui__modal__small -->

--- a/includes/plugins/woocommerce/my-account/templates/v1/group-subscription-members.php
+++ b/includes/plugins/woocommerce/my-account/templates/v1/group-subscription-members.php
@@ -25,7 +25,7 @@ $current_user_id      = get_current_user_id();
 $invite_link          = Group_Subscription_Invite::get_link_invite( $subscription, $current_user_id );
 $invite_link_url      = $invite_link ? Group_Subscription_Invite::get_link_invite_url( $subscription->get_id(), $current_user_id, $invite_link['key'] ) : '';
 $is_at_limit = $member_limit > 0 && ( count( $members ) + count( $pending_invites ) ) >= $member_limit;
-$active_tab  = ( isset( $_GET['activeTab'] ) && 'invites' === $_GET['activeTab'] ) ? 'invites' : 'members'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+$active_tab  = ( isset( $_GET['activeTab'] ) && 'invites' === sanitize_key( wp_unslash( $_GET['activeTab'] ) ) ) ? 'invites' : 'members'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 ?>
 <header class="newspack-my-account__subscription--header">
 	<?php

--- a/includes/plugins/woocommerce/my-account/templates/v1/group-subscription-members.php
+++ b/includes/plugins/woocommerce/my-account/templates/v1/group-subscription-members.php
@@ -150,7 +150,7 @@ $active_tab  = ( isset( $_GET['activeTab'] ) && 'invites' === sanitize_key( wp_u
 			</button>
 		</div>
 		<div class="newspack-ui__segmented-control__content">
-			<div class="newspack-ui__segmented-control__panel">
+			<div class="newspack-ui__segmented-control__panel<?php echo 'members' === $active_tab ? ' selected' : ''; ?>">
 	<table class="shop_table shop_table_responsive newspack-my-account__group_subscription__members">
 		<thead>
 			<tr>
@@ -215,7 +215,7 @@ $active_tab  = ( isset( $_GET['activeTab'] ) && 'invites' === sanitize_key( wp_u
 		</tbody>
 	</table>
 			</div><!-- .newspack-ui__segmented-control__panel (members) -->
-			<div class="newspack-ui__segmented-control__panel">
+			<div class="newspack-ui__segmented-control__panel<?php echo 'invites' === $active_tab ? ' selected' : ''; ?>">
 	<table class="shop_table shop_table_responsive newspack-my-account__group_subscription__invites">
 		<thead>
 			<tr>

--- a/src/my-account/v1/_group-subscriptions.scss
+++ b/src/my-account/v1/_group-subscriptions.scss
@@ -18,6 +18,14 @@
 	&__members,
 	&__invites {
 		margin-top: var(--newspack-ui-spacer-5);
+
+		// Match populated row height for empty-state cells.
+		td[colspan]::after {
+			content: '';
+			display: inline-block;
+			vertical-align: middle;
+			min-height: var(--newspack-ui-spacer-7);
+		}
 	}
 	&__members--actions,
 	&__invites--actions {
@@ -29,7 +37,7 @@
 					content: '';
 					display: inline-block;
 					vertical-align: middle;
-					min-height: 36px;
+					min-height: var(--newspack-ui-spacer-7);
 				}
 			}
 		}

--- a/src/my-account/v1/_group-subscriptions.scss
+++ b/src/my-account/v1/_group-subscriptions.scss
@@ -31,6 +31,14 @@
 			min-height: var(--newspack-ui-spacer-7);
 		}
 	}
+	&__invite-link__manual-copy {
+		width: 100%;
+		margin: var(--newspack-ui-spacer-2) 0;
+		padding: var(--newspack-ui-spacer-1) var(--newspack-ui-spacer-2);
+		font-family: monospace;
+		user-select: all;
+	}
+
 	&__members--actions,
 	&__invites--actions {
 		&--manager {

--- a/src/my-account/v1/_group-subscriptions.scss
+++ b/src/my-account/v1/_group-subscriptions.scss
@@ -1,31 +1,20 @@
 .newspack-ui .newspack-my-account__group_subscription {
-	&__tabs {
-		display: flex;
-		gap: 16px;
-		margin-bottom: 16px;
-	}
-	&__content {
-		.newspack-my-account__group_subscription__members,
-		.newspack-my-account__group_subscription__invites {
-			display: none;
-		}
-		&[data-active-tab="members"] {
-			.newspack-my-account__group_subscription__tabs--members {
-				font-weight: 600;
-			}
-			.newspack-my-account__group_subscription__members {
-				display: table;
-			}
-		}
-		&[data-active-tab="invites"] {
-			.newspack-my-account__group_subscription__tabs--invites {
-				font-weight: 600;
-			}
-			.newspack-my-account__group_subscription__invites {
-				display: table;
-			}
+	&__segmented-control {
+		align-items: flex-start;
+		margin-bottom: var(--newspack-ui-spacer-5);
+
+		.newspack-ui__button {
+			display: inline-flex;
+			align-items: center;
+			gap: var(--newspack-ui-spacer-2);
 		}
 	}
+
+	// Enter animation for invite-link controls revealed after the link is created.
+	&__entering {
+		animation: newspack-group-subscription-enter 125ms ease both;
+	}
+
 	&__members,
 	&__invites {
 		margin-top: var(--newspack-ui-spacer-5);
@@ -44,5 +33,16 @@
 				}
 			}
 		}
+	}
+}
+
+@keyframes newspack-group-subscription-enter {
+	from {
+		opacity: 0;
+		transform: translateY(-4px);
+	}
+	to {
+		opacity: 1;
+		transform: translateY(0);
 	}
 }

--- a/src/my-account/v1/_group-subscriptions.scss
+++ b/src/my-account/v1/_group-subscriptions.scss
@@ -13,6 +13,10 @@
 	// Enter animation for invite-link controls revealed after the link is created.
 	&__entering {
 		animation: newspack-group-subscription-enter 125ms ease both;
+
+		@media (prefers-reduced-motion: reduce) {
+			animation: none;
+		}
 	}
 
 	&__members,

--- a/src/my-account/v1/_group-subscriptions.scss
+++ b/src/my-account/v1/_group-subscriptions.scss
@@ -31,14 +31,6 @@
 			min-height: var(--newspack-ui-spacer-7);
 		}
 	}
-	&__invite-link__manual-copy {
-		width: 100%;
-		margin: var(--newspack-ui-spacer-2) 0;
-		padding: var(--newspack-ui-spacer-1) var(--newspack-ui-spacer-2);
-		font-family: monospace;
-		user-select: all;
-	}
-
 	&__members--actions,
 	&__invites--actions {
 		&--manager {

--- a/src/my-account/v1/group-subscriptions.js
+++ b/src/my-account/v1/group-subscriptions.js
@@ -113,8 +113,9 @@ domReady( function () {
 	};
 	// Minimum loading duration so the spinner reads as "system thinking" even when the API is instant.
 	const MIN_LOADING_MS = 500;
+	const now = () => ( typeof performance !== 'undefined' && performance.now ? performance.now() : Date.now() );
 	const waitForMinLoading = start => {
-		const elapsed = performance.now() - start;
+		const elapsed = now() - start;
 		return elapsed < MIN_LOADING_MS ? new Promise( resolve => setTimeout( resolve, MIN_LOADING_MS - elapsed ) ) : Promise.resolve();
 	};
 
@@ -124,7 +125,7 @@ domReady( function () {
 		el.setAttribute( 'aria-busy', 'true' );
 		el.setAttribute( 'disabled', '' );
 		const errorText = e.currentTarget.getAttribute( 'data-error-text' );
-		const loadingStart = performance.now();
+		const loadingStart = now();
 		try {
 			const response = await fetch( restUrl, {
 				method: 'POST',
@@ -166,7 +167,7 @@ domReady( function () {
 		el.setAttribute( 'aria-busy', 'true' );
 		el.setAttribute( 'disabled', '' );
 		const errorText = e.currentTarget.getAttribute( 'data-error-text' );
-		const loadingStart = performance.now();
+		const loadingStart = now();
 		try {
 			const response = await fetch( restUrl, {
 				method: 'DELETE',

--- a/src/my-account/v1/group-subscriptions.js
+++ b/src/my-account/v1/group-subscriptions.js
@@ -130,53 +130,9 @@ domReady( function () {
 		}
 	};
 
-	const showCopyFailureNotice = url => {
-		let wrapper = document.querySelector( '.newspack-ui' );
-		if ( ! wrapper ) {
-			wrapper = document.createElement( 'div' );
-			wrapper.classList.add( 'newspack-ui' );
-			document.body.appendChild( wrapper );
-		}
-		let snackbar = wrapper.querySelector( '.newspack-ui__snackbar--top-right' );
-		if ( ! snackbar ) {
-			snackbar = document.createElement( 'div' );
-			snackbar.classList.add( 'newspack-ui__snackbar', 'newspack-ui__snackbar--top-right' );
-			wrapper.appendChild( snackbar );
-		}
-		const item = document.createElement( 'div' );
-		item.classList.add( 'newspack-ui__snackbar__item', 'newspack-ui__snackbar__item--error' );
-		item.setAttribute( 'data-autohide', 'false' );
-
-		const itemContent = document.createElement( 'div' );
-		itemContent.classList.add( 'newspack-ui__snackbar__content' );
-
-		const msg = document.createElement( 'div' );
-		msg.textContent =
-			newspackMyAccountV1?.labels?.invite_link_copy_failed || "Couldn't copy the invite link to your clipboard. Copy it manually:";
-		itemContent.appendChild( msg );
-
-		const linkField = document.createElement( 'input' );
-		linkField.type = 'text';
-		linkField.readOnly = true;
-		linkField.value = url;
-		linkField.classList.add( 'newspack-my-account__group_subscription__invite-link__manual-copy' );
-		linkField.addEventListener( 'focus', () => linkField.select() );
-		itemContent.appendChild( linkField );
-
-		const close = document.createElement( 'button' );
-		close.type = 'button';
-		close.classList.add( 'newspack-ui__button', 'newspack-ui__button--ghost', 'newspack-ui__button--small' );
-		close.textContent = newspackMyAccountV1?.labels?.dismiss || 'Dismiss';
-		close.addEventListener( 'click', () => {
-			item.classList.remove( 'active' );
-			setTimeout( () => item.remove(), 250 );
-		} );
-		itemContent.appendChild( close );
-
-		item.appendChild( itemContent );
-		snackbar.appendChild( item );
-		requestAnimationFrame( () => item.classList.add( 'active' ) );
-		linkField.focus();
+	const copyFailedMessage = url => {
+		const text = newspackMyAccountV1?.labels?.invite_link_copy_failed || "Couldn't copy the invite link to your clipboard. Copy it manually:";
+		return `${ text } ${ url }`;
 	};
 	// Minimum loading duration so the spinner reads as "system thinking" even when the API is instant.
 	const MIN_LOADING_MS = 500;
@@ -219,7 +175,7 @@ domReady( function () {
 					: newspackMyAccountV1?.labels?.invite_link_copied || 'Invite link copied.';
 				showSnackbar( message );
 			} else {
-				showCopyFailureNotice( data.url );
+				showSnackbar( copyFailedMessage( data.url ), 'error' );
 			}
 		} catch ( error ) {
 			await waitForMinLoading( loadingStart );
@@ -276,7 +232,7 @@ domReady( function () {
 				if ( await copyToClipboard( inviteLink ) ) {
 					showSnackbar( newspackMyAccountV1?.labels?.invite_link_copied || 'Invite link copied.' );
 				} else {
-					showCopyFailureNotice( inviteLink );
+					showSnackbar( copyFailedMessage( inviteLink ), 'error' );
 				}
 			} else {
 				generateLink( e );

--- a/src/my-account/v1/group-subscriptions.js
+++ b/src/my-account/v1/group-subscriptions.js
@@ -36,9 +36,8 @@ domReady( function () {
 			} );
 		};
 		syncBadgeVariants();
-		segmentedControl.querySelectorAll( '.newspack-ui__segmented-control__tabs > .newspack-ui__button' ).forEach( button => {
-			button.addEventListener( 'click', syncBadgeVariants );
-		} );
+		// `content-selected` fires after `.selected` is toggled, avoiding a click-handler ordering race.
+		segmentedControl.addEventListener( 'content-selected', syncBadgeVariants );
 	}
 
 	// Handle invite modal.

--- a/src/my-account/v1/group-subscriptions.js
+++ b/src/my-account/v1/group-subscriptions.js
@@ -88,9 +88,13 @@ domReady( function () {
 				el.classList.remove( 'hidden' );
 				if ( wasHidden ) {
 					el.classList.add( 'newspack-my-account__group_subscription__entering' );
-					el.addEventListener( 'animationend', () => el.classList.remove( 'newspack-my-account__group_subscription__entering' ), {
-						once: true,
-					} );
+					if ( parseFloat( getComputedStyle( el ).animationDuration ) > 0 ) {
+						el.addEventListener( 'animationend', () => el.classList.remove( 'newspack-my-account__group_subscription__entering' ), {
+							once: true,
+						} );
+					} else {
+						el.classList.remove( 'newspack-my-account__group_subscription__entering' );
+					}
 				}
 			} else {
 				el.classList.add( 'hidden' );
@@ -108,8 +112,71 @@ domReady( function () {
 			await navigator.clipboard.writeText( text );
 			return true;
 		} catch ( e ) {
-			return false;
+			// Legacy fallback for insecure contexts / blocked clipboard permission.
+			try {
+				const textarea = document.createElement( 'textarea' );
+				textarea.value = text;
+				textarea.setAttribute( 'readonly', '' );
+				textarea.style.position = 'fixed';
+				textarea.style.opacity = '0';
+				document.body.appendChild( textarea );
+				textarea.select();
+				const ok = document.execCommand( 'copy' );
+				document.body.removeChild( textarea );
+				return ok;
+			} catch ( e2 ) {
+				return false;
+			}
 		}
+	};
+
+	const showCopyFailureNotice = url => {
+		let wrapper = document.querySelector( '.newspack-ui' );
+		if ( ! wrapper ) {
+			wrapper = document.createElement( 'div' );
+			wrapper.classList.add( 'newspack-ui' );
+			document.body.appendChild( wrapper );
+		}
+		let snackbar = wrapper.querySelector( '.newspack-ui__snackbar--top-right' );
+		if ( ! snackbar ) {
+			snackbar = document.createElement( 'div' );
+			snackbar.classList.add( 'newspack-ui__snackbar', 'newspack-ui__snackbar--top-right' );
+			wrapper.appendChild( snackbar );
+		}
+		const item = document.createElement( 'div' );
+		item.classList.add( 'newspack-ui__snackbar__item', 'newspack-ui__snackbar__item--error' );
+		item.setAttribute( 'data-autohide', 'false' );
+
+		const itemContent = document.createElement( 'div' );
+		itemContent.classList.add( 'newspack-ui__snackbar__content' );
+
+		const msg = document.createElement( 'div' );
+		msg.textContent =
+			newspackMyAccountV1?.labels?.invite_link_copy_failed || "Couldn't copy the invite link to your clipboard. Copy it manually:";
+		itemContent.appendChild( msg );
+
+		const linkField = document.createElement( 'input' );
+		linkField.type = 'text';
+		linkField.readOnly = true;
+		linkField.value = url;
+		linkField.classList.add( 'newspack-my-account__group_subscription__invite-link__manual-copy' );
+		linkField.addEventListener( 'focus', () => linkField.select() );
+		itemContent.appendChild( linkField );
+
+		const close = document.createElement( 'button' );
+		close.type = 'button';
+		close.classList.add( 'newspack-ui__button', 'newspack-ui__button--ghost', 'newspack-ui__button--small' );
+		close.textContent = newspackMyAccountV1?.labels?.dismiss || 'Dismiss';
+		close.addEventListener( 'click', () => {
+			item.classList.remove( 'active' );
+			setTimeout( () => item.remove(), 250 );
+		} );
+		itemContent.appendChild( close );
+
+		item.appendChild( itemContent );
+		snackbar.appendChild( item );
+		requestAnimationFrame( () => item.classList.add( 'active' ) );
+		linkField.focus();
 	};
 	// Minimum loading duration so the spinner reads as "system thinking" even when the API is instant.
 	const MIN_LOADING_MS = 500;
@@ -143,14 +210,17 @@ domReady( function () {
 				showSnackbar( message, 'error' );
 				return;
 			}
+			const isRegenerate = !! content.getAttribute( 'data-invite-link' );
+			content.setAttribute( 'data-invite-link', data.url );
+			afterInviteLink( true );
 			if ( await copyToClipboard( data.url ) ) {
-				const message = !! content.getAttribute( 'data-invite-link' )
+				const message = isRegenerate
 					? newspackMyAccountV1?.labels?.invite_link_regenerated || 'New invite link copied. The old one no longer works.'
 					: newspackMyAccountV1?.labels?.invite_link_copied || 'Invite link copied.';
 				showSnackbar( message );
+			} else {
+				showCopyFailureNotice( data.url );
 			}
-			content.setAttribute( 'data-invite-link', data.url );
-			afterInviteLink( true );
 		} catch ( error ) {
 			await waitForMinLoading( loadingStart );
 			showSnackbar( errorText, 'error' );
@@ -205,6 +275,8 @@ domReady( function () {
 			if ( inviteLink ) {
 				if ( await copyToClipboard( inviteLink ) ) {
 					showSnackbar( newspackMyAccountV1?.labels?.invite_link_copied || 'Invite link copied.' );
+				} else {
+					showCopyFailureNotice( inviteLink );
 				}
 			} else {
 				generateLink( e );

--- a/src/my-account/v1/group-subscriptions.js
+++ b/src/my-account/v1/group-subscriptions.js
@@ -12,9 +12,6 @@ domReady( function () {
 		return;
 	}
 
-	// Look for the activeTab parameter in the URL and set the active tab accordingly.
-	const params = new URLSearchParams( window.location.search );
-	const activeTab = params.get( 'activeTab' ) === 'invites' ? 'invites' : 'members';
 	const subId = parseInt( content.getAttribute( 'data-subscription-id' ), 10 );
 	const baseUrl = newspackMyAccountV1?.rest?.base_url;
 	const namespace = newspackMyAccountV1?.rest?.namespaces?.group;
@@ -23,22 +20,26 @@ domReady( function () {
 		typeof newspackUI?.notices?.createNotice === 'function'
 			? newspackUI.notices.createNotice
 			: ( msg, type ) => console.warn( '[group-subscriptions]', type, msg ); // eslint-disable-line no-console
-	if ( content ) {
-		content.setAttribute( 'data-active-tab', activeTab );
-	}
 
-	// Handle tab switching.
-	const tabs = [ ...document.querySelectorAll( '.newspack-my-account__group_subscription__tabs a' ) ];
-	tabs.forEach( tab => {
-		tab.addEventListener( 'click', event => {
-			event.preventDefault();
-			if ( ! content ) {
-				return;
-			}
-			const tabName = event.currentTarget.getAttribute( 'data-tab' );
-			content.setAttribute( 'data-active-tab', tabName );
+	// Swap each tab badge between --outline (default) and --secondary (selected).
+	const segmentedControl = content.querySelector( '.newspack-my-account__group_subscription__segmented-control' );
+	if ( segmentedControl ) {
+		const syncBadgeVariants = () => {
+			segmentedControl.querySelectorAll( '.newspack-ui__segmented-control__tabs > .newspack-ui__button' ).forEach( button => {
+				const badge = button.querySelector( '.newspack-ui__badge' );
+				if ( ! badge ) {
+					return;
+				}
+				const isSelected = button.classList.contains( 'selected' );
+				badge.classList.toggle( 'newspack-ui__badge--secondary', isSelected );
+				badge.classList.toggle( 'newspack-ui__badge--outline', ! isSelected );
+			} );
+		};
+		syncBadgeVariants();
+		segmentedControl.querySelectorAll( '.newspack-ui__segmented-control__tabs > .newspack-ui__button' ).forEach( button => {
+			button.addEventListener( 'click', syncBadgeVariants );
 		} );
-	} );
+	}
 
 	// Handle invite modal.
 	const inviteModal = document.getElementById( 'newspack-my-account__group_subscription--invite-member' );
@@ -84,7 +85,14 @@ domReady( function () {
 			const parent = button.closest( 'li' );
 			const el = parent || button;
 			if ( show ) {
+				const wasHidden = el.classList.contains( 'hidden' );
 				el.classList.remove( 'hidden' );
+				if ( wasHidden ) {
+					el.classList.add( 'newspack-my-account__group_subscription__entering' );
+					el.addEventListener( 'animationend', () => el.classList.remove( 'newspack-my-account__group_subscription__entering' ), {
+						once: true,
+					} );
+				}
 			} else {
 				el.classList.add( 'hidden' );
 			}
@@ -104,12 +112,20 @@ domReady( function () {
 			return false;
 		}
 	};
+	// Minimum loading duration so the spinner reads as "system thinking" even when the API is instant.
+	const MIN_LOADING_MS = 500;
+	const waitForMinLoading = start => {
+		const elapsed = performance.now() - start;
+		return elapsed < MIN_LOADING_MS ? new Promise( resolve => setTimeout( resolve, MIN_LOADING_MS - elapsed ) ) : Promise.resolve();
+	};
+
 	const generateLink = async e => {
 		const el = e.currentTarget;
 		el.classList.add( 'newspack-ui__button--loading' );
 		el.setAttribute( 'aria-busy', 'true' );
 		el.setAttribute( 'disabled', '' );
 		const errorText = e.currentTarget.getAttribute( 'data-error-text' );
+		const loadingStart = performance.now();
 		try {
 			const response = await fetch( restUrl, {
 				method: 'POST',
@@ -121,6 +137,7 @@ domReady( function () {
 				body: JSON.stringify( { subscription_id: subId } ),
 			} );
 			const data = await response.json();
+			await waitForMinLoading( loadingStart );
 			if ( ! response.ok || ! data || ! data.url ) {
 				const message = ( data && data.message ) || errorText;
 				showSnackbar( message, 'error' );
@@ -128,13 +145,14 @@ domReady( function () {
 			}
 			if ( await copyToClipboard( data.url ) ) {
 				const message = !! content.getAttribute( 'data-invite-link' )
-					? newspackMyAccountV1?.labels?.invite_link_regenerated || 'New invite link copied. Previous link is no longer valid.'
+					? newspackMyAccountV1?.labels?.invite_link_regenerated || 'New invite link copied. The old one no longer works.'
 					: newspackMyAccountV1?.labels?.invite_link_copied || 'Invite link copied.';
 				showSnackbar( message );
 			}
 			content.setAttribute( 'data-invite-link', data.url );
 			afterInviteLink( true );
 		} catch ( error ) {
+			await waitForMinLoading( loadingStart );
 			showSnackbar( errorText, 'error' );
 		} finally {
 			el.classList.remove( 'newspack-ui__button--loading' );
@@ -149,6 +167,7 @@ domReady( function () {
 		el.setAttribute( 'aria-busy', 'true' );
 		el.setAttribute( 'disabled', '' );
 		const errorText = e.currentTarget.getAttribute( 'data-error-text' );
+		const loadingStart = performance.now();
 		try {
 			const response = await fetch( restUrl, {
 				method: 'DELETE',
@@ -160,15 +179,17 @@ domReady( function () {
 				body: JSON.stringify( { subscription_id: subId } ),
 			} );
 			const data = await response.json();
+			await waitForMinLoading( loadingStart );
 			if ( ! response.ok ) {
 				const message = ( data && data.message ) || errorText;
 				showSnackbar( message, 'error' );
 				return;
 			}
-			showSnackbar( newspackMyAccountV1?.labels?.invite_link_disabled || 'Invite link disabled.' );
+			showSnackbar( newspackMyAccountV1?.labels?.invite_link_disabled || 'Invite link disabled. You can create a new link any time.' );
 			content.removeAttribute( 'data-invite-link' );
 			afterInviteLink( false );
 		} catch ( error ) {
+			await waitForMinLoading( loadingStart );
 			showSnackbar( errorText, 'error' );
 		} finally {
 			el.classList.remove( 'newspack-ui__button--loading' );

--- a/src/newspack-ui/js/segmented-control/index.js
+++ b/src/newspack-ui/js/segmented-control/index.js
@@ -68,6 +68,18 @@ domReady( function () {
 			element.dispatchEvent( new CustomEvent( 'content-selected', { detail: selectedContent } ) );
 		};
 
+		const isTablist = header && header.getAttribute( 'role' ) === 'tablist';
+		const updateAria = activeIndex => {
+			if ( ! isTablist ) {
+				return;
+			}
+			tab_headers.forEach( ( t, j ) => {
+				const isActive = j === activeIndex;
+				t.setAttribute( 'aria-selected', isActive ? 'true' : 'false' );
+				t.setAttribute( 'tabindex', isActive ? '0' : '-1' );
+			} );
+		};
+
 		tab_headers.forEach( ( tab, i ) => {
 			if ( tab_contents.length === 0 ) {
 				return;
@@ -84,13 +96,37 @@ domReady( function () {
 
 			if ( tab.classList.contains( 'selected' ) ) {
 				select_content( i );
+				updateAria( i );
 			}
 
 			tab.addEventListener( 'click', function () {
 				tab_headers.forEach( t => t.classList.remove( 'selected' ) );
 				this.classList.add( 'selected' );
 				select_content( i );
+				updateAria( i );
 			} );
+
+			if ( isTablist ) {
+				tab.addEventListener( 'keydown', function ( ev ) {
+					const last = tab_headers.length - 1;
+					let next = -1;
+					if ( ev.key === 'ArrowRight' ) {
+						next = i === last ? 0 : i + 1;
+					} else if ( ev.key === 'ArrowLeft' ) {
+						next = i === 0 ? last : i - 1;
+					} else if ( ev.key === 'Home' ) {
+						next = 0;
+					} else if ( ev.key === 'End' ) {
+						next = last;
+					}
+					if ( next < 0 ) {
+						return;
+					}
+					ev.preventDefault();
+					tab_headers[ next ].focus();
+					tab_headers[ next ].click();
+				} );
+			}
 		} );
 	}
 

--- a/tests/unit-tests/content-gate/group-subscriptions.php
+++ b/tests/unit-tests/content-gate/group-subscriptions.php
@@ -2449,6 +2449,8 @@ class Test_Group_Subscriptions extends \WP_UnitTestCase {
 			'2 hours'           => [ 2 * HOUR_IN_SECONDS, '2 hours' ],
 			'90 minutes'        => [ 90 * MINUTE_IN_SECONDS, '90 minutes' ],
 			'15 minutes'        => [ 15 * MINUTE_IN_SECONDS, '15 minutes' ],
+			'61 seconds'        => [ 61, '1 minute' ],
+			'90 seconds'        => [ 90, '1 minute' ],
 		];
 
 		foreach ( $cases as $label => $case ) {

--- a/tests/unit-tests/content-gate/group-subscriptions.php
+++ b/tests/unit-tests/content-gate/group-subscriptions.php
@@ -2487,4 +2487,36 @@ class Test_Group_Subscriptions extends \WP_UnitTestCase {
 			remove_filter( 'newspack_group_subscription_invite_expiration_time', $callback );
 		}
 	}
+
+	/**
+	 * Negative expiration times are coerced to the "1 minute" floor.
+	 */
+	public function test_get_expiration_label_floors_negative_values() {
+		$callback = function () {
+			return -100;
+		};
+		add_filter( 'newspack_group_subscription_invite_expiration_time', $callback );
+
+		try {
+			$this->assertSame( '1 minute', Group_Subscription_Invite::get_expiration_label() );
+		} finally {
+			remove_filter( 'newspack_group_subscription_invite_expiration_time', $callback );
+		}
+	}
+
+	/**
+	 * Large counts are formatted via number_format_i18n() (thousands separator under the active locale).
+	 */
+	public function test_get_expiration_label_uses_number_format_i18n() {
+		$callback = function () {
+			return 1000 * DAY_IN_SECONDS;
+		};
+		add_filter( 'newspack_group_subscription_invite_expiration_time', $callback );
+
+		try {
+			$this->assertSame( '1,000 days', Group_Subscription_Invite::get_expiration_label() );
+		} finally {
+			remove_filter( 'newspack_group_subscription_invite_expiration_time', $callback );
+		}
+	}
 }

--- a/tests/unit-tests/content-gate/group-subscriptions.php
+++ b/tests/unit-tests/content-gate/group-subscriptions.php
@@ -2460,13 +2460,15 @@ class Test_Group_Subscriptions extends \WP_UnitTestCase {
 			};
 			add_filter( 'newspack_group_subscription_invite_expiration_time', $callback );
 
-			$this->assertSame(
-				$expected,
-				Group_Subscription_Invite::get_expiration_label(),
-				"Expected '{$expected}' for case: {$label}"
-			);
-
-			remove_filter( 'newspack_group_subscription_invite_expiration_time', $callback );
+			try {
+				$this->assertSame(
+					$expected,
+					Group_Subscription_Invite::get_expiration_label(),
+					"Expected '{$expected}' for case: {$label}"
+				);
+			} finally {
+				remove_filter( 'newspack_group_subscription_invite_expiration_time', $callback );
+			}
 		}
 	}
 
@@ -2479,8 +2481,10 @@ class Test_Group_Subscriptions extends \WP_UnitTestCase {
 		};
 		add_filter( 'newspack_group_subscription_invite_expiration_time', $callback );
 
-		$this->assertSame( '1 minute', Group_Subscription_Invite::get_expiration_label() );
-
-		remove_filter( 'newspack_group_subscription_invite_expiration_time', $callback );
+		try {
+			$this->assertSame( '1 minute', Group_Subscription_Invite::get_expiration_label() );
+		} finally {
+			remove_filter( 'newspack_group_subscription_invite_expiration_time', $callback );
+		}
 	}
 }

--- a/tests/unit-tests/content-gate/group-subscriptions.php
+++ b/tests/unit-tests/content-gate/group-subscriptions.php
@@ -2430,4 +2430,55 @@ class Test_Group_Subscriptions extends \WP_UnitTestCase {
 			'Existing member must remain a member after re-clicking an invalid invite'
 		);
 	}
+
+	// -------------------------------------------------------------------------
+	// get_expiration_label()
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Promote to the largest unit that divides exactly; never round.
+	 */
+	public function test_get_expiration_label_uses_largest_exact_unit() {
+		$cases = [
+			'default (30 days)' => [ 30 * DAY_IN_SECONDS, '30 days' ],
+			'1 week'            => [ WEEK_IN_SECONDS, '1 week' ],
+			'2 weeks (14 days)' => [ 14 * DAY_IN_SECONDS, '2 weeks' ],
+			'10 days'           => [ 10 * DAY_IN_SECONDS, '10 days' ],
+			'1 day'             => [ DAY_IN_SECONDS, '1 day' ],
+			'1 hour'            => [ HOUR_IN_SECONDS, '1 hour' ],
+			'2 hours'           => [ 2 * HOUR_IN_SECONDS, '2 hours' ],
+			'90 minutes'        => [ 90 * MINUTE_IN_SECONDS, '90 minutes' ],
+			'15 minutes'        => [ 15 * MINUTE_IN_SECONDS, '15 minutes' ],
+		];
+
+		foreach ( $cases as $label => $case ) {
+			[ $seconds, $expected ] = $case;
+			$callback               = function () use ( $seconds ) {
+				return $seconds;
+			};
+			add_filter( 'newspack_group_subscription_invite_expiration_time', $callback );
+
+			$this->assertSame(
+				$expected,
+				Group_Subscription_Invite::get_expiration_label(),
+				"Expected '{$expected}' for case: {$label}"
+			);
+
+			remove_filter( 'newspack_group_subscription_invite_expiration_time', $callback );
+		}
+	}
+
+	/**
+	 * Sub-minute values are floored at "1 minute".
+	 */
+	public function test_get_expiration_label_floor_is_one_minute() {
+		$callback = function () {
+			return 0;
+		};
+		add_filter( 'newspack_group_subscription_invite_expiration_time', $callback );
+
+		$this->assertSame( '1 minute', Group_Subscription_Invite::get_expiration_label() );
+
+		remove_filter( 'newspack_group_subscription_invite_expiration_time', $callback );
+	}
 }


### PR DESCRIPTION
## Summary

Visual and UX polish on the Group Subscription invite-links UI introduced in #4704.

- **Modals**: rewrote Regenerate / Disable confirmation copy; replaced "OK" CTAs with action-verb labels; switched Regenerate CTA from destructive to primary (keeps destructive only for Disable).
- **Snackbars**: clarified the regenerate / disable success messages.
- **Tabs**: replaced the plain-link tab pair with the Newspack UI segmented control. Counts moved into badges that swap between `--outline` (unselected) and `--secondary` (selected) via JS so the literal classes flip with state.
- **Invite-by-email modal**: copy now focuses on what email invite actually does and includes the configured expiration window, rendered via a new `Group_Subscription_Invite::get_expiration_label()` so it follows whatever the `newspack_group_subscription_invite_expiration_time` filter is set to (e.g. "30 days", "1 hour", "2 weeks").
- **Empty-state rows**: "No members found." / "No invitations found." now match populated row height via the same `::after` + `var(--newspack-ui-spacer-7)` pattern the rest of the table uses.
- **Animations**: subtle 125ms fade-slide when Regenerate / Disable controls appear for the first time (no animation on subsequent page loads). 500ms minimum spinner duration on Copy / Regenerate / Disable so the click registers visibly even when the API is instant.

## Screenshots

| Members tab (segmented control + badge) | Invitations empty state |
|---|---|
| ![Members tab](https://raw.githubusercontent.com/Automattic/newspack-plugin/screenshots/pr-4719/.pr-screenshots/01-members-tab.png) | ![Invitations empty](https://raw.githubusercontent.com/Automattic/newspack-plugin/screenshots/pr-4719/.pr-screenshots/02-invitations-empty.png) |

| Actions dropdown (all 4 items) | Invite-by-email modal (dynamic expiration) |
|---|---|
| ![Actions dropdown](https://raw.githubusercontent.com/Automattic/newspack-plugin/screenshots/pr-4719/.pr-screenshots/03-actions-dropdown-open.png) | ![Invite by email](https://raw.githubusercontent.com/Automattic/newspack-plugin/screenshots/pr-4719/.pr-screenshots/06-invite-email-modal.png) |

| Regenerate modal (primary CTA) | Disable modal (destructive CTA) |
|---|---|
| ![Regenerate modal](https://raw.githubusercontent.com/Automattic/newspack-plugin/screenshots/pr-4719/.pr-screenshots/04-regenerate-modal.png) | ![Disable modal](https://raw.githubusercontent.com/Automattic/newspack-plugin/screenshots/pr-4719/.pr-screenshots/05-disable-modal.png) |

## Test plan
- [x] As the manager of a group subscription, visit the manage-members page.
- [x] Confirm the tabs render as a segmented control with badges; click between Members and Invitations and check that the badge class flips between `--outline` and `--secondary`.
- [x] With no invite link yet, click **Copy invite link** — spinner persists ~500ms, snackbar appears, **Regenerate** / **Disable** fade-slide in.
- [x] Open **Regenerate invite link** modal — primary "Regenerate link" CTA, body copy explains what happens.
- [x] Open **Disable invite link** modal — destructive "Disable link" CTA, body copy mentions a new link can still be created.
- [x] Open **Invite by email** modal — description mentions the expiration window. Add `add_filter( 'newspack_group_subscription_invite_expiration_time', fn() => HOUR_IN_SECONDS );` to confirm the label updates to "1 hour".
- [x] Confirm the "No invitations found." empty row has the same vertical height as populated rows.
