### PR TITLE
feat(integrations): add inactive plugin state

### DIFF
--- a/includes/class-plugin-manager.php
+++ b/includes/class-plugin-manager.php
@@ -32,6 +32,19 @@ class Plugin_Manager {
 	];
 
 	/**
+	 * Per-request memoization for get_managed_plugin_status(), keyed by slug.
+	 *
+	 * The underlying get_installed_plugins() calls wp_get_themes() which rescans
+	 * /themes on every call (get_plugins() is cached intra-request, themes are
+	 * not). With multiple integrations declaring the same required plugin, that
+	 * scan ran once per lookup. The cache is per-request, so plugin state changes
+	 * between requests are picked up on the next call.
+	 *
+	 * @var array<string, string>
+	 */
+	private static $managed_plugin_status_cache = [];
+
+	/**
 	 * Get info about all the managed plugins and their status.
 	 *
 	 * @todo Define what the structure of this looks like better and load it up from a config or something.
@@ -393,6 +406,9 @@ class Plugin_Manager {
 		if ( Newspack::is_debug_mode() ) {
 			return 'active';
 		}
+		if ( isset( self::$managed_plugin_status_cache[ $plugin_slug ] ) ) {
+			return self::$managed_plugin_status_cache[ $plugin_slug ];
+		}
 		$status            = 'uninstalled';
 		$installed_plugins = self::get_installed_plugins();
 
@@ -430,7 +446,18 @@ class Plugin_Manager {
 			}
 		}
 
+		self::$managed_plugin_status_cache[ $plugin_slug ] = $status;
 		return $status;
+	}
+
+	/**
+	 * Reset the per-request memoization of get_managed_plugin_status().
+	 *
+	 * Tests that mutate plugin install/active state mid-test must call this so
+	 * subsequent get_managed_plugin_status() calls re-derive the status.
+	 */
+	public static function reset_managed_plugin_status_cache() {
+		self::$managed_plugin_status_cache = [];
 	}
 
 	/**

--- a/includes/reader-activation/class-integrations.php
+++ b/includes/reader-activation/class-integrations.php
@@ -424,13 +424,14 @@ class Integrations {
 				continue;
 			}
 			$result[ $id ] = [
-				'id'          => $id,
-				'name'        => $integration->get_name(),
-				'description' => $integration->get_description(),
-				'enabled'     => self::is_enabled( $id ),
-				'is_set_up'   => $integration->is_set_up(),
-				'setup_url'   => $integration->get_setup_url(),
-				'settings'    => $integration->get_settings_config(),
+				'id'               => $id,
+				'name'             => $integration->get_name(),
+				'description'      => $integration->get_description(),
+				'enabled'          => self::is_enabled( $id ),
+				'is_set_up'        => $integration->is_set_up(),
+				'setup_url'        => $integration->get_setup_url(),
+				'settings'         => $integration->get_settings_config(),
+				'required_plugins' => $integration->get_required_plugins(),
 			];
 		}
 		return $result;

--- a/includes/reader-activation/integrations/class-esp.php
+++ b/includes/reader-activation/integrations/class-esp.php
@@ -65,6 +65,23 @@ class ESP extends Integration {
 	}
 
 	/**
+	 * Get the plugins this integration depends on, with their install/active status.
+	 *
+	 * @return array List of associative arrays with keys `slug`, `name`, `is_active`, `is_installed`.
+	 */
+	public function get_required_plugins() {
+		$status = \Newspack\Plugin_Manager::get_managed_plugin_status( 'newspack-newsletters' );
+		return [
+			[
+				'slug'         => 'newspack-newsletters',
+				'name'         => __( 'Newspack Newsletters', 'newspack-plugin' ),
+				'is_active'    => 'active' === $status,
+				'is_installed' => 'uninstalled' !== $status,
+			],
+		];
+	}
+
+	/**
 	 * Register the settings fields declared by this integration.
 	 *
 	 * Returns ALL possible ESP fields unconditionally as static

--- a/includes/reader-activation/integrations/class-integration.php
+++ b/includes/reader-activation/integrations/class-integration.php
@@ -152,6 +152,19 @@ abstract class Integration {
 	}
 
 	/**
+	 * Get the plugins this integration depends on, with their active status.
+	 *
+	 * Child classes should override this to declare any plugins that must be
+	 * active for the integration to function. The integrations UI uses this
+	 * to surface a "requirements" affordance on the integration card.
+	 *
+	 * @return array List of associative arrays with keys `slug`, `name`, `is_active`.
+	 */
+	public function get_required_plugins() {
+		return [];
+	}
+
+	/**
 	 * Whether this integration supports frontend reader registration.
 	 *
 	 * Integrations that return true will have their key output to the page

--- a/includes/reader-activation/integrations/class-integration.php
+++ b/includes/reader-activation/integrations/class-integration.php
@@ -158,7 +158,11 @@ abstract class Integration {
 	 * active for the integration to function. The integrations UI uses this
 	 * to surface a "requirements" affordance on the integration card.
 	 *
-	 * @return array List of associative arrays with keys `slug`, `name`, `is_active`.
+	 * Each entry must include all of `slug`, `name`, `is_active`, and `is_installed` —
+	 * the integrations UI treats a missing `is_installed` as uninstalled and renders
+	 * a disabled "Requires …" card instead of the Activate action.
+	 *
+	 * @return array List of associative arrays with keys `slug`, `name`, `is_active`, `is_installed`.
 	 */
 	public function get_required_plugins() {
 		return [];

--- a/packages/components/src/card-feature/README.md
+++ b/packages/components/src/card-feature/README.md
@@ -11,7 +11,7 @@ A card component for presenting a named feature or setting with a predictable, s
 
 | State | Condition | Button | Dropdown | Badge |
 |---|---|---|---|---|
-| **Unmet requirements** | `requirements` is set | "Enable" — disabled | Hidden | Error badge with `requirements` text |
+| **Unmet requirements** | `requirements` is set | "Enable" — disabled (clickable if `requirementsActionable`) | Hidden | Error badge with `requirements` text |
 | **Disabled** | `!enabled`, no requirements | "Enable" | Hidden | None |
 | **Enabled** | `enabled`, no requirements | "Configure" | Shown if `moreControls` provided | Success badge ("Enabled") |
 
@@ -155,6 +155,7 @@ import { __ } from '@wordpress/i18n';
 | `icon` | `CardFeatureIcon` | — | Icon displayed on the right. See `CardFeatureIcon` below. |
 | `enabled` | `boolean` | `false` | Whether the feature is currently enabled |
 | `requirements` | `string` | — | When set, enters the unmet-requirements state; value is used as the error badge text |
+| `requirementsActionable` | `boolean` | `false` | When `requirements` is set, keep the primary button clickable so it can remediate the unmet requirement |
 | `enableLabel` | `string` | `"Enable"` | Primary button label when not enabled |
 | `configureLabel` | `string` | `"Configure"` | Primary button label when enabled |
 | `onEnable` | `() => void` | — | Called when the primary button is clicked and the feature is not enabled |

--- a/packages/components/src/card-feature/index.tsx
+++ b/packages/components/src/card-feature/index.tsx
@@ -49,10 +49,17 @@ type CardFeatureProps = {
 	/** Whether the feature is currently enabled. */
 	enabled?: boolean;
 	/**
-	 * When set, the card enters the "unmet requirements" state: the primary
-	 * button is disabled and an error badge displays this string.
+	 * When set, the card enters the "unmet requirements" state: an error
+	 * badge displays this string and the title/description are muted. By
+	 * default the primary button is disabled — set `requirementsActionable`
+	 * if the primary button is the remediation for the unmet requirement.
 	 */
 	requirements?: string;
+	/**
+	 * When `requirements` is set, keep the primary button clickable so the
+	 * user can remediate the unmet requirement from this card.
+	 */
+	requirementsActionable?: boolean;
 	/** Primary button label when not enabled. Default: "Enable". */
 	enableLabel?: string;
 	/** Primary button label when enabled. Default: "Configure". */
@@ -83,6 +90,7 @@ const CardFeature = ( {
 	icon,
 	enabled = false,
 	requirements,
+	requirementsActionable = false,
 	enableLabel,
 	configureLabel,
 	onEnable,
@@ -151,7 +159,7 @@ const CardFeature = ( {
 							<HStack expanded={ false } spacing="8px">
 								<Button
 									variant={ isConfigureState ? 'tertiary' : 'secondary' }
-									disabled={ isMuted }
+									disabled={ isMuted && ! requirementsActionable }
 									onClick={ handleButtonClick }
 									size="compact"
 								>

--- a/src/wizards/audience/views/integrations/index.js
+++ b/src/wizards/audience/views/integrations/index.js
@@ -20,6 +20,7 @@ const AudienceIntegrations = ( props, ref ) => {
 	const [ pendingChanges, setPendingChanges ] = useState( {} );
 	const [ saving, setSaving ] = useState( {} );
 	const [ toggling, setToggling ] = useState( {} );
+	const [ activating, setActivating ] = useState( {} );
 	const [ loading, setLoading ] = useState( true );
 
 	const fetchSettings = useCallback( () => {
@@ -89,11 +90,49 @@ const AudienceIntegrations = ( props, ref ) => {
 	}, [] );
 
 	const handleActivatePlugin = useCallback(
-		pluginSlug =>
-			apiFetch( {
-				path: `/newspack/v1/plugins/${ pluginSlug }/activate`,
-				method: 'POST',
-			} ).then( () => fetchSettings() ),
+		pluginSlugs => {
+			const slugs = ( Array.isArray( pluginSlugs ) ? pluginSlugs : [ pluginSlugs ] ).filter( Boolean );
+			if ( ! slugs.length ) {
+				return;
+			}
+			// Set-as-guard: filter out slugs already in flight, then dispatch the
+			// activation only for the newly-claimed ones. Using the state setter
+			// callback gives us an atomic check-and-claim against concurrent clicks.
+			setActivating( prev => {
+				const claimed = slugs.filter( slug => ! prev[ slug ] );
+				if ( ! claimed.length ) {
+					return prev;
+				}
+				Promise.all(
+					claimed.map( slug =>
+						apiFetch( {
+							path: `/newspack/v1/plugins/${ slug }/activate`,
+							method: 'POST',
+						} )
+					)
+				)
+					.then( () => fetchSettings() )
+					.catch( () => {
+						// Surface nothing here; failures leave the integration in its
+						// previous state and the user can retry. apiFetch already logs
+						// the underlying error to the console.
+					} )
+					.finally( () => {
+						setActivating( current => {
+							const next = { ...current };
+							claimed.forEach( slug => {
+								delete next[ slug ];
+							} );
+							return next;
+						} );
+					} );
+				const next = { ...prev };
+				claimed.forEach( slug => {
+					next[ slug ] = true;
+				} );
+				return next;
+			} );
+		},
 		[ fetchSettings ]
 	);
 
@@ -102,6 +141,7 @@ const AudienceIntegrations = ( props, ref ) => {
 		pendingChanges,
 		saving,
 		toggling,
+		activating,
 		loading,
 		onFieldChange: handleFieldChange,
 		onSave: handleSave,

--- a/src/wizards/audience/views/integrations/index.js
+++ b/src/wizards/audience/views/integrations/index.js
@@ -88,6 +88,15 @@ const AudienceIntegrations = ( props, ref ) => {
 			} );
 	}, [] );
 
+	const handleActivatePlugin = useCallback(
+		pluginSlug =>
+			apiFetch( {
+				path: `/newspack/v1/plugins/${ pluginSlug }/activate`,
+				method: 'POST',
+			} ).then( () => fetchSettings() ),
+		[ fetchSettings ]
+	);
+
 	const sharedProps = {
 		integrations,
 		pendingChanges,
@@ -97,6 +106,7 @@ const AudienceIntegrations = ( props, ref ) => {
 		onFieldChange: handleFieldChange,
 		onSave: handleSave,
 		onToggleEnabled: handleToggleEnabled,
+		onActivatePlugin: handleActivatePlugin,
 	};
 
 	return (

--- a/src/wizards/audience/views/integrations/settings-section.js
+++ b/src/wizards/audience/views/integrations/settings-section.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { Icon, envelope } from '@wordpress/icons';
 
 /**
@@ -32,7 +32,9 @@ const DEFAULT_ICON = {
 	backgroundColor: colors[ 'neutral-100' ],
 };
 
-export const SettingsSection = ( { integrations, loading, onToggleEnabled, history } ) => {
+const getMissingPlugins = integration => ( integration.required_plugins || [] ).filter( plugin => ! plugin.is_active );
+
+export const SettingsSection = ( { integrations, loading, onToggleEnabled, onActivatePlugin, history } ) => {
 	const integrationIds = Object.keys( integrations );
 
 	return (
@@ -54,12 +56,29 @@ export const SettingsSection = ( { integrations, loading, onToggleEnabled, histo
 				{ ! loading && integrationIds.length > 0 && (
 					<Grid columns={ 2 } gutter={ 16 }>
 						{ integrationIds.map( id => {
-							const { enabled, is_set_up: isSetUp, setup_url, name, description } = integrations[ id ];
+							const integration = integrations[ id ];
+							const { enabled, is_set_up: isSetUp, setup_url, name, description } = integration;
+							const missingPlugins = getMissingPlugins( integration );
+							const uninstalledPlugin = missingPlugins.find( plugin => ! plugin.is_installed );
+							const activatablePlugin = missingPlugins.length && ! uninstalledPlugin ? missingPlugins[ 0 ] : null;
+							const requirements = uninstalledPlugin
+								? sprintf(
+										/* translators: %s: comma-separated list of required plugin names. */
+										__( 'Requires %s', 'newspack-plugin' ),
+										missingPlugins.map( plugin => plugin.name ).join( ', ' )
+								  )
+								: undefined;
 							const isEnabled = enabled;
 							const needsSetup = ! isSetUp && !! setup_url;
 							const goToSetup = () => {
 								window.location.href = setup_url;
 							};
+							let enableLabel = isSetUp ? __( 'Enable', 'newspack-plugin' ) : __( 'Connect', 'newspack-plugin' );
+							let onEnable = needsSetup ? goToSetup : () => onToggleEnabled( id, true );
+							if ( activatablePlugin ) {
+								enableLabel = __( 'Activate', 'newspack-plugin' );
+								onEnable = () => onActivatePlugin( activatablePlugin.slug );
+							}
 							return (
 								<CardFeature
 									key={ id }
@@ -67,9 +86,10 @@ export const SettingsSection = ( { integrations, loading, onToggleEnabled, histo
 									description={ description }
 									icon={ INTEGRATION_ICONS[ id ] || DEFAULT_ICON }
 									enabled={ isEnabled }
-									enableLabel={ isSetUp ? __( 'Enable', 'newspack-plugin' ) : __( 'Connect', 'newspack-plugin' ) }
+									requirements={ requirements }
+									enableLabel={ enableLabel }
 									configureLabel={ needsSetup ? __( 'Configure', 'newspack-plugin' ) : undefined }
-									onEnable={ needsSetup ? goToSetup : () => onToggleEnabled( id, true ) }
+									onEnable={ onEnable }
 									onConfigure={ needsSetup ? goToSetup : () => history?.push( `/settings/${ id }` ) }
 									moreControls={
 										isEnabled

--- a/src/wizards/audience/views/integrations/settings-section.js
+++ b/src/wizards/audience/views/integrations/settings-section.js
@@ -34,7 +34,7 @@ const DEFAULT_ICON = {
 
 const getMissingPlugins = integration => ( integration.required_plugins || [] ).filter( plugin => ! plugin.is_active );
 
-export const SettingsSection = ( { integrations, loading, onToggleEnabled, onActivatePlugin, history } ) => {
+export const SettingsSection = ( { integrations, loading, activating = {}, onToggleEnabled, onActivatePlugin, history } ) => {
 	const integrationIds = Object.keys( integrations );
 
 	return (
@@ -59,8 +59,13 @@ export const SettingsSection = ( { integrations, loading, onToggleEnabled, onAct
 							const integration = integrations[ id ];
 							const { enabled, is_set_up: isSetUp, setup_url, name, description } = integration;
 							const missingPlugins = getMissingPlugins( integration );
-							const uninstalledPlugin = missingPlugins.find( plugin => ! plugin.is_installed );
-							const activatablePlugin = missingPlugins.length && ! uninstalledPlugin ? missingPlugins[ 0 ] : null;
+							const requiresInstallPlugins = missingPlugins.filter( plugin => ! plugin.is_installed );
+							// Only offer Activate when every missing plugin is at least installed;
+							// otherwise the card stays in the disabled "Requires …" state until the
+							// uninstalled plugin is installed first.
+							const activatablePlugins = requiresInstallPlugins.length === 0 ? missingPlugins : [];
+							const canActivate = activatablePlugins.length > 0;
+							const isActivating = canActivate && activatablePlugins.some( plugin => activating[ plugin.slug ] );
 							const requirements = missingPlugins.length
 								? sprintf(
 										/* translators: %s: comma-separated list of required plugin names. */
@@ -75,9 +80,9 @@ export const SettingsSection = ( { integrations, loading, onToggleEnabled, onAct
 							};
 							let enableLabel = isSetUp ? __( 'Enable', 'newspack-plugin' ) : __( 'Connect', 'newspack-plugin' );
 							let onEnable = needsSetup ? goToSetup : () => onToggleEnabled( id, true );
-							if ( activatablePlugin ) {
-								enableLabel = __( 'Activate', 'newspack-plugin' );
-								onEnable = () => onActivatePlugin( activatablePlugin.slug );
+							if ( canActivate ) {
+								enableLabel = isActivating ? __( 'Activating…', 'newspack-plugin' ) : __( 'Activate', 'newspack-plugin' );
+								onEnable = () => onActivatePlugin( activatablePlugins.map( plugin => plugin.slug ) );
 							}
 							return (
 								<CardFeature
@@ -87,7 +92,7 @@ export const SettingsSection = ( { integrations, loading, onToggleEnabled, onAct
 									icon={ INTEGRATION_ICONS[ id ] || DEFAULT_ICON }
 									enabled={ isEnabled }
 									requirements={ requirements }
-									requirementsActionable={ !! activatablePlugin }
+									requirementsActionable={ canActivate }
 									enableLabel={ enableLabel }
 									configureLabel={ needsSetup ? __( 'Configure', 'newspack-plugin' ) : undefined }
 									onEnable={ onEnable }

--- a/src/wizards/audience/views/integrations/settings-section.js
+++ b/src/wizards/audience/views/integrations/settings-section.js
@@ -61,7 +61,7 @@ export const SettingsSection = ( { integrations, loading, onToggleEnabled, onAct
 							const missingPlugins = getMissingPlugins( integration );
 							const uninstalledPlugin = missingPlugins.find( plugin => ! plugin.is_installed );
 							const activatablePlugin = missingPlugins.length && ! uninstalledPlugin ? missingPlugins[ 0 ] : null;
-							const requirements = uninstalledPlugin
+							const requirements = missingPlugins.length
 								? sprintf(
 										/* translators: %s: comma-separated list of required plugin names. */
 										__( 'Requires %s', 'newspack-plugin' ),
@@ -87,6 +87,7 @@ export const SettingsSection = ( { integrations, loading, onToggleEnabled, onAct
 									icon={ INTEGRATION_ICONS[ id ] || DEFAULT_ICON }
 									enabled={ isEnabled }
 									requirements={ requirements }
+									requirementsActionable={ !! activatablePlugin }
 									enableLabel={ enableLabel }
 									configureLabel={ needsSetup ? __( 'Configure', 'newspack-plugin' ) : undefined }
 									onEnable={ onEnable }

--- a/tests/unit-tests/integrations/class-test-esp.php
+++ b/tests/unit-tests/integrations/class-test-esp.php
@@ -51,6 +51,7 @@ class Test_ESP extends \WP_UnitTestCase {
 			\update_option( 'active_plugins', $this->original_active_plugins );
 			$this->original_active_plugins = null;
 		}
+		\Newspack\Plugin_Manager::reset_managed_plugin_status_cache();
 		parent::tear_down();
 	}
 

--- a/tests/unit-tests/integrations/class-test-esp.php
+++ b/tests/unit-tests/integrations/class-test-esp.php
@@ -20,6 +20,22 @@ require_once dirname( __DIR__, 2 ) . '/mocks/newsletters-mocks.php';
 class Test_ESP extends \WP_UnitTestCase {
 
 	/**
+	 * Whether a test mutated the cached get_plugins() result. tear_down deletes
+	 * the cache when set, so the next caller rescans the real plugin directory.
+	 *
+	 * @var bool
+	 */
+	private $plugins_cache_dirty = false;
+
+	/**
+	 * Snapshot of the `active_plugins` option taken before a test mutates it,
+	 * so tear_down can restore the original value.
+	 *
+	 * @var array|null
+	 */
+	private $original_active_plugins = null;
+
+	/**
 	 * Cleanup state set up by individual tests so failures don't leak across cases.
 	 */
 	public function tear_down() {
@@ -27,7 +43,52 @@ class Test_ESP extends \WP_UnitTestCase {
 		remove_all_filters( 'newspack_ras_metadata_keys' );
 		remove_all_filters( 'newspack_ras_metadata_prefix' );
 		\delete_option( 'newspack_integration_incoming_fields_esp' );
+		if ( $this->plugins_cache_dirty ) {
+			\wp_cache_delete( 'plugins', 'plugins' );
+			$this->plugins_cache_dirty = false;
+		}
+		if ( null !== $this->original_active_plugins ) {
+			\update_option( 'active_plugins', $this->original_active_plugins );
+			$this->original_active_plugins = null;
+		}
 		parent::tear_down();
+	}
+
+	/**
+	 * Stub Plugin_Manager::get_managed_plugin_status() for the newspack-newsletters
+	 * slug by pre-populating the cached get_plugins() result and the active_plugins option.
+	 *
+	 * Core's get_plugins() short-circuits on its `plugins` cache key in the `plugins`
+	 * group, so writing into that cache bypasses the real filesystem scan. The
+	 * all_plugins filter does NOT cover this path — it only fires from the admin
+	 * plugins list table.
+	 *
+	 * @param string $status One of 'active', 'inactive', 'uninstalled'.
+	 */
+	private function stub_newsletters_status( $status ) {
+		if ( ! function_exists( 'get_plugins' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
+		$plugin_file                   = 'newspack-newsletters/newspack-newsletters.php';
+		$this->original_active_plugins = \get_option( 'active_plugins', [] );
+
+		$plugins = \get_plugins();
+		if ( 'uninstalled' === $status ) {
+			unset( $plugins[ $plugin_file ] );
+		} else {
+			$plugins[ $plugin_file ] = [
+				'Name'    => 'Newspack Newsletters',
+				'Version' => '1.0.0',
+			];
+		}
+		\wp_cache_set( 'plugins', [ '' => $plugins ], 'plugins' );
+		$this->plugins_cache_dirty = true;
+
+		\update_option(
+			'active_plugins',
+			'active' === $status ? [ $plugin_file ] : []
+		);
 	}
 
 	/**
@@ -407,5 +468,49 @@ class Test_ESP extends \WP_UnitTestCase {
 		$this->assertIsArray( $result );
 		$this->assertCount( 1, $result );
 		$this->assertSame( 'good', $result[0]->get_key() );
+	}
+
+	/**
+	 * Active newspack-newsletters maps to is_active=true, is_installed=true so the
+	 * integrations UI shows the normal Enable/Connect action, not the requirements badge.
+	 */
+	public function test_get_required_plugins_reports_active_state() {
+		$this->stub_newsletters_status( 'active' );
+
+		$required = ( new ESP() )->get_required_plugins();
+
+		$this->assertCount( 1, $required );
+		$this->assertSame( 'newspack-newsletters', $required[0]['slug'] );
+		$this->assertSame( 'Newspack Newsletters', $required[0]['name'] );
+		$this->assertTrue( $required[0]['is_active'] );
+		$this->assertTrue( $required[0]['is_installed'] );
+	}
+
+	/**
+	 * Installed-but-inactive newspack-newsletters maps to is_active=false, is_installed=true
+	 * so the integrations UI shows the Activate remediation button.
+	 */
+	public function test_get_required_plugins_reports_inactive_state() {
+		$this->stub_newsletters_status( 'inactive' );
+
+		$required = ( new ESP() )->get_required_plugins();
+
+		$this->assertCount( 1, $required );
+		$this->assertFalse( $required[0]['is_active'] );
+		$this->assertTrue( $required[0]['is_installed'] );
+	}
+
+	/**
+	 * Absent newspack-newsletters maps to is_active=false, is_installed=false so the
+	 * integrations UI falls back to a disabled "Requires …" affordance.
+	 */
+	public function test_get_required_plugins_reports_uninstalled_state() {
+		$this->stub_newsletters_status( 'uninstalled' );
+
+		$required = ( new ESP() )->get_required_plugins();
+
+		$this->assertCount( 1, $required );
+		$this->assertFalse( $required[0]['is_active'] );
+		$this->assertFalse( $required[0]['is_installed'] );
 	}
 }

--- a/tests/unit-tests/integrations/class-test-integrations.php
+++ b/tests/unit-tests/integrations/class-test-integrations.php
@@ -1201,6 +1201,7 @@ class Test_Integrations extends \WP_UnitTestCase {
 	}
 
 	/**
+<<<<<<< HEAD
 	 * OAuth settings field value: scalar strings are sanitized through sanitize_text_field.
 	 */
 	public function test_sanitize_settings_field_value_oauth_scalar() {
@@ -1380,5 +1381,73 @@ class Test_Integrations extends \WP_UnitTestCase {
 			'connected',
 			\get_option( Integration::SETTINGS_OPTION_PREFIX . 'test-id_connection' )
 		);
+	}
+
+	/**
+	 * Integrations that don't override get_required_plugins() report an empty
+	 * required_plugins array in the settings payload, so the audience UI renders
+	 * them without a requirements badge.
+	 */
+	public function test_get_all_integration_settings_defaults_required_plugins_to_empty_array() {
+		$integration = new Sample_Integration( 'no-overrides', 'No Overrides' );
+		Integrations::register( $integration );
+
+		$settings = Integrations::get_all_integration_settings();
+
+		$this->assertArrayHasKey( 'no-overrides', $settings );
+		$this->assertArrayHasKey( 'required_plugins', $settings['no-overrides'] );
+		$this->assertSame( [], $settings['no-overrides']['required_plugins'] );
+	}
+
+	/**
+	 * A child integration overriding get_required_plugins() has its declaration
+	 * surfaced verbatim in the settings payload that drives the audience UI card.
+	 */
+	public function test_get_all_integration_settings_surfaces_required_plugins_override() {
+		$declared    = [
+			[
+				'slug'         => 'some-dependency',
+				'name'         => 'Some Dependency',
+				'is_active'    => false,
+				'is_installed' => true,
+			],
+		];
+		$integration = new class( 'with-deps', 'With Deps', $declared ) extends Sample_Integration {
+			/**
+			 * Declared required-plugins payload returned by the override.
+			 *
+			 * @var array
+			 */
+			private $declared;
+
+			/**
+			 * Capture the declaration the test wants returned, then defer
+			 * construction to the parent.
+			 *
+			 * @param string $id       Integration id.
+			 * @param string $name     Integration name.
+			 * @param array  $declared Required-plugins payload to return.
+			 */
+			public function __construct( $id, $name, $declared ) {
+				$this->declared = $declared;
+				parent::__construct( $id, $name );
+			}
+
+			/**
+			 * Return the test-supplied required-plugins payload.
+			 *
+			 * @return array
+			 */
+			public function get_required_plugins() {
+				return $this->declared;
+			}
+		};
+
+		Integrations::register( $integration );
+
+		$settings = Integrations::get_all_integration_settings();
+
+		$this->assertArrayHasKey( 'with-deps', $settings );
+		$this->assertSame( $declared, $settings['with-deps']['required_plugins'] );
 	}
 }

--- a/tests/unit-tests/integrations/class-test-integrations.php
+++ b/tests/unit-tests/integrations/class-test-integrations.php
@@ -1201,7 +1201,6 @@ class Test_Integrations extends \WP_UnitTestCase {
 	}
 
 	/**
-<<<<<<< HEAD
 	 * OAuth settings field value: scalar strings are sanitized through sanitize_text_field.
 	 */
 	public function test_sanitize_settings_field_value_oauth_scalar() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and VIP Go coding standards?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Surfaces the install/active status of an integration's required plugins on the Audience → Integrations screen so admins can resolve missing dependencies without leaving the page.

- Adds `Integration::get_required_plugins()` so integrations can declare the plugins they depend on. The base implementation returns an empty array; `ESP` overrides it to report `newspack-newsletters` install/active state via `Plugin_Manager::get_managed_plugin_status()`.
- Exposes the new `required_plugins` payload on each integration in the wizard REST response.
- Updates the integrations card UI so that, when a required plugin is installed but inactive, the primary action becomes "Activate" and triggers a `POST /newspack/v1/plugins/{slug}/activate` call followed by a refetch. When a required plugin is not installed at all, the card renders a "Requires …" requirements affordance instead.
- 
<img width="2138" height="1056" alt="Screenshot 2026-05-14 at 12 27 49" src="https://github.com/user-attachments/assets/7987a20a-6b88-459f-80c8-4142578fa792" />

### How to test the changes in this Pull Request:

1. Check out the branch, build the plugin (`n build newspack-plugin`), and load **Newspack → Audience → Integrations** in the admin.
2. With Newspack Newsletters **active**: confirm the ESP integration card behaves as before (Enable / Connect / Configure actions, no requirements text).
3. Deactivate Newspack Newsletters (keep it installed): reload the page and confirm the ESP card now shows an **Activate** button. Click it and confirm the plugin activates, the page state refreshes, and the card returns to its normal Enable/Connect state.
4. Uninstall Newspack Newsletters entirely (or rename its directory): reload the page and confirm the ESP card shows a "Requires Newspack Newsletters" requirements label and no Activate action is offered.
5. Verify the REST response feeding the screen includes a `required_plugins` array for the ESP integration with `slug`, `name`, `is_active`, and `is_installed` keys.
6. Sanity-check other integrations (without overrides) still load with an empty `required_plugins` array and unchanged UI.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?