### PR TITLE
fix(web-preview): right-align toolbar close button

### DIFF
--- a/packages/components/src/web-preview/style.scss
+++ b/packages/components/src/web-preview/style.scss
@@ -103,10 +103,9 @@
 		}
 
 		&-right {
-			display: grid;
+			display: flex;
 			gap: 8px;
-			grid-template-columns: repeat(2, 1fr);
-			justify-self: end;
+			justify-content: flex-end;
 			margin-left: auto;
 		}
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Hotfix targeting `release`.

`.newspack-web-preview__toolbar-right` uses `display: grid; grid-template-columns: repeat(2, 1fr)`. When no `title` prop is passed to `<WebPreview>` (e.g. the Newspack Campaigns prompt preview), the toolbar has only one flex child and the two 1fr columns end up spreading the device-size dropdown and the close button across the full width of the toolbar – the close button is no longer right-aligned next to the device dropdown.

Switch the layout to `display: flex; justify-content: flex-end` so the two buttons always cluster together on the right edge, regardless of whether a title is rendered.

### How to test the changes in this Pull Request:

Tested locally on the components demo page (`/wp-admin/admin.php?page=newspack-components-demo`, the "Web Previews" section, which has one `<WebPreview>` with `title` and one without):

| Case | Result |
|---|---|
| Without title (Campaigns prompt preview case) | Device dropdown and close button cluster on the right edge of the toolbar |
| With title (Segments / Prompts wizard case) | Title left, buttons right |

Steps:
1. `n build newspack-plugin`
2. Visit `/wp-admin/admin.php?page=newspack-components-demo`
3. Scroll to the "Web Previews" card and click each "Preview Newspack Site" trigger.
4. Confirm in both modals the device-size icon and close X sit together at the right edge.

### Other information:

* CSS-only change in `packages/components/src/web-preview/style.scss` (1 file, +2 / -3).
* Affects every consumer of `WebPreview` from `newspack-components` (newspack-popups, newspack-newsletters, newspack-ads, newspack-multibranded-site, newspack-block-theme, newspack-manager, newspack-listings). Layout is backwards compatible.
* Supersedes #4734 (which was opened against trunk by mistake).