### PR TITLE
fix(access-control): increase expiration of IP access cookie to 1 year

### DIFF
--- a/includes/content-gate/class-ip-access-rule.php
+++ b/includes/content-gate/class-ip-access-rule.php
@@ -157,7 +157,7 @@ class IP_Access_Rule {
 		}
 
 		if ( $valid ) {
-			setcookie( self::COOKIE_NAME, '1', time() + MONTH_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN ); // phpcs:ignore
+			setcookie( self::COOKIE_NAME, '1', time() + YEAR_IN_SECONDS, COOKIEPATH, COOKIE_DOMAIN ); // phpcs:ignore
 		}
 
 		$data = [ 'valid' => $valid ];


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Increases the expiration of the cookie we set upon a successful IP check from 1 month to 1 year. The year-long expiration now matches the length of a true authenticated reader session.

### How to test the changes in this Pull Request:

1. With `NEWSPACK_CONTENT_GATES` defined in wp-config.php, publish an Institution (Audience > Access Control > [kebab menu] Institutions) with an IP access rule with a CIDR containing your public IP.
2. In an unauthenticated session, visit the institution's access URL and wait until you're redirected with the "Connected" confirmation snackbar.
3. In devtools > Application > Cookies, confirm that the `wp_nocache_ip` cookie is set with an expiration timestamp 1 year in the future.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->