### PR TITLE
fix(advertising): stabilize placement button width, add a11y labels

### DIFF
--- a/src/wizards/advertising/style.scss
+++ b/src/wizards/advertising/style.scss
@@ -6,6 +6,22 @@
 	z-index: 99999;
 }
 
+// Stack both Edit/Cancel labels so the button reserves the width of the
+// wider label and does not shift when the label toggles.
+.newspack-wizard-ads-placements__toggle-label {
+	display: inline-grid;
+	justify-items: center;
+
+	span {
+		grid-area: 1 / 1;
+		visibility: hidden;
+
+		&.is-visible {
+			visibility: visible;
+		}
+	}
+}
+
 .newspack-ads-display-ads {
 	.newspack-button-card .newspack-notice {
 		margin: 24px 0 0;

--- a/src/wizards/advertising/views/placements/index.js
+++ b/src/wizards/advertising/views/placements/index.js
@@ -189,6 +189,13 @@ const Placements = () => {
 							hasAdUnit = Object.keys( placement.hooks ).every( hookKey => !! placement.data?.hooks?.[ hookKey ]?.ad_unit );
 						}
 
+						/* translators: %s: placement name (e.g. "Sticky Footer"). */
+						const editButtonLabel = sprintf( __( 'Edit %s', 'newspack-plugin' ), placement.name );
+						/* translators: %s: placement name (e.g. "Sticky Footer"). */
+						const cancelButtonLabel = sprintf( __( 'Cancel editing %s', 'newspack-plugin' ), placement.name );
+						/* translators: %s: placement name (e.g. "Sticky Footer"). */
+						const enableButtonLabel = sprintf( __( 'Enable %s', 'newspack-plugin' ), placement.name );
+
 						return (
 							<CardForm
 								key={ key }
@@ -204,6 +211,7 @@ const Placements = () => {
 										<Button
 											variant="tertiary"
 											size="compact"
+											aria-label={ isEditing ? cancelButtonLabel : editButtonLabel }
 											disabled={ inFlight || ( !! editingPlacement && ! isEditing ) }
 											onClick={ () => {
 												if ( isEditing ) {
@@ -214,12 +222,20 @@ const Placements = () => {
 												}
 											} }
 										>
-											{ isEditing ? __( 'Cancel', 'newspack-plugin' ) : __( 'Edit', 'newspack-plugin' ) }
+											<span style={ { display: 'inline-grid', justifyItems: 'center' } }>
+												<span style={ { gridArea: '1 / 1', visibility: isEditing ? 'visible' : 'hidden' } }>
+													{ __( 'Cancel', 'newspack-plugin' ) }
+												</span>
+												<span style={ { gridArea: '1 / 1', visibility: isEditing ? 'hidden' : 'visible' } }>
+													{ __( 'Edit', 'newspack-plugin' ) }
+												</span>
+											</span>
 										</Button>
 									) : (
 										<Button
 											variant="secondary"
 											size="compact"
+											aria-label={ enableButtonLabel }
 											isBusy={ inFlight }
 											disabled={ inFlight || ! providers.length || !! editingPlacement }
 											onClick={ () => handlePlacementToggle( key )( true ) }

--- a/src/wizards/advertising/views/placements/index.js
+++ b/src/wizards/advertising/views/placements/index.js
@@ -211,6 +211,7 @@ const Placements = () => {
 										<Button
 											variant="tertiary"
 											size="compact"
+											// Load-bearing: the grid stack keeps both labels in the DOM (only `visibility: hidden`), so this aria-label is the button's only clean accessible name.
 											aria-label={ isEditing ? cancelButtonLabel : editButtonLabel }
 											disabled={ inFlight || ( !! editingPlacement && ! isEditing ) }
 											onClick={ () => {
@@ -222,11 +223,11 @@ const Placements = () => {
 												}
 											} }
 										>
-											<span style={ { display: 'inline-grid', justifyItems: 'center' } }>
-												<span style={ { gridArea: '1 / 1', visibility: isEditing ? 'visible' : 'hidden' } }>
+											<span className="newspack-wizard-ads-placements__toggle-label">
+												<span className={ classnames( { 'is-visible': isEditing } ) }>
 													{ __( 'Cancel', 'newspack-plugin' ) }
 												</span>
-												<span style={ { gridArea: '1 / 1', visibility: isEditing ? 'hidden' : 'visible' } }>
+												<span className={ classnames( { 'is-visible': ! isEditing } ) }>
 													{ __( 'Edit', 'newspack-plugin' ) }
 												</span>
 											</span>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Two small UX/accessibility refinements to the Ads placement cards (Advertising › Display Ads › Placements):

- **No more width jump on the Edit/Cancel toggle.** Previously the button visibly resized when its label switched from "Edit" to "Cancel", causing a layout shift in the card header. The button now reserves the width of the longer label via a CSS grid stack — both labels live in the DOM, and only the inactive one is `visibility: hidden`. Width is derived from the actual rendered text (no magic pixel value), so the fix holds across translations.
- **Screen reader context for placement actions.** "Edit", "Cancel", and "Enable" buttons repeat once per placement card, with no audible difference between them. Each button now gets an `aria-label` that includes the placement name — e.g. "Edit Sticky Footer", "Cancel editing Sticky Footer", "Enable Sticky Footer". The visible compact text is unchanged.

### How to test the changes in this Pull Request:

1. Go to **Advertising › Display Ads › Placements** (`/wp-admin/admin.php?page=newspack-ads-display-ads#/placements`).
2. On any enabled placement (e.g. Global Above Header), click **Edit**. Verify the button text swaps to **Cancel** without the button width changing or surrounding header elements shifting.
3. Click **Cancel**. Same check in reverse — no width jump.
4. Open the same page with a screen reader (VoiceOver, NVDA, etc.) and tab through the action buttons. Confirm each button is announced with its placement name appended, e.g. "Edit Global Above Header, button" and "Enable Sticky Footer, button".
5. For an enabled placement, expand it and confirm the announced label switches to "Cancel editing &lt;placement name&gt;".
6. Confirm no regression on the disabled placement state — **Enable** button still toggles the placement on as before.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?