### PR TITLE
feat(reader-activation): replace RAS auto-enable with manual toggle

### DIFF
--- a/includes/class-donations.php
+++ b/includes/class-donations.php
@@ -697,6 +697,18 @@ class Donations {
 	}
 
 	/**
+	 * Whether a reader revenue platform has been explicitly chosen.
+	 *
+	 * The platform option defaults to 'wc' and has no unset value, so first-run
+	 * is detected by whether the option was ever saved.
+	 *
+	 * @return bool
+	 */
+	public static function is_platform_selected() {
+		return null !== get_option( self::NEWSPACK_READER_REVENUE_PLATFORM, null );
+	}
+
+	/**
 	 * Set donation platform slug.
 	 *
 	 * @param string $platform Platform slug.

--- a/includes/class-donations.php
+++ b/includes/class-donations.php
@@ -702,6 +702,10 @@ class Donations {
 	 * The platform option defaults to 'wc' and has no unset value, so first-run
 	 * is detected by whether the option was ever saved.
 	 *
+	 * Note: get_platform_slug() persists 'wc' when migrating a legacy 'stripe'
+	 * platform, which marks the option as saved. Such sites are treated as
+	 * having selected Newspack.
+	 *
 	 * @return bool
 	 */
 	public static function is_platform_selected() {

--- a/includes/class-donations.php
+++ b/includes/class-donations.php
@@ -669,7 +669,6 @@ class Donations {
 	 * Remove all donation products from the cart.
 	 */
 	public static function remove_donations_from_cart() {
-		$donation_settings = self::get_donation_settings();
 		if ( ! self::is_platform_wc() || is_wp_error( self::is_woocommerce_suite_active() ) ) {
 			return;
 		}

--- a/includes/cli/class-ras.php
+++ b/includes/cli/class-ras.php
@@ -46,6 +46,9 @@ class RAS {
 			exit;
 		}
 
+		// Enabling is no longer implied by configured prerequisites, so set it explicitly here.
+		Reader_Activation::update_setting( 'enabled', true );
+
 		WP_CLI::success( __( 'RAS enabled with default prompts.', 'newspack-plugin' ) );
 	}
 

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -1272,9 +1272,11 @@ final class Reader_Activation {
 	 * Setup nav menu hooks.
 	 */
 	public static function setup_nav_menu() {
-		// Not checking if the whole WC suite is active (self::is_woocommerce_active()),
-		// because only the main WooCommerce plugin is actually required for this to work.
-		if ( ! self::get_setting( 'enabled_account_link' ) || ! function_exists( 'WC' ) ) {
+		// The account link works without WooCommerce: signed-out visitors get a JS-driven
+		// auth modal trigger. When WooCommerce is active, signed-in readers additionally
+		// get a "My Account" link to the Woo account page; without Woo, get_account_link()
+		// returns empty for signed-in users and no menu item is rendered.
+		if ( ! self::get_setting( 'enabled_account_link' ) ) {
 			return;
 		}
 

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -845,7 +845,7 @@ final class Reader_Activation {
 				'label'       => __( 'Legal Pages', 'newspack-plugin' ),
 				'description' => __( 'Displaying legal pages like Privacy Policy and Terms of Service on your site is recommended for allowing readers to register and access their account.', 'newspack-plugin' ),
 				'help_url'    => 'https://help.newspack.com/engagement/audience-management-system/',
-				'warning'     => __( 'Privacy policies that tell users how you collect and use their data are essential for running a  trustworthy website. While rules and regulations can differ by country, certain legal pages might be required by law.', 'newspack-plugin' ),
+				'warning'     => __( 'Privacy policies that tell users how you collect and use their data are essential for running a trustworthy website. While rules and regulations can differ by country, certain legal pages might be required by law.', 'newspack-plugin' ),
 				'fields'      => [
 					'terms_text' => [
 						'label'       => __( 'Legal Pages Disclaimer Text', 'newspack-plugin' ),

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -736,27 +736,6 @@ final class Reader_Activation {
 	}
 
 	/**
-	 * Are all Reader Revenue features configured and ready to use?
-	 * Platform must be "Newspack" and all donation settings must be configured.
-	 */
-	public static function is_reader_revenue_ready() {
-		$ready             = false;
-		$donation_settings = Donations::get_donation_settings();
-
-		if ( \is_wp_error( $donation_settings ) ) {
-			return $ready;
-		}
-
-		if ( Donations::is_platform_wc() ) {
-			$ready = true;
-		} elseif ( Donations::is_platform_nrh() && NRH::get_setting( 'nrh_organization_id' ) && method_exists( '\Newspack_Popups_Settings', 'donor_landing_page' ) && \Newspack_Popups_Settings::donor_landing_page() ) {
-			$ready = true;
-		}
-
-		return $ready;
-	}
-
-	/**
 	 * Get an array of required plugins for satisfying Reader Revenue prerequisites.
 	 * WooCommerce and Woo Subscriptions are required for Newspack, but not for NRH.
 	 */

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -820,35 +820,6 @@ final class Reader_Activation {
 	 */
 	public static function get_prerequisites_status() {
 		$prerequisites = [
-			'terms_conditions' => [
-				'active'      => self::is_terms_configured(),
-				'label'       => __( 'Legal Pages', 'newspack-plugin' ),
-				'description' => __( 'Displaying legal pages like Privacy Policy and Terms of Service on your site is recommended for allowing readers to register and access their account.', 'newspack-plugin' ),
-				'help_url'    => 'https://help.newspack.com/engagement/audience-management-system/',
-				'warning'     => __( 'Privacy policies that tell users how you collect and use their data are essential for running a  trustworthy website. While rules and regulations can differ by country, certain legal pages might be required by law.', 'newspack-plugin' ),
-				'fields'      => [
-					'terms_text' => [
-						'label'       => __( 'Legal Pages Disclaimer Text', 'newspack-plugin' ),
-						'description' => __( 'Legal pages disclaimer text to display on registration.', 'newspack-plugin' ),
-					],
-					'terms_url'  => [
-						'label'       => __( 'Legal Pages URL', 'newspack-plugin' ),
-						'description' => __( 'URL to the page containing the privacy policy or terms of service.', 'newspack-plugin' ),
-					],
-				],
-			],
-			'esp'              => [
-				'active'       => self::is_esp_configured(),
-				'plugins'      => [
-					'newspack-newsletters' => class_exists( '\Newspack_Newsletters' ),
-				],
-				'label'        => __( 'Email Service Provider (ESP)', 'newspack-plugin' ),
-				'description'  => __( 'Connect to your ESP to register readers with their email addresses and send newsletters.', 'newspack-plugin' ),
-				'instructions' => __( 'Connect to your email service provider (ESP) and enable at least one subscription list.', 'newspack-plugin' ),
-				'help_url'     => 'https://help.newspack.com/engagement/audience-management-system/',
-				'href'         => \admin_url( 'edit.php?post_type=newspack_nl_cpt&page=newspack-newsletters' ),
-				'action_text'  => __( 'ESP settings' ),
-			],
 			'emails'           => [
 				'active'      => self::is_transactional_email_configured(),
 				'label'       => __( 'Transactional Emails', 'newspack-plugin' ),
@@ -869,6 +840,23 @@ final class Reader_Activation {
 					],
 				],
 			],
+			'terms_conditions' => [
+				'active'      => self::is_terms_configured(),
+				'label'       => __( 'Legal Pages', 'newspack-plugin' ),
+				'description' => __( 'Displaying legal pages like Privacy Policy and Terms of Service on your site is recommended for allowing readers to register and access their account.', 'newspack-plugin' ),
+				'help_url'    => 'https://help.newspack.com/engagement/audience-management-system/',
+				'warning'     => __( 'Privacy policies that tell users how you collect and use their data are essential for running a  trustworthy website. While rules and regulations can differ by country, certain legal pages might be required by law.', 'newspack-plugin' ),
+				'fields'      => [
+					'terms_text' => [
+						'label'       => __( 'Legal Pages Disclaimer Text', 'newspack-plugin' ),
+						'description' => __( 'Legal pages disclaimer text to display on registration.', 'newspack-plugin' ),
+					],
+					'terms_url'  => [
+						'label'       => __( 'Legal Pages URL', 'newspack-plugin' ),
+						'description' => __( 'URL to the page containing the privacy policy or terms of service.', 'newspack-plugin' ),
+					],
+				],
+			],
 			'recaptcha'        => [
 				'active'       => self::is_recaptcha_enabled(),
 				'label'        => __( 'reCAPTCHA', 'newspack-plugin' ),
@@ -878,28 +866,23 @@ final class Reader_Activation {
 				'href'         => \admin_url( '/admin.php?page=newspack-settings&scrollTo=newspack-settings-recaptcha' ),
 				'action_text'  => __( 'reCAPTCHA settings' ),
 			],
-			'reader_revenue'   => [
-				'active'       => self::is_reader_revenue_ready(),
-				'plugins'      => self::get_reader_revenue_required_plugins(),
-				'label'        => __( 'Reader Revenue', 'newspack-plugin' ),
-				'description'  => __( 'Setting suggested donation amounts is required for enabling a streamlined donation experience.', 'newspack-plugin' ),
-				'instructions' => __( 'Set platform to "Newspack" or "News Revenue Hub" and configure your default donation settings. If using News Revenue Hub, set an Organization ID and a Donor Landing Page in News Revenue Hub Settings.', 'newspack-plugin' ),
-				'help_url'     => 'https://help.newspack.com/engagement/audience-management-system/',
-				'href'         => \admin_url( '/admin.php?page=newspack-audience#/payment' ),
-				'action_text'  => __( 'Reader Revenue settings' ),
-			],
-			'ras_campaign'     => [
-				'active'      => self::is_ras_campaign_configured(),
-				'plugins'     => [
-					'newspack-popups' => class_exists( '\Newspack_Popups_Model' ),
-				],
-				'label'       => __( 'Audience Management Campaign', 'newspack-plugin' ),
-				'description' => __( 'Building a set of prompts with default segments and settings allows for an improved experience optimized for audience management.', 'newspack-plugin' ),
-				'help_url'    => 'https://help.newspack.com/engagement/audience-management-system/',
-				'href'        => self::is_ras_campaign_configured() ? admin_url( '/admin.php?page=newspack-audience-campaigns' ) : admin_url( '/admin.php?page=newspack-audience#/campaign' ),
-				'action_text' => __( 'Audience Management campaign', 'newspack-plugin' ),
-			],
 		];
+
+		// ESP is only relevant when Newspack Newsletters is installed.
+		if ( class_exists( '\Newspack_Newsletters' ) ) {
+			$prerequisites['esp'] = [
+				'active'       => self::is_esp_configured(),
+				'plugins'      => [
+					'newspack-newsletters' => true,
+				],
+				'label'        => __( 'Email Service Provider (ESP)', 'newspack-plugin' ),
+				'description'  => __( 'Connect to your ESP to register readers with their email addresses and send newsletters.', 'newspack-plugin' ),
+				'instructions' => __( 'Connect to your email service provider (ESP) and enable at least one subscription list.', 'newspack-plugin' ),
+				'help_url'     => 'https://help.newspack.com/engagement/audience-management-system/',
+				'href'         => \admin_url( 'edit.php?post_type=newspack_nl_cpt&page=newspack-newsletters' ),
+				'action_text'  => __( 'ESP settings' ),
+			];
+		}
 
 		return $prerequisites;
 	}

--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -539,11 +539,7 @@ final class Reader_Activation {
 			return new \WP_Error( 'newspack_reader_activation_missing_dependencies', __( 'Newspack Campaigns plugin is required to activate Reader Activation features.', 'newspack-plugin' ) );
 		}
 
-		$activated = \Newspack_Popups_Presets::activate_ras_presets();
-		if ( $activated ) {
-			self::skip( 'ras_campaign', false );
-		}
-		return $activated;
+		return \Newspack_Popups_Presets::activate_ras_presets();
 	}
 
 	/**
@@ -780,22 +776,12 @@ final class Reader_Activation {
 	 * Are the Legal Pages settings configured?
 	 * Allows for blank values.
 	 *
-	 * @param bool $skip Whether to skip the check.
-	 *
 	 * @return bool
 	 */
-	public static function is_terms_configured( $skip = false ) {
+	public static function is_terms_configured() {
 		$terms_text = \get_option( self::OPTIONS_PREFIX . 'terms_text', false );
 		$terms_url  = \get_option( self::OPTIONS_PREFIX . 'terms_url', false );
-		$is_valid   = is_string( $terms_text ) && is_string( $terms_url );
-		if ( $skip ) {
-			return $is_valid || self::is_skipped( 'terms_conditions' );
-		}
-		if ( $is_valid ) {
-			self::skip( 'terms_conditions', false );
-		}
-
-		return $is_valid;
+		return is_string( $terms_text ) && is_string( $terms_url );
 	}
 
 	/**
@@ -812,97 +798,19 @@ final class Reader_Activation {
 	/**
 	 * Is reCAPTCHA enabled?
 	 *
-	 * @param bool $skip Whether to skip the check.
-	 *
 	 * @return bool
 	 */
-	public static function is_recaptcha_enabled( $skip = false ) {
-		$is_valid = method_exists( '\Newspack\Recaptcha', 'can_use_captcha' ) && \Newspack\Recaptcha::can_use_captcha();
-		if ( $skip ) {
-			return $is_valid || self::is_skipped( 'recaptcha' );
-		}
-		if ( $is_valid ) {
-			self::skip( 'recaptcha', false );
-		}
-		return $is_valid;
+	public static function is_recaptcha_enabled() {
+		return method_exists( '\Newspack\Recaptcha', 'can_use_captcha' ) && \Newspack\Recaptcha::can_use_captcha();
 	}
 
 	/**
 	 * Is the RAS campaign configured?
 	 *
-	 * @param bool $skip Whether to skip the check.
-	 *
 	 * @return bool
 	 */
-	public static function is_ras_campaign_configured( $skip = false ) {
-		$is_valid = class_exists( 'Newspack_Popups_Presets' ) && get_option( \Newspack_Popups_Presets::NEWSPACK_POPUPS_RAS_LAST_UPDATED, false );
-		if ( $skip ) {
-			return $is_valid || self::is_skipped( 'ras_campaign' );
-		}
-		if ( $is_valid ) {
-			self::skip( 'ras_campaign', false );
-		}
-		return $is_valid;
-	}
-
-	/**
-	 * Are all prerequisites for Reader Activation complete?
-	 *
-	 * @return bool
-	 */
-	public static function is_ras_ready_to_configure() {
-		$is_ready = self::is_terms_configured( true ) && self::is_esp_configured() && self::is_transactional_email_configured() && self::is_recaptcha_enabled( true ) && self::is_woocommerce_active();
-
-		// If all requirements are met or skipped, and RAS isn't yet enabled, enable it.
-		if ( $is_ready && self::is_ras_campaign_configured( true ) && ! self::is_enabled() ) {
-			self::update_setting( 'enabled', true );
-		}
-		return $is_ready;
-	}
-
-	/**
-	 * Has the given prerequisite been skipped?
-	 *
-	 * @param string $prerequisite The prerequisite to check.
-	 *
-	 * @return bool
-	 */
-	public static function is_skipped( $prerequisite ) {
-		// Legacy option name compabitility.
-		$legacy_is_skipped = false;
-		if ( 'ras_campaign' === $prerequisite ) {
-			$legacy_is_skipped = get_option( Audience_Wizard::SKIP_CAMPAIGN_SETUP_OPTION, false ) === '1';
-		}
-
-		return boolval( get_option( self::OPTIONS_PREFIX . $prerequisite . '_skipped', $legacy_is_skipped ) );
-	}
-
-	/**
-	 * Skip or unskip the given prerequisite.
-	 *
-	 * @param string $prerequisite The prerequisite to skip.
-	 * @param bool   $skip If true, skip the prerequisite. If false, unskip it.
-	 *
-	 * @return bool True if updated, false if not.
-	 */
-	public static function skip( $prerequisite, $skip = true ) {
-		if ( ( $skip && self::is_skipped( $prerequisite ) ) || ( ! $skip && ! self::is_skipped( $prerequisite ) ) ) {
-			return true;
-		}
-
-		$updated = $skip ? update_option( self::OPTIONS_PREFIX . $prerequisite . '_skipped', '1' ) : delete_option( self::OPTIONS_PREFIX . $prerequisite . '_skipped' );
-
-		// Legacy option name compabitility.
-		if ( 'ras_campaign' === $prerequisite && ! $skip && ! $updated ) {
-			$updated = delete_option( Audience_Wizard::SKIP_CAMPAIGN_SETUP_OPTION );
-		}
-
-		// If all requirements are met or skipped, and RAS isn't yet enabled, enable it.
-		if ( $skip && self::is_ras_ready_to_configure() && self::is_ras_campaign_configured( true ) && ! self::is_enabled() ) {
-			self::update_setting( 'enabled', true );
-		}
-
-		return $updated;
+	public static function is_ras_campaign_configured() {
+		return class_exists( 'Newspack_Popups_Presets' ) && (bool) get_option( \Newspack_Popups_Presets::NEWSPACK_POPUPS_RAS_LAST_UPDATED, false );
 	}
 
 	/**
@@ -928,8 +836,6 @@ final class Reader_Activation {
 						'description' => __( 'URL to the page containing the privacy policy or terms of service.', 'newspack-plugin' ),
 					],
 				],
-				'skippable'   => true,
-				'is_skipped'  => self::is_skipped( 'terms_conditions' ),
 			],
 			'esp'              => [
 				'active'       => self::is_esp_configured(),
@@ -971,8 +877,6 @@ final class Reader_Activation {
 				'help_url'     => 'https://help.newspack.com/engagement/audience-management-system/',
 				'href'         => \admin_url( '/admin.php?page=newspack-settings&scrollTo=newspack-settings-recaptcha' ),
 				'action_text'  => __( 'reCAPTCHA settings' ),
-				'skippable'    => true,
-				'is_skipped'   => self::is_skipped( 'recaptcha' ),
 			],
 			'reader_revenue'   => [
 				'active'       => self::is_reader_revenue_ready(),
@@ -985,19 +889,15 @@ final class Reader_Activation {
 				'action_text'  => __( 'Reader Revenue settings' ),
 			],
 			'ras_campaign'     => [
-				'active'         => self::is_ras_campaign_configured(),
-				'plugins'        => [
+				'active'      => self::is_ras_campaign_configured(),
+				'plugins'     => [
 					'newspack-popups' => class_exists( '\Newspack_Popups_Model' ),
 				],
-				'label'          => __( 'Audience Management Campaign', 'newspack-plugin' ),
-				'description'    => __( 'Building a set of prompts with default segments and settings allows for an improved experience optimized for audience management.', 'newspack-plugin' ),
-				'help_url'       => 'https://help.newspack.com/engagement/audience-management-system/',
-				'href'           => self::is_ras_campaign_configured() ? admin_url( '/admin.php?page=newspack-audience-campaigns' ) : admin_url( '/admin.php?page=newspack-audience#/campaign' ),
-				'action_enabled' => self::is_ras_ready_to_configure(),
-				'action_text'    => __( 'Audience Management campaign', 'newspack-plugin' ),
-				'disabled_text'  => __( 'Waiting for all settings to be ready', 'newspack-plugin' ),
-				'skippable'      => true,
-				'is_skipped'     => self::is_skipped( 'ras_campaign' ),
+				'label'       => __( 'Audience Management Campaign', 'newspack-plugin' ),
+				'description' => __( 'Building a set of prompts with default segments and settings allows for an improved experience optimized for audience management.', 'newspack-plugin' ),
+				'help_url'    => 'https://help.newspack.com/engagement/audience-management-system/',
+				'href'        => self::is_ras_campaign_configured() ? admin_url( '/admin.php?page=newspack-audience-campaigns' ) : admin_url( '/admin.php?page=newspack-audience#/campaign' ),
+				'action_text' => __( 'Audience Management campaign', 'newspack-plugin' ),
 			],
 		];
 

--- a/includes/wizards/audience/class-audience-donations.php
+++ b/includes/wizards/audience/class-audience-donations.php
@@ -48,8 +48,15 @@ class Audience_Donations extends Wizard {
 
 	/**
 	 * Add Donations page.
+	 *
+	 * The Donations wizard requires either the WooCommerce platform (with WC installed)
+	 * or the News Revenue Hub platform. Without one of those the page cannot render
+	 * anything meaningful, so the submenu entry is hidden entirely.
 	 */
 	public function add_page() {
+		if ( ! function_exists( 'WC' ) && ! Donations::is_platform_nrh() ) {
+			return;
+		}
 		add_submenu_page(
 			$this->parent_slug,
 			$this->get_name(),

--- a/includes/wizards/audience/class-audience-donations.php
+++ b/includes/wizards/audience/class-audience-donations.php
@@ -174,11 +174,17 @@ class Audience_Donations extends Wizard {
 	public function fetch_all_data() {
 		$platform = Donations::get_platform_slug();
 
+		// get_donation_settings() returns a WP_Error when the WooCommerce suite isn't
+		// fully active (e.g. platform is 'wc' but Subscriptions is missing). Surface an
+		// empty array in that case so the response doesn't carry a serialized WP_Error;
+		// missing plugins are reported separately via plugin_status below.
+		$donation_settings = Donations::get_donation_settings();
+
 		$args = [
 			'platform_data'      => [
 				'platform' => $platform,
 			],
-			'donation_data'      => Donations::get_donation_settings(),
+			'donation_data'      => is_wp_error( $donation_settings ) ? [] : $donation_settings,
 			'donation_page'      => Donations::get_donation_page_info(),
 			'product_validation' => $this->validate_donation_products(),
 		];

--- a/includes/wizards/audience/class-audience-wizard.php
+++ b/includes/wizards/audience/class-audience-wizard.php
@@ -641,7 +641,7 @@ class Audience_Wizard extends Wizard {
 	 * @return bool
 	 */
 	public function api_validate_platform( $value ) {
-		return in_array( $value, [ 'nrh', 'wc', 'other' ] );
+		return in_array( $value, [ 'nrh', 'wc', 'other' ], true );
 	}
 
 	/**
@@ -673,7 +673,9 @@ class Audience_Wizard extends Wizard {
 	public function api_update_payment_settings( $request ) {
 		$params = $request->get_params();
 
-		Donations::set_platform_slug( $params['platform'] );
+		if ( isset( $params['platform'] ) ) {
+			Donations::set_platform_slug( $params['platform'] );
+		}
 
 		// Update NRH settings.
 		if ( Donations::is_platform_nrh() ) {

--- a/includes/wizards/audience/class-audience-wizard.php
+++ b/includes/wizards/audience/class-audience-wizard.php
@@ -679,8 +679,13 @@ class Audience_Wizard extends Wizard {
 		}
 
 		// Ensure that any Reader Revenue settings changed while the platform wasn't WC are persisted to WC products.
+		// Skip when WooCommerce isn't ready yet (e.g. the platform was just set to 'wc' before WooCommerce is
+		// installed), in which case get_donation_settings() returns a WP_Error and product writes would fatal.
 		if ( Donations::is_platform_wc() ) {
-			Donations::update_donation_product( Donations::get_donation_settings() );
+			$donation_settings = Donations::get_donation_settings();
+			if ( ! \is_wp_error( $donation_settings ) ) {
+				Donations::update_donation_product( $donation_settings );
+			}
 		}
 
 		return \rest_ensure_response( $this->get_payment_data() );

--- a/includes/wizards/audience/class-audience-wizard.php
+++ b/includes/wizards/audience/class-audience-wizard.php
@@ -23,13 +23,6 @@ defined( 'ABSPATH' ) || exit;
 class Audience_Wizard extends Wizard {
 
 	/**
-	 * Option to skip campaign setup.
-	 *
-	 * @var string
-	 */
-	const SKIP_CAMPAIGN_SETUP_OPTION = '_newspack_ras_skip_campaign_setup';
-
-	/**
 	 * Admin page slug.
 	 *
 	 * @var string
@@ -106,8 +99,6 @@ class Audience_Wizard extends Wizard {
 			$data['preview_post']       = $newspack_popups->preview_post();
 			$data['preview_archive']    = $newspack_popups->preview_archive();
 		}
-
-		$data['is_skipped_campaign_setup'] = Reader_Activation::is_skipped( 'ras_campaign' );
 
 		$data['content_gifting'] = [
 			'can_use_gifting' => Content_Gifting::can_use_gifting( true ),
@@ -193,23 +184,6 @@ class Audience_Wizard extends Wizard {
 				'methods'             => \WP_REST_Server::DELETABLE,
 				'callback'            => [ $this, 'api_reset_reader_activation_email' ],
 				'permission_callback' => [ $this, 'api_permissions_check' ],
-			]
-		);
-		register_rest_route(
-			NEWSPACK_API_NAMESPACE,
-			'/wizard/' . $this->slug . '/audience-management/skip',
-			[
-				'methods'             => WP_REST_Server::EDITABLE,
-				'callback'            => [ $this, 'api_skip_prerequisite' ],
-				'permission_callback' => [ $this, 'api_permissions_check' ],
-				'args'                => [
-					'prerequisite' => [
-						'sanitize_callback' => 'sanitize_text_field',
-					],
-					'skip'         => [
-						'sanitize_callback' => 'Newspack\newspack_string_to_bool',
-					],
-				],
 			]
 		);
 		register_rest_route(
@@ -554,48 +528,18 @@ class Audience_Wizard extends Wizard {
 	}
 
 	/**
-	 * Activate reader activation and publish RAS prompts/segments.
+	 * Publish the Audience Management campaign (RAS prompts/segments).
 	 *
-	 * @param WP_REST_Request $request WP Rest Request object.
 	 * @return WP_REST_Response
 	 */
-	public function api_activate_reader_activation( WP_REST_Request $request ) {
-		$skip_activation = $request->get_param( 'skip_activation' ) ?? false;
-		$response = $skip_activation ? true : Reader_Activation::activate();
+	public function api_activate_reader_activation() {
+		$response = Reader_Activation::activate();
 
 		if ( is_wp_error( $response ) ) {
 			return new WP_REST_Response( [ 'message' => $response->get_error_message() ], 400 );
 		}
 
-		if ( true === $response ) {
-			Reader_Activation::update_setting( 'enabled', true );
-		}
-
 		return rest_ensure_response( $response );
-	}
-
-	/**
-	 * Activate reader activation and publish RAS prompts/segments.
-	 *
-	 * @param WP_REST_Request $request WP Rest Request object.
-	 * @return WP_REST_Response
-	 */
-	public function api_skip_prerequisite( WP_REST_Request $request ) {
-		$preqrequisite       = $request->get_param( 'prerequisite' );
-		$skip                = $request->get_param( 'skip' );
-		$skip_campaign_setup = Reader_Activation::skip( $preqrequisite, $skip );
-		if ( ! $skip_campaign_setup ) {
-			return new WP_REST_Response( [ 'message' => __( 'Error skipping prerequisite.', 'newspack-plugin' ) ], 400 );
-		}
-
-		return rest_ensure_response(
-			[
-				'config'               => Reader_Activation::get_settings(),
-				'prerequisites_status' => Reader_Activation::get_prerequisites_status(),
-				'memberships'          => self::get_memberships_settings(),
-				'can_esp_sync'         => Reader_Activation\Contact_Sync::has_one_syncable_integration( true ),
-			]
-		);
 	}
 
 	/**

--- a/includes/wizards/audience/class-audience-wizard.php
+++ b/includes/wizards/audience/class-audience-wizard.php
@@ -458,6 +458,7 @@ class Audience_Wizard extends Wizard {
 			[
 				'config'               => Reader_Activation::get_settings(),
 				'prerequisites_status' => Reader_Activation::get_prerequisites_status(),
+				'required_plugins'     => Reader_Activation::get_reader_revenue_required_plugins(),
 				'memberships'          => self::get_memberships_settings(),
 				'can_esp_sync'         => Reader_Activation\Contact_Sync::has_one_syncable_integration( true ),
 			]
@@ -481,6 +482,7 @@ class Audience_Wizard extends Wizard {
 			[
 				'config'               => Reader_Activation::get_settings(),
 				'prerequisites_status' => Reader_Activation::get_prerequisites_status(),
+				'required_plugins'     => Reader_Activation::get_reader_revenue_required_plugins(),
 				'memberships'          => self::get_memberships_settings(),
 				'can_esp_sync'         => Reader_Activation\Contact_Sync::has_one_syncable_integration( true ),
 			]

--- a/includes/wizards/audience/class-audience-wizard.php
+++ b/includes/wizards/audience/class-audience-wizard.php
@@ -530,9 +530,11 @@ class Audience_Wizard extends Wizard {
 	/**
 	 * Publish the Audience Management campaign (RAS prompts/segments).
 	 *
+	 * @param WP_REST_Request $request WP REST Request object (unused; declared to match the REST callback convention used by other api_* methods in this class).
 	 * @return WP_REST_Response
 	 */
-	public function api_activate_reader_activation() {
+	public function api_activate_reader_activation( WP_REST_Request $request ) {
+		unset( $request );
 		$response = Reader_Activation::activate();
 
 		if ( is_wp_error( $response ) ) {

--- a/includes/wizards/audience/class-audience-wizard.php
+++ b/includes/wizards/audience/class-audience-wizard.php
@@ -822,7 +822,8 @@ class Audience_Wizard extends Wizard {
 				'ppcp-gateway'         => $wc_configuration_manager->gateway_data( 'ppcp-gateway' ),
 			],
 			'platform_data'    => [
-				'platform' => $platform,
+				'platform'          => $platform,
+				'platform_selected' => Donations::is_platform_selected(),
 			],
 			'is_ssl'           => is_ssl(),
 			'errors'           => [],

--- a/src/wizards/audience/components/platform-selection/index.js
+++ b/src/wizards/audience/components/platform-selection/index.js
@@ -41,7 +41,7 @@ export const OPTIONS = [
 	},
 ];
 
-const PlatformSelection = ( { onComplete, onCancel, config, saveConfig, inFlight } ) => {
+const PlatformSelection = ( { onComplete, onCancel, config, saveConfig, inFlight, showEnableToggle } ) => {
 	const { saveWizardSettings } = useDispatch( WIZARD_STORE_NAMESPACE );
 	const [ installing, setInstalling ] = useState( null );
 	const [ installFailed, setInstallFailed ] = useState( false );
@@ -61,9 +61,8 @@ const PlatformSelection = ( { onComplete, onCancel, config, saveConfig, inFlight
 			if ( ! result ) {
 				return;
 			}
-			// First-run selection enables Audience Management. The toggle to disable it
-			// only appears when returning to this screen via "Change".
-			if ( ! onCancel ) {
+			// Selecting a platform enables Audience Management when it isn't already on.
+			if ( ! config?.enabled ) {
 				saveConfig( { enabled: true } );
 			}
 			if ( PLATFORM_PLUGINS[ value ].length ) {
@@ -121,7 +120,7 @@ const PlatformSelection = ( { onComplete, onCancel, config, saveConfig, inFlight
 				</>
 			) : (
 				<>
-					{ onCancel && (
+					{ showEnableToggle && (
 						<ActionCard
 							isMedium
 							title={ __( 'Audience Management', 'newspack-plugin' ) }
@@ -133,7 +132,8 @@ const PlatformSelection = ( { onComplete, onCancel, config, saveConfig, inFlight
 							toggleChecked={ Boolean( config?.enabled ) }
 							toggleOnChange={ value => {
 								if ( value ) {
-									saveConfig( { enabled: true } );
+									// Enabling moves the user forward to the configuration page.
+									saveConfig( { enabled: true } ).then( () => onComplete() );
 								} else {
 									setShowDisableConfirm( true );
 								}

--- a/src/wizards/audience/components/platform-selection/index.js
+++ b/src/wizards/audience/components/platform-selection/index.js
@@ -8,7 +8,7 @@ import { useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { ActionCard, Button, PluginInstaller, withWizardScreen } from '../../../../../packages/components/src';
+import { ActionCard, Button, Notice, PluginInstaller, withWizardScreen } from '../../../../../packages/components/src';
 import { WIZARD_STORE_NAMESPACE } from '../../../../../packages/components/src/wizard/store';
 import WizardsTab from '../../../wizards-tab';
 import { NEWSPACK, NRH, OTHER } from '../../constants';
@@ -44,6 +44,7 @@ export const OPTIONS = [
 const PlatformSelection = ( { onComplete, onCancel } ) => {
 	const { saveWizardSettings } = useDispatch( WIZARD_STORE_NAMESPACE );
 	const [ installing, setInstalling ] = useState( null );
+	const [ installFailed, setInstallFailed ] = useState( false );
 
 	const choose = value => {
 		saveWizardSettings( {
@@ -76,12 +77,42 @@ const PlatformSelection = ( { onComplete, onCancel } ) => {
 			) }
 		>
 			{ installing ? (
-				<PluginInstaller
-					plugins={ PLATFORM_PLUGINS[ installing ] }
-					autoInstall
-					withoutFooterButton
-					onStatus={ ( { complete } ) => complete && onComplete() }
-				/>
+				<>
+					<PluginInstaller
+						plugins={ PLATFORM_PLUGINS[ installing ] }
+						autoInstall
+						withoutFooterButton
+						onStatus={ ( { complete, pluginInfo } ) => {
+							if ( complete ) {
+								onComplete();
+								return;
+							}
+							// Some platform plugins (e.g. WooCommerce Subscriptions) can't be installed
+							// automatically. Once every plugin has either activated or reported an error,
+							// surface a way to continue instead of waiting on an install that won't finish.
+							const settled = Object.values( pluginInfo ).every( plugin => 'active' === plugin.Status || plugin.notification );
+							if ( settled ) {
+								setInstallFailed( true );
+							}
+						} }
+					/>
+					{ installFailed && (
+						<>
+							<Notice
+								isWarning
+								noticeText={ __(
+									'Some plugins could not be installed automatically. Install them manually using the links above, or continue and finish setup later.',
+									'newspack-plugin'
+								) }
+							/>
+							<div className="newspack-buttons-card">
+								<Button isPrimary onClick={ onComplete }>
+									{ __( 'Continue', 'newspack-plugin' ) }
+								</Button>
+							</div>
+						</>
+					) }
+				</>
 			) : (
 				<>
 					{ OPTIONS.map( option => (

--- a/src/wizards/audience/components/platform-selection/index.js
+++ b/src/wizards/audience/components/platform-selection/index.js
@@ -41,7 +41,7 @@ export const OPTIONS = [
 	},
 ];
 
-const PlatformSelection = ( { onComplete, onCancel, config, saveConfig, inFlight, showEnableToggle } ) => {
+const PlatformSelection = ( { onComplete, onCancel, config, saveConfig, inFlight, showEnableToggle, platform } ) => {
 	const { saveWizardSettings } = useDispatch( WIZARD_STORE_NAMESPACE );
 	const [ installing, setInstalling ] = useState( null );
 	const [ installFailed, setInstallFailed ] = useState( false );
@@ -147,6 +147,8 @@ const PlatformSelection = ( { onComplete, onCancel, config, saveConfig, inFlight
 							isMedium
 							title={ option.title }
 							description={ option.description }
+							badge={ option.value === platform ? __( 'Selected', 'newspack-plugin' ) : undefined }
+							badgeLevel={ option.value === platform ? 'success' : undefined }
 							actionText={ __( 'Select', 'newspack-plugin' ) }
 							onClick={ () => choose( option.value ) }
 						/>

--- a/src/wizards/audience/components/platform-selection/index.js
+++ b/src/wizards/audience/components/platform-selection/index.js
@@ -1,0 +1,100 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useDispatch } from '@wordpress/data';
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { ActionCard, Button, Card, PluginInstaller } from '../../../../../packages/components/src';
+import { WIZARD_STORE_NAMESPACE } from '../../../../../packages/components/src/wizard/store';
+import { NEWSPACK, NRH, OTHER } from '../../constants';
+
+// The payment endpoint (api_update_payment_settings) persists the platform slug and
+// is the same store slug the Setup view reads platform_selected from.
+const PAYMENT_WIZARD_SLUG = 'newspack-audience/payment';
+
+export const PLATFORM_PLUGINS = {
+	[ NEWSPACK ]: [ 'woocommerce', 'woocommerce-subscriptions', 'newspack-blocks' ],
+	[ NRH ]: [ 'newspack-blocks' ],
+	[ OTHER ]: [],
+};
+
+export const OPTIONS = [
+	{
+		value: NEWSPACK,
+		title: __( 'Newspack', 'newspack-plugin' ),
+		description: __( 'Full reader revenue stack with checkout, donations, and subscriptions.', 'newspack-plugin' ),
+	},
+	{
+		value: NRH,
+		title: __( 'RevEngine', 'newspack-plugin' ),
+		description: __( 'Use the Donate block with News Revenue Hub / RevEngine.', 'newspack-plugin' ),
+	},
+	{
+		value: OTHER,
+		title: __( 'Other', 'newspack-plugin' ),
+		description: __( 'Use your own integrations. No checkout or donation tools are configured.', 'newspack-plugin' ),
+	},
+];
+
+const PlatformSelection = ( { onComplete, onCancel } ) => {
+	const { saveWizardSettings } = useDispatch( WIZARD_STORE_NAMESPACE );
+	const [ installing, setInstalling ] = useState( null );
+
+	const choose = value => {
+		saveWizardSettings( {
+			slug: PAYMENT_WIZARD_SLUG,
+			payloadPath: [ 'platform_data' ],
+			updatePayload: {
+				path: [ 'platform_data', 'platform' ],
+				value,
+			},
+		} ).then( () => {
+			if ( PLATFORM_PLUGINS[ value ].length ) {
+				setInstalling( value );
+			} else {
+				onComplete();
+			}
+		} );
+	};
+
+	if ( installing ) {
+		return (
+			<Card noBorder>
+				<PluginInstaller
+					plugins={ PLATFORM_PLUGINS[ installing ] }
+					autoInstall
+					withoutFooterButton
+					onStatus={ ( { complete } ) => complete && onComplete() }
+				/>
+			</Card>
+		);
+	}
+
+	return (
+		<Card noBorder>
+			{ OPTIONS.map( option => (
+				<ActionCard
+					key={ option.value }
+					isMedium
+					title={ option.title }
+					description={ option.description }
+					actionText={ __( 'Select', 'newspack-plugin' ) }
+					onClick={ () => choose( option.value ) }
+				/>
+			) ) }
+			{ onCancel && (
+				<div className="newspack-buttons-card">
+					<Button isSecondary onClick={ onCancel }>
+						{ __( 'Cancel', 'newspack-plugin' ) }
+					</Button>
+				</div>
+			) }
+		</Card>
+	);
+};
+
+export default PlatformSelection;

--- a/src/wizards/audience/components/platform-selection/index.js
+++ b/src/wizards/audience/components/platform-selection/index.js
@@ -8,8 +8,9 @@ import { useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { ActionCard, Button, Card, PluginInstaller } from '../../../../../packages/components/src';
+import { ActionCard, Button, PluginInstaller, withWizardScreen } from '../../../../../packages/components/src';
 import { WIZARD_STORE_NAMESPACE } from '../../../../../packages/components/src/wizard/store';
+import WizardsTab from '../../../wizards-tab';
 import { NEWSPACK, NRH, OTHER } from '../../constants';
 
 // The payment endpoint (api_update_payment_settings) persists the platform slug and
@@ -66,40 +67,44 @@ const PlatformSelection = ( { onComplete, onCancel } ) => {
 		} );
 	};
 
-	if ( installing ) {
-		return (
-			<Card noBorder>
+	return (
+		<WizardsTab
+			title={ __( 'Reader Revenue Platform', 'newspack-plugin' ) }
+			description={ __(
+				'Choose how you collect reader revenue. Your selection determines which plugins are installed and which settings are available.',
+				'newspack-plugin'
+			) }
+		>
+			{ installing ? (
 				<PluginInstaller
 					plugins={ PLATFORM_PLUGINS[ installing ] }
 					autoInstall
 					withoutFooterButton
 					onStatus={ ( { complete } ) => complete && onComplete() }
 				/>
-			</Card>
-		);
-	}
-
-	return (
-		<Card noBorder>
-			{ OPTIONS.map( option => (
-				<ActionCard
-					key={ option.value }
-					isMedium
-					title={ option.title }
-					description={ option.description }
-					actionText={ __( 'Select', 'newspack-plugin' ) }
-					onClick={ () => choose( option.value ) }
-				/>
-			) ) }
-			{ onCancel && (
-				<div className="newspack-buttons-card">
-					<Button isSecondary onClick={ onCancel }>
-						{ __( 'Cancel', 'newspack-plugin' ) }
-					</Button>
-				</div>
+			) : (
+				<>
+					{ OPTIONS.map( option => (
+						<ActionCard
+							key={ option.value }
+							isMedium
+							title={ option.title }
+							description={ option.description }
+							actionText={ __( 'Select', 'newspack-plugin' ) }
+							onClick={ () => choose( option.value ) }
+						/>
+					) ) }
+					{ onCancel && (
+						<div className="newspack-buttons-card">
+							<Button isSecondary onClick={ onCancel }>
+								{ __( 'Cancel', 'newspack-plugin' ) }
+							</Button>
+						</div>
+					) }
+				</>
 			) }
-		</Card>
+		</WizardsTab>
 	);
 };
 
-export default PlatformSelection;
+export default withWizardScreen( PlatformSelection );

--- a/src/wizards/audience/components/platform-selection/index.js
+++ b/src/wizards/audience/components/platform-selection/index.js
@@ -52,7 +52,12 @@ const PlatformSelection = ( { onComplete, onCancel } ) => {
 				path: [ 'platform_data', 'platform' ],
 				value,
 			},
-		} ).then( () => {
+		} ).then( result => {
+			// On a failed save the store swallows the error and resolves to
+			// undefined; don't advance past an unsaved platform choice.
+			if ( ! result ) {
+				return;
+			}
 			if ( PLATFORM_PLUGINS[ value ].length ) {
 				setInstalling( value );
 			} else {

--- a/src/wizards/audience/components/platform-selection/index.js
+++ b/src/wizards/audience/components/platform-selection/index.js
@@ -8,7 +8,7 @@ import { useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { ActionCard, Button, Notice, PluginInstaller, withWizardScreen } from '../../../../../packages/components/src';
+import { ActionCard, Button, Modal, Notice, PluginInstaller, withWizardScreen } from '../../../../../packages/components/src';
 import { WIZARD_STORE_NAMESPACE } from '../../../../../packages/components/src/wizard/store';
 import WizardsTab from '../../../wizards-tab';
 import { NEWSPACK, NRH, OTHER } from '../../constants';
@@ -41,10 +41,11 @@ export const OPTIONS = [
 	},
 ];
 
-const PlatformSelection = ( { onComplete, onCancel } ) => {
+const PlatformSelection = ( { onComplete, onCancel, config, saveConfig, inFlight } ) => {
 	const { saveWizardSettings } = useDispatch( WIZARD_STORE_NAMESPACE );
 	const [ installing, setInstalling ] = useState( null );
 	const [ installFailed, setInstallFailed ] = useState( false );
+	const [ showDisableConfirm, setShowDisableConfirm ] = useState( false );
 
 	const choose = value => {
 		saveWizardSettings( {
@@ -59,6 +60,11 @@ const PlatformSelection = ( { onComplete, onCancel } ) => {
 			// undefined; don't advance past an unsaved platform choice.
 			if ( ! result ) {
 				return;
+			}
+			// First-run selection enables Audience Management. The toggle to disable it
+			// only appears when returning to this screen via "Change".
+			if ( ! onCancel ) {
+				saveConfig( { enabled: true } );
 			}
 			if ( PLATFORM_PLUGINS[ value ].length ) {
 				setInstalling( value );
@@ -115,6 +121,26 @@ const PlatformSelection = ( { onComplete, onCancel } ) => {
 				</>
 			) : (
 				<>
+					{ onCancel && (
+						<ActionCard
+							isMedium
+							title={ __( 'Audience Management', 'newspack-plugin' ) }
+							description={
+								config?.enabled
+									? __( 'Audience Management is enabled.', 'newspack-plugin' )
+									: __( 'Audience Management is disabled.', 'newspack-plugin' )
+							}
+							toggleChecked={ Boolean( config?.enabled ) }
+							toggleOnChange={ value => {
+								if ( value ) {
+									saveConfig( { enabled: true } );
+								} else {
+									setShowDisableConfirm( true );
+								}
+							} }
+							disabled={ inFlight }
+						/>
+					) }
 					{ OPTIONS.map( option => (
 						<ActionCard
 							key={ option.value }
@@ -133,6 +159,31 @@ const PlatformSelection = ( { onComplete, onCancel } ) => {
 						</div>
 					) }
 				</>
+			) }
+			{ showDisableConfirm && (
+				<Modal title={ __( 'Disable Audience Management?', 'newspack-plugin' ) } onRequestClose={ () => setShowDisableConfirm( false ) }>
+					<p>
+						{ __(
+							'Disabling Audience Management turns off reader registration, the My Account dashboard, and related reader features. Your settings are preserved and you can re-enable it later.',
+							'newspack-plugin'
+						) }
+					</p>
+					<div className="newspack-buttons-card">
+						<Button isSecondary onClick={ () => setShowDisableConfirm( false ) }>
+							{ __( 'Cancel', 'newspack-plugin' ) }
+						</Button>
+						<Button
+							isPrimary
+							isDestructive
+							onClick={ () => {
+								saveConfig( { enabled: false } );
+								setShowDisableConfirm( false );
+							} }
+						>
+							{ __( 'Disable', 'newspack-plugin' ) }
+						</Button>
+					</div>
+				</Modal>
 			) }
 		</WizardsTab>
 	);

--- a/src/wizards/audience/components/platform-selection/index.test.js
+++ b/src/wizards/audience/components/platform-selection/index.test.js
@@ -1,0 +1,17 @@
+import { OPTIONS, PLATFORM_PLUGINS } from './';
+
+describe( 'PlatformSelection mapping', () => {
+	it( 'offers the three platforms in order', () => {
+		expect( OPTIONS.map( o => o.value ) ).toEqual( [ 'wc', 'nrh', 'other' ] );
+	} );
+
+	it( 'relabels the NRH platform as RevEngine', () => {
+		expect( OPTIONS.find( o => o.value === 'nrh' ).title ).toBe( 'RevEngine' );
+	} );
+
+	it( 'maps each platform to its required plugins', () => {
+		expect( PLATFORM_PLUGINS.wc ).toEqual( [ 'woocommerce', 'woocommerce-subscriptions', 'newspack-blocks' ] );
+		expect( PLATFORM_PLUGINS.nrh ).toEqual( [ 'newspack-blocks' ] );
+		expect( PLATFORM_PLUGINS.other ).toEqual( [] );
+	} );
+} );

--- a/src/wizards/audience/components/prerequisite.tsx
+++ b/src/wizards/audience/components/prerequisite.tsx
@@ -140,15 +140,12 @@ export default function Prerequisite( { config, getSharedProps, inFlight, prereq
 	if ( isValid ) {
 		status = __( 'Ready', 'newspack-plugin' );
 	}
-	if ( prerequisite.is_unavailable ) {
-		status = __( 'Unavailable', 'newspack-plugin' );
-	}
 
 	return (
 		<ActionCard
 			className="newspack-ras-wizard__prerequisite"
 			isMedium
-			expandable={ ! prerequisite.is_unavailable }
+			expandable
 			collapse={ isValid }
 			title={ prerequisite.label }
 			description={ sprintf(
@@ -160,7 +157,7 @@ export default function Prerequisite( { config, getSharedProps, inFlight, prereq
 			notificationLevel="info"
 			notification={ hasEmptyFields() }
 		>
-			{ prerequisite.is_unavailable ? null : renderInnerContent() }
+			{ renderInnerContent() }
 		</ActionCard>
 	);
 }

--- a/src/wizards/audience/components/prerequisite.tsx
+++ b/src/wizards/audience/components/prerequisite.tsx
@@ -104,7 +104,7 @@ export default function Prerequisite( { config, getSharedProps, inFlight, prereq
 													message: sprintf(
 														// translators: %1$s: specific instructions for satisfying the prerequisite. %2$s: opening <a> tag for the link to the Audience Configuration page. %3$s: closing </a> tag.
 														__(
-															'%1$s%2$sReturn to the Audience Configuration page to complete the settings and activate%3$s.',
+															'%1$s%2$sReturn to the Audience Configuration page to complete the settings%3$s.',
 															'newspack-plugin'
 														),
 														prerequisite.instructions + ' ',

--- a/src/wizards/audience/components/prerequisite.tsx
+++ b/src/wizards/audience/components/prerequisite.tsx
@@ -13,10 +13,9 @@ import { HANDOFF_KEY } from '../../../../packages/components/src/consts';
 /**
  * Expandable ActionCard for RAS prerequisites checklist.
  */
-export default function Prerequisite( { slug, config, getSharedProps, inFlight, prerequisite, saveConfig, skipPrerequisite }: PrequisiteProps ) {
+export default function Prerequisite( { config, getSharedProps, inFlight, prerequisite, saveConfig }: PrequisiteProps ) {
 	const { href } = prerequisite;
-	const isSkipped = Boolean( prerequisite.is_skipped );
-	const isValid = Boolean( isSkipped || prerequisite.active );
+	const isValid = Boolean( prerequisite.active );
 
 	// If the prerequisite is active but has empty fields, show a warning.
 	const hasEmptyFields = () => {
@@ -92,69 +91,45 @@ export default function Prerequisite( { slug, config, getSharedProps, inFlight, 
 							)
 						}
 						{
-							// Link to another settings page or update config in place.
+							// Link to another settings page.
 							href && prerequisite.action_text && (
-								<>
-									{ ( ! prerequisite.hasOwnProperty( 'action_enabled' ) || prerequisite.action_enabled ) && (
-										<Button
-											variant={ 'primary' }
-											onClick={ () => {
-												// Set up a handoff to indicate that the user is coming from the RAS wizard page.
-												if ( prerequisite.instructions ) {
-													window.localStorage.setItem(
-														HANDOFF_KEY,
-														JSON.stringify( {
-															message: sprintf(
-																// translators: %1$s: specific instructions for satisfying the prerequisite. %2$s: opening <a> tag for the link to the Audience Configuration page. %3$s: closing </a> tag.
-																__(
-																	'%1$s%2$sReturn to the Audience Configuration page to complete the settings and activate%3$s.',
-																	'newspack-plugin'
-																),
-																prerequisite.instructions + ' ',
-																window.newspackAudience?.reader_activation_url
-																	? `<a href="${ window.newspackAudience.reader_activation_url }">`
-																	: '',
-																window.newspackAudience?.reader_activation_url ? '</a>' : ''
-															),
-															url: href,
-														} )
-													);
-												}
+								<Button
+									variant={ 'primary' }
+									onClick={ () => {
+										// Set up a handoff to indicate that the user is coming from the RAS wizard page.
+										if ( prerequisite.instructions ) {
+											window.localStorage.setItem(
+												HANDOFF_KEY,
+												JSON.stringify( {
+													message: sprintf(
+														// translators: %1$s: specific instructions for satisfying the prerequisite. %2$s: opening <a> tag for the link to the Audience Configuration page. %3$s: closing </a> tag.
+														__(
+															'%1$s%2$sReturn to the Audience Configuration page to complete the settings and activate%3$s.',
+															'newspack-plugin'
+														),
+														prerequisite.instructions + ' ',
+														window.newspackAudience?.reader_activation_url
+															? `<a href="${ window.newspackAudience.reader_activation_url }">`
+															: '',
+														window.newspackAudience?.reader_activation_url ? '</a>' : ''
+													),
+													url: href,
+												} )
+											);
+										}
 
-												window.location.href = href;
-											} }
-										>
-											{ /* eslint-disable no-nested-ternary */ }
-											{ ( isValid
-												? __( 'Update ', 'newspack-plugin' )
-												: prerequisite.fields
-												? __( 'Save ', 'newspack-plugin' )
-												: __( 'Configure ', 'newspack-plugin' ) ) + prerequisite.action_text }
-										</Button>
-									) }
-									{ prerequisite.hasOwnProperty( 'action_enabled' ) && ! prerequisite.action_enabled && (
-										<Button variant={ 'secondary' } disabled>
-											{ prerequisite.disabled_text || prerequisite.action_text }
-										</Button>
-									) }
-								</>
+										window.location.href = href;
+									} }
+								>
+									{ /* eslint-disable no-nested-ternary */ }
+									{ ( isValid
+										? __( 'Update ', 'newspack-plugin' )
+										: prerequisite.fields
+										? __( 'Save ', 'newspack-plugin' )
+										: __( 'Configure ', 'newspack-plugin' ) ) + prerequisite.action_text }
+								</Button>
 							)
 						}
-
-						{ prerequisite.skippable && ! prerequisite.active && ! isSkipped && (
-							<Button
-								variant={ 'secondary' }
-								isDestructive
-								onClick={ () => {
-									skipPrerequisite( {
-										prerequisite: slug,
-										skip: true,
-									} );
-								} }
-							>
-								{ __( 'Skip', 'newspack-plugin' ) }
-							</Button>
-						) }
 					</div>
 				</Grid>
 			) }
@@ -164,9 +139,6 @@ export default function Prerequisite( { slug, config, getSharedProps, inFlight, 
 	let status = __( 'Pending', 'newspack-plugin' );
 	if ( isValid ) {
 		status = __( 'Ready', 'newspack-plugin' );
-	}
-	if ( isSkipped && ! prerequisite.active ) {
-		status = __( 'Skipped', 'newspack-plugin' );
 	}
 	if ( prerequisite.is_unavailable ) {
 		status = __( 'Unavailable', 'newspack-plugin' );
@@ -184,7 +156,7 @@ export default function Prerequisite( { slug, config, getSharedProps, inFlight, 
 				__( 'Status: %s', 'newspack-plugin' ),
 				status
 			) }
-			checkbox={ isValid && ! isSkipped ? 'checked' : 'unchecked' }
+			checkbox={ isValid ? 'checked' : 'unchecked' }
 			notificationLevel="info"
 			notification={ hasEmptyFields() }
 		>

--- a/src/wizards/audience/types/index.d.ts
+++ b/src/wizards/audience/types/index.d.ts
@@ -108,7 +108,6 @@ type PrequisiteProps = {
 		};
 		href?: string;
 		action_text?: string;
-		is_unavailable?: boolean;
 	};
 };
 

--- a/src/wizards/audience/types/index.d.ts
+++ b/src/wizards/audience/types/index.d.ts
@@ -77,7 +77,6 @@ type ConfigKey = keyof Config;
 // Props for the Prequisite component.
 type PrequisiteProps = {
 	config: Config;
-	slug: string;
 	getSharedProps: (
 		configKey: string,
 		type: string
@@ -89,7 +88,6 @@ type PrequisiteProps = {
 	};
 	inFlight: boolean;
 	saveConfig: ( config: Config ) => void;
-	skipPrerequisite: ( data: { prerequisite: string; skip: boolean } ) => void;
 
 	// Schema for prequisite object is defined in PHP class Reader_Activation::get_prerequisites_status().
 	prerequisite: {
@@ -110,11 +108,7 @@ type PrequisiteProps = {
 		};
 		href?: string;
 		action_text?: string;
-		action_enabled?: boolean;
-		disabled_text?: string;
 		is_unavailable?: boolean;
-		is_skipped?: boolean;
-		skippable?: boolean;
 	};
 };
 

--- a/src/wizards/audience/views/setup/campaign.js
+++ b/src/wizards/audience/views/setup/campaign.js
@@ -13,17 +13,13 @@ import { useEffect, useState } from '@wordpress/element';
 import WizardsTab from '../../../wizards-tab';
 import { Button, Notice, Waiting, withWizardScreen } from '../../../../../packages/components/src';
 import Prompt from '../../components/prompt';
-import Router from '../../../../../packages/components/src/proxied-imports/router';
 import './style.scss';
 
-const { useHistory } = Router;
-
-const AudienceCampaign = withWizardScreen( ( { error, setError, skipPrerequisite } ) => {
+const AudienceCampaign = withWizardScreen( ( { error, setError } ) => {
 	const { reader_activation_url } = newspackAudience;
 	const [ inFlight, setInFlight ] = useState( false );
 	const [ prompts, setPrompts ] = useState( null );
 	const [ allReady, setAllReady ] = useState( false );
-	const history = useHistory();
 
 	const fetchPrompts = () => {
 		setError( false );
@@ -66,22 +62,6 @@ const AudienceCampaign = withWizardScreen( ( { error, setError, skipPrerequisite
 					<Prompt key={ prompt.slug } prompt={ prompt } inFlight={ inFlight } setInFlight={ setInFlight } setPrompts={ setPrompts } />
 				) ) }
 			<div className="newspack-buttons-card">
-				<Button
-					variant={ 'secondary' }
-					isDestructive
-					disabled={ inFlight }
-					onClick={ () => {
-						skipPrerequisite(
-							{
-								prerequisite: 'ras_campaign',
-								skip: true,
-							},
-							() => history.push( '/complete' )
-						);
-					} }
-				>
-					{ __( 'Skip', 'newspack-plugin' ) }
-				</Button>
 				<Button isPrimary disabled={ inFlight || ! allReady } href={ `${ reader_activation_url }complete` }>
 					{ __( 'Continue', 'newspack-plugin' ) }
 				</Button>

--- a/src/wizards/audience/views/setup/complete.js
+++ b/src/wizards/audience/views/setup/complete.js
@@ -82,6 +82,10 @@ export default withWizardScreen( ( { fetchConfig } ) => {
 				} )
 			);
 		} catch ( err ) {
+			if ( timer.current ) {
+				clearTimeout( timer.current );
+			}
+			setInFlight( false );
 			setError( err );
 		}
 	};

--- a/src/wizards/audience/views/setup/complete.js
+++ b/src/wizards/audience/views/setup/complete.js
@@ -15,27 +15,11 @@ import WizardsTab from '../../../wizards-tab';
 import { Button, withWizardScreen, Card, Notice, ProgressBar, StepsList } from '../../../../../packages/components/src';
 
 const listItems = [
-	{
-		text: __( 'Your <strong>current segments and prompts</strong> will be deactivated and archived.', 'newspack-plugin' ),
-		isSkipped: '<span class="is-skipped">[skipped]</span>',
-	},
-	{
-		text: __(
-			'<strong>Reader registration</strong> will be activated to enable better targeting for driving engagement and conversations.',
-			'newspack-plugin'
-		),
-	},
-	{
-		text: __( 'The <strong>Audience Management campaign</strong> will be activated with default segments and settings.', 'newspack-plugin' ),
-		isSkipped: '<span class="is-skipped">[skipped]</span>',
-	},
+	__( 'Your <strong>current segments and prompts</strong> will be deactivated and archived.', 'newspack-plugin' ),
+	__( 'The <strong>Audience Management campaign</strong> will be activated with default segments and settings.', 'newspack-plugin' ),
 ];
 
-const DEFAULT_ACTIVATION_STEPS = {
-	campaignsSegments: __( 'Setting up new segments…', 'newspack-plugin' ),
-	readerRegistration: __( 'Activating reader registration…', 'newspack-plugin' ),
-	campaignsPrompts: __( 'Activating Audience Management Campaign…', 'newspack-plugin' ),
-};
+const ACTIVATION_STEPS = [ __( 'Setting up new segments…', 'newspack-plugin' ), __( 'Activating Audience Management Campaign…', 'newspack-plugin' ) ];
 
 /**
  * Get a random number between min and max.
@@ -55,29 +39,7 @@ export default withWizardScreen( ( { fetchConfig } ) => {
 	const [ progressLabel, setProgressLabel ] = useState( false );
 	const [ completed, setCompleted ] = useState( false );
 	const timer = useRef();
-	const [ activationSteps, setActivationSteps ] = useState( Object.values( DEFAULT_ACTIVATION_STEPS ) );
-	const { reader_activation_url, is_skipped_campaign_setup = '' } = newspackAudience;
-	const isSkippedCampaignSetup = is_skipped_campaign_setup === '1';
-
-	useEffect( () => {
-		if ( isSkippedCampaignSetup ) {
-			setActivationSteps( [ DEFAULT_ACTIVATION_STEPS.readerRegistration ] );
-		}
-	}, [ isSkippedCampaignSetup ] );
-
-	/**
-	 * Generate step list strings
-	 */
-	for ( const listItemIndex in listItems ) {
-		if ( ! listItems[ listItemIndex ].text ) {
-			continue;
-		}
-		const suffix = isSkippedCampaignSetup ? ` ${ listItems[ listItemIndex ].isSkipped ?? '' }` : '';
-		listItems[ listItemIndex ] = `${ listItems[ listItemIndex ].text }${ suffix }`;
-		if ( isSkippedCampaignSetup ) {
-			listItems[ listItemIndex ] += ` ${ listItems[ listItemIndex ].isSkipped ?? '' }`;
-		}
-	}
+	const { reader_activation_url } = newspackAudience;
 
 	useEffect( () => {
 		if ( timer.current ) {
@@ -86,8 +48,8 @@ export default withWizardScreen( ( { fetchConfig } ) => {
 		if ( error ) {
 			setInFlight( false );
 		}
-		if ( ! error && inFlight && 0 <= progress && progress < activationSteps.length ) {
-			setProgressLabel( activationSteps[ progress ] );
+		if ( ! error && inFlight && 0 <= progress && progress < ACTIVATION_STEPS.length ) {
+			setProgressLabel( ACTIVATION_STEPS[ progress ] );
 			timer.current = setTimeout(
 				() => {
 					setProgress( _progress => _progress + 1 );
@@ -95,8 +57,8 @@ export default withWizardScreen( ( { fetchConfig } ) => {
 				generateRandomNumber( 1000, 2000 )
 			);
 		}
-		if ( progress >= activationSteps.length && completed ) {
-			setProgress( activationSteps.length + 1 ); // Plus one to account for the "Done!" step.
+		if ( progress >= ACTIVATION_STEPS.length && completed ) {
+			setProgress( ACTIVATION_STEPS.length + 1 ); // Plus one to account for the "Done!" step.
 			setProgressLabel( __( 'Done!', 'newspack-plugin' ) );
 			setTimeout( () => {
 				fetchConfig().finally( () => {
@@ -117,9 +79,6 @@ export default withWizardScreen( ( { fetchConfig } ) => {
 				await apiFetch( {
 					path: '/newspack/v1/wizard/newspack-audience/audience-management/activate',
 					method: 'post',
-					data: {
-						skip_activation: isSkippedCampaignSetup,
-					},
 				} )
 			);
 		} catch ( err ) {
@@ -130,11 +89,11 @@ export default withWizardScreen( ( { fetchConfig } ) => {
 	return (
 		<div className="newspack-ras-campaign__completed">
 			<WizardsTab
-				title={ __( 'Enable Audience Management', 'newspack-plugin' ) }
+				title={ __( 'Audience Management Campaign', 'newspack-plugin' ) }
 				description={
 					<>
 						{ __(
-							'An easy way to let your readers register for your site, sign up for newsletters, or become donors and paid members. ',
+							'Publish a set of prompts with default segments and settings, optimized for audience management. ',
 							'newspack-plugin'
 						) }
 
@@ -148,14 +107,14 @@ export default withWizardScreen( ( { fetchConfig } ) => {
 						<ProgressBar
 							completed={ progress }
 							displayFraction={ false }
-							total={ activationSteps.length + 1 } // Plus one to account for the "Done!" step.
+							total={ ACTIVATION_STEPS.length + 1 } // Plus one to account for the "Done!" step.
 							label={ progressLabel }
 						/>
 					</Card>
 				) }
 				{ ! inFlight && (
 					<Card className="newspack-ras-campaign__completed-card">
-						<h2>{ __( "You're all set to enable Audience Management!", 'newspack-plugin' ) }</h2>
+						<h2>{ __( "You're all set to publish the Audience Management campaign!", 'newspack-plugin' ) }</h2>
 						<p>{ __( 'This is what will happen next:', 'newspack-plugin' ) }</p>
 
 						<Card noBorder className="justify-center">
@@ -166,7 +125,7 @@ export default withWizardScreen( ( { fetchConfig } ) => {
 
 						<Card buttonsCard noBorder className="justify-center">
 							<Button isPrimary onClick={ () => activate() }>
-								{ __( 'Enable Audience Management', 'newspack-plugin' ) }
+								{ __( 'Publish campaign', 'newspack-plugin' ) }
 							</Button>
 						</Card>
 					</Card>

--- a/src/wizards/audience/views/setup/index.js
+++ b/src/wizards/audience/views/setup/index.js
@@ -23,7 +23,7 @@ import Payment from './payment';
 
 const { HashRouter, Redirect, Route, Switch } = Router;
 
-function AudienceWizard( { confirmAction, pluginRequirements, wizardApiFetch }, ref ) {
+function AudienceWizard( { pluginRequirements, wizardApiFetch }, ref ) {
 	const [ inFlight, setInFlight ] = useState( false );
 	const [ config, setConfig ] = useState( {} );
 	const [ prerequisites, setPrerequisites ] = useState( null );
@@ -63,32 +63,6 @@ function AudienceWizard( { confirmAction, pluginRequirements, wizardApiFetch }, 
 			} )
 			.catch( setError )
 			.finally( () => setInFlight( false ) );
-	};
-	const skipPrerequisite = ( data, callback = null ) => {
-		confirmAction( {
-			message: __( 'Are you sure you want to skip this step? You can always come back later.', 'newspack-plugin' ),
-			confirmText: __( 'Skip', 'newspack-plugin' ),
-			callback: () => {
-				setError( false );
-				setInFlight( true );
-				wizardApiFetch( {
-					path: '/newspack/v1/wizard/newspack-audience/audience-management/skip',
-					method: 'post',
-					quiet: true,
-					data,
-				} )
-					.then( ( { config: fetchedConfig, prerequisites_status, can_esp_sync } ) => {
-						setPrerequisites( prerequisites_status );
-						setConfig( fetchedConfig );
-						setEspSyncErrors( can_esp_sync.errors );
-						if ( callback ) {
-							callback();
-						}
-					} )
-					.catch( setError )
-					.finally( () => setInFlight( false ) );
-			},
-		} );
 	};
 
 	useEffect( () => {
@@ -141,7 +115,6 @@ function AudienceWizard( { confirmAction, pluginRequirements, wizardApiFetch }, 
 		fetchConfig,
 		updateConfig,
 		saveConfig,
-		skipPrerequisite,
 		setInFlight,
 		setError,
 		getSharedProps,

--- a/src/wizards/audience/views/setup/index.js
+++ b/src/wizards/audience/views/setup/index.js
@@ -32,6 +32,7 @@ function AudienceWizard( { pluginRequirements, wizardApiFetch }, ref ) {
 	const [ error, setError ] = useState( false );
 	const [ espSyncErrors, setEspSyncErrors ] = useState( [] );
 	const [ requiredPlugins, setRequiredPlugins ] = useState( {} );
+	const [ configLoaded, setConfigLoaded ] = useState( false );
 
 	const fetchConfig = () => {
 		setError( false );
@@ -44,6 +45,7 @@ function AudienceWizard( { pluginRequirements, wizardApiFetch }, ref ) {
 				setRequiredPlugins( required_plugins || {} );
 				setConfig( fetchedConfig );
 				setEspSyncErrors( can_esp_sync.errors );
+				setConfigLoaded( true );
 			} )
 			.catch( setError )
 			.finally( () => setInFlight( false ) );
@@ -54,7 +56,7 @@ function AudienceWizard( { pluginRequirements, wizardApiFetch }, ref ) {
 	const saveConfig = data => {
 		setError( false );
 		setInFlight( true );
-		wizardApiFetch( {
+		return wizardApiFetch( {
 			path: '/newspack/v1/wizard/newspack-audience/audience-management',
 			method: 'post',
 			quiet: true,
@@ -78,15 +80,17 @@ function AudienceWizard( { pluginRequirements, wizardApiFetch }, ref ) {
 	const paymentData = useWizardData( 'newspack-audience/payment' );
 	const platform = paymentData?.platform_data?.platform;
 	const platformSelected = paymentData?.platform_data?.platform_selected;
-	// `null` = undecided until payment data loads. Driven by local state (not the live
-	// `platform_selected`) so the chooser stays mounted while plugins auto-install — the
-	// save flips `platform_selected` to true before install finishes.
+	// `null` = undecided until config + payment data load. Driven by local state (not the
+	// live values) so the chooser stays mounted while plugins auto-install and while enabling
+	// — the saves flip platform_selected/enabled before the flow finishes. Open the chooser
+	// when no platform has been chosen OR Audience Management is disabled, so a disabled site
+	// lands on the platform/enable screen rather than the (active-looking) configuration page.
 	const [ showChooser, setShowChooser ] = useState( null );
 	useEffect( () => {
-		if ( showChooser === null && typeof platformSelected === 'boolean' ) {
-			setShowChooser( ! platformSelected );
+		if ( showChooser === null && configLoaded && typeof platformSelected === 'boolean' ) {
+			setShowChooser( ! platformSelected || ! config.enabled );
 		}
-	}, [ platformSelected, showChooser ] );
+	}, [ platformSelected, configLoaded, config.enabled, showChooser ] );
 	const chooserOpen = showChooser === true;
 
 	let tabs = chooserOpen
@@ -160,11 +164,12 @@ function AudienceWizard( { pluginRequirements, wizardApiFetch }, ref ) {
 								<PlatformSelection
 									{ ...props }
 									tabbedNavigation={ null }
+									showEnableToggle={ platformSelected }
 									onComplete={ () => {
 										setShowChooser( false );
 										fetchConfig();
 									} }
-									onCancel={ platformSelected ? () => setShowChooser( false ) : undefined }
+									onCancel={ platformSelected && config.enabled ? () => setShowChooser( false ) : undefined }
 								/>
 							) : (
 								<Setup { ...props } />

--- a/src/wizards/audience/views/setup/index.js
+++ b/src/wizards/audience/views/setup/index.js
@@ -154,6 +154,8 @@ function AudienceWizard( { pluginRequirements, wizardApiFetch }, ref ) {
 						render={ () =>
 							chooserOpen ? (
 								<PlatformSelection
+									{ ...props }
+									tabbedNavigation={ null }
 									onComplete={ () => {
 										setShowChooser( false );
 										fetchConfig();

--- a/src/wizards/audience/views/setup/index.js
+++ b/src/wizards/audience/views/setup/index.js
@@ -20,6 +20,8 @@ import { withWizard } from '../../../../../packages/components/src';
 import Router from '../../../../../packages/components/src/proxied-imports/router';
 import ContentGating from './content-gating';
 import Payment from './payment';
+import { useWizardData } from '../../../../../packages/components/src/wizard/store/utils';
+import PlatformSelection from '../../components/platform-selection';
 
 const { HashRouter, Redirect, Route, Switch } = Router;
 
@@ -70,21 +72,37 @@ function AudienceWizard( { pluginRequirements, wizardApiFetch }, ref ) {
 		fetchConfig();
 	}, [] );
 
-	let tabs = [
-		{
-			label: config.enabled ? __( 'Configuration', 'newspack-plugin' ) : __( 'Setup', 'newspack-plugin' ),
-			path: '/',
-		},
-		config.enabled &&
-			newspackAudience.has_memberships && {
-				label: __( 'Content Gating', 'newspack-plugin' ),
-				path: '/content-gating',
-			},
-		{
-			label: __( 'Checkout & Payment', 'newspack-plugin' ),
-			path: '/payment',
-		},
-	];
+	const paymentData = useWizardData( 'newspack-audience/payment' );
+	const platform = paymentData?.platform_data?.platform;
+	const platformSelected = paymentData?.platform_data?.platform_selected;
+	// `null` = undecided until payment data loads. Driven by local state (not the live
+	// `platform_selected`) so the chooser stays mounted while plugins auto-install — the
+	// save flips `platform_selected` to true before install finishes.
+	const [ showChooser, setShowChooser ] = useState( null );
+	useEffect( () => {
+		if ( showChooser === null && typeof platformSelected === 'boolean' ) {
+			setShowChooser( ! platformSelected );
+		}
+	}, [ platformSelected, showChooser ] );
+	const chooserOpen = showChooser === true;
+
+	let tabs = chooserOpen
+		? []
+		: [
+				{
+					label: config.enabled ? __( 'Configuration', 'newspack-plugin' ) : __( 'Setup', 'newspack-plugin' ),
+					path: '/',
+				},
+				config.enabled &&
+					newspackAudience.has_memberships && {
+						label: __( 'Content Gating', 'newspack-plugin' ),
+						path: '/content-gating',
+					},
+				[ 'wc', 'nrh' ].includes( platform ) && {
+					label: __( 'Checkout & Payment', 'newspack-plugin' ),
+					path: '/payment',
+				},
+		  ];
 	tabs = tabs.filter( tab => tab );
 
 	const getSharedProps = ( configKey, type = 'checkbox' ) => {
@@ -121,6 +139,8 @@ function AudienceWizard( { pluginRequirements, wizardApiFetch }, ref ) {
 		espSyncErrors,
 		prerequisites,
 		config,
+		onChangePlatform: () => setShowChooser( true ),
+		platform,
 	};
 
 	return (
@@ -128,7 +148,23 @@ function AudienceWizard( { pluginRequirements, wizardApiFetch }, ref ) {
 			<HashRouter hashType="slash">
 				<Switch>
 					{ pluginRequirements }
-					<Route path="/" exact render={ () => <Setup { ...props } /> } />
+					<Route
+						path="/"
+						exact
+						render={ () =>
+							chooserOpen ? (
+								<PlatformSelection
+									onComplete={ () => {
+										setShowChooser( false );
+										fetchConfig();
+									} }
+									onCancel={ platformSelected ? () => setShowChooser( false ) : undefined }
+								/>
+							) : (
+								<Setup { ...props } />
+							)
+						}
+					/>
 					<Route path="/content-gating" render={ () => <ContentGating { ...props } /> } />
 					<Route path="/payment" render={ () => <Payment { ...props } /> } />
 					<Route path="/campaign" render={ () => <Campaign { ...props } /> } />

--- a/src/wizards/audience/views/setup/index.js
+++ b/src/wizards/audience/views/setup/index.js
@@ -31,6 +31,7 @@ function AudienceWizard( { pluginRequirements, wizardApiFetch }, ref ) {
 	const [ prerequisites, setPrerequisites ] = useState( null );
 	const [ error, setError ] = useState( false );
 	const [ espSyncErrors, setEspSyncErrors ] = useState( [] );
+	const [ requiredPlugins, setRequiredPlugins ] = useState( {} );
 
 	const fetchConfig = () => {
 		setError( false );
@@ -38,8 +39,9 @@ function AudienceWizard( { pluginRequirements, wizardApiFetch }, ref ) {
 		return wizardApiFetch( {
 			path: '/newspack/v1/wizard/newspack-audience/audience-management',
 		} )
-			.then( ( { config: fetchedConfig, prerequisites_status, can_esp_sync } ) => {
+			.then( ( { config: fetchedConfig, prerequisites_status, required_plugins, can_esp_sync } ) => {
 				setPrerequisites( prerequisites_status );
+				setRequiredPlugins( required_plugins || {} );
 				setConfig( fetchedConfig );
 				setEspSyncErrors( can_esp_sync.errors );
 			} )
@@ -58,8 +60,9 @@ function AudienceWizard( { pluginRequirements, wizardApiFetch }, ref ) {
 			quiet: true,
 			data,
 		} )
-			.then( ( { config: fetchedConfig, prerequisites_status, can_esp_sync } ) => {
+			.then( ( { config: fetchedConfig, prerequisites_status, required_plugins, can_esp_sync } ) => {
 				setPrerequisites( prerequisites_status );
+				setRequiredPlugins( required_plugins || {} );
 				setConfig( fetchedConfig );
 				setEspSyncErrors( can_esp_sync.errors );
 			} )
@@ -139,6 +142,7 @@ function AudienceWizard( { pluginRequirements, wizardApiFetch }, ref ) {
 		espSyncErrors,
 		prerequisites,
 		config,
+		requiredPlugins,
 		onChangePlatform: () => setShowChooser( true ),
 		platform,
 	};

--- a/src/wizards/audience/views/setup/payment.js
+++ b/src/wizards/audience/views/setup/payment.js
@@ -9,7 +9,6 @@ import { __ } from '@wordpress/i18n';
 import { withWizardScreen } from '../../../../../packages/components/src';
 import { useWizardData } from '../../../../../packages/components/src/wizard/store/utils';
 import WizardsTab from '../../../wizards-tab';
-import Platform from '../../components/platform';
 import PaymentGateways from '../../components/payment-methods';
 import NRHSettings from '../../components/nrh-settings';
 import BillingFields from '../../components/billing-fields';
@@ -25,7 +24,6 @@ export default withWizardScreen( function ( { wizardApiFetch } ) {
 			title={ __( 'Checkout & Payment', 'newspack-plugin' ) }
 			description={ __( 'Reader revenue configuration for donations and subscriptions.', 'newspack-plugin' ) }
 		>
-			<Platform />
 			{ data?.platform_data?.platform === 'wc' && <PaymentGateways /> }
 			{ data?.platform_data?.platform === 'wc' && <BillingFields /> }
 			{ data?.platform_data?.platform === 'nrh' && <NRHSettings /> }

--- a/src/wizards/audience/views/setup/setup.js
+++ b/src/wizards/audience/views/setup/setup.js
@@ -101,7 +101,12 @@ export default withWizardScreen(
 					toggleOnChange={ value => saveConfig( { enabled: value } ) }
 					disabled={ inFlight }
 				/>
-				{ 0 < missingPlugins.length && <Notice noticeText={ __( 'The following plugins are required.', 'newspack-plugin' ) } isWarning /> }
+				{ 0 < missingPlugins.length && (
+					<Notice
+						noticeText={ __( 'The following plugins are recommended for full Audience Management functionality.', 'newspack-plugin' ) }
+						isWarning
+					/>
+				) }
 				{ 0 === missingPlugins.length && prerequisites && ! allReady && (
 					<Notice noticeText={ __( 'Some recommended settings are not yet configured.', 'newspack-plugin' ) } isWarning />
 				) }
@@ -114,8 +119,7 @@ export default withWizardScreen(
 				{ 0 < missingPlugins.length && prerequisites && (
 					<PluginInstaller plugins={ missingPlugins } withoutFooterButton onStatus={ ( { complete } ) => complete && fetchConfig() } />
 				) }
-				{ ! missingPlugins.length &&
-					prerequisites &&
+				{ prerequisites &&
 					Object.keys( prerequisites ).map( key => (
 						<Prerequisite
 							key={ key }

--- a/src/wizards/audience/views/setup/setup.js
+++ b/src/wizards/audience/views/setup/setup.js
@@ -32,7 +32,19 @@ import SortableNewsletterListControl from '../../../../../packages/components/sr
 import Salesforce from '../../components/salesforce';
 
 export default withWizardScreen(
-	( { config, fetchConfig, updateConfig, getSharedProps, saveConfig, prerequisites, espSyncErrors, error, inFlight } ) => {
+	( {
+		config,
+		fetchConfig,
+		updateConfig,
+		getSharedProps,
+		saveConfig,
+		prerequisites,
+		espSyncErrors,
+		error,
+		inFlight,
+		platform,
+		onChangePlatform,
+	} ) => {
 		const [ allReady, setAllReady ] = useState( false );
 		const [ missingPlugins, setMissingPlugins ] = useState( [] );
 		const [ esp, setEsp ] = useState( '' );
@@ -103,6 +115,22 @@ export default withWizardScreen(
 					toggleOnChange={ value => saveConfig( { enabled: value } ) }
 					disabled={ inFlight }
 				/>
+				{ onChangePlatform && (
+					<ActionCard
+						isMedium
+						title={ __( 'Reader Revenue Platform', 'newspack-plugin' ) }
+						description={ ( () => {
+							const labels = {
+								wc: __( 'Newspack', 'newspack-plugin' ),
+								nrh: __( 'RevEngine', 'newspack-plugin' ),
+								other: __( 'Other', 'newspack-plugin' ),
+							};
+							return labels[ platform ] || __( 'Not set', 'newspack-plugin' );
+						} )() }
+						actionText={ __( 'Change', 'newspack-plugin' ) }
+						onClick={ onChangePlatform }
+					/>
+				) }
 				{ 0 < missingPlugins.length && (
 					<Notice
 						noticeText={ __( 'The following plugins are recommended for full Audience Management functionality.', 'newspack-plugin' ) }

--- a/src/wizards/audience/views/setup/setup.js
+++ b/src/wizards/audience/views/setup/setup.js
@@ -59,39 +59,40 @@ export default withWizardScreen(
 		useEffect( () => {
 			apiFetch( {
 				path: '/newspack/v1/wizard/newspack-newsletters/settings',
-			} ).then( data => {
-				setEsp( data?.settings?.newspack_newsletters_service_provider?.value ?? '' );
-			} );
+			} )
+				.then( data => {
+					setEsp( data?.settings?.newspack_newsletters_service_provider?.value ?? '' );
+				} )
+				// Newspack Newsletters may not be installed, in which case the endpoint 404s.
+				.catch( () => setEsp( '' ) );
 		}, [] );
 
 		useEffect( () => {
-			const _allReady = ! missingPlugins.length && prerequisites && Object.keys( prerequisites ).every( key => prerequisites[ key ]?.active );
-
-			setAllReady( _allReady );
-
-			if ( prerequisites ) {
-				const missing = Object.keys( prerequisites ).reduce( ( acc, slug ) => {
-					const prerequisite = prerequisites[ slug ];
-					if ( prerequisite.plugins ) {
-						for ( const pluginSlug in prerequisite.plugins ) {
-							if ( ! prerequisite.plugins[ pluginSlug ] ) {
-								acc.push( pluginSlug );
+			const missing = prerequisites
+				? Object.keys( prerequisites ).reduce( ( acc, slug ) => {
+						const prerequisite = prerequisites[ slug ];
+						if ( prerequisite.plugins ) {
+							for ( const pluginSlug in prerequisite.plugins ) {
+								if ( ! prerequisite.plugins[ pluginSlug ] ) {
+									acc.push( pluginSlug );
+								}
 							}
 						}
-					}
-					return acc;
-				}, [] );
+						return acc;
+				  }, [] )
+				: [];
 
-				// Surface the selected platform's required plugins that aren't installed yet,
-				// so missing ones are presented here even if the chooser's install didn't finish.
-				for ( const pluginSlug in requiredPlugins ) {
-					if ( ! requiredPlugins[ pluginSlug ] && ! missing.includes( pluginSlug ) ) {
-						missing.push( pluginSlug );
-					}
+			// Surface the selected platform's required plugins that aren't installed yet,
+			// so missing ones are presented here even if the chooser's install didn't finish.
+			for ( const pluginSlug in requiredPlugins ) {
+				if ( ! requiredPlugins[ pluginSlug ] && ! missing.includes( pluginSlug ) ) {
+					missing.push( pluginSlug );
 				}
-
-				setMissingPlugins( missing );
 			}
+
+			setMissingPlugins( missing );
+			// Derive readiness from the freshly-computed list, not the (stale) missingPlugins state.
+			setAllReady( ! missing.length && prerequisites && Object.keys( prerequisites ).every( key => prerequisites[ key ]?.active ) );
 		}, [ prerequisites, requiredPlugins ] );
 
 		const hasNewsletters = Boolean( prerequisites?.esp?.plugins?.[ 'newspack-newsletters' ] );

--- a/src/wizards/audience/views/setup/setup.js
+++ b/src/wizards/audience/views/setup/setup.js
@@ -32,7 +32,7 @@ import SortableNewsletterListControl from '../../../../../packages/components/sr
 import Salesforce from '../../components/salesforce';
 
 export default withWizardScreen(
-	( { config, fetchConfig, updateConfig, getSharedProps, saveConfig, skipPrerequisite, prerequisites, espSyncErrors, error, inFlight } ) => {
+	( { config, fetchConfig, updateConfig, getSharedProps, saveConfig, prerequisites, espSyncErrors, error, inFlight } ) => {
 		const [ allReady, setAllReady ] = useState( false );
 		const [ missingPlugins, setMissingPlugins ] = useState( [] );
 		const [ esp, setEsp ] = useState( '' );
@@ -52,10 +52,7 @@ export default withWizardScreen(
 		}, [] );
 
 		useEffect( () => {
-			const _allReady =
-				! missingPlugins.length &&
-				prerequisites &&
-				Object.keys( prerequisites ).every( key => prerequisites[ key ]?.active || prerequisites[ key ]?.is_skipped );
+			const _allReady = ! missingPlugins.length && prerequisites && Object.keys( prerequisites ).every( key => prerequisites[ key ]?.active );
 
 			setAllReady( _allReady );
 
@@ -92,12 +89,21 @@ export default withWizardScreen(
 				}
 			>
 				{ error && <Notice noticeText={ error?.message || __( 'Something went wrong.', 'newspack-plugin' ) } isError /> }
+				<ActionCard
+					isMedium
+					title={ __( 'Enable Audience Management', 'newspack-plugin' ) }
+					description={
+						config.enabled
+							? __( 'Audience Management is enabled.', 'newspack-plugin' )
+							: __( 'Audience Management is disabled.', 'newspack-plugin' )
+					}
+					toggleChecked={ Boolean( config.enabled ) }
+					toggleOnChange={ value => saveConfig( { enabled: value } ) }
+					disabled={ inFlight }
+				/>
 				{ 0 < missingPlugins.length && <Notice noticeText={ __( 'The following plugins are required.', 'newspack-plugin' ) } isWarning /> }
 				{ 0 === missingPlugins.length && prerequisites && ! allReady && (
-					<Notice noticeText={ __( 'Complete these settings to enable Audience Management.', 'newspack-plugin' ) } isWarning />
-				) }
-				{ prerequisites && allReady && config.enabled && (
-					<Notice noticeText={ __( 'Audience Management is enabled.', 'newspack-plugin' ) } isSuccess />
+					<Notice noticeText={ __( 'Some recommended settings are not yet configured.', 'newspack-plugin' ) } isWarning />
 				) }
 				{ ! prerequisites && (
 					<>
@@ -113,14 +119,12 @@ export default withWizardScreen(
 					Object.keys( prerequisites ).map( key => (
 						<Prerequisite
 							key={ key }
-							slug={ key }
 							config={ config }
 							getSharedProps={ getSharedProps }
 							inFlight={ inFlight }
 							prerequisite={ prerequisites[ key ] }
 							fetchConfig={ fetchConfig }
 							saveConfig={ saveConfig }
-							skipPrerequisite={ skipPrerequisite }
 						/>
 					) ) }
 				{ config.enabled && (

--- a/src/wizards/audience/views/setup/setup.js
+++ b/src/wizards/audience/views/setup/setup.js
@@ -73,6 +73,8 @@ export default withWizardScreen(
 			}
 		}, [ prerequisites ] );
 
+		const hasNewsletters = Boolean( prerequisites?.esp?.plugins?.[ 'newspack-newsletters' ] );
+
 		return (
 			<WizardsTab
 				title={ __( 'Audience Management', 'newspack-plugin' ) }
@@ -134,39 +136,41 @@ export default withWizardScreen(
 				{ config.enabled && (
 					<Card noBorder>
 						<Divider alignment="full-width" variant="tertiary" />
-						<ActionCard
-							title={ __( 'Present newsletter signup after checkout and registration', 'newspack-plugin' ) }
-							description={ __(
-								'Ask readers to sign up for newsletters after creating an account or completing a purchase.',
-								'newspack-plugin'
-							) }
-							hasGreyHeader={ config.use_custom_lists }
-							isMedium
-							toggleChecked={ config.use_custom_lists }
-							toggleOnChange={ value => updateConfig( 'use_custom_lists', value ) }
-						>
-							{ config.use_custom_lists && (
-								<Grid columns={ 4 }>
-									<SortableNewsletterListControl
-										lists={ newspackAudience.available_newsletter_lists }
-										selected={ config.newsletter_lists }
-										onChange={ selected => updateConfig( 'newsletter_lists', selected ) }
-									/>
-									<RangeControl
-										min={ 1 }
-										max={ 10 }
-										initialPosition={ 2 }
-										label={ __( 'Initial list size', 'newspack-plugin' ) }
-										help={ __(
-											'Number of newsletters initially visible during signup. Additional newsletters will be hidden behind a "See all" button.',
-											'newspack-plugin'
-										) }
-										value={ config.newsletter_list_initial_size || '' }
-										onChange={ value => updateConfig( 'newsletter_list_initial_size', parseInt( value ) ) }
-									/>
-								</Grid>
-							) }
-						</ActionCard>
+						{ hasNewsletters && (
+							<ActionCard
+								title={ __( 'Present newsletter signup after checkout and registration', 'newspack-plugin' ) }
+								description={ __(
+									'Ask readers to sign up for newsletters after creating an account or completing a purchase.',
+									'newspack-plugin'
+								) }
+								hasGreyHeader={ config.use_custom_lists }
+								isMedium
+								toggleChecked={ config.use_custom_lists }
+								toggleOnChange={ value => updateConfig( 'use_custom_lists', value ) }
+							>
+								{ config.use_custom_lists && (
+									<Grid columns={ 4 }>
+										<SortableNewsletterListControl
+											lists={ newspackAudience.available_newsletter_lists }
+											selected={ config.newsletter_lists }
+											onChange={ selected => updateConfig( 'newsletter_lists', selected ) }
+										/>
+										<RangeControl
+											min={ 1 }
+											max={ 10 }
+											initialPosition={ 2 }
+											label={ __( 'Initial list size', 'newspack-plugin' ) }
+											help={ __(
+												'Number of newsletters initially visible during signup. Additional newsletters will be hidden behind a "See all" button.',
+												'newspack-plugin'
+											) }
+											value={ config.newsletter_list_initial_size || '' }
+											onChange={ value => updateConfig( 'newsletter_list_initial_size', parseInt( value ) ) }
+										/>
+									</Grid>
+								) }
+							</ActionCard>
+						) }
 
 						<ActionCard
 							title={ __( 'Use My Account login screen for OAuth clients', 'newspack-plugin' ) }
@@ -179,93 +183,97 @@ export default withWizardScreen(
 							toggleOnChange={ value => updateConfig( 'oauth_redirect_to_ras', value ) }
 						/>
 
-						<Divider alignment="full-width" variant="tertiary" />
+						{ hasNewsletters && (
+							<>
+								<Divider alignment="full-width" variant="tertiary" />
 
-						<SectionHeader
-							title={ __( 'Email Service Provider (ESP) Advanced Settings', 'newspack-plugin' ) }
-							description={ __( 'Settings for Newspack Newsletters integration.', 'newspack-plugin' ) }
-						/>
-						<TextControl
-							label={ __( 'Newsletter subscription text on registration', 'newspack-plugin' ) }
-							help={ __( 'The text to display while subscribing to newsletters from the sign-in modal.', 'newspack-plugin' ) }
-							{ ...getSharedProps( 'newsletters_label', 'text' ) }
-						/>
-						<ActionCard
-							description={ __( 'Configure options for syncing reader data to the connected ESP.', 'newspack-plugin' ) }
-							hasGreyHeader={ config.sync_esp }
-							isMedium
-							title={ __( 'Sync contacts to ESP', 'newspack-plugin' ) }
-							toggleChecked={ config.sync_esp }
-							toggleOnChange={ value => updateConfig( 'sync_esp', value ) }
-						>
-							{ config.sync_esp && (
-								<>
-									{ 0 < Object.keys( espSyncErrors ).length && (
-										<Notice noticeText={ Object.values( espSyncErrors ).join( ' ' ) } isError />
-									) }
-									{ esp === 'mailchimp' && (
-										<Settings
-											title={ 'Mailchimp' }
-											value={ {
-												audienceId: config.mailchimp_audience_id,
-												readerDefaultStatus: config.mailchimp_reader_default_status,
-											} }
-											onChange={ ( key, value ) => {
-												if ( key === 'audienceId' ) {
-													updateConfig( 'mailchimp_audience_id', value );
-												}
-												if ( key === 'readerDefaultStatus' ) {
-													updateConfig( 'mailchimp_reader_default_status', value );
-												}
-											} }
-										/>
-									) }
-									{ esp === 'active_campaign' && (
-										<Settings
-											title={ 'ActiveCampaign' }
-											value={ {
-												masterList: config.active_campaign_master_list,
-											} }
-											onChange={ ( key, value ) => {
-												if ( key === 'masterList' ) {
-													updateConfig( 'active_campaign_master_list', value );
-												}
-											} }
-										/>
-									) }
-									{ esp === 'constant_contact' && (
-										<Settings
-											title={ 'Constant Contact' }
-											value={ { masterList: config.constant_contact_list_id } }
-											onChange={ ( key, value ) => {
-												if ( key === 'masterList' ) {
-													updateConfig( 'constant_contact_list_id', value );
-												}
-											} }
-										/>
-									) }
+								<SectionHeader
+									title={ __( 'Email Service Provider (ESP) Advanced Settings', 'newspack-plugin' ) }
+									description={ __( 'Settings for Newspack Newsletters integration.', 'newspack-plugin' ) }
+								/>
+								<TextControl
+									label={ __( 'Newsletter subscription text on registration', 'newspack-plugin' ) }
+									help={ __( 'The text to display while subscribing to newsletters from the sign-in modal.', 'newspack-plugin' ) }
+									{ ...getSharedProps( 'newsletters_label', 'text' ) }
+								/>
+								<ActionCard
+									description={ __( 'Configure options for syncing reader data to the connected ESP.', 'newspack-plugin' ) }
+									hasGreyHeader={ config.sync_esp }
+									isMedium
+									title={ __( 'Sync contacts to ESP', 'newspack-plugin' ) }
+									toggleChecked={ config.sync_esp }
+									toggleOnChange={ value => updateConfig( 'sync_esp', value ) }
+								>
+									{ config.sync_esp && (
+										<>
+											{ 0 < Object.keys( espSyncErrors ).length && (
+												<Notice noticeText={ Object.values( espSyncErrors ).join( ' ' ) } isError />
+											) }
+											{ esp === 'mailchimp' && (
+												<Settings
+													title={ 'Mailchimp' }
+													value={ {
+														audienceId: config.mailchimp_audience_id,
+														readerDefaultStatus: config.mailchimp_reader_default_status,
+													} }
+													onChange={ ( key, value ) => {
+														if ( key === 'audienceId' ) {
+															updateConfig( 'mailchimp_audience_id', value );
+														}
+														if ( key === 'readerDefaultStatus' ) {
+															updateConfig( 'mailchimp_reader_default_status', value );
+														}
+													} }
+												/>
+											) }
+											{ esp === 'active_campaign' && (
+												<Settings
+													title={ 'ActiveCampaign' }
+													value={ {
+														masterList: config.active_campaign_master_list,
+													} }
+													onChange={ ( key, value ) => {
+														if ( key === 'masterList' ) {
+															updateConfig( 'active_campaign_master_list', value );
+														}
+													} }
+												/>
+											) }
+											{ esp === 'constant_contact' && (
+												<Settings
+													title={ 'Constant Contact' }
+													value={ { masterList: config.constant_contact_list_id } }
+													onChange={ ( key, value ) => {
+														if ( key === 'masterList' ) {
+															updateConfig( 'constant_contact_list_id', value );
+														}
+													} }
+												/>
+											) }
 
-									<SectionHeader
-										title={ __( 'Sync user account deletion', 'newspack-plugin' ) }
-										description={ __(
-											'If enabled, the contact will be deleted from the ESP when a user account is deleted. If disabled, the contact will be unsubscribed from all lists, but not deleted.',
-											'newspack-plugin'
-										) }
-									/>
-									<CheckboxControl
-										label={ __( 'Sync user account deletion', 'newspack-plugin' ) }
-										checked={ config.sync_esp_delete }
-										onChange={ value => updateConfig( 'sync_esp_delete', value ) }
-									/>
-									<MetadataFields
-										availableFields={ newspackAudience.esp_metadata_fields || [] }
-										selectedFields={ config.metadata_fields }
-										updateConfig={ updateConfig }
-										getSharedProps={ getSharedProps }
-									/>
-								</>
-							) }
-						</ActionCard>
+											<SectionHeader
+												title={ __( 'Sync user account deletion', 'newspack-plugin' ) }
+												description={ __(
+													'If enabled, the contact will be deleted from the ESP when a user account is deleted. If disabled, the contact will be unsubscribed from all lists, but not deleted.',
+													'newspack-plugin'
+												) }
+											/>
+											<CheckboxControl
+												label={ __( 'Sync user account deletion', 'newspack-plugin' ) }
+												checked={ config.sync_esp_delete }
+												onChange={ value => updateConfig( 'sync_esp_delete', value ) }
+											/>
+											<MetadataFields
+												availableFields={ newspackAudience.esp_metadata_fields || [] }
+												selectedFields={ config.metadata_fields }
+												updateConfig={ updateConfig }
+												getSharedProps={ getSharedProps }
+											/>
+										</>
+									) }
+								</ActionCard>
+							</>
+						) }
 						<div className="newspack-buttons-card">
 							<Button
 								isPrimary

--- a/src/wizards/audience/views/setup/setup.js
+++ b/src/wizards/audience/views/setup/setup.js
@@ -112,18 +112,6 @@ export default withWizardScreen(
 				}
 			>
 				{ error && <Notice noticeText={ error?.message || __( 'Something went wrong.', 'newspack-plugin' ) } isError /> }
-				<ActionCard
-					isMedium
-					title={ __( 'Enable Audience Management', 'newspack-plugin' ) }
-					description={
-						config.enabled
-							? __( 'Audience Management is enabled.', 'newspack-plugin' )
-							: __( 'Audience Management is disabled.', 'newspack-plugin' )
-					}
-					toggleChecked={ Boolean( config.enabled ) }
-					toggleOnChange={ value => saveConfig( { enabled: value } ) }
-					disabled={ inFlight }
-				/>
 				{ onChangePlatform && (
 					<ActionCard
 						isMedium

--- a/src/wizards/audience/views/setup/setup.js
+++ b/src/wizards/audience/views/setup/setup.js
@@ -39,6 +39,7 @@ export default withWizardScreen(
 		getSharedProps,
 		saveConfig,
 		prerequisites,
+		requiredPlugins,
 		espSyncErrors,
 		error,
 		inFlight,
@@ -69,21 +70,29 @@ export default withWizardScreen(
 			setAllReady( _allReady );
 
 			if ( prerequisites ) {
-				setMissingPlugins(
-					Object.keys( prerequisites ).reduce( ( acc, slug ) => {
-						const prerequisite = prerequisites[ slug ];
-						if ( prerequisite.plugins ) {
-							for ( const pluginSlug in prerequisite.plugins ) {
-								if ( ! prerequisite.plugins[ pluginSlug ] ) {
-									acc.push( pluginSlug );
-								}
+				const missing = Object.keys( prerequisites ).reduce( ( acc, slug ) => {
+					const prerequisite = prerequisites[ slug ];
+					if ( prerequisite.plugins ) {
+						for ( const pluginSlug in prerequisite.plugins ) {
+							if ( ! prerequisite.plugins[ pluginSlug ] ) {
+								acc.push( pluginSlug );
 							}
 						}
-						return acc;
-					}, [] )
-				);
+					}
+					return acc;
+				}, [] );
+
+				// Surface the selected platform's required plugins that aren't installed yet,
+				// so missing ones are presented here even if the chooser's install didn't finish.
+				for ( const pluginSlug in requiredPlugins ) {
+					if ( ! requiredPlugins[ pluginSlug ] && ! missing.includes( pluginSlug ) ) {
+						missing.push( pluginSlug );
+					}
+				}
+
+				setMissingPlugins( missing );
 			}
-		}, [ prerequisites ] );
+		}, [ prerequisites, requiredPlugins ] );
 
 		const hasNewsletters = Boolean( prerequisites?.esp?.plugins?.[ 'newspack-newsletters' ] );
 

--- a/src/wizards/types/hooks.d.ts
+++ b/src/wizards/types/hooks.d.ts
@@ -96,6 +96,7 @@ type AudienceDonationsWizardData = {
 	};
 	platform_data: {
 		platform: string;
+		platform_selected: boolean;
 	};
 	donation_page: {
 		editUrl: string;

--- a/tests/unit-tests/donations.php
+++ b/tests/unit-tests/donations.php
@@ -31,6 +31,25 @@ class Newspack_Test_Donations extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Saving the WC platform while WooCommerce is not active must not fatal by
+	 * attempting to write WooCommerce donation products. Regression: the platform
+	 * chooser saves the 'wc' platform before WooCommerce is installed.
+	 */
+	public function test_update_payment_settings_wc_without_woocommerce() {
+		$wizard  = new \Newspack\Audience_Wizard();
+		$request = new \WP_REST_Request( 'POST', '/newspack/v1/wizard/newspack-audience/payment' );
+		$request->set_param( 'platform', 'wc' );
+
+		$response = $wizard->api_update_payment_settings( $request );
+
+		self::assertInstanceOf(
+			'WP_REST_Response',
+			$response,
+			'Saving the WC platform without WooCommerce active should return a response, not fatal.'
+		);
+	}
+
+	/**
 	 * Test that is_donation_product returns false for unflagged products.
 	 *
 	 * @group donations

--- a/tests/unit-tests/reader-activation.php
+++ b/tests/unit-tests/reader-activation.php
@@ -171,4 +171,27 @@ class Newspack_Test_Reader_Activation extends WP_UnitTestCase {
 			'Custom OAuth route should be detected after adding via filter.'
 		);
 	}
+
+	/**
+	 * Test that the prerequisites status no longer exposes skip-related keys.
+	 */
+	public function test_prerequisites_status_has_no_skip_keys() {
+		$prerequisites = Reader_Activation::get_prerequisites_status();
+		$this->assertNotEmpty( $prerequisites );
+		foreach ( $prerequisites as $slug => $prerequisite ) {
+			$this->assertArrayNotHasKey( 'skippable', $prerequisite, "Prerequisite '$slug' should not expose 'skippable'." );
+			$this->assertArrayNotHasKey( 'is_skipped', $prerequisite, "Prerequisite '$slug' should not expose 'is_skipped'." );
+			$this->assertArrayNotHasKey( 'action_enabled', $prerequisite, "Prerequisite '$slug' should not expose 'action_enabled'." );
+			$this->assertArrayNotHasKey( 'disabled_text', $prerequisite, "Prerequisite '$slug' should not expose 'disabled_text'." );
+		}
+	}
+
+	/**
+	 * Test that the auto-enable and skip helpers have been removed.
+	 */
+	public function test_auto_enable_and_skip_helpers_removed() {
+		$this->assertFalse( method_exists( Reader_Activation::class, 'is_ras_ready_to_configure' ), 'is_ras_ready_to_configure() should be removed.' );
+		$this->assertFalse( method_exists( Reader_Activation::class, 'skip' ), 'skip() should be removed.' );
+		$this->assertFalse( method_exists( Reader_Activation::class, 'is_skipped' ), 'is_skipped() should be removed.' );
+	}
 }

--- a/tests/unit-tests/reader-activation.php
+++ b/tests/unit-tests/reader-activation.php
@@ -194,4 +194,23 @@ class Newspack_Test_Reader_Activation extends WP_UnitTestCase {
 		$this->assertFalse( method_exists( Reader_Activation::class, 'skip' ), 'skip() should be removed.' );
 		$this->assertFalse( method_exists( Reader_Activation::class, 'is_skipped' ), 'is_skipped() should be removed.' );
 	}
+
+	/**
+	 * Test the reader-revenue platform first-run signal.
+	 */
+	public function test_is_platform_selected() {
+		delete_option( 'newspack_reader_revenue_platform' );
+		$this->assertFalse(
+			\Newspack\Donations::is_platform_selected(),
+			'Platform should report not selected when the option was never saved.'
+		);
+
+		\Newspack\Donations::set_platform_slug( 'wc' );
+		$this->assertTrue(
+			\Newspack\Donations::is_platform_selected(),
+			'Platform should report selected after an explicit save.'
+		);
+
+		delete_option( 'newspack_reader_revenue_platform' );
+	}
 }

--- a/tests/unit-tests/reader-activation.php
+++ b/tests/unit-tests/reader-activation.php
@@ -196,6 +196,30 @@ class Newspack_Test_Reader_Activation extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that removed prerequisites are gone and ordering is correct.
+	 */
+	public function test_prerequisites_status_cleanup() {
+		$prerequisites = Reader_Activation::get_prerequisites_status();
+
+		$this->assertArrayNotHasKey( 'reader_revenue', $prerequisites, 'Reader Revenue prerequisite should be removed.' );
+		$this->assertArrayNotHasKey( 'ras_campaign', $prerequisites, 'Campaign defaults prerequisite should be removed.' );
+
+		// First three are always present and ordered.
+		$keys = array_keys( $prerequisites );
+		$this->assertSame( 'emails', $keys[0], 'Transactional Emails should be first.' );
+		$this->assertSame( 'terms_conditions', $keys[1], 'Legal Pages should be second.' );
+		$this->assertSame( 'recaptcha', $keys[2], 'reCAPTCHA should be third.' );
+
+		// ESP is gated on Newspack Newsletters; in the test env it is absent.
+		if ( class_exists( '\Newspack_Newsletters' ) ) {
+			$this->assertArrayHasKey( 'esp', $prerequisites, 'ESP should be present when Newsletters exists.' );
+			$this->assertSame( 'esp', $keys[3], 'ESP should be fourth when present.' );
+		} else {
+			$this->assertArrayNotHasKey( 'esp', $prerequisites, 'ESP should be absent without Newsletters.' );
+		}
+	}
+
+	/**
 	 * Test the reader-revenue platform first-run signal.
 	 */
 	public function test_is_platform_selected() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Closes NPPD-1066.

Reworks Audience Management (RAS) setup so it can be enabled with far fewer prerequisites, and reorganizes the wizard around an explicit reader‑revenue **platform selection**. RAS no longer auto‑enables based on a fully‑configured plugin stack; an administrator picks a platform and Audience Management is enabled as part of that choice, regardless of which optional plugins are installed.

**Platform selection (first‑run step)**

- The Audience wizard opens a three‑option platform chooser — **Newspack** (full WooCommerce stack), **RevEngine** (News Revenue Hub / donate block), and **Other** (bring‑your‑own integrations) — rendered in the standard wizard header/layout. It appears whenever no platform has been chosen yet.
- Selecting a platform persists the reader‑revenue platform, enables Audience Management, and auto‑installs that platform's plugins (Newspack → WooCommerce, WooCommerce Subscriptions, Newspack Blocks; RevEngine → Newspack Blocks; Other → none), then advances to the configuration page.
- Plugin installation is **non‑blocking**: if a plugin can't be auto‑installed (e.g. WooCommerce Subscriptions, which Newspack cannot install automatically), the installer surfaces the per‑plugin message and a **Continue** button instead of waiting indefinitely.
- The currently‑selected platform is marked with a **"Selected"** badge.

**Enable / disable**

- The enable/disable toggle now lives on the platform screen (not the configuration page, where it was easy to flip accidentally). First‑run enabling is implicit in selecting a platform; the toggle is shown when returning to the screen.
- **Disabling prompts a confirmation modal** (destructive action). Enabling is immediate.
- A site with Audience Management **disabled** lands on the platform screen (rather than the active‑looking configuration page), showing the current platform's "Selected" badge and the toggle.

**Tabs**

- The **Checkout & Payment** tab is shown only for the Newspack and RevEngine platforms; for "Other" it is hidden. The inline platform selector was removed from that tab (it is now the first‑run chooser).

**Configuration page cleanup**

- The prerequisites checklist is trimmed and reordered to: Transactional Emails → Legal Pages → reCAPTCHA → ESP. The **Reader Revenue** and **Audience Management Campaign** prerequisites were removed, and **ESP** appears only when Newspack Newsletters is installed.
- Any of the selected platform's required/recommended plugins that are still missing are surfaced on the configuration page (with install actions), so they can be completed there even if the chooser's install didn't finish.

**Plugin independence**

- Prerequisites are an informational checklist; the "Skip" buttons and the "waiting for all settings" disabled‑action state are gone. The skip subsystem is removed: `Reader_Activation::skip()` / `is_skipped()` / `is_ras_ready_to_configure()`, the `/audience-management/skip` REST route, the `SKIP_CAMPAIGN_SETUP_OPTION` constant, and the `is_skipped_campaign_setup` localized field.
- The now‑unused `Reader_Activation::is_reader_revenue_ready()` helper (only consumed by the removed Reader Revenue prerequisite) and other dead code (an unused `donation_settings` read in `Donations::remove_donations_from_cart()`, the never‑set `is_unavailable` prerequisite branch) are removed.
- Newsletters‑dependent controls (post‑checkout newsletter signup, ESP Advanced Settings) gate on Newspack Newsletters being installed.
- `Reader_Activation::setup_nav_menu()` no longer requires WooCommerce for the anonymous Sign In link.
- The Audience → Donations submenu hides when neither WooCommerce is installed nor NRH is the donations platform.

**Fixes**

- Saving the Newspack (`wc`) platform before WooCommerce is installed no longer fatals: the WooCommerce donation‑product write is skipped when WooCommerce isn't active (`Donations::get_donation_settings()` returns a `WP_Error`).
- The `wp newspack ras setup` CLI command now explicitly enables Audience Management (it previously relied on the removed auto‑enable path, so it published prompts but left RAS disabled).
- `Audience_Donations::fetch_all_data()` no longer serializes a `WP_Error` into `donation_data` when the WooCommerce suite is incomplete (returns an empty array instead; missing plugins are still surfaced via `plugin_status`), and `api_update_payment_settings` guards against a missing `platform` param.

**Migration**

- No upgrade migration: already‑enabled sites keep `enabled = true`. The legacy `newspack_reader_activation_*_skipped` options are left in the database, intentionally unread.

### How to test the changes in this Pull Request:

1. **First run:** On a site with no reader‑revenue platform chosen, open Audience. Confirm a platform chooser (Newspack / RevEngine / Other) renders in the wizard layout instead of the configuration page.
2. Select **Other**. Confirm Audience Management is enabled, no plugins are installed, the **Checkout & Payment** tab is absent, and you land on the configuration page.
3. Select **Newspack** (on a site without WooCommerce). Confirm it installs WooCommerce and Newspack Blocks, that WooCommerce Subscriptions reports it must be installed manually, and that a **Continue** button appears (no hang). Continue and confirm the **Checkout & Payment** tab is present.
4. **Missing plugins:** On the configuration page with the Newspack platform selected but WooCommerce/Subscriptions not installed, confirm they are listed as recommended/missing with install actions.
5. **Prerequisites:** Confirm the checklist shows Transactional Emails → Legal Pages → reCAPTCHA, with ESP appearing only when Newspack Newsletters is installed, and no Reader Revenue or Campaign‑defaults items.
6. **Disable + confirm:** From the configuration page, click **Change** to open the platform screen; toggle Audience Management **off** and confirm a confirmation modal appears before it is disabled.
7. **Disabled landing:** With Audience Management disabled, reload the wizard. Confirm it lands on the platform screen (not the configuration page), the previously‑selected platform shows a **"Selected"** badge, and the toggle reads "disabled".
8. **Re‑enable:** Toggle Audience Management on (or re‑select the platform) and confirm you move forward to the configuration page.
9. **Front‑end / menus:** With WooCommerce not installed and RAS enabled, confirm the Sign In link renders for anonymous visitors; confirm the Audience → Donations submenu is hidden until WooCommerce is installed or NRH is the platform.
10. **Regression:** On a site already enabled with all plugins present, confirm no regression in the wizard, reader auth, or RAS‑dependent features.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

