### PR TITLE
lite-site: skip module init when Newspack Lite Site plugin is active

### DIFF
--- a/includes/lite-site/class-lite-site.php
+++ b/includes/lite-site/class-lite-site.php
@@ -525,5 +525,7 @@ class Lite_Site {
 	}
 }
 
-// Initialize the class.
-Lite_Site::init();
+// Initialize the class unless the Newspack Lite Site plugin is active.
+if ( ! defined( 'NEWSPACK_LITE_SITE_PLUGIN_FILE' ) ) {
+	Lite_Site::init();
+}

--- a/includes/lite-site/class-lite-site.php
+++ b/includes/lite-site/class-lite-site.php
@@ -20,6 +20,11 @@ class Lite_Site {
 	 * Initialize the lite site functionality
 	 */
 	public static function init() {
+		// The standalone Newspack Lite Site plugin supersedes this module, so skip initialization to avoid conflicts.
+		if ( defined( 'NEWSPACK_LITE_SITE_PLUGIN_FILE' ) ) {
+			return;
+		}
+
 		// Only register rewrite rules if the feature is enabled.
 		if ( self::is_enabled() ) {
 			add_action( 'init', [ __CLASS__, 'register_rewrite_rules' ] );
@@ -525,7 +530,4 @@ class Lite_Site {
 	}
 }
 
-// Initialize the class unless the Newspack Lite Site plugin is active.
-if ( ! defined( 'NEWSPACK_LITE_SITE_PLUGIN_FILE' ) ) {
-	Lite_Site::init();
-}
+add_action( 'plugins_loaded', [ Lite_Site::class, 'init' ] );


### PR DESCRIPTION
## Description

When the [Newspack Lite Site](https://github.com/Automattic/newspack-lite-site) plugin ([code here](https://github.com/rtCamp/newspack-lite-site)) is active alongside `newspack-plugin`, both register identical WordPress identifiers and the same settings group (`newspack_lite_site`), option name (`newspack_lite_site_settings`), admin menu slug (`newspack-lite-site`), and rewrite rules. This causes:

- Doubled settings forms on the Settings > Lite Site admin page and **Lite Site → Settings & Appearance** page
- Duplicate sanitize callbacks stacked on `sanitize_option_newspack_lite_site_settings`.
- Conflicting rewrite rules registered twice

The standalone plugin defines `NEWSPACK_LITE_SITE_PLUGIN_FILE` in its main file at load time. Guarding `Lite_Site::init()` with a check for that constant prevents the built-in module from initializing at all when the standalone plugin is active, eliminating all four collision points.

### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Wrap `Lite_Site::init()` in `includes/lite-site/class-lite-site.php` with a `defined( 'NEWSPACK_LITE_SITE_PLUGIN_FILE' )` guard so the built-in lite-site module is a no-op when the Newspack Lite Site plugin is active.

### How to test the changes in this Pull Request:

1. Activate both `newspack-plugin` and the [Newspack Lite Site plugin](https://github.com/rtCamp/newspack-lite-site).
2. Navigate to **Lite Site → Settings & Appearance** and confirm only one settings form is rendered.
3. Save settings (e.g. toggle "Enable Lite Site", set a URL base) and confirm values persist correctly on reload with no fields stripped.
4. Check the **Settings** menu and confirm no "Lite Site" entry appears there.
5. Deactivate the standalone plugin and confirm the built-in **Settings → Lite Site** page is still fully functional (module initialises normally when `NEWSPACK_LITE_SITE_PLUGIN_FILE` is undefined).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?