### PR TITLE
fix(wc-memberships): skip expiry filter for non-subscription memberships

### DIFF
--- a/includes/plugins/wc-memberships/class-membership-expiry.php
+++ b/includes/plugins/wc-memberships/class-membership-expiry.php
@@ -28,11 +28,16 @@ class Membership_Expiry {
 	/**
 	 * Prevent membership expiration if there are other active subscriptions.
 	 *
-	 * @param bool                                                      $cancel_membership Whether to cancel the membership when the subscription is cancelled (default true).
-	 * @param \WC_Memberships_Integration_Subscriptions_User_Membership $user_membership The subscription-tied membership.
+	 * @param bool                            $cancel_membership Whether to cancel the membership when the subscription is cancelled (default true).
+	 * @param \WC_Memberships_User_Membership $user_membership   The membership. Only subscription-tied memberships (\WC_Memberships_Integration_Subscriptions_User_Membership) expose get_subscription_id()/set_subscription_id().
 	 */
 	public static function prevent_membership_expiration( $cancel_membership, $user_membership ) {
 		if ( ! function_exists( 'wcs_get_subscription' ) ) {
+			return $cancel_membership;
+		}
+		// `wc_memberships_expire_user_membership` fires for every membership, but only the
+		// Subscriptions integration class exposes get_subscription_id()/set_subscription_id().
+		if ( ! method_exists( $user_membership, 'get_subscription_id' ) ) {
 			return $cancel_membership;
 		}
 		$membership_product_id = $user_membership->get_product_id();

--- a/tests/unit-tests/plugins/wc-memberships/membership-expiry.php
+++ b/tests/unit-tests/plugins/wc-memberships/membership-expiry.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Tests for the WC Memberships expiry handler.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Membership_Expiry;
+
+require_once dirname( __DIR__, 3 ) . '/mocks/wc-mocks.php';
+
+/**
+ * Test Membership_Expiry::prevent_membership_expiration().
+ *
+ * @group membership-expiry
+ */
+class Test_Membership_Expiry extends WP_UnitTestCase {
+
+	/**
+	 * The wc_memberships_expire_user_membership filter fires for every user membership,
+	 * not just subscription-tied ones. Plain WC_Memberships_User_Membership objects do
+	 * not expose get_subscription_id(); calling it must not fatal.
+	 *
+	 * Reproduces the production fatal observed at v6.39.3 of newspack-plugin:
+	 *   Uncaught Error: Call to undefined method WC_Memberships_User_Membership::get_subscription_id()
+	 *   in includes/plugins/wc-memberships/class-membership-expiry.php:39
+	 */
+	public function test_passes_through_non_subscription_membership() {
+		$non_subscription_membership = new class() {
+			/**
+			 * Return a product id.
+			 *
+			 * @return int
+			 */
+			public function get_product_id() {
+				return 123;
+			}
+
+			/**
+			 * Return a user id.
+			 *
+			 * @return int
+			 */
+			public function get_user_id() {
+				return 456;
+			}
+
+			// Deliberately no get_subscription_id() — only the Subscriptions integration class has it.
+		};
+
+		$result = Membership_Expiry::prevent_membership_expiration( true, $non_subscription_membership );
+		$this->assertTrue( $result, 'Filter should return the incoming $cancel_membership unchanged when the membership is not subscription-tied.' );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

`Membership_Expiry::prevent_membership_expiration()` is hooked into `wc_memberships_expire_user_membership`, which fires for **every** user membership. The handler assumed every membership was a subscription-tied one (`\WC_Memberships_Integration_Subscriptions_User_Membership`) and called `get_subscription_id()` on it. For plain `WC_Memberships_User_Membership` objects (no linked subscription), that method does not exist, so the call throws `Uncaught Error: Call to undefined method WC_Memberships_User_Membership::get_subscription_id()`.

This adds an early `method_exists()` guard that returns the incoming `$cancel_membership` value unchanged when the membership is not subscription-tied, so the filter is effectively a no-op for memberships it cannot reason about. The docblock type for `$user_membership` is also widened from the integration class to the base class to match reality.

### How to test the changes in this Pull Request:

1. With WC Memberships active **but without WC Subscriptions** (or with a manually-granted membership that has no linked subscription), expire that membership in the admin or via `wp wc memberships ...`. Confirm no PHP fatal is logged.
2. With WC Subscriptions active and a subscription-tied membership, cancel the underlying subscription. Confirm the existing behavior still works: if another active subscription for the same product exists, the membership is reassigned and not expired; otherwise it expires normally.
3. Run the included unit test: `composer test -- --filter test_passes_through_non_subscription_membership`. It must pass; without the fix it errors with `Call to undefined method ... ::get_subscription_id()`.
4. Run the full plugin test suite to confirm no regressions: `composer test`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?