### PR TITLE
Card expiry warning email (NPPD-1524)

### DIFF
--- a/includes/plugins/woocommerce-subscriptions/class-card-expiry-warning.php
+++ b/includes/plugins/woocommerce-subscriptions/class-card-expiry-warning.php
@@ -44,12 +44,7 @@ class Card_Expiry_Warning {
 		add_filter( 'newspack_email_configs', [ __CLASS__, 'add_email_config' ] );
 		add_action( 'init', [ __CLASS__, 'schedule_cron' ] );
 		add_action( self::CRON_HOOK, [ __CLASS__, 'scan_expiring_cards' ] );
-		add_action(
-			'woocommerce_subscription_payment_method_updated',
-			[ __CLASS__, 'clear_sent_flag' ],
-			10,
-			2
-		);
+		add_action( 'woocommerce_subscription_payment_method_updated', [ __CLASS__, 'clear_sent_flag' ] );
 		add_action( 'newspack_deactivation', [ __CLASS__, 'unschedule_cron' ] );
 	}
 
@@ -256,10 +251,15 @@ class Card_Expiry_Warning {
 			? date_i18n( get_option( 'date_format', 'F j, Y' ), $subscription->get_time( 'next_payment' ) )
 			: __( 'your next renewal', 'newspack-plugin' );
 
+		$first_name = $subscription->get_billing_first_name();
+		if ( '' === $first_name ) {
+			$first_name = $customer->first_name;
+		}
+
 		$placeholders = [
 			[
 				'template' => '*BILLING_FIRST_NAME*',
-				'value'    => esc_html( $subscription->get_billing_first_name() ),
+				'value'    => esc_html( $first_name ),
 			],
 			[
 				'template' => '*CARD_LAST_4*',
@@ -296,10 +296,9 @@ class Card_Expiry_Warning {
 	 *
 	 * Hooked to 'woocommerce_subscription_payment_method_updated'.
 	 *
-	 * @param \WC_Subscription $subscription     The subscription.
-	 * @param string           $new_payment_method The new payment method ID.
+	 * @param \WC_Subscription $subscription The subscription.
 	 */
-	public static function clear_sent_flag( $subscription, $new_payment_method ) {
+	public static function clear_sent_flag( $subscription ) {
 		$subscription->delete_meta_data( self::SENT_META );
 		$subscription->save();
 	}

--- a/includes/plugins/woocommerce-subscriptions/class-card-expiry-warning.php
+++ b/includes/plugins/woocommerce-subscriptions/class-card-expiry-warning.php
@@ -1,0 +1,306 @@
+<?php
+/**
+ * Card Expiry Warning Email.
+ *
+ * Sends a warning email when a reader's saved credit card is about to expire
+ * on an active WooCommerce Subscription. Runs a daily cron scan to find
+ * expiring CC tokens and notifies the subscription owner.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Card Expiry Warning class.
+ */
+class Card_Expiry_Warning {
+
+	/**
+	 * Email type identifier used in the Newspack email config system.
+	 */
+	const EMAIL_TYPE = 'card-expiry-warning';
+
+	/**
+	 * Cron hook name for the daily expiry scan.
+	 */
+	const CRON_HOOK = 'newspack_card_expiry_warning_scan';
+
+	/**
+	 * Subscription meta key for idempotency tracking.
+	 */
+	const SENT_META = '_newspack_card_expiry_warning_sent';
+
+	/**
+	 * Initialize hooks and filters.
+	 */
+	public static function init() {
+		if ( ! WooCommerce_Subscriptions::is_enabled() ) {
+			return;
+		}
+
+		add_filter( 'newspack_email_configs', [ __CLASS__, 'add_email_config' ] );
+		add_action( 'init', [ __CLASS__, 'schedule_cron' ] );
+		add_action( self::CRON_HOOK, [ __CLASS__, 'scan_expiring_cards' ] );
+		add_action(
+			'woocommerce_subscription_payment_method_updated',
+			[ __CLASS__, 'clear_sent_flag' ],
+			10,
+			2
+		);
+		add_action( 'newspack_deactivation', [ __CLASS__, 'unschedule_cron' ] );
+	}
+
+	/**
+	 * Unschedule the cron event on plugin deactivation.
+	 */
+	public static function unschedule_cron() {
+		wp_clear_scheduled_hook( self::CRON_HOOK );
+	}
+
+	/**
+	 * Get the number of days before expiry to send the warning.
+	 *
+	 * @return int Days before card expiry.
+	 */
+	public static function get_days_before_expiry(): int {
+		/**
+		 * Filters the number of days before card expiry to send the warning email.
+		 *
+		 * @param int $days Default 14.
+		 */
+		return max( 1, (int) apply_filters( 'newspack_card_expiry_warning_days', 14 ) );
+	}
+
+	/**
+	 * Register the email configuration.
+	 *
+	 * @param array $configs Existing email configs.
+	 * @return array Modified email configs.
+	 */
+	public static function add_email_config( $configs ) {
+		$configs[ self::EMAIL_TYPE ] = [
+			'name'                   => self::EMAIL_TYPE,
+			'category'               => 'reader-revenue',
+			'label'                  => __( 'Card expiry warning', 'newspack-plugin' ),
+			'description'            => __( "Email sent when a reader's saved payment method is about to expire.", 'newspack-plugin' ),
+			'template'               => dirname( NEWSPACK_PLUGIN_FILE ) . '/includes/templates/reader-revenue-emails/card-expiry-warning.php',
+			'editor_notice'          => __( 'This email will be sent to readers when their saved credit card is about to expire on an active subscription.', 'newspack-plugin' ),
+			'from_email'             => Reader_Revenue_Emails::get_from_email(),
+			'available_placeholders' => [
+				[
+					'label'    => __( 'the customer billing first name', 'newspack-plugin' ),
+					'template' => '*BILLING_FIRST_NAME*',
+				],
+				[
+					'label'    => __( 'the last four digits of the expiring card', 'newspack-plugin' ),
+					'template' => '*CARD_LAST_4*',
+				],
+				[
+					'label'    => __( 'the card expiry date (MM/YYYY)', 'newspack-plugin' ),
+					'template' => '*EXPIRY_DATE*',
+				],
+				[
+					'label'    => __( 'the next renewal date', 'newspack-plugin' ),
+					'template' => '*RENEWAL_DATE*',
+				],
+				[
+					'label'    => __( 'link to update payment method', 'newspack-plugin' ),
+					'template' => '*UPDATE_PAYMENT_URL*',
+				],
+				[
+					'label'    => __(
+						'the contact email to your site (same as the "From" email address)',
+						'newspack-plugin'
+					),
+					'template' => '*CONTACT_EMAIL*',
+				],
+				[
+					'label'    => __( 'the site title', 'newspack-plugin' ),
+					'template' => '*SITE_TITLE*',
+				],
+				[
+					'label'    => __( 'the site url', 'newspack-plugin' ),
+					'template' => '*SITE_URL*',
+				],
+			],
+		];
+		return $configs;
+	}
+
+	/**
+	 * Schedule the daily cron event if not already scheduled.
+	 */
+	public static function schedule_cron() {
+		if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
+			wp_schedule_event( time(), 'daily', self::CRON_HOOK );
+		}
+	}
+
+	/**
+	 * Scan for expiring credit cards and send warning emails.
+	 *
+	 * Token-first approach: query CC tokens expiring within the warning window,
+	 * then find active subscriptions using each token via WCS_Payment_Tokens.
+	 */
+	public static function scan_expiring_cards() {
+		if ( ! Emails::can_send_email( self::EMAIL_TYPE ) ) {
+			return;
+		}
+		$days = self::get_days_before_expiry();
+
+		// 1. Find CC tokens expiring within the warning window.
+		$expiring_tokens = self::get_expiring_cc_tokens( $days );
+		if ( empty( $expiring_tokens ) ) {
+			return;
+		}
+
+		// 2. For each expiring token, find active subscriptions using it.
+		if ( ! class_exists( 'WCS_Payment_Tokens' ) ) {
+			return;
+		}
+		foreach ( $expiring_tokens as $token ) {
+			$subscription_ids = \WCS_Payment_Tokens::get_subscriptions_from_token( $token );
+			foreach ( $subscription_ids as $subscription_id ) {
+				$subscription = WooCommerce_Subscriptions::sanitize_subscription( $subscription_id );
+				if ( ! $subscription || 'active' !== $subscription->get_status() ) {
+					continue;
+				}
+				self::maybe_send_warning( $subscription, $token );
+			}
+		}
+	}
+
+	/**
+	 * Find CC tokens expiring within the given number of days.
+	 *
+	 * Direct DB query on woocommerce_payment_tokenmeta joined to
+	 * woocommerce_payment_tokens to filter at the DB level.
+	 *
+	 * @param int $days Number of days in the warning window.
+	 * @return \WC_Payment_Token_CC[] Array of expiring CC token objects.
+	 */
+	private static function get_expiring_cc_tokens( int $days ): array {
+		global $wpdb;
+
+		$today  = gmdate( 'Y-m-d' );
+		$cutoff = gmdate( 'Y-m-d', time() + $days * DAY_IN_SECONDS );
+
+		// A card with expiry MM/YYYY is valid through the last day of that month.
+		// Find tokens whose last-valid-day falls between today and $cutoff.
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$token_ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT t.token_id
+				FROM {$wpdb->prefix}woocommerce_payment_tokens t
+				INNER JOIN {$wpdb->prefix}woocommerce_payment_tokenmeta em
+					ON em.payment_token_id = t.token_id AND em.meta_key = 'expiry_month'
+				INNER JOIN {$wpdb->prefix}woocommerce_payment_tokenmeta ey
+					ON ey.payment_token_id = t.token_id AND ey.meta_key = 'expiry_year'
+				WHERE t.type = 'CC'
+					AND LAST_DAY(
+						STR_TO_DATE(
+							CONCAT(ey.meta_value, '-', em.meta_value, '-01'),
+							'%%Y-%%m-%%d'
+						)
+					) BETWEEN %s AND %s",
+				$today,
+				$cutoff
+			)
+		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+
+		if ( empty( $token_ids ) ) {
+			return [];
+		}
+
+		$tokens = [];
+		foreach ( $token_ids as $token_id ) {
+			$token = \WC_Payment_Tokens::get( (int) $token_id );
+			if ( $token instanceof \WC_Payment_Token_CC ) {
+				$tokens[] = $token;
+			}
+		}
+		return $tokens;
+	}
+
+	/**
+	 * Send the expiry warning for a subscription if not already sent.
+	 *
+	 * Uses per-subscription meta for idempotency: the meta value encodes
+	 * the token ID and expiry date, so it auto-invalidates when the
+	 * payment method changes or for a new expiry cycle.
+	 *
+	 * @param \WC_Subscription     $subscription The subscription.
+	 * @param \WC_Payment_Token_CC $token        The expiring CC token.
+	 */
+	private static function maybe_send_warning( $subscription, $token ) {
+		$expiry_key = $token->get_id() . ':'
+			. $token->get_expiry_month() . '/' . $token->get_expiry_year();
+
+		// Idempotency: skip if we already sent for this token+expiry combo.
+		if ( $subscription->get_meta( self::SENT_META, true ) === $expiry_key ) {
+			return;
+		}
+
+		$customer = $subscription->get_user();
+		if ( ! $customer ) {
+			return;
+		}
+
+		$update_url   = \wc_get_account_endpoint_url( 'payment-methods' );
+		$next_payment = $subscription->get_date( 'next_payment' );
+		$renewal_date = $next_payment
+			? date_i18n( get_option( 'date_format', 'F j, Y' ), $subscription->get_time( 'next_payment' ) )
+			: __( 'your next renewal', 'newspack-plugin' );
+
+		$placeholders = [
+			[
+				'template' => '*BILLING_FIRST_NAME*',
+				'value'    => esc_html( $subscription->get_billing_first_name() ),
+			],
+			[
+				'template' => '*CARD_LAST_4*',
+				'value'    => esc_html( $token->get_last4() ),
+			],
+			[
+				'template' => '*EXPIRY_DATE*',
+				'value'    => esc_html( $token->get_expiry_month() . '/' . $token->get_expiry_year() ),
+			],
+			[
+				'template' => '*RENEWAL_DATE*',
+				'value'    => esc_html( $renewal_date ),
+			],
+			[
+				'template' => '*UPDATE_PAYMENT_URL*',
+				'value'    => esc_url( $update_url ),
+			],
+		];
+
+		$sent = Emails::send_email(
+			self::EMAIL_TYPE,
+			$subscription->get_billing_email(),
+			$placeholders
+		);
+
+		if ( $sent ) {
+			$subscription->update_meta_data( self::SENT_META, $expiry_key );
+			$subscription->save();
+		}
+	}
+
+	/**
+	 * Clear the sent flag when the payment method is updated on a subscription.
+	 *
+	 * Hooked to 'woocommerce_subscription_payment_method_updated'.
+	 *
+	 * @param \WC_Subscription $subscription     The subscription.
+	 * @param string           $new_payment_method The new payment method ID.
+	 */
+	public static function clear_sent_flag( $subscription, $new_payment_method ) {
+		$subscription->delete_meta_data( self::SENT_META );
+		$subscription->save();
+	}
+}

--- a/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
+++ b/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
@@ -88,11 +88,13 @@ class WooCommerce_Subscriptions {
 		include_once __DIR__ . '/class-subscriptions-meta.php';
 		include_once __DIR__ . '/class-subscriptions-confirmation.php';
 		include_once __DIR__ . '/class-subscriptions-tiers.php';
+		include_once __DIR__ . '/class-card-expiry-warning.php';
 
 		On_Hold_Duration::init();
 		Renewal::init();
 		Subscriptions_Meta::init();
 		Subscriptions_Confirmation::init();
+		Card_Expiry_Warning::init();
 	}
 
 

--- a/includes/templates/reader-revenue-emails/card-expiry-warning.php
+++ b/includes/templates/reader-revenue-emails/card-expiry-warning.php
@@ -1,0 +1,308 @@
+<?php
+/**
+ * Card Expiry Warning Email Template.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+// phpcs:disable WordPressVIPMinimum.Security.Mustache.OutputNotation
+
+[
+	'primary_color'        => $primary_color,
+	'primary_text_color'   => $primary_text_color,
+] = newspack_get_theme_colors();
+
+[
+	'block_markup' => $social_links,
+	'html_markup'  => $social_links_html
+] = newspack_get_social_markup( $primary_text_color );
+
+$post_title = __( 'Update your payment method', 'newspack-plugin' );
+
+$post_content =
+	// Main body.
+	'<!-- wp:group {"style":{"spacing":{"padding":{"top":"56px","bottom":"56px","left":"56px","right":"56px"}},"elements":{"link":{"color":{"textColor":"primary","text":"var:preset|color|primary"}}}},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group has-link-color" style="padding-top:56px;padding-right:56px;padding-bottom:56px;padding-left:56px">
+
+	<!-- wp:site-logo {"width":125} /-->
+
+	<!-- wp:heading {"style":{"typography":{"fontSize":"46px","fontStyle":"normal","fontWeight":"500"}}} -->
+	<h2 class="wp-block-heading" style="font-size:46px;font-style:normal;font-weight:500">' . $post_title . '</h2>
+	<!-- /wp:heading -->
+
+	<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"400"}}} -->
+	<p style="font-style:normal;font-weight:400">' . sprintf(
+		/* translators: 1: billing first name. 2: last 4 digits of card. 3: expiry date. 4: site title. 5: renewal date. */
+		__( 'Hi %1$s, the card ending in %2$s (expires %3$s) is the payment method for your subscription to %4$s. Your next renewal is on %5$s.', 'newspack-plugin' ),
+		'*BILLING_FIRST_NAME*',
+		'*CARD_LAST_4*',
+		'*EXPIRY_DATE*',
+		'*SITE_TITLE*',
+		'*RENEWAL_DATE*'
+	) . '</p>
+	<!-- /wp:paragraph -->
+
+	<!-- wp:paragraph -->
+	<p>' . __( 'To avoid any interruption, please update your payment method before your card expires.', 'newspack-plugin' ) . '</p>
+	<!-- /wp:paragraph -->
+
+	<!-- wp:buttons {"layout":{"type":"flex","orientation":"horizontal","flexWrap":"nowrap","justifyContent":"left"},"style":{"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"medium"} -->
+	<div class="wp-block-buttons has-custom-font-size has-medium-font-size" style="font-style:normal;font-weight:400">
+	<!-- wp:button {"textAlign":"center","backgroundColor":"primary","style":{"border":{"radius":"4px"},"elements":{"link":{"color":{"text":"secondary"}}}}} -->
+	<div class="wp-block-button">
+	<a class="wp-block-button__link has-primary-background-color has-background has-link-color has-text-align-center wp-element-button" href="*UPDATE_PAYMENT_URL*" style="border-radius:4px">' . __( 'Update payment method', 'newspack-plugin' ) . '</a>
+	</div>
+	<!-- /wp:button -->
+	</div>
+	<!-- /wp:buttons -->
+
+	<!-- wp:paragraph {"fontSize":"small"} -->
+	<p class="has-small-font-size">' . __( "If you've already updated your payment method, you can disregard this email.", 'newspack-plugin' ) . '</p>
+	<!-- /wp:paragraph -->
+
+	<!-- wp:paragraph -->
+	<p>' . sprintf(
+		/* translators: %s: site admin email address. */
+		__( 'Questions? Contact us at %s.', 'newspack-plugin' ),
+		'*CONTACT_EMAIL*'
+	) . '</p>
+	<!-- /wp:paragraph -->
+
+	</div>
+	<!-- /wp:group -->' .
+
+	// Footer.
+	'<!-- wp:group {"style":{"spacing":{"padding":{"top":"56px","bottom":"56px","left":"56px","right":"56px"}},"elements":{"link":{"color":{"text":"primary-text"}}}},"backgroundColor":"primary","textColor":"primary-text","className":"has-secondary-color has-secondary-text-color ' . \Newspack\Emails::POST_TYPE . '-has-primary-text-color","layout":{"type":"constrained"}} -->
+	<div class="wp-block-group has-secondary-color has-secondary-text-color has-primary-text-color has-primary-background-color has-text-color has-background has-link-color ' . \Newspack\Emails::POST_TYPE . '-has-primary-text-color" style="padding-top:56px;padding-right:56px;padding-bottom:56px;padding-left:56px">' .
+
+	$social_links .
+
+	'<!-- wp:paragraph {"fontSize":"small"} -->
+	<p class="has-small-font-size">*SITE_CONTACT*<br>' . sprintf(
+		/* translators: %s: link to site url. */
+		__( 'You received this email because you have an active subscription to %s', 'newspack-plugin' ),
+		'<a href="*SITE_URL*">*SITE_URL*</a>'
+	) . '</p>
+	<!-- /wp:paragraph -->
+
+	</div>
+	<!-- /wp:group -->';
+
+$email_html = '
+	<!doctype html>
+	<html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+		<head>
+			<title>' . esc_html( $post_title ) . '</title>
+			<!--[if !mso]><!-->
+			<meta http-equiv="X-UA-Compatible" content="IE=edge">
+			<!--<![endif]-->
+			<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+			<meta name="viewport" content="width=device-width,initial-scale=1">
+			<style type="text/css">
+				#outlook a { padding:0; }
+				body { margin:0;padding:0;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%; }
+				table, td { border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt; }
+				img { border:0;height:auto;line-height:100%; outline:none;text-decoration:none;-ms-interpolation-mode:bicubic; }
+				p { display:block;margin:13px 0; }
+			</style>
+			<!--[if mso]>
+			<noscript>
+			<xml>
+			<o:OfficeDocumentSettings>
+			<o:AllowPNG/>
+			<o:PixelsPerInch>96</o:PixelsPerInch>
+			</o:OfficeDocumentSettings>
+			</xml>
+			</noscript>
+			<![endif]-->
+			<!--[if lte mso 11]>
+			<style type="text/css">
+			.mj-outlook-group-fix { width:100% !important; }
+			</style>
+			<![endif]-->
+			<style type="text/css">
+				@media only screen and (min-width:480px) {
+					.mj-column-per-100 { width:100% !important; max-width: 100%; }
+				}
+			</style>
+			<style media="screen and (min-width:480px)">
+				.moz-text-html .mj-column-per-100 { width:100% !important; max-width: 100%; }
+			</style>
+			<style type="text/css">
+				@media only screen and (max-width:479px) {
+					table.mj-full-width-mobile { width: 100% !important; }
+					td.mj-full-width-mobile { width: auto !important; }
+				}
+			</style>
+			<style type="text/css">
+				/* Paragraph */
+				p {
+					margin-top: 0 !important;
+					margin-bottom: 0 !important;
+				}
+
+				/* Link */
+				a {
+					color: ' . esc_attr( $primary_color ) . '!important;
+					text-decoration: underline;
+				}
+				a:active, a:focus, a:hover {
+					text-decoration: none;
+				}
+				a:focus {
+					outline: thin dotted #000;
+				}
+
+				/* Button */
+				.is-style-outline a {
+					background: #fff !important;
+					border: 2px solid !important;
+					display: block !important;
+				}
+
+				/* Heading */
+				h1, h2, h3, h4, h5, h6 {
+					margin-top: 0;
+					margin-bottom: 0;
+				}
+
+				h1 {
+					font-size: 2.44em;
+					line-height: 1.24;
+				}
+
+				h2 {
+					font-size: 1.95em;
+					line-height: 1.36;
+				}
+
+				h3 {
+					font-size: 1.56em;
+					line-height: 1.44;
+				}
+
+				h4 {
+					font-size: 1.25em;
+					line-height: 1.6;
+				}
+
+				h5 {
+					font-size: 1em;
+					line-height: 1.5em;
+				}
+
+				h6 {
+					font-size: 0.8em;
+					line-height: 1.56;
+				}
+
+				/* List */
+				ul, ol {
+					margin: 12px 0;
+					padding: 0;
+					list-style-position: inside;
+				}
+
+				/* Quote */
+				blockquote,
+				.wp-block-quote {
+					background: transparent;
+					border-left: 0.25em solid;
+					margin: 0;
+					padding-left: 24px;
+				}
+				blockquote cite,
+				.wp-block-quote cite {
+					color: #767676;
+				}
+				blockquote p,
+				.wp-block-quote p {
+					padding-bottom: 12px;
+				}
+				.wp-block-quote.is-style-plain,
+				.wp-block-quote.is-style-large {
+					border-left: 0;
+					padding-left: 0;
+				}
+				.wp-block-quote.is-style-large p {
+					font-size: 24px;
+					font-style: italic;
+					line-height: 1.6;
+				}
+
+				/* Image */
+				@media all and (max-width: 590px) {
+					img {
+						height: auto !important;
+					}
+				}
+
+				/* Social links */
+				.social-element img {
+					border-radius: 0 !important;
+				}
+
+				/* Has Background */
+				.mj-column-has-width .has-background,
+				.mj-column-per-50 .has-background {
+					padding: 12px;
+				}
+
+				/* Mailchimp Footer */
+				#canspamBarWrapper {
+					border: 0 !important;
+				}
+
+				.has-primary-color { color: ' . esc_attr( $primary_color ) . '; }
+			</style>
+		</head>
+		<body style="word-spacing:normal;background-color:#ffffff;">
+			<div style="background-color:#ffffff;" lang="und" dir="auto"><!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#ffffff !important"><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+				<div style="margin:0px auto;max-width:600px;">
+					<table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"><tbody><tr><td style="direction:ltr;font-size:0px;padding:56px 56px 56px 56px;text-align:center;"><!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:488px;" width="488" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+					<div style="margin:0px auto;max-width:488px;"><table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"><tbody><tr><td style="direction:ltr;font-size:0px;padding:0;text-align:center;"><!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:488px;" ><![endif]-->
+						<div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"><table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%"><tbody><tr><td style="vertical-align:top;padding:12px;"><table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%"><tbody><tr><td align="left" style="font-size:0px;padding:0;word-break:break-word;"><table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;"><tbody><tr><td style="width:125px;"><a href="*SITE_URL*" target="_blank"><img src="*SITE_LOGO*" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="125" height="auto"></a></td></tr></tbody></table></td></tr></tbody></table></td></tr></tbody></table></div><!--[if mso | IE]></td></tr></table><![endif]--></td></tr></tbody></table></div><!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:488px;" width="488" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+					<div style="margin:0px auto;max-width:488px;"><table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"><tbody><tr><td style="direction:ltr;font-size:0px;padding:0;text-align:center;"><!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:488px;" ><![endif]-->
+						<div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"><table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%"><tbody><tr><td style="vertical-align:top;padding:12px;"><table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%"><tbody><tr><td align="left" style="font-size:0px;padding:0;word-break:break-word;"><div style="font-family:Arial;font-size:16px;line-height:1.5;text-align:left;color:#000000"><h2 class="wp-block-heading" style="font-size:46px;font-style:normal;font-weight:500">' . esc_html( $post_title ) . '</h2></div></td></tr></tbody></table></td></tr></tbody></table></div><!--[if mso | IE]></td></tr></table><![endif]--></td></tr></tbody></table></div><!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:488px;" width="488" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+					<div style="margin:0px auto;max-width:488px;"><table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"><tbody><tr><td style="direction:ltr;font-size:0px;padding:0;text-align:center;"><!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:488px;" ><![endif]-->
+						<div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"><table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%"><tbody><tr><td style="vertical-align:top;padding:12px;"><table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%"><tbody><tr><td align="left" style="font-size:0px;padding:0;word-break:break-word;"><div style="font-family:Arial;font-size:16px;line-height:1.5;text-align:left;color:#000000;"><p style="font-style:normal;font-weight:400">' . sprintf(
+		/* translators: 1: billing first name. 2: last 4 digits of card. 3: expiry date. 4: site title. 5: renewal date. */
+							__( 'Hi %1$s, the card ending in %2$s (expires %3$s) is the payment method for your subscription to %4$s. Your next renewal is on %5$s.', 'newspack-plugin' ),
+							'*BILLING_FIRST_NAME*',
+							'*CARD_LAST_4*',
+							'*EXPIRY_DATE*',
+							'*SITE_TITLE*',
+							'*RENEWAL_DATE*'
+						) . '</p></div></td></tr></tbody></table></td></tr></tbody></table></div><!--[if mso | IE]></td></tr></table><![endif]--></td></tr></tbody></table></div><!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:488px;" width="488" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+					<div style="margin:0px auto;max-width:488px;"><table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"><tbody><tr><td style="direction:ltr;font-size:0px;padding:0;text-align:center;"><!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:488px;" ><![endif]-->
+						<div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"><table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%"><tbody><tr><td style="vertical-align:top;padding:12px;"><table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%"><tbody><tr><td align="left" style="font-size:0px;padding:0;word-break:break-word;"><div style="font-family:Arial;font-size:16px;line-height:1.5;text-align:left;color:#000000;"><p>' . __( 'To avoid any interruption, please update your payment method before your card expires.', 'newspack-plugin' ) . '</p></div></td></tr></tbody></table></td></tr></tbody></table></div><!--[if mso | IE]></td></tr></table><![endif]--></td></tr></tbody></table></div><!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:488px;" width="488" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+					<div style="margin:0px auto;max-width:488px;"><table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"><tbody><tr><td style="direction:ltr;font-size:0px;padding:0;text-align:center;"><!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="mj-column-has-width-outlook" style="vertical-align:top;width:488px;" ><![endif]-->
+						<div class="mj-column-per-100 mj-outlook-group-fix mj-column-has-width" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"><table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%"><tbody><tr><td style="vertical-align:top;padding:12px;"><table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%"><tbody><tr><td align="left" style="font-size:0px;padding:0;word-break:break-word;"><table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;"><tbody><tr><td align="center" bgcolor="' . esc_attr( $primary_color ) . ' !important" role="presentation" style="border:none;border-radius:4px;cursor:auto;mso-padding-alt:12px 24px;background:' . esc_attr( $primary_color ) . ' !important;" valign="middle"><a href="*UPDATE_PAYMENT_URL*" style="display:inline-block;background:' . esc_attr( $primary_color ) . ' !important;color:' . esc_attr( $primary_text_color ) . ' !important;font-family:Arial;font-size:16px;font-weight:bold;line-height:1.5;margin:0;text-decoration:none;text-transform:none;padding:12px 24px;mso-padding-alt:0px;border-radius:4px;" target="_blank">' . __( 'Update payment method', 'newspack-plugin' ) . '</a></td></tr></tbody></table></td></tr></tbody></table></td></tr></tbody></table></div><!--[if mso | IE]></td></tr></table><![endif]--></td></tr></tbody></table></div><!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:488px;" width="488" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+					<div style="margin:0px auto;max-width:488px;"><table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"><tbody><tr><td style="direction:ltr;font-size:0px;padding:0;text-align:center;"><!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:488px;" ><![endif]-->
+						<div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"><table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%"><tbody><tr><td style="vertical-align:top;padding:12px;"><table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%"><tbody><tr><td align="left" style="font-size:0px;padding:0;word-break:break-word;"><div style="font-family:Arial;font-size:12px;line-height:1.5;text-align:left;color:#000000;"><p class="has-small-font-size">' . __( "If you've already updated your payment method, you can disregard this email.", 'newspack-plugin' ) . '</p></div></td></tr></tbody></table></td></tr></tbody></table></div><!--[if mso | IE]></td></tr></table><![endif]--></td></tr></tbody></table></div><!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:488px;" width="488" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+					<div style="margin:0px auto;max-width:488px;"><table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"><tbody><tr><td style="direction:ltr;font-size:0px;padding:0;text-align:center;"><!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:488px;" ><![endif]-->
+						<div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"><table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%"><tbody><tr><td style="vertical-align:top;padding:12px;"><table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%"><tbody><tr><td align="left" style="font-size:0px;padding:0;word-break:break-word;"><div style="font-family:Arial;font-size:16px;line-height:1.5;text-align:left;color:#000000;"><p>' . sprintf(
+		/* translators: %s: site admin email address. */
+							__( 'Questions? Contact us at %s.', 'newspack-plugin' ),
+							'*CONTACT_EMAIL*'
+						) . '</p></div></td></tr></tbody></table></td></tr></tbody></table></div><!--[if mso | IE]></td></tr></table><![endif]--></td></tr></tbody></table></div><!--[if mso | IE]></td></tr></table></td></tr></table><![endif]--></td></tr></tbody></table></div><!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="' . esc_attr( $primary_color ) . ' !important" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+				<div style="background:' . esc_attr( $primary_color ) . ' !important;background-color:' . esc_attr( $primary_color ) . ' !important;margin:0px auto;max-width:600px;"><table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:' . esc_attr( $primary_color ) . ' !important;background-color:' . esc_attr( $primary_color ) . ' !important;width:100%;"><tbody><tr><td style="direction:ltr;font-size:0px;padding:56px 56px 56px 56px;text-align:center;"><!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:488px;" width="488" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+					<div style="margin:0px auto;max-width:488px;"><table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"><tbody><tr><td style="direction:ltr;font-size:0px;padding:0;text-align:center;"><!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:488px;" ><![endif]-->
+						<div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"><table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%"><tbody><tr><td style="vertical-align:top;padding:12px;"><table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%"><tbody><tr><td align="left" style="font-size:0px;padding:0;word-break:break-word;"><!--[if mso | IE]><table align="left" border="0" cellpadding="0" cellspacing="0" role="presentation" ><tr><td><![endif]-->' . $social_links_html . '<!--[if mso | IE]></td></td></tr></table><![endif]--></td></tr></tbody></table></td></tr></tbody></table></div><!--[if mso | IE]></td></tr></table><![endif]--></td></tr></tbody></table></div><!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:488px;" width="488" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+					<div style="margin:0px auto;max-width:488px;"><table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;"><tbody><tr><td style="direction:ltr;font-size:0px;padding:0;text-align:center;"><!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:488px;" ><![endif]-->
+						<div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;"><table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%"><tbody><tr><td style="vertical-align:top;padding:12px;"><table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%"><tbody><tr><td align="left" style="font-size:0px;padding:0;word-break:break-word;"><div style="font-family:Arial;font-size:12px;line-height:1.5;text-align:left;color:' . esc_attr( $primary_text_color ) . ';"><p class="has-small-font-size">*SITE_CONTACT*<br> ' . sprintf(
+		/* translators: %s: link to site url. */
+							__( 'You received this email because you have an active subscription to %s', 'newspack-plugin' ),
+							'<a style="color:' . esc_attr( $primary_text_color ) . ' !important" href="*SITE_URL*">*SITE_URL*</a>'
+						) . '</p></div></td></tr></tbody></table></td></tr></tbody></table></div><!--[if mso | IE]></td></tr></table><![endif]--></td></tr></tbody></table></div><!--[if mso | IE]></td></tr></table></td></tr></table><![endif]--></td></tr></tbody></table></div><!--[if mso | IE]></td></tr></table><![endif]-->
+			</div>
+		</body>
+	</html>';
+
+return array(
+	'post_title'   => $post_title,
+	'post_content' => $post_content,
+	'email_html'   => $email_html,
+);

--- a/includes/wizards/newspack/class-email-preview.php
+++ b/includes/wizards/newspack/class-email-preview.php
@@ -182,7 +182,7 @@ class Email_Preview {
 				// Card expiry warning details.
 				'*CARD_LAST_4*'           => '4242',
 				'*EXPIRY_DATE*'           => '12/2026',
-				'*RENEWAL_DATE*'          => wp_date( get_option( 'date_format', 'F j, Y' ), strtotime( '+1 year' ) ),
+				'*RENEWAL_DATE*'          => wp_date( get_option( 'date_format', 'F j, Y' ), strtotime( '+30 days' ) ),
 
 				// OTP code — stable sample value.
 				'*MAGIC_LINK_OTP*'        => '123456',

--- a/includes/wizards/newspack/class-emails-section.php
+++ b/includes/wizards/newspack/class-emails-section.php
@@ -164,6 +164,16 @@ class Emails_Section extends Wizard_Section {
 				'label'               => __( 'Cancellation confirmation', 'newspack-plugin' ),
 				'trigger_description' => __( 'Sent when a reader cancels their subscription.', 'newspack-plugin' ),
 			],
+			'card-expiry-warning'              => [
+				'source'              => 'newspack',
+				'newspack_type'       => 'card-expiry-warning',
+				'recommended'         => true,
+				'plugin_dependency'   => 'woocommerce-subscriptions',
+				'recipient'           => 'reader',
+				'chip'                => 'reader-revenue',
+				'label'               => __( 'Card expiry warning', 'newspack-plugin' ),
+				'trigger_description' => __( 'Sent when a reader\'s saved payment method is about to expire.', 'newspack-plugin' ),
+			],
 			'woo-renewal-reminder'             => [
 				'source'              => 'woocommerce',
 				'woo_email_id'        => 'customer_notification_auto_renewal',

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -1,0 +1,21 @@
+# Integration Smoke Tests
+
+Integration smoke tests that exercise Newspack features against a real WordPress + WooCommerce environment. Unlike the PHPUnit suite under `tests/unit-tests/`, these scripts are run manually via `wp eval-file` and require the full plugin stack to be active.
+
+## Running
+
+```bash
+wp eval-file tests/integration/<script>.php
+```
+
+Each script prints `PASS`/`FAIL` lines per scenario, a final `N/M PASSED` summary, and exits non-zero on any failure. Scripts create their own fixtures and clean up after themselves.
+
+## Scripts
+
+### `card-expiry-warning-smoke.php`
+
+End-to-end coverage for the Card Expiry Warning email (`includes/plugins/woocommerce-subscriptions/class-card-expiry-warning.php`).
+
+**Requires:** WooCommerce, WooCommerce Subscriptions, Newspack Newsletters, and Reader Activation enabled.
+
+Exercises cron scheduling, happy-path send, idempotency, the payment-method-update flag clear, new-card re-send, and the unattached-card no-op.

--- a/tests/integration/card-expiry-warning-smoke.php
+++ b/tests/integration/card-expiry-warning-smoke.php
@@ -1,0 +1,457 @@
+<?php
+/**
+ * Card Expiry Warning — Integration Smoke Test.
+ *
+ * Usage: wp eval-file tests/integration/card-expiry-warning-smoke.php
+ *
+ * Requires WooCommerce, WooCommerce Subscriptions, and Newspack Newsletters
+ * to be active on the site.
+ *
+ * Creates temporary fixtures, runs 7 scenarios, and cleans up after itself.
+ *
+ * Scenarios:
+ *  1. Cron scheduled
+ *  2. Happy-path send (token → subscription → email)
+ *  3. Idempotency (no duplicate send)
+ *  4. clear_sent_flag() handler clears meta (called directly; the full
+ *     woocommerce_subscription_payment_method_updated action fatals on
+ *     WCS PayPal's hook which expects 3 args)
+ *  5. New card triggers new send
+ *  6. Unattached card does not trigger email
+ *  7. Cleanup
+ *
+ * Delete this file after the PR merges.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Card_Expiry_Warning;
+use Newspack\Emails;
+
+// ── Globals ──────────────────────────────────────────────────────────
+// wp eval-file runs via eval(), so file-scope vars are local to the eval
+// context. Named functions use `global` which references $GLOBALS. Declare
+// these as global so both scopes see the same variables.
+global $passed, $total, $mails, $cleanup;
+$passed  = 0;
+$total   = 7;
+$mails   = [];
+$cleanup = []; // Closures executed in reverse order during cleanup.
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Record a passing scenario.
+ *
+ * @param string $label Description.
+ */
+function smoke_pass( string $label ): void {
+	global $passed;
+	++$passed;
+	WP_CLI::log( "  PASS: $label" );
+}
+
+/**
+ * Record a failing scenario.
+ *
+ * @param string $label  Description.
+ * @param string $detail Optional extra info.
+ */
+function smoke_fail( string $label, string $detail = '' ): void {
+	WP_CLI::log( "  FAIL: $label" . ( $detail ? " -- $detail" : '' ) );
+}
+
+// ── Prerequisites ────────────────────────────────────────────────────
+WP_CLI::log( '' );
+WP_CLI::log( '== Card Expiry Warning -- Smoke Test ==' );
+WP_CLI::log( '' );
+
+$prereqs = [
+	'WC_Payment_Token_CC'           => 'WooCommerce (WC_Payment_Token_CC)',
+	'WC_Payment_Tokens'             => 'WooCommerce (WC_Payment_Tokens)',
+	'WCS_Payment_Tokens'            => 'WooCommerce Subscriptions (WCS_Payment_Tokens)',
+	'Newspack\\Card_Expiry_Warning' => 'Newspack Card_Expiry_Warning',
+	'Newspack\\Emails'              => 'Newspack Emails',
+	'Newspack_Newsletters'          => 'Newspack Newsletters',
+];
+foreach ( $prereqs as $class => $label ) {
+	if ( ! class_exists( $class ) ) {
+		WP_CLI::error( "Prerequisite not met: $label ($class). Aborting." );
+	}
+}
+if ( ! function_exists( 'wcs_create_subscription' ) ) {
+	WP_CLI::error( 'wcs_create_subscription() not available. Aborting.' );
+}
+WP_CLI::log( 'Prerequisites OK.' );
+
+// ── Intercept wp_mail via pre_wp_mail ────────────────────────────────
+// Returning non-null from pre_wp_mail short-circuits wp_mail() without
+// actually sending. We capture the args and return true ("sent OK").
+add_filter(
+	'pre_wp_mail',
+	function ( $null, $atts ) use ( &$mails ) {
+		$mails[] = $atts;
+		return true;
+	},
+	10,
+	2
+);
+
+// ── Widen scan window for reliable expiry detection ──────────────────
+// A CC token "expires" at the end of its expiry month. The scan query
+// finds tokens whose LAST_DAY(expiry) falls in [today, today + N days].
+// End-of-current-month is at most ~30 days away, so a 32-day window
+// guarantees the token is within range regardless of when the test runs.
+add_filter(
+	'newspack_card_expiry_warning_days',
+	function () {
+		return 32;
+	},
+	99
+);
+
+// ── Create test user ─────────────────────────────────────────────────
+$rand    = wp_rand( 10000, 99999 );
+$user_id = wp_insert_user(
+	[
+		'user_login' => "smoke_cew_$rand",
+		'user_email' => "smoke-cew-$rand@example.test",
+		'user_pass'  => wp_generate_password(),
+		'first_name' => 'Smoke',
+		'last_name'  => 'Tester',
+		'role'       => 'subscriber',
+	]
+);
+if ( is_wp_error( $user_id ) ) {
+	WP_CLI::error( 'Could not create test user: ' . $user_id->get_error_message() );
+}
+$cleanup[] = function () use ( $user_id ) {
+	wp_delete_user( $user_id );
+};
+WP_CLI::log( "  Created user #$user_id." );
+
+// ── Create CC token 1 (expires end of current month) ─────────────────
+$expiry_month = (int) gmdate( 'n' );
+$expiry_year  = (int) gmdate( 'Y' );
+
+$token1 = new WC_Payment_Token_CC();
+$token1->set_gateway_id( 'stripe' );
+$token1->set_token( 'pm_smoke_' . $rand . '_a' );
+$token1->set_last4( '4242' );
+$token1->set_expiry_month( str_pad( $expiry_month, 2, '0', STR_PAD_LEFT ) );
+$token1->set_expiry_year( (string) $expiry_year );
+$token1->set_card_type( 'visa' );
+$token1->set_user_id( $user_id );
+$token1->save();
+$cleanup[] = function () use ( $token1 ) {
+	$token1->delete( true );
+};
+WP_CLI::log( "  Created token #{$token1->get_id()} (last4=4242, exp=$expiry_month/$expiry_year)." );
+
+// ── Create WC Subscription linked to token 1 ────────────────────────
+$subscription = wcs_create_subscription(
+	[
+		'customer_id'      => $user_id,
+		'status'           => 'active',
+		'billing_period'   => 'month',
+		'billing_interval' => 1,
+	]
+);
+if ( is_wp_error( $subscription ) ) {
+	WP_CLI::error( 'Could not create subscription: ' . $subscription->get_error_message() );
+}
+$sub_id = $subscription->get_id();
+
+$subscription->set_billing_email( "smoke-cew-$rand@example.test" );
+$subscription->set_billing_first_name( 'Smoke' );
+$subscription->set_payment_method( 'stripe' );
+
+// Mark as automatic renewal — wcs_create_subscription() defaults to
+// manual, and get_subscriptions_from_token() excludes manual-renewal subs.
+$subscription->set_requires_manual_renewal( false );
+
+// Store token string in gateway-specific meta so
+// WCS_Payment_Tokens::get_subscriptions_from_token() can match it
+// (key-less meta_query on the raw token string).
+$subscription->update_meta_data( '_stripe_source_id', $token1->get_token() );
+
+// Set a future next-payment date.
+$subscription->update_dates(
+	[ 'next_payment' => gmdate( 'Y-m-d H:i:s', time() + 20 * DAY_IN_SECONDS ) ]
+);
+$subscription->save();
+
+$cleanup[] = function () use ( $sub_id ) {
+	wp_delete_post( $sub_id, true );
+};
+WP_CLI::log( "  Created subscription #$sub_id." );
+
+
+// ══════════════════════════════════════════════════════════════════════
+// SCENARIO 1: Cron scheduled
+// ══════════════════════════════════════════════════════════════════════
+WP_CLI::log( '' );
+WP_CLI::log( '1. Cron scheduled' );
+
+Card_Expiry_Warning::schedule_cron();
+
+if ( wp_next_scheduled( Card_Expiry_Warning::CRON_HOOK ) ) {
+	smoke_pass( 'Cron event is scheduled.' );
+} else {
+	smoke_fail( 'Cron event was not scheduled.' );
+}
+
+
+// ══════════════════════════════════════════════════════════════════════
+// SCENARIO 2: Happy-path send
+// ══════════════════════════════════════════════════════════════════════
+WP_CLI::log( '' );
+WP_CLI::log( '2. Happy-path send' );
+
+$mails = [];
+Card_Expiry_Warning::scan_expiring_cards();
+
+$s2_ok = true;
+if ( count( $mails ) !== 1 ) {
+	smoke_fail( 'Expected exactly 1 email, got ' . count( $mails ) . '.' );
+	if ( count( $mails ) === 0 ) {
+		// Debug: check prerequisites.
+		if ( ! Emails::can_send_email( 'card-expiry-warning' ) ) {
+			WP_CLI::log( '    (Debug: Emails::can_send_email returned false.)' );
+		}
+	}
+	$s2_ok = false;
+} else {
+	$mail = $mails[0];
+
+	// Check recipient.
+	if ( $mail['to'] !== "smoke-cew-$rand@example.test" ) {
+		smoke_fail( "Wrong recipient: expected smoke-cew-$rand@example.test, got {$mail['to']}." );
+		$s2_ok = false;
+	}
+
+	// Check body contains last-4 and expiry.
+	$body = $mail['message'] ?? '';
+	if ( false === strpos( $body, '4242' ) ) {
+		smoke_fail( 'Email body missing card last-4 "4242".' );
+		$s2_ok = false;
+	}
+	// Use the token's own accessors for the padded month format.
+	$expiry_str = $token1->get_expiry_month() . '/' . $token1->get_expiry_year();
+	if ( false === strpos( $body, $expiry_str ) ) {
+		smoke_fail( "Email body missing expiry \"$expiry_str\"." );
+		$s2_ok = false;
+	}
+
+	// Check idempotency meta.
+	$subscription  = wcs_get_subscription( $sub_id );
+	$meta_val      = $subscription->get_meta( '_newspack_card_expiry_warning_sent', true );
+	$expected_meta = $token1->get_id() . ':' . $token1->get_expiry_month() . '/' . $token1->get_expiry_year();
+	if ( $meta_val !== $expected_meta ) {
+		smoke_fail( "Idempotency meta mismatch: expected '$expected_meta', got '$meta_val'." );
+		$s2_ok = false;
+	}
+}
+
+if ( $s2_ok ) {
+	smoke_pass( 'Correct recipient, body tokens, and idempotency meta.' );
+}
+
+
+// ══════════════════════════════════════════════════════════════════════
+// SCENARIO 3: Idempotency — re-running scan sends nothing
+// ══════════════════════════════════════════════════════════════════════
+WP_CLI::log( '' );
+WP_CLI::log( '3. Idempotency (no duplicate send)' );
+
+$mails = [];
+Card_Expiry_Warning::scan_expiring_cards();
+
+if ( 0 === count( $mails ) ) {
+	$subscription  = wcs_get_subscription( $sub_id );
+	$meta_val      = $subscription->get_meta( '_newspack_card_expiry_warning_sent', true );
+	$expected_meta = $token1->get_id() . ':' . $token1->get_expiry_month() . '/' . $token1->get_expiry_year();
+
+	if ( $meta_val === $expected_meta ) {
+		smoke_pass( 'No duplicate email; meta unchanged.' );
+	} else {
+		smoke_fail( "Meta changed unexpectedly to '$meta_val'." );
+	}
+} else {
+	smoke_fail( 'Duplicate email sent (' . count( $mails ) . ' captured).' );
+}
+
+
+// ══════════════════════════════════════════════════════════════════════
+// SCENARIO 4: clear_sent_flag() handler clears idempotency meta
+// ══════════════════════════════════════════════════════════════════════
+WP_CLI::log( '' );
+WP_CLI::log( '4. clear_sent_flag() handler clears meta' );
+
+// Call clear_sent_flag() directly rather than firing the full
+// woocommerce_subscription_payment_method_updated action. That action
+// triggers third-party hooks (WCS PayPal, etc.) whose callbacks expect
+// 3 args and fatal with our minimal test fixture.
+$subscription = wcs_get_subscription( $sub_id );
+Card_Expiry_Warning::clear_sent_flag( $subscription, 'stripe' );
+
+$subscription = wcs_get_subscription( $sub_id );
+$meta_val     = $subscription->get_meta( '_newspack_card_expiry_warning_sent', true );
+
+if ( empty( $meta_val ) ) {
+	smoke_pass( 'Idempotency meta cleared.' );
+} else {
+	smoke_fail( "Meta should be empty after clear, got '$meta_val'." );
+}
+
+
+// ══════════════════════════════════════════════════════════════════════
+// SCENARIO 5: New card in window triggers a new send
+// ══════════════════════════════════════════════════════════════════════
+WP_CLI::log( '' );
+WP_CLI::log( '5. New card triggers new send' );
+
+$token2 = new WC_Payment_Token_CC();
+$token2->set_gateway_id( 'stripe' );
+$token2->set_token( 'pm_smoke_' . $rand . '_b' );
+$token2->set_last4( '1234' );
+$token2->set_expiry_month( str_pad( $expiry_month, 2, '0', STR_PAD_LEFT ) );
+$token2->set_expiry_year( (string) $expiry_year );
+$token2->set_card_type( 'mastercard' );
+$token2->set_user_id( $user_id );
+$token2->save();
+$cleanup[] = function () use ( $token2 ) {
+	$token2->delete( true );
+};
+WP_CLI::log( "  Created token #{$token2->get_id()} (last4=1234)." );
+
+// Point subscription at the new token.
+$subscription = wcs_get_subscription( $sub_id );
+$subscription->update_meta_data( '_stripe_source_id', $token2->get_token() );
+$subscription->save();
+
+$mails = [];
+Card_Expiry_Warning::scan_expiring_cards();
+
+$s5_ok = true;
+if ( count( $mails ) < 1 ) {
+	smoke_fail( 'No email sent for the new token.' );
+	$s5_ok = false;
+} else {
+	$mail = $mails[ count( $mails ) - 1 ];
+	$body = $mail['message'] ?? '';
+
+	if ( false === strpos( $body, '1234' ) ) {
+		smoke_fail( 'Email body missing new card last-4 "1234".' );
+		$s5_ok = false;
+	}
+
+	$subscription  = wcs_get_subscription( $sub_id );
+	$meta_val      = $subscription->get_meta( '_newspack_card_expiry_warning_sent', true );
+	$expected_meta = $token2->get_id() . ':' . $token2->get_expiry_month() . '/' . $token2->get_expiry_year();
+	if ( $meta_val !== $expected_meta ) {
+		smoke_fail( "Meta should reflect token2: expected '$expected_meta', got '$meta_val'." );
+		$s5_ok = false;
+	}
+}
+
+if ( $s5_ok ) {
+	smoke_pass( 'New card triggered email with correct last-4 and updated meta.' );
+}
+
+
+// ══════════════════════════════════════════════════════════════════════
+// SCENARIO 6: Unattached card does NOT trigger an email
+// ══════════════════════════════════════════════════════════════════════
+WP_CLI::log( '' );
+WP_CLI::log( '6. Unattached card does not trigger email' );
+
+// Create a separate user + token with no subscription.
+$orphan_user_id = wp_insert_user(
+	[
+		'user_login' => "smoke_cew_orphan_$rand",
+		'user_email' => "smoke-orphan-$rand@example.test",
+		'user_pass'  => wp_generate_password(),
+		'role'       => 'subscriber',
+	]
+);
+if ( is_wp_error( $orphan_user_id ) ) {
+	WP_CLI::error( 'Could not create orphan user: ' . $orphan_user_id->get_error_message() );
+}
+$cleanup[] = function () use ( $orphan_user_id ) {
+	wp_delete_user( $orphan_user_id );
+};
+
+$token3 = new WC_Payment_Token_CC();
+$token3->set_gateway_id( 'stripe' );
+$token3->set_token( 'pm_smoke_' . $rand . '_c' );
+$token3->set_last4( '9999' );
+$token3->set_expiry_month( str_pad( $expiry_month, 2, '0', STR_PAD_LEFT ) );
+$token3->set_expiry_year( (string) $expiry_year );
+$token3->set_card_type( 'amex' );
+$token3->set_user_id( $orphan_user_id );
+$token3->save();
+$cleanup[] = function () use ( $token3 ) {
+	$token3->delete( true );
+};
+WP_CLI::log( "  Created orphan token #{$token3->get_id()} (last4=9999, no subscription)." );
+
+// Token2's subscription already has the idempotency flag from scenario 5,
+// so no email for that. Token1 is no longer on the subscription (replaced
+// by token2). Token3 has no subscription at all.
+$mails = [];
+Card_Expiry_Warning::scan_expiring_cards();
+
+if ( 0 === count( $mails ) ) {
+	smoke_pass( 'No email sent for unattached card.' );
+} else {
+	$orphan_hit = false;
+	foreach ( $mails as $mail_item ) {
+		if ( false !== strpos( $mail_item['to'], 'orphan' ) ) {
+			$orphan_hit = true;
+		}
+	}
+	if ( $orphan_hit ) {
+		smoke_fail( 'Email was sent to orphan user with no subscription.' );
+	} else {
+		smoke_fail( count( $mails ) . ' unexpected email(s) sent (not to orphan user).' );
+	}
+}
+
+
+// ══════════════════════════════════════════════════════════════════════
+// SCENARIO 7: Cleanup
+// ══════════════════════════════════════════════════════════════════════
+WP_CLI::log( '' );
+WP_CLI::log( '7. Cleanup' );
+
+$clean_ok = true;
+foreach ( array_reverse( $cleanup ) as $fn ) {
+	try {
+		$fn();
+	} catch ( \Throwable $e ) {
+		WP_CLI::log( '    Cleanup error: ' . $e->getMessage() );
+		$clean_ok = false;
+	}
+}
+
+// Remove filters added by this script.
+remove_all_filters( 'pre_wp_mail' );
+remove_all_filters( 'newspack_card_expiry_warning_days' );
+
+// Unschedule cron (may have been scheduled before the test too).
+wp_clear_scheduled_hook( Card_Expiry_Warning::CRON_HOOK );
+
+if ( $clean_ok ) {
+	smoke_pass( 'All fixtures cleaned up.' );
+} else {
+	smoke_fail( 'Some cleanup steps failed (see above).' );
+}
+
+
+// ── Summary ──────────────────────────────────────────────────────────
+WP_CLI::log( '' );
+WP_CLI::log( "== $passed/$total PASSED ==" );
+WP_CLI::log( '' );
+
+exit( $passed === $total ? 0 : 1 );

--- a/tests/integration/card-expiry-warning-smoke.php
+++ b/tests/integration/card-expiry-warning-smoke.php
@@ -14,19 +14,18 @@
  *  2. Happy-path send (token → subscription → email)
  *  3. Idempotency (no duplicate send)
  *  4. clear_sent_flag() handler clears meta (called directly; the full
- *     woocommerce_subscription_payment_method_updated action fatals on
- *     WCS PayPal's hook which expects 3 args)
+ *     woocommerce_subscription_payment_method_updated action triggers
+ *     third-party hooks like WCS PayPal that fatal on a minimal fixture)
  *  5. New card triggers new send
  *  6. Unattached card does not trigger email
  *  7. Cleanup
- *
- * Delete this file after the PR merges.
  *
  * @package Newspack\Tests
  */
 
 use Newspack\Card_Expiry_Warning;
 use Newspack\Emails;
+use Newspack\Reader_Activation;
 
 // ── Globals ──────────────────────────────────────────────────────────
 // wp eval-file runs via eval(), so file-scope vars are local to the eval
@@ -81,6 +80,14 @@ foreach ( $prereqs as $class => $label ) {
 }
 if ( ! function_exists( 'wcs_create_subscription' ) ) {
 	WP_CLI::error( 'wcs_create_subscription() not available. Aborting.' );
+}
+
+// Card_Expiry_Warning::init() only registers the email config when
+// WooCommerce_Subscriptions::is_enabled() returns true, which in turn
+// requires Reader Activation to be enabled. Without this, scan_expiring_cards()
+// silently captures 0 emails and the test gives a misleading failure.
+if ( ! Reader_Activation::is_enabled() ) {
+	WP_CLI::error( 'Reader Activation is not enabled. Aborting.' );
 }
 WP_CLI::log( 'Prerequisites OK.' );
 
@@ -290,10 +297,10 @@ WP_CLI::log( '4. clear_sent_flag() handler clears meta' );
 
 // Call clear_sent_flag() directly rather than firing the full
 // woocommerce_subscription_payment_method_updated action. That action
-// triggers third-party hooks (WCS PayPal, etc.) whose callbacks expect
-// 3 args and fatal with our minimal test fixture.
+// triggers third-party hooks (WCS PayPal, etc.) that fatal with our
+// minimal test fixture.
 $subscription = wcs_get_subscription( $sub_id );
-Card_Expiry_Warning::clear_sent_flag( $subscription, 'stripe' );
+Card_Expiry_Warning::clear_sent_flag( $subscription );
 
 $subscription = wcs_get_subscription( $sub_id );
 $meta_val     = $subscription->get_meta( '_newspack_card_expiry_warning_sent', true );

--- a/tests/unit-tests/card-expiry-warning.php
+++ b/tests/unit-tests/card-expiry-warning.php
@@ -181,6 +181,8 @@ class Newspack_Test_Card_Expiry_Warning extends WP_UnitTestCase {
 		$renewal_reminder_idx = array_search( 'woo-renewal-reminder', $slugs, true );
 
 		$this->assertNotFalse( $card_expiry_idx, 'card-expiry-warning should be in the registry.' );
+		$this->assertNotFalse( $cancellation_idx, 'cancellation should be in the registry.' );
+		$this->assertNotFalse( $renewal_reminder_idx, 'woo-renewal-reminder should be in the registry.' );
 		$this->assertGreaterThan( $cancellation_idx, $card_expiry_idx, 'card-expiry-warning should appear after cancellation.' );
 		$this->assertLessThan( $renewal_reminder_idx, $card_expiry_idx, 'card-expiry-warning should appear before woo-renewal-reminder.' );
 	}

--- a/tests/unit-tests/card-expiry-warning.php
+++ b/tests/unit-tests/card-expiry-warning.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * Tests Card_Expiry_Warning.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Card_Expiry_Warning;
+use Newspack\Wizards\Newspack\Emails_Section;
+
+/**
+ * Tests Card_Expiry_Warning.
+ */
+class Newspack_Test_Card_Expiry_Warning extends WP_UnitTestCase {
+
+	/**
+	 * Test the email config is registered via the newspack_email_configs filter.
+	 */
+	public function test_email_config_registered() {
+		$configs = apply_filters( 'newspack_email_configs', [] );
+		$this->assertArrayHasKey( 'card-expiry-warning', $configs, 'card-expiry-warning email config should be registered.' );
+	}
+
+	/**
+	 * Test the email config has all required keys.
+	 */
+	public function test_email_config_has_required_keys() {
+		$configs       = apply_filters( 'newspack_email_configs', [] );
+		$config        = $configs['card-expiry-warning'];
+		$required_keys = [ 'name', 'category', 'label', 'description', 'template', 'editor_notice', 'from_email', 'available_placeholders' ];
+
+		foreach ( $required_keys as $key ) {
+			$this->assertArrayHasKey( $key, $config, "Email config is missing required key '$key'." );
+		}
+	}
+
+	/**
+	 * Test the email config name matches the constant.
+	 */
+	public function test_email_config_name() {
+		$configs = apply_filters( 'newspack_email_configs', [] );
+		$config  = $configs['card-expiry-warning'];
+		$this->assertSame( 'card-expiry-warning', $config['name'] );
+	}
+
+	/**
+	 * Test the email config category is reader-revenue.
+	 */
+	public function test_email_config_category() {
+		$configs = apply_filters( 'newspack_email_configs', [] );
+		$config  = $configs['card-expiry-warning'];
+		$this->assertSame( 'reader-revenue', $config['category'] );
+	}
+
+	/**
+	 * Test the email config template file exists.
+	 */
+	public function test_email_config_template_exists() {
+		$configs = apply_filters( 'newspack_email_configs', [] );
+		$config  = $configs['card-expiry-warning'];
+		$this->assertFileExists( $config['template'], 'Email template file should exist.' );
+	}
+
+	/**
+	 * Test the email config has the expected placeholders.
+	 */
+	public function test_email_config_placeholders() {
+		$configs      = apply_filters( 'newspack_email_configs', [] );
+		$placeholders = $configs['card-expiry-warning']['available_placeholders'];
+		$templates    = array_column( $placeholders, 'template' );
+
+		$expected = [
+			'*BILLING_FIRST_NAME*',
+			'*CARD_LAST_4*',
+			'*EXPIRY_DATE*',
+			'*RENEWAL_DATE*',
+			'*UPDATE_PAYMENT_URL*',
+			'*CONTACT_EMAIL*',
+			'*SITE_TITLE*',
+			'*SITE_URL*',
+		];
+
+		foreach ( $expected as $token ) {
+			$this->assertContains( $token, $templates, "Placeholder '$token' should be in available_placeholders." );
+		}
+	}
+
+	/**
+	 * Test the registry entry is present.
+	 */
+	public function test_registry_entry_present() {
+		$registry = Emails_Section::get_email_registry();
+		$this->assertArrayHasKey( 'card-expiry-warning', $registry, 'card-expiry-warning should be in the email registry.' );
+	}
+
+	/**
+	 * Test the registry entry has the correct newspack_type.
+	 */
+	public function test_registry_entry_newspack_type() {
+		$registry = Emails_Section::get_email_registry();
+		$this->assertSame( 'card-expiry-warning', $registry['card-expiry-warning']['newspack_type'] );
+	}
+
+	/**
+	 * Test the registry entry chip is reader-revenue.
+	 */
+	public function test_registry_entry_chip_is_reader_revenue() {
+		$registry = Emails_Section::get_email_registry();
+		$this->assertSame( 'reader-revenue', $registry['card-expiry-warning']['chip'] );
+	}
+
+	/**
+	 * Test the registry entry is recommended.
+	 */
+	public function test_registry_entry_is_recommended() {
+		$registry = Emails_Section::get_email_registry();
+		$this->assertTrue( $registry['card-expiry-warning']['recommended'] );
+	}
+
+	/**
+	 * Test the registry entry has woocommerce-subscriptions plugin dependency.
+	 */
+	public function test_registry_entry_plugin_dependency() {
+		$registry = Emails_Section::get_email_registry();
+		$this->assertSame( 'woocommerce-subscriptions', $registry['card-expiry-warning']['plugin_dependency'] );
+	}
+
+	/**
+	 * Test the registry entry recipient is reader.
+	 */
+	public function test_registry_entry_recipient() {
+		$registry = Emails_Section::get_email_registry();
+		$this->assertSame( 'reader', $registry['card-expiry-warning']['recipient'] );
+	}
+
+	/**
+	 * Test the default days before expiry is 14.
+	 */
+	public function test_days_before_expiry_default() {
+		$this->assertSame( 14, Card_Expiry_Warning::get_days_before_expiry() );
+	}
+
+	/**
+	 * Test the days before expiry is filterable.
+	 */
+	public function test_days_before_expiry_filterable() {
+		add_filter( 'newspack_card_expiry_warning_days', fn() => 7 );
+		$this->assertSame( 7, Card_Expiry_Warning::get_days_before_expiry() );
+		remove_all_filters( 'newspack_card_expiry_warning_days' );
+	}
+
+	/**
+	 * Test the registry entry appears after cancellation and before woo-renewal-reminder.
+	 */
+	public function test_registry_entry_order() {
+		$slugs = array_keys( Emails_Section::get_email_registry() );
+
+		$cancellation_idx       = array_search( 'cancellation', $slugs, true );
+		$card_expiry_idx        = array_search( 'card-expiry-warning', $slugs, true );
+		$renewal_reminder_idx   = array_search( 'woo-renewal-reminder', $slugs, true );
+
+		$this->assertNotFalse( $card_expiry_idx, 'card-expiry-warning should be in the registry.' );
+		$this->assertGreaterThan( $cancellation_idx, $card_expiry_idx, 'card-expiry-warning should appear after cancellation.' );
+		$this->assertLessThan( $renewal_reminder_idx, $card_expiry_idx, 'card-expiry-warning should appear before woo-renewal-reminder.' );
+	}
+}

--- a/tests/unit-tests/card-expiry-warning.php
+++ b/tests/unit-tests/card-expiry-warning.php
@@ -14,10 +14,22 @@ use Newspack\Wizards\Newspack\Emails_Section;
 class Newspack_Test_Card_Expiry_Warning extends WP_UnitTestCase {
 
 	/**
-	 * Test the email config is registered via the newspack_email_configs filter.
+	 * Helper: get the email config by calling add_email_config directly.
+	 *
+	 * In CI, WooCommerce Subscriptions is not active so init() never hooks
+	 * the filter. We test the static method directly instead.
+	 *
+	 * @return array Email configs including card-expiry-warning.
+	 */
+	private function get_email_configs(): array {
+		return Card_Expiry_Warning::add_email_config( [] );
+	}
+
+	/**
+	 * Test the email config is registered.
 	 */
 	public function test_email_config_registered() {
-		$configs = apply_filters( 'newspack_email_configs', [] );
+		$configs = $this->get_email_configs();
 		$this->assertArrayHasKey( 'card-expiry-warning', $configs, 'card-expiry-warning email config should be registered.' );
 	}
 
@@ -25,7 +37,7 @@ class Newspack_Test_Card_Expiry_Warning extends WP_UnitTestCase {
 	 * Test the email config has all required keys.
 	 */
 	public function test_email_config_has_required_keys() {
-		$configs       = apply_filters( 'newspack_email_configs', [] );
+		$configs       = $this->get_email_configs();
 		$config        = $configs['card-expiry-warning'];
 		$required_keys = [ 'name', 'category', 'label', 'description', 'template', 'editor_notice', 'from_email', 'available_placeholders' ];
 
@@ -38,7 +50,7 @@ class Newspack_Test_Card_Expiry_Warning extends WP_UnitTestCase {
 	 * Test the email config name matches the constant.
 	 */
 	public function test_email_config_name() {
-		$configs = apply_filters( 'newspack_email_configs', [] );
+		$configs = $this->get_email_configs();
 		$config  = $configs['card-expiry-warning'];
 		$this->assertSame( 'card-expiry-warning', $config['name'] );
 	}
@@ -47,7 +59,7 @@ class Newspack_Test_Card_Expiry_Warning extends WP_UnitTestCase {
 	 * Test the email config category is reader-revenue.
 	 */
 	public function test_email_config_category() {
-		$configs = apply_filters( 'newspack_email_configs', [] );
+		$configs = $this->get_email_configs();
 		$config  = $configs['card-expiry-warning'];
 		$this->assertSame( 'reader-revenue', $config['category'] );
 	}
@@ -56,7 +68,7 @@ class Newspack_Test_Card_Expiry_Warning extends WP_UnitTestCase {
 	 * Test the email config template file exists.
 	 */
 	public function test_email_config_template_exists() {
-		$configs = apply_filters( 'newspack_email_configs', [] );
+		$configs = $this->get_email_configs();
 		$config  = $configs['card-expiry-warning'];
 		$this->assertFileExists( $config['template'], 'Email template file should exist.' );
 	}
@@ -65,7 +77,7 @@ class Newspack_Test_Card_Expiry_Warning extends WP_UnitTestCase {
 	 * Test the email config has the expected placeholders.
 	 */
 	public function test_email_config_placeholders() {
-		$configs      = apply_filters( 'newspack_email_configs', [] );
+		$configs      = $this->get_email_configs();
 		$placeholders = $configs['card-expiry-warning']['available_placeholders'];
 		$templates    = array_column( $placeholders, 'template' );
 
@@ -150,14 +162,23 @@ class Newspack_Test_Card_Expiry_Warning extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test the days before expiry enforces a minimum of 1.
+	 */
+	public function test_days_before_expiry_minimum() {
+		add_filter( 'newspack_card_expiry_warning_days', fn() => -5 );
+		$this->assertSame( 1, Card_Expiry_Warning::get_days_before_expiry() );
+		remove_all_filters( 'newspack_card_expiry_warning_days' );
+	}
+
+	/**
 	 * Test the registry entry appears after cancellation and before woo-renewal-reminder.
 	 */
 	public function test_registry_entry_order() {
 		$slugs = array_keys( Emails_Section::get_email_registry() );
 
-		$cancellation_idx       = array_search( 'cancellation', $slugs, true );
-		$card_expiry_idx        = array_search( 'card-expiry-warning', $slugs, true );
-		$renewal_reminder_idx   = array_search( 'woo-renewal-reminder', $slugs, true );
+		$cancellation_idx     = array_search( 'cancellation', $slugs, true );
+		$card_expiry_idx      = array_search( 'card-expiry-warning', $slugs, true );
+		$renewal_reminder_idx = array_search( 'woo-renewal-reminder', $slugs, true );
 
 		$this->assertNotFalse( $card_expiry_idx, 'card-expiry-warning should be in the registry.' );
 		$this->assertGreaterThan( $cancellation_idx, $card_expiry_idx, 'card-expiry-warning should appear after cancellation.' );


### PR DESCRIPTION
## What this PR does

Adds a new Newspack-managed **Card expiry warning** email ([NPPD-1524](https://linear.app/a8c/issue/NPPD-1524)). Sent ~14 days before a reader's saved card expires on an active WC Subscription, prompting them to update their payment method before renewal fails silently.

<img width="1304" height="1336" alt="image" src="https://github.com/user-attachments/assets/9146815b-b149-4a55-b2b8-72b8297965a0" />

Depends on slice 2 ([#4732](https://github.com/Automattic/newspack-plugin/pull/4732)) for the chip mechanism, which depends on slice 1 ([#4727](https://github.com/Automattic/newspack-plugin/pull/4727)).

## Code changes

**Backend — `includes/plugins/woocommerce-subscriptions/class-card-expiry-warning.php` (new)**

- New `Card_Expiry_Warning` class. Registers the email config on `newspack_email_configs`, schedules a daily cron via `wp_schedule_event`, and hooks `woocommerce_subscription_payment_method_updated` to clear the idempotency flag. Unschedules the cron on `newspack_deactivation`.
- Token-first scan algorithm: a direct DB query on `wp_woocommerce_payment_tokens` + `wp_woocommerce_payment_tokenmeta` finds `type='CC'` tokens whose last-valid-day falls within the configured window (default 14 days). For each match, `WCS_Payment_Tokens::get_subscriptions_from_token()` resolves to the active subscriptions actually using that token for automatic renewals. This avoids scanning all subscriptions: the matching set is narrow by definition.
- Multi-card aware: only warns about the card in use on a subscription, not all saved cards. A reader with three saved cards but only one in use on a sub gets one warning (or none, if the in-use card isn't in the expiry window) — `get_subscriptions_from_token()` matches the token string against the gateway-specific subscription meta, scoped to automatic-renewal subs only.
- Idempotency: per-subscription meta `_newspack_card_expiry_warning_sent` storing `{token_id}:{MM}/{YYYY}`. Self-invalidates when the token changes (new token_id) or for a new expiry cycle (different MM/YYYY). Explicitly cleared via `woocommerce_subscription_payment_method_updated` so an updated card resets the warning state immediately.
- Filterable window: `apply_filters( 'newspack_card_expiry_warning_days', 14 )`. No UI control in v1 — filter-only.
- Scope: active subscriptions only (skips pending and on-hold even though `get_subscriptions_from_token()` returns them — deliberate narrowing for v1, documented inline), automatic-renewal only (manual subs have no stored token), `WC_Payment_Token_CC` only (skips eCheck, PayPal, etc.), and not-yet-expired cards only.

**Backend — `includes/templates/reader-revenue-emails/card-expiry-warning.php` (new)**

- Email template matching the structure of `receipt.php` and `cancellation.php`. Returns `post_title`, `post_content` (Gutenberg blocks for the email editor), and `email_html` (MJML-style HTML for delivery). Uses `newspack_get_theme_colors()` and `newspack_get_social_markup()` for consistent branding.
- Tokens: `*BILLING_FIRST_NAME*`, `*CARD_LAST_4*`, `*EXPIRY_DATE*`, `*RENEWAL_DATE*`, `*UPDATE_PAYMENT_URL*` (resolves to `wc_get_account_endpoint_url( 'payment-methods' )`).
- Includes an "if you've already updated your payment method, you can disregard this email" disclaimer to handle the 14-day lead time.

**Backend — registry + bootstrap**

- `includes/wizards/newspack/class-emails-section.php`: adds `card-expiry-warning` to `get_email_registry()` (inserted after `cancellation`, before `woo-renewal-reminder`) with `chip='reader-revenue'`, `recommended=true`, `plugin_dependency='woocommerce-subscriptions'`, `recipient='reader'`.
- `includes/wizards/newspack/class-email-preview.php`: extends `get_sample_substitutions()` with new tokens — `*CARD_LAST_4*` → `4242`, `*EXPIRY_DATE*` → `12/2026`, `*RENEWAL_DATE*` → a stable future date, `*UPDATE_PAYMENT_URL*` → `#`.
- `includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php`: includes the new class and calls `Card_Expiry_Warning::init()` from the WC Subs integration init.

**Tests**

PHPUnit (`tests/unit-tests/card-expiry-warning.php`, new): email config registration + required keys + template file existence + placeholder shape; registry entry presence, chip, recommended, plugin_dependency, recipient, position in the registry; default 14-day window + filter override.

Integration smoke test (`tests/integration/card-expiry-warning-smoke.php`, new): runnable via `wp eval-file` on a site with WooCommerce + WC Subscriptions active. Creates real DB fixtures (user, CC tokens, subscription) and exercises the full scan pipeline — 7 scenarios covering cron scheduling, happy-path send with wp_mail capture, idempotency, clear_sent_flag handler, new-card re-send, unattached-card filtering, and cleanup. 7/7 passing on local.

No frontend test changes — no UI surface in v1.

## Why slice this PR

Card expiry warning is a self-contained email. Keeping it as a separate PR off slice 2 makes it easier to review the cron + token scan logic on its own and ships independent reader-facing value as soon as slice 2 lands.

## Manual testing

Tested locally with Newspack, WooCommerce, and WooCommerce Subscriptions active. Verified:

- "Card expiry warning" appears in Settings > Emails > Reader revenue chip with the expected label, description, and enabled-by-default state
- Preview renders with sample tokens (4242, 12/2026, etc.)
- `wp cron event list | grep newspack_card_expiry_warning_scan` confirms the daily cron is scheduled
- Set up a test subscription with a Stripe test card expiring next month, manually ran the cron (`wp cron event run newspack_card_expiry_warning_scan`), verified the email sent to the customer email with correct token substitutions
- Re-ran the cron: no-op (idempotency meta present)
- Updated the payment method on the sub via My Account: idempotency meta cleared; re-ran cron, no send (new card not in expiry window)
- Swapped to a different test card also in the expiry window: cron sent a new warning with the new token's last 4
- Multi-card check: added a second saved card (not used on any sub) also expiring soon → cron correctly ignored it; only the card on the sub triggered a send

### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?