### PR TITLE
fix(reader-activation): exclude peeking newsletter from a11y tree

### DIFF
--- a/includes/class-newspack-ui.php
+++ b/includes/class-newspack-ui.php
@@ -1183,15 +1183,17 @@ class Newspack_UI {
 								<input type="hidden" name="email_address" value="<?php echo esc_attr( $demo_email_address ); ?>" />
 
 								<?php $demo_has_overflow = count( $demo_newsletters_lists ) > (int) $demo_default_list_size; ?>
-								<div class="newspack-ui__stack newspack-ui__stack--vertical newspack-ui__stack--gap-2 overflow-hidden position-relative newsletter-list-container" data-list-default-size="<?php echo esc_attr( $demo_default_list_size ); ?>">
+								<div class="newspack-ui__stack newspack-ui__stack--vertical newspack-ui__stack--gap-2 overflow-hidden position-relative newsletter-list-container">
 								<?php
 								foreach ( $demo_newsletters_lists as $list ) {
-									$checkbox_id = sprintf( 'newspack-plugin-list-%s', $list['id'] );
-									$is_peek     = $loop_index === (int) $demo_default_list_size;
-									$is_hidden   = $loop_index > (int) $demo_default_list_size;
+									$checkbox_id   = sprintf( 'newspack-plugin-list-%s', $list['id'] );
+									$is_peek       = $loop_index === (int) $demo_default_list_size;
+									$is_hidden     = $loop_index > (int) $demo_default_list_size;
+									$label_classes = 'newspack-ui__input-card' . ( $is_hidden ? ' hidden' : '' );
+									$label_inert   = ( $is_peek || $is_hidden ) ? ' inert' : '';
 									$loop_index++;
 									?>
-									<label class="newspack-ui__input-card<?php echo $is_hidden ? ' hidden' : ''; ?>" for="<?php echo esc_attr( $checkbox_id ); ?>"<?php echo ( $is_peek || $is_hidden ) ? ' inert' : ''; ?>>
+									<label class="<?php echo esc_attr( $label_classes ); ?>" for="<?php echo esc_attr( $checkbox_id ); ?>"<?php echo esc_attr( $label_inert ); ?>>
 										<input
 											type="checkbox"
 											name="lists[]"
@@ -1258,7 +1260,7 @@ class Newspack_UI {
 									} );
 
 									if ( peekItem ) {
-										const peekAmount = 32;
+										const peekAmount = ( divider && divider.offsetHeight ) || 32;
 										newsletterContainer.style.maxHeight = ( peekItem.offsetTop + peekAmount ) + 'px';
 									}
 								};

--- a/includes/class-newspack-ui.php
+++ b/includes/class-newspack-ui.php
@@ -1229,13 +1229,12 @@ class Newspack_UI {
 						</div>
 						<script>
 							( function() {
-								const container = document.querySelector( '.newspack-newsletters-signup' );
-								if ( ! container ) {
-									return;
-								}
-								const seeAllButton = container.querySelector( '.see-all-button' );
-								const newsletterContainer = container.querySelector( '.newsletter-list-container' );
-								if ( seeAllButton && newsletterContainer ) {
+								const setupReveal = function( container ) {
+									const seeAllButton = container.querySelector( '.see-all-button' );
+									const newsletterContainer = container.querySelector( '.newsletter-list-container' );
+									if ( ! seeAllButton || ! newsletterContainer ) {
+										return;
+									}
 									const divider = newsletterContainer.querySelector( '.newspack-ui__gradient-divider' );
 									const peekItem = newsletterContainer.querySelector( '.newspack-ui__input-card[inert]:not(.hidden)' );
 
@@ -1262,6 +1261,11 @@ class Newspack_UI {
 										const peekAmount = 32;
 										newsletterContainer.style.maxHeight = ( peekItem.offsetTop + peekAmount ) + 'px';
 									}
+								};
+
+								const container = document.querySelector( '.newspack-newsletters-signup' );
+								if ( container ) {
+									setupReveal( container );
 								}
 							} )();
 						</script>

--- a/includes/class-newspack-ui.php
+++ b/includes/class-newspack-ui.php
@@ -1182,14 +1182,16 @@ class Newspack_UI {
 								<input type="hidden" name="reader-activation-newsletters-signup" value="1" />
 								<input type="hidden" name="email_address" value="<?php echo esc_attr( $demo_email_address ); ?>" />
 
+								<?php $demo_has_overflow = count( $demo_newsletters_lists ) > (int) $demo_default_list_size; ?>
 								<div class="newspack-ui__stack newspack-ui__stack--vertical newspack-ui__stack--gap-2 overflow-hidden position-relative newsletter-list-container" data-list-default-size="<?php echo esc_attr( $demo_default_list_size ); ?>">
 								<?php
 								foreach ( $demo_newsletters_lists as $list ) {
 									$checkbox_id = sprintf( 'newspack-plugin-list-%s', $list['id'] );
-									$is_hidden   = $loop_index <= $demo_default_list_size ? '' : 'hidden';
+									$is_peek     = $loop_index === (int) $demo_default_list_size;
+									$is_hidden   = $loop_index > (int) $demo_default_list_size;
 									$loop_index++;
 									?>
-									<label class="newspack-ui__input-card <?php echo esc_attr( $is_hidden ); ?>" for="<?php echo esc_attr( $checkbox_id ); ?>">
+									<label class="newspack-ui__input-card<?php echo $is_hidden ? ' hidden' : ''; ?>" for="<?php echo esc_attr( $checkbox_id ); ?>"<?php echo ( $is_peek || $is_hidden ) ? ' inert' : ''; ?>>
 										<input
 											type="checkbox"
 											name="lists[]"
@@ -1207,17 +1209,15 @@ class Newspack_UI {
 										<?php endif; ?>
 									</label>
 									<?php
-									if ( $loop_index === (int) $demo_default_list_size && count( $demo_newsletters_lists ) > $demo_default_list_size ) :
-										?>
-										<div class="newspack-ui__gradient-divider"></div>
-										<?php
-									endif;
 								}
 								?>
+								<?php if ( $demo_has_overflow ) : ?>
+									<div class="newspack-ui__gradient-divider"></div>
+								<?php endif; ?>
 								</div>
 
 								<div class="newspack-ui__stack newspack-ui__stack--vertical newspack-ui__stack--gap-2 newspack-ui__spacing-top--5">
-									<?php if ( count( $demo_newsletters_lists ) > $demo_default_list_size ) : ?>
+									<?php if ( $demo_has_overflow ) : ?>
 										<button type="button" class="newspack-ui__button newspack-ui__button--wide newspack-ui__button--secondary see-all-button" aria-label="<?php esc_attr_e( 'See all newsletters', 'newspack-plugin' ); ?>">
 											<span aria-hidden="true"><?php esc_html_e( 'See all', 'newspack-plugin' ); ?></span>
 											<?php Newspack_UI_Icons::print_svg( 'chevronDownSmall' ); ?>
@@ -1237,34 +1237,30 @@ class Newspack_UI {
 								const newsletterContainer = container.querySelector( '.newsletter-list-container' );
 								if ( seeAllButton && newsletterContainer ) {
 									const divider = newsletterContainer.querySelector( '.newspack-ui__gradient-divider' );
+									const peekItem = newsletterContainer.querySelector( '.newspack-ui__input-card[inert]:not(.hidden)' );
+
 									seeAllButton.addEventListener( 'click', function() {
-										newsletterContainer.querySelectorAll( '.hidden' ).forEach( function( item ) {
+										const firstRevealed = newsletterContainer.querySelector( '.newspack-ui__input-card[inert]' );
+										newsletterContainer.querySelectorAll( '.newspack-ui__input-card[inert]' ).forEach( function( item ) {
 											item.classList.remove( 'hidden' );
+											item.removeAttribute( 'inert' );
 										} );
 										newsletterContainer.style.maxHeight = 'none';
 										if ( divider ) {
 											divider.classList.add( 'hidden' );
 										}
 										seeAllButton.classList.add( 'hidden' );
+										if ( firstRevealed ) {
+											const firstInput = firstRevealed.querySelector( 'input' );
+											if ( firstInput ) {
+												firstInput.focus();
+											}
+										}
 									} );
 
-									// Set the initial height to show partially visible.
-									const listDefaultSize = parseInt( newsletterContainer.dataset.listDefaultSize, 10 );
-									const newsletterItems = newsletterContainer.querySelectorAll( '.newspack-ui__input-card' );
-
-									if ( newsletterItems.length > listDefaultSize ) {
-										const gap = 12;
-										const extraSpace = 32;
-
-										let totalHeight = 0;
-										newsletterItems.forEach( function( item, index ) {
-											if ( index < listDefaultSize ) {
-												totalHeight += item.offsetHeight;
-											}
-										} );
-
-										const maxHeight = totalHeight + listDefaultSize * gap + extraSpace;
-										newsletterContainer.style.maxHeight = maxHeight + 'px';
+									if ( peekItem ) {
+										const peekAmount = 32;
+										newsletterContainer.style.maxHeight = ( peekItem.offsetTop + peekAmount ) + 'px';
 									}
 								}
 							} )();

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1731,10 +1731,13 @@ final class Reader_Activation {
 					<?php
 					foreach ( $newsletters_lists as $list ) {
 						$checkbox_id = sprintf( 'newspack-plugin-list-%s', $list['id'] );
+						// Peeking item: stays in DOM flow so the container's max-height reveals its top edge,
+						// but is hidden from assistive tech and keyboard focus until "See all" is clicked.
+						$is_peek     = $loop_index === (int) $default_list_size;
 						$is_hidden   = $loop_index <= $default_list_size ? '' : 'hidden';
 						$loop_index++;
 						?>
-						<label class="newspack-ui__input-card <?php echo esc_attr( $is_hidden ); ?>" for="<?php echo \esc_attr( $checkbox_id ); ?>">
+						<label class="newspack-ui__input-card <?php echo esc_attr( $is_hidden ); ?>" for="<?php echo \esc_attr( $checkbox_id ); ?>"<?php echo $is_peek ? ' aria-hidden="true"' : ''; ?>>
 							<input
 								type="checkbox"
 								name="lists[]"
@@ -1743,6 +1746,9 @@ final class Reader_Activation {
 								<?php
 								if ( isset( $list['checked'] ) && $list['checked'] ) {
 									echo 'checked';
+								}
+								if ( $is_peek ) {
+									echo 'tabindex="-1"';
 								}
 								?>
 							>

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1732,12 +1732,13 @@ final class Reader_Activation {
 					foreach ( $newsletters_lists as $list ) {
 						$checkbox_id = sprintf( 'newspack-plugin-list-%s', $list['id'] );
 						// Peeking item: stays in DOM flow so the container's max-height reveals its top edge,
-						// but is hidden from assistive tech and keyboard focus until "See all" is clicked.
+						// but is made inert so it is excluded from the a11y tree and all focus paths
+						// (keyboard, mouse, and programmatic) until "See all" is clicked.
 						$is_peek     = $loop_index === (int) $default_list_size;
 						$is_hidden   = $loop_index <= $default_list_size ? '' : 'hidden';
 						$loop_index++;
 						?>
-						<label class="newspack-ui__input-card <?php echo esc_attr( $is_hidden ); ?>" for="<?php echo \esc_attr( $checkbox_id ); ?>"<?php echo $is_peek ? ' aria-hidden="true"' : ''; ?>>
+						<label class="newspack-ui__input-card <?php echo esc_attr( $is_hidden ); ?>" for="<?php echo \esc_attr( $checkbox_id ); ?>"<?php echo $is_peek ? ' inert' : ''; ?>>
 							<input
 								type="checkbox"
 								name="lists[]"
@@ -1746,9 +1747,6 @@ final class Reader_Activation {
 								<?php
 								if ( isset( $list['checked'] ) && $list['checked'] ) {
 									echo 'checked';
-								}
-								if ( $is_peek ) {
-									echo 'tabindex="-1"';
 								}
 								?>
 							>

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1727,18 +1727,16 @@ final class Reader_Activation {
 					<input type="hidden" name="<?php echo \esc_attr( self::NEWSLETTERS_SIGNUP_FORM_ACTION ); ?>" value="1" />
 					<input type="hidden" name="email_address" value="<?php echo esc_attr( $email_address ); ?>" />
 
+					<?php $has_overflow = count( $newsletters_lists ) > (int) $default_list_size; ?>
 					<div class="newspack-ui__stack newspack-ui__stack--vertical newspack-ui__stack--gap-2 overflow-hidden position-relative newsletter-list-container" data-list-default-size="<?php echo esc_attr( $default_list_size ); ?>">
 					<?php
 					foreach ( $newsletters_lists as $list ) {
 						$checkbox_id = sprintf( 'newspack-plugin-list-%s', $list['id'] );
-						// Peeking item: stays in DOM flow so the container's max-height reveals its top edge,
-						// but is made inert so it is excluded from the a11y tree and all focus paths
-						// (keyboard, mouse, and programmatic) until "See all" is clicked.
 						$is_peek     = $loop_index === (int) $default_list_size;
-						$is_hidden   = $loop_index <= $default_list_size ? '' : 'hidden';
+						$is_hidden   = $loop_index > (int) $default_list_size;
 						$loop_index++;
 						?>
-						<label class="newspack-ui__input-card <?php echo esc_attr( $is_hidden ); ?>" for="<?php echo \esc_attr( $checkbox_id ); ?>"<?php echo $is_peek ? ' inert' : ''; ?>>
+						<label class="newspack-ui__input-card<?php echo $is_hidden ? ' hidden' : ''; ?>" for="<?php echo \esc_attr( $checkbox_id ); ?>"<?php echo ( $is_peek || $is_hidden ) ? ' inert' : ''; ?>>
 							<input
 								type="checkbox"
 								name="lists[]"
@@ -1756,13 +1754,11 @@ final class Reader_Activation {
 							<?php endif; ?>
 						</label>
 						<?php
-						if ( $loop_index === (int) $default_list_size && count( $newsletters_lists ) > $default_list_size ) :
-							?>
-							<div class="newspack-ui__gradient-divider"></div>
-							<?php
-						endif;
 					}
 					?>
+					<?php if ( $has_overflow ) : ?>
+						<div class="newspack-ui__gradient-divider"></div>
+					<?php endif; ?>
 					</div>
 
 					<div class="newspack-ui__stack newspack-ui__stack--vertical newspack-ui__stack--gap-2 newspack-ui__spacing-top--5">

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1728,15 +1728,17 @@ final class Reader_Activation {
 					<input type="hidden" name="email_address" value="<?php echo esc_attr( $email_address ); ?>" />
 
 					<?php $has_overflow = count( $newsletters_lists ) > (int) $default_list_size; ?>
-					<div class="newspack-ui__stack newspack-ui__stack--vertical newspack-ui__stack--gap-2 overflow-hidden position-relative newsletter-list-container" data-list-default-size="<?php echo esc_attr( $default_list_size ); ?>">
+					<div class="newspack-ui__stack newspack-ui__stack--vertical newspack-ui__stack--gap-2 overflow-hidden position-relative newsletter-list-container">
 					<?php
 					foreach ( $newsletters_lists as $list ) {
-						$checkbox_id = sprintf( 'newspack-plugin-list-%s', $list['id'] );
-						$is_peek     = $loop_index === (int) $default_list_size;
-						$is_hidden   = $loop_index > (int) $default_list_size;
+						$checkbox_id   = sprintf( 'newspack-plugin-list-%s', $list['id'] );
+						$is_peek       = $loop_index === (int) $default_list_size;
+						$is_hidden     = $loop_index > (int) $default_list_size;
+						$label_classes = 'newspack-ui__input-card' . ( $is_hidden ? ' hidden' : '' );
+						$label_inert   = ( $is_peek || $is_hidden ) ? ' inert' : '';
 						$loop_index++;
 						?>
-						<label class="newspack-ui__input-card<?php echo $is_hidden ? ' hidden' : ''; ?>" for="<?php echo \esc_attr( $checkbox_id ); ?>"<?php echo ( $is_peek || $is_hidden ) ? ' inert' : ''; ?>>
+						<label class="<?php echo esc_attr( $label_classes ); ?>" for="<?php echo \esc_attr( $checkbox_id ); ?>"<?php echo esc_attr( $label_inert ); ?>>
 							<input
 								type="checkbox"
 								name="lists[]"
@@ -1762,7 +1764,7 @@ final class Reader_Activation {
 					</div>
 
 					<div class="newspack-ui__stack newspack-ui__stack--vertical newspack-ui__stack--gap-2 newspack-ui__spacing-top--5">
-						<?php if ( count( $newsletters_lists ) > $default_list_size ) : ?>
+						<?php if ( $has_overflow ) : ?>
 							<button type="button" class="newspack-ui__button newspack-ui__button--wide newspack-ui__button--secondary see-all-button" aria-label="<?php esc_attr_e( 'See all newsletters', 'newspack-plugin' ); ?>">
 								<span aria-hidden="true"><?php esc_html_e( 'See all', 'newspack-plugin' ); ?></span>
 								<?php Newspack_UI_Icons::print_svg( 'chevronDownSmall' ); ?>

--- a/src/newspack-ui/scss/elements/_stack.scss
+++ b/src/newspack-ui/scss/elements/_stack.scss
@@ -38,18 +38,18 @@ $stack-gaps: (
 		&--horizontal {
 			flex-direction: row;
 
-			> :where(:not([class*="newspack-ui__spacing-"])) {
-				margin-left: 0;
-				margin-right: 0;
+			> :not([class*="newspack-ui__spacing-"]) {
+				margin-left: 0 !important;
+				margin-right: 0 !important;
 			}
 		}
 
 		&--vertical {
 			flex-direction: column;
 
-			> :where(:not([class*="newspack-ui__spacing-"])) {
-				margin-bottom: 0;
-				margin-top: 0;
+			> :not([class*="newspack-ui__spacing-"]) {
+				margin-bottom: 0 !important;
+				margin-top: 0 !important;
 			}
 		}
 

--- a/src/reader-activation-newsletters/newsletters-form.js
+++ b/src/reader-activation-newsletters/newsletters-form.js
@@ -32,6 +32,11 @@ window.newspackRAS.push( function ( readerActivation ) {
 					newsletterContainer.querySelectorAll( '.hidden' ).forEach( item => {
 						item.classList.remove( 'hidden' );
 					} );
+					// Restore the peeking item to the a11y tree and tab order.
+					newsletterContainer.querySelectorAll( '.newspack-ui__input-card[aria-hidden="true"]' ).forEach( item => {
+						item.removeAttribute( 'aria-hidden' );
+						item.querySelector( 'input[tabindex="-1"]' )?.removeAttribute( 'tabindex' );
+					} );
 					newsletterContainer.style.maxHeight = 'none';
 					if ( divider ) {
 						divider.classList.add( 'hidden' );

--- a/src/reader-activation-newsletters/newsletters-form.js
+++ b/src/reader-activation-newsletters/newsletters-form.js
@@ -32,10 +32,9 @@ window.newspackRAS.push( function ( readerActivation ) {
 					newsletterContainer.querySelectorAll( '.hidden' ).forEach( item => {
 						item.classList.remove( 'hidden' );
 					} );
-					// Restore the peeking item to the a11y tree and tab order.
-					newsletterContainer.querySelectorAll( '.newspack-ui__input-card[aria-hidden="true"]' ).forEach( item => {
-						item.removeAttribute( 'aria-hidden' );
-						item.querySelector( 'input[tabindex="-1"]' )?.removeAttribute( 'tabindex' );
+					// Restore the peeking item to the a11y tree and focus order by removing inert.
+					newsletterContainer.querySelectorAll( '.newspack-ui__input-card[inert]' ).forEach( item => {
+						item.removeAttribute( 'inert' );
 					} );
 					newsletterContainer.style.maxHeight = 'none';
 					if ( divider ) {

--- a/src/reader-activation-newsletters/newsletters-form.js
+++ b/src/reader-activation-newsletters/newsletters-form.js
@@ -39,7 +39,7 @@ window.newspackRAS.push( function ( readerActivation ) {
 			} );
 
 			if ( peekItem ) {
-				const peekAmount = 32;
+				const peekAmount = divider?.offsetHeight || 32;
 				newsletterContainer.style.maxHeight = `${ peekItem.offsetTop + peekAmount }px`;
 			}
 		};

--- a/src/reader-activation-newsletters/newsletters-form.js
+++ b/src/reader-activation-newsletters/newsletters-form.js
@@ -21,19 +21,17 @@ window.newspackRAS.push( function ( readerActivation ) {
 				return;
 			}
 
-			// Handle "See all" button logic.
 			const seeAllButton = container.querySelector( '.see-all-button' );
 			const newsletterContainer = container.querySelector( '.newsletter-list-container' );
 			const divider = newsletterContainer?.querySelector( '.newspack-ui__gradient-divider' );
 
 			if ( seeAllButton && newsletterContainer ) {
-				// Remove the "hidden" class from all newsletter items.
+				const peekItem = newsletterContainer.querySelector( '.newspack-ui__input-card[inert]:not(.hidden)' );
+
 				seeAllButton.addEventListener( 'click', () => {
-					newsletterContainer.querySelectorAll( '.hidden' ).forEach( item => {
-						item.classList.remove( 'hidden' );
-					} );
-					// Restore the peeking item to the a11y tree and focus order by removing inert.
+					const firstRevealed = newsletterContainer.querySelector( '.newspack-ui__input-card[inert]' );
 					newsletterContainer.querySelectorAll( '.newspack-ui__input-card[inert]' ).forEach( item => {
+						item.classList.remove( 'hidden' );
 						item.removeAttribute( 'inert' );
 					} );
 					newsletterContainer.style.maxHeight = 'none';
@@ -41,26 +39,12 @@ window.newspackRAS.push( function ( readerActivation ) {
 						divider.classList.add( 'hidden' );
 					}
 					seeAllButton.classList.add( 'hidden' );
+					firstRevealed?.querySelector( 'input' )?.focus();
 				} );
 
-				// Set the initial height to show partially visible.
-				const listDefaultSize = parseInt( newsletterContainer.dataset.listDefaultSize, 10 );
-				const newsletterItems = newsletterContainer.querySelectorAll( '.newspack-ui__input-card' );
-
-				if ( newsletterItems.length > listDefaultSize ) {
-					const gap = 12;
-					const extraSpace = 32; // Additional space for partial visibility.
-
-					let totalHeight = 0;
-					newsletterItems.forEach( ( item, index ) => {
-						if ( index < listDefaultSize ) {
-							totalHeight += item.offsetHeight;
-						}
-					} );
-
-					const maxHeight = totalHeight + listDefaultSize * gap + extraSpace;
-
-					newsletterContainer.style.maxHeight = `${ maxHeight }px`;
+				if ( peekItem ) {
+					const peekAmount = 32;
+					newsletterContainer.style.maxHeight = `${ peekItem.offsetTop + peekAmount }px`;
 				}
 			}
 

--- a/src/reader-activation-newsletters/newsletters-form.js
+++ b/src/reader-activation-newsletters/newsletters-form.js
@@ -15,38 +15,42 @@ window.newspackRAS.push( function ( readerActivation ) {
 			return;
 		}
 
+		const setupReveal = container => {
+			const seeAllButton = container.querySelector( '.see-all-button' );
+			const newsletterContainer = container.querySelector( '.newsletter-list-container' );
+			if ( ! seeAllButton || ! newsletterContainer ) {
+				return;
+			}
+			const divider = newsletterContainer.querySelector( '.newspack-ui__gradient-divider' );
+			const peekItem = newsletterContainer.querySelector( '.newspack-ui__input-card[inert]:not(.hidden)' );
+
+			seeAllButton.addEventListener( 'click', () => {
+				const firstRevealed = newsletterContainer.querySelector( '.newspack-ui__input-card[inert]' );
+				newsletterContainer.querySelectorAll( '.newspack-ui__input-card[inert]' ).forEach( item => {
+					item.classList.remove( 'hidden' );
+					item.removeAttribute( 'inert' );
+				} );
+				newsletterContainer.style.maxHeight = 'none';
+				if ( divider ) {
+					divider.classList.add( 'hidden' );
+				}
+				seeAllButton.classList.add( 'hidden' );
+				firstRevealed?.querySelector( 'input' )?.focus();
+			} );
+
+			if ( peekItem ) {
+				const peekAmount = 32;
+				newsletterContainer.style.maxHeight = `${ peekItem.offsetTop + peekAmount }px`;
+			}
+		};
+
 		containers.forEach( container => {
 			let form = container.querySelector( 'form' );
 			if ( ! form ) {
 				return;
 			}
 
-			const seeAllButton = container.querySelector( '.see-all-button' );
-			const newsletterContainer = container.querySelector( '.newsletter-list-container' );
-			const divider = newsletterContainer?.querySelector( '.newspack-ui__gradient-divider' );
-
-			if ( seeAllButton && newsletterContainer ) {
-				const peekItem = newsletterContainer.querySelector( '.newspack-ui__input-card[inert]:not(.hidden)' );
-
-				seeAllButton.addEventListener( 'click', () => {
-					const firstRevealed = newsletterContainer.querySelector( '.newspack-ui__input-card[inert]' );
-					newsletterContainer.querySelectorAll( '.newspack-ui__input-card[inert]' ).forEach( item => {
-						item.classList.remove( 'hidden' );
-						item.removeAttribute( 'inert' );
-					} );
-					newsletterContainer.style.maxHeight = 'none';
-					if ( divider ) {
-						divider.classList.add( 'hidden' );
-					}
-					seeAllButton.classList.add( 'hidden' );
-					firstRevealed?.querySelector( 'input' )?.focus();
-				} );
-
-				if ( peekItem ) {
-					const peekAmount = 32;
-					newsletterContainer.style.maxHeight = `${ peekItem.offsetTop + peekAmount }px`;
-				}
-			}
+			setupReveal( container );
 
 			const handleSubmit = ev => {
 				ev.preventDefault();
@@ -110,6 +114,7 @@ window.newspackRAS.push( function ( readerActivation ) {
 				// Make sure we aren't adding multiple event listeners to the form.
 				form.removeEventListener( 'submit', handleSubmit );
 				form.addEventListener( 'submit', handleSubmit );
+				setupReveal( container );
 			} );
 		} );
 	} );

--- a/src/reader-activation-newsletters/style.scss
+++ b/src/reader-activation-newsletters/style.scss
@@ -6,10 +6,14 @@
 
 	.newspack-newsletters-signup {
 		margin-top: var(--newspack-ui-spacer-5);
+	}
+}
 
-		.newsletter-list-container {
-			transition: max-height 250ms ease-in-out;
-		}
+.newspack-newsletters-signup .newsletter-list-container {
+	transition: max-height 250ms ease-in-out;
+
+	.newspack-ui__input-card.hidden {
+		display: none !important;
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes accessibility and layout issues in the post-checkout newsletters signup form's "peek + See all" mechanic. The original Copilot review flagged the peeking row leaking into the a11y tree; @dkoo's manual pass surfaced three more visible bugs that all traced back to the same root cause.

## Root cause

`label:has(input[type="checkbox"]) { display: grid !important; }` in `_labels.scss` silently overrode the `.hidden` utility, so overflow rows beyond the peek weren't actually `display: none` — they were just visually clipped by the container's `overflow:hidden`, but stayed in layout and in the focus order. Compounded by `newspack-ui__stack`'s child-margin reset using `:where(...)` for zero specificity, so component-level margins fought the stack's flex `gap`.

## Changes

### Newsletter signup form (`includes/reader-activation/class-reader-activation.php`, `src/reader-activation-newsletters/`)

- The peek row and all overflow rows get `inert` — blocks focus from keyboard, mouse, and programmatic paths, and removes them from the a11y tree. Replaces the original `aria-hidden="true"` + `tabindex="-1"` approach.
- A scoped `display: none !important` for `.input-card.hidden` beats the `display: grid !important` on the label, so overflow rows actually leave layout.
- The gradient divider is now a sibling of the row stack (not interleaved between rows), so it doesn't break the `.input-card + .input-card { margin-top }` compensation chain.
- The `maxHeight` calculation is `peekItem.offsetTop + 32px` (matches the gradient divider height) instead of a brittle `sum(itemHeights) + N*12 + 32` heuristic.
- When "See all" is clicked, focus moves to the first revealed row's checkbox so keyboard users keep their place instead of falling back to `<body>`.

### `newspack-ui__stack` (`src/newspack-ui/scss/elements/_stack.scss`)

The vertical/horizontal stack child-margin reset used `:where(...)` for zero specificity, which lost to any component-level margin rule (cards, buttons, anything with `margin-bottom`). The convention is documented as "stack gap is the source of vertical/horizontal rhythm" — now it actually wins, via `!important` and direct specificity. Prevents the same trap for any stacked component going forward.

### UI demo (`includes/class-newspack-ui.php`)

The `?ui-demo#modals` newsletters preview is synced with the same markup and behavior so designers can verify the peek mechanic outside the live modal.

## Test plan

- [x] Open the newsletters signup form with more lists than the default size. Confirm two visible rows + a peek row clipped under the gradient divider.
- [x] Tab through the modal — focus skips the peek row and all hidden rows.
- [x] Click "See all" — all rows become focusable, the gradient hides, and focus lands on the first previously-peeking row's checkbox.
- [x] Verify with a screen reader that only the visible rows are announced before "See all", and all rows are announced after.
- [x] Repeat in the `?ui-demo#modals` newsletters preview.
- [x] Spot-check other vertical stacks (modal button stacks, content gate IP check) for spacing regressions from the stack convention enforcement.