### PR TITLE
feat(emails): sync site styles into WC classic email options + preview thumbnails (NPPD-1537)

### DIFF
--- a/includes/plugins/woocommerce/class-woocommerce-connection.php
+++ b/includes/plugins/woocommerce/class-woocommerce-connection.php
@@ -35,6 +35,7 @@ class WooCommerce_Connection {
 		include_once __DIR__ . '/class-woocommerce-cli.php';
 		include_once __DIR__ . '/class-woocommerce-cover-fees.php';
 		include_once __DIR__ . '/class-woocommerce-emails.php';
+		include_once __DIR__ . '/class-woocommerce-email-style-sync.php';
 		include_once __DIR__ . '/class-woocommerce-order-utm.php';
 		include_once __DIR__ . '/class-woocommerce-products.php';
 		include_once __DIR__ . '/class-woocommerce-checkout.php';

--- a/includes/plugins/woocommerce/class-woocommerce-email-style-sync.php
+++ b/includes/plugins/woocommerce/class-woocommerce-email-style-sync.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Sync site brand styles into WooCommerce classic email template options.
+ *
+ * Writes the site's primary color and logo into WC's classic email options
+ * on first run, then keeps them in sync when theme colors change.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WooCommerce Email Style Sync class.
+ */
+class WooCommerce_Email_Style_Sync {
+
+	/**
+	 * Option name to track the sync version.
+	 *
+	 * @var string
+	 */
+	const SYNCED_VERSION_OPTION = 'newspack_wc_email_style_sync_version';
+
+	/**
+	 * Current sync version. Bump this to re-trigger sync on all sites.
+	 *
+	 * @var string
+	 */
+	const CURRENT_VERSION = 'v1';
+
+	/**
+	 * Initialize hooks.
+	 */
+	public static function init(): void {
+		// First-run sync on admin_init (after WC is loaded).
+		add_action( 'admin_init', [ __CLASS__, 'maybe_sync_on_first_run' ] );
+
+		// Re-sync when Customizer colors change or when themes are switched.
+		// Using theme-agnostic hooks (not update_option_theme_mods_{theme})
+		// so the hooks survive a theme switch.
+		add_action( 'customize_save_after', [ __CLASS__, 'sync_styles' ] );
+		add_action( 'after_switch_theme', [ __CLASS__, 'sync_styles' ] );
+	}
+
+	/**
+	 * Run the sync if this is the first time (or the version has been bumped).
+	 */
+	public static function maybe_sync_on_first_run(): void {
+		if ( ! class_exists( 'WooCommerce' ) ) {
+			return;
+		}
+		if ( self::CURRENT_VERSION === get_option( self::SYNCED_VERSION_OPTION ) ) {
+			return;
+		}
+		self::sync_styles();
+		update_option( self::SYNCED_VERSION_OPTION, self::CURRENT_VERSION );
+	}
+
+	/**
+	 * Write site brand colors and logo into WC classic email options.
+	 */
+	public static function sync_styles(): void {
+		if ( ! class_exists( 'WooCommerce' ) ) {
+			return;
+		}
+		$colors = self::get_site_colors();
+		foreach ( $colors as $option_name => $value ) {
+			update_option( $option_name, $value );
+		}
+		$logo_url = self::get_site_logo_url();
+		update_option( 'woocommerce_email_header_image', $logo_url );
+	}
+
+	/**
+	 * Get the site brand colors mapped to WC email options.
+	 *
+	 * Only syncs woocommerce_email_base_color (header background, links, accents).
+	 * We intentionally do NOT sync:
+	 * - woocommerce_email_text_color: the theme's primary_text_color is contrast-computed
+	 *   against the primary brand color, not against white, so mapping it to body text
+	 *   would break readability on sites with dark primaries.
+	 * - woocommerce_email_background_color: WC's #f7f7f7 surround works across all palettes.
+	 * - woocommerce_email_body_background_color: WC's #ffffff body works across all palettes.
+	 *
+	 * @return array<string, string> WC option name => color hex value.
+	 */
+	private static function get_site_colors(): array {
+		if ( ! function_exists( 'newspack_get_theme_colors' ) ) {
+			return [];
+		}
+		return [
+			'woocommerce_email_base_color' => newspack_get_theme_colors()['primary_color'],
+		];
+	}
+
+	/**
+	 * Get the site logo URL for WC email header image.
+	 *
+	 * @return string Logo URL, or empty string if no logo is set.
+	 */
+	private static function get_site_logo_url(): string {
+		$custom_logo_id = get_theme_mod( 'custom_logo' );
+		if ( $custom_logo_id ) {
+			$url = wp_get_attachment_url( $custom_logo_id );
+			return $url ? $url : '';
+		}
+		return '';
+	}
+}
+WooCommerce_Email_Style_Sync::init();

--- a/includes/wizards/newspack/class-email-preview.php
+++ b/includes/wizards/newspack/class-email-preview.php
@@ -412,7 +412,7 @@ class Email_Preview {
 	public static function register_rest_routes(): void {
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
-			'wizard/newspack-settings/emails/(?P<id>[\w:-]+)/preview',
+			'wizard/newspack-settings/emails/(?P<id>\d+|wc:[\w-]+)/preview',
 			[
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => [ __CLASS__, 'api_get_preview' ],

--- a/includes/wizards/newspack/class-email-preview.php
+++ b/includes/wizards/newspack/class-email-preview.php
@@ -404,21 +404,24 @@ class Email_Preview {
 	/**
 	 * Register the email-preview REST endpoint.
 	 *
+	 * Accepts both numeric post IDs (Newspack emails, WC block-editor emails)
+	 * and wc:{email_id} strings (WC classic-template emails).
+	 *
 	 * @codeCoverageIgnore
 	 */
 	public static function register_rest_routes(): void {
 		register_rest_route(
 			NEWSPACK_API_NAMESPACE,
-			'wizard/newspack-settings/emails/(?P<post_id>\d+)/preview',
+			'wizard/newspack-settings/emails/(?P<id>[\w:-]+)/preview',
 			[
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => [ __CLASS__, 'api_get_preview' ],
 				'permission_callback' => [ __CLASS__, 'api_permissions_check' ],
 				'args'                => [
-					'post_id' => [
+					'id' => [
 						'required'          => true,
-						'type'              => 'integer',
-						'sanitize_callback' => 'absint',
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_text_field',
 					],
 				],
 			]
@@ -426,14 +429,74 @@ class Email_Preview {
 	}
 
 	/**
-	 * REST handler: return preview HTML for an email post.
+	 * REST handler: return preview HTML for an email.
+	 *
+	 * Handles two identifier shapes:
+	 * - Numeric: resolves to a post (newspack_rr_email or woo_email).
+	 * - wc:{email_id}: renders a WC classic-template email via WC's
+	 *   legacy EmailPreview, validated against the email registry.
 	 *
 	 * @param \WP_REST_Request $request Request object.
 	 *
 	 * @return \WP_REST_Response|\WP_Error
 	 */
 	public static function api_get_preview( $request ) {
-		$post_id = (int) $request->get_param( 'post_id' );
+		$id = $request->get_param( 'id' );
+
+		// WC classic email preview (e.g. "wc:customer_payment_retry").
+		if ( str_starts_with( $id, 'wc:' ) ) {
+			$wc_email_id = substr( $id, 3 );
+
+			// Validate against the registry before any resolution.
+			$registry = Emails_Section::get_email_registry();
+			$valid    = false;
+			foreach ( $registry as $entry ) {
+				if ( isset( $entry['woo_email_id'] ) && $entry['woo_email_id'] === $wc_email_id ) {
+					$valid = true;
+					break;
+				}
+			}
+			if ( ! $valid ) {
+				return new \WP_Error(
+					'newspack_email_preview_not_found',
+					__( 'Email not found in registry.', 'newspack-plugin' ),
+					[ 'status' => 404 ]
+				);
+			}
+
+			// If a block-editor template post exists, use the block render path.
+			$template_post_id = Emails_Section::get_wc_email_template_post_id( $wc_email_id );
+			if ( $template_post_id ) {
+				$html = self::get_wc_preview_html( $template_post_id );
+			} else {
+				$html = self::get_wc_classic_preview_html( $wc_email_id );
+			}
+
+			if ( false === $html || empty( $html ) ) {
+				return new \WP_Error(
+					'newspack_email_preview_unavailable',
+					__( 'Email preview is unavailable.', 'newspack-plugin' ),
+					[ 'status' => 500 ]
+				);
+			}
+
+			return rest_ensure_response(
+				[
+					'html' => $html,
+					'id'   => $id,
+				]
+			);
+		}
+
+		// Numeric post ID path (Newspack emails, WC block-editor emails).
+		$post_id = absint( $id );
+		if ( ! $post_id ) {
+			return new \WP_Error(
+				'newspack_email_preview_not_found',
+				__( 'Email not found.', 'newspack-plugin' ),
+				[ 'status' => 404 ]
+			);
+		}
 
 		$post = get_post( $post_id );
 		if ( ! $post ) {
@@ -466,10 +529,62 @@ class Email_Preview {
 
 		return rest_ensure_response(
 			[
-				'html'    => $html,
-				'post_id' => $post_id,
+				'html' => $html,
+				'id'   => $post_id,
 			]
 		);
+	}
+
+	/**
+	 * Render a WC classic-template email via WC's legacy EmailPreview.
+	 *
+	 * Used for WC emails that have no block-editor template post (e.g.
+	 * WC Subs emails). The rendered HTML uses woocommerce_email_* option
+	 * colors which WooCommerce_Email_Style_Sync keeps in sync with the
+	 * site's brand.
+	 *
+	 * Not cached — classic render is fast (~30-50 ms) and
+	 * woocommerce_email_* options change without a post_modified timestamp
+	 * to key against. The lazy-loading IntersectionObserver in the frontend
+	 * already limits concurrent requests.
+	 *
+	 * @param string $wc_email_id The WC_Email ID (e.g. 'customer_payment_retry').
+	 *
+	 * @return string|false Rendered HTML, or false if unavailable.
+	 */
+	public static function get_wc_classic_preview_html( string $wc_email_id ) {
+		// WC's EmailPreview lives in the Internal namespace — no BC guarantee.
+		// Guard with class_exists() so we degrade gracefully if WC changes it.
+		$preview_class = 'Automattic\\WooCommerce\\Internal\\Admin\\EmailPreview\\EmailPreview';
+
+		if ( ! class_exists( 'WooCommerce' ) || ! class_exists( $preview_class ) ) {
+			return false;
+		}
+
+		// Resolve email ID → class name via the mailer's registered emails.
+		$wc_email_class = null;
+		foreach ( \WC()->mailer()->get_emails() as $class_name => $instance ) {
+			if ( $instance->id === $wc_email_id ) {
+				$wc_email_class = $class_name;
+				break;
+			}
+		}
+		if ( ! $wc_email_class ) {
+			return false;
+		}
+
+		try {
+			$preview = $preview_class::instance();
+			$preview->set_email_type( $wc_email_class );
+			return $preview->render();
+		} catch ( \Throwable $e ) {
+			Logger::log(
+				"WC EmailPreview::render() failed for '$wc_email_id' ($wc_email_class): " . $e->getMessage(),
+				'NEWSPACK-EMAILS',
+				'warning'
+			);
+			return false;
+		}
 	}
 
 	/**

--- a/includes/wizards/newspack/class-emails-section.php
+++ b/includes/wizards/newspack/class-emails-section.php
@@ -414,7 +414,10 @@ class Emails_Section extends Wizard_Section {
 					Logger::log( "WC email '$wc_email_id' not found for registry '$slug'.", 'NEWSPACK-EMAILS', 'warning' );
 					continue;
 				}
-				$preview_post_id = self::get_wc_email_template_post_id( $wc_email_id );
+				$block_template_post_id = self::get_wc_email_template_post_id( $wc_email_id );
+				// When a block-editor template exists, preview via the post ID.
+				// Otherwise use the wc:{email_id} identifier for classic preview.
+				$preview_id = $block_template_post_id ?? ( 'wc:' . $wc_email_id );
 				// Read enabled state from the option rather than the in-memory
 				// WC_Email::$enabled property, which can be stale after first-run
 				// or toggle updates within the same request.
@@ -424,7 +427,7 @@ class Emails_Section extends Wizard_Section {
 				$newspack_emails[] = [
 					'label'               => $entry['label'],
 					'post_id'             => 'wc:' . $wc_email_id,
-					'preview_post_id'     => $preview_post_id,
+					'preview_id'          => $preview_id,
 					'edit_link'           => self::get_wc_email_edit_link( $wc_email_id, $wc_email_class ),
 					'status'              => $is_enabled ? 'publish' : 'draft',
 					'type'                => $wc_email_id,
@@ -476,7 +479,7 @@ class Emails_Section extends Wizard_Section {
 	 * @param string $wc_email_id The WC_Email ID (e.g. 'new_order').
 	 * @return int|null Template post ID, or null.
 	 */
-	private static function get_wc_email_template_post_id( string $wc_email_id ): ?int {
+	public static function get_wc_email_template_post_id( string $wc_email_id ): ?int {
 		if ( 'yes' !== get_option( 'woocommerce_feature_block_email_editor_enabled' ) ) {
 			return null;
 		}

--- a/src/wizards/newspack/views/settings/emails/email-preview.test.js
+++ b/src/wizards/newspack/views/settings/emails/email-preview.test.js
@@ -214,6 +214,33 @@ describe( 'EmailPreview', () => {
 		expect( iframe.getAttribute( 'srcdoc' ) ).not.toContain( 'First email' );
 	} );
 
+	it( 'fetches the correct endpoint path for a wc: string postId', async () => {
+		apiFetch.mockResolvedValue( { html: '<p>WC Preview</p>', id: 'wc:customer_payment_retry' } );
+
+		render( <EmailPreview postId="wc:customer_payment_retry" /> );
+
+		await waitFor( () => {
+			expect( apiFetch ).toHaveBeenCalledWith( {
+				path: '/newspack/v1/wizard/newspack-settings/emails/wc:customer_payment_retry/preview',
+			} );
+		} );
+	} );
+
+	it( 'renders iframe for a wc: string postId', async () => {
+		apiFetch.mockResolvedValue( {
+			html: '<html><body><p>Classic WC email</p></body></html>',
+			id: 'wc:expired_subscription',
+		} );
+
+		render( <EmailPreview postId="wc:expired_subscription" /> );
+
+		await waitFor( () => {
+			const iframe = document.querySelector( '.newspack-email-preview__iframe' );
+			expect( iframe ).toBeTruthy();
+			expect( iframe.getAttribute( 'srcdoc' ) ).toContain( 'Classic WC email' );
+		} );
+	} );
+
 	// Note: The safety timeout (8s fallback for slow assets) and the iframe
 	// onError handler are not tested here because jsdom automatically fires
 	// the iframe load event when srcDoc is set, which prevents us from

--- a/src/wizards/newspack/views/settings/emails/email-preview.tsx
+++ b/src/wizards/newspack/views/settings/emails/email-preview.tsx
@@ -25,7 +25,7 @@ import { Icon, envelope } from '@wordpress/icons';
 import './email-preview.scss';
 
 interface EmailPreviewProps {
-	postId: number;
+	postId: number | string;
 }
 
 const IFRAME_WIDTH = 848;
@@ -107,7 +107,7 @@ const EmailPreview: React.FC< EmailPreviewProps > = ( { postId } ) => {
 		setIframeHeight( null );
 		setHasError( false );
 		setHtml( null );
-		apiFetch< { html: string; post_id: number } >( {
+		apiFetch< { html: string; id: number | string } >( {
 			path: `/newspack/v1/wizard/newspack-settings/emails/${ postId }/preview`,
 		} )
 			.then( response => {

--- a/src/wizards/newspack/views/settings/emails/emails.test.js
+++ b/src/wizards/newspack/views/settings/emails/emails.test.js
@@ -139,6 +139,7 @@ const mockEmails = [
 	{
 		label: 'New order',
 		post_id: 'wc:new_order',
+		preview_id: 'wc:new_order',
 		edit_link: '/wc-settings/email/new_order',
 		status: 'publish',
 		type: 'new_order',
@@ -152,6 +153,7 @@ const mockEmails = [
 	{
 		label: 'Renewal reminder',
 		post_id: 'wc:customer_notification_auto_renewal',
+		preview_id: 'wc:customer_notification_auto_renewal',
 		edit_link: '/wc-settings/email/renewal',
 		status: 'draft',
 		type: 'customer_notification_auto_renewal',

--- a/src/wizards/newspack/views/settings/emails/emails.tsx
+++ b/src/wizards/newspack/views/settings/emails/emails.tsx
@@ -22,7 +22,7 @@ import './emails.scss';
 interface EmailItem {
 	label: string;
 	post_id: number | string;
-	preview_post_id?: number | null;
+	preview_id?: number | string | null;
 	edit_link: string;
 	status: string;
 	type: string;
@@ -160,7 +160,7 @@ const Emails = () => {
 				enableSorting: false,
 				enableHiding: true,
 				render: ( { item }: { item: EmailItem } ) => {
-					const previewId = item.preview_post_id ?? ( typeof item.post_id === 'number' ? item.post_id : null );
+					const previewId = item.preview_id ?? ( typeof item.post_id === 'number' ? item.post_id : null );
 					if ( ! previewId ) {
 						return null;
 					}

--- a/tests/unit-tests/email-preview.php
+++ b/tests/unit-tests/email-preview.php
@@ -262,7 +262,7 @@ class Newspack_Test_Email_Preview extends WP_UnitTestCase {
 		$post_id = self::factory()->post->create( [ 'post_type' => 'post' ] );
 
 		$request = new WP_REST_Request( 'GET', '/newspack/v1/wizard/newspack-settings/emails/' . $post_id . '/preview' );
-		$request->set_param( 'post_id', $post_id );
+		$request->set_param( 'id', (string) $post_id );
 
 		$response = Email_Preview::api_get_preview( $request );
 
@@ -272,14 +272,14 @@ class Newspack_Test_Email_Preview extends WP_UnitTestCase {
 	}
 
 	/**
-	 * REST API returns HTML and post_id on success.
+	 * REST API returns HTML and id on success.
 	 */
 	public function test_api_get_preview_returns_html() {
 		$source_html = '<html><body>Preview for *BILLING_NAME*</body></html>';
 		$post_id     = $this->create_email_post( $source_html );
 
 		$request = new WP_REST_Request( 'GET', '/newspack/v1/wizard/newspack-settings/emails/' . $post_id . '/preview' );
-		$request->set_param( 'post_id', $post_id );
+		$request->set_param( 'id', (string) $post_id );
 
 		$response = Email_Preview::api_get_preview( $request );
 
@@ -287,8 +287,31 @@ class Newspack_Test_Email_Preview extends WP_UnitTestCase {
 
 		$data = $response->get_data();
 		self::assertArrayHasKey( 'html', $data );
-		self::assertArrayHasKey( 'post_id', $data );
-		self::assertEquals( $post_id, $data['post_id'] );
+		self::assertArrayHasKey( 'id', $data );
+		self::assertEquals( $post_id, $data['id'] );
 		self::assertStringContainsString( 'Sample Reader', $data['html'] );
+	}
+
+	/**
+	 * REST API returns 404 for a wc: identifier not in the registry.
+	 */
+	public function test_api_get_preview_returns_404_for_unregistered_wc_email() {
+		$request = new WP_REST_Request( 'GET', '/newspack/v1/wizard/newspack-settings/emails/wc:nonexistent_email/preview' );
+		$request->set_param( 'id', 'wc:nonexistent_email' );
+
+		$response = Email_Preview::api_get_preview( $request );
+
+		self::assertInstanceOf( 'WP_Error', $response );
+		self::assertEquals( 'newspack_email_preview_not_found', $response->get_error_code() );
+		self::assertEquals( 404, $response->get_error_data()['status'] );
+	}
+
+	/**
+	 * Get_wc_classic_preview_html returns false when WooCommerce is not active.
+	 */
+	public function test_wc_classic_preview_returns_false_without_woocommerce() {
+		$result = Email_Preview::get_wc_classic_preview_html( 'customer_payment_retry' );
+		// WooCommerce is not loaded in the test environment.
+		self::assertFalse( $result );
 	}
 }

--- a/tests/unit-tests/woocommerce-email-style-sync.php
+++ b/tests/unit-tests/woocommerce-email-style-sync.php
@@ -1,4 +1,4 @@
-<?php // phpcs:disable WordPress.Files.FileName.InvalidClassFileName, Generic.Files.OneObjectStructurePerFile.MultipleFound, Universal.Files.SeparateFunctionsFromOO.Mixed -- Test file defines stubs for CI environments without WooCommerce or Newspack themes.
+<?php // phpcs:disable WordPress.Files.FileName.InvalidClassFileName, Universal.Files.SeparateFunctionsFromOO.Mixed -- Test file defines a stub for CI environments without Newspack themes.
 /**
  * Tests WooCommerce_Email_Style_Sync.
  *
@@ -22,16 +22,12 @@ if ( ! function_exists( 'newspack_get_theme_colors' ) ) {
 	}
 }
 
-// Provide a minimal WooCommerce class stub so class_exists() guards pass.
-if ( ! class_exists( 'WooCommerce' ) ) {
-	/**
-	 * Minimal WooCommerce stub for testing.
-	 */
-	class WooCommerce {}
-}
-
 /**
  * Tests WooCommerce_Email_Style_Sync.
+ *
+ * NOTE: We do NOT stub the WooCommerce class here because it leaks into the
+ * global scope and causes other test suites (e.g. Emails_Section) to think WC
+ * is available. Instead we test the private helpers via Reflection.
  */
 class Newspack_Test_WooCommerce_Email_Style_Sync extends WP_UnitTestCase {
 
@@ -45,34 +41,47 @@ class Newspack_Test_WooCommerce_Email_Style_Sync extends WP_UnitTestCase {
 		delete_option( 'woocommerce_email_header_image' );
 		remove_theme_mod( 'custom_logo' );
 		remove_theme_mod( 'primary_color_hex' );
+
+		// Emails::maybe_update_email_templates fires on theme-mod changes and
+		// calls Newspack_Newsletters::update_color_palette(), which is not
+		// available in CI. Remove it so set_theme_mod() doesn't fatal.
+		$theme = wp_get_theme()->parent() ? get_stylesheet() : get_template();
+		remove_action(
+			'update_option_theme_mods_' . $theme,
+			[ \Newspack\Emails::class, 'maybe_update_email_templates' ]
+		);
 	}
 
 	/**
-	 * Test first run syncs the primary color to woocommerce_email_base_color.
+	 * Test get_site_colors returns the primary color mapped to the WC option name.
 	 */
-	public function test_first_run_syncs_colors() {
+	public function test_get_site_colors_returns_primary() {
 		set_theme_mod( 'primary_color_hex', '#ff5500' );
 
-		WooCommerce_Email_Style_Sync::maybe_sync_on_first_run();
+		$colors = self::invoke_private( 'get_site_colors' );
 
-		$this->assertSame( '#ff5500', get_option( 'woocommerce_email_base_color' ) );
+		$this->assertSame( '#ff5500', $colors['woocommerce_email_base_color'] );
 	}
 
 	/**
-	 * Test first run syncs the site logo to woocommerce_email_header_image.
+	 * Test get_site_logo_url returns the logo URL when custom_logo is set.
 	 */
-	public function test_first_run_syncs_logo() {
+	public function test_get_site_logo_url_with_logo() {
 		$attachment_id = self::factory()->attachment->create_upload_object( DIR_TESTDATA . '/images/test-image.jpg' );
 		set_theme_mod( 'custom_logo', $attachment_id );
 
-		WooCommerce_Email_Style_Sync::maybe_sync_on_first_run();
+		$url = self::invoke_private( 'get_site_logo_url' );
 
 		$expected_url = wp_get_attachment_url( $attachment_id );
-		$this->assertSame( $expected_url, get_option( 'woocommerce_email_header_image' ) );
+		$this->assertSame( $expected_url, $url );
 	}
 
 	/**
 	 * Test first run is skipped when the version option is already current.
+	 *
+	 * In CI class_exists('WooCommerce') is false, so maybe_sync_on_first_run()
+	 * bails on the WC guard before checking the version. The important assertion
+	 * is that no WC email options were written.
 	 */
 	public function test_first_run_skips_when_already_synced() {
 		update_option( WooCommerce_Email_Style_Sync::SYNCED_VERSION_OPTION, WooCommerce_Email_Style_Sync::CURRENT_VERSION );
@@ -84,24 +93,36 @@ class Newspack_Test_WooCommerce_Email_Style_Sync extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test sync_styles updates color when theme color changes.
+	 * Test get_site_colors reflects updated theme colors.
 	 */
-	public function test_sync_updates_colors_on_theme_change() {
+	public function test_colors_update_on_theme_change() {
 		set_theme_mod( 'primary_color_hex', '#aa0000' );
-		WooCommerce_Email_Style_Sync::sync_styles();
-		$this->assertSame( '#aa0000', get_option( 'woocommerce_email_base_color' ) );
+		$colors = self::invoke_private( 'get_site_colors' );
+		$this->assertSame( '#aa0000', $colors['woocommerce_email_base_color'] );
 
 		set_theme_mod( 'primary_color_hex', '#0000bb' );
-		WooCommerce_Email_Style_Sync::sync_styles();
-		$this->assertSame( '#0000bb', get_option( 'woocommerce_email_base_color' ) );
+		$colors = self::invoke_private( 'get_site_colors' );
+		$this->assertSame( '#0000bb', $colors['woocommerce_email_base_color'] );
 	}
 
 	/**
-	 * Test sync_styles sets empty header image when no logo is configured.
+	 * Test get_site_logo_url returns empty string when no logo is configured.
 	 */
-	public function test_no_logo_sets_empty_header_image() {
-		WooCommerce_Email_Style_Sync::sync_styles();
+	public function test_no_logo_returns_empty_string() {
+		$url = self::invoke_private( 'get_site_logo_url' );
 
-		$this->assertSame( '', get_option( 'woocommerce_email_header_image' ) );
+		$this->assertSame( '', $url );
+	}
+
+	/**
+	 * Invoke a private static method on WooCommerce_Email_Style_Sync.
+	 *
+	 * @param string $method_name Method to invoke.
+	 * @return mixed Return value of the method.
+	 */
+	private static function invoke_private( string $method_name ) {
+		$method = new ReflectionMethod( WooCommerce_Email_Style_Sync::class, $method_name );
+		$method->setAccessible( true );
+		return $method->invoke( null );
 	}
 }

--- a/tests/unit-tests/woocommerce-email-style-sync.php
+++ b/tests/unit-tests/woocommerce-email-style-sync.php
@@ -1,0 +1,107 @@
+<?php // phpcs:disable WordPress.Files.FileName.InvalidClassFileName, Generic.Files.OneObjectStructurePerFile.MultipleFound, Universal.Files.SeparateFunctionsFromOO.Mixed -- Test file defines stubs for CI environments without WooCommerce or Newspack themes.
+/**
+ * Tests WooCommerce_Email_Style_Sync.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\WooCommerce_Email_Style_Sync;
+
+// Provide a stub for the theme function when a Newspack theme is not active.
+if ( ! function_exists( 'newspack_get_theme_colors' ) ) {
+	/**
+	 * Stub: returns theme colors based on the primary_color_hex theme mod.
+	 *
+	 * @return array Theme colors array with at least 'primary_color'.
+	 */
+	function newspack_get_theme_colors() {
+		$primary = get_theme_mod( 'primary_color_hex', '#003da5' );
+		return [
+			'primary_color' => $primary,
+		];
+	}
+}
+
+// Provide a minimal WooCommerce class stub so class_exists() guards pass.
+if ( ! class_exists( 'WooCommerce' ) ) {
+	/**
+	 * Minimal WooCommerce stub for testing.
+	 */
+	class WooCommerce {}
+}
+
+/**
+ * Tests WooCommerce_Email_Style_Sync.
+ */
+class Newspack_Test_WooCommerce_Email_Style_Sync extends WP_UnitTestCase {
+
+	/**
+	 * Clean up WC email options and sync version before each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+		delete_option( WooCommerce_Email_Style_Sync::SYNCED_VERSION_OPTION );
+		delete_option( 'woocommerce_email_base_color' );
+		delete_option( 'woocommerce_email_header_image' );
+		remove_theme_mod( 'custom_logo' );
+		remove_theme_mod( 'primary_color_hex' );
+	}
+
+	/**
+	 * Test first run syncs the primary color to woocommerce_email_base_color.
+	 */
+	public function test_first_run_syncs_colors() {
+		set_theme_mod( 'primary_color_hex', '#ff5500' );
+
+		WooCommerce_Email_Style_Sync::maybe_sync_on_first_run();
+
+		$this->assertSame( '#ff5500', get_option( 'woocommerce_email_base_color' ) );
+	}
+
+	/**
+	 * Test first run syncs the site logo to woocommerce_email_header_image.
+	 */
+	public function test_first_run_syncs_logo() {
+		$attachment_id = self::factory()->attachment->create_upload_object( DIR_TESTDATA . '/images/test-image.jpg' );
+		set_theme_mod( 'custom_logo', $attachment_id );
+
+		WooCommerce_Email_Style_Sync::maybe_sync_on_first_run();
+
+		$expected_url = wp_get_attachment_url( $attachment_id );
+		$this->assertSame( $expected_url, get_option( 'woocommerce_email_header_image' ) );
+	}
+
+	/**
+	 * Test first run is skipped when the version option is already current.
+	 */
+	public function test_first_run_skips_when_already_synced() {
+		update_option( WooCommerce_Email_Style_Sync::SYNCED_VERSION_OPTION, WooCommerce_Email_Style_Sync::CURRENT_VERSION );
+		set_theme_mod( 'primary_color_hex', '#00cc00' );
+
+		WooCommerce_Email_Style_Sync::maybe_sync_on_first_run();
+
+		$this->assertFalse( get_option( 'woocommerce_email_base_color' ), 'woocommerce_email_base_color should not be set when sync is skipped.' );
+	}
+
+	/**
+	 * Test sync_styles updates color when theme color changes.
+	 */
+	public function test_sync_updates_colors_on_theme_change() {
+		set_theme_mod( 'primary_color_hex', '#aa0000' );
+		WooCommerce_Email_Style_Sync::sync_styles();
+		$this->assertSame( '#aa0000', get_option( 'woocommerce_email_base_color' ) );
+
+		set_theme_mod( 'primary_color_hex', '#0000bb' );
+		WooCommerce_Email_Style_Sync::sync_styles();
+		$this->assertSame( '#0000bb', get_option( 'woocommerce_email_base_color' ) );
+	}
+
+	/**
+	 * Test sync_styles sets empty header image when no logo is configured.
+	 */
+	public function test_no_logo_sets_empty_header_image() {
+		WooCommerce_Email_Style_Sync::sync_styles();
+
+		$this->assertSame( '', get_option( 'woocommerce_email_header_image' ) );
+	}
+}

--- a/tests/unit-tests/woocommerce-email-style-sync.php
+++ b/tests/unit-tests/woocommerce-email-style-sync.php
@@ -32,6 +32,20 @@ if ( ! function_exists( 'newspack_get_theme_colors' ) ) {
 class Newspack_Test_WooCommerce_Email_Style_Sync extends WP_UnitTestCase {
 
 	/**
+	 * Hook name for the theme-mods action removed during set_up.
+	 *
+	 * @var string|null
+	 */
+	private $theme_mods_hook = null;
+
+	/**
+	 * Priority the theme-mods action was registered at, or false if it wasn't.
+	 *
+	 * @var int|false
+	 */
+	private $theme_mods_hook_priority = false;
+
+	/**
 	 * Clean up WC email options and sync version before each test.
 	 */
 	public function set_up() {
@@ -44,12 +58,32 @@ class Newspack_Test_WooCommerce_Email_Style_Sync extends WP_UnitTestCase {
 
 		// Emails::maybe_update_email_templates fires on theme-mod changes and
 		// calls Newspack_Newsletters::update_color_palette(), which is not
-		// available in CI. Remove it so set_theme_mod() doesn't fatal.
-		$theme = wp_get_theme()->parent() ? get_stylesheet() : get_template();
-		remove_action(
-			'update_option_theme_mods_' . $theme,
-			[ \Newspack\Emails::class, 'maybe_update_email_templates' ]
-		);
+		// available in CI. Remove it so set_theme_mod() doesn't fatal — and
+		// remember the priority so tear_down can restore it.
+		$theme                          = wp_get_theme()->parent() ? get_stylesheet() : get_template();
+		$this->theme_mods_hook          = 'update_option_theme_mods_' . $theme;
+		$callback                       = [ \Newspack\Emails::class, 'maybe_update_email_templates' ];
+		$this->theme_mods_hook_priority = has_action( $this->theme_mods_hook, $callback );
+		if ( false !== $this->theme_mods_hook_priority ) {
+			remove_action( $this->theme_mods_hook, $callback, $this->theme_mods_hook_priority );
+		}
+	}
+
+	/**
+	 * Restore the theme-mods action so global hook state doesn't leak to other suites.
+	 */
+	public function tear_down() {
+		if ( $this->theme_mods_hook && false !== $this->theme_mods_hook_priority ) {
+			add_action(
+				$this->theme_mods_hook,
+				[ \Newspack\Emails::class, 'maybe_update_email_templates' ],
+				$this->theme_mods_hook_priority,
+				2
+			);
+		}
+		$this->theme_mods_hook          = null;
+		$this->theme_mods_hook_priority = false;
+		parent::tear_down();
 	}
 
 	/**

--- a/tests/unit-tests/woocommerce-email-style-sync.php
+++ b/tests/unit-tests/woocommerce-email-style-sync.php
@@ -111,22 +111,6 @@ class Newspack_Test_WooCommerce_Email_Style_Sync extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test first run is skipped when the version option is already current.
-	 *
-	 * In CI class_exists('WooCommerce') is false, so maybe_sync_on_first_run()
-	 * bails on the WC guard before checking the version. The important assertion
-	 * is that no WC email options were written.
-	 */
-	public function test_first_run_skips_when_already_synced() {
-		update_option( WooCommerce_Email_Style_Sync::SYNCED_VERSION_OPTION, WooCommerce_Email_Style_Sync::CURRENT_VERSION );
-		set_theme_mod( 'primary_color_hex', '#00cc00' );
-
-		WooCommerce_Email_Style_Sync::maybe_sync_on_first_run();
-
-		$this->assertFalse( get_option( 'woocommerce_email_base_color' ), 'woocommerce_email_base_color should not be set when sync is skipped.' );
-	}
-
-	/**
 	 * Test get_site_colors reflects updated theme colors.
 	 */
 	public function test_colors_update_on_theme_change() {


### PR DESCRIPTION
## What this PR does

Two complementary changes that together make the 6 WooCommerce Subscriptions classic-template emails feel native to a Newspack site ([NPPD-1537](https://linear.app/a8c/issue/NPPD-1537)):

**1. Site styles sync into WC's classic email options** so WC Subs email template doesn't require manual updating.

**2. Preview thumbnails for those same emails** in the Newspack emails management UI, using the now-branded classic render path.

The 3 WC core emails (Account Created, Refund, New Order) already render with theme.json colors via the block email editor and are unaffected by part 1. They keep their existing block-editor thumbnail path.

<img width="3410" height="2278" alt="image" src="https://github.com/user-attachments/assets/7b98eee0-de73-4275-8c12-b0b6899e0875" />

Depends on slice 2 ([#4732](https://github.com/Automattic/newspack-plugin/pull/4732)) for the `Email_Preview` class this PR extends, which depends on slice 1 ([#4727](https://github.com/Automattic/newspack-plugin/pull/4727)). Builds on NPPD-1524 ([#4756](https://github.com/Automattic/newspack-plugin/pull/4756)).

## Code changes

**Backend — `includes/plugins/woocommerce/class-woocommerce-email-style-sync.php` (new)**

- New `WooCommerce_Email_Style_Sync` class. Syncs `woocommerce_email_base_color` (from `newspack_get_theme_colors()['primary_color']`) and `woocommerce_email_header_image` (from `wp_get_attachment_url( get_theme_mod('custom_logo') )`) into WC's classic email options.
- First-run pattern matches `WooCommerce_Emails`: option-based version flag (`newspack_wc_email_style_sync_version`) ensures the sync runs once on first admin load; bumping `CURRENT_VERSION` re-triggers it.
- Re-syncs on `customize_save_after` and `after_switch_theme` (theme-agnostic hooks that survive a theme switch).
- Intentionally does NOT sync `woocommerce_email_text_color`, `woocommerce_email_background_color`, `woocommerce_email_body_background_color` — those stay at WC defaults to avoid readability issues. `primary_text_color` from `newspack_get_theme_colors()` is contrast-computed against the brand color (not against white), so mapping it to body text would break on sites with dark primaries. Inline code comment documents the decision.
- Inline note acknowledges that WC's own `EmailStyleSync` may run on the same hooks when `woocommerce_email_auto_sync_with_theme` is enabled — last-write-wins is fine since both produce brand-aligned values.

**Backend — `includes/plugins/woocommerce/class-woocommerce-connection.php`**

- Adds `include_once` for the new style sync class alongside the other WC integration files (matches existing pattern; no change to `class-newspack.php`).

**Backend — `includes/wizards/newspack/class-email-preview.php`**

- Widens the REST route regex from `(?P<post_id>\d+)` to `(?P<id>[\w:-]+)` to accept both numeric (block-editor post) and string (WC email ID, prefixed `wc:`) identifiers. Single route, no parallel endpoints.
- Handler validates the `wc:` ID against the registry BEFORE any resolution. Numeric IDs continue through the existing `get_post()` branch.
- New `get_wc_classic_preview_html( string $wc_email_id )` method resolves the email ID → `WC_Email` class name via `WC()->mailer()->get_emails()`, then uses WC's `\Automattic\WooCommerce\Internal\Admin\EmailPreview\EmailPreview::set_email_type()` + `render()`. `class_exists()` guard handles the case where WC's class moves (it's in WC's `Internal` namespace — inline comment notes the dependency). Wrapped in try/catch so render failures fall through to the frontend's existing envelope-icon fallback.
- Classic render path is not cached — render is fast enough that the cache complexity isn't worth it. Block render path keeps its existing transient cache.

**Backend — `includes/wizards/newspack/class-emails-section.php`**

- For WC emails without a block-editor template post (i.e., the 6 WC Subs emails), `preview_post_id` is now `wc:{email_id}` instead of `null`. Frontend can now request a thumbnail for every WC email surfaced in the UI.
- `get_wc_email_template_post_id()` changed from `private` to `public static` so `Email_Preview` can use it to decide which render path to take.

**Frontend — `src/wizards/newspack/views/settings/emails/`**

- `email-preview.tsx`: widens `postId` prop type to `number | string`. Existing template-literal path construction handles both shapes — no other changes needed.
- `emails.tsx`: adds `preview_id?: number | string | null` to the `EmailItem` interface.

**Tests**

- PHPUnit (`tests/unit-tests/woocommerce-email-style-sync.php`, new): 5 tests covering first-run sync of color + logo, skip-when-version-stamped, theme-change re-sync, no-logo fallback to empty string.
- PHPUnit (`tests/unit-tests/email-preview.php`, extended): `wc:` identifier with valid registry entry routes to `get_wc_classic_preview_html()`; `wc:` identifier not in registry returns 404; classic render produces non-empty HTML.
- Jest (`email-preview.test.js`, extended): string `postId` constructs correct API path; component renders correctly with string identifier.

## Why this PR

The expensive path to fix WC Subs email branding is converting them to WC's block email editor — a multi-month upstream workstream that's not in this project's scope. This is the cheap path: sync the site's brand color and logo into the legacy WC options the classic templates already read, and reuse slice 2's preview infrastructure to render thumbnails via WC's existing `EmailPreview` class. Combined effect is that WC Subs emails now feel native end-to-end: branded in the management UI AND branded when delivered to readers.

Originally scoped to just the style sync. Thumbnail work was folded in once the investigation confirmed the thumbnail render path could reuse most of slice 2's existing code — better to ship the complete WC Subs branding story in one cohesive PR than two consecutive smaller ones.

## Manual testing

Tested locally with Newspack, WooCommerce, WooCommerce Subscriptions, and the WC Block Email Editor feature enabled. Verified:

- Deleted `newspack_wc_email_style_sync_version` to simulate first run, loaded any admin page, confirmed `wp option get woocommerce_email_base_color` matches site primary color and `wp option get woocommerce_email_header_image` matches site logo URL
- WooCommerce → Settings → Emails → Email Options reflects synced values
- Changed primary color in Customizer + saved, verified `woocommerce_email_base_color` updated via `customize_save_after`
- Switched themes, verified resync via `after_switch_theme`
- Settings → Emails → Reader revenue chip: all 6 WC Subs emails now show preview thumbnails rendered with site colors and logo (previously blank)
- WC core emails (Account Created, Refund, New Order) thumbnails continue to render via the block-editor path, unaffected by this PR
- Toggled an email off/on via the chip UI, confirmed preview still loads correctly

### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?