### PR TITLE
fix(editor): exclude Customizer Additional CSS from iframed editor

### DIFF
--- a/includes/class-patches.php
+++ b/includes/class-patches.php
@@ -44,6 +44,9 @@ class Patches {
 
 		// Fix an issue when running The Events Calendar where all posts block items have same date.
 		add_action( 'tribe_events_views_v2_after_make_view', [ __CLASS__, 'remove_tec_extra_excerpt_filtering' ], 1 );
+
+		// Prevent Customizer "Additional CSS" from leaking into the iframed block editor in WP 7.0+.
+		add_filter( 'block_editor_settings_all', [ __CLASS__, 'strip_customizer_css_from_editor' ], 999 );
 	}
 
 	/**
@@ -517,6 +520,49 @@ class Patches {
 	 */
 	public static function remove_tec_extra_excerpt_filtering() {
 		remove_all_actions( 'tribe_events_views_v2_after_make_view' );
+	}
+
+	/**
+	 * Remove the Customizer "Additional CSS" entry from the block editor styles array.
+	 *
+	 * WP core injects `wp_get_custom_css()` into the editor's styles array as
+	 * `[ '__unstableType' => 'user', 'isGlobalStyles' => false ]`. Since WP 7.0
+	 * iframes the post editor when all blocks use Block API v3+, any front-end
+	 * `body { ... }` rule in Customizer → Additional CSS now lands on the
+	 * editor canvas. The front-end is unaffected — that copy is printed by
+	 * `wp_custom_css_cb()` on `wp_head`.
+	 *
+	 * @param array $settings Block editor settings.
+	 * @return array
+	 */
+	public static function strip_customizer_css_from_editor( $settings ) {
+		if ( empty( $settings['styles'] ) || ! is_array( $settings['styles'] ) ) {
+			return $settings;
+		}
+
+		/**
+		 * Filters whether to strip Customizer Additional CSS from the editor iframe.
+		 *
+		 * @param bool $strip Default true.
+		 */
+		if ( ! apply_filters( 'newspack_strip_customizer_css_in_editor', true ) ) {
+			return $settings;
+		}
+
+		$settings['styles'] = array_values(
+			array_filter(
+				$settings['styles'],
+				function ( $entry ) {
+					return ! (
+						isset( $entry['__unstableType'] )
+						&& 'user' === $entry['__unstableType']
+						&& empty( $entry['isGlobalStyles'] )
+					);
+				}
+			)
+		);
+
+		return $settings;
 	}
 
 	/**

--- a/includes/class-patches.php
+++ b/includes/class-patches.php
@@ -46,7 +46,9 @@ class Patches {
 		add_action( 'tribe_events_views_v2_after_make_view', [ __CLASS__, 'remove_tec_extra_excerpt_filtering' ], 1 );
 
 		// Prevent Customizer "Additional CSS" from leaking into the iframed block editor in WP 7.0+.
-		add_filter( 'block_editor_settings_all', [ __CLASS__, 'strip_customizer_css_from_editor' ], 999 );
+		if ( version_compare( get_bloginfo( 'version' ), '7.0', '>=' ) ) {
+			add_filter( 'block_editor_settings_all', [ __CLASS__, 'strip_customizer_css_from_editor' ], 999 );
+		}
 	}
 
 	/**

--- a/includes/class-patches.php
+++ b/includes/class-patches.php
@@ -551,6 +551,7 @@ class Patches {
 			return $settings;
 		}
 
+		// Note: `__unstableType` is a private WP core key. Re-verify on WP upgrades.
 		$settings['styles'] = array_values(
 			array_filter(
 				$settings['styles'],


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

WordPress 7.0 iframes the post editor whenever every block in the post uses Block API v3+. The iframed editor pulls in the front-end style pipeline, which includes the Customizer's **Additional CSS**. Any front-end rule that targets \`body { ... }\` (or other broad selectors) therefore lands on the editor canvas itself, distorting the editing UX on sites that have customized the body element.

This PR filters `block_editor_settings_all` to drop the specific entry WP core injects for Customizer Additional CSS — identified by `__unstableType === 'user'` AND `isGlobalStyles === false`. The front-end is unaffected: the CSS is still printed by `wp_custom_css_cb()` on `wp_head`.

A new `newspack_strip_customizer_css_in_editor` filter is exposed as an escape hatch for sites that intentionally want Customizer CSS in the editor.

Scope notes:
- Only the Customizer entry is removed. The block-theme **Global Styles → Additional CSS** entry (`isGlobalStyles === true`) is left untouched.
- Per-block Custom CSS introduced in WP 7.0 is not affected — that's scoped to individual blocks.

### How to test the changes in this Pull Request:

1. On a site running WP 7.0, add a rule like `.wp-block-quote { background: red; }` in **Appearance → Customize → Additional CSS**.
2. Draft a post  and add a quote block
3. Before this fix on `release`: the block turns red. After this fix: the block stays normal; the front-end is still red.
4. Confirm the escape hatch: add `add_filter( 'newspack_strip_customizer_css_in_editor', '__return_false' );` in mu-plugins → editor canvas turns red again.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally? (PHPCS clean)