### PR TITLE
fix(reader-activation): return all labels when no key is requested

### DIFF
--- a/includes/reader-activation/class-reader-activation.php
+++ b/includes/reader-activation/class-reader-activation.php
@@ -332,18 +332,18 @@ final class Reader_Activation {
 			*/
 			$filtered_labels = apply_filters( 'newspack_reader_activation_auth_labels', $default_labels );
 
-			foreach ( $default_labels as $key => $label ) {
-				if ( isset( $filtered_labels[ $key ] ) ) {
-					if ( is_array( $label ) && is_array( $filtered_labels[ $key ] ) ) {
-						self::$reader_activation_labels[ $key ] = array_merge( $label, $filtered_labels[ $key ] );
-					} elseif ( is_string( $label ) && is_string( $filtered_labels[ $key ] ) ) {
-						self::$reader_activation_labels[ $key ] = $filtered_labels[ $key ];
+			foreach ( $default_labels as $label_key => $label ) {
+				if ( isset( $filtered_labels[ $label_key ] ) ) {
+					if ( is_array( $label ) && is_array( $filtered_labels[ $label_key ] ) ) {
+						self::$reader_activation_labels[ $label_key ] = array_merge( $label, $filtered_labels[ $label_key ] );
+					} elseif ( is_string( $label ) && is_string( $filtered_labels[ $label_key ] ) ) {
+						self::$reader_activation_labels[ $label_key ] = $filtered_labels[ $label_key ];
 					} else {
 						// If filtered label type doesn't match, fallback to default.
-						self::$reader_activation_labels[ $key ] = $label;
+						self::$reader_activation_labels[ $label_key ] = $label;
 					}
 				} else {
-					self::$reader_activation_labels[ $key ] = $label;
+					self::$reader_activation_labels[ $label_key ] = $label;
 				}
 			}
 		}

--- a/tests/unit-tests/reader-activation.php
+++ b/tests/unit-tests/reader-activation.php
@@ -33,6 +33,34 @@ class Newspack_Test_Reader_Activation extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Calling the labels getter with no key must return the full labels array.
+	 *
+	 * The label-building loop reused the method's own `$key` parameter as its
+	 * loop variable, so after the loop `$key` held the last label key instead
+	 * of null and a no-argument call returned a single label string instead of
+	 * the whole array. Regression guard for #4560.
+	 */
+	public function test_get_reader_activation_labels_returns_full_array() {
+		$reflection = new \ReflectionClass( Reader_Activation::class );
+
+		// Reset the cached labels so the label-building loop runs on this call.
+		$cache = $reflection->getProperty( 'reader_activation_labels' );
+		$cache->setAccessible( true );
+		$cache->setValue( null, [] );
+
+		$method = $reflection->getMethod( 'get_reader_activation_labels' );
+		$method->setAccessible( true );
+
+		$labels = $method->invoke( null );
+
+		$this->assertIsArray( $labels, 'A no-key call must return the full labels array, not a single label.' );
+		$this->assertArrayHasKey( 'account_link', $labels );
+
+		// Leave no static residue for later tests in this process.
+		$cache->setValue( null, [] );
+	}
+
+	/**
 	 * Test that registering a reader creates and authenticates a user with reader
 	 * meta.
 	 */


### PR DESCRIPTION
Hey folks,

Calling `get_reader_activation_labels()` with no key returns a single label string instead of the full labels array. The label-building loop reuses the method's own `$key` parameter as its `foreach` variable, so by the time the loop ends `$key` holds the last label key rather than null. The `if ( ! $key )` guard then falls through and returns one label. Since that array is what `wp_localize_script()` hands to the auth script, the front end receives a broken labels object.

Renaming the loop variable is the whole fix. I added a test that calls the getter with no key and asserts it returns the full array; it resets the static label cache afterward so it leaves no residue for other tests in the process.

To verify by hand: register a filter on `newspack_reader_activation_auth_labels`, load a page that enqueues the auth script, and confirm the localized `newspack_reader_activation_labels` is the full object rather than a single string. Or run `test_get_reader_activation_labels_returns_full_array`. I proved the logic with a standalone harness (a no-key call returns a string without the fix, the full array with it); I don't have a local wp-env, so the PHPUnit case is written to match the existing tests and runs on CI.

Closes #4560

(full disclosure: AI helped me identify the issue and verify my work)
