### PR TITLE
feat(emails): surface WC emails with chip filtering and preview thumbnails (NPPD-1527)

### DIFF
--- a/includes/class-newspack.php
+++ b/includes/class-newspack.php
@@ -167,6 +167,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/newspack/class-newspack-settings.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/newspack/class-custom-events-section.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/newspack/class-emails-section.php';
+		include_once NEWSPACK_ABSPATH . 'includes/wizards/newspack/class-email-preview.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/newspack/class-syndication-section.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/newspack/class-seo-section.php';
 		include_once NEWSPACK_ABSPATH . 'includes/wizards/newspack/class-pixels-section.php';

--- a/includes/wizards/newspack/class-email-preview.php
+++ b/includes/wizards/newspack/class-email-preview.php
@@ -1,0 +1,467 @@
+<?php
+/**
+ * Email preview rendering for the Settings → Emails screen.
+ *
+ * Renders a publisher-facing preview of a transactional email by substituting
+ * known template tokens with realistic sample values. Used by the unified
+ * email management UI to display a per-card thumbnail.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Wizards\Newspack;
+
+use Newspack\Emails;
+use Newspack\Logger;
+use Newspack_Newsletters;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Email Preview Class.
+ */
+class Email_Preview {
+
+	/**
+	 * Get the rendered HTML for an email post, with sample token values substituted.
+	 *
+	 * Falls back to the registered template file's HTML when the post's saved
+	 * EMAIL_HTML_META is empty (i.e. the email has never been customized).
+	 *
+	 * @param int $post_id ID of the email post.
+	 *
+	 * @return string|false Rendered HTML, or false if the email can't be resolved.
+	 */
+	public static function get_preview_html( int $post_id ) {
+		if ( ! self::is_supported() ) {
+			return false;
+		}
+
+		$html = self::get_source_html( $post_id );
+		if ( empty( $html ) ) {
+			return false;
+		}
+
+		return self::apply_sample_substitutions( $html, $post_id );
+	}
+
+	/**
+	 * Get the source HTML for an email post.
+	 *
+	 * Reads the saved EMAIL_HTML_META first; falls back to the registered
+	 * template's default email_html when that meta is empty.
+	 *
+	 * @param int $post_id ID of the email post.
+	 *
+	 * @return string Source HTML, or empty string if unavailable.
+	 */
+	private static function get_source_html( int $post_id ): string {
+		$html = get_post_meta( $post_id, Newspack_Newsletters::EMAIL_HTML_META, true );
+		if ( ! empty( $html ) ) {
+			return $html;
+		}
+
+		// Fallback: look up the registered template for this post type and use its default HTML.
+		$type = get_post_meta( $post_id, Emails::EMAIL_CONFIG_NAME_META, true );
+		if ( empty( $type ) ) {
+			return '';
+		}
+
+		// Trigger the template load by requesting the email config. This is the
+		// same path Emails::get_email_config_by_type() uses; we just want the
+		// raw template HTML, which is available via reflection on the loaded config.
+		$configs = apply_filters( 'newspack_email_configs', [] );
+		if ( ! isset( $configs[ $type ], $configs[ $type ]['template'] ) ) {
+			return '';
+		}
+
+		$template_path = $configs[ $type ]['template'];
+		if ( ! is_readable( $template_path ) ) {
+			return '';
+		}
+
+		$template_data = include $template_path;
+		if ( ! is_array( $template_data ) || empty( $template_data['email_html'] ) ) {
+			return '';
+		}
+
+		return $template_data['email_html'];
+	}
+
+	/**
+	 * Apply sample-value substitutions to email HTML.
+	 *
+	 * Site/branding tokens use the publisher's real site config (so the preview
+	 * reflects their actual branding). Reader/transaction tokens use stable
+	 * fake values. Action URLs are replaced with anchor placeholders so
+	 * preview iframes don't trigger live navigation.
+	 *
+	 * @param string $html    Source HTML containing *TOKEN* placeholders.
+	 * @param int    $post_id The email post being previewed (passed to the filter).
+	 *
+	 * @return string HTML with tokens substituted.
+	 */
+	private static function apply_sample_substitutions( string $html, int $post_id = 0 ): string {
+		$substitutions = self::get_sample_substitutions();
+
+		/**
+		 * Filters the sample substitution map used for email previews.
+		 *
+		 * Allows plugins to inject sample values for custom tokens
+		 * (e.g. group-subscription invite tokens, future token additions).
+		 *
+		 * @param array $substitutions Map of `*TOKEN*` => sample value.
+		 * @param int   $post_id       The email post being previewed (0 if unknown).
+		 */
+		$substitutions = apply_filters( 'newspack_email_preview_substitutions', $substitutions, $post_id );
+
+		return strtr( $html, $substitutions );
+	}
+
+	/**
+	 * Get the substitution map of email-template tokens to sample values.
+	 *
+	 * @return array Map of `*TOKEN*` => sample value.
+	 */
+	public static function get_sample_substitutions(): array {
+		$site_logo_url   = wp_get_attachment_url( get_theme_mod( 'custom_logo' ) );
+		$site_title      = get_bloginfo( 'name' );
+		$site_url        = get_bloginfo( 'wpurl' );
+		$reply_to_email  = Emails::get_reply_to_email();
+		$site_address    = self::get_site_address();
+		$site_contact    = $site_address
+			? sprintf( '<strong>%s</strong> — %s', $site_title, $site_address )
+			: $site_title;
+
+		return [
+			// Site / branding — real values from the publisher's config.
+			'*SITE_TITLE*'             => $site_title,
+			'*SITE_URL*'               => $site_url,
+			'*SITE_LOGO*'              => $site_logo_url ? esc_url( $site_logo_url ) : '',
+			'*SITE_ADDRESS*'           => $site_address,
+			'*SITE_CONTACT*'           => $site_contact,
+			'*CONTACT_EMAIL*'          => sprintf( '<a href="%s">%s</a>', esc_url( 'mailto:' . $reply_to_email ), esc_html( $reply_to_email ) ),
+
+			// Reader identity — stable sample values.
+			'*BILLING_FIRST_NAME*'     => 'Sample',
+			'*BILLING_LAST_NAME*'      => 'Reader',
+			'*BILLING_NAME*'           => 'Sample Reader',
+			'*PENDING_EMAIL_ADDRESS*'  => 'sample.reader@example.com',
+
+			// Transaction / subscription details — stable sample values.
+			'*AMOUNT*'                 => '$25.00',
+			'*PAYMENT_METHOD*'         => 'Visa ending in 4242',
+			'*PRODUCT_NAME*'           => 'Monthly Membership',
+			'*BILLING_FREQUENCY*'      => 'monthly',
+			'*DATE*'                   => wp_date( get_option( 'date_format', 'F j, Y' ) ),
+			'*CANCELLATION_TITLE*'     => __( 'Subscription Cancelled', 'newspack-plugin' ),
+			'*CANCELLATION_TYPE*'      => __( 'subscription', 'newspack-plugin' ),
+
+			// Action URLs — anchors so preview clicks don't navigate.
+			'*ACCOUNT_URL*'            => '#',
+			'*CANCELLATION_URL*'       => '#',
+			'*EMAIL_CANCELLATION_URL*' => '#',
+			'*EMAIL_VERIFICATION_URL*' => '#',
+			'*VERIFICATION_URL*'       => '#',
+			'*RECEIPT_URL*'            => '#',
+			'*MAGIC_LINK_URL*'         => '#',
+			'*PASSWORD_RESET_LINK*'    => '#',
+			'*SET_PASSWORD_LINK*'      => '#',
+			'*DELETION_LINK*'          => '#',
+			'*WP_LOGIN_URL*'           => '#',
+
+			// OTP code — stable sample value.
+			'*MAGIC_LINK_OTP*'         => '123456',
+		];
+	}
+
+	/**
+	 * Get the site's store address as a formatted string.
+	 *
+	 * Mirrors the logic in Emails::get_email_payload() so the preview
+	 * shows the same address format the real email would use.
+	 *
+	 * @return string Formatted site address, or empty string.
+	 */
+	private static function get_site_address(): string {
+		if ( class_exists( 'WC' ) ) {
+			$base_address  = WC()->countries->get_base_address();
+			$base_city     = WC()->countries->get_base_city();
+			$base_postcode = WC()->countries->get_base_postcode();
+		} else {
+			$base_address  = get_option( 'woocommerce_store_address', '' );
+			$base_city     = get_option( 'woocommerce_store_city', '' );
+			$base_postcode = get_option( 'woocommerce_store_postcode', '' );
+		}
+
+		if ( ! $base_address ) {
+			return '';
+		}
+
+		if ( ! $base_city && ! $base_postcode ) {
+			return $base_address;
+		}
+
+		return sprintf(
+			/* translators: 1: street address, 2: city, 3: postcode. */
+			__( '%1$s, %2$s %3$s', 'newspack-plugin' ),
+			$base_address,
+			$base_city,
+			$base_postcode
+		);
+	}
+
+	/**
+	 * Get rendered preview HTML for a WooCommerce block-editor email template.
+	 *
+	 * Tries the block-editor render path first (BlockEmailRenderer) which
+	 * produces HTML styled with the site's theme.json colors and logo — the
+	 * same output the block email editor preview shows. Falls back to
+	 * EmailPreview::render() (legacy WC template with woocommerce_email_*
+	 * option colors) if the block path is unavailable or fails.
+	 *
+	 * @param int $post_id ID of the woo_email post.
+	 *
+	 * @return string|false Rendered HTML, or false if unavailable.
+	 */
+	private static function get_wc_preview_html( int $post_id ) {
+		$manager_class = 'Automattic\\WooCommerce\\Internal\\EmailEditor\\WCTransactionalEmails\\WCTransactionalEmailPostsManager';
+		$preview_class = 'Automattic\\WooCommerce\\Internal\\Admin\\EmailPreview\\EmailPreview';
+
+		if ( ! class_exists( $manager_class ) || ! class_exists( $preview_class ) ) {
+			return false;
+		}
+
+		// Reverse-lookup: post ID → email class name (e.g. 'WC_Email_New_Order').
+		$email_class_name = $manager_class::get_instance()->get_email_type_class_name_from_post_id( $post_id );
+		if ( empty( $email_class_name ) ) {
+			return false;
+		}
+
+		// Check transient cache (block render is ~180 ms per email).
+		$cache_key = self::get_wc_preview_cache_key( $post_id );
+		$cached    = get_transient( $cache_key );
+		if ( is_string( $cached ) && '' !== $cached ) {
+			return $cached;
+		}
+
+		// Set up the WC_Email with a dummy order/user so both render paths
+		// have realistic sample data to work with.
+		try {
+			$preview = $preview_class::instance();
+			$preview->set_email_type( $email_class_name );
+		} catch ( \Throwable $e ) {
+			return false;
+		}
+
+		// Try the block-editor render path (themed, with site logo + theme colors).
+		$block_html = self::try_block_render( $preview, $post_id, $email_class_name );
+		if ( ! empty( $block_html ) ) {
+			set_transient( $cache_key, $block_html, HOUR_IN_SECONDS );
+			return $block_html;
+		}
+
+		// Fallback: legacy render via EmailPreview (WC default styling).
+		try {
+			$html = $preview->render();
+			if ( ! empty( $html ) ) {
+				set_transient( $cache_key, $html, HOUR_IN_SECONDS );
+			}
+			return $html;
+		} catch ( \Throwable $e ) {
+			return false;
+		}
+	}
+
+	/**
+	 * Build the transient cache key for a WC email preview.
+	 *
+	 * Includes the post's modified date so the cache naturally misses
+	 * after an edit, even if the save_post hook fails to fire.
+	 *
+	 * @param int $post_id The woo_email post ID.
+	 * @return string Transient key (max 172 chars — within the 172-char limit).
+	 */
+	private static function get_wc_preview_cache_key( int $post_id ): string {
+		$post     = get_post( $post_id );
+		$modified = $post ? strtotime( $post->post_modified_gmt ) : 0;
+		return 'newspack_wc_email_preview_' . $post_id . '_' . $modified;
+	}
+
+	/**
+	 * Invalidate the WC email preview cache when a template post is saved.
+	 *
+	 * Hooked to `save_post_woo_email` so any edit in the block email editor
+	 * immediately clears the cached thumbnail.
+	 *
+	 * @param int $post_id The post ID being saved.
+	 */
+	public static function invalidate_wc_preview_cache( int $post_id ): void {
+		delete_transient( self::get_wc_preview_cache_key( $post_id ) );
+	}
+
+	/**
+	 * Attempt to render a WC email through the block-editor pipeline.
+	 *
+	 * Uses BlockEmailRenderer::maybe_render_block_email() which renders
+	 * through the email-editor package's Renderer — applying theme.json
+	 * global styles, CSS inlining, and personalization tag replacement.
+	 *
+	 * @param object $preview          WC EmailPreview instance (with email type already set).
+	 * @param int    $post_id          The woo_email post ID being previewed.
+	 * @param string $email_class_name The WC_Email class name (for logging).
+	 *
+	 * @return string|null Rendered HTML, or null if the block path is unavailable.
+	 */
+	private static function try_block_render( $preview, int $post_id, string $email_class_name ): ?string {
+		$renderer_class = 'Automattic\\WooCommerce\\Internal\\EmailEditor\\BlockEmailRenderer';
+
+		if ( ! class_exists( $renderer_class ) || ! function_exists( 'wc_get_container' ) ) {
+			Logger::log(
+				"BlockEmailRenderer not available for woo_email post $post_id ($email_class_name); using legacy preview.",
+				'NEWSPACK-EMAILS',
+				'warning'
+			);
+			return null;
+		}
+
+		try {
+			$preview->set_up_filters();
+			$renderer = wc_get_container()->get( $renderer_class );
+			$html     = $renderer->maybe_render_block_email( $preview->get_email() );
+			$preview->clean_up_filters();
+
+			if ( empty( $html ) ) {
+				Logger::log(
+					"BlockEmailRenderer returned empty for woo_email post $post_id ($email_class_name); using legacy preview.",
+					'NEWSPACK-EMAILS',
+					'warning'
+				);
+				return null;
+			}
+
+			return $html;
+		} catch ( \Throwable $e ) {
+			$preview->clean_up_filters();
+			Logger::log(
+				'BlockEmailRenderer threw ' . get_class( $e ) . " for woo_email post $post_id ($email_class_name): " . $e->getMessage() . '; using legacy preview.',
+				'NEWSPACK-EMAILS',
+				'warning'
+			);
+			return null;
+		}
+	}
+
+	/**
+	 * Is email preview supported on this install?
+	 *
+	 * Requires Newspack Newsletters (the same dependency that gates
+	 * email management in general).
+	 *
+	 * @return bool
+	 */
+	private static function is_supported(): bool {
+		return class_exists( 'Newspack_Newsletters' );
+	}
+
+	/**
+	 * Initialize the class. Hooked from class-newspack.php inclusion.
+	 *
+	 * @codeCoverageIgnore
+	 */
+	public static function init(): void {
+		add_action( 'rest_api_init', [ __CLASS__, 'register_rest_routes' ] );
+		add_action( 'save_post_woo_email', [ __CLASS__, 'invalidate_wc_preview_cache' ] );
+	}
+
+	/**
+	 * Register the email-preview REST endpoint.
+	 *
+	 * @codeCoverageIgnore
+	 */
+	public static function register_rest_routes(): void {
+		register_rest_route(
+			NEWSPACK_API_NAMESPACE,
+			'wizard/newspack-settings/emails/(?P<post_id>\d+)/preview',
+			[
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ __CLASS__, 'api_get_preview' ],
+				'permission_callback' => [ __CLASS__, 'api_permissions_check' ],
+				'args'                => [
+					'post_id' => [
+						'required'          => true,
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * REST handler: return preview HTML for an email post.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 *
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public static function api_get_preview( $request ) {
+		$post_id = (int) $request->get_param( 'post_id' );
+
+		$post = get_post( $post_id );
+		if ( ! $post ) {
+			return new \WP_Error(
+				'newspack_email_preview_not_found',
+				__( 'Email not found.', 'newspack-plugin' ),
+				[ 'status' => 404 ]
+			);
+		}
+
+		if ( 'woo_email' === $post->post_type ) {
+			$html = self::get_wc_preview_html( $post_id );
+		} elseif ( Emails::POST_TYPE === $post->post_type ) {
+			$html = self::get_preview_html( $post_id );
+		} else {
+			return new \WP_Error(
+				'newspack_email_preview_not_found',
+				__( 'Email not found.', 'newspack-plugin' ),
+				[ 'status' => 404 ]
+			);
+		}
+
+		if ( false === $html || empty( $html ) ) {
+			return new \WP_Error(
+				'newspack_email_preview_unavailable',
+				__( 'Email preview is unavailable.', 'newspack-plugin' ),
+				[ 'status' => 500 ]
+			);
+		}
+
+		return rest_ensure_response(
+			[
+				'html'    => $html,
+				'post_id' => $post_id,
+			]
+		);
+	}
+
+	/**
+	 * Permissions check for the preview endpoint. Mirrors other Newspack email endpoints.
+	 *
+	 * @codeCoverageIgnore
+	 * @return bool|\WP_Error
+	 */
+	public static function api_permissions_check() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return new \WP_Error(
+				'newspack_rest_forbidden',
+				esc_html__( 'You cannot use this resource.', 'newspack-plugin' ),
+				[ 'status' => 403 ]
+			);
+		}
+		return true;
+	}
+}
+
+
+Email_Preview::init();

--- a/includes/wizards/newspack/class-email-preview.php
+++ b/includes/wizards/newspack/class-email-preview.php
@@ -107,21 +107,35 @@ class Email_Preview {
 		/**
 		 * Filters the sample substitution map used for email previews.
 		 *
-		 * Allows plugins to inject sample values for custom tokens
-		 * (e.g. group-subscription invite tokens, future token additions).
+		 * The map is structured as three sub-arrays keyed by escaping context:
+		 * - 'html': Tokens rendered as visible text (escaped with esc_html()).
+		 * - 'url':  Tokens used in href/src attributes (escaped with esc_url()).
+		 * - 'raw':  Tokens containing pre-escaped HTML (not escaped again).
 		 *
-		 * @param array $substitutions Map of `*TOKEN*` => sample value.
+		 * @param array $substitutions Structured map of `*TOKEN*` => sample value.
 		 * @param int   $post_id       The email post being previewed (0 if unknown).
 		 */
 		$substitutions = apply_filters( 'newspack_email_preview_substitutions', $substitutions, $post_id );
 
-		return strtr( $html, $substitutions );
+		// Escape HTML-text tokens.
+		$html_map = array_map( 'esc_html', $substitutions['html'] );
+		// Escape URL tokens.
+		$url_map = array_map( 'esc_url', $substitutions['url'] );
+		// Raw tokens are already safe (contain pre-escaped markup).
+		$raw_map = $substitutions['raw'];
+
+		return strtr( $html, array_merge( $html_map, $url_map, $raw_map ) );
 	}
 
 	/**
 	 * Get the substitution map of email-template tokens to sample values.
 	 *
-	 * @return array Map of `*TOKEN*` => sample value.
+	 * Returns a three-key array grouped by escaping context:
+	 * - 'html': Tokens rendered as visible text (escaped with esc_html() at call site).
+	 * - 'url':  Tokens used in href/src attributes (escaped with esc_url() at call site).
+	 * - 'raw':  Tokens containing pre-escaped HTML markup (not escaped again).
+	 *
+	 * @return array{ html: array<string, string>, url: array<string, string>, raw: array<string, string> }
 	 */
 	public static function get_sample_substitutions(): array {
 		$site_logo_url   = wp_get_attachment_url( get_theme_mod( 'custom_logo' ) );
@@ -134,44 +148,59 @@ class Email_Preview {
 			: $site_title;
 
 		return [
-			// Site / branding — real values from the publisher's config.
-			'*SITE_TITLE*'             => $site_title,
-			'*SITE_URL*'               => $site_url,
-			'*SITE_LOGO*'              => $site_logo_url ? esc_url( $site_logo_url ) : '',
-			'*SITE_ADDRESS*'           => $site_address,
-			'*SITE_CONTACT*'           => $site_contact,
-			'*CONTACT_EMAIL*'          => sprintf( '<a href="%s">%s</a>', esc_url( 'mailto:' . $reply_to_email ), esc_html( $reply_to_email ) ),
+			// Tokens rendered as visible text inside HTML — escaped with esc_html().
+			'html' => [
+				// Site / branding — real values from the publisher's config.
+				'*SITE_TITLE*'            => $site_title,
+				'*SITE_ADDRESS*'          => $site_address,
 
-			// Reader identity — stable sample values.
-			'*BILLING_FIRST_NAME*'     => 'Sample',
-			'*BILLING_LAST_NAME*'      => 'Reader',
-			'*BILLING_NAME*'           => 'Sample Reader',
-			'*PENDING_EMAIL_ADDRESS*'  => 'sample.reader@example.com',
+				// Reader identity — stable sample values.
+				'*BILLING_FIRST_NAME*'    => __( 'Sample', 'newspack-plugin' ),
+				'*BILLING_LAST_NAME*'     => __( 'Reader', 'newspack-plugin' ),
+				'*BILLING_NAME*'          => __( 'Sample Reader', 'newspack-plugin' ),
+				'*PENDING_EMAIL_ADDRESS*' => 'sample.reader@example.com',
 
-			// Transaction / subscription details — stable sample values.
-			'*AMOUNT*'                 => '$25.00',
-			'*PAYMENT_METHOD*'         => 'Visa ending in 4242',
-			'*PRODUCT_NAME*'           => 'Monthly Membership',
-			'*BILLING_FREQUENCY*'      => 'monthly',
-			'*DATE*'                   => wp_date( get_option( 'date_format', 'F j, Y' ) ),
-			'*CANCELLATION_TITLE*'     => __( 'Subscription Cancelled', 'newspack-plugin' ),
-			'*CANCELLATION_TYPE*'      => __( 'subscription', 'newspack-plugin' ),
+				// Transaction / subscription details.
+				'*AMOUNT*'                => '$25.00',
+				'*PAYMENT_METHOD*'        => __( 'Visa ending in 4242', 'newspack-plugin' ),
+				'*PRODUCT_NAME*'          => __( 'Monthly Membership', 'newspack-plugin' ),
+				'*BILLING_FREQUENCY*'     => __( 'monthly', 'newspack-plugin' ),
+				'*DATE*'                  => wp_date( get_option( 'date_format', 'F j, Y' ) ),
+				'*CANCELLATION_TITLE*'    => __( 'Subscription Cancelled', 'newspack-plugin' ),
+				'*CANCELLATION_TYPE*'     => __( 'subscription', 'newspack-plugin' ),
 
-			// Action URLs — anchors so preview clicks don't navigate.
-			'*ACCOUNT_URL*'            => '#',
-			'*CANCELLATION_URL*'       => '#',
-			'*EMAIL_CANCELLATION_URL*' => '#',
-			'*EMAIL_VERIFICATION_URL*' => '#',
-			'*VERIFICATION_URL*'       => '#',
-			'*RECEIPT_URL*'            => '#',
-			'*MAGIC_LINK_URL*'         => '#',
-			'*PASSWORD_RESET_LINK*'    => '#',
-			'*SET_PASSWORD_LINK*'      => '#',
-			'*DELETION_LINK*'          => '#',
-			'*WP_LOGIN_URL*'           => '#',
+				// Card expiry warning details.
+				'*CARD_LAST_4*'           => '4242',
+				'*EXPIRY_DATE*'           => '12/2026',
+				'*RENEWAL_DATE*'          => wp_date( get_option( 'date_format', 'F j, Y' ), strtotime( '+1 year' ) ),
 
-			// OTP code — stable sample value.
-			'*MAGIC_LINK_OTP*'         => '123456',
+				// OTP code — stable sample value.
+				'*MAGIC_LINK_OTP*'        => '123456',
+			],
+
+			// Tokens used in href/src attributes — escaped with esc_url().
+			'url'  => [
+				'*SITE_URL*'               => $site_url,
+				'*SITE_LOGO*'              => $site_logo_url ? $site_logo_url : '',
+				'*ACCOUNT_URL*'            => '#',
+				'*CANCELLATION_URL*'       => '#',
+				'*EMAIL_CANCELLATION_URL*' => '#',
+				'*EMAIL_VERIFICATION_URL*' => '#',
+				'*VERIFICATION_URL*'       => '#',
+				'*RECEIPT_URL*'            => '#',
+				'*MAGIC_LINK_URL*'         => '#',
+				'*PASSWORD_RESET_LINK*'    => '#',
+				'*SET_PASSWORD_LINK*'      => '#',
+				'*DELETION_LINK*'          => '#',
+				'*WP_LOGIN_URL*'           => '#',
+				'*UPDATE_PAYMENT_URL*'     => '#',
+			],
+
+			// Tokens containing pre-escaped HTML — NOT escaped again.
+			'raw'  => [
+				'*CONTACT_EMAIL*' => sprintf( '<a href="%s">%s</a>', esc_url( 'mailto:' . $reply_to_email ), esc_html( $reply_to_email ) ),
+				'*SITE_CONTACT*'  => $site_contact,
+			],
 		];
 	}
 

--- a/includes/wizards/newspack/class-email-preview.php
+++ b/includes/wizards/newspack/class-email-preview.php
@@ -277,7 +277,8 @@ class Email_Preview {
 	 * Build the transient cache key for a WC email preview.
 	 *
 	 * Includes the post's modified date so the cache naturally misses
-	 * after an edit, even if the save_post hook fails to fire.
+	 * after an edit — this is the sole invalidation mechanism. Old
+	 * transients expire via TTL.
 	 *
 	 * @param int $post_id The woo_email post ID.
 	 * @return string Transient key (max 172 chars — within the 172-char limit).
@@ -286,18 +287,6 @@ class Email_Preview {
 		$post     = get_post( $post_id );
 		$modified = $post ? strtotime( $post->post_modified_gmt ) : 0;
 		return 'newspack_wc_email_preview_' . $post_id . '_' . $modified;
-	}
-
-	/**
-	 * Invalidate the WC email preview cache when a template post is saved.
-	 *
-	 * Hooked to `save_post_woo_email` so any edit in the block email editor
-	 * immediately clears the cached thumbnail.
-	 *
-	 * @param int $post_id The post ID being saved.
-	 */
-	public static function invalidate_wc_preview_cache( int $post_id ): void {
-		delete_transient( self::get_wc_preview_cache_key( $post_id ) );
 	}
 
 	/**
@@ -371,7 +360,6 @@ class Email_Preview {
 	 */
 	public static function init(): void {
 		add_action( 'rest_api_init', [ __CLASS__, 'register_rest_routes' ] );
-		add_action( 'save_post_woo_email', [ __CLASS__, 'invalidate_wc_preview_cache' ] );
 	}
 
 	/**

--- a/includes/wizards/newspack/class-email-preview.php
+++ b/includes/wizards/newspack/class-email-preview.php
@@ -67,9 +67,8 @@ class Email_Preview {
 			return '';
 		}
 
-		// Trigger the template load by requesting the email config. This is the
-		// same path Emails::get_email_config_by_type() uses; we just want the
-		// raw template HTML, which is available via reflection on the loaded config.
+		// Look up the registered template and include it to get the default HTML.
+		// The template file returns an array with an 'email_html' key.
 		$configs = apply_filters( 'newspack_email_configs', [] );
 		if ( ! isset( $configs[ $type ], $configs[ $type ]['template'] ) ) {
 			return '';
@@ -116,6 +115,17 @@ class Email_Preview {
 		 * @param int   $post_id       The email post being previewed (0 if unknown).
 		 */
 		$substitutions = apply_filters( 'newspack_email_preview_substitutions', $substitutions, $post_id );
+
+		// Validate the filtered value — fall back to defaults if a filter broke the structure.
+		if (
+			! is_array( $substitutions )
+			|| ! isset( $substitutions['html'], $substitutions['url'], $substitutions['raw'] )
+			|| ! is_array( $substitutions['html'] )
+			|| ! is_array( $substitutions['url'] )
+			|| ! is_array( $substitutions['raw'] )
+		) {
+			$substitutions = self::get_sample_substitutions();
+		}
 
 		// Escape HTML-text tokens.
 		$html_map = array_map( 'esc_html', $substitutions['html'] );

--- a/includes/wizards/newspack/class-emails-section.php
+++ b/includes/wizards/newspack/class-emails-section.php
@@ -593,7 +593,11 @@ class Emails_Section extends Wizard_Section {
 		$enabled     = $request->get_param( 'enabled' );
 
 		if ( ! class_exists( 'WooCommerce' ) ) {
-			return new \WP_Error( 'not_found', 'WooCommerce is not active.', [ 'status' => 404 ] );
+			return new \WP_Error(
+				'newspack_wc_not_active',
+				__( 'WooCommerce is not active.', 'newspack-plugin' ),
+				[ 'status' => 404 ]
+			);
 		}
 
 		// Only allow toggling IDs that exist in our registry.
@@ -603,7 +607,11 @@ class Emails_Section extends Wizard_Section {
 			'woo_email_id'
 		);
 		if ( ! in_array( $wc_email_id, $allowed_wc_ids, true ) ) {
-			return new \WP_Error( 'not_found', 'WC email not found in registry.', [ 'status' => 404 ] );
+			return new \WP_Error(
+				'newspack_wc_email_not_in_registry',
+				__( 'WC email not found in registry.', 'newspack-plugin' ),
+				[ 'status' => 404 ]
+			);
 		}
 
 		$wc_mailer_emails = \WC()->mailer()->get_emails();
@@ -616,7 +624,11 @@ class Emails_Section extends Wizard_Section {
 		}
 
 		if ( ! $wc_email ) {
-			return new \WP_Error( 'not_found', 'WC email not found.', [ 'status' => 404 ] );
+			return new \WP_Error(
+				'newspack_wc_email_not_found',
+				__( 'WC email not found.', 'newspack-plugin' ),
+				[ 'status' => 404 ]
+			);
 		}
 
 		$option_key = $wc_email->get_option_key();

--- a/includes/wizards/newspack/class-emails-section.php
+++ b/includes/wizards/newspack/class-emails-section.php
@@ -368,11 +368,11 @@ class Emails_Section extends Wizard_Section {
 		}
 
 		// First-run: enable recommended WC emails by default.
-		// Runs on this GET handler for simplicity — guarded by a one-shot option
-		// flag so it only fires once, and the enable logic is idempotent.
-		if ( class_exists( 'WooCommerce' ) && ! get_option( 'newspack_unified_emails_wc_first_run', false ) ) {
+		// Runs on this GET handler for simplicity — the enable logic is idempotent
+		// and tracks which emails have been processed so newly-available plugins
+		// (e.g. WC Subs activated later) get their emails enabled too.
+		if ( class_exists( 'WooCommerce' ) ) {
 			self::first_run_enable_wc_emails( $registry );
-			update_option( 'newspack_unified_emails_wc_first_run', true, false );
 		}
 
 		// Resolve woocommerce-source registry entries to live WC_Email instances.
@@ -404,13 +404,19 @@ class Emails_Section extends Wizard_Section {
 					Logger::log( "WC email '$wc_email_id' not found for registry '$slug'.", 'NEWSPACK-EMAILS', 'warning' );
 					continue;
 				}
-				$preview_post_id   = self::get_wc_email_template_post_id( $wc_email_id );
+				$preview_post_id = self::get_wc_email_template_post_id( $wc_email_id );
+				// Read enabled state from the option rather than the in-memory
+				// WC_Email::$enabled property, which can be stale after first-run
+				// or toggle updates within the same request.
+				$option_key = $wc_email->get_option_key();
+				$wc_options = (array) get_option( $option_key, [] );
+				$is_enabled = isset( $wc_options['enabled'] ) ? 'yes' === $wc_options['enabled'] : 'yes' === $wc_email->enabled;
 				$newspack_emails[] = [
 					'label'               => $entry['label'],
 					'post_id'             => 'wc:' . $wc_email_id,
 					'preview_post_id'     => $preview_post_id,
 					'edit_link'           => self::get_wc_email_edit_link( $wc_email_id, $wc_email_class ),
-					'status'              => 'yes' === $wc_email->enabled ? 'publish' : 'draft',
+					'status'              => $is_enabled ? 'publish' : 'draft',
 					'type'                => $wc_email_id,
 					'category'            => 'woocommerce',
 					'trigger_description' => $entry['trigger_description'],
@@ -516,8 +522,10 @@ class Emails_Section extends Wizard_Section {
 	/**
 	 * Enable all recommended WC emails on first run.
 	 *
-	 * Called once so that registry WC emails default to enabled when the
-	 * unified emails UI is first loaded.
+	 * Called so that recommended WC emails default to enabled when the
+	 * unified emails UI is first loaded. Tracks which emails have been
+	 * processed so that newly-available plugins (e.g. WC Subscriptions
+	 * activated after the initial visit) still get their emails enabled.
 	 *
 	 * @param array $registry The email registry.
 	 */
@@ -525,9 +533,15 @@ class Emails_Section extends Wizard_Section {
 		if ( ! class_exists( 'WooCommerce' ) ) {
 			return;
 		}
+		$processed = (array) get_option( 'newspack_unified_emails_wc_first_run', [] );
 		$wc_mailer_emails = \WC()->mailer()->get_emails();
-		foreach ( $registry as $entry ) {
+		$changed = false;
+		foreach ( $registry as $slug => $entry ) {
 			if ( 'woocommerce' !== $entry['source'] || empty( $entry['recommended'] ) ) {
+				continue;
+			}
+			// Already processed this entry.
+			if ( in_array( $slug, $processed, true ) ) {
 				continue;
 			}
 			// Plugin dependency check.
@@ -560,6 +574,11 @@ class Emails_Section extends Wizard_Section {
 					update_option( 'woocommerce_subscriptions_customer_notifications_enabled', 'yes' );
 				}
 			}
+			$processed[] = $slug;
+			$changed     = true;
+		}
+		if ( $changed ) {
+			update_option( 'newspack_unified_emails_wc_first_run', $processed, false );
 		}
 	}
 

--- a/includes/wizards/newspack/class-emails-section.php
+++ b/includes/wizards/newspack/class-emails-section.php
@@ -404,7 +404,7 @@ class Emails_Section extends Wizard_Section {
 					Logger::log( "WC email '$wc_email_id' not found for registry '$slug'.", 'NEWSPACK-EMAILS', 'warning' );
 					continue;
 				}
-				$preview_post_id   = self::get_wc_email_preview_post_id( $wc_email_id );
+				$preview_post_id   = self::get_wc_email_template_post_id( $wc_email_id );
 				$newspack_emails[] = [
 					'label'               => $entry['label'],
 					'post_id'             => 'wc:' . $wc_email_id,
@@ -452,6 +452,33 @@ class Emails_Section extends Wizard_Section {
 	}
 
 	/**
+	 * Get the WC block-editor template post ID for a given email, if available.
+	 *
+	 * Checks whether the WC block email editor feature is enabled and
+	 * whether a woo_email template post exists for the given email ID.
+	 *
+	 * @param string $wc_email_id The WC_Email ID (e.g. 'new_order').
+	 * @return int|null Template post ID, or null.
+	 */
+	private static function get_wc_email_template_post_id( string $wc_email_id ): ?int {
+		if ( 'yes' !== get_option( 'woocommerce_feature_block_email_editor_enabled' ) ) {
+			return null;
+		}
+
+		$posts_manager_class = 'Automattic\\WooCommerce\\Internal\\EmailEditor\\WCTransactionalEmails\\WCTransactionalEmailPostsManager';
+		if ( ! class_exists( $posts_manager_class ) ) {
+			return null;
+		}
+
+		$template_post_id = $posts_manager_class::get_instance()->get_email_template_post_id( $wc_email_id );
+		if ( empty( $template_post_id ) ) {
+			return null;
+		}
+
+		return (int) $template_post_id;
+	}
+
+	/**
 	 * Build the edit link for a WooCommerce email.
 	 *
 	 * When the WC block email editor is enabled and a template post exists
@@ -472,19 +499,8 @@ class Emails_Section extends Wizard_Section {
 			admin_url( 'admin.php' )
 		);
 
-		// Check if the WC block email editor is enabled.
-		if ( 'yes' !== get_option( 'woocommerce_feature_block_email_editor_enabled' ) ) {
-			return $classic_url;
-		}
-
-		// Look up the template post for this email.
-		$posts_manager_class = 'Automattic\\WooCommerce\\Internal\\EmailEditor\\WCTransactionalEmails\\WCTransactionalEmailPostsManager';
-		if ( ! class_exists( $posts_manager_class ) ) {
-			return $classic_url;
-		}
-
-		$template_post_id = $posts_manager_class::get_instance()->get_email_template_post_id( $wc_email_id );
-		if ( empty( $template_post_id ) ) {
+		$template_post_id = self::get_wc_email_template_post_id( $wc_email_id );
+		if ( ! $template_post_id ) {
 			return $classic_url;
 		}
 
@@ -495,34 +511,6 @@ class Emails_Section extends Wizard_Section {
 			],
 			admin_url( 'post.php' )
 		);
-	}
-
-	/**
-	 * Get the block-editor template post ID for a WC email, if available.
-	 *
-	 * Returns the post ID of the woo_email post that backs this email in
-	 * the WC block email editor. Returns null when the block editor is
-	 * disabled or the email has no template post.
-	 *
-	 * @param string $wc_email_id The WC_Email ID (e.g. 'new_order').
-	 * @return int|null Template post ID, or null.
-	 */
-	private static function get_wc_email_preview_post_id( string $wc_email_id ): ?int {
-		if ( 'yes' !== get_option( 'woocommerce_feature_block_email_editor_enabled' ) ) {
-			return null;
-		}
-
-		$posts_manager_class = 'Automattic\\WooCommerce\\Internal\\EmailEditor\\WCTransactionalEmails\\WCTransactionalEmailPostsManager';
-		if ( ! class_exists( $posts_manager_class ) ) {
-			return null;
-		}
-
-		$template_post_id = $posts_manager_class::get_instance()->get_email_template_post_id( $wc_email_id );
-		if ( empty( $template_post_id ) ) {
-			return null;
-		}
-
-		return (int) $template_post_id;
 	}
 
 	/**

--- a/includes/wizards/newspack/class-emails-section.php
+++ b/includes/wizards/newspack/class-emails-section.php
@@ -8,6 +8,7 @@
 namespace Newspack\Wizards\Newspack;
 
 use Newspack\Emails;
+use Newspack\Logger;
 use Newspack\Reader_Activation;
 use Newspack\Reader_Revenue_Emails;
 use Newspack\Wizards\Wizard_Section;
@@ -58,6 +59,29 @@ class Emails_Section extends Wizard_Section {
 				]
 			);
 		}
+		if ( class_exists( 'WooCommerce' ) ) {
+			register_rest_route(
+				NEWSPACK_API_NAMESPACE,
+				'wizard/' . $this->wizard_slug . '/emails/(?P<id>[A-Za-z0-9_]+)/toggle',
+				[
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => [ __CLASS__, 'api_toggle_wc_email' ],
+					'permission_callback' => [ $this, 'api_permissions_check' ],
+					'args'                => [
+						'id'      => [
+							'type'              => 'string',
+							'required'          => true,
+							'sanitize_callback' => 'sanitize_text_field',
+						],
+						'enabled' => [
+							'type'              => 'boolean',
+							'required'          => true,
+							'sanitize_callback' => 'rest_sanitize_boolean',
+						],
+					],
+				]
+			);
+		}
 	}
 
 	/**
@@ -70,214 +94,214 @@ class Emails_Section extends Wizard_Section {
 	 */
 	public static function get_email_registry(): array {
 		$registry = [
-			'verification'                  => [
+			'verification'                     => [
 				'source'              => 'newspack',
 				'newspack_type'       => 'reader-activation-verification',
 				'recommended'         => true,
 				'plugin_dependency'   => null,
 				'recipient'           => 'reader',
+				'chip'                => 'auth-account',
 				'label'               => __( 'Reader verification', 'newspack-plugin' ),
 				'trigger_description' => __( 'Sent when a reader needs to verify their email address.', 'newspack-plugin' ),
 			],
-			'login-link'                    => [
+			'login-link'                       => [
 				'source'              => 'newspack',
 				'newspack_type'       => 'reader-activation-magic-link',
 				'recommended'         => true,
 				'plugin_dependency'   => null,
 				'recipient'           => 'reader',
+				'chip'                => 'auth-account',
 				'label'               => __( 'Magic login link', 'newspack-plugin' ),
 				'trigger_description' => __( 'Sent when a reader requests a magic login link.', 'newspack-plugin' ),
 			],
-			'login-otp'                     => [
+			'login-otp'                        => [
 				'source'              => 'newspack',
 				'newspack_type'       => 'reader-activation-otp-authentication',
 				'recommended'         => true,
 				'plugin_dependency'   => null,
 				'recipient'           => 'reader',
+				'chip'                => 'auth-account',
 				'label'               => __( 'Login one-time password', 'newspack-plugin' ),
 				'trigger_description' => __( 'Sent when a reader logs in with a one-time password.', 'newspack-plugin' ),
 			],
-			'set-new-password'              => [
+			'set-new-password'                 => [
 				'source'              => 'newspack',
 				'newspack_type'       => 'reader-activation-reset-password',
 				'recommended'         => true,
 				'plugin_dependency'   => null,
 				'recipient'           => 'reader',
+				'chip'                => 'auth-account',
 				'label'               => __( 'Password reset', 'newspack-plugin' ),
 				'trigger_description' => __( 'Sent when a reader requests a password reset.', 'newspack-plugin' ),
 			],
-			'receipt'                       => [
+			'receipt'                          => [
 				'source'              => 'newspack',
 				'newspack_type'       => 'receipt',
 				'recommended'         => true,
 				'plugin_dependency'   => null,
 				'recipient'           => 'reader',
+				'chip'                => 'reader-revenue',
 				'label'               => __( 'Payment receipt', 'newspack-plugin' ),
 				'trigger_description' => __( 'Sent after a successful payment.', 'newspack-plugin' ),
 			],
-			'welcome'                       => [
+			'welcome'                          => [
 				'source'              => 'newspack',
 				'newspack_type'       => 'welcome',
 				'recommended'         => true,
 				'plugin_dependency'   => null,
 				'recipient'           => 'reader',
+				'chip'                => 'reader-revenue',
 				'label'               => __( 'Welcome email', 'newspack-plugin' ),
 				'trigger_description' => __( 'Sent to new supporters after their first payment.', 'newspack-plugin' ),
 			],
-			'cancellation'                  => [
+			'cancellation'                     => [
 				'source'              => 'newspack',
 				'newspack_type'       => 'cancellation',
 				'recommended'         => true,
 				'plugin_dependency'   => null,
 				'recipient'           => 'reader',
+				'chip'                => 'reader-revenue',
 				'label'               => __( 'Cancellation confirmation', 'newspack-plugin' ),
 				'trigger_description' => __( 'Sent when a reader cancels their subscription.', 'newspack-plugin' ),
 			],
-			'woo-renewal-reminder'          => [
+			'woo-renewal-reminder'             => [
 				'source'              => 'woocommerce',
-				'woo_email_id'        => 'customer_renewal_invoice',
+				'woo_email_id'        => 'customer_notification_auto_renewal',
 				'recommended'         => true,
 				'plugin_dependency'   => 'woocommerce-subscriptions',
 				'recipient'           => 'reader',
-				'label'               => __( 'Subscription renewal invoice', 'newspack-plugin' ),
-				'trigger_description' => __( 'Sent to remind a customer that a renewal payment is due.', 'newspack-plugin' ),
+				'chip'                => 'reader-revenue',
+				'label'               => __( 'Renewal reminder', 'newspack-plugin' ),
+				'trigger_description' => __( 'Sent 3 days before automatic renewal.', 'newspack-plugin' ),
 			],
-			'woo-payment-retry'             => [
+			'woo-payment-retry'                => [
 				'source'              => 'woocommerce',
 				'woo_email_id'        => 'customer_payment_retry',
 				'recommended'         => true,
 				'plugin_dependency'   => 'woocommerce-subscriptions',
 				'recipient'           => 'reader',
-				'label'               => __( 'Subscription payment retry', 'newspack-plugin' ),
-				'trigger_description' => __( 'Sent when a failed subscription payment is about to be retried.', 'newspack-plugin' ),
+				'chip'                => 'reader-revenue',
+				'label'               => __( 'Failed order retry', 'newspack-plugin' ),
+				'trigger_description' => __( 'Sent when a renewal payment fails, before the retry attempt.', 'newspack-plugin' ),
 			],
-			'woo-subscription-cancelled'    => [
-				'source'              => 'woocommerce',
-				'woo_email_id'        => 'cancelled_subscription',
-				'recommended'         => true,
-				'plugin_dependency'   => 'woocommerce-subscriptions',
-				'recipient'           => 'reader',
-				'label'               => __( 'Subscription cancelled', 'newspack-plugin' ),
-				'trigger_description' => __( 'Sent when a subscription is cancelled.', 'newspack-plugin' ),
-			],
-			'woo-expired-subscription'      => [
+			'woo-expired-subscription'         => [
 				'source'              => 'woocommerce',
 				'woo_email_id'        => 'expired_subscription',
 				'recommended'         => true,
 				'plugin_dependency'   => 'woocommerce-subscriptions',
 				'recipient'           => 'reader',
+				'chip'                => 'reader-revenue',
 				'label'               => __( 'Subscription expired', 'newspack-plugin' ),
 				'trigger_description' => __( 'Sent when a subscription reaches its expiration date.', 'newspack-plugin' ),
 			],
-			'woo-customer-new-account'      => [
+			'woo-subscription-switch-complete' => [
+				'source'              => 'woocommerce',
+				'woo_email_id'        => 'customer_completed_switch_order',
+				'recommended'         => true,
+				'plugin_dependency'   => 'woocommerce-subscriptions',
+				'recipient'           => 'reader',
+				'chip'                => 'reader-revenue',
+				'label'               => __( 'Subscription switch complete', 'newspack-plugin' ),
+				'trigger_description' => __( 'Sent when a reader switches their subscription.', 'newspack-plugin' ),
+			],
+			'woo-new-giftee-account'           => [
+				'source'              => 'woocommerce',
+				'woo_email_id'        => 'WCSG_Email_Customer_New_Account',
+				'recommended'         => true,
+				'plugin_dependency'   => 'woocommerce-subscriptions',
+				'recipient'           => 'reader',
+				'chip'                => 'reader-revenue',
+				'label'               => __( 'New giftee account', 'newspack-plugin' ),
+				'trigger_description' => __( 'Sent to the giftee when a gift subscription creates their account.', 'newspack-plugin' ),
+			],
+			'woo-new-gift-order'               => [
+				'source'              => 'woocommerce',
+				'woo_email_id'        => 'recipient_completed_order',
+				'recommended'         => true,
+				'plugin_dependency'   => 'woocommerce-subscriptions',
+				'recipient'           => 'reader',
+				'chip'                => 'reader-revenue',
+				'label'               => __( 'New gift order', 'newspack-plugin' ),
+				'trigger_description' => __( 'Sent to the giftee to notify them of a gift subscription.', 'newspack-plugin' ),
+			],
+			'woo-customer-new-account'         => [
 				'source'              => 'woocommerce',
 				'woo_email_id'        => 'customer_new_account',
 				'recommended'         => true,
 				'plugin_dependency'   => null,
 				'recipient'           => 'reader',
+				'chip'                => 'auth-account',
 				'label'               => __( 'New account', 'newspack-plugin' ),
 				'trigger_description' => __( 'Sent when a customer creates a new account.', 'newspack-plugin' ),
 			],
-			'woo-password-reset'            => [
-				'source'              => 'woocommerce',
-				'woo_email_id'        => 'customer_reset_password',
-				'recommended'         => true,
-				'plugin_dependency'   => null,
-				'recipient'           => 'reader',
-				'label'               => __( 'Password reset (WooCommerce)', 'newspack-plugin' ),
-				'trigger_description' => __( 'Sent when a customer resets their password via WooCommerce.', 'newspack-plugin' ),
-			],
-			'delete-account'                => [
+			'delete-account'                   => [
 				'source'              => 'newspack',
 				'newspack_type'       => 'reader-activation-delete-account',
 				'recommended'         => false,
 				'plugin_dependency'   => null,
 				'recipient'           => 'reader',
+				'chip'                => 'auth-account',
 				'label'               => __( 'Account deletion', 'newspack-plugin' ),
 				'trigger_description' => __( 'Sent when a reader requests to delete their account.', 'newspack-plugin' ),
 			],
-			'change-email-notification'     => [
+			'change-email-notification'        => [
 				'source'              => 'newspack',
 				'newspack_type'       => 'reader-activation-change-email-cancel',
 				'recommended'         => false,
 				'plugin_dependency'   => null,
 				'recipient'           => 'reader',
+				'chip'                => 'auth-account',
 				'label'               => __( 'Email change notification', 'newspack-plugin' ),
 				'trigger_description' => __( 'Sent to the old address when a reader changes their email.', 'newspack-plugin' ),
 			],
-			'change-email-confirmation'     => [
+			'change-email-confirmation'        => [
 				'source'              => 'newspack',
 				'newspack_type'       => 'reader-activation-change-email',
 				'recommended'         => false,
 				'plugin_dependency'   => null,
 				'recipient'           => 'reader',
+				'chip'                => 'auth-account',
 				'label'               => __( 'Email change confirmation', 'newspack-plugin' ),
 				'trigger_description' => __( 'Sent to the new address to confirm an email change.', 'newspack-plugin' ),
 			],
-			'non-reader-login-reminder'     => [
+			'non-reader-login-reminder'        => [
 				'source'              => 'newspack',
 				'newspack_type'       => 'reader-activation-non-reader-user',
 				'recommended'         => false,
 				'plugin_dependency'   => null,
 				'recipient'           => 'reader',
+				'chip'                => 'auth-account',
 				'label'               => __( 'Non-reader login reminder', 'newspack-plugin' ),
 				'trigger_description' => __( 'Sent when a non-reader WordPress user tries to log in as a reader.', 'newspack-plugin' ),
 			],
-			'group-subscription-invitation' => [
+			'group-subscription-invitation'    => [
 				'source'              => 'newspack',
 				'newspack_type'       => 'group-subscription-invite',
 				'recommended'         => false,
 				'plugin_dependency'   => null,
 				'recipient'           => 'reader',
+				'chip'                => 'reader-revenue',
 				'label'               => __( 'Group subscription invitation', 'newspack-plugin' ),
 				'trigger_description' => __( 'Sent to invite a reader to join a group subscription.', 'newspack-plugin' ),
 			],
-			'woo-refund'                    => [
+			'woo-refund'                       => [
 				'source'              => 'woocommerce',
 				'woo_email_id'        => 'customer_refunded_order',
 				'recommended'         => false,
 				'plugin_dependency'   => null,
 				'recipient'           => 'reader',
+				'chip'                => 'reader-revenue',
 				'label'               => __( 'Order refund', 'newspack-plugin' ),
 				'trigger_description' => __( 'Sent when an order is refunded.', 'newspack-plugin' ),
 			],
-			// The following three WooCommerce emails are customer-facing but marked
-			// recommended=false because they are lower customization priority for
-			// subscription-focused publishers.
-			'woo-processing-order'          => [
-				'source'              => 'woocommerce',
-				'woo_email_id'        => 'customer_processing_order',
-				'recommended'         => false,
-				'plugin_dependency'   => null,
-				'recipient'           => 'reader',
-				'label'               => __( 'Order processing', 'newspack-plugin' ),
-				'trigger_description' => __( 'Sent when an order payment is received and the order begins processing.', 'newspack-plugin' ),
-			],
-			'woo-completed-order'           => [
-				'source'              => 'woocommerce',
-				'woo_email_id'        => 'customer_completed_order',
-				'recommended'         => false,
-				'plugin_dependency'   => null,
-				'recipient'           => 'reader',
-				'label'               => __( 'Order complete', 'newspack-plugin' ),
-				'trigger_description' => __( 'Sent when an order is marked as complete.', 'newspack-plugin' ),
-			],
-			'woo-on-hold-order'             => [
-				'source'              => 'woocommerce',
-				'woo_email_id'        => 'customer_on_hold_order',
-				'recommended'         => false,
-				'plugin_dependency'   => null,
-				'recipient'           => 'reader',
-				'label'               => __( 'Order on hold', 'newspack-plugin' ),
-				'trigger_description' => __( 'Sent when an order is placed on hold.', 'newspack-plugin' ),
-			],
-			'woo-new-order'                 => [
+			'woo-new-order'                    => [
 				'source'              => 'woocommerce',
 				'woo_email_id'        => 'new_order',
 				'recommended'         => false,
 				'plugin_dependency'   => null,
 				'recipient'           => 'admin',
-				'label'               => __( 'New order (admin)', 'newspack-plugin' ),
+				'chip'                => 'reader-revenue',
+				'label'               => __( 'New order', 'newspack-plugin' ),
 				'trigger_description' => __( 'Sent to the admin when a new order is placed.', 'newspack-plugin' ),
 			],
 		];
@@ -331,14 +355,69 @@ class Emails_Section extends Wizard_Section {
 				$email['registry_slug']       = $match['registry_slug'];
 				$email['recipient']           = $match['recipient'];
 				$email['source']              = $match['source'];
+				$email['chip']                = $match['chip'];
 			} else {
 				$email['recommended']         = false;
 				$email['trigger_description'] = '';
 				$email['registry_slug']       = '';
 				$email['recipient']           = 'reader';
 				$email['source']              = 'newspack'; // Default; WooCommerce emails always match above.
+				$email['chip']                = '';
 			}
 			$newspack_emails[] = $email;
+		}
+
+		// First-run: enable all registry WC emails by default.
+		if ( class_exists( 'WooCommerce' ) && ! get_option( 'newspack_unified_emails_wc_first_run', false ) ) {
+			self::first_run_enable_wc_emails( $registry );
+			update_option( 'newspack_unified_emails_wc_first_run', true, false );
+		}
+
+		// Resolve woocommerce-source registry entries to live WC_Email instances.
+		if ( class_exists( 'WooCommerce' ) ) {
+			$wc_mailer_emails = \WC()->mailer()->get_emails();
+			foreach ( $registry as $slug => $entry ) {
+				if ( 'woocommerce' !== $entry['source'] ) {
+					continue;
+				}
+				// Plugin dependency check.
+				if ( ! empty( $entry['plugin_dependency'] ) ) {
+					$plugin_file = $entry['plugin_dependency'] . '/' . $entry['plugin_dependency'] . '.php';
+					if ( ! \Newspack\is_plugin_active( $plugin_file ) ) {
+						continue;
+					}
+				}
+				$wc_email_id = $entry['woo_email_id'];
+				// WC stores emails keyed by class name. Find the instance by matching $id.
+				$wc_email       = null;
+				$wc_email_class = null;
+				foreach ( $wc_mailer_emails as $class_name => $email_instance ) {
+					if ( $email_instance->id === $wc_email_id ) {
+						$wc_email       = $email_instance;
+						$wc_email_class = $class_name;
+						break;
+					}
+				}
+				if ( ! $wc_email ) {
+					Logger::log( "WC email '$wc_email_id' not found for registry '$slug'.", 'NEWSPACK-EMAILS', 'warning' );
+					continue;
+				}
+				$preview_post_id   = self::get_wc_email_preview_post_id( $wc_email_id );
+				$newspack_emails[] = [
+					'label'               => $entry['label'],
+					'post_id'             => 'wc:' . $wc_email_id,
+					'preview_post_id'     => $preview_post_id,
+					'edit_link'           => self::get_wc_email_edit_link( $wc_email_id, $wc_email_class ),
+					'status'              => 'yes' === $wc_email->enabled ? 'publish' : 'draft',
+					'type'                => $wc_email_id,
+					'category'            => 'woocommerce',
+					'trigger_description' => $entry['trigger_description'],
+					'registry_slug'       => $slug,
+					'recipient'           => $entry['recipient'],
+					'source'              => 'woocommerce',
+					'chip'                => $entry['chip'],
+				];
+			}
 		}
 
 		// Sort: reader-revenue first, reader-activation second, woocommerce last.
@@ -368,6 +447,165 @@ class Emails_Section extends Wizard_Section {
 		$settings['post_type']       = Emails::POST_TYPE;
 
 		return $settings;
+	}
+
+	/**
+	 * Build the edit link for a WooCommerce email.
+	 *
+	 * When the WC block email editor is enabled and a template post exists
+	 * for the email, returns the block editor URL. Otherwise falls back to
+	 * the classic WC settings page.
+	 *
+	 * @param string $wc_email_id    The WC_Email ID (e.g. 'customer_new_account').
+	 * @param string $wc_email_class The WC_Email class name (array key from get_emails()).
+	 * @return string Admin URL for editing this email.
+	 */
+	private static function get_wc_email_edit_link( string $wc_email_id, string $wc_email_class ): string {
+		$classic_url = add_query_arg(
+			[
+				'page'    => 'wc-settings',
+				'tab'     => 'email',
+				'section' => strtolower( $wc_email_class ),
+			],
+			admin_url( 'admin.php' )
+		);
+
+		// Check if the WC block email editor is enabled.
+		if ( 'yes' !== get_option( 'woocommerce_feature_block_email_editor_enabled' ) ) {
+			return $classic_url;
+		}
+
+		// Look up the template post for this email.
+		$posts_manager_class = 'Automattic\\WooCommerce\\Internal\\EmailEditor\\WCTransactionalEmails\\WCTransactionalEmailPostsManager';
+		if ( ! class_exists( $posts_manager_class ) ) {
+			return $classic_url;
+		}
+
+		$template_post_id = $posts_manager_class::get_instance()->get_email_template_post_id( $wc_email_id );
+		if ( empty( $template_post_id ) ) {
+			return $classic_url;
+		}
+
+		return add_query_arg(
+			[
+				'post'   => $template_post_id,
+				'action' => 'edit',
+			],
+			admin_url( 'post.php' )
+		);
+	}
+
+	/**
+	 * Get the block-editor template post ID for a WC email, if available.
+	 *
+	 * Returns the post ID of the woo_email post that backs this email in
+	 * the WC block email editor. Returns null when the block editor is
+	 * disabled or the email has no template post.
+	 *
+	 * @param string $wc_email_id The WC_Email ID (e.g. 'new_order').
+	 * @return int|null Template post ID, or null.
+	 */
+	private static function get_wc_email_preview_post_id( string $wc_email_id ): ?int {
+		if ( 'yes' !== get_option( 'woocommerce_feature_block_email_editor_enabled' ) ) {
+			return null;
+		}
+
+		$posts_manager_class = 'Automattic\\WooCommerce\\Internal\\EmailEditor\\WCTransactionalEmails\\WCTransactionalEmailPostsManager';
+		if ( ! class_exists( $posts_manager_class ) ) {
+			return null;
+		}
+
+		$template_post_id = $posts_manager_class::get_instance()->get_email_template_post_id( $wc_email_id );
+		if ( empty( $template_post_id ) ) {
+			return null;
+		}
+
+		return (int) $template_post_id;
+	}
+
+	/**
+	 * Enable all recommended WC emails on first run.
+	 *
+	 * Called once so that registry WC emails default to enabled when the
+	 * unified emails UI is first loaded.
+	 *
+	 * @param array $registry The email registry.
+	 */
+	private static function first_run_enable_wc_emails( array $registry ) {
+		if ( ! class_exists( 'WooCommerce' ) ) {
+			return;
+		}
+		$wc_mailer_emails = \WC()->mailer()->get_emails();
+		foreach ( $registry as $entry ) {
+			if ( 'woocommerce' !== $entry['source'] ) {
+				continue;
+			}
+			// Plugin dependency check.
+			if ( ! empty( $entry['plugin_dependency'] ) ) {
+				$plugin_file = $entry['plugin_dependency'] . '/' . $entry['plugin_dependency'] . '.php';
+				if ( ! \Newspack\is_plugin_active( $plugin_file ) ) {
+					continue;
+				}
+			}
+			$wc_email_id = $entry['woo_email_id'];
+			$wc_email    = null;
+			foreach ( $wc_mailer_emails as $email_instance ) {
+				if ( $email_instance->id === $wc_email_id ) {
+					$wc_email = $email_instance;
+					break;
+				}
+			}
+			if ( ! $wc_email ) {
+				continue;
+			}
+			if ( 'yes' !== $wc_email->enabled ) {
+				$option_key = $wc_email->get_option_key();
+				$options    = (array) get_option( $option_key, [] );
+				$options['enabled'] = 'yes';
+				update_option( $option_key, $options );
+			}
+			// Auto-renewal notice needs the master switch enabled too.
+			if ( 'customer_notification_auto_renewal' === $wc_email_id ) {
+				if ( 'yes' !== get_option( 'woocommerce_subscriptions_customer_notifications_enabled' ) ) {
+					update_option( 'woocommerce_subscriptions_customer_notifications_enabled', 'yes' );
+				}
+			}
+		}
+	}
+
+	/**
+	 * Toggle a WooCommerce email on or off.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 * @return \WP_REST_Response|\WP_Error Response or error.
+	 */
+	public static function api_toggle_wc_email( $request ) {
+		$wc_email_id = $request->get_param( 'id' );
+		$enabled     = $request->get_param( 'enabled' );
+
+		if ( ! class_exists( 'WooCommerce' ) ) {
+			return new \WP_Error( 'not_found', 'WooCommerce is not active.', [ 'status' => 404 ] );
+		}
+
+		$wc_mailer_emails = \WC()->mailer()->get_emails();
+		$wc_email         = null;
+		foreach ( $wc_mailer_emails as $email_instance ) {
+			if ( $email_instance->id === $wc_email_id ) {
+				$wc_email = $email_instance;
+				break;
+			}
+		}
+
+		if ( ! $wc_email ) {
+			return new \WP_Error( 'not_found', 'WC email not found.', [ 'status' => 404 ] );
+		}
+
+		$option_key = $wc_email->get_option_key();
+		$options    = (array) get_option( $option_key, [] );
+		$options['enabled'] = $enabled ? 'yes' : 'no';
+		update_option( $option_key, $options );
+
+		return rest_ensure_response( self::api_get_email_settings() );
 	}
 
 	/**

--- a/includes/wizards/newspack/class-emails-section.php
+++ b/includes/wizards/newspack/class-emails-section.php
@@ -172,7 +172,7 @@ class Emails_Section extends Wizard_Section {
 				'recipient'           => 'reader',
 				'chip'                => 'reader-revenue',
 				'label'               => __( 'Renewal reminder', 'newspack-plugin' ),
-				'trigger_description' => __( 'Sent 3 days before automatic renewal.', 'newspack-plugin' ),
+				'trigger_description' => __( 'Sent before automatic renewal (timing depends on WooCommerce Subscriptions settings).', 'newspack-plugin' ),
 			],
 			'woo-payment-retry'                => [
 				'source'              => 'woocommerce',
@@ -362,12 +362,14 @@ class Emails_Section extends Wizard_Section {
 				$email['registry_slug']       = '';
 				$email['recipient']           = 'reader';
 				$email['source']              = 'newspack'; // Default; WooCommerce emails always match above.
-				$email['chip']                = '';
+				$email['chip']                = 'auth-account'; // Fallback so unregistered emails still appear in a tab.
 			}
 			$newspack_emails[] = $email;
 		}
 
-		// First-run: enable all registry WC emails by default.
+		// First-run: enable recommended WC emails by default.
+		// Runs on this GET handler for simplicity — guarded by a one-shot option
+		// flag so it only fires once, and the enable logic is idempotent.
 		if ( class_exists( 'WooCommerce' ) && ! get_option( 'newspack_unified_emails_wc_first_run', false ) ) {
 			self::first_run_enable_wc_emails( $registry );
 			update_option( 'newspack_unified_emails_wc_first_run', true, false );
@@ -537,7 +539,7 @@ class Emails_Section extends Wizard_Section {
 		}
 		$wc_mailer_emails = \WC()->mailer()->get_emails();
 		foreach ( $registry as $entry ) {
-			if ( 'woocommerce' !== $entry['source'] ) {
+			if ( 'woocommerce' !== $entry['source'] || empty( $entry['recommended'] ) ) {
 				continue;
 			}
 			// Plugin dependency check.
@@ -585,6 +587,16 @@ class Emails_Section extends Wizard_Section {
 
 		if ( ! class_exists( 'WooCommerce' ) ) {
 			return new \WP_Error( 'not_found', 'WooCommerce is not active.', [ 'status' => 404 ] );
+		}
+
+		// Only allow toggling IDs that exist in our registry.
+		$registry          = self::get_email_registry();
+		$allowed_wc_ids    = array_column(
+			array_filter( $registry, fn( $e ) => 'woocommerce' === $e['source'] ),
+			'woo_email_id'
+		);
+		if ( ! in_array( $wc_email_id, $allowed_wc_ids, true ) ) {
+			return new \WP_Error( 'not_found', 'WC email not found in registry.', [ 'status' => 404 ] );
 		}
 
 		$wc_mailer_emails = \WC()->mailer()->get_emails();

--- a/src/wizards/newspack/views/settings/emails/email-preview.scss
+++ b/src/wizards/newspack/views/settings/emails/email-preview.scss
@@ -1,0 +1,40 @@
+@use "~@wordpress/base-styles/colors" as wp-colors;
+
+// Email preview thumbnail container.
+.newspack-email-preview {
+	width: 100%;
+	aspect-ratio: 1;
+	overflow: hidden;
+	position: relative;
+	background: transparent;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+
+	&__iframe {
+		width: 848px;
+		height: auto;
+		border: 0;
+		position: absolute;
+		top: 0;
+		left: 0;
+		transform-origin: top left;
+		pointer-events: none;
+		opacity: 0;
+		transition: opacity 200ms ease-out;
+	}
+
+	&.is-ready &__iframe {
+		opacity: 1;
+	}
+
+	// Loading / error placeholder overlay.
+	&__placeholder {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 100%;
+		height: 100%;
+		color: wp-colors.$gray-400;
+	}
+}

--- a/src/wizards/newspack/views/settings/emails/email-preview.test.js
+++ b/src/wizards/newspack/views/settings/emails/email-preview.test.js
@@ -1,0 +1,222 @@
+/**
+ * External dependencies
+ */
+import { render, waitFor, act } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import EmailPreview from './email-preview';
+
+// Mock @wordpress/api-fetch — jest.mock is hoisted above imports.
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+// Store observer instances so tests can trigger intersection.
+let observerInstances = [];
+
+// Default IntersectionObserver mock: triggers immediately.
+function createObserverMock( triggerImmediately = true ) {
+	observerInstances = [];
+	global.IntersectionObserver = class {
+		constructor( callback ) {
+			this.callback = callback;
+			observerInstances.push( this );
+		}
+		observe() {
+			if ( triggerImmediately ) {
+				this.callback( [ { isIntersecting: true } ] );
+			}
+		}
+		disconnect() {}
+	};
+}
+
+// ResizeObserver mock: immediately reports a 300px-wide container.
+global.ResizeObserver = class {
+	constructor( callback ) {
+		this.callback = callback;
+	}
+	observe() {
+		this.callback( [ { contentRect: { width: 300 } } ] );
+	}
+	disconnect() {}
+};
+
+/**
+ * Helper: simulate iframe onLoad and stub contentDocument so
+ * handleIframeLoad resolves immediately (no pending assets).
+ */
+function simulateIframeLoad( iframe ) {
+	Object.defineProperty( iframe, 'contentDocument', {
+		value: {
+			querySelectorAll: () => [],
+			body: { scrollHeight: 900 },
+		},
+		configurable: true,
+	} );
+	iframe.dispatchEvent( new Event( 'load' ) );
+}
+
+describe( 'EmailPreview', () => {
+	beforeEach( () => {
+		apiFetch.mockReset();
+		createObserverMock( true );
+	} );
+
+	it( 'renders loading state while fetching', async () => {
+		// Keep the promise pending so we can observe the loading state.
+		apiFetch.mockReturnValue( new Promise( () => {} ) );
+
+		render( <EmailPreview postId={ 123 } /> );
+
+		expect( document.querySelector( '.newspack-email-preview__placeholder' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders iframe on successful fetch and gains is-ready after load', async () => {
+		apiFetch.mockResolvedValue( {
+			html: '<html><body><p>Hello Sample Reader</p></body></html>',
+			post_id: 123,
+		} );
+
+		render( <EmailPreview postId={ 123 } /> );
+
+		await waitFor( () => {
+			const iframe = document.querySelector( '.newspack-email-preview__iframe' );
+			expect( iframe ).toBeTruthy();
+			expect( iframe.getAttribute( 'srcdoc' ) ).toContain( 'Sample Reader' );
+		} );
+
+		// Simulate iframe load (also fires automatically in jsdom, but explicit
+		// call ensures the contentDocument stub is in place for assertion).
+		const iframe = document.querySelector( '.newspack-email-preview__iframe' );
+		simulateIframeLoad( iframe );
+
+		const container = document.querySelector( '.newspack-email-preview' );
+		await waitFor( () => {
+			expect( container.classList.contains( 'is-ready' ) ).toBe( true );
+		} );
+	} );
+
+	it( 'renders fallback placeholder on fetch error', async () => {
+		apiFetch.mockRejectedValue( new Error( 'Server error' ) );
+
+		render( <EmailPreview postId={ 456 } /> );
+
+		await waitFor( () => {
+			const placeholder = document.querySelector( '.newspack-email-preview__placeholder' );
+			expect( placeholder ).toBeTruthy();
+			// No iframe should be present.
+			expect( document.querySelector( '.newspack-email-preview__iframe' ) ).toBeNull();
+		} );
+	} );
+
+	it( 'does not fetch until element is visible', () => {
+		// Observer that does NOT trigger intersection.
+		createObserverMock( false );
+
+		render( <EmailPreview postId={ 789 } /> );
+
+		expect( apiFetch ).not.toHaveBeenCalled();
+	} );
+
+	it( 'fetches the correct endpoint path', async () => {
+		apiFetch.mockResolvedValue( { html: '<p>Test</p>', post_id: 42 } );
+
+		render( <EmailPreview postId={ 42 } /> );
+
+		await waitFor( () => {
+			expect( apiFetch ).toHaveBeenCalledWith( {
+				path: '/newspack/v1/wizard/newspack-settings/emails/42/preview',
+			} );
+		} );
+	} );
+
+	it( 'resets state when postId changes', async () => {
+		apiFetch.mockResolvedValue( {
+			html: '<html><body><p>First email</p></body></html>',
+			post_id: 1,
+		} );
+
+		const { rerender } = render( <EmailPreview postId={ 1 } /> );
+
+		// Wait for first render to complete.
+		await waitFor( () => {
+			const iframe = document.querySelector( '.newspack-email-preview__iframe' );
+			expect( iframe ).toBeTruthy();
+		} );
+
+		// Simulate onLoad for first email.
+		simulateIframeLoad( document.querySelector( '.newspack-email-preview__iframe' ) );
+		await waitFor( () => {
+			expect( document.querySelector( '.newspack-email-preview' ).classList.contains( 'is-ready' ) ).toBe( true );
+		} );
+
+		// Change postId — should reset and re-fetch.
+		apiFetch.mockResolvedValue( {
+			html: '<html><body><p>Second email</p></body></html>',
+			post_id: 2,
+		} );
+
+		rerender( <EmailPreview postId={ 2 } /> );
+
+		// New iframe should appear with updated content.
+		await waitFor( () => {
+			const iframe = document.querySelector( '.newspack-email-preview__iframe' );
+			expect( iframe ).toBeTruthy();
+			expect( iframe.getAttribute( 'srcdoc' ) ).toContain( 'Second email' );
+		} );
+	} );
+
+	it( 'cancelled fetch does not update state when postId changes mid-flight', async () => {
+		// First fetch: controlled promise that resolves AFTER the second.
+		let resolveFirst;
+		const firstPromise = new Promise( resolve => {
+			resolveFirst = resolve;
+		} );
+		apiFetch.mockReturnValueOnce( firstPromise );
+
+		const { rerender } = render( <EmailPreview postId={ 1 } /> );
+
+		// Change postId before first fetch resolves.
+		apiFetch.mockResolvedValueOnce( {
+			html: '<html><body><p>Second email</p></body></html>',
+			post_id: 2,
+		} );
+
+		rerender( <EmailPreview postId={ 2 } /> );
+
+		// Wait for second fetch to render.
+		await waitFor( () => {
+			const iframe = document.querySelector( '.newspack-email-preview__iframe' );
+			expect( iframe ).toBeTruthy();
+			expect( iframe.getAttribute( 'srcdoc' ) ).toContain( 'Second email' );
+		} );
+
+		// Now resolve the first (stale) fetch — it should NOT overwrite the iframe.
+		await act( async () => {
+			resolveFirst( {
+				html: '<html><body><p>First email (stale)</p></body></html>',
+				post_id: 1,
+			} );
+		} );
+
+		// The iframe should still show the second email, not the stale first.
+		const iframe = document.querySelector( '.newspack-email-preview__iframe' );
+		expect( iframe.getAttribute( 'srcdoc' ) ).toContain( 'Second email' );
+		expect( iframe.getAttribute( 'srcdoc' ) ).not.toContain( 'First email' );
+	} );
+
+	// Note: The safety timeout (8s fallback for slow assets) and the iframe
+	// onError handler are not tested here because jsdom automatically fires
+	// the iframe load event when srcDoc is set, which prevents us from
+	// simulating pending-asset scenarios. These defensive measures work in
+	// real browsers but require an integration/e2e test environment.
+} );

--- a/src/wizards/newspack/views/settings/emails/email-preview.tsx
+++ b/src/wizards/newspack/views/settings/emails/email-preview.tsx
@@ -1,0 +1,217 @@
+/**
+ * EmailPreview — renders a scaled thumbnail of an email template.
+ *
+ * Lazy-loads via IntersectionObserver: the REST fetch only fires once the
+ * component scrolls into view. On success an iframe with srcDoc displays the
+ * rendered HTML; on error an envelope icon placeholder is shown instead.
+ *
+ * Rendering contract mirrors NewsletterPreview in newspack-newsletters:
+ * 848 px source viewport, 1 : 1 aspect ratio, fade-in via `is-ready` class,
+ * and iframe height measured from the loaded document.
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { useState, useEffect, useRef, useCallback } from '@wordpress/element';
+import { Spinner } from '@wordpress/components';
+import { Icon, envelope } from '@wordpress/icons';
+
+/**
+ * Internal dependencies.
+ */
+import './email-preview.scss';
+
+interface EmailPreviewProps {
+	postId: number;
+}
+
+const IFRAME_WIDTH = 848;
+
+const EmailPreview: React.FC< EmailPreviewProps > = ( { postId } ) => {
+	const containerRef = useRef< HTMLDivElement >( null );
+	const iframeRef = useRef< HTMLIFrameElement >( null );
+	const safetyTimerRef = useRef< ReturnType< typeof setTimeout > | null >( null );
+	const [ isVisible, setIsVisible ] = useState( false );
+	const [ html, setHtml ] = useState< string | null >( null );
+	const [ isLoading, setIsLoading ] = useState( false );
+	const [ hasError, setHasError ] = useState( false );
+	const [ scale, setScale ] = useState< number | null >( null );
+	const [ iframeHeight, setIframeHeight ] = useState< number | null >( null );
+	const [ isReady, setIsReady ] = useState( false );
+
+	// Observe visibility — fetch only when the thumbnail enters the viewport.
+	useEffect( () => {
+		if ( isVisible ) {
+			return;
+		}
+		if ( typeof IntersectionObserver === 'undefined' ) {
+			setIsVisible( true );
+			return;
+		}
+		const node = containerRef.current;
+		if ( ! node ) {
+			return;
+		}
+
+		const observer = new IntersectionObserver(
+			entries => {
+				if ( entries[ 0 ]?.isIntersecting ) {
+					setIsVisible( true );
+				}
+			},
+			{ rootMargin: '200px' }
+		);
+
+		observer.observe( node );
+		return () => observer.disconnect();
+	}, [ isVisible ] );
+
+	// Measure container width and compute iframe scale.
+	useEffect( () => {
+		if ( typeof ResizeObserver === 'undefined' ) {
+			setScale( 1 );
+			return;
+		}
+		const node = containerRef.current;
+		if ( ! node ) {
+			return;
+		}
+
+		const ro = new ResizeObserver( ( [ entry ] ) => {
+			setScale( entry.contentRect.width / IFRAME_WIDTH );
+		} );
+
+		ro.observe( node );
+		return () => ro.disconnect();
+	}, [] );
+
+	// Fetch preview HTML once visible. Cancel on postId change or unmount.
+	useEffect( () => {
+		if ( ! isVisible ) {
+			return;
+		}
+
+		let cancelled = false;
+
+		// Clear any lingering safety timer from a previous postId.
+		if ( safetyTimerRef.current ) {
+			clearTimeout( safetyTimerRef.current );
+			safetyTimerRef.current = null;
+		}
+
+		setIsLoading( true );
+		setIsReady( false );
+		setIframeHeight( null );
+		setHasError( false );
+		setHtml( null );
+		apiFetch< { html: string; post_id: number } >( {
+			path: `/newspack/v1/wizard/newspack-settings/emails/${ postId }/preview`,
+		} )
+			.then( response => {
+				if ( ! cancelled ) {
+					setHtml( response.html );
+				}
+			} )
+			.catch( () => {
+				if ( ! cancelled ) {
+					setHasError( true );
+				}
+			} )
+			.finally( () => {
+				if ( ! cancelled ) {
+					setIsLoading( false );
+				}
+			} );
+
+		return () => {
+			cancelled = true;
+			if ( safetyTimerRef.current ) {
+				clearTimeout( safetyTimerRef.current );
+				safetyTimerRef.current = null;
+			}
+		};
+	}, [ isVisible, postId ] );
+
+	// Handle iframe load: wait for stylesheets and images, then measure height and reveal.
+	const handleIframeLoad = useCallback( () => {
+		const doc = iframeRef.current?.contentDocument;
+		if ( ! doc ) {
+			return;
+		}
+
+		const awaitLoad = ( el: HTMLLinkElement | HTMLImageElement ) =>
+			new Promise< void >( resolve => {
+				el.addEventListener( 'load', () => resolve(), { once: true } );
+				el.addEventListener( 'error', () => resolve(), { once: true } );
+			} );
+
+		const linkPromises = Array.from( doc.querySelectorAll< HTMLLinkElement >( 'link[rel="stylesheet"]' ) )
+			.filter( link => ! link.sheet )
+			.map( awaitLoad );
+		const imgPromises = Array.from( doc.querySelectorAll< HTMLImageElement >( 'img' ) )
+			.filter( img => ! img.complete )
+			.map( awaitLoad );
+
+		let finalized = false;
+		const finalize = () => {
+			if ( finalized ) {
+				return;
+			}
+			finalized = true;
+			if ( safetyTimerRef.current ) {
+				clearTimeout( safetyTimerRef.current );
+				safetyTimerRef.current = null;
+			}
+			setIframeHeight( doc.body.scrollHeight );
+			setIsReady( true );
+		};
+
+		// 8 s safety so a slow asset never strands the spinner.
+		safetyTimerRef.current = setTimeout( finalize, 8000 );
+
+		Promise.all( [ ...linkPromises, ...imgPromises ] ).then( finalize );
+	}, [] );
+
+	const showSpinner = ! hasError && ! isReady && ( isLoading || Boolean( html ) );
+
+	return (
+		<div ref={ containerRef } className={ `newspack-email-preview${ isReady ? ' is-ready' : '' }` }>
+			{ showSpinner && (
+				<div className="newspack-email-preview__placeholder">
+					<Spinner />
+				</div>
+			) }
+			{ hasError && (
+				<div className="newspack-email-preview__placeholder">
+					<Icon icon={ envelope } size={ 48 } />
+				</div>
+			) }
+			{ html && ! hasError && scale !== null && scale > 0 && (
+				<iframe
+					ref={ iframeRef }
+					className="newspack-email-preview__iframe"
+					srcDoc={ html }
+					/* sandbox: allow-same-origin is required so handleIframeLoad can
+					 * read contentDocument (body.scrollHeight, stylesheet load state).
+					 * allow-scripts is NOT present, so JS cannot execute.
+					 * Residual risk: a <form> in the HTML could submit with admin
+					 * cookies, but this is admin-only code and the email HTML is
+					 * publisher-controlled post meta. */
+					sandbox="allow-same-origin"
+					tabIndex={ -1 }
+					title="Email preview"
+					onLoad={ handleIframeLoad }
+					onError={ () => setHasError( true ) }
+					style={ {
+						transform: `scale(${ scale })`,
+						height: iframeHeight ? `${ iframeHeight }px` : undefined,
+					} }
+				/>
+			) }
+		</div>
+	);
+};
+
+export default EmailPreview;

--- a/src/wizards/newspack/views/settings/emails/email-preview.tsx
+++ b/src/wizards/newspack/views/settings/emails/email-preview.tsx
@@ -141,18 +141,27 @@ const EmailPreview: React.FC< EmailPreviewProps > = ( { postId } ) => {
 			return;
 		}
 
-		const awaitLoad = ( el: HTMLLinkElement | HTMLImageElement ) =>
+		// Wire up listeners before checking loaded state to avoid a race where
+		// the asset finishes between the check and the listener attachment.
+		const awaitLink = ( link: HTMLLinkElement ) =>
 			new Promise< void >( resolve => {
-				el.addEventListener( 'load', () => resolve(), { once: true } );
-				el.addEventListener( 'error', () => resolve(), { once: true } );
+				link.addEventListener( 'load', () => resolve(), { once: true } );
+				link.addEventListener( 'error', () => resolve(), { once: true } );
+				if ( link.sheet ) {
+					resolve();
+				}
+			} );
+		const awaitImg = ( img: HTMLImageElement ) =>
+			new Promise< void >( resolve => {
+				img.addEventListener( 'load', () => resolve(), { once: true } );
+				img.addEventListener( 'error', () => resolve(), { once: true } );
+				if ( img.complete ) {
+					resolve();
+				}
 			} );
 
-		const linkPromises = Array.from( doc.querySelectorAll< HTMLLinkElement >( 'link[rel="stylesheet"]' ) )
-			.filter( link => ! link.sheet )
-			.map( awaitLoad );
-		const imgPromises = Array.from( doc.querySelectorAll< HTMLImageElement >( 'img' ) )
-			.filter( img => ! img.complete )
-			.map( awaitLoad );
+		const linkPromises = Array.from( doc.querySelectorAll< HTMLLinkElement >( 'link[rel="stylesheet"]' ) ).map( awaitLink );
+		const imgPromises = Array.from( doc.querySelectorAll< HTMLImageElement >( 'img' ) ).map( awaitImg );
 
 		let finalized = false;
 		const finalize = () => {

--- a/src/wizards/newspack/views/settings/emails/email-preview.tsx
+++ b/src/wizards/newspack/views/settings/emails/email-preview.tsx
@@ -205,10 +205,8 @@ const EmailPreview: React.FC< EmailPreviewProps > = ( { postId } ) => {
 					srcDoc={ html }
 					/* sandbox: allow-same-origin is required so handleIframeLoad can
 					 * read contentDocument (body.scrollHeight, stylesheet load state).
-					 * allow-scripts is NOT present, so JS cannot execute.
-					 * Residual risk: a <form> in the HTML could submit with admin
-					 * cookies, but this is admin-only code and the email HTML is
-					 * publisher-controlled post meta. */
+					 * Without allow-scripts, JS cannot execute. Without allow-forms,
+					 * form submissions are blocked. */
 					sandbox="allow-same-origin"
 					tabIndex={ -1 }
 					title={ __( 'Email preview', 'newspack-plugin' ) }

--- a/src/wizards/newspack/views/settings/emails/email-preview.tsx
+++ b/src/wizards/newspack/views/settings/emails/email-preview.tsx
@@ -15,6 +15,7 @@
  */
 import apiFetch from '@wordpress/api-fetch';
 import { useState, useEffect, useRef, useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 import { Spinner } from '@wordpress/components';
 import { Icon, envelope } from '@wordpress/icons';
 
@@ -210,7 +211,7 @@ const EmailPreview: React.FC< EmailPreviewProps > = ( { postId } ) => {
 					 * publisher-controlled post meta. */
 					sandbox="allow-same-origin"
 					tabIndex={ -1 }
-					title="Email preview"
+					title={ __( 'Email preview', 'newspack-plugin' ) }
 					onLoad={ handleIframeLoad }
 					onError={ () => setHasError( true ) }
 					style={ {

--- a/src/wizards/newspack/views/settings/emails/emails.scss
+++ b/src/wizards/newspack/views/settings/emails/emails.scss
@@ -22,16 +22,19 @@
 	}
 }
 
-// Preview placeholder (grid view media field).
-.newspack-emails__preview-placeholder {
+// Chip filter bar above DataViews.
+.newspack-emails__chips {
 	display: flex;
-	align-items: center;
-	justify-content: center;
-	aspect-ratio: 1;
-	width: 100%;
-	background: wp-colors.$gray-100;
-	border-radius: 4px;
-	color: wp-colors.$gray-700;
+	gap: 8px;
+	margin-bottom: 16px;
+
+	// Nested for specificity over WP Button defaults.
+	.newspack-emails__chip.components-button {
+		border-radius: 20px;
+		padding: 4px 16px;
+		font-size: 13px;
+		line-height: 1.4;
+	}
 }
 
 // Clickable name link in grid/table view.

--- a/src/wizards/newspack/views/settings/emails/emails.test.js
+++ b/src/wizards/newspack/views/settings/emails/emails.test.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 
 /**
  * WordPress dependencies
@@ -16,9 +16,12 @@ jest.mock( '@wordpress/api-fetch', () => ( {
 	default: jest.fn(),
 } ) );
 
-jest.mock( '@wordpress/icons', () => ( {
-	Icon: ( { icon } ) => <span data-testid="icon">{ icon }</span>,
-	envelope: 'envelope',
+jest.mock( '@wordpress/components', () => ( {
+	Button: ( { children, onClick, className, variant } ) => (
+		<button onClick={ onClick } className={ className } data-variant={ variant }>
+			{ children }
+		</button>
+	),
 } ) );
 
 jest.mock( '@wordpress/dataviews', () => ( {
@@ -75,6 +78,11 @@ jest.mock(
 		}
 );
 
+jest.mock( './email-preview', () => ( {
+	__esModule: true,
+	default: () => null,
+} ) );
+
 const mockEmails = [
 	{
 		label: 'Payment receipt',
@@ -87,6 +95,7 @@ const mockEmails = [
 		registry_slug: 'receipt',
 		recipient: 'reader',
 		source: 'newspack',
+		chip: 'reader-revenue',
 	},
 	{
 		label: 'Cancellation confirmation',
@@ -99,6 +108,7 @@ const mockEmails = [
 		registry_slug: 'cancellation',
 		recipient: 'reader',
 		source: 'newspack',
+		chip: 'reader-revenue',
 	},
 	{
 		label: 'Reader verification',
@@ -111,6 +121,7 @@ const mockEmails = [
 		registry_slug: 'verification',
 		recipient: 'reader',
 		source: 'newspack',
+		chip: 'auth-account',
 	},
 	{
 		label: 'Account deletion',
@@ -123,11 +134,12 @@ const mockEmails = [
 		registry_slug: 'delete-account',
 		recipient: 'reader',
 		source: 'newspack',
+		chip: 'auth-account',
 	},
 	{
-		label: 'New order (admin)',
-		post_id: 5,
-		edit_link: '/edit/5',
+		label: 'New order',
+		post_id: 'wc:new_order',
+		edit_link: '/wc-settings/email/new_order',
 		status: 'publish',
 		type: 'new_order',
 		category: 'woocommerce',
@@ -135,18 +147,20 @@ const mockEmails = [
 		registry_slug: 'woo-new-order',
 		recipient: 'admin',
 		source: 'woocommerce',
+		chip: 'reader-revenue',
 	},
 	{
-		label: 'Order on hold',
-		post_id: 6,
-		edit_link: '/edit/6',
+		label: 'Renewal reminder',
+		post_id: 'wc:customer_notification_auto_renewal',
+		edit_link: '/wc-settings/email/renewal',
 		status: 'draft',
-		type: 'customer_on_hold_order',
+		type: 'customer_notification_auto_renewal',
 		category: 'woocommerce',
-		trigger_description: 'Sent when an order is placed on hold.',
-		registry_slug: 'woo-on-hold-order',
+		trigger_description: 'Sent 3 days before automatic renewal.',
+		registry_slug: 'woo-renewal-reminder',
 		recipient: 'reader',
 		source: 'woocommerce',
+		chip: 'reader-revenue',
 	},
 ];
 
@@ -172,18 +186,41 @@ describe( 'Emails', () => {
 		} );
 	} );
 
-	it( 'renders all emails in a single view', async () => {
+	it( 'renders reader-revenue emails by default', async () => {
 		const Emails = require( './emails' ).default;
 		render( <Emails /> );
 
 		await waitFor( () => {
 			expect( screen.getByText( 'Payment receipt' ) ).toBeInTheDocument();
 			expect( screen.getByText( 'Cancellation confirmation' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'New order' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Renewal reminder' ) ).toBeInTheDocument();
+		} );
+
+		// Auth-account items should not be visible in the default chip.
+		expect( screen.queryByText( 'Reader verification' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Account deletion' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'chip toggle shows auth-account emails and hides reader-revenue', async () => {
+		const Emails = require( './emails' ).default;
+		render( <Emails /> );
+
+		await waitFor( () => {
+			expect( screen.getByText( 'Payment receipt' ) ).toBeInTheDocument();
+		} );
+
+		// Click "Authentication & account" chip.
+		fireEvent.click( screen.getByText( 'Authentication & account' ) );
+
+		await waitFor( () => {
 			expect( screen.getByText( 'Reader verification' ) ).toBeInTheDocument();
 			expect( screen.getByText( 'Account deletion' ) ).toBeInTheDocument();
-			expect( screen.getByText( 'New order (admin)' ) ).toBeInTheDocument();
-			expect( screen.getByText( 'Order on hold' ) ).toBeInTheDocument();
 		} );
+
+		// Reader-revenue items should be hidden.
+		expect( screen.queryByText( 'Payment receipt' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'New order' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'renders Recipient column with correct values', async () => {
@@ -191,8 +228,9 @@ describe( 'Emails', () => {
 		render( <Emails /> );
 
 		await waitFor( () => {
+			// Default chip is reader-revenue: 2 Newspack reader + 1 WC reader + 1 WC admin = 3 Reader, 1 Admin.
 			const readerCells = screen.getAllByText( 'Reader' );
-			expect( readerCells.length ).toBeGreaterThanOrEqual( 4 );
+			expect( readerCells.length ).toBeGreaterThanOrEqual( 3 );
 			expect( screen.getByText( 'Admin' ) ).toBeInTheDocument();
 		} );
 	} );
@@ -202,14 +240,15 @@ describe( 'Emails', () => {
 		render( <Emails /> );
 
 		await waitFor( () => {
+			// Default chip (reader-revenue): 3 publish (receipt, cancellation, new_order) + 1 draft (renewal).
 			const enabledCells = screen.getAllByText( 'Enabled' );
 			expect( enabledCells.length ).toBeGreaterThanOrEqual( 3 );
 			const disabledCells = screen.getAllByText( 'Disabled' );
-			expect( disabledCells.length ).toBeGreaterThanOrEqual( 2 );
+			expect( disabledCells.length ).toBeGreaterThanOrEqual( 1 );
 		} );
 	} );
 
-	it( 'deactivate action calls apiFetch with draft status', async () => {
+	it( 'deactivate action calls apiFetch with draft status for Newspack emails', async () => {
 		const Emails = require( './emails' ).default;
 		render( <Emails /> );
 
@@ -225,6 +264,26 @@ describe( 'Emails', () => {
 				path: '/wp/v2/newspack_rr_email/1',
 				method: 'POST',
 				data: { status: 'draft' },
+			} );
+		} );
+	} );
+
+	it( 'deactivate action calls toggle endpoint for WC emails', async () => {
+		const Emails = require( './emails' ).default;
+		render( <Emails /> );
+
+		await waitFor( () => {
+			expect( screen.getByTestId( 'dataviews' ) ).toBeInTheDocument();
+		} );
+
+		const deactivate = mockCapturedActions.find( a => a.id === 'deactivate' );
+		deactivate.callback( [ mockEmails[ 4 ] ] ); // New order — WC, publish.
+
+		await waitFor( () => {
+			expect( apiFetch ).toHaveBeenCalledWith( {
+				path: '/newspack/v1/wizard/newspack-settings/emails/new_order/toggle',
+				method: 'POST',
+				data: { enabled: false },
 			} );
 		} );
 	} );
@@ -253,8 +312,14 @@ describe( 'Emails', () => {
 		const Emails = require( './emails' ).default;
 		render( <Emails /> );
 
+		// Switch to auth-account chip to get Account deletion (draft, newspack).
 		await waitFor( () => {
 			expect( screen.getByTestId( 'dataviews' ) ).toBeInTheDocument();
+		} );
+		fireEvent.click( screen.getByText( 'Authentication & account' ) );
+
+		await waitFor( () => {
+			expect( screen.getByText( 'Account deletion' ) ).toBeInTheDocument();
 		} );
 
 		const activate = mockCapturedActions.find( a => a.id === 'activate' );
@@ -270,7 +335,27 @@ describe( 'Emails', () => {
 		} );
 	} );
 
-	it( 'deactivate/activate are not eligible for reader-activation or woocommerce emails', async () => {
+	it( 'activate action calls toggle endpoint for WC emails', async () => {
+		const Emails = require( './emails' ).default;
+		render( <Emails /> );
+
+		await waitFor( () => {
+			expect( screen.getByTestId( 'dataviews' ) ).toBeInTheDocument();
+		} );
+
+		const activate = mockCapturedActions.find( a => a.id === 'activate' );
+		activate.callback( [ mockEmails[ 5 ] ] ); // Renewal reminder — WC, draft.
+
+		await waitFor( () => {
+			expect( apiFetch ).toHaveBeenCalledWith( {
+				path: '/newspack/v1/wizard/newspack-settings/emails/customer_notification_auto_renewal/toggle',
+				method: 'POST',
+				data: { enabled: true },
+			} );
+		} );
+	} );
+
+	it( 'deactivate/activate are not eligible for reader-activation emails', async () => {
 		const Emails = require( './emails' ).default;
 		render( <Emails /> );
 
@@ -283,14 +368,14 @@ describe( 'Emails', () => {
 
 		// Reader-activation emails cannot be toggled.
 		expect( deactivate.isEligible( mockEmails[ 2 ] ) ).toBe( false );
-		// WooCommerce emails cannot be toggled.
-		expect( deactivate.isEligible( mockEmails[ 4 ] ) ).toBe( false );
 		// Newspack reader-revenue email can be deactivated.
 		expect( deactivate.isEligible( mockEmails[ 0 ] ) ).toBe( true );
+		// WooCommerce email can be deactivated.
+		expect( deactivate.isEligible( mockEmails[ 4 ] ) ).toBe( true );
 		// Draft reader-activation email cannot be activated.
 		expect( activate.isEligible( mockEmails[ 3 ] ) ).toBe( false );
-		// Draft WooCommerce email cannot be activated.
-		expect( activate.isEligible( mockEmails[ 5 ] ) ).toBe( false );
+		// Draft WooCommerce email can be activated.
+		expect( activate.isEligible( mockEmails[ 5 ] ) ).toBe( true );
 	} );
 
 	it( 'reset action calls apiFetch with DELETE after confirmation', async () => {

--- a/src/wizards/newspack/views/settings/emails/emails.test.js
+++ b/src/wizards/newspack/views/settings/emails/emails.test.js
@@ -156,7 +156,7 @@ const mockEmails = [
 		status: 'draft',
 		type: 'customer_notification_auto_renewal',
 		category: 'woocommerce',
-		trigger_description: 'Sent 3 days before automatic renewal.',
+		trigger_description: 'Sent before automatic renewal (timing depends on WooCommerce Subscriptions settings).',
 		registry_slug: 'woo-renewal-reminder',
 		recipient: 'reader',
 		source: 'woocommerce',

--- a/src/wizards/newspack/views/settings/emails/emails.tsx
+++ b/src/wizards/newspack/views/settings/emails/emails.tsx
@@ -8,20 +8,21 @@
 import { __ } from '@wordpress/i18n';
 import { useState, useEffect, useCallback, useMemo, Fragment } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
+import { Button } from '@wordpress/components';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import type { Action, Field, View } from '@wordpress/dataviews';
-import { Icon, envelope } from '@wordpress/icons';
-
 /**
  * Internal dependencies.
  */
 import { Badge, DataViews, Notice, utils } from '../../../../../../packages/components/src';
 import WizardsPluginCard from '../../../../wizards-plugin-card';
+import EmailPreview from './email-preview';
 import './emails.scss';
 
 interface EmailItem {
 	label: string;
-	post_id: number;
+	post_id: number | string;
+	preview_post_id?: number | null;
 	edit_link: string;
 	status: string;
 	type: string;
@@ -30,6 +31,7 @@ interface EmailItem {
 	registry_slug: string;
 	recipient: 'reader' | 'admin';
 	source: 'newspack' | 'woocommerce';
+	chip: 'auth-account' | 'reader-revenue' | '';
 }
 
 interface EmailSettings {
@@ -63,6 +65,7 @@ const Emails = () => {
 	const [ isLoading, setIsLoading ] = useState( true );
 	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
 	const [ error, setError ] = useState< string | null >( null );
+	const [ activeChip, setActiveChip ] = useState< 'reader-revenue' | 'auth-account' >( 'reader-revenue' );
 
 	const fetchData = useCallback( () => {
 		setIsLoading( true );
@@ -102,6 +105,20 @@ const Emails = () => {
 		[ postType, fetchData ]
 	);
 
+	const toggleWcEmail = useCallback( ( wcPostId: string, enabled: boolean ) => {
+		setError( null );
+		const previousStatus = enabled ? 'draft' : 'publish';
+		setData( prev => prev.map( email => ( email.post_id === wcPostId ? { ...email, status: enabled ? 'publish' : 'draft' } : email ) ) );
+		apiFetch( {
+			path: `/newspack/v1/wizard/newspack-settings/emails/${ wcPostId.replace( 'wc:', '' ) }/toggle`,
+			method: 'POST',
+			data: { enabled },
+		} ).catch( () => {
+			setData( prev => prev.map( email => ( email.post_id === wcPostId ? { ...email, status: previousStatus } : email ) ) );
+			setError( __( 'Failed to update email status.', 'newspack-plugin' ) );
+		} );
+	}, [] );
+
 	const resetEmail = useCallback(
 		( postId: number ) => {
 			setError( null );
@@ -130,12 +147,17 @@ const Emails = () => {
 				type: 'media',
 				enableSorting: false,
 				enableHiding: true,
-				// @todo NPPD-1525 Replace with <EmailPreview> component.
-				render: ( { item }: { item: EmailItem } ) => (
-					<a href={ item.edit_link } className="newspack-emails__preview-placeholder">
-						<Icon icon={ envelope } size={ 32 } />
-					</a>
-				),
+				render: ( { item }: { item: EmailItem } ) => {
+					const previewId = item.preview_post_id ?? ( typeof item.post_id === 'number' ? item.post_id : null );
+					if ( ! previewId ) {
+						return null;
+					}
+					return (
+						<a href={ item.edit_link } className="newspack-emails__preview-link">
+							<EmailPreview postId={ previewId } />
+						</a>
+					);
+				},
 			},
 			{
 				id: 'name',
@@ -204,19 +226,27 @@ const Emails = () => {
 			{
 				id: 'deactivate',
 				label: __( 'Deactivate', 'newspack-plugin' ),
-				isEligible: ( item: EmailItem ) =>
-					item.source !== 'woocommerce' && item.category !== 'reader-activation' && item.status === 'publish',
+				isEligible: ( item: EmailItem ) => item.category !== 'reader-activation' && item.status === 'publish',
 				callback: ( items: EmailItem[] ) => {
-					updateStatus( items[ 0 ].post_id, 'draft' );
+					const item = items[ 0 ];
+					if ( typeof item.post_id === 'string' ) {
+						toggleWcEmail( item.post_id, false );
+					} else {
+						updateStatus( item.post_id, 'draft' );
+					}
 				},
 			},
 			{
 				id: 'activate',
 				label: __( 'Activate', 'newspack-plugin' ),
-				isEligible: ( item: EmailItem ) =>
-					item.source !== 'woocommerce' && item.category !== 'reader-activation' && item.status !== 'publish',
+				isEligible: ( item: EmailItem ) => item.category !== 'reader-activation' && item.status !== 'publish',
 				callback: ( items: EmailItem[] ) => {
-					updateStatus( items[ 0 ].post_id, 'publish' );
+					const item = items[ 0 ];
+					if ( typeof item.post_id === 'string' ) {
+						toggleWcEmail( item.post_id, true );
+					} else {
+						updateStatus( item.post_id, 'publish' );
+					}
 				},
 			},
 			{
@@ -226,15 +256,20 @@ const Emails = () => {
 				isEligible: ( item: EmailItem ) => item.source !== 'woocommerce' && Boolean( item.registry_slug ),
 				callback: ( items: EmailItem[] ) => {
 					if ( utils.confirmAction( __( 'Are you sure you want to reset the contents of this email?', 'newspack-plugin' ) ) ) {
-						resetEmail( items[ 0 ].post_id );
+						resetEmail( items[ 0 ].post_id as number );
 					}
 				},
 			},
 		],
-		[ resetEmail, updateStatus ]
+		[ resetEmail, updateStatus, toggleWcEmail ]
 	);
 
-	const { data: processedData, paginationInfo } = useMemo( () => filterSortAndPaginate( data, view, fields ), [ data, view, fields ] );
+	const chipFilteredData = useMemo( () => data.filter( item => item.chip === activeChip ), [ data, activeChip ] );
+
+	const { data: processedData, paginationInfo } = useMemo(
+		() => filterSortAndPaginate( chipFilteredData, view, fields ),
+		[ chipFilteredData, view, fields ]
+	);
 
 	if ( false === pluginsReady ) {
 		return (
@@ -269,6 +304,28 @@ const Emails = () => {
 		<Fragment>
 			<PageHeading />
 			{ error && <Notice isError noticeText={ error } /> }
+			<div className="newspack-emails__chips">
+				<Button
+					variant={ activeChip === 'reader-revenue' ? 'primary' : 'secondary' }
+					onClick={ () => {
+						setActiveChip( 'reader-revenue' );
+						setView( prev => ( { ...prev, search: '', page: 1 } ) );
+					} }
+					className="newspack-emails__chip"
+				>
+					{ __( 'Reader revenue', 'newspack-plugin' ) }
+				</Button>
+				<Button
+					variant={ activeChip === 'auth-account' ? 'primary' : 'secondary' }
+					onClick={ () => {
+						setActiveChip( 'auth-account' );
+						setView( prev => ( { ...prev, search: '', page: 1 } ) );
+					} }
+					className="newspack-emails__chip"
+				>
+					{ __( 'Authentication & account', 'newspack-plugin' ) }
+				</Button>
+			</div>
 			<DataViews
 				className="newspack-emails"
 				data={ processedData }

--- a/src/wizards/newspack/views/settings/emails/emails.tsx
+++ b/src/wizards/newspack/views/settings/emails/emails.tsx
@@ -31,7 +31,7 @@ interface EmailItem {
 	registry_slug: string;
 	recipient: 'reader' | 'admin';
 	source: 'newspack' | 'woocommerce';
-	chip: 'auth-account' | 'reader-revenue' | '';
+	chip: 'auth-account' | 'reader-revenue';
 }
 
 interface EmailSettings {
@@ -66,6 +66,16 @@ const Emails = () => {
 	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
 	const [ error, setError ] = useState< string | null >( null );
 	const [ activeChip, setActiveChip ] = useState< 'reader-revenue' | 'auth-account' >( 'reader-revenue' );
+
+	const CHIPS: { value: 'reader-revenue' | 'auth-account'; label: string }[] = [
+		{ value: 'reader-revenue', label: __( 'Reader revenue', 'newspack-plugin' ) },
+		{ value: 'auth-account', label: __( 'Authentication & account', 'newspack-plugin' ) },
+	];
+
+	const selectChip = ( chip: 'reader-revenue' | 'auth-account' ) => {
+		setActiveChip( chip );
+		setView( prev => ( { ...prev, search: '', page: 1 } ) );
+	};
 
 	const fetchData = useCallback( () => {
 		setIsLoading( true );
@@ -305,26 +315,16 @@ const Emails = () => {
 			<PageHeading />
 			{ error && <Notice isError noticeText={ error } /> }
 			<div className="newspack-emails__chips">
-				<Button
-					variant={ activeChip === 'reader-revenue' ? 'primary' : 'secondary' }
-					onClick={ () => {
-						setActiveChip( 'reader-revenue' );
-						setView( prev => ( { ...prev, search: '', page: 1 } ) );
-					} }
-					className="newspack-emails__chip"
-				>
-					{ __( 'Reader revenue', 'newspack-plugin' ) }
-				</Button>
-				<Button
-					variant={ activeChip === 'auth-account' ? 'primary' : 'secondary' }
-					onClick={ () => {
-						setActiveChip( 'auth-account' );
-						setView( prev => ( { ...prev, search: '', page: 1 } ) );
-					} }
-					className="newspack-emails__chip"
-				>
-					{ __( 'Authentication & account', 'newspack-plugin' ) }
-				</Button>
+				{ CHIPS.map( chip => (
+					<Button
+						key={ chip.value }
+						variant={ activeChip === chip.value ? 'primary' : 'secondary' }
+						onClick={ () => selectChip( chip.value ) }
+						className="newspack-emails__chip"
+					>
+						{ chip.label }
+					</Button>
+				) ) }
 			</div>
 			<DataViews
 				className="newspack-emails"

--- a/src/wizards/newspack/views/settings/emails/emails.tsx
+++ b/src/wizards/newspack/views/settings/emails/emails.tsx
@@ -115,19 +115,21 @@ const Emails = () => {
 		[ postType, fetchData ]
 	);
 
-	const toggleWcEmail = useCallback( ( wcPostId: string, enabled: boolean ) => {
-		setError( null );
-		const previousStatus = enabled ? 'draft' : 'publish';
-		setData( prev => prev.map( email => ( email.post_id === wcPostId ? { ...email, status: enabled ? 'publish' : 'draft' } : email ) ) );
-		apiFetch( {
-			path: `/newspack/v1/wizard/newspack-settings/emails/${ wcPostId.replace( 'wc:', '' ) }/toggle`,
-			method: 'POST',
-			data: { enabled },
-		} ).catch( () => {
-			setData( prev => prev.map( email => ( email.post_id === wcPostId ? { ...email, status: previousStatus } : email ) ) );
-			setError( __( 'Failed to update email status.', 'newspack-plugin' ) );
-		} );
-	}, [] );
+	const toggleWcEmail = useCallback(
+		( wcPostId: string, enabled: boolean ) => {
+			setError( null );
+			apiFetch( {
+				path: `/newspack/v1/wizard/newspack-settings/emails/${ wcPostId.replace( 'wc:', '' ) }/toggle`,
+				method: 'POST',
+				data: { enabled },
+			} )
+				.then( () => fetchData() )
+				.catch( () => {
+					setError( __( 'Failed to update email status.', 'newspack-plugin' ) );
+				} );
+		},
+		[ fetchData ]
+	);
 
 	const resetEmail = useCallback(
 		( postId: number ) => {

--- a/src/wizards/newspack/views/settings/emails/emails.tsx
+++ b/src/wizards/newspack/views/settings/emails/emails.tsx
@@ -319,6 +319,7 @@ const Emails = () => {
 					<Button
 						key={ chip.value }
 						variant={ activeChip === chip.value ? 'primary' : 'secondary' }
+						aria-pressed={ activeChip === chip.value }
 						onClick={ () => selectChip( chip.value ) }
 						className="newspack-emails__chip"
 					>

--- a/tests/unit-tests/email-preview.php
+++ b/tests/unit-tests/email-preview.php
@@ -1,0 +1,210 @@
+<?php
+/**
+ * Tests Email_Preview.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Emails;
+use Newspack\Wizards\Newspack\Email_Preview;
+
+require_once __DIR__ . '/../mocks/newsletters-mocks.php';
+
+/**
+ * Tests Email_Preview.
+ */
+class Newspack_Test_Email_Preview extends WP_UnitTestCase {
+
+	/**
+	 * Test email config name.
+	 *
+	 * @var string
+	 */
+	private static $test_config_name = 'test-preview-config';
+
+	/**
+	 * Filter callback reference so it can be removed in tear_down().
+	 *
+	 * @var callable
+	 */
+	private $config_filter_callback;
+
+	/**
+	 * Setup.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->config_filter_callback = function ( $types ) {
+			$types[ self::$test_config_name ] = [
+				'name'        => self::$test_config_name,
+				'label'       => __( 'Test preview config', 'newspack' ),
+				'description' => __( 'Email for testing preview.', 'newspack' ),
+				'template'    => dirname( NEWSPACK_PLUGIN_FILE ) . '/includes/templates/reader-revenue-emails/receipt.php',
+				'category'    => 'test',
+			];
+			return $types;
+		};
+		add_filter( 'newspack_email_configs', $this->config_filter_callback );
+	}
+
+	/**
+	 * Teardown.
+	 */
+	public function tear_down() {
+		remove_filter( 'newspack_email_configs', $this->config_filter_callback );
+		parent::tear_down();
+	}
+
+	/**
+	 * Helper: create a newspack_rr_email post with the test config type.
+	 *
+	 * @param string $html Optional stored email HTML.
+	 * @return int Post ID.
+	 */
+	private function create_email_post( string $html = '' ): int {
+		$post_id = self::factory()->post->create(
+			[
+				'post_type'   => Emails::POST_TYPE,
+				'post_status' => 'publish',
+			]
+		);
+		update_post_meta( $post_id, Emails::EMAIL_CONFIG_NAME_META, self::$test_config_name );
+		if ( ! empty( $html ) ) {
+			update_post_meta( $post_id, \Newspack_Newsletters::EMAIL_HTML_META, $html );
+		}
+		return $post_id;
+	}
+
+	/**
+	 * The sample-substitutions map contains all expected token keys.
+	 */
+	public function test_sample_substitutions_map() {
+		$subs = Email_Preview::get_sample_substitutions();
+
+		self::assertIsArray( $subs );
+		self::assertGreaterThanOrEqual( 28, count( $subs ), 'Substitution map should have at least 28 entries.' );
+
+		$expected_keys = [
+			'*SITE_TITLE*',
+			'*SITE_URL*',
+			'*SITE_LOGO*',
+			'*BILLING_NAME*',
+			'*BILLING_FIRST_NAME*',
+			'*AMOUNT*',
+			'*PAYMENT_METHOD*',
+			'*DATE*',
+			'*ACCOUNT_URL*',
+			'*MAGIC_LINK_OTP*',
+		];
+		foreach ( $expected_keys as $key ) {
+			self::assertArrayHasKey( $key, $subs, "Missing expected token: $key" );
+		}
+	}
+
+	/**
+	 * CONTACT_EMAIL resolves through Emails::get_reply_to_email() — not admin_email.
+	 *
+	 * Pins the fix for the function_exists() bug: function_exists() cannot
+	 * test class methods, so the guard was always false and the token fell
+	 * back to admin_email regardless of the Reader Activation contact setting.
+	 */
+	public function test_contact_email_uses_reply_to_email() {
+		$custom_email = 'reply@example.org';
+		add_filter( 'newspack_reply_to_email', fn() => $custom_email );
+
+		$source_html = '<html><body>Contact us at *CONTACT_EMAIL*</body></html>';
+		$post_id     = $this->create_email_post( $source_html );
+
+		$result = Email_Preview::get_preview_html( $post_id );
+
+		self::assertStringContainsString( $custom_email, $result, 'CONTACT_EMAIL should resolve to the filtered reply-to address.' );
+		self::assertStringNotContainsString( '*CONTACT_EMAIL*', $result, 'Raw CONTACT_EMAIL token should not remain.' );
+
+		remove_all_filters( 'newspack_reply_to_email' );
+	}
+
+	/**
+	 * Tests that get_preview_html() substitutes tokens in stored EMAIL_HTML_META.
+	 */
+	public function test_get_preview_html_with_stored_meta() {
+		$source_html = '<html><body>Hello *BILLING_NAME*, your total is *AMOUNT*.</body></html>';
+		$post_id     = $this->create_email_post( $source_html );
+
+		$result = Email_Preview::get_preview_html( $post_id );
+
+		self::assertIsString( $result );
+		self::assertStringContainsString( 'Sample Reader', $result, 'BILLING_NAME should be substituted.' );
+		self::assertStringContainsString( '$25.00', $result, 'AMOUNT should be substituted.' );
+		self::assertStringNotContainsString( '*BILLING_NAME*', $result, 'Raw token should not remain.' );
+		self::assertStringNotContainsString( '*AMOUNT*', $result, 'Raw token should not remain.' );
+	}
+
+	/**
+	 * Tests that get_preview_html() falls back to template HTML when no stored meta exists.
+	 */
+	public function test_get_preview_html_fallback_to_template() {
+		$post_id = $this->create_email_post();
+
+		$result = Email_Preview::get_preview_html( $post_id );
+
+		self::assertIsString( $result );
+		self::assertNotEmpty( $result, 'Fallback to template should produce non-empty HTML.' );
+		// The receipt template contains "Thank you!" — verify substitution ran.
+		self::assertStringContainsString( 'Thank you!', $result );
+	}
+
+	/**
+	 * Tests that get_preview_html() returns false for a nonexistent post.
+	 */
+	public function test_get_preview_html_returns_false_for_nonexistent() {
+		$result = Email_Preview::get_preview_html( 999999 );
+		self::assertFalse( $result );
+	}
+
+	/**
+	 * Permission check rejects non-admin users.
+	 */
+	public function test_api_permissions_check_rejects_non_admin() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'subscriber' ] ) );
+		$result = Email_Preview::api_permissions_check();
+		self::assertInstanceOf( 'WP_Error', $result );
+	}
+
+	/**
+	 * REST API returns 404 for a post that is not of the email post type.
+	 */
+	public function test_api_get_preview_returns_404_for_wrong_post_type() {
+		$post_id = self::factory()->post->create( [ 'post_type' => 'post' ] );
+
+		$request = new WP_REST_Request( 'GET', '/newspack/v1/wizard/newspack-settings/emails/' . $post_id . '/preview' );
+		$request->set_param( 'post_id', $post_id );
+
+		$response = Email_Preview::api_get_preview( $request );
+
+		self::assertInstanceOf( 'WP_Error', $response );
+		self::assertEquals( 'newspack_email_preview_not_found', $response->get_error_code() );
+		self::assertEquals( 404, $response->get_error_data()['status'] );
+	}
+
+	/**
+	 * REST API returns HTML and post_id on success.
+	 */
+	public function test_api_get_preview_returns_html() {
+		$source_html = '<html><body>Preview for *BILLING_NAME*</body></html>';
+		$post_id     = $this->create_email_post( $source_html );
+
+		$request = new WP_REST_Request( 'GET', '/newspack/v1/wizard/newspack-settings/emails/' . $post_id . '/preview' );
+		$request->set_param( 'post_id', $post_id );
+
+		$response = Email_Preview::api_get_preview( $request );
+
+		self::assertInstanceOf( 'WP_REST_Response', $response );
+
+		$data = $response->get_data();
+		self::assertArrayHasKey( 'html', $data );
+		self::assertArrayHasKey( 'post_id', $data );
+		self::assertEquals( $post_id, $data['post_id'] );
+		self::assertStringContainsString( 'Sample Reader', $data['html'] );
+	}
+}

--- a/tests/unit-tests/email-preview.php
+++ b/tests/unit-tests/email-preview.php
@@ -77,13 +77,26 @@ class Newspack_Test_Email_Preview extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The substitution map has the expected three-key structure.
+	 */
+	public function test_sample_substitutions_structure() {
+		$subs = Email_Preview::get_sample_substitutions();
+
+		self::assertIsArray( $subs );
+		self::assertArrayHasKey( 'html', $subs, 'Missing "html" key.' );
+		self::assertArrayHasKey( 'url', $subs, 'Missing "url" key.' );
+		self::assertArrayHasKey( 'raw', $subs, 'Missing "raw" key.' );
+		self::assertCount( 3, $subs, 'Substitution map should have exactly 3 top-level keys.' );
+	}
+
+	/**
 	 * The sample-substitutions map contains all expected token keys.
 	 */
 	public function test_sample_substitutions_map() {
 		$subs = Email_Preview::get_sample_substitutions();
+		$all  = array_merge( $subs['html'], $subs['url'], $subs['raw'] );
 
-		self::assertIsArray( $subs );
-		self::assertGreaterThanOrEqual( 28, count( $subs ), 'Substitution map should have at least 28 entries.' );
+		self::assertGreaterThanOrEqual( 32, count( $all ), 'Substitution map should have at least 32 entries.' );
 
 		$expected_keys = [
 			'*SITE_TITLE*',
@@ -98,8 +111,79 @@ class Newspack_Test_Email_Preview extends WP_UnitTestCase {
 			'*MAGIC_LINK_OTP*',
 		];
 		foreach ( $expected_keys as $key ) {
-			self::assertArrayHasKey( $key, $subs, "Missing expected token: $key" );
+			self::assertArrayHasKey( $key, $all, "Missing expected token: $key" );
 		}
+	}
+
+	/**
+	 * HTML metacharacters in html-context tokens are escaped.
+	 */
+	public function test_html_tokens_are_escaped() {
+		$source_html = '<html><body>Hello *BILLING_FIRST_NAME*</body></html>';
+		$post_id     = $this->create_email_post( $source_html );
+
+		// Inject a malicious value via the filter.
+		$filter = function ( $subs ) {
+			$subs['html']['*BILLING_FIRST_NAME*'] = '<script>alert(1)</script>';
+			return $subs;
+		};
+		add_filter( 'newspack_email_preview_substitutions', $filter );
+
+		$result = Email_Preview::get_preview_html( $post_id );
+
+		self::assertStringContainsString( '&lt;script&gt;', $result, 'HTML metacharacters should be escaped.' );
+		self::assertStringNotContainsString( '<script>alert(1)</script>', $result, 'Raw script tag should not appear.' );
+
+		remove_filter( 'newspack_email_preview_substitutions', $filter );
+	}
+
+	/**
+	 * URL tokens reject dangerous protocols.
+	 */
+	public function test_url_tokens_are_sanitized() {
+		$source_html = '<html><body><a href="*ACCOUNT_URL*">Account</a></body></html>';
+		$post_id     = $this->create_email_post( $source_html );
+
+		$filter = function ( $subs ) {
+			$subs['url']['*ACCOUNT_URL*'] = 'javascript:alert(1)';
+			return $subs;
+		};
+		add_filter( 'newspack_email_preview_substitutions', $filter );
+
+		$result = Email_Preview::get_preview_html( $post_id );
+
+		self::assertStringNotContainsString( 'javascript:', $result, 'javascript: protocol should be rejected by esc_url().' );
+
+		remove_filter( 'newspack_email_preview_substitutions', $filter );
+	}
+
+	/**
+	 * Raw tokens preserve their pre-escaped HTML intact.
+	 */
+	public function test_raw_tokens_are_not_double_escaped() {
+		$source_html = '<html><body>Contact: *CONTACT_EMAIL*</body></html>';
+		$post_id     = $this->create_email_post( $source_html );
+
+		$result = Email_Preview::get_preview_html( $post_id );
+
+		self::assertStringContainsString( '<a href=', $result, 'CONTACT_EMAIL <a> tag should be preserved.' );
+		self::assertStringNotContainsString( '&lt;a href=', $result, 'CONTACT_EMAIL <a> tag should not be double-escaped.' );
+	}
+
+	/**
+	 * Translatable sample strings are wrapped in __().
+	 */
+	public function test_translated_strings() {
+		$subs = Email_Preview::get_sample_substitutions();
+
+		// These values should match __() output (in English they're identical,
+		// but this asserts the wrapping is in place).
+		self::assertEquals( __( 'Sample', 'newspack-plugin' ), $subs['html']['*BILLING_FIRST_NAME*'] );
+		self::assertEquals( __( 'Reader', 'newspack-plugin' ), $subs['html']['*BILLING_LAST_NAME*'] );
+		self::assertEquals( __( 'Sample Reader', 'newspack-plugin' ), $subs['html']['*BILLING_NAME*'] );
+		self::assertEquals( __( 'Visa ending in 4242', 'newspack-plugin' ), $subs['html']['*PAYMENT_METHOD*'] );
+		self::assertEquals( __( 'Monthly Membership', 'newspack-plugin' ), $subs['html']['*PRODUCT_NAME*'] );
+		self::assertEquals( __( 'monthly', 'newspack-plugin' ), $subs['html']['*BILLING_FREQUENCY*'] );
 	}
 
 	/**

--- a/tests/unit-tests/emails-section.php
+++ b/tests/unit-tests/emails-section.php
@@ -16,7 +16,7 @@ class Newspack_Test_Emails_Section extends WP_UnitTestCase {
 	 */
 	public function test_registry_entries_have_required_keys() {
 		$registry     = Emails_Section::get_email_registry();
-		$required_keys = [ 'source', 'recommended', 'plugin_dependency', 'recipient', 'label', 'trigger_description' ];
+		$required_keys = [ 'source', 'recommended', 'plugin_dependency', 'recipient', 'chip', 'label', 'trigger_description' ];
 
 		foreach ( $registry as $slug => $entry ) {
 			foreach ( $required_keys as $key ) {
@@ -42,6 +42,16 @@ class Newspack_Test_Emails_Section extends WP_UnitTestCase {
 		$registry = Emails_Section::get_email_registry();
 		foreach ( $registry as $slug => $entry ) {
 			$this->assertContains( $entry['recipient'], [ 'reader', 'admin' ], "Entry '$slug' has an invalid recipient value." );
+		}
+	}
+
+	/**
+	 * Test all registry entries have a valid chip value.
+	 */
+	public function test_registry_entries_have_valid_chip() {
+		$registry = Emails_Section::get_email_registry();
+		foreach ( $registry as $slug => $entry ) {
+			$this->assertContains( $entry['chip'], [ 'auth-account', 'reader-revenue' ], "Entry '$slug' has an invalid chip value." );
 		}
 	}
 
@@ -117,6 +127,57 @@ class Newspack_Test_Emails_Section extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test dropped entries are absent from the registry.
+	 */
+	public function test_dropped_entries_are_absent() {
+		$registry     = Emails_Section::get_email_registry();
+		$dropped_slugs = [
+			'woo-password-reset',
+			'woo-processing-order',
+			'woo-completed-order',
+			'woo-on-hold-order',
+			'woo-subscription-cancelled',
+		];
+		foreach ( $dropped_slugs as $slug ) {
+			$this->assertArrayNotHasKey( $slug, $registry, "Dropped entry '$slug' should not be in the registry." );
+		}
+	}
+
+	/**
+	 * Test new WC Subscriptions entries are present with correct woo_email_id values.
+	 */
+	public function test_new_entries_are_present() {
+		$registry = Emails_Section::get_email_registry();
+
+		$this->assertArrayHasKey( 'woo-subscription-switch-complete', $registry );
+		$this->assertSame( 'customer_completed_switch_order', $registry['woo-subscription-switch-complete']['woo_email_id'] );
+
+		$this->assertArrayHasKey( 'woo-new-giftee-account', $registry );
+		$this->assertSame( 'WCSG_Email_Customer_New_Account', $registry['woo-new-giftee-account']['woo_email_id'] );
+
+		$this->assertArrayHasKey( 'woo-new-gift-order', $registry );
+		$this->assertSame( 'recipient_completed_order', $registry['woo-new-gift-order']['woo_email_id'] );
+	}
+
+	/**
+	 * Test renamed entries have updated labels.
+	 */
+	public function test_renamed_entries_have_updated_labels() {
+		$registry = Emails_Section::get_email_registry();
+
+		$this->assertSame( 'Renewal reminder', $registry['woo-renewal-reminder']['label'] );
+		$this->assertSame( 'Failed order retry', $registry['woo-payment-retry']['label'] );
+	}
+
+	/**
+	 * Test renewal reminder maps to the auto-renewal notification ID.
+	 */
+	public function test_renewal_reminder_maps_to_auto_renewal_id() {
+		$registry = Emails_Section::get_email_registry();
+		$this->assertSame( 'customer_notification_auto_renewal', $registry['woo-renewal-reminder']['woo_email_id'] );
+	}
+
+	/**
 	 * Test api_get_email_settings returns the expected response shape.
 	 */
 	public function test_api_get_email_settings_response_shape() {
@@ -133,7 +194,7 @@ class Newspack_Test_Emails_Section extends WP_UnitTestCase {
 		}
 
 		// Verify enriched fields on each Newspack email that has a registry_slug.
-		$enriched_keys  = [ 'label', 'recommended', 'trigger_description', 'registry_slug', 'recipient', 'source' ];
+		$enriched_keys  = [ 'label', 'recommended', 'trigger_description', 'registry_slug', 'recipient', 'source', 'chip' ];
 		$enriched_count = 0;
 		foreach ( $result['newspack_emails'] as $email ) {
 			if ( empty( $email['registry_slug'] ) ) {
@@ -141,6 +202,7 @@ class Newspack_Test_Emails_Section extends WP_UnitTestCase {
 				$this->assertArrayHasKey( 'recommended', $email, 'Fallback email is missing recommended.' );
 				$this->assertFalse( $email['recommended'], 'Fallback email should have recommended=false.' );
 				$this->assertArrayHasKey( 'source', $email, 'Fallback email is missing source.' );
+				$this->assertArrayHasKey( 'chip', $email, 'Fallback email is missing chip.' );
 				continue;
 			}
 			++$enriched_count;
@@ -158,7 +220,7 @@ class Newspack_Test_Emails_Section extends WP_UnitTestCase {
 		$result     = Emails_Section::api_get_email_settings();
 		$categories = array_column( $result['newspack_emails'], 'category' );
 
-		// Build the expected group order: reader-revenue → reader-activation → everything else.
+		// Build the expected group order: reader-revenue -> reader-activation -> everything else.
 		$last_group = -1;
 		$group_map  = [
 			'reader-revenue'    => 0,
@@ -185,9 +247,6 @@ class Newspack_Test_Emails_Section extends WP_UnitTestCase {
 			)
 		);
 		$this->assertContains( 'woo-new-order', $admin_slugs, 'new_order is an admin email.' );
-		// woo-subscription-cancelled is reader-facing (Newspack notifies the reader);
-		// the separate WC admin notification is handled by WooCommerce core.
-		$this->assertNotContains( 'woo-subscription-cancelled', $admin_slugs );
 	}
 
 	/**
@@ -200,6 +259,7 @@ class Newspack_Test_Emails_Section extends WP_UnitTestCase {
 			'recommended'         => false,
 			'plugin_dependency'   => null,
 			'recipient'           => 'reader',
+			'chip'                => 'auth-account',
 			'label'               => 'Test filter email',
 			'trigger_description' => 'Added via filter.',
 		];
@@ -226,7 +286,7 @@ class Newspack_Test_Emails_Section extends WP_UnitTestCase {
 	public function test_registry_order_within_groups() {
 		$slugs = array_keys( Emails_Section::get_email_registry() );
 
-		// Reader-revenue group: receipt → welcome → cancellation.
+		// Reader-revenue group: receipt -> welcome -> cancellation.
 		$this->assertLessThan(
 			array_search( 'welcome', $slugs, true ),
 			array_search( 'receipt', $slugs, true ),
@@ -238,7 +298,7 @@ class Newspack_Test_Emails_Section extends WP_UnitTestCase {
 			'welcome should appear before cancellation.'
 		);
 
-		// Reader-activation group: verification → login-link → set-new-password.
+		// Reader-activation group: verification -> login-link -> set-new-password.
 		$this->assertLessThan(
 			array_search( 'login-link', $slugs, true ),
 			array_search( 'verification', $slugs, true ),


### PR DESCRIPTION
## What this PR does

Second slice of the unified email management UI ([NPPD-1527](https://linear.app/a8c/issue/NPPD-1527)). Builds on slice 1's registry + DataViews scaffolding to surface WooCommerce emails as first-class rows, adds chip-based filtering, and renders themed preview thumbnails matched to the block editor's in-editor view.

This slice closes the loop on the PRD's "one place to manage all reader emails" promise — Newspack-managed emails and curated WC emails now share a single screen with consistent search, status, and toggle behavior.

<img width="3246" height="2192" alt="image" src="https://github.com/user-attachments/assets/ec791ba5-af40-47a4-a61c-a4509191fafe" />

Depends on slice 1 ([#4727](https://github.com/Automattic/newspack-plugin/pull/4727)).

## Code changes

**Backend — `includes/wizards/newspack/class-emails-section.php`**

- Adds a `chip` key (`auth-account` or `reader-revenue`) to every registry entry. Cleans up 5 entries that don't belong in the unified UI (`woo-password-reset`, `woo-processing-order`, `woo-completed-order`, `woo-on-hold-order`, `woo-subscription-cancelled`).
- Adds 3 new WC Subscriptions entries: subscription switch complete, new giftee account, new gift order (gifting is bundled into WC Subs core, so all three gate on `woocommerce-subscriptions`).
- Renames woo-renewal-reminder → "Renewal reminder" and switches its woo_email_id from customer_renewal_invoice to customer_notification_auto_renewal. Trigger description references WC Subs settings rather than hardcoding the day count, since publishers can change the Reminder Timing in WooCommerce → Settings → Subscriptions.
- Extends `api_get_email_settings()` to resolve `woocommerce`-source registry entries to live `WC_Email` instances via `WC()->mailer()->get_emails()`. Plugin-dependency gating skips entries whose dependency isn't active. Each row gets a string `post_id` (`wc:{email_id}`), a contextual `edit_link` (block editor if `woocommerce_feature_block_email_editor_enabled`, classic settings otherwise), and a `preview_post_id` for block-editor-backed emails.
- Adds a first-run option (newspack_unified_emails_wc_first_run) that enables only recommended WC emails on first load (skipping woo-refund and woo-new-order, both recommended=false, so pubs who intentionally left those off aren't surprised).
- Adds a new REST route: POST /newspack/v1/wizard/newspack-settings/emails/{id}/toggle for enabling/disabling WC emails. Conditional on WooCommerce being active, uses [A-Za-z0-9_]+ to accommodate the mixed-case WCSG_Email_Customer_New_Account ID, and validates the email ID against the registry before toggling so the API surface matches the UI.

**Backend — `includes/wizards/newspack/class-email-preview.php` (new)**

- New `Email_Preview` class consolidates preview rendering for both Newspack-managed and WooCommerce emails.
- For Newspack emails: substitutes template tokens (`*BILLING_NAME*`, `*AMOUNT*`, `*SITE_LOGO*`, etc.) with stable sample values. Site/branding tokens use real publisher config; reader/transaction tokens use stable fakes; action URLs become anchor placeholders so preview clicks don't navigate. Falls back to the registered template's default HTML when the post has no saved meta. Exposed via filter `newspack_email_preview_substitutions` for extension.
- For WooCommerce emails: tries the block-editor render path first via `BlockEmailRenderer::maybe_render_block_email()`, producing HTML styled with the site's theme.json colors and logo (matching what the block editor shows). Falls back to WC's legacy `EmailPreview::render()` if the block path is unavailable or throws. Block output is cached in a transient keyed by post ID + modified time (1 hr TTL) since the block render benchmarks at ~180 ms per email.
- Adds a new REST route: `GET /newspack/v1/wizard/newspack-settings/emails/{post_id}/preview` returning rendered HTML, with permission check.

**Frontend — `src/wizards/newspack/views/settings/emails/`**

- New `EmailPreview` component (`email-preview.tsx`) replaces the slice 1 envelope placeholder. Lazy-loads via `IntersectionObserver` (fetch only when the row scrolls into view), measures container width via `ResizeObserver` and scales an iframe accordingly. Uses `srcDoc` with `sandbox="allow-same-origin"` (no scripts) for safety. Stale-request cancellation guards against postId changes mid-fetch. Fade-in via `is-ready` class after stylesheets and images load (with an 8s safety timeout).
- Adds a chip bar above the DataViews grid with two options: Reader revenue (default) and Authentication & account. Switching chips filters the data and resets search/page.
- Updates `EmailItem` interface: `post_id` is now `number | string` (WC emails use `wc:` prefix), adds `preview_post_id?: number | null` and `chip` fields.
- Deactivate/activate actions now route based on `post_id` type: string → toggle endpoint, number → existing `wp/v2` status update. Removes the slice 1 `source !== 'woocommerce'` eligibility guard. Reset action remains Newspack-only (different storage backend).
- Updated styles (`emails.scss`, new `email-preview.scss`): pill-shaped chip buttons, preview iframe container with aspect-ratio + transform-origin sizing.

**Tests**

- PHPUnit (`tests/unit-tests/emails-section.php`, `tests/unit-tests/email-preview.php`): chip-key validation, dropped entries absent, new entries present with correct `woo_email_id` values, renamed labels, source switch for renewal reminder, fallback shape; preview HTML generation with stored meta and template fallback, `CONTACT_EMAIL` resolves via `Emails::get_reply_to_email()`, REST permissions, REST 404 on wrong post type.
- Jest (`emails.test.js`, `email-preview.test.js`): chip toggling between auth-account and reader-revenue, WC toggle endpoint routing for deactivate/activate, WC emails now eligible for activate/deactivate, lazy load via IntersectionObserver, stale-request cancellation, error fallback to envelope icon, correct REST path.

## Why slice this PR

Same rationale as slice 1: the full PRD scope (Newspack + WC + WC Subs + WC Subs Gifting, chips UI, plugin-conditional logic, status toggling across different storage backends, themed preview rendering) is meaty. Splitting at the registry-surfacing boundary kept slice 1 reviewable; this slice picks up where that left off without dragging in slice 1's churn.

## Manual testing

Tested locally with Newspack, Newspack Newsletters, WooCommerce, WooCommerce Subscriptions (including bundled gifting), and the WC Block Email Editor feature enabled. Verified:

- Chip bar renders with Reader revenue selected by default; toggling to Auth & account swaps the visible rows and resets search/page
- All 9 WC emails (1 Auth, 8 Reader revenue) surface alongside Newspack-managed emails when WC + WC Subs are active
- Renewal reminder maps to the auto-renewal notice and reflects the WC Subs default 3-day offset
- WC email toggle persists across page refresh and reflects in WC's own settings page
- Block editor edit-link works for the 3 core WC emails (Account created, Refund, New order); WC Subs emails fall back to classic settings (no block editor support yet from Woo)
- Preview thumbnails for the 3 core WC emails render with site logo and theme colors (not Woo purple), matching the block editor's in-editor view
- WC Subs emails show no thumbnail (intentional — they don't have block editor templates yet)
- First-run enable-by-default activates all recommended WC emails the first time the screen loads
- Newspack-managed emails still render their thumbnails correctly via the substitution path
- Editing a WC email template in the block editor causes the preview cache to refresh on next load

PHPUnit not run locally.

### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?