### PR TITLE
feat(rolling-content): hidden DataViews demo wizard

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -159,6 +159,7 @@ final class Newspack {
 
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-setup-wizard.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-components-demo.php';
+		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-rolling-content-demo.php';
 
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/traits/trait-wizards-admin-header.php';
 
@@ -176,6 +177,7 @@ final class Newspack {
 
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-setup-wizard.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-components-demo.php';
+		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-rolling-content-demo.php';
 
 		// Listings Wizard.
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/class-listings-wizard.php';

--- a/includes/class-wizards.php
+++ b/includes/class-wizards.php
@@ -42,6 +42,7 @@ class Wizards {
 	public static function init_wizards() {
 		self::$wizards = [
 			'components-demo'         => new Components_Demo(),
+			'rolling-content-demo'    => new Rolling_Content_Demo(),
 			// v2 Information Architecture.
 			'newspack-dashboard'      => new Newspack_Dashboard(),
 			'setup'                   => new Setup_Wizard(),

--- a/includes/wizards/class-rolling-content-demo.php
+++ b/includes/wizards/class-rolling-content-demo.php
@@ -65,6 +65,18 @@ class Rolling_Content_Demo extends Wizard {
 	}
 
 	/**
+	 * Render the container div. Override the parent so the id matches the current page slug,
+	 * not `$this->slug`. Required because React mounts into `getElementById(pageParam)`.
+	 */
+	public function render_wizard() {
+		$page = filter_input( INPUT_GET, 'page', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+		$id   = in_array( $page, [ $this->slug, self::SLUG_ADD ], true ) ? $page : $this->slug;
+		?>
+		<div class="newspack-wizard <?php echo esc_attr( $id ); ?>" id="<?php echo esc_attr( $id ); ?>"></div>
+		<?php
+	}
+
+	/**
 	 * Register admin pages.
 	 *
 	 * Both pages are ALWAYS registered as hidden so direct URL navigation works.

--- a/includes/wizards/class-rolling-content-demo.php
+++ b/includes/wizards/class-rolling-content-demo.php
@@ -60,7 +60,8 @@ class Rolling_Content_Demo extends Wizard {
 	 * @return bool
 	 */
 	public function is_wizard_page() {
-		$page = filter_input( INPUT_GET, 'page', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$page = isset( $_GET['page'] ) ? sanitize_key( wp_unslash( $_GET['page'] ) ) : '';
 		return in_array( $page, [ $this->slug, self::SLUG_ADD ], true );
 	}
 
@@ -69,7 +70,8 @@ class Rolling_Content_Demo extends Wizard {
 	 * not `$this->slug`. Required because React mounts into `getElementById(pageParam)`.
 	 */
 	public function render_wizard() {
-		$page = filter_input( INPUT_GET, 'page', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$page = isset( $_GET['page'] ) ? sanitize_key( wp_unslash( $_GET['page'] ) ) : '';
 		$id   = in_array( $page, [ $this->slug, self::SLUG_ADD ], true ) ? $page : $this->slug;
 		?>
 		<div class="newspack-wizard <?php echo esc_attr( $id ); ?>" id="<?php echo esc_attr( $id ); ?>"></div>
@@ -124,27 +126,53 @@ class Rolling_Content_Demo extends Wizard {
 	/**
 	 * Enqueue scripts and styles.
 	 *
-	 * Delegate to the parent class so the standard wizard chrome (newspack_urls,
-	 * newspack_aux_data, newspack-wizards registration, etc.) gets set up.
-	 * The parent's enqueue function checks `$_GET['page'] === $this->slug` and
-	 * bails otherwise; for the SLUG_ADD page we temporarily spoof `page` so the
-	 * parent runs, then restore it.
+	 * Replicates the relevant parts of the parent class's enqueue logic. We can't
+	 * just call `parent::enqueue_scripts_and_styles()` because its slug check uses
+	 * `filter_input(INPUT_GET, 'page')`, which reads from the frozen request state
+	 * and ignores any local `$_GET` mutations — so it would bail on the SLUG_ADD
+	 * page.
 	 */
 	public function enqueue_scripts_and_styles() {
 		if ( ! $this->is_wizard_page() ) {
 			return;
 		}
 
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- $_GET['page'] is only stored briefly and restored verbatim.
-		$original_page = isset( $_GET['page'] ) ? $_GET['page'] : null;
-		$_GET['page']  = $this->slug;
-		parent::enqueue_scripts_and_styles();
-		if ( null === $original_page ) {
-			unset( $_GET['page'] );
-		} else {
-			$_GET['page'] = $original_page;
-		}
+		Newspack::load_common_assets();
 
+		// Data carrier (no source script).
+		wp_register_script( 'newspack_data', '', [], '1.0', false );
+
+		$plugin_data = get_plugin_data( NEWSPACK_PLUGIN_FILE );
+		$urls        = [
+			'dashboard'      => Wizards::get_url( 'newspack-dashboard' ),
+			'public_path'    => Newspack::plugin_url() . '/dist/',
+			'bloginfo'       => [ 'name' => get_bloginfo( 'name' ) ],
+			'plugin_version' => [ 'label' => $plugin_data['Name'] . ' ' . $plugin_data['Version'] ],
+			'homepage'       => get_edit_post_link( get_option( 'page_on_front', false ) ),
+			'site'           => get_site_url(),
+			'support'        => esc_url( 'https://help.newspack.com/' ),
+			'support_email'  => false,
+		];
+
+		$aux_data = [
+			'is_e2e'              => Starter_Content::is_e2e(),
+			'is_debug_mode'       => Newspack::is_debug_mode(),
+			'has_completed_setup' => get_option( NEWSPACK_SETUP_COMPLETE ),
+			'site_title'          => get_option( 'blogname' ),
+			'is_managed'          => method_exists( 'Newspack_Manager', 'is_connected_to_manager' ) && \Newspack_Manager::is_connected_to_manager(),
+		];
+
+		wp_localize_script( 'newspack_data', 'newspack_urls', $urls );
+		wp_localize_script( 'newspack_data', 'newspack_aux_data', $aux_data );
+		wp_enqueue_script( 'newspack_data' );
+
+		wp_register_script(
+			'newspack-wizards',
+			Newspack::plugin_url() . '/dist/wizards.js',
+			$this->get_script_dependencies(),
+			NEWSPACK_PLUGIN_VERSION,
+			true
+		);
 		wp_enqueue_script( 'newspack-wizards' );
 	}
 }

--- a/includes/wizards/class-rolling-content-demo.php
+++ b/includes/wizards/class-rolling-content-demo.php
@@ -79,29 +79,13 @@ class Rolling_Content_Demo extends Wizard {
 	/**
 	 * Register admin pages.
 	 *
-	 * Both pages are ALWAYS registered as hidden so direct URL navigation works.
-	 * When the user is on either page, a visible top-level menu with sub-items is
-	 * also registered so the demo's IA can be observed in the sidebar.
+	 * The visible top-level menu and its sub-items are only registered when the
+	 * user is actually on one of the demo pages. URL access still works because
+	 * `admin_menu` fires before WP validates the slug — `$_GET['page']` is set
+	 * by the time `is_wizard_page()` runs, the menu registers, and WP accepts
+	 * the page.
 	 */
 	public function add_page() {
-		// Always register both slugs as hidden so direct URL access works.
-		add_submenu_page(
-			'hidden',
-			$this->get_name(),
-			$this->get_name(),
-			$this->capability,
-			$this->slug,
-			[ $this, 'render_wizard' ]
-		);
-		add_submenu_page(
-			'hidden',
-			__( 'Add Rolling Content', 'newspack-plugin' ),
-			__( 'Add Rolling Content', 'newspack-plugin' ),
-			$this->capability,
-			self::SLUG_ADD,
-			[ $this, 'render_wizard' ]
-		);
-
 		if ( ! $this->is_wizard_page() ) {
 			return;
 		}
@@ -140,36 +124,27 @@ class Rolling_Content_Demo extends Wizard {
 	/**
 	 * Enqueue scripts and styles.
 	 *
-	 * The parent class's slug check is too strict (single slug). We replicate the
-	 * parts we need so both demo pages get the shared `newspack-wizards` chrome.
+	 * Delegate to the parent class so the standard wizard chrome (newspack_urls,
+	 * newspack_aux_data, newspack-wizards registration, etc.) gets set up.
+	 * The parent's enqueue function checks `$_GET['page'] === $this->slug` and
+	 * bails otherwise; for the SLUG_ADD page we temporarily spoof `page` so the
+	 * parent runs, then restore it.
 	 */
 	public function enqueue_scripts_and_styles() {
 		if ( ! $this->is_wizard_page() ) {
 			return;
 		}
 
-		Newspack::load_common_assets();
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- $_GET['page'] is only stored briefly and restored verbatim.
+		$original_page = isset( $_GET['page'] ) ? $_GET['page'] : null;
+		$_GET['page']  = $this->slug;
+		parent::enqueue_scripts_and_styles();
+		if ( null === $original_page ) {
+			unset( $_GET['page'] );
+		} else {
+			$_GET['page'] = $original_page;
+		}
 
-		// Data carrier script (no source).
-		wp_register_script( 'newspack_data', '', [], '1.0', false );
-		wp_localize_script(
-			'newspack_data',
-			'newspack_urls',
-			[
-				'public_path' => Newspack::plugin_url() . '/dist/',
-				'site'        => get_site_url(),
-			]
-		);
-		wp_enqueue_script( 'newspack_data' );
-
-		// Shared wizards bundle (contains the components map our routes are added to).
-		wp_register_script(
-			'newspack-wizards',
-			Newspack::plugin_url() . '/dist/wizards.js',
-			$this->get_script_dependencies(),
-			NEWSPACK_PLUGIN_VERSION,
-			true
-		);
 		wp_enqueue_script( 'newspack-wizards' );
 	}
 }

--- a/includes/wizards/class-rolling-content-demo.php
+++ b/includes/wizards/class-rolling-content-demo.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * Newspack Rolling Content Demo.
+ *
+ * A hidden, URL-gated admin area used to explore DataViews patterns with
+ * fake in-memory data. Not intended for production use.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+require_once NEWSPACK_ABSPATH . '/includes/wizards/class-wizard.php';
+
+/**
+ * Rolling Content demo wizard.
+ */
+class Rolling_Content_Demo extends Wizard {
+
+	/**
+	 * The slug of the main page (All Rolling Content).
+	 *
+	 * @var string
+	 */
+	protected $slug = 'newspack-rolling-content';
+
+	/**
+	 * The capability required to access this wizard.
+	 *
+	 * @var string
+	 */
+	protected $capability = 'manage_options';
+
+	/**
+	 * Hidden from Newspack's own submenu; this wizard manages its own top-level menu conditionally.
+	 *
+	 * @var bool
+	 */
+	protected $hidden = true;
+
+	/**
+	 * Slug for the "Add Rolling Content" placeholder page.
+	 */
+	const SLUG_ADD = 'newspack-rolling-content-add';
+
+	/**
+	 * Get the name for this wizard.
+	 *
+	 * @return string
+	 */
+	public function get_name() {
+		return __( 'Rolling Content', 'newspack-plugin' );
+	}
+
+	/**
+	 * Override the parent slug check so both demo pages are recognized.
+	 *
+	 * @return bool
+	 */
+	public function is_wizard_page() {
+		$page = filter_input( INPUT_GET, 'page', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+		return in_array( $page, [ $this->slug, self::SLUG_ADD ], true );
+	}
+
+	/**
+	 * Register admin pages.
+	 *
+	 * Both pages are ALWAYS registered as hidden so direct URL navigation works.
+	 * When the user is on either page, a visible top-level menu with sub-items is
+	 * also registered so the demo's IA can be observed in the sidebar.
+	 */
+	public function add_page() {
+		// Always register both slugs as hidden so direct URL access works.
+		add_submenu_page(
+			'hidden',
+			$this->get_name(),
+			$this->get_name(),
+			$this->capability,
+			$this->slug,
+			[ $this, 'render_wizard' ]
+		);
+		add_submenu_page(
+			'hidden',
+			__( 'Add Rolling Content', 'newspack-plugin' ),
+			__( 'Add Rolling Content', 'newspack-plugin' ),
+			$this->capability,
+			self::SLUG_ADD,
+			[ $this, 'render_wizard' ]
+		);
+
+		if ( ! $this->is_wizard_page() ) {
+			return;
+		}
+
+		$icon = sprintf(
+			'data:image/svg+xml;base64,%s',
+			base64_encode( Newspack_UI_Icons::get_svg( 'collections' ) )
+		);
+
+		add_menu_page(
+			$this->get_name(),
+			$this->get_name(),
+			$this->capability,
+			$this->slug,
+			[ $this, 'render_wizard' ],
+			$icon
+		);
+		add_submenu_page(
+			$this->slug,
+			$this->get_name(),
+			__( 'All Rolling Content', 'newspack-plugin' ),
+			$this->capability,
+			$this->slug,
+			[ $this, 'render_wizard' ]
+		);
+		add_submenu_page(
+			$this->slug,
+			__( 'Add Rolling Content', 'newspack-plugin' ),
+			__( 'Add Rolling Content', 'newspack-plugin' ),
+			$this->capability,
+			self::SLUG_ADD,
+			[ $this, 'render_wizard' ]
+		);
+	}
+
+	/**
+	 * Enqueue scripts and styles.
+	 *
+	 * The parent class's slug check is too strict (single slug). We replicate the
+	 * parts we need so both demo pages get the shared `newspack-wizards` chrome.
+	 */
+	public function enqueue_scripts_and_styles() {
+		if ( ! $this->is_wizard_page() ) {
+			return;
+		}
+
+		Newspack::load_common_assets();
+
+		// Data carrier script (no source).
+		wp_register_script( 'newspack_data', '', [], '1.0', false );
+		wp_localize_script(
+			'newspack_data',
+			'newspack_urls',
+			[
+				'public_path' => Newspack::plugin_url() . '/dist/',
+				'site'        => get_site_url(),
+			]
+		);
+		wp_enqueue_script( 'newspack_data' );
+
+		// Shared wizards bundle (contains the components map our routes are added to).
+		wp_register_script(
+			'newspack-wizards',
+			Newspack::plugin_url() . '/dist/wizards.js',
+			$this->get_script_dependencies(),
+			NEWSPACK_PLUGIN_VERSION,
+			true
+		);
+		wp_enqueue_script( 'newspack-wizards' );
+	}
+}

--- a/includes/wizards/class-rolling-content-demo.php
+++ b/includes/wizards/class-rolling-content-demo.php
@@ -92,6 +92,9 @@ class Rolling_Content_Demo extends Wizard {
 			return;
 		}
 
+		add_filter( 'parent_file', [ $this, 'set_parent_file' ] );
+		add_filter( 'submenu_file', [ $this, 'set_submenu_file' ] );
+
 		$icon = sprintf(
 			'data:image/svg+xml;base64,%s',
 			base64_encode( Newspack_UI_Icons::get_svg( 'collections' ) )
@@ -125,6 +128,30 @@ class Rolling_Content_Demo extends Wizard {
 			self::SLUG_ADD,
 			[ $this, 'render_wizard' ]
 		);
+	}
+
+	/**
+	 * Force-highlight the top-level menu when on any rolling-content page.
+	 * Required because WP's automatic highlighting can lose the trail through
+	 * the conditional menu registration.
+	 *
+	 * @param string $parent_file The current parent file.
+	 * @return string
+	 */
+	public function set_parent_file( $parent_file ) {
+		return $this->slug;
+	}
+
+	/**
+	 * Highlight the correct submenu item for the current page.
+	 *
+	 * @param string $submenu_file The current submenu file.
+	 * @return string
+	 */
+	public function set_submenu_file( $submenu_file ) {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$page = isset( $_GET['page'] ) ? sanitize_key( wp_unslash( $_GET['page'] ) ) : '';
+		return in_array( $page, [ $this->slug, self::SLUG_ADD ], true ) ? $page : $submenu_file;
 	}
 
 	/**

--- a/includes/wizards/class-rolling-content-demo.php
+++ b/includes/wizards/class-rolling-content-demo.php
@@ -97,13 +97,17 @@ class Rolling_Content_Demo extends Wizard {
 			base64_encode( Newspack_UI_Icons::get_svg( 'collections' ) )
 		);
 
+		// Anchor the menu near the top of the sidebar (just after Dashboard at pos 2)
+		// so the demo is easy to find — `add_menu_page` defaults to appending, which
+		// pushes the demo below every other plugin's menu.
 		add_menu_page(
 			$this->get_name(),
 			$this->get_name(),
 			$this->capability,
 			$this->slug,
 			[ $this, 'render_wizard' ],
-			$icon
+			$icon,
+			'2.5'
 		);
 		add_submenu_page(
 			$this->slug,

--- a/src/wizards/index.tsx
+++ b/src/wizards/index.tsx
@@ -60,6 +60,14 @@ const components: Record< string, any > = {
 		label: __( 'Premium newsletters', 'newspack-plugin' ),
 		component: lazy( () => import( /* webpackChunkName: "newsletters-wizards" */ './newsletters/views/premium-newsletters' ) ),
 	},
+	'newspack-rolling-content': {
+		label: __( 'Rolling Content', 'newspack-plugin' ),
+		component: lazy( () => import( /* webpackChunkName: "rolling-content-wizards" */ './rollingContent/views/all' ) ),
+	},
+	'newspack-rolling-content-add': {
+		label: __( 'Add Rolling Content', 'newspack-plugin' ),
+		component: lazy( () => import( /* webpackChunkName: "rolling-content-wizards" */ './rollingContent/views/add' ) ),
+	},
 } as const;
 
 // Conditionally add the Audience Integrations page if the feature is enabled.

--- a/src/wizards/rollingContent/components/status-pill.tsx
+++ b/src/wizards/rollingContent/components/status-pill.tsx
@@ -1,0 +1,34 @@
+/**
+ * Rolling Content demo — shared status pill.
+ *
+ * Used by both the All Rolling Content view and the Manage Entries modal.
+ * Generic over the status union so each caller passes its own labels and colors.
+ */
+
+type Palette = { bg: string; fg: string };
+
+export default function StatusPill< S extends string >( {
+	status,
+	labels,
+	colors,
+}: {
+	status: S;
+	labels: Record< S, string >;
+	colors: Record< S, Palette >;
+} ) {
+	const c = colors[ status ];
+	return (
+		<span
+			style={ {
+				background: c.bg,
+				color: c.fg,
+				padding: '2px 10px',
+				borderRadius: 999,
+				fontSize: 12,
+				fontWeight: 500,
+			} }
+		>
+			{ labels[ status ] }
+		</span>
+	);
+}

--- a/src/wizards/rollingContent/components/status-pill.tsx
+++ b/src/wizards/rollingContent/components/status-pill.tsx
@@ -1,34 +1,28 @@
 /**
- * Rolling Content demo — shared status pill.
+ * Rolling Content demo — shared status indicator.
  *
- * Used by both the All Rolling Content view and the Manage Entries modal.
- * Generic over the status union so each caller passes its own labels and colors.
+ * Renders a small icon + label for an item's status. Each caller passes its
+ * own labels and icons keyed by its status union.
  */
 
-type Palette = { bg: string; fg: string };
+/**
+ * WordPress dependencies
+ */
+import { Icon } from '@wordpress/components';
 
 export default function StatusPill< S extends string >( {
 	status,
 	labels,
-	colors,
+	icons,
 }: {
 	status: S;
 	labels: Record< S, string >;
-	colors: Record< S, Palette >;
+	icons: Record< S, JSX.Element >;
 } ) {
-	const c = colors[ status ];
 	return (
-		<span
-			style={ {
-				background: c.bg,
-				color: c.fg,
-				padding: '2px 10px',
-				borderRadius: 999,
-				fontSize: 12,
-				fontWeight: 500,
-			} }
-		>
-			{ labels[ status ] }
+		<span style={ { display: 'inline-flex', alignItems: 'center', gap: 4 } }>
+			<Icon icon={ icons[ status ] } size={ 18 } />
+			<span>{ labels[ status ] }</span>
 		</span>
 	);
 }

--- a/src/wizards/rollingContent/data.ts
+++ b/src/wizards/rollingContent/data.ts
@@ -1,0 +1,132 @@
+/**
+ * Rolling Content demo — fake in-memory dataset.
+ *
+ * 30 rolling contents, each with 5-25 deterministic entries. All values are
+ * stable across renders (no Math.random, no Date.now at module scope).
+ */
+
+const ROLLING_TITLES: string[] = [
+	'Election Night 2026: Live Updates',
+	'City Council Budget Hearings',
+	'Wildfire Response Coverage',
+	'School Board Recall Effort',
+	'Hurricane Season Live Coverage',
+	'Mayoral Debate Aftermath',
+	'Transit Strike Day Two',
+	'Federal Inquiry Hearings',
+	'Stadium Vote Live',
+	'Climate Protest Coverage',
+	'Tech Company Layoffs Tracker',
+	'Inauguration Day',
+	'Special Session Coverage',
+	'Tax Reform Town Halls',
+	'Water Restriction Updates',
+	'Election Recount Results',
+	'Public Health Emergency Briefings',
+	'Budget Override Vote',
+	'Police Reform Hearings',
+	'Bond Measure Election Night',
+	'School District Negotiations',
+	'Housing Crisis Forum',
+	'Power Grid Outage Updates',
+	'Recall Petition Tracker',
+	'City Charter Vote',
+	'Special Counsel Updates',
+	'Park District Vote',
+	'Casino Referendum Coverage',
+	'Voter Roll Audit Hearings',
+	'Annexation Vote Live',
+];
+
+const ENTRY_TITLES: string[] = [
+	'Polls close in District 4',
+	'Mayor responds to opposition statement',
+	'Vote count delayed by ballot challenge',
+	'Lawmakers reach tentative deal',
+	'Live update: returns from precinct 12',
+	'Statement from city attorney',
+	'Crowd gathers outside city hall',
+	'Press conference scheduled for 8 PM',
+	'New witness called to testify',
+	'Council moves into closed session',
+	'Update: highway reopens to traffic',
+	'Officials confirm timeline for vote',
+	'Spokesperson denies allegations',
+	'Crowd estimate revised upward',
+	'Decision expected by tomorrow morning',
+];
+
+const AUTHORS: string[] = [ 'Alex Rivera', 'Jamie Chen', 'Morgan Patel', 'Sam Johnson', 'Riley Cooper', 'Jordan Kim' ];
+
+const TAGS: string[] = [ 'breaking', 'politics', 'local', 'national', 'elections', 'transit', 'weather', 'courts', 'education', 'climate' ];
+
+const BASE_DATE = new Date( '2026-05-01T12:00:00Z' );
+
+function makeDate( seed: number ): string {
+	const dayOffset = ( seed * 17 ) % 90;
+	const d = new Date( BASE_DATE );
+	d.setDate( d.getDate() - dayOffset );
+	return d.toISOString();
+}
+
+function entryStatusFor( id: number ): EntryStatus {
+	const statusRoll = ( id * 13 ) % 100;
+	if ( statusRoll < 70 ) {
+		return 'published';
+	}
+	if ( statusRoll < 90 ) {
+		return 'draft';
+	}
+	return 'scheduled';
+}
+
+function rollingStatusFor( idx: number ): RollingContentStatus {
+	if ( idx < 12 ) {
+		return 'active';
+	}
+	if ( idx < 22 ) {
+		return 'archived';
+	}
+	return 'scheduled';
+}
+
+function makeEntries( parentId: number, count: number ): Entry[] {
+	const entries: Entry[] = [];
+	for ( let i = 0; i < count; i++ ) {
+		const id = parentId * 1000 + i;
+		const status: EntryStatus = entryStatusFor( id );
+
+		const tagCount = 1 + ( ( id * 3 ) % 3 );
+		const tags: string[] = [];
+		for ( let t = 0; t < tagCount; t++ ) {
+			tags.push( TAGS[ ( id * 7 + t * 11 ) % TAGS.length ] );
+		}
+
+		entries.push( {
+			id,
+			title: ENTRY_TITLES[ ( id * 5 ) % ENTRY_TITLES.length ],
+			date: makeDate( id ),
+			author: AUTHORS[ id % AUTHORS.length ],
+			featuredImage: `https://picsum.photos/seed/entry-${ id }/200/120`,
+			status,
+			tags,
+		} );
+	}
+	return entries;
+}
+
+export const ROLLING_CONTENTS: RollingContent[] = ROLLING_TITLES.map( ( title, idx ) => {
+	const id = idx + 1;
+	const status: RollingContentStatus = rollingStatusFor( idx );
+	const entryCount = 5 + ( ( id * 7 ) % 21 );
+	return {
+		id,
+		title,
+		date: makeDate( id ),
+		featuredImage: `https://picsum.photos/seed/rolling-${ id }/200/120`,
+		status,
+		entries: makeEntries( id, entryCount ),
+	};
+} );
+
+export const getRollingContent = ( id: number ): RollingContent | undefined => ROLLING_CONTENTS.find( r => r.id === id );

--- a/src/wizards/rollingContent/data.ts
+++ b/src/wizards/rollingContent/data.ts
@@ -96,7 +96,7 @@ function makeEntries( parentId: number, count: number ): Entry[] {
 		const id = parentId * 1000 + i;
 		const status: EntryStatus = entryStatusFor( id );
 
-		const tagCount = 1 + ( ( id * 3 ) % 3 );
+		const tagCount = 1 + ( id % 3 );
 		const tags: string[] = [];
 		for ( let t = 0; t < tagCount; t++ ) {
 			tags.push( TAGS[ ( id * 7 + t * 11 ) % TAGS.length ] );
@@ -104,7 +104,7 @@ function makeEntries( parentId: number, count: number ): Entry[] {
 
 		entries.push( {
 			id,
-			title: ENTRY_TITLES[ ( id * 5 ) % ENTRY_TITLES.length ],
+			title: ENTRY_TITLES[ ( id * 7 ) % ENTRY_TITLES.length ],
 			date: makeDate( id ),
 			author: AUTHORS[ id % AUTHORS.length ],
 			featuredImage: `https://picsum.photos/seed/entry-${ id }/200/120`,
@@ -118,7 +118,7 @@ function makeEntries( parentId: number, count: number ): Entry[] {
 export const ROLLING_CONTENTS: RollingContent[] = ROLLING_TITLES.map( ( title, idx ) => {
 	const id = idx + 1;
 	const status: RollingContentStatus = rollingStatusFor( idx );
-	const entryCount = 5 + ( ( id * 7 ) % 21 );
+	const entryCount = 5 + ( ( id * 11 ) % 21 );
 	return {
 		id,
 		title,

--- a/src/wizards/rollingContent/modals/add-entry-info.tsx
+++ b/src/wizards/rollingContent/modals/add-entry-info.tsx
@@ -1,0 +1,40 @@
+/**
+ * Rolling Content demo — Add Entry info modal.
+ *
+ * Explains the implicit parent association: in a real implementation,
+ * choosing "Add New Entry" from a Rolling Content row (or from inside the
+ * Manage Entries modal) would open the block editor with the chosen
+ * Rolling Content preselected as the parent.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { Button, Modal } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+
+export default function AddEntryInfoModal( { parentTitle, onClose }: { parentTitle: string; onClose: () => void } ) {
+	return (
+		<Modal title={ __( 'Add new entry', 'newspack-plugin' ) } onRequestClose={ onClose } size="medium">
+			<p>
+				{ createInterpolateElement(
+					sprintf(
+						/* translators: %s: parent rolling content title, wrapped in <name/>. */
+						__(
+							'Selecting "Add New Entry" would open the post editor with <name>%s</name> preselected as the parent. The link between an entry and its parent is implicit in how you enter the editor — no manual selection required.',
+							'newspack-plugin'
+						),
+						parentTitle
+					),
+					{ name: <strong /> }
+				) }
+			</p>
+			<div style={ { display: 'flex', justifyContent: 'flex-end', marginTop: 16 } }>
+				<Button variant="primary" onClick={ onClose }>
+					{ __( 'Got it', 'newspack-plugin' ) }
+				</Button>
+			</div>
+		</Modal>
+	);
+}

--- a/src/wizards/rollingContent/modals/delete-confirm.tsx
+++ b/src/wizards/rollingContent/modals/delete-confirm.tsx
@@ -13,11 +13,6 @@ import { Button, Modal } from '@wordpress/components';
 
 type ItemType = 'rolling-content' | 'entry';
 
-const ITEM_NOUN: Record< ItemType, string > = {
-	'rolling-content': __( 'rolling content', 'newspack-plugin' ),
-	entry: __( 'entry', 'newspack-plugin' ),
-};
-
 export default function DeleteConfirmModal( {
 	itemType,
 	title,
@@ -29,6 +24,8 @@ export default function DeleteConfirmModal( {
 	onConfirm: () => void;
 	onClose: () => void;
 } ) {
+	const itemNoun = itemType === 'entry' ? __( 'entry', 'newspack-plugin' ) : __( 'rolling content', 'newspack-plugin' );
+
 	return (
 		<Modal
 			title={ sprintf(
@@ -43,7 +40,7 @@ export default function DeleteConfirmModal( {
 				{ sprintf(
 					/* translators: %s: item type. */
 					__( 'This will permanently delete this %s. This action cannot be undone.', 'newspack-plugin' ),
-					ITEM_NOUN[ itemType ]
+					itemNoun
 				) }
 			</p>
 			<div style={ { display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 16 } }>

--- a/src/wizards/rollingContent/modals/delete-confirm.tsx
+++ b/src/wizards/rollingContent/modals/delete-confirm.tsx
@@ -1,0 +1,66 @@
+/**
+ * Rolling Content demo — Delete confirmation modal.
+ *
+ * Shared destructive confirmation used for both Rolling Content and Entry deletes.
+ * On confirm, calls `onConfirm`; the caller mutates local state.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { Button, Modal } from '@wordpress/components';
+
+type ItemType = 'rolling-content' | 'entry';
+
+const ITEM_NOUN: Record< ItemType, string > = {
+	'rolling-content': __( 'rolling content', 'newspack-plugin' ),
+	entry: __( 'entry', 'newspack-plugin' ),
+};
+
+export default function DeleteConfirmModal( {
+	itemType,
+	title,
+	onConfirm,
+	onClose,
+}: {
+	itemType: ItemType;
+	title: string;
+	onConfirm: () => void;
+	onClose: () => void;
+} ) {
+	return (
+		<Modal
+			title={ sprintf(
+				/* translators: %s: item title. */
+				__( 'Delete %s', 'newspack-plugin' ),
+				title
+			) }
+			onRequestClose={ onClose }
+			size="small"
+		>
+			<p>
+				{ sprintf(
+					/* translators: %s: item type. */
+					__( 'This will permanently delete this %s. This action cannot be undone.', 'newspack-plugin' ),
+					ITEM_NOUN[ itemType ]
+				) }
+			</p>
+			<div style={ { display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 16 } }>
+				<Button variant="tertiary" onClick={ onClose }>
+					{ __( 'Cancel', 'newspack-plugin' ) }
+				</Button>
+				<Button
+					variant="primary"
+					isDestructive
+					onClick={ () => {
+						onConfirm();
+						onClose();
+					} }
+				>
+					{ __( 'Delete', 'newspack-plugin' ) }
+				</Button>
+			</div>
+		</Modal>
+	);
+}

--- a/src/wizards/rollingContent/modals/edit-info.tsx
+++ b/src/wizards/rollingContent/modals/edit-info.tsx
@@ -13,18 +13,15 @@ import { Button, Modal } from '@wordpress/components';
 
 type ItemType = 'rolling-content' | 'entry';
 
-const ITEM_NOUN: Record< ItemType, string > = {
-	'rolling-content': __( 'rolling content', 'newspack-plugin' ),
-	entry: __( 'entry', 'newspack-plugin' ),
-};
-
 export default function EditInfoModal( { itemType, title, onClose }: { itemType: ItemType; title: string; onClose: () => void } ) {
+	const itemNoun = itemType === 'entry' ? __( 'entry', 'newspack-plugin' ) : __( 'rolling content', 'newspack-plugin' );
+
 	return (
 		<Modal
 			title={ sprintf(
 				/* translators: %s: item type, e.g. "rolling content" or "entry". */
 				__( 'Edit %s', 'newspack-plugin' ),
-				ITEM_NOUN[ itemType ]
+				itemNoun
 			) }
 			onRequestClose={ onClose }
 			size="medium"

--- a/src/wizards/rollingContent/modals/edit-info.tsx
+++ b/src/wizards/rollingContent/modals/edit-info.tsx
@@ -1,0 +1,46 @@
+/**
+ * Rolling Content demo — Edit info modal.
+ *
+ * Shared info modal used for both Rolling Content and Entry "Edit" row actions.
+ * Explains that, in a real implementation, this would open the block editor.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { Button, Modal } from '@wordpress/components';
+
+type ItemType = 'rolling-content' | 'entry';
+
+const ITEM_NOUN: Record< ItemType, string > = {
+	'rolling-content': __( 'rolling content', 'newspack-plugin' ),
+	entry: __( 'entry', 'newspack-plugin' ),
+};
+
+export default function EditInfoModal( { itemType, title, onClose }: { itemType: ItemType; title: string; onClose: () => void } ) {
+	return (
+		<Modal
+			title={ sprintf(
+				/* translators: %s: item type, e.g. "rolling content" or "entry". */
+				__( 'Edit %s', 'newspack-plugin' ),
+				ITEM_NOUN[ itemType ]
+			) }
+			onRequestClose={ onClose }
+			size="medium"
+		>
+			<p>
+				{ sprintf(
+					/* translators: %s: item title. */
+					__( 'This would open the block editor for %s.', 'newspack-plugin' ),
+					title
+				) }
+			</p>
+			<div style={ { display: 'flex', justifyContent: 'flex-end', marginTop: 16 } }>
+				<Button variant="primary" onClick={ onClose }>
+					{ __( 'Got it', 'newspack-plugin' ) }
+				</Button>
+			</div>
+		</Modal>
+	);
+}

--- a/src/wizards/rollingContent/modals/manage-entries.tsx
+++ b/src/wizards/rollingContent/modals/manage-entries.tsx
@@ -14,6 +14,7 @@ import { useState, useMemo } from '@wordpress/element';
 import { Button } from '@wordpress/components';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import type { Action, Field, View } from '@wordpress/dataviews';
+import { published, drafts, scheduled } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -30,10 +31,10 @@ const STATUS_LABELS: Record< EntryStatus, string > = {
 	scheduled: __( 'Scheduled', 'newspack-plugin' ),
 };
 
-const STATUS_COLORS: Record< EntryStatus, { bg: string; fg: string } > = {
-	published: { bg: '#d1fae5', fg: '#065f46' },
-	draft: { bg: '#e5e7eb', fg: '#374151' },
-	scheduled: { bg: '#dbeafe', fg: '#1e40af' },
+const STATUS_ICONS: Record< EntryStatus, JSX.Element > = {
+	published,
+	draft: drafts,
+	scheduled,
 };
 
 const DEFAULT_VIEW: View = {
@@ -100,7 +101,7 @@ export default function ManageEntriesModal( {
 				id: 'status',
 				label: __( 'Status', 'newspack-plugin' ),
 				getValue: ( { item } ) => item.status,
-				render: ( { item } ) => <StatusPill status={ item.status } labels={ STATUS_LABELS } colors={ STATUS_COLORS } />,
+				render: ( { item } ) => <StatusPill status={ item.status } labels={ STATUS_LABELS } icons={ STATUS_ICONS } />,
 				elements: ( Object.keys( STATUS_LABELS ) as EntryStatus[] ).map( value => ( {
 					value,
 					label: STATUS_LABELS[ value ],

--- a/src/wizards/rollingContent/modals/manage-entries.tsx
+++ b/src/wizards/rollingContent/modals/manage-entries.tsx
@@ -11,7 +11,7 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { useState, useMemo } from '@wordpress/element';
-import { Button, Modal } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import type { Action, Field, View } from '@wordpress/dataviews';
 
@@ -53,6 +53,7 @@ export default function ManageEntriesModal( {
 	parent,
 	entries,
 	onEntriesChange,
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	onClose,
 }: {
 	parent: RollingContent;
@@ -162,15 +163,7 @@ export default function ManageEntriesModal( {
 	const { data: processedData, paginationInfo } = useMemo( () => filterSortAndPaginate( entries, view, fields ), [ entries, view, fields ] );
 
 	return (
-		<Modal
-			title={ sprintf(
-				/* translators: %s: parent rolling content title. */
-				__( 'Manage entries — %s', 'newspack-plugin' ),
-				parent.title
-			) }
-			onRequestClose={ onClose }
-			isFullScreen
-		>
+		<>
 			<div
 				style={ {
 					display: 'flex',
@@ -204,6 +197,6 @@ export default function ManageEntriesModal( {
 			/>
 
 			{ isAddingEntry && <AddEntryInfoModal parentTitle={ parent.title } onClose={ () => setIsAddingEntry( false ) } /> }
-		</Modal>
+		</>
 	);
 }

--- a/src/wizards/rollingContent/modals/manage-entries.tsx
+++ b/src/wizards/rollingContent/modals/manage-entries.tsx
@@ -19,6 +19,7 @@ import type { Action, Field, View } from '@wordpress/dataviews';
  * Internal dependencies
  */
 import { DataViews } from '../../../../packages/components/src';
+import StatusPill from '../components/status-pill';
 import EditInfoModal from './edit-info';
 import DeleteConfirmModal from './delete-confirm';
 import AddEntryInfoModal from './add-entry-info';
@@ -34,24 +35,6 @@ const STATUS_COLORS: Record< EntryStatus, { bg: string; fg: string } > = {
 	draft: { bg: '#e5e7eb', fg: '#374151' },
 	scheduled: { bg: '#dbeafe', fg: '#1e40af' },
 };
-
-function StatusPill( { status }: { status: EntryStatus } ) {
-	const c = STATUS_COLORS[ status ];
-	return (
-		<span
-			style={ {
-				background: c.bg,
-				color: c.fg,
-				padding: '2px 10px',
-				borderRadius: 999,
-				fontSize: 12,
-				fontWeight: 500,
-			} }
-		>
-			{ STATUS_LABELS[ status ] }
-		</span>
-	);
-}
 
 const DEFAULT_VIEW: View = {
 	type: 'table',
@@ -116,7 +99,7 @@ export default function ManageEntriesModal( {
 				id: 'status',
 				label: __( 'Status', 'newspack-plugin' ),
 				getValue: ( { item } ) => item.status,
-				render: ( { item } ) => <StatusPill status={ item.status } />,
+				render: ( { item } ) => <StatusPill status={ item.status } labels={ STATUS_LABELS } colors={ STATUS_COLORS } />,
 				elements: ( Object.keys( STATUS_LABELS ) as EntryStatus[] ).map( value => ( {
 					value,
 					label: STATUS_LABELS[ value ],

--- a/src/wizards/rollingContent/modals/manage-entries.tsx
+++ b/src/wizards/rollingContent/modals/manage-entries.tsx
@@ -140,14 +140,16 @@ export default function ManageEntriesModal( {
 				label: __( 'Edit', 'newspack-plugin' ),
 				isPrimary: true,
 				supportsBulk: false,
-				RenderModal: ( { items, closeModal } ) => <EditInfoModal itemType="entry" title={ items[ 0 ].title } onClose={ closeModal } />,
+				RenderModal: ( { items, closeModal }: { items: Entry[]; closeModal: () => void } ) => (
+					<EditInfoModal itemType="entry" title={ items[ 0 ].title } onClose={ closeModal } />
+				),
 			},
 			{
 				id: 'delete',
 				label: __( 'Delete', 'newspack-plugin' ),
 				isDestructive: true,
 				supportsBulk: false,
-				RenderModal: ( { items, closeModal } ) => (
+				RenderModal: ( { items, closeModal }: { items: Entry[]; closeModal: () => void } ) => (
 					<DeleteConfirmModal
 						itemType="entry"
 						title={ items[ 0 ].title }

--- a/src/wizards/rollingContent/modals/manage-entries.tsx
+++ b/src/wizards/rollingContent/modals/manage-entries.tsx
@@ -11,7 +11,7 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { useState, useMemo } from '@wordpress/element';
-import { Button } from '@wordpress/components';
+import { Button, Modal } from '@wordpress/components';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import type { Action, Field, View } from '@wordpress/dataviews';
 import { published, drafts, scheduled } from '@wordpress/icons';
@@ -54,7 +54,6 @@ export default function ManageEntriesModal( {
 	parent,
 	entries,
 	onEntriesChange,
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	onClose,
 }: {
 	parent: RollingContent;
@@ -166,7 +165,15 @@ export default function ManageEntriesModal( {
 	const { data: processedData, paginationInfo } = useMemo( () => filterSortAndPaginate( entries, view, fields ), [ entries, view, fields ] );
 
 	return (
-		<>
+		<Modal
+			title={ sprintf(
+				/* translators: %s: parent rolling content title. */
+				__( 'Manage entries — %s', 'newspack-plugin' ),
+				parent.title
+			) }
+			isFullScreen
+			onRequestClose={ onClose }
+		>
 			<div
 				style={ {
 					display: 'flex',
@@ -200,6 +207,6 @@ export default function ManageEntriesModal( {
 			/>
 
 			{ isAddingEntry && <AddEntryInfoModal parentTitle={ parent.title } onClose={ () => setIsAddingEntry( false ) } /> }
-		</>
+		</Modal>
 	);
 }

--- a/src/wizards/rollingContent/modals/manage-entries.tsx
+++ b/src/wizards/rollingContent/modals/manage-entries.tsx
@@ -1,0 +1,226 @@
+/**
+ * Rolling Content demo — Manage Entries modal.
+ *
+ * Full-screen modal containing a nested DataViews of all entries belonging
+ * to one parent Rolling Content. Reuses the shared Edit Info, Delete
+ * Confirm, and Add Entry Info modals for row-level and toolbar actions.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { useState, useMemo } from '@wordpress/element';
+import { Button, Modal } from '@wordpress/components';
+import { filterSortAndPaginate } from '@wordpress/dataviews';
+import type { Action, Field, View } from '@wordpress/dataviews';
+
+/**
+ * Internal dependencies
+ */
+import { DataViews } from '../../../../packages/components/src';
+import EditInfoModal from './edit-info';
+import DeleteConfirmModal from './delete-confirm';
+import AddEntryInfoModal from './add-entry-info';
+
+const STATUS_LABELS: Record< EntryStatus, string > = {
+	published: __( 'Published', 'newspack-plugin' ),
+	draft: __( 'Draft', 'newspack-plugin' ),
+	scheduled: __( 'Scheduled', 'newspack-plugin' ),
+};
+
+const STATUS_COLORS: Record< EntryStatus, { bg: string; fg: string } > = {
+	published: { bg: '#d1fae5', fg: '#065f46' },
+	draft: { bg: '#e5e7eb', fg: '#374151' },
+	scheduled: { bg: '#dbeafe', fg: '#1e40af' },
+};
+
+function StatusPill( { status }: { status: EntryStatus } ) {
+	const c = STATUS_COLORS[ status ];
+	return (
+		<span
+			style={ {
+				background: c.bg,
+				color: c.fg,
+				padding: '2px 10px',
+				borderRadius: 999,
+				fontSize: 12,
+				fontWeight: 500,
+			} }
+		>
+			{ STATUS_LABELS[ status ] }
+		</span>
+	);
+}
+
+const DEFAULT_VIEW: View = {
+	type: 'table',
+	page: 1,
+	perPage: 20,
+	sort: { field: 'date', direction: 'desc' },
+	search: '',
+	fields: [ 'date', 'author', 'status', 'tags' ],
+	filters: [],
+	layout: {},
+	titleField: 'title',
+	mediaField: 'featured_image',
+};
+
+export default function ManageEntriesModal( {
+	parent,
+	entries,
+	onEntriesChange,
+	onClose,
+}: {
+	parent: RollingContent;
+	entries: Entry[];
+	onEntriesChange: ( next: Entry[] ) => void;
+	onClose: () => void;
+} ) {
+	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
+	const [ isAddingEntry, setIsAddingEntry ] = useState( false );
+
+	const fields: Field< Entry >[] = useMemo(
+		() => [
+			{
+				id: 'featured_image',
+				label: __( 'Featured image', 'newspack-plugin' ),
+				type: 'media',
+				render: ( { item } ) => <img src={ item.featuredImage } alt={ item.title } style={ { maxWidth: 80 } } />,
+				enableSorting: false,
+			},
+			{
+				id: 'title',
+				label: __( 'Title', 'newspack-plugin' ),
+				enableGlobalSearch: true,
+				getValue: ( { item } ) => item.title,
+				render: ( { item } ) => <strong>{ item.title }</strong>,
+			},
+			{
+				id: 'date',
+				label: __( 'Date', 'newspack-plugin' ),
+				getValue: ( { item } ) => item.date,
+				render: ( { item } ) =>
+					new Date( item.date ).toLocaleDateString( undefined, {
+						year: 'numeric',
+						month: 'short',
+						day: 'numeric',
+					} ),
+			},
+			{
+				id: 'author',
+				label: __( 'Author', 'newspack-plugin' ),
+				getValue: ( { item } ) => item.author,
+			},
+			{
+				id: 'status',
+				label: __( 'Status', 'newspack-plugin' ),
+				getValue: ( { item } ) => item.status,
+				render: ( { item } ) => <StatusPill status={ item.status } />,
+				elements: ( Object.keys( STATUS_LABELS ) as EntryStatus[] ).map( value => ( {
+					value,
+					label: STATUS_LABELS[ value ],
+				} ) ),
+			},
+			{
+				id: 'tags',
+				label: __( 'Tags', 'newspack-plugin' ),
+				getValue: ( { item } ) => item.tags.join( ', ' ),
+				render: ( { item } ) => (
+					<span style={ { display: 'inline-flex', gap: 4, flexWrap: 'wrap' } }>
+						{ item.tags.map( tag => (
+							<span
+								key={ tag }
+								style={ {
+									background: '#f3f4f6',
+									padding: '2px 8px',
+									borderRadius: 4,
+									fontSize: 12,
+								} }
+							>
+								{ tag }
+							</span>
+						) ) }
+					</span>
+				),
+				enableSorting: false,
+			},
+		],
+		[]
+	);
+
+	const actions: Action< Entry >[] = useMemo(
+		() => [
+			{
+				id: 'edit',
+				label: __( 'Edit', 'newspack-plugin' ),
+				isPrimary: true,
+				supportsBulk: false,
+				RenderModal: ( { items, closeModal } ) => <EditInfoModal itemType="entry" title={ items[ 0 ].title } onClose={ closeModal } />,
+			},
+			{
+				id: 'delete',
+				label: __( 'Delete', 'newspack-plugin' ),
+				isDestructive: true,
+				supportsBulk: false,
+				RenderModal: ( { items, closeModal } ) => (
+					<DeleteConfirmModal
+						itemType="entry"
+						title={ items[ 0 ].title }
+						onConfirm={ () => onEntriesChange( entries.filter( e => e.id !== items[ 0 ].id ) ) }
+						onClose={ closeModal }
+					/>
+				),
+			},
+		],
+		[ entries, onEntriesChange ]
+	);
+
+	const { data: processedData, paginationInfo } = useMemo( () => filterSortAndPaginate( entries, view, fields ), [ entries, view, fields ] );
+
+	return (
+		<Modal
+			title={ sprintf(
+				/* translators: %s: parent rolling content title. */
+				__( 'Manage entries — %s', 'newspack-plugin' ),
+				parent.title
+			) }
+			onRequestClose={ onClose }
+			isFullScreen
+		>
+			<div
+				style={ {
+					display: 'flex',
+					alignItems: 'center',
+					justifyContent: 'space-between',
+					marginBottom: 16,
+				} }
+			>
+				<p style={ { margin: 0, color: '#6b7280' } }>
+					{ sprintf(
+						/* translators: %s: parent rolling content title. */
+						__( 'Entries for: %s', 'newspack-plugin' ),
+						parent.title
+					) }
+				</p>
+				<Button variant="primary" onClick={ () => setIsAddingEntry( true ) }>
+					{ __( 'Add New Entry', 'newspack-plugin' ) }
+				</Button>
+			</div>
+
+			<DataViews
+				data={ processedData }
+				fields={ fields }
+				view={ view }
+				onChangeView={ setView }
+				actions={ actions }
+				paginationInfo={ paginationInfo }
+				defaultLayouts={ { table: {} } }
+				getItemId={ ( item: Entry ) => String( item.id ) }
+				search
+			/>
+
+			{ isAddingEntry && <AddEntryInfoModal parentTitle={ parent.title } onClose={ () => setIsAddingEntry( false ) } /> }
+		</Modal>
+	);
+}

--- a/src/wizards/rollingContent/types.d.ts
+++ b/src/wizards/rollingContent/types.d.ts
@@ -1,0 +1,29 @@
+/**
+ * Rolling Content demo — type definitions.
+ */
+
+declare global {
+	type RollingContentStatus = 'active' | 'archived' | 'scheduled';
+	type EntryStatus = 'published' | 'draft' | 'scheduled';
+
+	interface Entry {
+		id: number;
+		title: string;
+		date: string;
+		author: string;
+		featuredImage: string;
+		status: EntryStatus;
+		tags: string[];
+	}
+
+	interface RollingContent {
+		id: number;
+		title: string;
+		date: string;
+		featuredImage: string;
+		status: RollingContentStatus;
+		entries: Entry[];
+	}
+}
+
+export {};

--- a/src/wizards/rollingContent/views/add.tsx
+++ b/src/wizards/rollingContent/views/add.tsx
@@ -46,10 +46,5 @@ function AddRollingContent() {
 }
 
 export default function Add() {
-	return (
-		<Wizard
-			headerText={ __( 'Newspack / Rolling Content', 'newspack-plugin' ) }
-			sections={ [ { path: '/', render: () => <AddRollingContent /> } ] }
-		/>
-	);
+	return <Wizard headerText={ __( 'Newspack', 'newspack-plugin' ) } sections={ [ { path: '/', render: () => <AddRollingContent /> } ] } />;
 }

--- a/src/wizards/rollingContent/views/add.tsx
+++ b/src/wizards/rollingContent/views/add.tsx
@@ -6,40 +6,38 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useEffect } from '@wordpress/element';
-import { useDispatch } from '@wordpress/data';
+import { Button } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
-import { WIZARD_STORE_NAMESPACE } from '../../../../packages/components/src/wizard/store';
 import WizardSection from '../../wizards-section';
 
 export default function Add() {
-	const { setHeaderData } = useDispatch( WIZARD_STORE_NAMESPACE );
-
-	useEffect( () => {
-		setHeaderData( {
-			sectionName: __( 'Add Rolling Content', 'newspack-plugin' ),
-			actions: [
-				{
-					type: 'secondary',
-					label: __( 'Back to All Rolling Content', 'newspack-plugin' ),
-					href: 'admin.php?page=newspack-rolling-content',
-				},
-			],
-		} );
-	}, [ setHeaderData ] );
-
 	return (
-		<WizardSection
-			title={ __( 'Add Rolling Content', 'newspack-plugin' ) }
-			description={ __(
-				'This is where the block editor would open to create a new Rolling Content. For this demo, no editor is wired up.',
-				'newspack-plugin'
-			) }
-		>
-			<></>
-		</WizardSection>
+		<>
+			<div
+				style={ {
+					display: 'flex',
+					alignItems: 'center',
+					justifyContent: 'space-between',
+					marginBottom: 16,
+				} }
+			>
+				<h2 style={ { margin: 0 } }>{ __( 'Add Rolling Content', 'newspack-plugin' ) }</h2>
+				<Button variant="secondary" href="admin.php?page=newspack-rolling-content">
+					{ __( 'Back to All Rolling Content', 'newspack-plugin' ) }
+				</Button>
+			</div>
+			<WizardSection
+				title={ __( 'Add Rolling Content', 'newspack-plugin' ) }
+				description={ __(
+					'This is where the block editor would open to create a new Rolling Content. For this demo, no editor is wired up.',
+					'newspack-plugin'
+				) }
+			>
+				<></>
+			</WizardSection>
+		</>
 	);
 }

--- a/src/wizards/rollingContent/views/add.tsx
+++ b/src/wizards/rollingContent/views/add.tsx
@@ -1,0 +1,17 @@
+/**
+ * Rolling Content — Add view (placeholder; expanded in Task 5).
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+export default function Add() {
+	return (
+		<div>
+			<h1>{ __( 'Add Rolling Content', 'newspack-plugin' ) }</h1>
+			<p>{ __( 'Placeholder — Final copy comes in Task 5.', 'newspack-plugin' ) }</p>
+		</div>
+	);
+}

--- a/src/wizards/rollingContent/views/add.tsx
+++ b/src/wizards/rollingContent/views/add.tsx
@@ -1,17 +1,45 @@
 /**
- * Rolling Content — Add view (placeholder; expanded in Task 5).
+ * Rolling Content — Add view (placeholder).
  */
 
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { useEffect } from '@wordpress/element';
+import { useDispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { WIZARD_STORE_NAMESPACE } from '../../../../packages/components/src/wizard/store';
+import WizardSection from '../../wizards-section';
 
 export default function Add() {
+	const { setHeaderData } = useDispatch( WIZARD_STORE_NAMESPACE );
+
+	useEffect( () => {
+		setHeaderData( {
+			sectionName: __( 'Add Rolling Content', 'newspack-plugin' ),
+			actions: [
+				{
+					type: 'secondary',
+					label: __( 'Back to All Rolling Content', 'newspack-plugin' ),
+					href: 'admin.php?page=newspack-rolling-content',
+				},
+			],
+		} );
+	}, [ setHeaderData ] );
+
 	return (
-		<div>
-			<h1>{ __( 'Add Rolling Content', 'newspack-plugin' ) }</h1>
-			<p>{ __( 'Placeholder — Final copy comes in Task 5.', 'newspack-plugin' ) }</p>
-		</div>
+		<WizardSection
+			title={ __( 'Add Rolling Content', 'newspack-plugin' ) }
+			description={ __(
+				'This is where the block editor would open to create a new Rolling Content. For this demo, no editor is wired up.',
+				'newspack-plugin'
+			) }
+		>
+			<></>
+		</WizardSection>
 	);
 }

--- a/src/wizards/rollingContent/views/add.tsx
+++ b/src/wizards/rollingContent/views/add.tsx
@@ -6,38 +6,50 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Button } from '@wordpress/components';
+import { useEffect } from '@wordpress/element';
+import { useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
+import { Wizard } from '../../../../packages/components/src';
+import { WIZARD_STORE_NAMESPACE } from '../../../../packages/components/src/wizard/store';
 import WizardSection from '../../wizards-section';
+
+function AddRollingContent() {
+	const { setHeaderData } = useDispatch( WIZARD_STORE_NAMESPACE );
+
+	useEffect( () => {
+		setHeaderData( {
+			sectionName: __( 'Add Rolling Content', 'newspack-plugin' ),
+			actions: [
+				{
+					type: 'secondary',
+					label: __( 'Back to All Rolling Content', 'newspack-plugin' ),
+					href: 'admin.php?page=newspack-rolling-content',
+				},
+			],
+		} );
+	}, [ setHeaderData ] );
+
+	return (
+		<WizardSection
+			title={ __( 'Add Rolling Content', 'newspack-plugin' ) }
+			description={ __(
+				'This is where the block editor would open to create a new Rolling Content. For this demo, no editor is wired up.',
+				'newspack-plugin'
+			) }
+		>
+			<></>
+		</WizardSection>
+	);
+}
 
 export default function Add() {
 	return (
-		<>
-			<div
-				style={ {
-					display: 'flex',
-					alignItems: 'center',
-					justifyContent: 'space-between',
-					marginBottom: 16,
-				} }
-			>
-				<h2 style={ { margin: 0 } }>{ __( 'Add Rolling Content', 'newspack-plugin' ) }</h2>
-				<Button variant="secondary" href="admin.php?page=newspack-rolling-content">
-					{ __( 'Back to All Rolling Content', 'newspack-plugin' ) }
-				</Button>
-			</div>
-			<WizardSection
-				title={ __( 'Add Rolling Content', 'newspack-plugin' ) }
-				description={ __(
-					'This is where the block editor would open to create a new Rolling Content. For this demo, no editor is wired up.',
-					'newspack-plugin'
-				) }
-			>
-				<></>
-			</WizardSection>
-		</>
+		<Wizard
+			headerText={ __( 'Newspack / Rolling Content', 'newspack-plugin' ) }
+			sections={ [ { path: '/', render: () => <AddRollingContent /> } ] }
+		/>
 	);
 }

--- a/src/wizards/rollingContent/views/all.tsx
+++ b/src/wizards/rollingContent/views/all.tsx
@@ -19,6 +19,7 @@ import { WIZARD_STORE_NAMESPACE } from '../../../../packages/components/src/wiza
 import { ROLLING_CONTENTS } from '../data';
 import EditInfoModal from '../modals/edit-info';
 import DeleteConfirmModal from '../modals/delete-confirm';
+import AddEntryInfoModal from '../modals/add-entry-info';
 
 const STATUS_LABELS: Record< RollingContentStatus, string > = {
 	active: __( 'Active', 'newspack-plugin' ),
@@ -133,6 +134,12 @@ export default function All() {
 				RenderModal: ( { items, closeModal } ) => (
 					<EditInfoModal itemType="rolling-content" title={ items[ 0 ].title } onClose={ closeModal } />
 				),
+			},
+			{
+				id: 'add-entry',
+				label: __( 'Add New Entry', 'newspack-plugin' ),
+				supportsBulk: false,
+				RenderModal: ( { items, closeModal } ) => <AddEntryInfoModal parentTitle={ items[ 0 ].title } onClose={ closeModal } />,
 			},
 			{
 				id: 'delete',

--- a/src/wizards/rollingContent/views/all.tsx
+++ b/src/wizards/rollingContent/views/all.tsx
@@ -43,7 +43,7 @@ const DEFAULT_VIEW: View = {
 	perPage: 20,
 	sort: { field: 'date', direction: 'desc' },
 	search: '',
-	fields: [ 'date', 'entries_count', 'last_updated', 'status', 'inline_actions' ],
+	fields: [ 'date', 'entries_count', 'last_updated', 'status' ],
 	filters: [],
 	layout: {},
 	titleField: 'title',
@@ -101,7 +101,17 @@ function AllRollingContent() {
 				id: 'entries_count',
 				label: __( 'Entries', 'newspack-plugin' ),
 				getValue: ( { item } ) => item.entries.length,
-				render: ( { item } ) => item.entries.length,
+				render: ( { item } ) => (
+					<div style={ { display: 'flex', alignItems: 'center', gap: 8 } }>
+						<span>{ item.entries.length }</span>
+						<Button variant="secondary" size="small" onClick={ () => setManagingEntriesFor( item ) }>
+							{ __( 'Manage', 'newspack-plugin' ) }
+						</Button>
+						<Button variant="secondary" size="small" onClick={ () => setAddingEntryFor( item ) }>
+							{ __( 'Add', 'newspack-plugin' ) }
+						</Button>
+					</div>
+				),
 			},
 			{
 				id: 'last_updated',
@@ -133,22 +143,6 @@ function AllRollingContent() {
 					value,
 					label: STATUS_LABELS[ value ],
 				} ) ),
-			},
-			{
-				id: 'inline_actions',
-				label: '',
-				enableSorting: false,
-				enableHiding: false,
-				render: ( { item } ) => (
-					<div style={ { display: 'flex', gap: 4 } }>
-						<Button variant="secondary" size="small" onClick={ () => setManagingEntriesFor( item ) }>
-							{ __( 'Manage', 'newspack-plugin' ) }
-						</Button>
-						<Button variant="secondary" size="small" onClick={ () => setAddingEntryFor( item ) }>
-							{ __( 'Add', 'newspack-plugin' ) }
-						</Button>
-					</div>
-				),
 			},
 		],
 		[]

--- a/src/wizards/rollingContent/views/all.tsx
+++ b/src/wizards/rollingContent/views/all.tsx
@@ -217,7 +217,7 @@ export default function All() {
 	return (
 		<Wizard
 			headerText={ __( 'Newspack / Rolling Content', 'newspack-plugin' ) }
-			sections={ [ { path: '/', render: () => <AllRollingContent /> } ] }
+			sections={ [ { path: '/', render: () => <AllRollingContent />, fullWidth: true } ] }
 		/>
 	);
 }

--- a/src/wizards/rollingContent/views/all.tsx
+++ b/src/wizards/rollingContent/views/all.tsx
@@ -6,8 +6,8 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useState, useEffect, useMemo } from '@wordpress/element';
-import { useDispatch } from '@wordpress/data';
+import { useState, useMemo } from '@wordpress/element';
+import { Button } from '@wordpress/components';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import type { Action, Field, View } from '@wordpress/dataviews';
 
@@ -15,7 +15,6 @@ import type { Action, Field, View } from '@wordpress/dataviews';
  * Internal dependencies
  */
 import { DataViews } from '../../../../packages/components/src';
-import { WIZARD_STORE_NAMESPACE } from '../../../../packages/components/src/wizard/store';
 import { ROLLING_CONTENTS } from '../data';
 import StatusPill from '../components/status-pill';
 import EditInfoModal from '../modals/edit-info';
@@ -49,22 +48,8 @@ const DEFAULT_VIEW: View = {
 };
 
 export default function All() {
-	const { setHeaderData } = useDispatch( WIZARD_STORE_NAMESPACE );
 	const [ data, setData ] = useState< RollingContent[] >( ROLLING_CONTENTS );
 	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
-
-	useEffect( () => {
-		setHeaderData( {
-			sectionName: __( 'Rolling Content', 'newspack-plugin' ),
-			actions: [
-				{
-					type: 'primary',
-					label: __( 'Add Rolling Content', 'newspack-plugin' ),
-					href: 'admin.php?page=newspack-rolling-content-add',
-				},
-			],
-		} );
-	}, [ setHeaderData ] );
 
 	const fields: Field< RollingContent >[] = useMemo(
 		() => [
@@ -114,7 +99,7 @@ export default function All() {
 				label: __( 'Edit', 'newspack-plugin' ),
 				isPrimary: true,
 				supportsBulk: false,
-				RenderModal: ( { items, closeModal } ) => (
+				RenderModal: ( { items, closeModal }: { items: RollingContent[]; closeModal: () => void } ) => (
 					<EditInfoModal itemType="rolling-content" title={ items[ 0 ].title } onClose={ closeModal } />
 				),
 			},
@@ -123,7 +108,7 @@ export default function All() {
 				label: __( 'Manage Entries', 'newspack-plugin' ),
 				supportsBulk: false,
 				modalSize: 'fill',
-				RenderModal: ( { items, closeModal } ) => {
+				RenderModal: ( { items, closeModal }: { items: RollingContent[]; closeModal: () => void } ) => {
 					const parent = items[ 0 ];
 					return (
 						<ManageEntriesModal
@@ -141,14 +126,16 @@ export default function All() {
 				id: 'add-entry',
 				label: __( 'Add New Entry', 'newspack-plugin' ),
 				supportsBulk: false,
-				RenderModal: ( { items, closeModal } ) => <AddEntryInfoModal parentTitle={ items[ 0 ].title } onClose={ closeModal } />,
+				RenderModal: ( { items, closeModal }: { items: RollingContent[]; closeModal: () => void } ) => (
+					<AddEntryInfoModal parentTitle={ items[ 0 ].title } onClose={ closeModal } />
+				),
 			},
 			{
 				id: 'delete',
 				label: __( 'Delete', 'newspack-plugin' ),
 				isDestructive: true,
 				supportsBulk: false,
-				RenderModal: ( { items, closeModal } ) => (
+				RenderModal: ( { items, closeModal }: { items: RollingContent[]; closeModal: () => void } ) => (
 					<DeleteConfirmModal
 						itemType="rolling-content"
 						title={ items[ 0 ].title }
@@ -164,16 +151,31 @@ export default function All() {
 	const { data: processedData, paginationInfo } = useMemo( () => filterSortAndPaginate( data, view, fields ), [ data, view, fields ] );
 
 	return (
-		<DataViews
-			data={ processedData }
-			fields={ fields }
-			view={ view }
-			onChangeView={ setView }
-			actions={ actions }
-			paginationInfo={ paginationInfo }
-			defaultLayouts={ { table: {} } }
-			getItemId={ ( item: RollingContent ) => String( item.id ) }
-			search
-		/>
+		<>
+			<div
+				style={ {
+					display: 'flex',
+					alignItems: 'center',
+					justifyContent: 'space-between',
+					marginBottom: 16,
+				} }
+			>
+				<h2 style={ { margin: 0 } }>{ __( 'Rolling Content', 'newspack-plugin' ) }</h2>
+				<Button variant="primary" href="admin.php?page=newspack-rolling-content-add">
+					{ __( 'Add Rolling Content', 'newspack-plugin' ) }
+				</Button>
+			</div>
+			<DataViews
+				data={ processedData }
+				fields={ fields }
+				view={ view }
+				onChangeView={ setView }
+				actions={ actions }
+				paginationInfo={ paginationInfo }
+				defaultLayouts={ { table: {} } }
+				getItemId={ ( item: RollingContent ) => String( item.id ) }
+				search
+			/>
+		</>
 	);
 }

--- a/src/wizards/rollingContent/views/all.tsx
+++ b/src/wizards/rollingContent/views/all.tsx
@@ -20,6 +20,7 @@ import { ROLLING_CONTENTS } from '../data';
 import EditInfoModal from '../modals/edit-info';
 import DeleteConfirmModal from '../modals/delete-confirm';
 import AddEntryInfoModal from '../modals/add-entry-info';
+import ManageEntriesModal from '../modals/manage-entries';
 
 const STATUS_LABELS: Record< RollingContentStatus, string > = {
 	active: __( 'Active', 'newspack-plugin' ),
@@ -134,6 +135,24 @@ export default function All() {
 				RenderModal: ( { items, closeModal } ) => (
 					<EditInfoModal itemType="rolling-content" title={ items[ 0 ].title } onClose={ closeModal } />
 				),
+			},
+			{
+				id: 'manage-entries',
+				label: __( 'Manage Entries', 'newspack-plugin' ),
+				supportsBulk: false,
+				RenderModal: ( { items, closeModal } ) => {
+					const parent = items[ 0 ];
+					return (
+						<ManageEntriesModal
+							parent={ parent }
+							entries={ parent.entries }
+							onEntriesChange={ nextEntries =>
+								setData( prev => prev.map( r => ( r.id === parent.id ? { ...r, entries: nextEntries } : r ) ) )
+							}
+							onClose={ closeModal }
+						/>
+					);
+				},
 			},
 			{
 				id: 'add-entry',

--- a/src/wizards/rollingContent/views/all.tsx
+++ b/src/wizards/rollingContent/views/all.tsx
@@ -17,6 +17,8 @@ import type { Action, Field, View } from '@wordpress/dataviews';
 import { DataViews } from '../../../../packages/components/src';
 import { WIZARD_STORE_NAMESPACE } from '../../../../packages/components/src/wizard/store';
 import { ROLLING_CONTENTS } from '../data';
+import EditInfoModal from '../modals/edit-info';
+import DeleteConfirmModal from '../modals/delete-confirm';
 
 const STATUS_LABELS: Record< RollingContentStatus, string > = {
 	active: __( 'Active', 'newspack-plugin' ),
@@ -64,7 +66,6 @@ const DEFAULT_VIEW: View = {
 
 export default function All() {
 	const { setHeaderData } = useDispatch( WIZARD_STORE_NAMESPACE );
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	const [ data, setData ] = useState< RollingContent[] >( ROLLING_CONTENTS );
 	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
 
@@ -122,7 +123,32 @@ export default function All() {
 		[]
 	);
 
-	const actions: Action< RollingContent >[] = useMemo( () => [], [] );
+	const actions: Action< RollingContent >[] = useMemo(
+		() => [
+			{
+				id: 'edit',
+				label: __( 'Edit', 'newspack-plugin' ),
+				isPrimary: true,
+				RenderModal: ( { items, closeModal } ) => (
+					<EditInfoModal itemType="rolling-content" title={ items[ 0 ].title } onClose={ closeModal } />
+				),
+			},
+			{
+				id: 'delete',
+				label: __( 'Delete', 'newspack-plugin' ),
+				isDestructive: true,
+				RenderModal: ( { items, closeModal } ) => (
+					<DeleteConfirmModal
+						itemType="rolling-content"
+						title={ items[ 0 ].title }
+						onConfirm={ () => setData( prev => prev.filter( r => r.id !== items[ 0 ].id ) ) }
+						onClose={ closeModal }
+					/>
+				),
+			},
+		],
+		[]
+	);
 
 	const { data: processedData, paginationInfo } = useMemo( () => filterSortAndPaginate( data, view, fields ), [ data, view, fields ] );
 

--- a/src/wizards/rollingContent/views/all.tsx
+++ b/src/wizards/rollingContent/views/all.tsx
@@ -210,7 +210,7 @@ function AllRollingContent() {
 export default function All() {
 	return (
 		<Wizard
-			headerText={ __( 'Newspack / Rolling Content', 'newspack-plugin' ) }
+			headerText={ __( 'Newspack', 'newspack-plugin' ) }
 			sections={ [ { path: '/', render: () => <AllRollingContent />, fullWidth: true } ] }
 		/>
 	);

--- a/src/wizards/rollingContent/views/all.tsx
+++ b/src/wizards/rollingContent/views/all.tsx
@@ -1,17 +1,142 @@
 /**
- * Rolling Content — All view (placeholder; replaced in Task 4).
+ * Rolling Content — All view (DataViews).
  */
 
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { useState, useEffect, useMemo } from '@wordpress/element';
+import { useDispatch } from '@wordpress/data';
+import { filterSortAndPaginate } from '@wordpress/dataviews';
+import type { Action, Field, View } from '@wordpress/dataviews';
+
+/**
+ * Internal dependencies
+ */
+import { DataViews } from '../../../../packages/components/src';
+import { WIZARD_STORE_NAMESPACE } from '../../../../packages/components/src/wizard/store';
+import { ROLLING_CONTENTS } from '../data';
+
+const STATUS_LABELS: Record< RollingContentStatus, string > = {
+	active: __( 'Active', 'newspack-plugin' ),
+	archived: __( 'Archived', 'newspack-plugin' ),
+	scheduled: __( 'Scheduled', 'newspack-plugin' ),
+};
+
+const STATUS_COLORS: Record< RollingContentStatus, { bg: string; fg: string } > = {
+	active: { bg: '#d1fae5', fg: '#065f46' },
+	archived: { bg: '#e5e7eb', fg: '#374151' },
+	scheduled: { bg: '#dbeafe', fg: '#1e40af' },
+};
+
+function StatusPill( { status }: { status: RollingContentStatus } ) {
+	const c = STATUS_COLORS[ status ];
+	return (
+		<span
+			style={ {
+				background: c.bg,
+				color: c.fg,
+				padding: '2px 10px',
+				borderRadius: 999,
+				fontSize: 12,
+				fontWeight: 500,
+				textTransform: 'capitalize',
+			} }
+		>
+			{ STATUS_LABELS[ status ] }
+		</span>
+	);
+}
+
+const DEFAULT_VIEW: View = {
+	type: 'table',
+	page: 1,
+	perPage: 20,
+	sort: { field: 'date', direction: 'desc' },
+	search: '',
+	fields: [ 'date', 'status' ],
+	filters: [],
+	layout: {},
+	titleField: 'title',
+	mediaField: 'featured_image',
+};
 
 export default function All() {
+	const { setHeaderData } = useDispatch( WIZARD_STORE_NAMESPACE );
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	const [ data, setData ] = useState< RollingContent[] >( ROLLING_CONTENTS );
+	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
+
+	useEffect( () => {
+		setHeaderData( {
+			sectionName: __( 'Rolling Content', 'newspack-plugin' ),
+			actions: [
+				{
+					type: 'primary',
+					label: __( 'Add Rolling Content', 'newspack-plugin' ),
+					href: 'admin.php?page=newspack-rolling-content-add',
+				},
+			],
+		} );
+	}, [ setHeaderData ] );
+
+	const fields: Field< RollingContent >[] = useMemo(
+		() => [
+			{
+				id: 'featured_image',
+				label: __( 'Featured image', 'newspack-plugin' ),
+				type: 'media',
+				render: ( { item } ) => <img src={ item.featuredImage } alt={ item.title } style={ { maxWidth: 80 } } />,
+				enableSorting: false,
+			},
+			{
+				id: 'title',
+				label: __( 'Title', 'newspack-plugin' ),
+				enableGlobalSearch: true,
+				getValue: ( { item } ) => item.title,
+				render: ( { item } ) => <strong>{ item.title }</strong>,
+			},
+			{
+				id: 'date',
+				label: __( 'Date', 'newspack-plugin' ),
+				getValue: ( { item } ) => item.date,
+				render: ( { item } ) =>
+					new Date( item.date ).toLocaleDateString( undefined, {
+						year: 'numeric',
+						month: 'short',
+						day: 'numeric',
+					} ),
+			},
+			{
+				id: 'status',
+				label: __( 'Status', 'newspack-plugin' ),
+				getValue: ( { item } ) => item.status,
+				render: ( { item } ) => <StatusPill status={ item.status } />,
+				elements: ( Object.keys( STATUS_LABELS ) as RollingContentStatus[] ).map( value => ( {
+					value,
+					label: STATUS_LABELS[ value ],
+				} ) ),
+			},
+		],
+		[]
+	);
+
+	const actions: Action< RollingContent >[] = useMemo( () => [], [] );
+
+	const { data: processedData, paginationInfo } = useMemo( () => filterSortAndPaginate( data, view, fields ), [ data, view, fields ] );
+
 	return (
-		<div>
-			<h1>{ __( 'All Rolling Content', 'newspack-plugin' ) }</h1>
-			<p>{ __( 'Placeholder — DataViews comes in Task 4.', 'newspack-plugin' ) }</p>
-		</div>
+		<DataViews
+			data={ processedData }
+			fields={ fields }
+			view={ view }
+			onChangeView={ setView }
+			actions={ actions }
+			paginationInfo={ paginationInfo }
+			defaultLayouts={ { table: {} } }
+			getItemId={ ( item: RollingContent ) => String( item.id ) }
+			search
+		/>
 	);
 }

--- a/src/wizards/rollingContent/views/all.tsx
+++ b/src/wizards/rollingContent/views/all.tsx
@@ -1,0 +1,17 @@
+/**
+ * Rolling Content — All view (placeholder; replaced in Task 4).
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+export default function All() {
+	return (
+		<div>
+			<h1>{ __( 'All Rolling Content', 'newspack-plugin' ) }</h1>
+			<p>{ __( 'Placeholder — DataViews comes in Task 4.', 'newspack-plugin' ) }</p>
+		</div>
+	);
+}

--- a/src/wizards/rollingContent/views/all.tsx
+++ b/src/wizards/rollingContent/views/all.tsx
@@ -129,6 +129,7 @@ export default function All() {
 				id: 'edit',
 				label: __( 'Edit', 'newspack-plugin' ),
 				isPrimary: true,
+				supportsBulk: false,
 				RenderModal: ( { items, closeModal } ) => (
 					<EditInfoModal itemType="rolling-content" title={ items[ 0 ].title } onClose={ closeModal } />
 				),
@@ -137,6 +138,7 @@ export default function All() {
 				id: 'delete',
 				label: __( 'Delete', 'newspack-plugin' ),
 				isDestructive: true,
+				supportsBulk: false,
 				RenderModal: ( { items, closeModal } ) => (
 					<DeleteConfirmModal
 						itemType="rolling-content"

--- a/src/wizards/rollingContent/views/all.tsx
+++ b/src/wizards/rollingContent/views/all.tsx
@@ -6,8 +6,9 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useState, useMemo } from '@wordpress/element';
+import { useState, useMemo, useEffect } from '@wordpress/element';
 import { Button } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import type { Action, Field, View } from '@wordpress/dataviews';
 import { published, scheduled, archive } from '@wordpress/icons';
@@ -15,7 +16,8 @@ import { published, scheduled, archive } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import { DataViews } from '../../../../packages/components/src';
+import { DataViews, Wizard } from '../../../../packages/components/src';
+import { WIZARD_STORE_NAMESPACE } from '../../../../packages/components/src/wizard/store';
 import { ROLLING_CONTENTS } from '../data';
 import StatusPill from '../components/status-pill';
 import EditInfoModal from '../modals/edit-info';
@@ -41,16 +43,32 @@ const DEFAULT_VIEW: View = {
 	perPage: 20,
 	sort: { field: 'date', direction: 'desc' },
 	search: '',
-	fields: [ 'date', 'status' ],
+	fields: [ 'date', 'entries_count', 'last_updated', 'status', 'inline_actions' ],
 	filters: [],
 	layout: {},
 	titleField: 'title',
 	mediaField: 'featured_image',
 };
 
-export default function All() {
+function AllRollingContent() {
+	const { setHeaderData } = useDispatch( WIZARD_STORE_NAMESPACE );
 	const [ data, setData ] = useState< RollingContent[] >( ROLLING_CONTENTS );
 	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
+	const [ managingEntriesFor, setManagingEntriesFor ] = useState< RollingContent | null >( null );
+	const [ addingEntryFor, setAddingEntryFor ] = useState< RollingContent | null >( null );
+
+	useEffect( () => {
+		setHeaderData( {
+			sectionName: __( 'Rolling Content', 'newspack-plugin' ),
+			actions: [
+				{
+					type: 'primary',
+					label: __( 'Add Rolling Content', 'newspack-plugin' ),
+					href: 'admin.php?page=newspack-rolling-content-add',
+				},
+			],
+		} );
+	}, [ setHeaderData ] );
 
 	const fields: Field< RollingContent >[] = useMemo(
 		() => [
@@ -80,6 +98,33 @@ export default function All() {
 					} ),
 			},
 			{
+				id: 'entries_count',
+				label: __( 'Entries', 'newspack-plugin' ),
+				getValue: ( { item } ) => item.entries.length,
+				render: ( { item } ) => item.entries.length,
+			},
+			{
+				id: 'last_updated',
+				label: __( 'Last updated', 'newspack-plugin' ),
+				getValue: ( { item } ) => {
+					if ( item.entries.length === 0 ) {
+						return '';
+					}
+					return Math.max( ...item.entries.map( e => new Date( e.date ).getTime() ) );
+				},
+				render: ( { item } ) => {
+					if ( item.entries.length === 0 ) {
+						return '—';
+					}
+					const ms = Math.max( ...item.entries.map( e => new Date( e.date ).getTime() ) );
+					return new Date( ms ).toLocaleDateString( undefined, {
+						year: 'numeric',
+						month: 'short',
+						day: 'numeric',
+					} );
+				},
+			},
+			{
 				id: 'status',
 				label: __( 'Status', 'newspack-plugin' ),
 				getValue: ( { item } ) => item.status,
@@ -88,6 +133,22 @@ export default function All() {
 					value,
 					label: STATUS_LABELS[ value ],
 				} ) ),
+			},
+			{
+				id: 'inline_actions',
+				label: '',
+				enableSorting: false,
+				enableHiding: false,
+				render: ( { item } ) => (
+					<div style={ { display: 'flex', gap: 4 } }>
+						<Button variant="secondary" size="small" onClick={ () => setManagingEntriesFor( item ) }>
+							{ __( 'Manage', 'newspack-plugin' ) }
+						</Button>
+						<Button variant="secondary" size="small" onClick={ () => setAddingEntryFor( item ) }>
+							{ __( 'Add', 'newspack-plugin' ) }
+						</Button>
+					</div>
+				),
 			},
 		],
 		[]
@@ -102,33 +163,6 @@ export default function All() {
 				supportsBulk: false,
 				RenderModal: ( { items, closeModal }: { items: RollingContent[]; closeModal: () => void } ) => (
 					<EditInfoModal itemType="rolling-content" title={ items[ 0 ].title } onClose={ closeModal } />
-				),
-			},
-			{
-				id: 'manage-entries',
-				label: __( 'Manage Entries', 'newspack-plugin' ),
-				supportsBulk: false,
-				modalSize: 'fill',
-				RenderModal: ( { items, closeModal }: { items: RollingContent[]; closeModal: () => void } ) => {
-					const parent = items[ 0 ];
-					return (
-						<ManageEntriesModal
-							parent={ parent }
-							entries={ parent.entries }
-							onEntriesChange={ nextEntries =>
-								setData( prev => prev.map( r => ( r.id === parent.id ? { ...r, entries: nextEntries } : r ) ) )
-							}
-							onClose={ closeModal }
-						/>
-					);
-				},
-			},
-			{
-				id: 'add-entry',
-				label: __( 'Add New Entry', 'newspack-plugin' ),
-				supportsBulk: false,
-				RenderModal: ( { items, closeModal }: { items: RollingContent[]; closeModal: () => void } ) => (
-					<AddEntryInfoModal parentTitle={ items[ 0 ].title } onClose={ closeModal } />
 				),
 			},
 			{
@@ -153,19 +187,6 @@ export default function All() {
 
 	return (
 		<>
-			<div
-				style={ {
-					display: 'flex',
-					alignItems: 'center',
-					justifyContent: 'space-between',
-					marginBottom: 16,
-				} }
-			>
-				<h2 style={ { margin: 0 } }>{ __( 'Rolling Content', 'newspack-plugin' ) }</h2>
-				<Button variant="primary" href="admin.php?page=newspack-rolling-content-add">
-					{ __( 'Add Rolling Content', 'newspack-plugin' ) }
-				</Button>
-			</div>
 			<DataViews
 				data={ processedData }
 				fields={ fields }
@@ -177,6 +198,26 @@ export default function All() {
 				getItemId={ ( item: RollingContent ) => String( item.id ) }
 				search
 			/>
+			{ managingEntriesFor && (
+				<ManageEntriesModal
+					parent={ managingEntriesFor }
+					entries={ managingEntriesFor.entries }
+					onEntriesChange={ nextEntries =>
+						setData( prev => prev.map( r => ( r.id === managingEntriesFor.id ? { ...r, entries: nextEntries } : r ) ) )
+					}
+					onClose={ () => setManagingEntriesFor( null ) }
+				/>
+			) }
+			{ addingEntryFor && <AddEntryInfoModal parentTitle={ addingEntryFor.title } onClose={ () => setAddingEntryFor( null ) } /> }
 		</>
+	);
+}
+
+export default function All() {
+	return (
+		<Wizard
+			headerText={ __( 'Newspack / Rolling Content', 'newspack-plugin' ) }
+			sections={ [ { path: '/', render: () => <AllRollingContent /> } ] }
+		/>
 	);
 }

--- a/src/wizards/rollingContent/views/all.tsx
+++ b/src/wizards/rollingContent/views/all.tsx
@@ -122,7 +122,6 @@ export default function All() {
 				id: 'manage-entries',
 				label: __( 'Manage Entries', 'newspack-plugin' ),
 				supportsBulk: false,
-				hideModalHeader: true,
 				modalSize: 'fill',
 				RenderModal: ( { items, closeModal } ) => {
 					const parent = items[ 0 ];

--- a/src/wizards/rollingContent/views/all.tsx
+++ b/src/wizards/rollingContent/views/all.tsx
@@ -17,6 +17,7 @@ import type { Action, Field, View } from '@wordpress/dataviews';
 import { DataViews } from '../../../../packages/components/src';
 import { WIZARD_STORE_NAMESPACE } from '../../../../packages/components/src/wizard/store';
 import { ROLLING_CONTENTS } from '../data';
+import StatusPill from '../components/status-pill';
 import EditInfoModal from '../modals/edit-info';
 import DeleteConfirmModal from '../modals/delete-confirm';
 import AddEntryInfoModal from '../modals/add-entry-info';
@@ -33,25 +34,6 @@ const STATUS_COLORS: Record< RollingContentStatus, { bg: string; fg: string } > 
 	archived: { bg: '#e5e7eb', fg: '#374151' },
 	scheduled: { bg: '#dbeafe', fg: '#1e40af' },
 };
-
-function StatusPill( { status }: { status: RollingContentStatus } ) {
-	const c = STATUS_COLORS[ status ];
-	return (
-		<span
-			style={ {
-				background: c.bg,
-				color: c.fg,
-				padding: '2px 10px',
-				borderRadius: 999,
-				fontSize: 12,
-				fontWeight: 500,
-				textTransform: 'capitalize',
-			} }
-		>
-			{ STATUS_LABELS[ status ] }
-		</span>
-	);
-}
 
 const DEFAULT_VIEW: View = {
 	type: 'table',
@@ -115,7 +97,7 @@ export default function All() {
 				id: 'status',
 				label: __( 'Status', 'newspack-plugin' ),
 				getValue: ( { item } ) => item.status,
-				render: ( { item } ) => <StatusPill status={ item.status } />,
+				render: ( { item } ) => <StatusPill status={ item.status } labels={ STATUS_LABELS } colors={ STATUS_COLORS } />,
 				elements: ( Object.keys( STATUS_LABELS ) as RollingContentStatus[] ).map( value => ( {
 					value,
 					label: STATUS_LABELS[ value ],
@@ -140,6 +122,8 @@ export default function All() {
 				id: 'manage-entries',
 				label: __( 'Manage Entries', 'newspack-plugin' ),
 				supportsBulk: false,
+				hideModalHeader: true,
+				modalSize: 'fill',
 				RenderModal: ( { items, closeModal } ) => {
 					const parent = items[ 0 ];
 					return (

--- a/src/wizards/rollingContent/views/all.tsx
+++ b/src/wizards/rollingContent/views/all.tsx
@@ -54,8 +54,11 @@ function AllRollingContent() {
 	const { setHeaderData } = useDispatch( WIZARD_STORE_NAMESPACE );
 	const [ data, setData ] = useState< RollingContent[] >( ROLLING_CONTENTS );
 	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
-	const [ managingEntriesFor, setManagingEntriesFor ] = useState< RollingContent | null >( null );
-	const [ addingEntryFor, setAddingEntryFor ] = useState< RollingContent | null >( null );
+	const [ managingEntriesForId, setManagingEntriesForId ] = useState< number | null >( null );
+	const [ addingEntryForId, setAddingEntryForId ] = useState< number | null >( null );
+
+	const managingEntriesFor = managingEntriesForId === null ? null : data.find( r => r.id === managingEntriesForId ) ?? null;
+	const addingEntryFor = addingEntryForId === null ? null : data.find( r => r.id === addingEntryForId ) ?? null;
 
 	useEffect( () => {
 		setHeaderData( {
@@ -104,10 +107,10 @@ function AllRollingContent() {
 				render: ( { item } ) => (
 					<div style={ { display: 'flex', alignItems: 'center', gap: 8 } }>
 						<span>{ item.entries.length }</span>
-						<Button variant="secondary" size="small" onClick={ () => setManagingEntriesFor( item ) }>
+						<Button variant="secondary" size="small" onClick={ () => setManagingEntriesForId( item.id ) }>
 							{ __( 'Manage', 'newspack-plugin' ) }
 						</Button>
-						<Button variant="secondary" size="small" onClick={ () => setAddingEntryFor( item ) }>
+						<Button variant="secondary" size="small" onClick={ () => setAddingEntryForId( item.id ) }>
 							{ __( 'Add', 'newspack-plugin' ) }
 						</Button>
 					</div>
@@ -118,7 +121,7 @@ function AllRollingContent() {
 				label: __( 'Last updated', 'newspack-plugin' ),
 				getValue: ( { item } ) => {
 					if ( item.entries.length === 0 ) {
-						return '';
+						return 0;
 					}
 					return Math.max( ...item.entries.map( e => new Date( e.date ).getTime() ) );
 				},
@@ -199,10 +202,10 @@ function AllRollingContent() {
 					onEntriesChange={ nextEntries =>
 						setData( prev => prev.map( r => ( r.id === managingEntriesFor.id ? { ...r, entries: nextEntries } : r ) ) )
 					}
-					onClose={ () => setManagingEntriesFor( null ) }
+					onClose={ () => setManagingEntriesForId( null ) }
 				/>
 			) }
-			{ addingEntryFor && <AddEntryInfoModal parentTitle={ addingEntryFor.title } onClose={ () => setAddingEntryFor( null ) } /> }
+			{ addingEntryFor && <AddEntryInfoModal parentTitle={ addingEntryFor.title } onClose={ () => setAddingEntryForId( null ) } /> }
 		</>
 	);
 }

--- a/src/wizards/rollingContent/views/all.tsx
+++ b/src/wizards/rollingContent/views/all.tsx
@@ -10,6 +10,7 @@ import { useState, useMemo } from '@wordpress/element';
 import { Button } from '@wordpress/components';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import type { Action, Field, View } from '@wordpress/dataviews';
+import { published, scheduled, archive } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -28,10 +29,10 @@ const STATUS_LABELS: Record< RollingContentStatus, string > = {
 	scheduled: __( 'Scheduled', 'newspack-plugin' ),
 };
 
-const STATUS_COLORS: Record< RollingContentStatus, { bg: string; fg: string } > = {
-	active: { bg: '#d1fae5', fg: '#065f46' },
-	archived: { bg: '#e5e7eb', fg: '#374151' },
-	scheduled: { bg: '#dbeafe', fg: '#1e40af' },
+const STATUS_ICONS: Record< RollingContentStatus, JSX.Element > = {
+	active: published,
+	archived: archive,
+	scheduled,
 };
 
 const DEFAULT_VIEW: View = {
@@ -82,7 +83,7 @@ export default function All() {
 				id: 'status',
 				label: __( 'Status', 'newspack-plugin' ),
 				getValue: ( { item } ) => item.status,
-				render: ( { item } ) => <StatusPill status={ item.status } labels={ STATUS_LABELS } colors={ STATUS_COLORS } />,
+				render: ( { item } ) => <StatusPill status={ item.status } labels={ STATUS_LABELS } icons={ STATUS_ICONS } />,
 				elements: ( Object.keys( STATUS_LABELS ) as RollingContentStatus[] ).map( value => ( {
 					value,
 					label: STATUS_LABELS[ value ],


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds a hidden, URL-gated "Rolling Content" admin area to explore DataViews patterns with fake in-memory data. It is not intended for production use — the goal is to give us a sandbox for evaluating how a parent/child content model could be presented inside Newspack's admin chrome.

The wizard is invisible by default. Visiting `wp-admin/admin.php?page=newspack-rolling-content` registers a top-level sidebar menu with "All Rolling Content" and "Add Rolling Content" sub-items, anchored near the top of the sidebar. Direct URL access remains the only entry point — no setting, link, or feature flag exposes it.

**All Rolling Content view** uses `@wordpress/dataviews` to render 30 fake rolling content items with featured image, title, date, entries count, last updated, and status (Active / Archived / Scheduled, shown as `@wordpress/icons` + plain text). Each row has inline "Manage" and "Add" buttons in the entries cell, plus kebab actions for Edit and Delete.

<img width="3024" height="1540" alt="rolling-content-all" src="https://github.com/user-attachments/assets/55cd890c-a0ea-4f57-839a-349d3772cc30" />

**Manage Entries** opens a full-screen modal with a nested DataViews of child entries (title, date, author, featured image, status, tags). **Add New Entry** opens an info modal explaining the implicit parent association.

<img width="3024" height="1540" alt="rolling-content-entries" src="https://github.com/user-attachments/assets/d5ef775e-2e21-4556-8234-2bfdc9961ce1" />

**Add Rolling Content** is a placeholder view that explains no editor is wired up for the demo.

The fake dataset is generated deterministically with coprime multipliers so we get variety across rows (5–25 entries per parent, varied tag counts, varied title selection).

### How to test the changes in this Pull Request:

1. Check out this branch and run `n ci-build newspack-plugin` (or `n build newspack-plugin` if dependencies are already installed).
2. Verify the menu is hidden by default: load any other wp-admin page and confirm there is no "Rolling Content" item in the sidebar.
3. Visit `/wp-admin/admin.php?page=newspack-rolling-content` directly. Confirm:
   - A top-level "Rolling Content" menu appears near the top of the sidebar (just after Dashboard).
   - Two sub-items are visible: "All Rolling Content" and "Add Rolling Content".
   - The top-level item is highlighted as Active, with "All Rolling Content" highlighted underneath.
   - The Newspack admin chrome (header with "Newspack" / "Rolling Content" section name, "Add Rolling Content" primary action) is present.
4. In the All view, confirm:
   - 30 rows render in a DataViews table at 20 per page.
   - Columns: Featured image, Title, Date, Entries (with count + Manage + Add buttons inline), Last updated, Status.
   - Status renders as an icon plus plain text (no colored pill).
   - DataViews spans the full content width (no max-width cap inside `newspack-wizard__content`).
   - Sorting and global search work.
5. Click the row kebab. Confirm only "Edit" and "Delete" appear (no bulk actions).
   - Edit opens an info modal.
   - Delete opens a confirm modal and removes the row on confirm.
6. Click "Manage" on a row. Confirm a full-screen modal opens with:
   - A nested DataViews of entries (title, date, author, featured image, status, tags).
   - A toolbar showing "Entries for: <parent title>" and an "Add New Entry" button.
   - The modal closes via the X button.
7. Click "Add" on a row. Confirm an info modal opens explaining the implicit parent association.
8. Visit `/wp-admin/admin.php?page=newspack-rolling-content-add` directly. Confirm:
   - The sub-item "Add Rolling Content" is highlighted.
   - The view renders a placeholder section with a "Back to All Rolling Content" secondary action in the header.
9. Reload the page on both URLs and confirm menu state persists.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

This is a hidden demo — not intended to ship as a user-facing feature. No automated tests are included; verification is by direct admin URL access only.