### PR TITLE
fix: prevent recursion in lite-site primary color on block themes

### DIFF
--- a/includes/lite-site/class-lite-site.php
+++ b/includes/lite-site/class-lite-site.php
@@ -375,6 +375,10 @@ class Lite_Site {
 	 */
 	public static function get_primary_color() {
 		if ( wp_is_block_theme() ) {
+			// Guard against re-entry via wp_theme_json_data_theme — wp_get_global_settings() re-fires that filter and recurses.
+			if ( doing_filter( 'wp_theme_json_data_theme' ) ) {
+				return 'currentcolor';
+			}
 			$settings = wp_get_global_settings();
 			$palettes = $settings['color']['palette'] ?? [];
 			$palette  = [];


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and VIP Go coding standards?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

`Lite_Site::get_primary_color()` calls `wp_get_global_settings()` when running on a block theme, which re-fires the `wp_theme_json_data_theme` filter. If the lite-site code is itself executing inside that filter, this caused unbounded recursion and a fatal error.

This adds a re-entry guard so the method returns `currentcolor` when invoked while `wp_theme_json_data_theme` is already on the filter stack, breaking the loop while still producing a valid CSS value.

### How to test the changes in this Pull Request:

1. Activate a block theme (e.g. `newspack-block-theme`) on a Newspack site with the Lite Site feature enabled.
2. Load any front-end page and confirm there are no PHP fatal errors or "maximum function nesting level" warnings.
3. Verify the lite-site styling still renders with the expected primary color in the resulting CSS.
4. Switch back to a classic theme (e.g. `newspack-theme`) and confirm the primary color resolution still works unchanged.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?