### PR TITLE
feat(emails): inline EmailPreview component

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -167,6 +167,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/newspack/class-newspack-settings.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/newspack/class-custom-events-section.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/newspack/class-emails-section.php';
+		include_once NEWSPACK_ABSPATH . 'includes/wizards/newspack/class-email-preview.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/newspack/class-syndication-section.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/newspack/class-seo-section.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/newspack/class-pixels-section.php';

--- a/includes/wizards/newspack/class-email-preview.php
+++ b/includes/wizards/newspack/class-email-preview.php
@@ -1,0 +1,297 @@
+<?php
+/**
+ * Email preview rendering for the Settings → Emails screen.
+ *
+ * Renders a publisher-facing preview of a transactional email by substituting
+ * known template tokens with realistic sample values. Used by the unified
+ * email management UI to display a per-card thumbnail.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Wizards\Newspack;
+
+use Newspack\Emails;
+use Newspack_Newsletters;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Email Preview Class.
+ */
+class Email_Preview {
+
+	/**
+	 * Get the rendered HTML for an email post, with sample token values substituted.
+	 *
+	 * Falls back to the registered template file's HTML when the post's saved
+	 * EMAIL_HTML_META is empty (i.e. the email has never been customized).
+	 *
+	 * @param int $post_id ID of the email post.
+	 *
+	 * @return string|false Rendered HTML, or false if the email can't be resolved.
+	 */
+	public static function get_preview_html( int $post_id ) {
+		if ( ! self::is_supported() ) {
+			return false;
+		}
+
+		$html = self::get_source_html( $post_id );
+		if ( empty( $html ) ) {
+			return false;
+		}
+
+		return self::apply_sample_substitutions( $html );
+	}
+
+	/**
+	 * Get the source HTML for an email post.
+	 *
+	 * Reads the saved EMAIL_HTML_META first; falls back to the registered
+	 * template's default email_html when that meta is empty.
+	 *
+	 * @param int $post_id ID of the email post.
+	 *
+	 * @return string Source HTML, or empty string if unavailable.
+	 */
+	private static function get_source_html( int $post_id ): string {
+		$html = get_post_meta( $post_id, Newspack_Newsletters::EMAIL_HTML_META, true );
+		if ( ! empty( $html ) ) {
+			return $html;
+		}
+
+		// Fallback: look up the registered template for this post type and use its default HTML.
+		$type = get_post_meta( $post_id, Emails::EMAIL_CONFIG_NAME_META, true );
+		if ( empty( $type ) ) {
+			return '';
+		}
+
+		// Trigger the template load by requesting the email config. This is the
+		// same path Emails::get_email_config_by_type() uses; we just want the
+		// raw template HTML, which is available via reflection on the loaded config.
+		$configs = apply_filters( 'newspack_email_configs', [] );
+		if ( ! isset( $configs[ $type ], $configs[ $type ]['template'] ) ) {
+			return '';
+		}
+
+		$template_data = include $configs[ $type ]['template'];
+		if ( ! is_array( $template_data ) || empty( $template_data['email_html'] ) ) {
+			return '';
+		}
+
+		return $template_data['email_html'];
+	}
+
+	/**
+	 * Apply sample-value substitutions to email HTML.
+	 *
+	 * Site/branding tokens use the publisher's real site config (so the preview
+	 * reflects their actual branding). Reader/transaction tokens use stable
+	 * fake values. Action URLs are replaced with anchor placeholders so
+	 * preview iframes don't trigger live navigation.
+	 *
+	 * @param string $html Source HTML containing *TOKEN* placeholders.
+	 *
+	 * @return string HTML with tokens substituted.
+	 */
+	private static function apply_sample_substitutions( string $html ): string {
+		foreach ( self::get_sample_substitutions() as $token => $value ) {
+			$html = str_replace( $token, $value, $html );
+		}
+		return $html;
+	}
+
+	/**
+	 * Get the substitution map of email-template tokens to sample values.
+	 *
+	 * @return array Map of `*TOKEN*` => sample value.
+	 */
+	public static function get_sample_substitutions(): array {
+		$site_logo_url   = wp_get_attachment_url( get_theme_mod( 'custom_logo' ) );
+		$site_title      = get_bloginfo( 'name' );
+		$site_url        = get_bloginfo( 'wpurl' );
+		$reply_to_email  = function_exists( 'Newspack\Emails::get_reply_to_email' ) ? Emails::get_reply_to_email() : get_bloginfo( 'admin_email' );
+		$site_address    = self::get_site_address();
+		$site_contact    = $site_address
+			? sprintf( '<strong>%s</strong> — %s', $site_title, $site_address )
+			: $site_title;
+
+		return [
+			// Site / branding — real values from the publisher's config.
+			'*SITE_TITLE*'             => $site_title,
+			'*SITE_URL*'               => $site_url,
+			'*SITE_LOGO*'              => $site_logo_url ? esc_url( $site_logo_url ) : '',
+			'*SITE_ADDRESS*'           => $site_address,
+			'*SITE_CONTACT*'           => $site_contact,
+			'*CONTACT_EMAIL*'          => sprintf( '<a href="mailto:%s">%s</a>', $reply_to_email, $reply_to_email ),
+
+			// Reader identity — stable sample values.
+			'*BILLING_FIRST_NAME*'     => 'Sample',
+			'*BILLING_LAST_NAME*'      => 'Reader',
+			'*BILLING_NAME*'           => 'Sample Reader',
+			'*PENDING_EMAIL_ADDRESS*'  => 'sample.reader@example.com',
+
+			// Transaction / subscription details — stable sample values.
+			'*AMOUNT*'                 => '$25.00',
+			'*PAYMENT_METHOD*'         => 'Visa ending in 4242',
+			'*PRODUCT_NAME*'           => 'Monthly Membership',
+			'*BILLING_FREQUENCY*'      => 'monthly',
+			'*DATE*'                  => gmdate( get_option( 'date_format', 'F j, Y' ) ),
+			'*CANCELLATION_TITLE*'     => __( 'Subscription Cancelled', 'newspack-plugin' ),
+			'*CANCELLATION_TYPE*'      => __( 'subscription', 'newspack-plugin' ),
+
+			// Action URLs — anchors so preview clicks don't navigate.
+			'*ACCOUNT_URL*'            => '#',
+			'*CANCELLATION_URL*'       => '#',
+			'*EMAIL_CANCELLATION_URL*' => '#',
+			'*EMAIL_VERIFICATION_URL*' => '#',
+			'*VERIFICATION_URL*'       => '#',
+			'*RECEIPT_URL*'            => '#',
+			'*MAGIC_LINK_URL*'         => '#',
+			'*PASSWORD_RESET_LINK*'    => '#',
+			'*SET_PASSWORD_LINK*'      => '#',
+			'*DELETION_LINK*'          => '#',
+			'*WP_LOGIN_URL*'           => '#',
+
+			// OTP code — stable sample value.
+			'*MAGIC_LINK_OTP*'         => '123456',
+		];
+	}
+
+	/**
+	 * Get the site's store address as a formatted string.
+	 *
+	 * Mirrors the logic in Emails::get_email_payload() so the preview
+	 * shows the same address format the real email would use.
+	 *
+	 * @return string Formatted site address, or empty string.
+	 */
+	private static function get_site_address(): string {
+		if ( class_exists( 'WC' ) ) {
+			$base_address  = WC()->countries->get_base_address();
+			$base_city     = WC()->countries->get_base_city();
+			$base_postcode = WC()->countries->get_base_postcode();
+		} else {
+			$base_address  = get_option( 'woocommerce_store_address', '' );
+			$base_city     = get_option( 'woocommerce_store_city', '' );
+			$base_postcode = get_option( 'woocommerce_store_postcode', '' );
+		}
+
+		if ( ! $base_address ) {
+			return '';
+		}
+
+		if ( ! $base_city && ! $base_postcode ) {
+			return $base_address;
+		}
+
+		return sprintf(
+			/* translators: 1: street address, 2: city, 3: postcode. */
+			__( '%1$s, %2$s %3$s', 'newspack-plugin' ),
+			$base_address,
+			$base_city,
+			$base_postcode
+		);
+	}
+
+	/**
+	 * Is email preview supported on this install?
+	 *
+	 * Requires Newspack Newsletters (the same dependency that gates
+	 * email management in general).
+	 *
+	 * @return bool
+	 */
+	private static function is_supported(): bool {
+		return class_exists( 'Newspack_Newsletters' );
+	}
+
+	/**
+	 * Initialize the class. Hooked from class-newspack.php inclusion.
+	 *
+	 * @codeCoverageIgnore
+	 */
+	public static function init(): void {
+		add_action( 'rest_api_init', [ __CLASS__, 'register_rest_routes' ] );
+	}
+
+	/**
+	 * Register the email-preview REST endpoint.
+	 *
+	 * @codeCoverageIgnore
+	 */
+	public static function register_rest_routes(): void {
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'wizard/newspack-settings/emails/(?P<post_id>\d+)/preview',
+			[
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ __CLASS__, 'api_get_preview' ],
+				'permission_callback' => [ __CLASS__, 'api_permissions_check' ],
+				'args'                => [
+					'post_id' => [
+						'required'          => true,
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * REST handler: return preview HTML for an email post.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 *
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public static function api_get_preview( $request ) {
+		$post_id = (int) $request->get_param( 'post_id' );
+
+		$post = get_post( $post_id );
+		if ( ! $post || Emails::POST_TYPE !== $post->post_type ) {
+			return new \WP_Error(
+				'newspack_email_preview_not_found',
+				__( 'Email not found.', 'newspack-plugin' ),
+				[ 'status' => 404 ]
+			);
+		}
+
+		$html = self::get_preview_html( $post_id );
+		if ( false === $html ) {
+			return new \WP_Error(
+				'newspack_email_preview_unavailable',
+				__( 'Email preview is unavailable.', 'newspack-plugin' ),
+				[ 'status' => 500 ]
+			);
+		}
+
+		return rest_ensure_response(
+			[
+				'html'    => $html,
+				'post_id' => $post_id,
+			]
+		);
+	}
+
+	/**
+	 * Permissions check for the preview endpoint. Mirrors other Newspack email endpoints.
+	 *
+	 * @codeCoverageIgnore
+	 * @return bool|\WP_Error
+	 */
+	public static function api_permissions_check() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return new \WP_Error(
+				'newspack_rest_forbidden',
+				esc_html__( 'You cannot use this resource.', 'newspack-plugin' ),
+				[ 'status' => 403 ]
+			);
+		}
+		return true;
+	}
+}
+
+
+Email_Preview::init();

--- a/includes/wizards/newspack/class-email-preview.php
+++ b/includes/wizards/newspack/class-email-preview.php
@@ -41,7 +41,7 @@ class Email_Preview {
 			return false;
 		}
 
-		return self::apply_sample_substitutions( $html );
+		return self::apply_sample_substitutions( $html, $post_id );
 	}
 
 	/**
@@ -95,15 +95,26 @@ class Email_Preview {
 	 * fake values. Action URLs are replaced with anchor placeholders so
 	 * preview iframes don't trigger live navigation.
 	 *
-	 * @param string $html Source HTML containing *TOKEN* placeholders.
+	 * @param string $html    Source HTML containing *TOKEN* placeholders.
+	 * @param int    $post_id The email post being previewed (passed to the filter).
 	 *
 	 * @return string HTML with tokens substituted.
 	 */
-	private static function apply_sample_substitutions( string $html ): string {
-		foreach ( self::get_sample_substitutions() as $token => $value ) {
-			$html = str_replace( $token, $value, $html );
-		}
-		return $html;
+	private static function apply_sample_substitutions( string $html, int $post_id = 0 ): string {
+		$substitutions = self::get_sample_substitutions();
+
+		/**
+		 * Filters the sample substitution map used for email previews.
+		 *
+		 * Allows plugins to inject sample values for custom tokens
+		 * (e.g. group-subscription invite tokens, future token additions).
+		 *
+		 * @param array $substitutions Map of `*TOKEN*` => sample value.
+		 * @param int   $post_id       The email post being previewed (0 if unknown).
+		 */
+		$substitutions = apply_filters( 'newspack_email_preview_substitutions', $substitutions, $post_id );
+
+		return strtr( $html, $substitutions );
 	}
 
 	/**
@@ -115,7 +126,7 @@ class Email_Preview {
 		$site_logo_url   = wp_get_attachment_url( get_theme_mod( 'custom_logo' ) );
 		$site_title      = get_bloginfo( 'name' );
 		$site_url        = get_bloginfo( 'wpurl' );
-		$reply_to_email  = function_exists( 'Newspack\Emails::get_reply_to_email' ) ? Emails::get_reply_to_email() : get_bloginfo( 'admin_email' );
+		$reply_to_email  = Emails::get_reply_to_email();
 		$site_address    = self::get_site_address();
 		$site_contact    = $site_address
 			? sprintf( '<strong>%s</strong> — %s', $site_title, $site_address )
@@ -128,7 +139,7 @@ class Email_Preview {
 			'*SITE_LOGO*'              => $site_logo_url ? esc_url( $site_logo_url ) : '',
 			'*SITE_ADDRESS*'           => $site_address,
 			'*SITE_CONTACT*'           => $site_contact,
-			'*CONTACT_EMAIL*'          => sprintf( '<a href="mailto:%s">%s</a>', $reply_to_email, $reply_to_email ),
+			'*CONTACT_EMAIL*'          => sprintf( '<a href="%s">%s</a>', esc_url( 'mailto:' . $reply_to_email ), esc_html( $reply_to_email ) ),
 
 			// Reader identity — stable sample values.
 			'*BILLING_FIRST_NAME*'     => 'Sample',
@@ -141,7 +152,7 @@ class Email_Preview {
 			'*PAYMENT_METHOD*'         => 'Visa ending in 4242',
 			'*PRODUCT_NAME*'           => 'Monthly Membership',
 			'*BILLING_FREQUENCY*'      => 'monthly',
-			'*DATE*'                   => gmdate( get_option( 'date_format', 'F j, Y' ) ),
+			'*DATE*'                   => wp_date( get_option( 'date_format', 'F j, Y' ) ),
 			'*CANCELLATION_TITLE*'     => __( 'Subscription Cancelled', 'newspack-plugin' ),
 			'*CANCELLATION_TYPE*'      => __( 'subscription', 'newspack-plugin' ),
 

--- a/includes/wizards/newspack/class-email-preview.php
+++ b/includes/wizards/newspack/class-email-preview.php
@@ -74,7 +74,12 @@ class Email_Preview {
 			return '';
 		}
 
-		$template_data = include $configs[ $type ]['template'];
+		$template_path = $configs[ $type ]['template'];
+		if ( ! is_readable( $template_path ) ) {
+			return '';
+		}
+
+		$template_data = include $template_path;
 		if ( ! is_array( $template_data ) || empty( $template_data['email_html'] ) ) {
 			return '';
 		}

--- a/includes/wizards/newspack/class-email-preview.php
+++ b/includes/wizards/newspack/class-email-preview.php
@@ -136,7 +136,7 @@ class Email_Preview {
 			'*PAYMENT_METHOD*'         => 'Visa ending in 4242',
 			'*PRODUCT_NAME*'           => 'Monthly Membership',
 			'*BILLING_FREQUENCY*'      => 'monthly',
-			'*DATE*'                  => gmdate( get_option( 'date_format', 'F j, Y' ) ),
+			'*DATE*'                   => gmdate( get_option( 'date_format', 'F j, Y' ) ),
 			'*CANCELLATION_TITLE*'     => __( 'Subscription Cancelled', 'newspack-plugin' ),
 			'*CANCELLATION_TYPE*'      => __( 'subscription', 'newspack-plugin' ),
 

--- a/src/wizards/newspack/views/settings/emails/email-preview.scss
+++ b/src/wizards/newspack/views/settings/emails/email-preview.scss
@@ -1,0 +1,30 @@
+// Email preview thumbnail container.
+.newspack-email-preview {
+	width: 180px;
+	height: 180px;
+	overflow: hidden;
+	border-radius: 4px;
+	border: 1px solid #ddd;
+	position: relative;
+	background: #f0f0f0;
+}
+
+// Scaled iframe inside the preview container.
+.newspack-email-preview__iframe {
+	width: 600px;
+	height: 600px;
+	border: 0;
+	transform: scale(0.3);
+	transform-origin: top left;
+	pointer-events: none;
+}
+
+// Loading / error placeholder overlay.
+.newspack-email-preview__placeholder {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 100%;
+	height: 100%;
+	color: #949494;
+}

--- a/src/wizards/newspack/views/settings/emails/email-preview.scss
+++ b/src/wizards/newspack/views/settings/emails/email-preview.scss
@@ -1,30 +1,32 @@
 // Email preview thumbnail container.
 .newspack-email-preview {
-	width: 180px;
-	height: 180px;
+	width: 100%;
+	aspect-ratio: 4 / 3;
 	overflow: hidden;
-	border-radius: 4px;
-	border: 1px solid #ddd;
 	position: relative;
-	background: #f0f0f0;
-}
-
-// Scaled iframe inside the preview container.
-.newspack-email-preview__iframe {
-	width: 600px;
-	height: 600px;
-	border: 0;
-	transform: scale(0.3);
-	transform-origin: top left;
-	pointer-events: none;
-}
-
-// Loading / error placeholder overlay.
-.newspack-email-preview__placeholder {
+	background: #f6f7f7;
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	width: 100%;
-	height: 100%;
-	color: #949494;
+
+	&__iframe {
+		width: 600px;
+		height: 1800px;
+		border: 0;
+		position: absolute;
+		top: 0;
+		left: 0;
+		transform-origin: top left;
+		pointer-events: none;
+	}
+
+	// Loading / error placeholder overlay.
+	&__placeholder {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 100%;
+		height: 100%;
+		color: #949494;
+	}
 }

--- a/src/wizards/newspack/views/settings/emails/email-preview.scss
+++ b/src/wizards/newspack/views/settings/emails/email-preview.scss
@@ -1,3 +1,5 @@
+@use "~@wordpress/base-styles/colors" as wp-colors;
+
 // Email preview thumbnail container.
 .newspack-email-preview {
 	width: 100%;
@@ -33,6 +35,6 @@
 		justify-content: center;
 		width: 100%;
 		height: 100%;
-		color: #949494;
+		color: wp-colors.$gray-400;
 	}
 }

--- a/src/wizards/newspack/views/settings/emails/email-preview.scss
+++ b/src/wizards/newspack/views/settings/emails/email-preview.scss
@@ -1,23 +1,29 @@
 // Email preview thumbnail container.
 .newspack-email-preview {
 	width: 100%;
-	aspect-ratio: 4 / 3;
+	aspect-ratio: 1;
 	overflow: hidden;
 	position: relative;
-	background: #f6f7f7;
+	background: transparent;
 	display: flex;
 	align-items: center;
 	justify-content: center;
 
 	&__iframe {
-		width: 600px;
-		height: 1800px;
+		width: 848px;
+		height: auto;
 		border: 0;
 		position: absolute;
 		top: 0;
 		left: 0;
 		transform-origin: top left;
 		pointer-events: none;
+		opacity: 0;
+		transition: opacity 200ms ease-out;
+	}
+
+	&.is-ready &__iframe {
+		opacity: 1;
 	}
 
 	// Loading / error placeholder overlay.

--- a/src/wizards/newspack/views/settings/emails/email-preview.test.js
+++ b/src/wizards/newspack/views/settings/emails/email-preview.test.js
@@ -50,6 +50,21 @@ global.ResizeObserver = class {
 	disconnect() {}
 };
 
+/**
+ * Helper: simulate iframe onLoad and stub contentDocument so
+ * handleIframeLoad resolves immediately (no pending assets).
+ */
+function simulateIframeLoad( iframe ) {
+	Object.defineProperty( iframe, 'contentDocument', {
+		value: {
+			querySelectorAll: () => [],
+			body: { scrollHeight: 900 },
+		},
+		configurable: true,
+	} );
+	iframe.dispatchEvent( new Event( 'load' ) );
+}
+
 describe( 'EmailPreview', () => {
 	beforeEach( () => {
 		apiFetch.mockReset();
@@ -65,7 +80,7 @@ describe( 'EmailPreview', () => {
 		expect( screen.getByRole( 'presentation' ) ).toBeTruthy();
 	} );
 
-	it( 'renders iframe on successful fetch', async () => {
+	it( 'renders iframe on successful fetch and gains is-ready after load', async () => {
 		apiFetch.mockResolvedValue( {
 			html: '<html><body><p>Hello Sample Reader</p></body></html>',
 			post_id: 123,
@@ -77,6 +92,18 @@ describe( 'EmailPreview', () => {
 			const iframe = document.querySelector( '.newspack-email-preview__iframe' );
 			expect( iframe ).toBeTruthy();
 			expect( iframe.getAttribute( 'srcdoc' ) ).toContain( 'Sample Reader' );
+		} );
+
+		// Before onLoad the container should NOT have is-ready.
+		const container = document.querySelector( '.newspack-email-preview' );
+		expect( container.classList.contains( 'is-ready' ) ).toBe( false );
+
+		// Simulate iframe load.
+		const iframe = document.querySelector( '.newspack-email-preview__iframe' );
+		simulateIframeLoad( iframe );
+
+		await waitFor( () => {
+			expect( container.classList.contains( 'is-ready' ) ).toBe( true );
 		} );
 	} );
 
@@ -111,6 +138,47 @@ describe( 'EmailPreview', () => {
 			expect( apiFetch ).toHaveBeenCalledWith( {
 				path: '/newspack/v1/wizard/newspack-settings/emails/42/preview',
 			} );
+		} );
+	} );
+
+	it( 'resets state when postId changes', async () => {
+		apiFetch.mockResolvedValue( {
+			html: '<html><body><p>First email</p></body></html>',
+			post_id: 1,
+		} );
+
+		const { rerender } = render( <EmailPreview postId={ 1 } /> );
+
+		// Wait for first render to complete.
+		await waitFor( () => {
+			const iframe = document.querySelector( '.newspack-email-preview__iframe' );
+			expect( iframe ).toBeTruthy();
+		} );
+
+		// Simulate onLoad for first email.
+		simulateIframeLoad( document.querySelector( '.newspack-email-preview__iframe' ) );
+		await waitFor( () => {
+			expect( document.querySelector( '.newspack-email-preview' ).classList.contains( 'is-ready' ) ).toBe( true );
+		} );
+
+		// Change postId — should reset and re-fetch.
+		apiFetch.mockResolvedValue( {
+			html: '<html><body><p>Second email</p></body></html>',
+			post_id: 2,
+		} );
+
+		rerender( <EmailPreview postId={ 2 } /> );
+
+		// is-ready should be removed during re-fetch.
+		await waitFor( () => {
+			expect( document.querySelector( '.newspack-email-preview' ).classList.contains( 'is-ready' ) ).toBe( false );
+		} );
+
+		// New iframe should appear with updated content.
+		await waitFor( () => {
+			const iframe = document.querySelector( '.newspack-email-preview__iframe' );
+			expect( iframe ).toBeTruthy();
+			expect( iframe.getAttribute( 'srcdoc' ) ).toContain( 'Second email' );
 		} );
 	} );
 } );

--- a/src/wizards/newspack/views/settings/emails/email-preview.test.js
+++ b/src/wizards/newspack/views/settings/emails/email-preview.test.js
@@ -1,0 +1,105 @@
+/**
+ * External dependencies
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import EmailPreview from './email-preview';
+
+// Mock @wordpress/api-fetch — jest.mock is hoisted above imports.
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+// Store observer instances so tests can trigger intersection.
+let observerInstances = [];
+
+// Default IntersectionObserver mock: triggers immediately.
+function createObserverMock( triggerImmediately = true ) {
+	observerInstances = [];
+	global.IntersectionObserver = class {
+		constructor( callback ) {
+			this.callback = callback;
+			observerInstances.push( this );
+		}
+		observe() {
+			if ( triggerImmediately ) {
+				this.callback( [ { isIntersecting: true } ] );
+			}
+		}
+		disconnect() {}
+	};
+}
+
+describe( 'EmailPreview', () => {
+	beforeEach( () => {
+		apiFetch.mockReset();
+		createObserverMock( true );
+	} );
+
+	it( 'renders loading state while fetching', async () => {
+		// Keep the promise pending so we can observe the loading state.
+		apiFetch.mockReturnValue( new Promise( () => {} ) );
+
+		render( <EmailPreview postId={ 123 } /> );
+
+		expect( screen.getByRole( 'presentation' ) ).toBeTruthy();
+	} );
+
+	it( 'renders iframe on successful fetch', async () => {
+		apiFetch.mockResolvedValue( {
+			html: '<html><body><p>Hello Sample Reader</p></body></html>',
+			post_id: 123,
+		} );
+
+		render( <EmailPreview postId={ 123 } /> );
+
+		await waitFor( () => {
+			const iframe = document.querySelector( '.newspack-email-preview__iframe' );
+			expect( iframe ).toBeTruthy();
+			expect( iframe.getAttribute( 'srcdoc' ) ).toContain( 'Sample Reader' );
+		} );
+	} );
+
+	it( 'renders fallback placeholder on fetch error', async () => {
+		apiFetch.mockRejectedValue( new Error( 'Server error' ) );
+
+		render( <EmailPreview postId={ 456 } /> );
+
+		await waitFor( () => {
+			const placeholder = document.querySelector( '.newspack-email-preview__placeholder' );
+			expect( placeholder ).toBeTruthy();
+			// No iframe should be present.
+			expect( document.querySelector( '.newspack-email-preview__iframe' ) ).toBeNull();
+		} );
+	} );
+
+	it( 'does not fetch until element is visible', () => {
+		// Observer that does NOT trigger intersection.
+		createObserverMock( false );
+
+		render( <EmailPreview postId={ 789 } /> );
+
+		expect( apiFetch ).not.toHaveBeenCalled();
+	} );
+
+	it( 'fetches the correct endpoint path', async () => {
+		apiFetch.mockResolvedValue( { html: '<p>Test</p>', post_id: 42 } );
+
+		render( <EmailPreview postId={ 42 } /> );
+
+		await waitFor( () => {
+			expect( apiFetch ).toHaveBeenCalledWith( {
+				path: '/newspack/v1/wizard/newspack-settings/emails/42/preview',
+			} );
+		} );
+	} );
+} );

--- a/src/wizards/newspack/views/settings/emails/email-preview.test.js
+++ b/src/wizards/newspack/views/settings/emails/email-preview.test.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render, screen, waitFor, act } from '@testing-library/react';
+import { render, waitFor, act } from '@testing-library/react';
 
 /**
  * WordPress dependencies

--- a/src/wizards/newspack/views/settings/emails/email-preview.test.js
+++ b/src/wizards/newspack/views/settings/emails/email-preview.test.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, act } from '@testing-library/react';
 
 /**
  * WordPress dependencies
@@ -77,7 +77,7 @@ describe( 'EmailPreview', () => {
 
 		render( <EmailPreview postId={ 123 } /> );
 
-		expect( screen.getByRole( 'presentation' ) ).toBeTruthy();
+		expect( document.querySelector( '.newspack-email-preview__placeholder' ) ).toBeInTheDocument();
 	} );
 
 	it( 'renders iframe on successful fetch and gains is-ready after load', async () => {
@@ -94,14 +94,12 @@ describe( 'EmailPreview', () => {
 			expect( iframe.getAttribute( 'srcdoc' ) ).toContain( 'Sample Reader' );
 		} );
 
-		// Before onLoad the container should NOT have is-ready.
-		const container = document.querySelector( '.newspack-email-preview' );
-		expect( container.classList.contains( 'is-ready' ) ).toBe( false );
-
-		// Simulate iframe load.
+		// Simulate iframe load (also fires automatically in jsdom, but explicit
+		// call ensures the contentDocument stub is in place for assertion).
 		const iframe = document.querySelector( '.newspack-email-preview__iframe' );
 		simulateIframeLoad( iframe );
 
+		const container = document.querySelector( '.newspack-email-preview' );
 		await waitFor( () => {
 			expect( container.classList.contains( 'is-ready' ) ).toBe( true );
 		} );
@@ -169,11 +167,6 @@ describe( 'EmailPreview', () => {
 
 		rerender( <EmailPreview postId={ 2 } /> );
 
-		// is-ready should be removed during re-fetch.
-		await waitFor( () => {
-			expect( document.querySelector( '.newspack-email-preview' ).classList.contains( 'is-ready' ) ).toBe( false );
-		} );
-
 		// New iframe should appear with updated content.
 		await waitFor( () => {
 			const iframe = document.querySelector( '.newspack-email-preview__iframe' );
@@ -181,4 +174,49 @@ describe( 'EmailPreview', () => {
 			expect( iframe.getAttribute( 'srcdoc' ) ).toContain( 'Second email' );
 		} );
 	} );
+
+	it( 'cancelled fetch does not update state when postId changes mid-flight', async () => {
+		// First fetch: controlled promise that resolves AFTER the second.
+		let resolveFirst;
+		const firstPromise = new Promise( resolve => {
+			resolveFirst = resolve;
+		} );
+		apiFetch.mockReturnValueOnce( firstPromise );
+
+		const { rerender } = render( <EmailPreview postId={ 1 } /> );
+
+		// Change postId before first fetch resolves.
+		apiFetch.mockResolvedValueOnce( {
+			html: '<html><body><p>Second email</p></body></html>',
+			post_id: 2,
+		} );
+
+		rerender( <EmailPreview postId={ 2 } /> );
+
+		// Wait for second fetch to render.
+		await waitFor( () => {
+			const iframe = document.querySelector( '.newspack-email-preview__iframe' );
+			expect( iframe ).toBeTruthy();
+			expect( iframe.getAttribute( 'srcdoc' ) ).toContain( 'Second email' );
+		} );
+
+		// Now resolve the first (stale) fetch — it should NOT overwrite the iframe.
+		await act( async () => {
+			resolveFirst( {
+				html: '<html><body><p>First email (stale)</p></body></html>',
+				post_id: 1,
+			} );
+		} );
+
+		// The iframe should still show the second email, not the stale first.
+		const iframe = document.querySelector( '.newspack-email-preview__iframe' );
+		expect( iframe.getAttribute( 'srcdoc' ) ).toContain( 'Second email' );
+		expect( iframe.getAttribute( 'srcdoc' ) ).not.toContain( 'First email' );
+	} );
+
+	// Note: The safety timeout (8s fallback for slow assets) and the iframe
+	// onError handler are not tested here because jsdom automatically fires
+	// the iframe load event when srcDoc is set, which prevents us from
+	// simulating pending-asset scenarios. These defensive measures work in
+	// real browsers but require an integration/e2e test environment.
 } );

--- a/src/wizards/newspack/views/settings/emails/email-preview.test.js
+++ b/src/wizards/newspack/views/settings/emails/email-preview.test.js
@@ -39,6 +39,17 @@ function createObserverMock( triggerImmediately = true ) {
 	};
 }
 
+// ResizeObserver mock: immediately reports a 300px-wide container.
+global.ResizeObserver = class {
+	constructor( callback ) {
+		this.callback = callback;
+	}
+	observe() {
+		this.callback( [ { contentRect: { width: 300 } } ] );
+	}
+	disconnect() {}
+};
+
 describe( 'EmailPreview', () => {
 	beforeEach( () => {
 		apiFetch.mockReset();

--- a/src/wizards/newspack/views/settings/emails/email-preview.tsx
+++ b/src/wizards/newspack/views/settings/emails/email-preview.tsx
@@ -4,13 +4,17 @@
  * Lazy-loads via IntersectionObserver: the REST fetch only fires once the
  * component scrolls into view. On success an iframe with srcDoc displays the
  * rendered HTML; on error an envelope icon placeholder is shown instead.
+ *
+ * Rendering contract mirrors NewsletterPreview in newspack-newsletters:
+ * 848 px source viewport, 1 : 1 aspect ratio, fade-in via `is-ready` class,
+ * and iframe height measured from the loaded document.
  */
 
 /**
  * WordPress dependencies.
  */
 import apiFetch from '@wordpress/api-fetch';
-import { useState, useEffect, useRef } from '@wordpress/element';
+import { useState, useEffect, useRef, useCallback } from '@wordpress/element';
 import { Spinner } from '@wordpress/components';
 import { Icon, envelope } from '@wordpress/icons';
 
@@ -23,15 +27,18 @@ interface EmailPreviewProps {
 	postId: number;
 }
 
-const IFRAME_WIDTH = 600;
+const IFRAME_WIDTH = 848;
 
 const EmailPreview: React.FC< EmailPreviewProps > = ( { postId } ) => {
 	const containerRef = useRef< HTMLDivElement >( null );
+	const iframeRef = useRef< HTMLIFrameElement >( null );
 	const [ isVisible, setIsVisible ] = useState( false );
 	const [ html, setHtml ] = useState< string | null >( null );
 	const [ isLoading, setIsLoading ] = useState( false );
 	const [ hasError, setHasError ] = useState( false );
 	const [ scale, setScale ] = useState( 0 );
+	const [ iframeHeight, setIframeHeight ] = useState< number | null >( null );
+	const [ isReady, setIsReady ] = useState( false );
 
 	// Observe visibility — fetch only when the thumbnail enters the viewport.
 	useEffect( () => {
@@ -79,13 +86,17 @@ const EmailPreview: React.FC< EmailPreviewProps > = ( { postId } ) => {
 		return () => ro.disconnect();
 	}, [] );
 
-	// Fetch preview HTML once visible.
+	// Fetch preview HTML once visible. Reset state on postId change.
 	useEffect( () => {
 		if ( ! isVisible ) {
 			return;
 		}
 
 		setIsLoading( true );
+		setIsReady( false );
+		setIframeHeight( null );
+		setHasError( false );
+		setHtml( null );
 		apiFetch< { html: string; post_id: number } >( {
 			path: `/newspack/v1/wizard/newspack-settings/emails/${ postId }/preview`,
 		} )
@@ -100,9 +111,42 @@ const EmailPreview: React.FC< EmailPreviewProps > = ( { postId } ) => {
 			} );
 	}, [ isVisible, postId ] );
 
+	// Handle iframe load: wait for stylesheets and images, then measure height and reveal.
+	const handleIframeLoad = useCallback( () => {
+		const doc = iframeRef.current?.contentDocument;
+		if ( ! doc ) {
+			return;
+		}
+
+		const awaitLoad = ( el: HTMLLinkElement | HTMLImageElement ) =>
+			new Promise< void >( resolve => {
+				el.addEventListener( 'load', () => resolve(), { once: true } );
+				el.addEventListener( 'error', () => resolve(), { once: true } );
+			} );
+
+		const linkPromises = Array.from( doc.querySelectorAll< HTMLLinkElement >( 'link[rel="stylesheet"]' ) )
+			.filter( link => ! link.sheet )
+			.map( awaitLoad );
+		const imgPromises = Array.from( doc.querySelectorAll< HTMLImageElement >( 'img' ) )
+			.filter( img => ! img.complete )
+			.map( awaitLoad );
+
+		// 8 s safety so a slow asset never strands the spinner.
+		const safety = setTimeout( () => {
+			setIframeHeight( doc.body.scrollHeight );
+			setIsReady( true );
+		}, 8000 );
+
+		Promise.all( [ ...linkPromises, ...imgPromises ] ).then( () => {
+			clearTimeout( safety );
+			setIframeHeight( doc.body.scrollHeight );
+			setIsReady( true );
+		} );
+	}, [] );
+
 	return (
-		<div ref={ containerRef } className="newspack-email-preview">
-			{ isLoading && (
+		<div ref={ containerRef } className={ `newspack-email-preview${ isReady ? ' is-ready' : '' }` }>
+			{ ( isLoading || ( html && ! isReady ) ) && ! hasError && (
 				<div className="newspack-email-preview__placeholder">
 					<Spinner />
 				</div>
@@ -112,14 +156,19 @@ const EmailPreview: React.FC< EmailPreviewProps > = ( { postId } ) => {
 					<Icon icon={ envelope } size={ 48 } />
 				</div>
 			) }
-			{ html && ! hasError && ! isLoading && scale > 0 && (
+			{ html && ! hasError && scale > 0 && (
 				<iframe
+					ref={ iframeRef }
 					className="newspack-email-preview__iframe"
 					srcDoc={ html }
 					sandbox=""
 					tabIndex={ -1 }
 					title="Email preview"
-					style={ { transform: `scale(${ scale })` } }
+					onLoad={ handleIframeLoad }
+					style={ {
+						transform: `scale(${ scale })`,
+						height: iframeHeight ? `${ iframeHeight }px` : undefined,
+					} }
 				/>
 			) }
 		</div>

--- a/src/wizards/newspack/views/settings/emails/email-preview.tsx
+++ b/src/wizards/newspack/views/settings/emails/email-preview.tsx
@@ -44,7 +44,7 @@ const EmailPreview: React.FC< EmailPreviewProps > = ( { postId } ) => {
 		}
 
 		const observer = new IntersectionObserver(
-			( entries ) => {
+			entries => {
 				if ( entries[ 0 ]?.isIntersecting ) {
 					setIsVisible( true );
 				}

--- a/src/wizards/newspack/views/settings/emails/email-preview.tsx
+++ b/src/wizards/newspack/views/settings/emails/email-preview.tsx
@@ -35,16 +35,18 @@ const EmailPreview: React.FC< EmailPreviewProps > = ( { postId } ) => {
 
 	// Observe visibility — fetch only when the thumbnail enters the viewport.
 	useEffect( () => {
+		if ( isVisible ) {
+			return;
+		}
 		const node = containerRef.current;
 		if ( ! node ) {
 			return;
 		}
 
 		const observer = new IntersectionObserver(
-			( [ entry ] ) => {
-				if ( entry.isIntersecting ) {
+			( entries ) => {
+				if ( entries[ 0 ]?.isIntersecting ) {
 					setIsVisible( true );
-					observer.disconnect();
 				}
 			},
 			{ rootMargin: '200px' }
@@ -52,7 +54,7 @@ const EmailPreview: React.FC< EmailPreviewProps > = ( { postId } ) => {
 
 		observer.observe( node );
 		return () => observer.disconnect();
-	}, [] );
+	}, [ isVisible ] );
 
 	// Measure container width and compute iframe scale.
 	useEffect( () => {

--- a/src/wizards/newspack/views/settings/emails/email-preview.tsx
+++ b/src/wizards/newspack/views/settings/emails/email-preview.tsx
@@ -23,12 +23,15 @@ interface EmailPreviewProps {
 	postId: number;
 }
 
+const IFRAME_WIDTH = 600;
+
 const EmailPreview: React.FC< EmailPreviewProps > = ( { postId } ) => {
 	const containerRef = useRef< HTMLDivElement >( null );
 	const [ isVisible, setIsVisible ] = useState( false );
 	const [ html, setHtml ] = useState< string | null >( null );
 	const [ isLoading, setIsLoading ] = useState( false );
 	const [ hasError, setHasError ] = useState( false );
+	const [ scale, setScale ] = useState( 0 );
 
 	// Observe visibility — fetch only when the thumbnail enters the viewport.
 	useEffect( () => {
@@ -49,6 +52,21 @@ const EmailPreview: React.FC< EmailPreviewProps > = ( { postId } ) => {
 
 		observer.observe( node );
 		return () => observer.disconnect();
+	}, [] );
+
+	// Measure container width and compute iframe scale.
+	useEffect( () => {
+		const node = containerRef.current;
+		if ( ! node ) {
+			return;
+		}
+
+		const ro = new ResizeObserver( ( [ entry ] ) => {
+			setScale( entry.contentRect.width / IFRAME_WIDTH );
+		} );
+
+		ro.observe( node );
+		return () => ro.disconnect();
 	}, [] );
 
 	// Fetch preview HTML once visible.
@@ -84,8 +102,15 @@ const EmailPreview: React.FC< EmailPreviewProps > = ( { postId } ) => {
 					<Icon icon={ envelope } size={ 48 } />
 				</div>
 			) }
-			{ html && ! hasError && ! isLoading && (
-				<iframe className="newspack-email-preview__iframe" srcDoc={ html } sandbox="" tabIndex={ -1 } title="Email preview" />
+			{ html && ! hasError && ! isLoading && scale > 0 && (
+				<iframe
+					className="newspack-email-preview__iframe"
+					srcDoc={ html }
+					sandbox=""
+					tabIndex={ -1 }
+					title="Email preview"
+					style={ { transform: `scale(${ scale })` } }
+				/>
 			) }
 		</div>
 	);

--- a/src/wizards/newspack/views/settings/emails/email-preview.tsx
+++ b/src/wizards/newspack/views/settings/emails/email-preview.tsx
@@ -161,7 +161,7 @@ const EmailPreview: React.FC< EmailPreviewProps > = ( { postId } ) => {
 					ref={ iframeRef }
 					className="newspack-email-preview__iframe"
 					srcDoc={ html }
-					sandbox=""
+					sandbox="allow-same-origin"
 					tabIndex={ -1 }
 					title="Email preview"
 					onLoad={ handleIframeLoad }

--- a/src/wizards/newspack/views/settings/emails/email-preview.tsx
+++ b/src/wizards/newspack/views/settings/emails/email-preview.tsx
@@ -38,6 +38,10 @@ const EmailPreview: React.FC< EmailPreviewProps > = ( { postId } ) => {
 		if ( isVisible ) {
 			return;
 		}
+		if ( typeof IntersectionObserver === 'undefined' ) {
+			setIsVisible( true );
+			return;
+		}
 		const node = containerRef.current;
 		if ( ! node ) {
 			return;
@@ -58,6 +62,10 @@ const EmailPreview: React.FC< EmailPreviewProps > = ( { postId } ) => {
 
 	// Measure container width and compute iframe scale.
 	useEffect( () => {
+		if ( typeof ResizeObserver === 'undefined' ) {
+			setScale( 1 );
+			return;
+		}
 		const node = containerRef.current;
 		if ( ! node ) {
 			return;

--- a/src/wizards/newspack/views/settings/emails/email-preview.tsx
+++ b/src/wizards/newspack/views/settings/emails/email-preview.tsx
@@ -1,0 +1,94 @@
+/**
+ * EmailPreview — renders a scaled thumbnail of an email template.
+ *
+ * Lazy-loads via IntersectionObserver: the REST fetch only fires once the
+ * component scrolls into view. On success an iframe with srcDoc displays the
+ * rendered HTML; on error an envelope icon placeholder is shown instead.
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { useState, useEffect, useRef } from '@wordpress/element';
+import { Spinner } from '@wordpress/components';
+import { Icon, envelope } from '@wordpress/icons';
+
+/**
+ * Internal dependencies.
+ */
+import './email-preview.scss';
+
+interface EmailPreviewProps {
+	postId: number;
+}
+
+const EmailPreview: React.FC< EmailPreviewProps > = ( { postId } ) => {
+	const containerRef = useRef< HTMLDivElement >( null );
+	const [ isVisible, setIsVisible ] = useState( false );
+	const [ html, setHtml ] = useState< string | null >( null );
+	const [ isLoading, setIsLoading ] = useState( false );
+	const [ hasError, setHasError ] = useState( false );
+
+	// Observe visibility — fetch only when the thumbnail enters the viewport.
+	useEffect( () => {
+		const node = containerRef.current;
+		if ( ! node ) {
+			return;
+		}
+
+		const observer = new IntersectionObserver(
+			( [ entry ] ) => {
+				if ( entry.isIntersecting ) {
+					setIsVisible( true );
+					observer.disconnect();
+				}
+			},
+			{ rootMargin: '200px' }
+		);
+
+		observer.observe( node );
+		return () => observer.disconnect();
+	}, [] );
+
+	// Fetch preview HTML once visible.
+	useEffect( () => {
+		if ( ! isVisible ) {
+			return;
+		}
+
+		setIsLoading( true );
+		apiFetch< { html: string; post_id: number } >( {
+			path: `/newspack/v1/wizard/newspack-settings/emails/${ postId }/preview`,
+		} )
+			.then( response => {
+				setHtml( response.html );
+			} )
+			.catch( () => {
+				setHasError( true );
+			} )
+			.finally( () => {
+				setIsLoading( false );
+			} );
+	}, [ isVisible, postId ] );
+
+	return (
+		<div ref={ containerRef } className="newspack-email-preview">
+			{ isLoading && (
+				<div className="newspack-email-preview__placeholder">
+					<Spinner />
+				</div>
+			) }
+			{ hasError && (
+				<div className="newspack-email-preview__placeholder">
+					<Icon icon={ envelope } size={ 48 } />
+				</div>
+			) }
+			{ html && ! hasError && ! isLoading && (
+				<iframe className="newspack-email-preview__iframe" srcDoc={ html } sandbox="" tabIndex={ -1 } title="Email preview" />
+			) }
+		</div>
+	);
+};
+
+export default EmailPreview;

--- a/src/wizards/newspack/views/settings/emails/email-preview.tsx
+++ b/src/wizards/newspack/views/settings/emails/email-preview.tsx
@@ -32,11 +32,12 @@ const IFRAME_WIDTH = 848;
 const EmailPreview: React.FC< EmailPreviewProps > = ( { postId } ) => {
 	const containerRef = useRef< HTMLDivElement >( null );
 	const iframeRef = useRef< HTMLIFrameElement >( null );
+	const safetyTimerRef = useRef< ReturnType< typeof setTimeout > | null >( null );
 	const [ isVisible, setIsVisible ] = useState( false );
 	const [ html, setHtml ] = useState< string | null >( null );
 	const [ isLoading, setIsLoading ] = useState( false );
 	const [ hasError, setHasError ] = useState( false );
-	const [ scale, setScale ] = useState( 0 );
+	const [ scale, setScale ] = useState< number | null >( null );
 	const [ iframeHeight, setIframeHeight ] = useState< number | null >( null );
 	const [ isReady, setIsReady ] = useState( false );
 
@@ -86,10 +87,18 @@ const EmailPreview: React.FC< EmailPreviewProps > = ( { postId } ) => {
 		return () => ro.disconnect();
 	}, [] );
 
-	// Fetch preview HTML once visible. Reset state on postId change.
+	// Fetch preview HTML once visible. Cancel on postId change or unmount.
 	useEffect( () => {
 		if ( ! isVisible ) {
 			return;
+		}
+
+		let cancelled = false;
+
+		// Clear any lingering safety timer from a previous postId.
+		if ( safetyTimerRef.current ) {
+			clearTimeout( safetyTimerRef.current );
+			safetyTimerRef.current = null;
 		}
 
 		setIsLoading( true );
@@ -101,14 +110,28 @@ const EmailPreview: React.FC< EmailPreviewProps > = ( { postId } ) => {
 			path: `/newspack/v1/wizard/newspack-settings/emails/${ postId }/preview`,
 		} )
 			.then( response => {
-				setHtml( response.html );
+				if ( ! cancelled ) {
+					setHtml( response.html );
+				}
 			} )
 			.catch( () => {
-				setHasError( true );
+				if ( ! cancelled ) {
+					setHasError( true );
+				}
 			} )
 			.finally( () => {
-				setIsLoading( false );
+				if ( ! cancelled ) {
+					setIsLoading( false );
+				}
 			} );
+
+		return () => {
+			cancelled = true;
+			if ( safetyTimerRef.current ) {
+				clearTimeout( safetyTimerRef.current );
+				safetyTimerRef.current = null;
+			}
+		};
 	}, [ isVisible, postId ] );
 
 	// Handle iframe load: wait for stylesheets and images, then measure height and reveal.
@@ -131,22 +154,31 @@ const EmailPreview: React.FC< EmailPreviewProps > = ( { postId } ) => {
 			.filter( img => ! img.complete )
 			.map( awaitLoad );
 
-		// 8 s safety so a slow asset never strands the spinner.
-		const safety = setTimeout( () => {
+		let finalized = false;
+		const finalize = () => {
+			if ( finalized ) {
+				return;
+			}
+			finalized = true;
+			if ( safetyTimerRef.current ) {
+				clearTimeout( safetyTimerRef.current );
+				safetyTimerRef.current = null;
+			}
 			setIframeHeight( doc.body.scrollHeight );
 			setIsReady( true );
-		}, 8000 );
+		};
 
-		Promise.all( [ ...linkPromises, ...imgPromises ] ).then( () => {
-			clearTimeout( safety );
-			setIframeHeight( doc.body.scrollHeight );
-			setIsReady( true );
-		} );
+		// 8 s safety so a slow asset never strands the spinner.
+		safetyTimerRef.current = setTimeout( finalize, 8000 );
+
+		Promise.all( [ ...linkPromises, ...imgPromises ] ).then( finalize );
 	}, [] );
+
+	const showSpinner = ! hasError && ! isReady && ( isLoading || Boolean( html ) );
 
 	return (
 		<div ref={ containerRef } className={ `newspack-email-preview${ isReady ? ' is-ready' : '' }` }>
-			{ ( isLoading || ( html && ! isReady ) ) && ! hasError && (
+			{ showSpinner && (
 				<div className="newspack-email-preview__placeholder">
 					<Spinner />
 				</div>
@@ -156,15 +188,22 @@ const EmailPreview: React.FC< EmailPreviewProps > = ( { postId } ) => {
 					<Icon icon={ envelope } size={ 48 } />
 				</div>
 			) }
-			{ html && ! hasError && scale > 0 && (
+			{ html && ! hasError && scale !== null && scale > 0 && (
 				<iframe
 					ref={ iframeRef }
 					className="newspack-email-preview__iframe"
 					srcDoc={ html }
+					/* sandbox: allow-same-origin is required so handleIframeLoad can
+					 * read contentDocument (body.scrollHeight, stylesheet load state).
+					 * allow-scripts is NOT present, so JS cannot execute.
+					 * Residual risk: a <form> in the HTML could submit with admin
+					 * cookies, but this is admin-only code and the email HTML is
+					 * publisher-controlled post meta. */
 					sandbox="allow-same-origin"
 					tabIndex={ -1 }
 					title="Email preview"
 					onLoad={ handleIframeLoad }
+					onError={ () => setHasError( true ) }
 					style={ {
 						transform: `scale(${ scale })`,
 						height: iframeHeight ? `${ iframeHeight }px` : undefined,

--- a/src/wizards/newspack/views/settings/emails/emails.scss
+++ b/src/wizards/newspack/views/settings/emails/emails.scss
@@ -34,6 +34,12 @@
 	color: wp-colors.$gray-700;
 }
 
+// Clickable preview link in grid view.
+.newspack-emails__preview-link {
+	display: block;
+	text-decoration: none;
+}
+
 // Clickable name link in grid/table view.
 .newspack-emails__name-link {
 	color: inherit;

--- a/src/wizards/newspack/views/settings/emails/emails.scss
+++ b/src/wizards/newspack/views/settings/emails/emails.scss
@@ -22,18 +22,6 @@
 	}
 }
 
-// Preview placeholder (grid view media field).
-.newspack-emails__preview-placeholder {
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	aspect-ratio: 1;
-	width: 100%;
-	background: wp-colors.$gray-100;
-	border-radius: 4px;
-	color: wp-colors.$gray-700;
-}
-
 // Clickable preview link in grid view.
 .newspack-emails__preview-link {
 	display: block;
@@ -50,6 +38,7 @@
 		text-decoration: underline;
 	}
 }
+
 
 // Trigger description sub-text under the title.
 // Two-line clamp keeps grid cards uniform while still showing enough context.

--- a/src/wizards/newspack/views/settings/emails/emails.test.js
+++ b/src/wizards/newspack/views/settings/emails/emails.test.js
@@ -86,6 +86,11 @@ jest.mock(
 		}
 );
 
+jest.mock( './email-preview', () => ( {
+	__esModule: true,
+	default: () => null,
+} ) );
+
 const mockEmails = [
 	{
 		label: 'Payment receipt',

--- a/src/wizards/newspack/views/settings/emails/emails.test.js
+++ b/src/wizards/newspack/views/settings/emails/emails.test.js
@@ -10,6 +10,17 @@ import { render, screen, waitFor } from '@testing-library/react';
  */
 import apiFetch from '@wordpress/api-fetch';
 
+// ResizeObserver mock (needed by EmailPreview rendered inside Emails).
+global.ResizeObserver = class {
+	constructor( callback ) {
+		this.callback = callback;
+	}
+	observe() {
+		this.callback( [ { contentRect: { width: 300 } } ] );
+	}
+	disconnect() {}
+};
+
 jest.mock( './emails.scss', () => ( {} ) );
 jest.mock( '@wordpress/api-fetch', () => ( {
 	__esModule: true,

--- a/src/wizards/newspack/views/settings/emails/emails.test.js
+++ b/src/wizards/newspack/views/settings/emails/emails.test.js
@@ -10,17 +10,6 @@ import { render, screen, waitFor } from '@testing-library/react';
  */
 import apiFetch from '@wordpress/api-fetch';
 
-// ResizeObserver mock (needed by EmailPreview rendered inside Emails).
-global.ResizeObserver = class {
-	constructor( callback ) {
-		this.callback = callback;
-	}
-	observe() {
-		this.callback( [ { contentRect: { width: 300 } } ] );
-	}
-	disconnect() {}
-};
-
 jest.mock( './emails.scss', () => ( {} ) );
 jest.mock( '@wordpress/api-fetch', () => ( {
 	__esModule: true,

--- a/src/wizards/newspack/views/settings/emails/emails.tsx
+++ b/src/wizards/newspack/views/settings/emails/emails.tsx
@@ -10,13 +10,13 @@ import { useState, useEffect, useCallback, useMemo, Fragment } from '@wordpress/
 import apiFetch from '@wordpress/api-fetch';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import type { Action, Field, View } from '@wordpress/dataviews';
-import { Icon, envelope } from '@wordpress/icons';
 
 /**
  * Internal dependencies.
  */
 import { Badge, DataViews, Notice, utils } from '../../../../../../packages/components/src';
 import WizardsPluginCard from '../../../../wizards-plugin-card';
+import EmailPreview from './email-preview';
 import './emails.scss';
 
 interface EmailItem {
@@ -130,10 +130,9 @@ const Emails = () => {
 				type: 'media',
 				enableSorting: false,
 				enableHiding: true,
-				// @todo NPPD-1525 Replace with <EmailPreview> component.
 				render: ( { item }: { item: EmailItem } ) => (
-					<a href={ item.edit_link } className="newspack-emails__preview-placeholder">
-						<Icon icon={ envelope } size={ 32 } />
+					<a href={ item.edit_link } className="newspack-emails__preview-link">
+						<EmailPreview postId={ item.post_id } />
 					</a>
 				),
 			},

--- a/tests/unit-tests/email-preview.php
+++ b/tests/unit-tests/email-preview.php
@@ -90,7 +90,7 @@ class Newspack_Test_Email_Preview extends WP_UnitTestCase {
 	}
 
 	/**
-	 * get_preview_html() substitutes tokens in stored EMAIL_HTML_META.
+	 * Tests that get_preview_html() substitutes tokens in stored EMAIL_HTML_META.
 	 */
 	public function test_get_preview_html_with_stored_meta() {
 		$source_html = '<html><body>Hello *BILLING_NAME*, your total is *AMOUNT*.</body></html>';
@@ -106,7 +106,7 @@ class Newspack_Test_Email_Preview extends WP_UnitTestCase {
 	}
 
 	/**
-	 * get_preview_html() falls back to template HTML when no stored meta exists.
+	 * Tests that get_preview_html() falls back to template HTML when no stored meta exists.
 	 */
 	public function test_get_preview_html_fallback_to_template() {
 		$post_id = $this->create_email_post();
@@ -120,7 +120,7 @@ class Newspack_Test_Email_Preview extends WP_UnitTestCase {
 	}
 
 	/**
-	 * get_preview_html() returns false for a nonexistent post.
+	 * Tests that get_preview_html() returns false for a nonexistent post.
 	 */
 	public function test_get_preview_html_returns_false_for_nonexistent() {
 		$result = Email_Preview::get_preview_html( 999999 );

--- a/tests/unit-tests/email-preview.php
+++ b/tests/unit-tests/email-preview.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * Tests Email_Preview.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Emails;
+use Newspack\Wizards\Newspack\Email_Preview;
+
+require_once __DIR__ . '/../mocks/newsletters-mocks.php';
+
+/**
+ * Tests Email_Preview.
+ */
+class Newspack_Test_Email_Preview extends WP_UnitTestCase {
+
+	/**
+	 * Test email config name.
+	 *
+	 * @var string
+	 */
+	private static $test_config_name = 'test-preview-config';
+
+	/**
+	 * Setup.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		add_filter(
+			'newspack_email_configs',
+			function ( $types ) {
+				$types[ self::$test_config_name ] = [
+					'name'        => self::$test_config_name,
+					'label'       => __( 'Test preview config', 'newspack' ),
+					'description' => __( 'Email for testing preview.', 'newspack' ),
+					'template'    => dirname( NEWSPACK_PLUGIN_FILE ) . '/includes/templates/reader-revenue-emails/receipt.php',
+					'category'    => 'test',
+				];
+				return $types;
+			}
+		);
+	}
+
+	/**
+	 * Helper: create a newspack_rr_email post with the test config type.
+	 *
+	 * @param string $html Optional stored email HTML.
+	 * @return int Post ID.
+	 */
+	private function create_email_post( string $html = '' ): int {
+		$post_id = self::factory()->post->create(
+			[
+				'post_type'   => Emails::POST_TYPE,
+				'post_status' => 'publish',
+			]
+		);
+		update_post_meta( $post_id, Emails::EMAIL_CONFIG_NAME_META, self::$test_config_name );
+		if ( ! empty( $html ) ) {
+			update_post_meta( $post_id, \Newspack_Newsletters::EMAIL_HTML_META, $html );
+		}
+		return $post_id;
+	}
+
+	/**
+	 * The sample-substitutions map contains all expected token keys.
+	 */
+	public function test_sample_substitutions_map() {
+		$subs = Email_Preview::get_sample_substitutions();
+
+		self::assertIsArray( $subs );
+		self::assertGreaterThanOrEqual( 28, count( $subs ), 'Substitution map should have at least 28 entries.' );
+
+		$expected_keys = [
+			'*SITE_TITLE*',
+			'*SITE_URL*',
+			'*SITE_LOGO*',
+			'*BILLING_NAME*',
+			'*BILLING_FIRST_NAME*',
+			'*AMOUNT*',
+			'*PAYMENT_METHOD*',
+			'*DATE*',
+			'*ACCOUNT_URL*',
+			'*MAGIC_LINK_OTP*',
+		];
+		foreach ( $expected_keys as $key ) {
+			self::assertArrayHasKey( $key, $subs, "Missing expected token: $key" );
+		}
+	}
+
+	/**
+	 * get_preview_html() substitutes tokens in stored EMAIL_HTML_META.
+	 */
+	public function test_get_preview_html_with_stored_meta() {
+		$source_html = '<html><body>Hello *BILLING_NAME*, your total is *AMOUNT*.</body></html>';
+		$post_id     = $this->create_email_post( $source_html );
+
+		$result = Email_Preview::get_preview_html( $post_id );
+
+		self::assertIsString( $result );
+		self::assertStringContainsString( 'Sample Reader', $result, 'BILLING_NAME should be substituted.' );
+		self::assertStringContainsString( '$25.00', $result, 'AMOUNT should be substituted.' );
+		self::assertStringNotContainsString( '*BILLING_NAME*', $result, 'Raw token should not remain.' );
+		self::assertStringNotContainsString( '*AMOUNT*', $result, 'Raw token should not remain.' );
+	}
+
+	/**
+	 * get_preview_html() falls back to template HTML when no stored meta exists.
+	 */
+	public function test_get_preview_html_fallback_to_template() {
+		$post_id = $this->create_email_post();
+
+		$result = Email_Preview::get_preview_html( $post_id );
+
+		self::assertIsString( $result );
+		self::assertNotEmpty( $result, 'Fallback to template should produce non-empty HTML.' );
+		// The receipt template contains "Thank you!" — verify substitution ran.
+		self::assertStringContainsString( 'Thank you!', $result );
+	}
+
+	/**
+	 * get_preview_html() returns false for a nonexistent post.
+	 */
+	public function test_get_preview_html_returns_false_for_nonexistent() {
+		$result = Email_Preview::get_preview_html( 999999 );
+		self::assertFalse( $result );
+	}
+
+	/**
+	 * REST API returns 404 for a post that is not of the email post type.
+	 */
+	public function test_api_get_preview_returns_404_for_wrong_post_type() {
+		$post_id = self::factory()->post->create( [ 'post_type' => 'post' ] );
+
+		$request = new WP_REST_Request( 'GET', '/newspack/v1/wizard/newspack-settings/emails/' . $post_id . '/preview' );
+		$request->set_param( 'post_id', $post_id );
+
+		$response = Email_Preview::api_get_preview( $request );
+
+		self::assertInstanceOf( 'WP_Error', $response );
+		self::assertEquals( 'newspack_email_preview_not_found', $response->get_error_code() );
+	}
+
+	/**
+	 * REST API returns HTML and post_id on success.
+	 */
+	public function test_api_get_preview_returns_html() {
+		$source_html = '<html><body>Preview for *BILLING_NAME*</body></html>';
+		$post_id     = $this->create_email_post( $source_html );
+
+		$request = new WP_REST_Request( 'GET', '/newspack/v1/wizard/newspack-settings/emails/' . $post_id . '/preview' );
+		$request->set_param( 'post_id', $post_id );
+
+		$response = Email_Preview::api_get_preview( $request );
+
+		self::assertInstanceOf( 'WP_REST_Response', $response );
+
+		$data = $response->get_data();
+		self::assertArrayHasKey( 'html', $data );
+		self::assertArrayHasKey( 'post_id', $data );
+		self::assertEquals( $post_id, $data['post_id'] );
+		self::assertStringContainsString( 'Sample Reader', $data['html'] );
+	}
+}

--- a/tests/unit-tests/email-preview.php
+++ b/tests/unit-tests/email-preview.php
@@ -90,6 +90,28 @@ class Newspack_Test_Email_Preview extends WP_UnitTestCase {
 	}
 
 	/**
+	 * CONTACT_EMAIL resolves through Emails::get_reply_to_email() — not admin_email.
+	 *
+	 * Pins the fix for the function_exists() bug: function_exists() cannot
+	 * test class methods, so the guard was always false and the token fell
+	 * back to admin_email regardless of the Reader Activation contact setting.
+	 */
+	public function test_contact_email_uses_reply_to_email() {
+		$custom_email = 'reply@example.org';
+		add_filter( 'newspack_reply_to_email', fn() => $custom_email );
+
+		$source_html = '<html><body>Contact us at *CONTACT_EMAIL*</body></html>';
+		$post_id     = $this->create_email_post( $source_html );
+
+		$result = Email_Preview::get_preview_html( $post_id );
+
+		self::assertStringContainsString( $custom_email, $result, 'CONTACT_EMAIL should resolve to the filtered reply-to address.' );
+		self::assertStringNotContainsString( '*CONTACT_EMAIL*', $result, 'Raw CONTACT_EMAIL token should not remain.' );
+
+		remove_all_filters( 'newspack_reply_to_email' );
+	}
+
+	/**
 	 * Tests that get_preview_html() substitutes tokens in stored EMAIL_HTML_META.
 	 */
 	public function test_get_preview_html_with_stored_meta() {
@@ -128,6 +150,15 @@ class Newspack_Test_Email_Preview extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Permission check rejects non-admin users.
+	 */
+	public function test_api_permissions_check_rejects_non_admin() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'subscriber' ] ) );
+		$result = Email_Preview::api_permissions_check();
+		self::assertInstanceOf( 'WP_Error', $result );
+	}
+
+	/**
 	 * REST API returns 404 for a post that is not of the email post type.
 	 */
 	public function test_api_get_preview_returns_404_for_wrong_post_type() {
@@ -140,6 +171,7 @@ class Newspack_Test_Email_Preview extends WP_UnitTestCase {
 
 		self::assertInstanceOf( 'WP_Error', $response );
 		self::assertEquals( 'newspack_email_preview_not_found', $response->get_error_code() );
+		self::assertEquals( 404, $response->get_error_data()['status'] );
 	}
 
 	/**

--- a/tests/unit-tests/email-preview.php
+++ b/tests/unit-tests/email-preview.php
@@ -23,24 +23,37 @@ class Newspack_Test_Email_Preview extends WP_UnitTestCase {
 	private static $test_config_name = 'test-preview-config';
 
 	/**
+	 * Filter callback reference so it can be removed in tear_down().
+	 *
+	 * @var callable
+	 */
+	private $config_filter_callback;
+
+	/**
 	 * Setup.
 	 */
 	public function set_up() {
 		parent::set_up();
 
-		add_filter(
-			'newspack_email_configs',
-			function ( $types ) {
-				$types[ self::$test_config_name ] = [
-					'name'        => self::$test_config_name,
-					'label'       => __( 'Test preview config', 'newspack' ),
-					'description' => __( 'Email for testing preview.', 'newspack' ),
-					'template'    => dirname( NEWSPACK_PLUGIN_FILE ) . '/includes/templates/reader-revenue-emails/receipt.php',
-					'category'    => 'test',
-				];
-				return $types;
-			}
-		);
+		$this->config_filter_callback = function ( $types ) {
+			$types[ self::$test_config_name ] = [
+				'name'        => self::$test_config_name,
+				'label'       => __( 'Test preview config', 'newspack' ),
+				'description' => __( 'Email for testing preview.', 'newspack' ),
+				'template'    => dirname( NEWSPACK_PLUGIN_FILE ) . '/includes/templates/reader-revenue-emails/receipt.php',
+				'category'    => 'test',
+			];
+			return $types;
+		};
+		add_filter( 'newspack_email_configs', $this->config_filter_callback );
+	}
+
+	/**
+	 * Teardown.
+	 */
+	public function tear_down() {
+		remove_filter( 'newspack_email_configs', $this->config_filter_callback );
+		parent::tear_down();
 	}
 
 	/**


### PR DESCRIPTION
## What this PR does

Adds an inline email preview component ([NPPD-1525](https://linear.app/a8c/issue/NPPD-1525)) that renders a live thumbnail of each email's HTML inside the DataViews grid built in #4727. Replaces the envelope-icon placeholder with real previews — readers see the actual rendered template at a glance.

<img width="3246" height="2192" alt="image" src="https://github.com/user-attachments/assets/e70ac403-7662-4d2b-887b-42b3d423a348" />

## ⚠️ Stacked on #4727

**Base branch is `nppd-945-unified-emails-newspack-slice`, not `trunk`.** 

The diff in this PR shows only the NPPD-1525 work. The slice 1 changes (`#4727`) are excluded from the diff by virtue of the base branch.

## Code changes

**Backend** (`includes/wizards/newspack/class-email-preview.php`)

- New `Email_Preview` class registers `GET /wizard/newspack-settings/emails/{post_id}/preview`
- Returns the cached `EMAIL_HTML_META` post meta with sample-value token substitution applied
- Falls back to rendering the template file if no cached HTML is stored
- Substitutes 29 template tokens: reader/transaction values use stable fakes (e.g. "Sample Reader", "$25.00", "May 14, 2026"); site/branding values use real publisher values from `get_option`; action URLs use `#` anchors

**Frontend** (`src/wizards/newspack/views/settings/emails/`)

- New `EmailPreview` React component
- IntersectionObserver lazy-load via `isVisible` state bridge — cards only fetch when scrolled into view, avoiding 24 simultaneous requests on initial render
- Iframe `srcDoc` rendering with empty `sandbox=""` for security (scripts in email HTML cannot execute)
- Spinner loading state, envelope icon fallback on render error
- ResizeObserver-based proportional scaling: source iframe rendered at 1200×900, scaled via inline `transform` to match container width while preserving 4:3 aspect ratio
- Wired into `emails.tsx` to replace the envelope-icon placeholder in the Preview column

**Loader fix** (`includes/class-newspack.php`)

- Fixed missing tab indentation on the new `class-email-preview.php` include line

**Tests**

- 6 PHPUnit tests (`tests/unit-tests/email-preview.php`): substitution map, preview HTML with stored meta, template fallback, nonexistent post, wrong post type returns 404, successful API response
- 5 Jest tests (`src/wizards/newspack/views/settings/emails/email-preview.test.js`): loading state, successful iframe render, error fallback, lazy-load gating, correct endpoint path

## Manual testing

Tested locally on katie.local (Homebrew-served Apache + PHP, symlinked plugin) with the slice 1 grid view. Verified:

- ✅ Each card renders a live iframe thumbnail of the rendered email HTML
- ✅ Token substitution working (publisher name, dates, sample amounts visible in rendered previews)
- ✅ IntersectionObserver gates fetching — initial page load doesn't trigger all 24 requests
- ✅ Iframe scales proportionally as container width changes
- ✅ Fallback envelope icon renders when REST returns an error

### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?