### PR TITLE
fix(web-preview): right-align toolbar close button

### DIFF
--- a/packages/components/src/web-preview/style.scss
+++ b/packages/components/src/web-preview/style.scss
@@ -103,10 +103,9 @@
 		}
 
 		&-right {
-			display: grid;
+			display: flex;
 			gap: 8px;
-			grid-template-columns: repeat(2, 1fr);
-			justify-self: end;
+			justify-content: flex-end;
 			margin-left: auto;
 		}
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The `.newspack-web-preview__toolbar-right` container uses `display: grid; grid-template-columns: repeat(2, 1fr)`. When no `title` prop is passed to `<WebPreview>` (e.g. the Newspack Campaigns prompt preview), the toolbar has only one flex child and the two 1fr columns end up spreading the device-size dropdown and the close button across the full width of the toolbar — the close button ends up apparently centered/misaligned instead of right-aligned next to the device dropdown.

Switch the layout to `display: flex; justify-content: flex-end` so the two buttons always cluster together on the right edge, regardless of whether a title is rendered.

Before:

![before](https://github.com/user-attachments/assets/placeholder-before)

After: device dropdown and close button sit together at the right edge of the toolbar.

### How to test the changes in this Pull Request:

1. With this branch built into the `newspack-plugin` (and `newspack-components` consumed by `newspack-popups`), edit a Newspack Campaigns prompt.
2. Click the **Preview** button in the sidebar to open the web preview modal.
3. Confirm the device-size dropdown (laptop icon) and the close (X) button sit next to each other on the right edge of the toolbar.
4. Also verify the segments / prompts wizard (which passes `title`) still renders correctly with the title on the left and buttons on the right.

### Other information:

* CSS-only change; no PHP or JS logic touched.
* Affects every consumer of `WebPreview` from `newspack-components`.